### PR TITLE
Bookmarks: Undo behavior

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -3802,6 +3802,44 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenDeleteBookmarkUndoThenViewStateUpdated() = runTest {
+        val bookmark =
+            Bookmark(id = UUID.randomUUID().toString(), title = "A title", url = "www.example.com", lastModified = "timestamp")
+
+        bookmarksListFlow.send(listOf(bookmark))
+
+        loadUrl(bookmark.url, isBrowserShowing = true)
+
+        testee.onSavedSiteDeleted(bookmark)
+
+        assertTrue(browserViewState().bookmark == null)
+        assertTrue(browserViewState().favorite == null)
+
+        testee.undoDelete(bookmark)
+
+        assertTrue(browserViewState().bookmark == bookmark)
+    }
+
+    @Test
+    fun whenDeleteFavouriteUndoThenViewStateUpdated() = runTest {
+        val favourite =
+            Favorite(id = UUID.randomUUID().toString(), title = "A title", url = "www.example.com", lastModified = "timestamp", 0)
+
+        favoriteListFlow.send(listOf(favourite))
+
+        loadUrl(favourite.url, isBrowserShowing = true)
+
+        testee.onSavedSiteDeleted(favourite)
+
+        assertTrue(browserViewState().bookmark == null)
+        assertTrue(browserViewState().favorite == null)
+
+        testee.undoDelete(favourite)
+
+        assertTrue(browserViewState().favorite == favourite)
+    }
+
+    @Test
     fun whenPageChangedThenUpdatePreviousUrlAndUserQueryStateSetToFalse() {
         loadUrl(url = "www.example.com", isBrowserShowing = true)
         verify(mockAppLinksHandler).updatePreviousUrl("www.example.com")

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -685,7 +685,7 @@ class BrowserTabViewModelTest {
         val bookmark =
             Bookmark(id = UUID.randomUUID().toString(), title = "A title", url = "www.example.com", lastModified = "timestamp")
 
-        testee.delete(bookmark)
+        testee.onDeleteSavedSiteSnackbarDismissed(bookmark)
 
         verify(mockFaviconManager).deletePersistedFavicon(bookmark.url)
         verify(mockSavedSitesRepository).delete(bookmark)
@@ -737,7 +737,7 @@ class BrowserTabViewModelTest {
     fun whenDeleteQuickAccessItemCalledWithFavoriteThenRepositoryUpdated() = runTest {
         val savedSite = Favorite(UUID.randomUUID().toString(), "title", "http://example.com", lastModified = "timestamp", 0)
 
-        testee.delete(savedSite)
+        testee.onDeleteSavedSiteSnackbarDismissed(savedSite)
 
         verify(mockSavedSitesRepository).delete(savedSite)
     }
@@ -746,7 +746,7 @@ class BrowserTabViewModelTest {
     fun whenDeleteQuickAccessItemCalledWithBookmarkThenRepositoryUpdated() = runTest {
         val savedSite = Bookmark(UUID.randomUUID().toString(), "title", "http://example.com", lastModified = "timestamp")
 
-        testee.delete(savedSite)
+        testee.onDeleteSavedSiteSnackbarDismissed(savedSite)
 
         verify(mockSavedSitesRepository).delete(savedSite)
     }
@@ -3794,7 +3794,7 @@ class BrowserTabViewModelTest {
         assertTrue(autoCompleteViewState().favorites.isEmpty())
         assertTrue(ctaViewState().favorites.isEmpty())
 
-        testee.undoDelete(favoriteSite, 0)
+        testee.undoDelete(favoriteSite)
 
         assertTrue(browserViewState().favorite == favoriteSite)
         assertTrue(autoCompleteViewState().favorites == quickAccessFavorites)
@@ -3806,12 +3806,14 @@ class BrowserTabViewModelTest {
         val bookmark =
             Bookmark(id = UUID.randomUUID().toString(), title = "A title", url = "www.example.com", lastModified = "timestamp")
 
+        bookmarksListFlow.send(listOf(bookmark))
+
         testee.onSavedSiteDeleted(bookmark)
 
         assertTrue(browserViewState().bookmark == null)
         assertTrue(browserViewState().favorite == null)
 
-        testee.undoDelete(bookmark, 0)
+        testee.undoDelete(bookmark)
 
         assertTrue(browserViewState().bookmark == bookmark)
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -3802,23 +3802,6 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenDeleteBookmarkUndoThenViewStateUpdated() = runTest {
-        val bookmark =
-            Bookmark(id = UUID.randomUUID().toString(), title = "A title", url = "www.example.com", lastModified = "timestamp")
-
-        bookmarksListFlow.send(listOf(bookmark))
-
-        testee.onSavedSiteDeleted(bookmark)
-
-        assertTrue(browserViewState().bookmark == null)
-        assertTrue(browserViewState().favorite == null)
-
-        testee.undoDelete(bookmark)
-
-        assertTrue(browserViewState().bookmark == bookmark)
-    }
-
-    @Test
     fun whenPageChangedThenUpdatePreviousUrlAndUserQueryStateSetToFalse() {
         loadUrl(url = "www.example.com", isBrowserShowing = true)
         verify(mockAppLinksHandler).updatePreviousUrl("www.example.com")

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -56,6 +56,7 @@ import com.duckduckgo.app.browser.addtohome.AddToHomeCapabilityDetector
 import com.duckduckgo.app.browser.applinks.AppLinksHandler
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.browser.favicon.FaviconSource
+import com.duckduckgo.app.browser.favorites.FavoritesQuickAccessAdapter
 import com.duckduckgo.app.browser.favorites.FavoritesQuickAccessAdapter.QuickAccessFavorite
 import com.duckduckgo.app.browser.history.NavigationHistoryEntry
 import com.duckduckgo.app.browser.logindetection.FireproofDialogsEventHandler
@@ -3782,20 +3783,26 @@ class BrowserTabViewModelTest {
     @Test
     fun whenRemoveFavoriteUndoThenViewStateUpdated() = runTest {
         val favoriteSite = Favorite(id = UUID.randomUUID().toString(), title = "", url = "www.example.com", position = 0, lastModified = "timestamp")
+        val quickAccessFavorites = listOf(FavoritesQuickAccessAdapter.QuickAccessFavorite(favoriteSite))
+
         whenever(mockSavedSitesRepository.getFavorite("www.example.com")).thenReturn(favoriteSite)
         favoriteListFlow.send(listOf(favoriteSite))
         loadUrl("www.example.com", isBrowserShowing = true)
         testee.onFavoriteMenuClicked()
 
         assertTrue(browserViewState().favorite == null)
+        assertTrue(autoCompleteViewState().favorites.isEmpty())
+        assertTrue(ctaViewState().favorites.isEmpty())
 
         testee.undoDelete(favoriteSite, 0)
 
         assertTrue(browserViewState().favorite == favoriteSite)
+        assertTrue(autoCompleteViewState().favorites == quickAccessFavorites)
+        assertTrue(ctaViewState().favorites == quickAccessFavorites)
     }
 
     @Test
-    fun whenDeleteFavoriteUndoThenViewStateUpdated() = runTest {
+    fun whenDeleteBookmarkUndoThenViewStateUpdated() = runTest {
         val bookmark =
             Bookmark(id = UUID.randomUUID().toString(), title = "A title", url = "www.example.com", lastModified = "timestamp")
 

--- a/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksActivity.kt
@@ -63,7 +63,6 @@ import com.google.android.material.snackbar.Snackbar
 import java.text.SimpleDateFormat
 import java.util.*
 import javax.inject.Inject
-import timber.log.Timber
 
 @InjectWith(ActivityScope::class)
 @ContributeToActivityStarter(BookmarksScreenNoParams::class)

--- a/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksActivity.kt
@@ -42,17 +42,17 @@ import com.duckduckgo.app.browser.R.plurals
 import com.duckduckgo.app.browser.databinding.ActivityBookmarksBinding
 import com.duckduckgo.app.browser.databinding.ContentBookmarksBinding
 import com.duckduckgo.app.browser.favicon.FaviconManager
-import com.duckduckgo.app.global.DispatcherProvider
-import com.duckduckgo.app.global.DuckDuckGoActivity
-import com.duckduckgo.app.global.extensions.html
 import com.duckduckgo.app.global.view.DividerAdapter
+import com.duckduckgo.common.ui.DuckDuckGoActivity
+import com.duckduckgo.common.ui.view.SearchBar
+import com.duckduckgo.common.ui.view.dialog.ActionBottomSheetDialog.EventListener
+import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
+import com.duckduckgo.common.ui.view.gone
+import com.duckduckgo.common.ui.view.show
+import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.extensions.html
 import com.duckduckgo.di.scopes.ActivityScope
-import com.duckduckgo.mobile.android.ui.view.SearchBar
-import com.duckduckgo.mobile.android.ui.view.dialog.TextAlertDialogBuilder
-import com.duckduckgo.mobile.android.ui.view.dialog.TextAlertDialogBuilder.EventListener
-import com.duckduckgo.mobile.android.ui.view.gone
-import com.duckduckgo.mobile.android.ui.view.show
-import com.duckduckgo.mobile.android.ui.viewbinding.viewBinding
 import com.duckduckgo.savedsites.api.models.BookmarkFolder
 import com.duckduckgo.savedsites.api.models.SavedSite
 import com.duckduckgo.savedsites.api.models.SavedSitesNames
@@ -364,7 +364,7 @@ class BookmarksActivity : DuckDuckGoActivity() {
                     override fun onDismissed(
                         transientBottomBar: Snackbar?,
                         event: Int,
-                    ) { )
+                    ) {
                         if (event != DISMISS_EVENT_ACTION) {
                             viewModel.onDeleteSavedSiteSnackbarDismissed(savedSite)
                         }
@@ -419,7 +419,7 @@ class BookmarksActivity : DuckDuckGoActivity() {
             .setPositiveButton(R.string.delete)
             .setNegativeButton(R.string.cancel)
             .addEventListener(
-                object : EventListener() {
+                object : TextAlertDialogBuilder.EventListener() {
                     override fun onPositiveButtonClicked() {
                         viewModel.onDeleteFolderAccepted(bookmarkFolder)
                     }

--- a/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksActivity.kt
@@ -54,17 +54,16 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.extensions.html
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.savedsites.api.models.BookmarkFolder
-import com.duckduckgo.savedsites.api.models.FolderBranch
 import com.duckduckgo.savedsites.api.models.SavedSite
 import com.duckduckgo.savedsites.api.models.SavedSitesNames
 import com.duckduckgo.savedsites.api.service.ExportSavedSitesResult
 import com.duckduckgo.savedsites.api.service.ImportSavedSitesResult
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
-import timber.log.Timber
 import java.text.SimpleDateFormat
 import java.util.*
 import javax.inject.Inject
+import timber.log.Timber
 
 @InjectWith(ActivityScope::class)
 @ContributeToActivityStarter(BookmarksScreenNoParams::class)
@@ -179,8 +178,15 @@ class BookmarksActivity : DuckDuckGoActivity() {
                 if (parentId == SavedSitesNames.BOOKMARKS_ROOT) {
                     favoritesAdapter?.setItems(state.favorites.filter { it.deleted == null }.map { FavoritesAdapter.FavoriteItem(it) })
                 }
-                bookmarksAdapter.setItems(state.bookmarks.filter { it.deleted == null }.map { BookmarksAdapter.BookmarkItem(it) }, state.bookmarkFolders.isEmpty())
-                bookmarkFoldersAdapter.bookmarkFolderItems = state.bookmarkFolders.filter { it.deleted == null }.map { BookmarkFoldersAdapter.BookmarkFolderItem(it) }
+                bookmarksAdapter.setItems(
+                    state.bookmarks.filter { it.deleted == null }.map { BookmarksAdapter.BookmarkItem(it) },
+                    state.bookmarkFolders.isEmpty(),
+                )
+                bookmarkFoldersAdapter.bookmarkFolderItems = state.bookmarkFolders.filter { it.deleted == null }.map {
+                    BookmarkFoldersAdapter.BookmarkFolderItem(
+                        it,
+                    )
+                }
                 setSearchMenuItemVisibility()
             }
         }
@@ -364,7 +370,7 @@ class BookmarksActivity : DuckDuckGoActivity() {
                 object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
                     override fun onDismissed(
                         transientBottomBar: Snackbar?,
-                        event: Int
+                        event: Int,
                     ) {
                         // when snackbar is not dismissed because of an action we want to
                         // actually delete the saved site
@@ -375,12 +381,11 @@ class BookmarksActivity : DuckDuckGoActivity() {
                     }
                 },
             )
-
             .show()
     }
 
     private fun confirmDeleteBookmarkFolder(
-        bookmarkFolder: BookmarkFolder
+        bookmarkFolder: BookmarkFolder,
     ) {
         val message = getString(R.string.bookmarkDeleteConfirmationMessage, bookmarkFolder.name).html(this)
         Snackbar.make(
@@ -394,7 +399,7 @@ class BookmarksActivity : DuckDuckGoActivity() {
                 object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
                     override fun onDismissed(
                         transientBottomBar: Snackbar?,
-                        event: Int
+                        event: Int,
                     ) {
                         // when snackbar is not dismissed because of an action we want to
                         // actually delete the saved site

--- a/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModel.kt
@@ -33,7 +33,6 @@ import com.duckduckgo.app.utils.ConflatedJob
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.savedsites.api.models.BookmarkFolder
-import com.duckduckgo.savedsites.api.models.FolderBranch
 import com.duckduckgo.savedsites.api.models.SavedSite
 import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
 import com.duckduckgo.savedsites.api.models.SavedSite.Favorite
@@ -167,9 +166,11 @@ class BookmarksViewModel @Inject constructor(
         }
     }
 
-    fun delete(savedSite: SavedSite){
+    fun delete(savedSite: SavedSite) {
         viewModelScope.launch(dispatcherProvider.io() + NonCancellable) {
-            faviconManager.deletePersistedFavicon(savedSite.url)
+            if (savedSite is Bookmark) {
+                faviconManager.deletePersistedFavicon(savedSite.url)
+            }
             savedSitesRepository.delete(savedSite)
         }
     }
@@ -313,12 +314,6 @@ class BookmarksViewModel @Inject constructor(
             bookmarkFolders = bookmarkFolders,
             enableSearch = bookmarks.size + bookmarkFolders.size >= MIN_ITEMS_FOR_SEARCH,
         )
-    }
-
-    fun insertDeletedFolderBranch(folderBranch: FolderBranch) {
-        viewModelScope.launch(dispatcherProvider.io() + NonCancellable) {
-            savedSitesRepository.insertFolderBranch(folderBranch)
-        }
     }
 
     fun onBookmarkFoldersActivityResult(savedSiteUrl: String) {

--- a/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModel.kt
@@ -29,7 +29,6 @@ import com.duckduckgo.app.global.SingleLiveEvent
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.utils.DispatcherProvider
-import com.duckduckgo.app.utils.ConflatedJob
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.savedsites.api.models.BookmarkFolder

--- a/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModel.kt
@@ -169,7 +169,7 @@ class BookmarksViewModel @Inject constructor(
                 favourites[index] = savedSite.copy(deleted = "1")
 
                 viewState.value = viewState.value?.copy(
-                    favorites = favourites
+                    favorites = favourites,
                 )
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModel.kt
@@ -25,10 +25,10 @@ import com.duckduckgo.app.bookmarks.ui.EditSavedSiteDialogFragment.EditSavedSite
 import com.duckduckgo.app.bookmarks.ui.bookmarkfolders.AddBookmarkFolderDialogFragment.AddBookmarkFolderListener
 import com.duckduckgo.app.bookmarks.ui.bookmarkfolders.EditBookmarkFolderDialogFragment.EditBookmarkFolderListener
 import com.duckduckgo.app.browser.favicon.FaviconManager
-import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.global.SingleLiveEvent
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.savedsites.api.models.BookmarkFolder

--- a/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModel.kt
@@ -150,17 +150,26 @@ class BookmarksViewModel @Inject constructor(
                 val index = bookmarks.indexOf(savedSite)
                 bookmarks[index] = savedSite.copy(deleted = "1")
                 val bookmarkFolders = viewState.value?.bookmarkFolders!!
+
+                val favourites = viewState.value?.favorites!!.toMutableList()
+                val favourite = favourites.find { it.id == savedSite.id }!!
+                val favouritesIndex = favourites.indexOf(favourite)
+                favourites[favouritesIndex] = favourite.copy(deleted = "1")
+
                 viewState.value = viewState.value?.copy(
+                    favorites = favourites,
                     bookmarks = bookmarks,
                     enableSearch = bookmarks.size + bookmarkFolders.size >= MIN_ITEMS_FOR_SEARCH,
                 )
             }
+
             is Favorite -> {
                 val favourites = viewState.value?.favorites!!.toMutableList()
                 val index = favourites.indexOf(savedSite)
                 favourites[index] = savedSite.copy(deleted = "1")
+
                 viewState.value = viewState.value?.copy(
-                    favorites = favourites,
+                    favorites = favourites
                 )
             }
         }
@@ -184,7 +193,14 @@ class BookmarksViewModel @Inject constructor(
                 val index = bookmarks.indexOf(bookmark)
                 bookmarks[index] = savedSite.copy(deleted = null)
                 val bookmarkFolders = viewState.value?.bookmarkFolders!!
+
+                val favourites = viewState.value?.favorites!!.toMutableList()
+                val favourite = favourites.find { it.id == savedSite.id }!!
+                val favouriteIndex = favourites.indexOf(favourite)
+                favourites[favouriteIndex] = favourite.copy(deleted = null)
+
                 viewState.value = viewState.value?.copy(
+                    favorites = favourites,
                     bookmarks = bookmarks,
                     enableSearch = bookmarks.size + bookmarkFolders.size >= MIN_ITEMS_FOR_SEARCH,
                 )
@@ -194,8 +210,16 @@ class BookmarksViewModel @Inject constructor(
                 val favourite = favourites.find { it.id == savedSite.id }
                 val index = favourites.indexOf(favourite)
                 favourites[index] = savedSite.copy(deleted = null)
+
+                val bookmarks = viewState.value?.bookmarks!!.toMutableList()
+                val bookmark = bookmarks.find { it.id == savedSite.id }!!
+                val bookmarkIndex = bookmarks.indexOf(bookmark)
+                bookmarks[bookmarkIndex] = bookmark.copy(deleted = null)
+                val bookmarkFolders = viewState.value?.bookmarkFolders!!
                 viewState.value = viewState.value?.copy(
                     favorites = favourites,
+                    bookmarks = bookmarks,
+                    enableSearch = bookmarks.size + bookmarkFolders.size >= MIN_ITEMS_FOR_SEARCH,
                 )
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModel.kt
@@ -131,7 +131,7 @@ class BookmarksViewModel @Inject constructor(
         hide(savedSite)
     }
 
-    fun onDeleteSavedSiteSnackbarDismissed(savedSite: SavedSite){
+    fun onDeleteSavedSiteSnackbarDismissed(savedSite: SavedSite) {
         delete(savedSite)
     }
 
@@ -245,7 +245,7 @@ class BookmarksViewModel @Inject constructor(
         }
     }
 
-    fun onDeleteBookmarkFolderSnackbarDismissed(bookmarkFolder: BookmarkFolder){
+    fun onDeleteBookmarkFolderSnackbarDismissed(bookmarkFolder: BookmarkFolder) {
         delete(bookmarkFolder)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1123,7 +1123,7 @@ class BrowserTabFragment :
             is Command.LaunchNewTab -> browserActivity?.launchNewTab()
             is Command.ShowSavedSiteAddedConfirmation -> savedSiteAdded(it.savedSiteChangedViewState)
             is Command.ShowEditSavedSiteDialog -> editSavedSite(it.savedSiteChangedViewState)
-            is Command.DeleteSavedSiteConfirmation -> confirmDeleteSavedSite(it.savedSite, it.position)
+            is Command.DeleteSavedSiteConfirmation -> confirmDeleteSavedSite(it.savedSite)
             is Command.ShowFireproofWebSiteConfirmation -> fireproofWebsiteConfirmation(it.fireproofWebsiteEntity)
             is Command.DeleteFireproofConfirmation -> removeFireproofWebsiteConfirmation(it.fireproofWebsiteEntity)
             is Command.ShowPrivacyProtectionEnabledConfirmation -> privacyProtectionEnabledConfirmation(it.domain)
@@ -1964,7 +1964,7 @@ class BrowserTabFragment :
                 viewModel.onUserSubmittedQuery(it.favorite.url)
             },
             { viewModel.onEditSavedSiteRequested(it.favorite) },
-            { viewModel.hide(it.favorite) },
+            { viewModel.onDeleteSavedSiteRequested(it.favorite) },
         )
     }
 
@@ -2402,7 +2402,7 @@ class BrowserTabFragment :
         addBookmarkDialog.deleteBookmarkListener = viewModel
     }
 
-    private fun confirmDeleteSavedSite(savedSite: SavedSite, position: Int) {
+    private fun confirmDeleteSavedSite(savedSite: SavedSite) {
         val message = when (savedSite) {
             is Favorite -> getString(R.string.favoriteDeleteConfirmationMessage)
             is Bookmark -> getString(R.string.bookmarkDeleteConfirmationMessage, savedSite.title).html(requireContext())
@@ -2411,7 +2411,7 @@ class BrowserTabFragment :
             message,
             Snackbar.LENGTH_LONG,
         ).setAction(R.string.fireproofWebsiteSnackbarAction) {
-            viewModel.undoDelete(savedSite, position)
+            viewModel.undoDelete(savedSite)
         }
             .addCallback(
                 object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
@@ -2419,11 +2419,8 @@ class BrowserTabFragment :
                         transientBottomBar: Snackbar?,
                         event: Int,
                     ) {
-                        // when snackbar is not dismissed because of an action we want to
-                        // actually delete the saved site
-                        Timber.d("Bookmark: dismissed with $event")
                         if (event != DISMISS_EVENT_ACTION) {
-                            viewModel.delete(savedSite)
+                            viewModel.onDeleteSavedSiteSnackbarDismissed(savedSite)
                         }
                     }
                 },

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2758,7 +2758,9 @@ class BrowserTabViewModel @Inject constructor(
 
     fun deleteQuickAccessItem(savedSite: SavedSite) {
         viewModelScope.launch(dispatchers.io() + NonCancellable) {
-            faviconManager.deletePersistedFavicon(savedSite.url)
+            if (savedSite is Bookmark) {
+                faviconManager.deletePersistedFavicon(savedSite.url)
+            }
             savedSitesRepository.delete(savedSite)
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2777,7 +2777,7 @@ class BrowserTabViewModel @Inject constructor(
 
             ctaViewState.value = currentCtaViewState().copy(favorites = quickAccessFavorites)
             browserViewState.value = currentBrowserViewState().copy(favorite = null)
-
+            autoCompleteViewState.value = currentAutoCompleteViewState().copy(favorites = quickAccessFavorites)
             index
         } else {
             browserViewState.value = currentBrowserViewState().copy(bookmark = null, favorite = null)
@@ -2806,6 +2806,7 @@ class BrowserTabViewModel @Inject constructor(
 
                 ctaViewState.value = currentCtaViewState().copy(favorites = quickAccessFavorites)
                 browserViewState.value = currentBrowserViewState().copy(favorite = savedSite)
+                autoCompleteViewState.value = currentAutoCompleteViewState().copy(favorites = quickAccessFavorites)
             }
 
             is Bookmark -> {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -700,24 +700,6 @@ class BrowserTabViewModel @Inject constructor(
             .flowOn(dispatchers.main())
             .launchIn(viewModelScope)
 
-        // savedSitesRepository.getFavorites().map { favoriteSites ->
-        //     val favorites = favoriteSites.map { FavoritesQuickAccessAdapter.QuickAccessFavorite(it) }
-        //     ctaViewState.value = currentCtaViewState().copy(favorites = favorites)
-        //     autoCompleteViewState.value = currentAutoCompleteViewState().copy(favorites = favorites)
-        //     val favorite = favoriteSites.firstOrNull { it.url == url }
-        //     browserViewState.value = currentBrowserViewState().copy(favorite = favorite)
-        // }
-        //     .launchIn(viewModelScope)
-
-        // savedSitesRepository.getBookmarks()
-        //     .flowOn(dispatchers.io())
-        //     .map { bookmarks ->
-        //         val bookmark = bookmarks.firstOrNull { it.url == url }
-        //         browserViewState.value = currentBrowserViewState().copy(bookmark = bookmark)
-        //     }
-        //     .flowOn(dispatchers.main())
-        //     .launchIn(viewModelScope)
-
         viewModelScope.launch(dispatchers.io()) {
             remoteMessagingModel.get().activeMessages
                 .combine(ctaChangedTicker.asStateFlow(), ::Pair)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -672,10 +672,10 @@ class BrowserTabViewModel @Inject constructor(
         observeAccessibilitySettings()
 
         savedSitesRepository.getFavorites()
-            .flowOn(dispatchers.io())
             .combine(hiddenIds) { favorites, hiddenIds ->
                 favorites.filter { it.id !in hiddenIds.favorites }
             }
+            .flowOn(dispatchers.io())
             .onEach { filteredFavourites ->
                 withContext(dispatchers.main()) {
                     val favorites = filteredFavourites.map { FavoritesQuickAccessAdapter.QuickAccessFavorite(it) }
@@ -685,7 +685,6 @@ class BrowserTabViewModel @Inject constructor(
                     browserViewState.value = currentBrowserViewState().copy(favorite = favorite)
                 }
             }
-            .flowOn(dispatchers.main())
             .launchIn(viewModelScope)
 
         savedSitesRepository.getBookmarks()
@@ -2802,7 +2801,6 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     private fun hide(savedSite: SavedSite) {
-        Timber.d("FLOW: hide $savedSite")
         viewModelScope.launch(dispatchers.io()) {
             when (savedSite) {
                 is Bookmark -> {
@@ -2818,7 +2816,6 @@ class BrowserTabViewModel @Inject constructor(
                     hiddenIds.emit(hiddenIds.value.copy(favorites = hiddenIds.value.favorites + savedSite.id))
                 }
             }
-            Timber.d("FLOW: hide ${hiddenIds.value}")
             withContext(dispatchers.main()) {
                 command.value = DeleteSavedSiteConfirmation(savedSite)
             }
@@ -2826,7 +2823,6 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     fun undoDelete(savedSite: SavedSite) {
-        Timber.d("FLOW: undoDelete $savedSite")
         viewModelScope.launch(dispatchers.io()) {
             hiddenIds.emit(
                 hiddenIds.value.copy(
@@ -2834,7 +2830,6 @@ class BrowserTabViewModel @Inject constructor(
                     bookmarks = hiddenIds.value.bookmarks - savedSite.id,
                 ),
             )
-            Timber.d("FLOW: hide ${hiddenIds.value}")
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -353,7 +353,11 @@ class BrowserTabViewModel @Inject constructor(
 
         class ShowSavedSiteAddedConfirmation(val savedSiteChangedViewState: SavedSiteChangedViewState) : Command()
         class ShowEditSavedSiteDialog(val savedSiteChangedViewState: SavedSiteChangedViewState) : Command()
-        class DeleteSavedSiteConfirmation(val savedSite: SavedSite) : Command()
+        class DeleteSavedSiteConfirmation(
+            val savedSite: SavedSite,
+            val position: Int,
+        ) : Command()
+
         class ShowFireproofWebSiteConfirmation(val fireproofWebsiteEntity: FireproofWebsiteEntity) : Command()
         class DeleteFireproofConfirmation(val fireproofWebsiteEntity: FireproofWebsiteEntity) : Command()
         class ShowPrivacyProtectionEnabledConfirmation(val domain: String) : Command()
@@ -361,9 +365,21 @@ class BrowserTabViewModel @Inject constructor(
         object AskToDisableLoginDetection : Command()
         class AskToFireproofWebsite(val fireproofWebsite: FireproofWebsiteEntity) : Command()
         class AskToAutomateFireproofWebsite(val fireproofWebsite: FireproofWebsiteEntity) : Command()
-        class ShareLink(val url: String, val title: String = "") : Command()
-        class SharePromoLinkRMF(val url: String, val shareTitle: String) : Command()
-        class PrintLink(val url: String, val mediaSize: PrintAttributes.MediaSize) : Command()
+        class ShareLink(
+            val url: String,
+            val title: String = "",
+        ) : Command()
+
+        class SharePromoLinkRMF(
+            val url: String,
+            val shareTitle: String,
+        ) : Command()
+
+        class PrintLink(
+            val url: String,
+            val mediaSize: PrintAttributes.MediaSize,
+        ) : Command()
+
         class CopyLink(val url: String) : Command()
         class FindInPageCommand(val searchTerm: String) : Command()
         class BrokenSiteFeedback(val data: BrokenSiteData) : Command()
@@ -442,6 +458,7 @@ class BrowserTabViewModel @Inject constructor(
             val originalUrl: String,
             val autoSaveLogin: Boolean,
         ) : Command()
+
         class ShowEmailProtectionChooseEmailPrompt(val address: String) : Command()
         object ShowEmailProtectionInContextSignUpPrompt : Command()
         sealed class DaxCommand : Command() {
@@ -466,7 +483,10 @@ class BrowserTabViewModel @Inject constructor(
             val messageResourceId: Int,
         ) : Command()
 
-        data class WebViewError(val errorType: WebViewErrorResponse, val url: String) : Command()
+        data class WebViewError(
+            val errorType: WebViewErrorResponse,
+            val url: String,
+        ) : Command()
     }
 
     sealed class NavigationCommand : Command() {
@@ -1910,7 +1930,8 @@ class BrowserTabViewModel @Inject constructor(
             val favorite = currentBrowserViewState().favorite
             if (favorite != null) {
                 pixel.fire(AppPixelName.MENU_ACTION_REMOVE_FAVORITE_PRESSED.pixelName)
-                removeFavoriteSite(favorite)
+                // removeFavoriteSite(favorite)
+                hide(favorite)
             } else {
                 val buttonHighlighted = currentBrowserViewState().addFavorite.isHighlighted()
                 pixel.fire(
@@ -1935,17 +1956,6 @@ class BrowserTabViewModel @Inject constructor(
         val bookmarkFolder = getBookmarkFolder(savedBookmark)
         withContext(dispatchers.main()) {
             command.value = ShowSavedSiteAddedConfirmation(SavedSiteChangedViewState(savedBookmark, bookmarkFolder))
-        }
-    }
-
-    private fun removeFavoriteSite(favorite: SavedSite.Favorite) {
-        viewModelScope.launch {
-            withContext(dispatchers.io()) {
-                savedSitesRepository.delete(favorite)
-            }
-            withContext(dispatchers.main()) {
-                command.value = DeleteSavedSiteConfirmation(favorite)
-            }
         }
     }
 
@@ -2072,15 +2082,7 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     override fun onSavedSiteDeleted(savedSite: SavedSite) {
-        command.value = DeleteSavedSiteConfirmation(savedSite)
-        delete(savedSite)
-    }
-
-    private fun delete(savedSite: SavedSite) {
-        viewModelScope.launch(dispatchers.io()) {
-            faviconManager.deletePersistedFavicon(savedSite.url)
-            savedSitesRepository.delete(savedSite)
-        }
+        hide(savedSite)
     }
 
     fun onEditSavedSiteRequested(savedSite: SavedSite) {
@@ -2101,10 +2103,6 @@ class BrowserTabViewModel @Inject constructor(
                 )
             }
         }
-    }
-
-    fun onDeleteQuickAccessItemRequested(savedSite: SavedSite) {
-        command.value = DeleteSavedSiteConfirmation(savedSite)
     }
 
     fun onBrokenSiteSelected() {
@@ -2744,11 +2742,17 @@ class BrowserTabViewModel @Inject constructor(
     /**
      * API called after user selected to autofill a private alias into a form
      */
-    fun usePrivateDuckAddress(originalUrl: String, duckAddress: String) {
+    fun usePrivateDuckAddress(
+        originalUrl: String,
+        duckAddress: String,
+    ) {
         command.postValue(InjectEmailAddress(duckAddress = duckAddress, originalUrl = originalUrl, autoSaveLogin = true))
     }
 
-    fun usePersonalDuckAddress(originalUrl: String, duckAddress: String) {
+    fun usePersonalDuckAddress(
+        originalUrl: String,
+        duckAddress: String,
+    ) {
         command.postValue(InjectEmailAddress(duckAddress = duckAddress, originalUrl = originalUrl, autoSaveLogin = false))
     }
 
@@ -2756,12 +2760,61 @@ class BrowserTabViewModel @Inject constructor(
         fileDownloader.enqueueDownload(pendingFileDownload)
     }
 
-    fun deleteQuickAccessItem(savedSite: SavedSite) {
+    fun delete(savedSite: SavedSite) {
         viewModelScope.launch(dispatchers.io() + NonCancellable) {
             if (savedSite is Bookmark) {
                 faviconManager.deletePersistedFavicon(savedSite.url)
             }
             savedSitesRepository.delete(savedSite)
+        }
+    }
+
+    fun hide(savedSite: SavedSite): Int {
+        val oldPosition = if (savedSite is Favorite) {
+            val quickAccessFavorite = FavoritesQuickAccessAdapter.QuickAccessFavorite(savedSite)
+            val quickAccessFavorites = currentCtaViewState().favorites.toMutableList()
+            val index = quickAccessFavorites.indexOf(quickAccessFavorite)
+            quickAccessFavorites.remove(quickAccessFavorite)
+
+            ctaViewState.value = currentCtaViewState().copy(favorites = quickAccessFavorites)
+            browserViewState.value = currentBrowserViewState().copy(favorite = null)
+
+            index
+        } else {
+            browserViewState.value = currentBrowserViewState().copy(bookmark = null, favorite = null)
+            0
+        }
+
+        viewModelScope.launch {
+            withContext(dispatchers.main()) {
+                command.value = DeleteSavedSiteConfirmation(savedSite, oldPosition)
+            }
+        }
+
+        return oldPosition
+    }
+
+    fun undoDelete(
+        savedSite: SavedSite,
+        position: Int,
+    ) {
+        when (savedSite) {
+            is Favorite -> {
+                val quickAccessFavorite = FavoritesQuickAccessAdapter.QuickAccessFavorite(savedSite)
+                val quickAccessFavorites = currentCtaViewState().favorites.toMutableList()
+
+                quickAccessFavorites.add(position, quickAccessFavorite)
+
+                ctaViewState.value = currentCtaViewState().copy(favorites = quickAccessFavorites)
+                browserViewState.value = currentBrowserViewState().copy(favorite = savedSite)
+            }
+
+            is Bookmark -> {
+                val quickAccessFavorites = currentCtaViewState().favorites.toMutableList()
+                val quickAccessFavorite = quickAccessFavorites.find { it.favorite.id == savedSite.id }
+
+                browserViewState.value = currentBrowserViewState().copy(favorite = quickAccessFavorite?.favorite, bookmark = savedSite)
+            }
         }
     }
 
@@ -2833,13 +2886,19 @@ class BrowserTabViewModel @Inject constructor(
         return false
     }
 
-    override fun onReceivedError(errorType: WebViewErrorResponse, url: String) {
+    override fun onReceivedError(
+        errorType: WebViewErrorResponse,
+        url: String,
+    ) {
         browserViewState.value =
             currentBrowserViewState().copy(browserError = errorType, showPrivacyShield = false, showDaxIcon = false, showSearchIcon = false)
         command.postValue(WebViewError(errorType, url))
     }
 
-    override fun recordErrorCode(error: String, url: String) {
+    override fun recordErrorCode(
+        error: String,
+        url: String,
+    ) {
         // when navigating from one page to another it can happen that errors are recorded before pageChanged etc. are
         // called triggering a buildSite.
         if (url != site?.url) {
@@ -2849,7 +2908,10 @@ class BrowserTabViewModel @Inject constructor(
         site?.onErrorDetected(error)
     }
 
-    override fun recordHttpErrorCode(statusCode: Int, url: String) {
+    override fun recordHttpErrorCode(
+        statusCode: Int,
+        url: String,
+    ) {
         // when navigating from one page to another it can happen that errors are recorded before pageChanged etc. are
         // called triggering a buildSite.
         if (url != site?.url) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2802,6 +2802,7 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     private fun hide(savedSite: SavedSite) {
+        Timber.d("FLOW: hide $savedSite")
         viewModelScope.launch(dispatchers.io()) {
             when (savedSite) {
                 is Bookmark -> {
@@ -2817,6 +2818,7 @@ class BrowserTabViewModel @Inject constructor(
                     hiddenIds.emit(hiddenIds.value.copy(favorites = hiddenIds.value.favorites + savedSite.id))
                 }
             }
+            Timber.d("FLOW: hide ${hiddenIds.value}")
             withContext(dispatchers.main()) {
                 command.value = DeleteSavedSiteConfirmation(savedSite)
             }
@@ -2824,6 +2826,7 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     fun undoDelete(savedSite: SavedSite) {
+        Timber.d("FLOW: undoDelete $savedSite")
         viewModelScope.launch(dispatchers.io()) {
             hiddenIds.emit(
                 hiddenIds.value.copy(
@@ -2831,6 +2834,7 @@ class BrowserTabViewModel @Inject constructor(
                     bookmarks = hiddenIds.value.bookmarks - savedSite.id,
                 ),
             )
+            Timber.d("FLOW: hide ${hiddenIds.value}")
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1930,7 +1930,6 @@ class BrowserTabViewModel @Inject constructor(
             val favorite = currentBrowserViewState().favorite
             if (favorite != null) {
                 pixel.fire(AppPixelName.MENU_ACTION_REMOVE_FAVORITE_PRESSED.pixelName)
-                // removeFavoriteSite(favorite)
                 hide(favorite)
             } else {
                 val buttonHighlighted = currentBrowserViewState().addFavorite.isHighlighted()
@@ -2815,12 +2814,6 @@ class BrowserTabViewModel @Inject constructor(
 
                 browserViewState.value = currentBrowserViewState().copy(favorite = quickAccessFavorite?.favorite, bookmark = savedSite)
             }
-        }
-    }
-
-    fun insertQuickAccessItem(savedSite: SavedSite) {
-        viewModelScope.launch(dispatchers.io()) {
-            savedSitesRepository.insert(savedSite)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -521,7 +521,7 @@ class BrowserTabViewModel @Inject constructor(
 
     data class HiddenBookmarksIds(
         val favorites: List<String> = emptyList(),
-        val bookmarks: List<String> = emptyList()
+        val bookmarks: List<String> = emptyList(),
     )
 
     /*
@@ -1584,7 +1584,7 @@ class BrowserTabViewModel @Inject constructor(
 
     private fun sameEffectiveTldPlusOne(
         site: Site?,
-        origin: String
+        origin: String,
     ): Boolean {
         val siteDomain = site?.url?.toHttpUrlOrNull() ?: return false
         val originDomain = origin.toUri().toString().toHttpUrlOrNull() ?: return false
@@ -2797,7 +2797,7 @@ class BrowserTabViewModel @Inject constructor(
         }
     }
 
-    fun onDeleteSavedSiteRequested(savedSite: SavedSite){
+    fun onDeleteSavedSiteRequested(savedSite: SavedSite) {
         hide(savedSite)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
@@ -391,7 +391,7 @@ class SystemSearchActivity : DuckDuckGoActivity() {
             }
 
             is DeleteSavedSiteConfirmation -> {
-                confirmDeleteSavedSite(command.savedSite, command.position)
+                confirmDeleteSavedSite(command.savedSite)
             }
 
             is UpdateVoiceSearch -> {
@@ -405,17 +405,14 @@ class SystemSearchActivity : DuckDuckGoActivity() {
         omnibarTextInput.setSelection(query.length)
     }
 
-    private fun confirmDeleteSavedSite(
-        savedSite: SavedSite,
-        oldPosition: Int,
-    ) {
+    private fun confirmDeleteSavedSite(savedSite: SavedSite) {
         val message = getString(R.string.bookmarkDeleteConfirmationMessage, savedSite.title).html(this)
         Snackbar.make(
             binding.root,
             message,
             Snackbar.LENGTH_LONG,
         ).setAction(R.string.fireproofWebsiteSnackbarAction) {
-            viewModel.undoDelete(savedSite, oldPosition)
+            viewModel.undoDelete(savedSite)
         }
             .addCallback(
                 object : BaseTransientBottomBar.BaseCallback<Snackbar>() {

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
@@ -50,7 +50,6 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.*
 import com.duckduckgo.app.tabs.ui.GridViewColumnCalculator
 import com.duckduckgo.common.ui.DuckDuckGoActivity
-import com.duckduckgo.common.ui.view.*
 import com.duckduckgo.common.ui.view.hideKeyboard
 import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.common.ui.viewbinding.viewBinding
@@ -64,7 +63,6 @@ import com.duckduckgo.voice.api.VoiceSearchLauncher.Source.WIDGET
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import javax.inject.Inject
-import timber.log.Timber
 
 @InjectWith(ActivityScope::class)
 class SystemSearchActivity : DuckDuckGoActivity() {
@@ -420,11 +418,8 @@ class SystemSearchActivity : DuckDuckGoActivity() {
                         transientBottomBar: Snackbar?,
                         event: Int,
                     ) {
-                        // when snackbar is not dismissed because of an action we want to
-                        // actually delete the saved site
-                        Timber.d("Bookmark: dismissed with $event")
                         if (event != DISMISS_EVENT_ACTION) {
-                            viewModel.deleteQuickAccessItem(savedSite)
+                            viewModel.deleteSavedSiteSnackbarDismissed(savedSite)
                         }
                     }
                 },

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
@@ -23,9 +23,7 @@ import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.autocomplete.api.AutoComplete
 import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteResult
 import com.duckduckgo.app.bookmarks.ui.EditSavedSiteDialogFragment
-import com.duckduckgo.app.browser.BrowserTabViewModel.Command.DeleteSavedSiteConfirmation
 import com.duckduckgo.app.browser.favorites.FavoritesQuickAccessAdapter
-import com.duckduckgo.app.browser.favorites.FavoritesQuickAccessAdapter.QuickAccessFavorite
 import com.duckduckgo.app.global.SingleLiveEvent
 import com.duckduckgo.app.onboarding.store.AppStage
 import com.duckduckgo.app.onboarding.store.UserStageStore
@@ -34,7 +32,6 @@ import com.duckduckgo.app.pixels.AppPixelName.*
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.UpdateVoiceSearch
-import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Suggestions.QuickAccessItems
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.savedsites.api.SavedSitesRepository
@@ -124,10 +121,10 @@ class SystemSearchViewModel @Inject constructor(
         refreshAppList()
 
         savedSitesRepository.getFavorites()
-            .flowOn(dispatchers.io())
             .combine(hiddenIds) { favorites, hiddenIds ->
                 favorites.filter { it.id !in hiddenIds.favorites }
             }
+            .flowOn(dispatchers.io())
             .onEach { filteredFavourites ->
                 withContext(dispatchers.main()) {
                     latestQuickAccessItems =
@@ -135,7 +132,6 @@ class SystemSearchViewModel @Inject constructor(
                     resultsViewState.postValue(latestQuickAccessItems)
                 }
             }
-            .flowOn(dispatchers.main())
             .launchIn(viewModelScope)
     }
 
@@ -349,7 +345,7 @@ class SystemSearchViewModel @Inject constructor(
         }
     }
 
-    fun deleteQuickAccessItem(savedSite: SavedSite) {
+    fun deleteSavedSiteSnackbarDismissed(savedSite: SavedSite) {
         when (savedSite) {
             is SavedSite.Favorite -> {
                 viewModelScope.launch(dispatchers.io() + NonCancellable) {

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
@@ -33,7 +33,11 @@ import com.duckduckgo.app.pixels.AppPixelName.*
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.UpdateVoiceSearch
+<<<<<<< HEAD
 import com.duckduckgo.common.utils.DispatcherProvider
+=======
+import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Suggestions.QuickAccessItems
+>>>>>>> 741191fa3 (added undo to system search)
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.savedsites.api.models.SavedSite
@@ -87,7 +91,7 @@ class SystemSearchViewModel @Inject constructor(
         object LaunchDuckDuckGo : Command()
         data class LaunchBrowser(val query: String) : Command()
         data class LaunchEditDialog(val savedSite: SavedSite) : Command()
-        data class DeleteSavedSiteConfirmation(val savedSite: SavedSite) : Command()
+        data class DeleteSavedSiteConfirmation(val savedSite: SavedSite, val position: Int) : Command()
         data class LaunchDeviceApplication(val deviceApp: DeviceApp) : Command()
         data class ShowAppNotFoundMessage(val appName: String) : Command()
         object DismissKeyboard : Command()
@@ -220,6 +224,7 @@ class SystemSearchViewModel @Inject constructor(
                         appResults = updatedApps,
                     )
                 }
+
                 is Suggestions.QuickAccessItems -> Suggestions.SystemSearchResultsViewState(
                     autocompleteResults = AutoCompleteResult(results.autocomplete.query, updatedSuggestions),
                     appResults = updatedApps,
@@ -304,8 +309,8 @@ class SystemSearchViewModel @Inject constructor(
     }
 
     fun onDeleteQuickAccessItemRequested(it: FavoritesQuickAccessAdapter.QuickAccessFavorite) {
-        deleteQuickAccessItem(it.favorite)
-        command.value = Command.DeleteSavedSiteConfirmation(it.favorite)
+        val position = hideQuickAccessItem(it)
+        command.value = Command.DeleteSavedSiteConfirmation(it.favorite, position)
     }
 
     companion object {
@@ -328,25 +333,38 @@ class SystemSearchViewModel @Inject constructor(
         }
     }
 
-    private fun deleteQuickAccessItem(savedSite: SavedSite) {
+    fun deleteQuickAccessItem(savedSite: SavedSite) {
         when (savedSite) {
             is SavedSite.Favorite -> {
                 viewModelScope.launch(dispatchers.io() + NonCancellable) {
                     savedSitesRepository.delete(savedSite)
                 }
             }
+
             else -> throw IllegalArgumentException("Illegal SavedSite to delete received")
         }
     }
 
-    fun insertQuickAccessItem(savedSite: SavedSite) {
-        when (savedSite) {
-            is SavedSite.Favorite -> {
-                viewModelScope.launch(dispatchers.io()) {
-                    savedSitesRepository.insert(savedSite)
-                }
-            }
-            else -> throw IllegalArgumentException("Illegal SavedSite to delete received")
+    private fun hideQuickAccessItem(quickAccessFavourite: FavoritesQuickAccessAdapter.QuickAccessFavorite): Int {
+        val quickAccessItems = resultsViewState.value as QuickAccessItems
+        val favourites = quickAccessItems.favorites.toMutableList()
+        val index = favourites.indexOf(quickAccessFavourite)
+        favourites.remove(quickAccessFavourite)
+
+        latestQuickAccessItems = QuickAccessItems(favourites)
+        resultsViewState.postValue(latestQuickAccessItems)
+        return index
+    }
+
+    fun undoDelete(savedSite: SavedSite, oldPosition: Int) {
+        if (savedSite is Favorite) {
+            val quickAccessItems = resultsViewState.value as QuickAccessItems
+            val favourites = quickAccessItems.favorites.toMutableList()
+            val restoredFavourite = FavoritesQuickAccessAdapter.QuickAccessFavorite(savedSite)
+            favourites.add(oldPosition, restoredFavourite)
+
+            latestQuickAccessItems = QuickAccessItems(favourites)
+            resultsViewState.postValue(latestQuickAccessItems)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
@@ -24,7 +24,6 @@ import com.duckduckgo.app.autocomplete.api.AutoComplete
 import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteResult
 import com.duckduckgo.app.bookmarks.ui.EditSavedSiteDialogFragment
 import com.duckduckgo.app.browser.BrowserTabViewModel.Command.DeleteSavedSiteConfirmation
-import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.browser.favorites.FavoritesQuickAccessAdapter
 import com.duckduckgo.app.browser.favorites.FavoritesQuickAccessAdapter.QuickAccessFavorite
 import com.duckduckgo.app.global.SingleLiveEvent
@@ -35,8 +34,8 @@ import com.duckduckgo.app.pixels.AppPixelName.*
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.UpdateVoiceSearch
-import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Suggestions.QuickAccessItems
+import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.savedsites.api.models.SavedSite

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
@@ -33,11 +33,8 @@ import com.duckduckgo.app.pixels.AppPixelName.*
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.UpdateVoiceSearch
-<<<<<<< HEAD
 import com.duckduckgo.common.utils.DispatcherProvider
-=======
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Suggestions.QuickAccessItems
->>>>>>> 741191fa3 (added undo to system search)
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.savedsites.api.models.SavedSite

--- a/app/src/test/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModelTest.kt
@@ -106,6 +106,8 @@ class BookmarksViewModelTest {
                 ),
             ),
         )
+
+        testee.fetchBookmarksAndFolders(SavedSitesNames.BOOKMARKS_ROOT)
     }
 
     @After
@@ -115,36 +117,57 @@ class BookmarksViewModelTest {
     }
 
     @Test
-    fun whenBookmarkInsertedThenDaoUpdated() = runTest {
+    fun whenBookmarkDeleteUndoThenRepositoryNotUpdated() = runTest {
+        testee.onDeleteSavedSiteRequested(bookmark)
         testee.undoDelete(bookmark)
 
-        verify(savedSitesRepository).insert(bookmark)
+        verify(savedSitesRepository, never()).delete(bookmark)
+        verify(faviconManager, never()).deletePersistedFavicon(bookmark.url)
     }
 
     @Test
-    fun whenFavoriteInsertedThenRepositoryUpdated() = runTest {
-        testee.undoDelete(favorite)
-
-        verify(savedSitesRepository).insert(favorite)
-    }
-
-    @Test
-    fun whenBookmarkDeleteRequestedThenDaoUpdated() = runTest {
+    fun whenBookmarkDeleteThenRepositoryUpdated() = runTest {
         testee.onDeleteSavedSiteRequested(bookmark)
+        testee.delete(bookmark)
 
         verify(faviconManager).deletePersistedFavicon(bookmark.url)
         verify(savedSitesRepository).delete(bookmark)
     }
 
     @Test
-    fun whenFavoriteDeleteRequestedThenDeleteFromRepository() = runTest {
+    fun whenBookmarkDeleteRequestedThenConfirmCommandSent() = runTest {
+        testee.onDeleteSavedSiteRequested(bookmark)
+
+        verify(commandObserver).onChanged(commandCaptor.capture())
+        assertNotNull(commandCaptor.value)
+        assertTrue(commandCaptor.value is BookmarksViewModel.Command.ConfirmDeleteSavedSite)
+    }
+
+    @Test
+    fun whenFavoriteDeleteUndoThenRepositoryNotUpdated() = runTest {
+        testee.onDeleteSavedSiteRequested(favorite)
+        testee.undoDelete(favorite)
+
+        verify(savedSitesRepository, never()).delete(favorite)
+        verify(faviconManager, never()).deletePersistedFavicon(favorite.url)
+    }
+
+    @Test
+    fun whenFavoriteDeleteThenRepositoryUpdated() = runTest {
+        testee.onDeleteSavedSiteRequested(favorite)
+        testee.delete(favorite)
+
+        verify(savedSitesRepository).delete(favorite)
+        verify(faviconManager, never()).deletePersistedFavicon(favorite.url)
+    }
+
+    @Test
+    fun whenFavoriteDeleteRequestedThenConfirmCommandSent() = runTest {
         testee.onDeleteSavedSiteRequested(favorite)
 
         verify(commandObserver).onChanged(commandCaptor.capture())
         assertNotNull(commandCaptor.value)
         assertTrue(commandCaptor.value is BookmarksViewModel.Command.ConfirmDeleteSavedSite)
-
-        verifyNoMoreInteractions(savedSitesRepository)
     }
 
     @Test
@@ -159,17 +182,6 @@ class BookmarksViewModelTest {
         testee.onFavouriteEdited(favorite)
 
         verify(savedSitesRepository).updateFavourite(favorite)
-    }
-
-    @Test
-    fun whenBookmarkDeletedThenConfirmDeleteSavedSiteCommandAndRepositoryIsUpdated() = runTest {
-        testee.onSavedSiteDeleted(bookmark)
-
-        verify(commandObserver).onChanged(commandCaptor.capture())
-        assertNotNull(commandCaptor.value)
-        assertTrue(commandCaptor.value is BookmarksViewModel.Command.ConfirmDeleteSavedSite)
-        verify(faviconManager).deletePersistedFavicon(bookmark.url)
-        verify(savedSitesRepository).delete(bookmark)
     }
 
     @Test
@@ -198,14 +210,6 @@ class BookmarksViewModelTest {
     }
 
     @Test
-    fun whenBookmarksChangedThenObserverNotified() {
-        testee
-        verify(viewStateObserver).onChanged(viewStateCaptor.capture())
-        assertNotNull(viewStateCaptor.value)
-        assertNotNull(viewStateCaptor.value.bookmarks)
-    }
-
-    @Test
     fun whenBookmarkFolderSelectedThenIssueOpenBookmarkFolderCommand() {
         testee.onBookmarkFolderSelected(bookmarkFolder)
 
@@ -221,7 +225,7 @@ class BookmarksViewModelTest {
 
         verify(savedSitesRepository).getSavedSites(parentId)
 
-        verify(viewStateObserver, times(2)).onChanged(viewStateCaptor.capture())
+        verify(viewStateObserver, times(3)).onChanged(viewStateCaptor.capture())
 
         assertEquals(emptyList<BookmarkEntity>(), viewStateCaptor.allValues[0].bookmarks)
         assertEquals(emptyList<BookmarkFolder>(), viewStateCaptor.allValues[0].bookmarkFolders)
@@ -245,16 +249,16 @@ class BookmarksViewModelTest {
         verify(savedSitesRepository).getBookmarksTree()
         verify(savedSitesRepository).getFolderTree(SavedSitesNames.BOOKMARKS_ROOT, null)
 
-        verify(viewStateObserver, times(2)).onChanged(viewStateCaptor.capture())
+        verify(viewStateObserver, times(3)).onChanged(viewStateCaptor.capture())
 
         assertEquals(emptyList<Bookmark>(), viewStateCaptor.allValues[0].bookmarks)
         assertEquals(emptyList<BookmarkFolder>(), viewStateCaptor.allValues[0].bookmarkFolders)
         assertEquals(false, viewStateCaptor.allValues[0].enableSearch)
 
-        assertEquals(listOf(favorite), viewStateCaptor.allValues[1].favorites)
-        assertEquals(listOf(bookmark, bookmark, bookmark), viewStateCaptor.allValues[1].bookmarks)
-        assertEquals(listOf(bookmarkFolder, bookmarkFolder), viewStateCaptor.allValues[1].bookmarkFolders)
-        assertEquals(true, viewStateCaptor.allValues[1].enableSearch)
+        assertEquals(emptyList<Favorite>(), viewStateCaptor.allValues[2].favorites)
+        assertEquals(listOf(bookmark, bookmark, bookmark), viewStateCaptor.allValues[2].bookmarks)
+        assertEquals(listOf(bookmarkFolder, bookmarkFolder), viewStateCaptor.allValues[2].bookmarkFolders)
+        assertEquals(true, viewStateCaptor.allValues[2].enableSearch)
     }
 
     @Test
@@ -280,7 +284,23 @@ class BookmarksViewModelTest {
     }
 
     @Test
-    fun whenDeleteEmptyBookmarkFolderRequestedThenDeleteFolderAndIssueConfirmDeleteBookmarkFolderCommand() = runTest {
+    fun whenDeleteEmptyFolderRequestedThenCommandIssued() = runTest {
+        testee.onDeleteBookmarkFolderRequested(bookmarkFolder)
+        verify(commandObserver).onChanged(commandCaptor.capture())
+        assertEquals(bookmarkFolder, (commandCaptor.value as BookmarksViewModel.Command.ConfirmDeleteBookmarkFolder).bookmarkFolder)
+    }
+
+    @Test
+    fun whenDeleteFolderRequestedThenCommandIssued() = runTest {
+        val bookmarkFolder = BookmarkFolder(id = "folder1", name = "folder", parentId = SavedSitesNames.BOOKMARKS_ROOT, 1, 1, "timestamp")
+        testee.onDeleteBookmarkFolderRequested(bookmarkFolder)
+
+        verify(commandObserver).onChanged(commandCaptor.capture())
+        assertEquals(bookmarkFolder, (commandCaptor.value as BookmarksViewModel.Command.DeleteBookmarkFolder).bookmarkFolder)
+    }
+
+    @Test
+    fun whenDeleteBookmarkFolderUndoThenReposistoryNotUpdated() = runTest {
         val parentFolder = BookmarkFolder("folder1", "Parent Folder", SavedSitesNames.BOOKMARKS_ROOT, 0, 0, "timestamp")
         val childFolder = BookmarkFolder("folder2", "Parent Folder", "folder1", 0, 0, "timestamp")
         val childBookmark = Bookmark("bookmark1", "title", "www.example.com", "folder2", "timestamp")
@@ -289,6 +309,22 @@ class BookmarksViewModelTest {
         whenever(savedSitesRepository.deleteFolderBranch(any())).thenReturn(folderBranch)
 
         testee.onDeleteBookmarkFolderRequested(bookmarkFolder)
+        testee.undoDelete(bookmarkFolder)
+
+        verify(savedSitesRepository, never()).deleteFolderBranch(bookmarkFolder)
+    }
+
+    @Test
+    fun whenDeleteBookmarkFolderConfirmedThenDeleteFolderAndIssueConfirmDeleteBookmarkFolderCommand() = runTest {
+        val parentFolder = BookmarkFolder("folder1", "Parent Folder", SavedSitesNames.BOOKMARKS_ROOT, 0, 0, "timestamp")
+        val childFolder = BookmarkFolder("folder2", "Parent Folder", "folder1", 0, 0, "timestamp")
+        val childBookmark = Bookmark("bookmark1", "title", "www.example.com", "folder2", "timestamp")
+        val folderBranch = FolderBranch(listOf(childBookmark), listOf(parentFolder, childFolder))
+
+        whenever(savedSitesRepository.deleteFolderBranch(any())).thenReturn(folderBranch)
+
+        testee.onDeleteBookmarkFolderRequested(bookmarkFolder)
+        testee.delete(bookmarkFolder)
 
         verify(savedSitesRepository).deleteFolderBranch(bookmarkFolder)
 
@@ -297,7 +333,7 @@ class BookmarksViewModelTest {
     }
 
     @Test
-    fun whenDeleteNonEmptyBookmarkFolderRequestedThenIssueDeleteBookmarkFolderCommand() = runTest {
+    fun whenDeleteBookmarkFolderRequestedThenIssueDeleteBookmarkFolderCommand() = runTest {
         val parentFolder = BookmarkFolder("folder1", "Parent Folder", SavedSitesNames.BOOKMARKS_ROOT, 0, 0, "timestamp")
         val childFolder = BookmarkFolder("folder2", "Parent Folder", "folder1", 0, 0, "timestamp")
         val childBookmark = Bookmark("bookmark1", "title", "www.example.com", "folder2", "timestamp")
@@ -310,18 +346,6 @@ class BookmarksViewModelTest {
 
         verify(commandObserver).onChanged(commandCaptor.capture())
         assertEquals(nonEmptyBookmarkFolder, (commandCaptor.value as BookmarksViewModel.Command.DeleteBookmarkFolder).bookmarkFolder)
-    }
-
-    @Test
-    fun whenInsertRecentlyDeletedBookmarksAndFoldersThenInsertCachedFolderBranch() = runTest {
-        val parentFolder = BookmarkFolder("folder1", "Parent Folder", SavedSitesNames.BOOKMARKS_ROOT, 0, 0, "timestamp")
-        val childFolder = BookmarkFolder("folder2", "Parent Folder", "folder1", 0, 0, "timestamp")
-        val childBookmark = Bookmark("bookmark1", "title", "www.example.com", "folder2", "timestamp")
-        val folderBranch = FolderBranch(listOf(childBookmark), listOf(parentFolder, childFolder))
-
-        testee.insertDeletedFolderBranch(folderBranch)
-
-        verify(savedSitesRepository).insertFolderBranch(folderBranch)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModelTest.kt
@@ -28,7 +28,6 @@ import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.savedsites.api.models.BookmarkFolder
 import com.duckduckgo.savedsites.api.models.BookmarkFolderItem
 import com.duckduckgo.savedsites.api.models.FolderBranch
-import com.duckduckgo.savedsites.api.models.SavedSite
 import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
 import com.duckduckgo.savedsites.api.models.SavedSites
 import com.duckduckgo.savedsites.api.models.SavedSitesNames
@@ -74,8 +73,8 @@ class BookmarksViewModelTest {
     private val pixel: Pixel = mock()
 
     private val bookmark =
-        SavedSite.Bookmark(id = "bookmark1", title = "title", url = "www.example.com", parentId = SavedSitesNames.BOOKMARKS_ROOT, "timestamp")
-    private val favorite = SavedSite.Favorite(id = "favorite1", title = "title", url = "www.example.com", position = 0, lastModified = "timestamp")
+        Bookmark(id = "bookmark1", title = "title", url = "www.example.com", parentId = SavedSitesNames.BOOKMARKS_ROOT, "timestamp")
+    private val favorite = Favorite(id = "bookmark1", title = "title", url = "www.example.com", position = 0, lastModified = "timestamp")
     private val bookmarkFolder = BookmarkFolder(id = "folder1", name = "folder", parentId = SavedSitesNames.BOOKMARKS_ROOT, 0, 0, "timestamp")
     private val bookmarkFolderItem = BookmarkFolderItem(0, bookmarkFolder, true)
 
@@ -95,7 +94,7 @@ class BookmarksViewModelTest {
 
     @Before
     fun before() = runTest {
-        whenever(savedSitesRepository.getFavorites()).thenReturn(flowOf())
+        whenever(savedSitesRepository.getFavorites()).thenReturn(flowOf(listOf(favorite)))
 
         whenever(savedSitesRepository.getSavedSites(anyString())).thenReturn(
             flowOf(

--- a/app/src/test/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModelTest.kt
@@ -254,7 +254,7 @@ class BookmarksViewModelTest {
         assertEquals(emptyList<BookmarkFolder>(), viewStateCaptor.allValues[0].bookmarkFolders)
         assertEquals(false, viewStateCaptor.allValues[0].enableSearch)
 
-        assertEquals(emptyList<Favorite>(), viewStateCaptor.allValues[2].favorites)
+        assertEquals(listOf(favorite), viewStateCaptor.allValues[2].favorites)
         assertEquals(listOf(bookmark, bookmark, bookmark), viewStateCaptor.allValues[2].bookmarks)
         assertEquals(listOf(bookmarkFolder, bookmarkFolder), viewStateCaptor.allValues[2].bookmarkFolders)
         assertEquals(true, viewStateCaptor.allValues[2].enableSearch)

--- a/app/src/test/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModelTest.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.savedsites.api.models.BookmarkFolder
 import com.duckduckgo.savedsites.api.models.BookmarkFolderItem
 import com.duckduckgo.savedsites.api.models.FolderBranch
 import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
+import com.duckduckgo.savedsites.api.models.SavedSite.Favorite
 import com.duckduckgo.savedsites.api.models.SavedSites
 import com.duckduckgo.savedsites.api.models.SavedSitesNames
 import com.duckduckgo.savedsites.api.service.SavedSitesManager
@@ -127,7 +128,7 @@ class BookmarksViewModelTest {
     @Test
     fun whenBookmarkDeleteThenRepositoryUpdated() = runTest {
         testee.onDeleteSavedSiteRequested(bookmark)
-        testee.delete(bookmark)
+        testee.onDeleteSavedSiteSnackbarDismissed(bookmark)
 
         verify(faviconManager).deletePersistedFavicon(bookmark.url)
         verify(savedSitesRepository).delete(bookmark)
@@ -154,7 +155,7 @@ class BookmarksViewModelTest {
     @Test
     fun whenFavoriteDeleteThenRepositoryUpdated() = runTest {
         testee.onDeleteSavedSiteRequested(favorite)
-        testee.delete(favorite)
+        testee.onDeleteSavedSiteSnackbarDismissed(favorite)
 
         verify(savedSitesRepository).delete(favorite)
         verify(faviconManager, never()).deletePersistedFavicon(favorite.url)
@@ -323,7 +324,7 @@ class BookmarksViewModelTest {
         whenever(savedSitesRepository.deleteFolderBranch(any())).thenReturn(folderBranch)
 
         testee.onDeleteBookmarkFolderRequested(bookmarkFolder)
-        testee.delete(bookmarkFolder)
+        testee.onDeleteBookmarkFolderSnackbarDismissed(bookmarkFolder)
 
         verify(savedSitesRepository).deleteFolderBranch(bookmarkFolder)
 

--- a/app/src/test/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
@@ -327,7 +327,7 @@ class SystemSearchViewModelTest {
         testee.onDeleteQuickAccessItemRequested(quickAccessItem)
 
         verify(commandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
-        assertEquals(Command.DeleteSavedSiteConfirmation(quickAccessItem.favorite, 0), commandCaptor.lastValue)
+        assertEquals(Command.DeleteSavedSiteConfirmation(quickAccessItem.favorite, -1), commandCaptor.lastValue)
     }
 
     @Test
@@ -366,13 +366,22 @@ class SystemSearchViewModelTest {
     @Test
     fun whenQuickAccessDeleteUndoThenViewStateUpdated() = runTest {
         val savedSite = Favorite("favorite1", "title", "http://example.com", "timestamp", 0)
+        whenever(mocksavedSitesRepository.getFavorites()).thenReturn(flowOf(listOf(savedSite)))
+        testee = SystemSearchViewModel(
+            mockUserStageStore,
+            mockAutoComplete,
+            mockDeviceAppLookup,
+            mockPixel,
+            mocksavedSitesRepository,
+            mockFaviconManager,
+            mockSettingsStore,
+            coroutineRule.testDispatcherProvider,
+        )
 
         val viewState = testee.resultsViewState.value as QuickAccessItems
         assertFalse(viewState.favorites.isEmpty())
 
         testee.undoDelete(savedSite, 0)
-
-        verify(mocksavedSitesRepository).delete(savedSite)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
@@ -377,13 +377,15 @@ class SystemSearchViewModelTest {
         assertFalse(viewState.favorites.isEmpty())
 
         testee.undoDelete(savedSite)
+
+        assertFalse(viewState.favorites.isEmpty())
     }
 
     @Test
     fun whenQuickAccessDeletedThenRepositoryDeletesSavedSite() = runTest {
         val savedSite = Favorite("favorite1", "title", "http://example.com", "timestamp", 0)
 
-        testee.deleteQuickAccessItem(savedSite)
+        testee.deleteSavedSiteSnackbarDismissed(savedSite)
 
         verify(mocksavedSitesRepository).delete(savedSite)
     }

--- a/app/src/test/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
@@ -22,7 +22,6 @@ import androidx.lifecycle.Observer
 import com.duckduckgo.app.autocomplete.api.AutoComplete
 import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteResult
 import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteSuggestion.AutoCompleteSearchSuggestion
-import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.browser.favorites.FavoritesQuickAccessAdapter.QuickAccessFavorite
 import com.duckduckgo.app.onboarding.store.*
 import com.duckduckgo.app.pixels.AppPixelName.*
@@ -61,7 +60,6 @@ class SystemSearchViewModelTest {
     private val mockDeviceAppLookup: DeviceAppLookup = mock()
     private val mockAutoComplete: AutoComplete = mock()
     private val mocksavedSitesRepository: SavedSitesRepository = mock()
-    private val mockFaviconManager: FaviconManager = mock()
     private val mockPixel: Pixel = mock()
     private val mockSettingsStore: SettingsDataStore = mock()
 
@@ -84,7 +82,6 @@ class SystemSearchViewModelTest {
             mockDeviceAppLookup,
             mockPixel,
             mocksavedSitesRepository,
-            mockFaviconManager,
             mockSettingsStore,
             coroutineRule.testDispatcherProvider,
         )
@@ -327,7 +324,7 @@ class SystemSearchViewModelTest {
         testee.onDeleteQuickAccessItemRequested(quickAccessItem)
 
         verify(commandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
-        assertEquals(Command.DeleteSavedSiteConfirmation(quickAccessItem.favorite, -1), commandCaptor.lastValue)
+        assertEquals(Command.DeleteSavedSiteConfirmation(quickAccessItem.favorite), commandCaptor.lastValue)
     }
 
     @Test
@@ -349,7 +346,6 @@ class SystemSearchViewModelTest {
             mockDeviceAppLookup,
             mockPixel,
             mocksavedSitesRepository,
-            mockFaviconManager,
             mockSettingsStore,
             coroutineRule.testDispatcherProvider,
         )
@@ -373,7 +369,6 @@ class SystemSearchViewModelTest {
             mockDeviceAppLookup,
             mockPixel,
             mocksavedSitesRepository,
-            mockFaviconManager,
             mockSettingsStore,
             coroutineRule.testDispatcherProvider,
         )
@@ -381,7 +376,7 @@ class SystemSearchViewModelTest {
         val viewState = testee.resultsViewState.value as QuickAccessItems
         assertFalse(viewState.favorites.isEmpty())
 
-        testee.undoDelete(savedSite, 0)
+        testee.undoDelete(savedSite)
     }
 
     @Test
@@ -413,7 +408,6 @@ class SystemSearchViewModelTest {
             mockDeviceAppLookup,
             mockPixel,
             mocksavedSitesRepository,
-            mockFaviconManager,
             mockSettingsStore,
             coroutineRule.testDispatcherProvider,
         )


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205171041444238/f

### Description
This PR changes how undo works at a UI layer level for saved sites.
Until now, when the user wanted to delete a bookmark, we were directly removing it from the DB. In the case that the user were to undo the change, we were adding a new row to the DB. This is problematic in many levels, changing order of Favourites and also triggering unnecessary Sync operations.

### Steps to test this PR
All test cases assume that Sync is enabled

_Remove Favourite from Bookmarks screen_
- [x] Add a favourite 
- [x] Verify that Sync operation is triggered
- [x] Open Bookmarks screen
- [x] Remove favourite
- [x] Verify Sync operation is not triggered
- [x] Verify Site does not appear in Favourites list
- [x] Tap on Undo
- [x] Verify Sync operation is not triggered
- [x] Verify Site appears in the Favourites list
- [x] Remove favourite and let Snackbar disappear
- [x] Verify that Sync operation is triggered

_Remove Bookmark from Browser_
- [x] Add a bookmark 
- [x] Verify that Sync operation is triggered
- [x] Open Bookmarks screen
- [x] Remove bookmark
- [x] Verify Sync operation is not triggered
- [x] Verify Site does not appear in Favourites list
- [x] Verify Site does not appear in Bookmarks list
- [x] Tap on Undo
- [x] Verify Sync operation is not triggered
- [x] Verify Site appears in the Favourites list
- [x] Verify Site appears in the Bookmarks list
- [x] Remove bookmark and let Snackbar disappear
- [x] Verify that Sync operation is triggered

_Remove Favourite from Browser_
- [x] Add a favourite 
- [x] Verify that Sync operation is triggered
- [x] Remove favourite
- [x] Verify Sync operation is not triggered
- [x] Verify Site is not favourited in the Browser Menu
- [x] Tap on Undo
- [x] Verify Sync operation is not triggered
- [x] Verify Site is favourited in the Browser Menu
- [x] Remove favourite and let Snackbar disappear
- [x] Verify that Sync operation is triggered

_Remove Bookmark from Browser_
- [x] Add a bookmark 
- [x] Verify that Sync operation is triggered
- [x] Open Browser Menu and tap on Edit
- [x] Remove bookmark
- [x] Verify Sync operation is not triggered
- [x] Verify Site is not favourited in the Browser Menu
- [x] Verify Site is not bookmarked in the Browser Menu (should see Add bookmark instead)
- [x] Tap on Undo
- [x] Verify Sync operation is not triggered
- [x] Verify Site is favourited in the Browser Menu
- [x] Remove favourite and let Snackbar disappear
- [x] Verify that Sync operation is triggered

_Remove Favourite from New Tab_
- [x] Add a favourite 
- [x] Verify that Sync operation is triggered
- [x] Open New Tab
- [x] Long tap on Favourite and Delete it
- [x] Verify Sync operation is not triggered
- [x] Verify Site no longer appears in the grid
- [x] Tap on Undo
- [x] Verify Sync operation is not triggered
- [x] Verify Site is visible in the grid
- [x] Remove favourite and let Snackbar disappear
- [x] Verify that Sync operation is triggered

_Remove Favourite from Omnibar Quick Access_
- [x] Add a favourite 
- [x] Verify that Sync operation is triggered
- [x] Tap on omnibar so that the quick access panel appears
- [x] Long tap on Favourite and Delete it
- [x] Verify Sync operation is not triggered
- [x] Verify Site no longer appears in the grid
- [x] Tap on Undo
- [x] Verify Sync operation is not triggered
- [x] Verify Site is visible in the quick access panel
- [x] Remove favourite and let Snackbar disappear
- [x] Verify that Sync operation is triggered

_Remove Favourite from Favourites Widget_
- [x] Add Favourites Widget to device Home screen
- [x] Add a favourite 
- [x] Verify that Sync operation is triggered
- [x] Send device to home and tap on Favourites Widget
- [x] Long tap on Favourite and Delete it
- [x] Verify Sync operation is not triggered
- [x] Verify Site no longer appears in the grid
- [x] Tap on Undo
- [x] Verify Sync operation is not triggered
- [x] Verify Site is visible in the quick access panel
- [x] Remove favourite and let Snackbar disappear
- [x] Verify that Sync operation is triggered