### PR TITLE
Update reference tests to version 1699439919

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/SurrogatesReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/SurrogatesReferenceTest.kt
@@ -178,7 +178,11 @@ class SurrogatesReferenceTest(private val testCase: TestCase) {
     @Test
     fun whenReferenceTestRunsItReturnsTheExpectedResult() = runBlocking<Unit> {
         whenever(mockRequest.url).thenReturn(testCase.requestURL.toUri())
-        whenever(mockRequest.requestHeaders).thenReturn(mapOf("Accept" to "${testCase.requestType}/"))
+        val type = when(testCase.requestType) {
+            "script" -> "application/javascript"
+            else -> "${testCase.requestType}/"
+        }
+        whenever(mockRequest.requestHeaders).thenReturn(mapOf("Accept" to type))
 
         val response = testee.shouldIntercept(
             request = mockRequest,

--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/SurrogatesReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/SurrogatesReferenceTest.kt
@@ -178,7 +178,7 @@ class SurrogatesReferenceTest(private val testCase: TestCase) {
     @Test
     fun whenReferenceTestRunsItReturnsTheExpectedResult() = runBlocking<Unit> {
         whenever(mockRequest.url).thenReturn(testCase.requestURL.toUri())
-        val type = when(testCase.requestType) {
+        val type = when (testCase.requestType) {
             "script" -> "application/javascript"
             else -> "${testCase.requestType}/"
         }

--- a/app/src/androidTest/resources/reference_tests/domain_matching_tests.json
+++ b/app/src/androidTest/resources/reference_tests/domain_matching_tests.json
@@ -1011,10 +1011,17 @@
                 "name": "options blocking with surrogate",
                 "siteURL": "https://site-that-tracks.com/",
                 "requestURL": "https://sometimes-bad.third-party.site/surrogate-and-option-blocking-only?abc=2",
-                "requestType": "image",
+                "requestType": "script",
                 "expectAction": "redirect",
                 "expectRedirect": "data:application/javascript;base64,KGZ1bmN0aW9uKCkge3dpbmRvdy5zdXJyb2dhdGUxPXRydWV9KSgpOw==",
                 "expectExpression": "window.surrogate1 === true"
+            },
+            {
+                "name": "options blocking, wrong type",
+                "siteURL": "https://site-that-tracks.com/",
+                "requestURL": "https://sometimes-bad.third-party.site/surrogate-and-option-blocking-only?abc=2",
+                "requestType": "image",
+                "expectAction": "ignore"
             },
             {
                 "name": "require exact match for surrogates",

--- a/app/src/androidTest/resources/reference_tests/tracker_radar_reference.json
+++ b/app/src/androidTest/resources/reference_tests/tracker_radar_reference.json
@@ -222,7 +222,7 @@
                             "site-that-tracks.com"
                         ],
                         "types": [
-                            "image"
+                            "script"
                         ]
                     },
                     "surrogate": "tracker"

--- a/app/src/test/resources/reference_tests/brokensites/multiple_report_tests.json
+++ b/app/src/test/resources/reference_tests/brokensites/multiple_report_tests.json
@@ -1,126 +1,126 @@
 {
-  "reportURL": {
-    "name": "Broken site report testing",
-    "tests": [
-      {
-        "name": "Simple test with a common set of fields (without config version)",
-        "reports": [
-          {
-            "siteURL": "https://example.test/",
-            "wasUpgraded": true,
-            "category": "content",
-            "blockedTrackers": ["bad.tracker.test", "tracking.test"],
-            "surrogates": ["surrogate.domain.test", "domain2.test"],
-            "atb": "v123-456g",
-            "blocklistVersion": "abc123",
-            "remoteConfigEtag": "abd142",
-            "remoteConfigVersion": "1234",
-            "expectReportURLPrefix": "https://improving.duckduckgo.com/t/epbf",
-            "expectReportURLParams": [
-              {"name": "category", "value": "content"},
-              {"name": "siteUrl", "value": "https%3A%2F%2Fexample.test%2F"},
-              {"name": "upgradedHttps", "value": "true"},
-              {"name": "tds", "value": "abc123"},
-              {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
-              {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"},
-              {"name": "lastSentDay", "present": false}
-            ]
-          },
-          {
-            "siteURL": "https://example.test/",
-            "wasUpgraded": true,
-            "category": "content",
-            "blockedTrackers": ["bad.tracker.test", "tracking.test"],
-            "surrogates": ["surrogate.domain.test", "domain2.test"],
-            "atb": "v123-456g",
-            "blocklistVersion": "abc123",
-            "remoteConfigEtag": "abd142",
-            "remoteConfigVersion": "1234",
-            "expectReportURLPrefix": "https://improving.duckduckgo.com/t/epbf",
-            "expectReportURLParams": [
-              {"name": "category", "value": "content"},
-              {"name": "siteUrl", "value": "https%3A%2F%2Fexample.test%2F"},
-              {"name": "upgradedHttps", "value": "true"},
-              {"name": "tds", "value": "abc123"},
-              {"name": "remoteConfigEtag", "value": "abd142"},
-              {"name": "remoteConfigVersion", "value": "1234"},
-              {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
-              {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"},
-              {"name": "lastSentDay", "present": true, "matchesCurrentDay": true, "matches": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"}
-            ]
-          },
-          {
-            "siteURL": "https://sub.example.test/",
-            "wasUpgraded": true,
-            "category": "content",
-            "blockedTrackers": ["bad.tracker.test", "tracking.test"],
-            "surrogates": ["surrogate.domain.test", "domain2.test"],
-            "atb": "v123-456g",
-            "blocklistVersion": "abc123",
-            "remoteConfigEtag": "abd142",
-            "remoteConfigVersion": "1234",
-            "expectReportURLPrefix": "https://improving.duckduckgo.com/t/epbf",
-            "expectReportURLParams": [
-              {"name": "category", "value": "content"},
-              {"name": "siteUrl", "value": "https%3A%2F%2Fsub.example.test%2F"},
-              {"name": "upgradedHttps", "value": "true"},
-              {"name": "tds", "value": "abc123"},
-              {"name": "remoteConfigEtag", "value": "abd142"},
-              {"name": "remoteConfigVersion", "value": "1234"},
-              {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
-              {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"},
-              {"name": "lastSentDay", "present": false}
-            ]
-          },
-          {
-            "siteURL": "https://sub.example.test/",
-            "wasUpgraded": true,
-            "category": "content",
-            "blockedTrackers": ["bad.tracker.test", "tracking.test"],
-            "surrogates": ["surrogate.domain.test", "domain2.test"],
-            "atb": "v123-456g",
-            "blocklistVersion": "abc123",
-            "remoteConfigEtag": "abd142",
-            "remoteConfigVersion": "1234",
-            "expectReportURLPrefix": "https://improving.duckduckgo.com/t/epbf",
-            "expectReportURLParams": [
-              {"name": "category", "value": "content"},
-              {"name": "siteUrl", "value": "https%3A%2F%2Fsub.example.test%2F"},
-              {"name": "upgradedHttps", "value": "true"},
-              {"name": "tds", "value": "abc123"},
-              {"name": "remoteConfigEtag", "value": "abd142"},
-              {"name": "remoteConfigVersion", "value": "1234"},
-              {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
-              {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"},
-              {"name": "lastSentDay", "present": true, "matchesCurrentDay": true, "matches": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"}
-            ]
-          },
-          {
-            "siteURL": "https://sub.other.test/",
-            "wasUpgraded": true,
-            "category": "content",
-            "blockedTrackers": ["bad.tracker.test", "tracking.test"],
-            "surrogates": ["surrogate.domain.test", "domain2.test"],
-            "atb": "v123-456g",
-            "blocklistVersion": "abc123",
-            "remoteConfigEtag": "abd142",
-            "remoteConfigVersion": "1234",
-            "expectReportURLPrefix": "https://improving.duckduckgo.com/t/epbf",
-            "expectReportURLParams": [
-              {"name": "category", "value": "content"},
-              {"name": "siteUrl", "value": "https%3A%2F%2Fsub.other.test%2F"},
-              {"name": "upgradedHttps", "value": "true"},
-              {"name": "tds", "value": "abc123"},
-              {"name": "remoteConfigEtag", "value": "abd142"},
-              {"name": "remoteConfigVersion", "value": "1234"},
-              {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
-              {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"},
-              {"name": "lastSentDay", "present": false}
-            ]
-          }
-        ],
-        "exceptPlatforms": []
-      }
-    ]
-  }
+    "reportURL": {
+        "name": "Broken site report testing",
+        "tests": [
+            {
+                "name": "Simple test with a common set of fields (without config version)",
+                "reports": [
+                    {
+                        "siteURL": "https://example.test/",
+                        "wasUpgraded": true,
+                        "category": "content",
+                        "blockedTrackers": ["bad.tracker.test", "tracking.test"],
+                        "surrogates": ["surrogate.domain.test", "domain2.test"],
+                        "atb": "v123-456g",
+                        "blocklistVersion": "abc123",
+                        "remoteConfigEtag": "abd142",
+                        "remoteConfigVersion": "1234",
+                        "expectReportURLPrefix": "https://improving.duckduckgo.com/t/epbf",
+                        "expectReportURLParams": [
+                            {"name": "category", "value": "content"},
+                            {"name": "siteUrl", "value": "https%3A%2F%2Fexample.test%2F"},
+                            {"name": "upgradedHttps", "value": "true"},
+                            {"name": "tds", "value": "abc123"},
+                            {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
+                            {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"},
+                            {"name": "lastSentDay", "present": false}
+                        ]
+                    },
+                    {
+                        "siteURL": "https://example.test/",
+                        "wasUpgraded": true,
+                        "category": "content",
+                        "blockedTrackers": ["bad.tracker.test", "tracking.test"],
+                        "surrogates": ["surrogate.domain.test", "domain2.test"],
+                        "atb": "v123-456g",
+                        "blocklistVersion": "abc123",
+                        "remoteConfigEtag": "abd142",
+                        "remoteConfigVersion": "1234",
+                        "expectReportURLPrefix": "https://improving.duckduckgo.com/t/epbf",
+                        "expectReportURLParams": [
+                            {"name": "category", "value": "content"},
+                            {"name": "siteUrl", "value": "https%3A%2F%2Fexample.test%2F"},
+                            {"name": "upgradedHttps", "value": "true"},
+                            {"name": "tds", "value": "abc123"},
+                            {"name": "remoteConfigEtag", "value": "abd142"},
+                            {"name": "remoteConfigVersion", "value": "1234"},
+                            {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
+                            {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"},
+                            {"name": "lastSentDay", "present": true, "matchesCurrentDay": true, "matches": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"}
+                        ]
+                    },
+                    {
+                        "siteURL": "https://sub.example.test/",
+                        "wasUpgraded": true,
+                        "category": "content",
+                        "blockedTrackers": ["bad.tracker.test", "tracking.test"],
+                        "surrogates": ["surrogate.domain.test", "domain2.test"],
+                        "atb": "v123-456g",
+                        "blocklistVersion": "abc123",
+                        "remoteConfigEtag": "abd142",
+                        "remoteConfigVersion": "1234",
+                        "expectReportURLPrefix": "https://improving.duckduckgo.com/t/epbf",
+                        "expectReportURLParams": [
+                            {"name": "category", "value": "content"},
+                            {"name": "siteUrl", "value": "https%3A%2F%2Fsub.example.test%2F"},
+                            {"name": "upgradedHttps", "value": "true"},
+                            {"name": "tds", "value": "abc123"},
+                            {"name": "remoteConfigEtag", "value": "abd142"},
+                            {"name": "remoteConfigVersion", "value": "1234"},
+                            {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
+                            {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"},
+                            {"name": "lastSentDay", "present": false}
+                        ]
+                    },
+                    {
+                        "siteURL": "https://sub.example.test/",
+                        "wasUpgraded": true,
+                        "category": "content",
+                        "blockedTrackers": ["bad.tracker.test", "tracking.test"],
+                        "surrogates": ["surrogate.domain.test", "domain2.test"],
+                        "atb": "v123-456g",
+                        "blocklistVersion": "abc123",
+                        "remoteConfigEtag": "abd142",
+                        "remoteConfigVersion": "1234",
+                        "expectReportURLPrefix": "https://improving.duckduckgo.com/t/epbf",
+                        "expectReportURLParams": [
+                            {"name": "category", "value": "content"},
+                            {"name": "siteUrl", "value": "https%3A%2F%2Fsub.example.test%2F"},
+                            {"name": "upgradedHttps", "value": "true"},
+                            {"name": "tds", "value": "abc123"},
+                            {"name": "remoteConfigEtag", "value": "abd142"},
+                            {"name": "remoteConfigVersion", "value": "1234"},
+                            {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
+                            {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"},
+                            {"name": "lastSentDay", "present": true, "matchesCurrentDay": true, "matches": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"}
+                        ]
+                    },
+                    {
+                        "siteURL": "https://sub.other.test/",
+                        "wasUpgraded": true,
+                        "category": "content",
+                        "blockedTrackers": ["bad.tracker.test", "tracking.test"],
+                        "surrogates": ["surrogate.domain.test", "domain2.test"],
+                        "atb": "v123-456g",
+                        "blocklistVersion": "abc123",
+                        "remoteConfigEtag": "abd142",
+                        "remoteConfigVersion": "1234",
+                        "expectReportURLPrefix": "https://improving.duckduckgo.com/t/epbf",
+                        "expectReportURLParams": [
+                            {"name": "category", "value": "content"},
+                            {"name": "siteUrl", "value": "https%3A%2F%2Fsub.other.test%2F"},
+                            {"name": "upgradedHttps", "value": "true"},
+                            {"name": "tds", "value": "abc123"},
+                            {"name": "remoteConfigEtag", "value": "abd142"},
+                            {"name": "remoteConfigVersion", "value": "1234"},
+                            {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
+                            {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"},
+                            {"name": "lastSentDay", "present": false}
+                        ]
+                    }
+                ],
+                "exceptPlatforms": []
+            }
+        ]
+    }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#9.0.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.44.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.7.0",
-        "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1698918761"
+        "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1699439919"
       },
       "devDependencies": {
         "@rollup/plugin-json": "^4.1.0",
@@ -90,7 +90,7 @@
       }
     },
     "node_modules/@duckduckgo/privacy-reference-tests": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#bfa5ea412e3b5275e4693673fbd307fa4466d9a8",
+      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#7519c3d430e5dcef75b6128bfdadb0de3f463a49",
       "license": "Apache-2.0"
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -242,9 +242,9 @@
       "dev": true
     },
     "node_modules/@types/fs-extra": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.4.tgz",
-      "integrity": "sha512-OMcQKnlrkrOI0TaZ/MgVDA8LYFl7CykzFsjMj9l5x3un2nFxCY20ZFlnqrM0lcqlbs0Yro2HbnZlmopyRaoJ5w==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.5.tgz",
+      "integrity": "sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -267,9 +267,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.8.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
-      "integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
+      "integrity": "sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#9.0.0",
     "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.44.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.7.0",
-    "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1698918761"
+    "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1699439919"
   }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1205912857649722/f 

 ----- 
- Automated reference tests dependency update

This PR updates the reference tests dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/0/1203766026095653/f for further information on what to do next.

- [ ] All tests must pass