### PR TITLE
switch to true|false for protectionsState param

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/brokensite/api/BrokenSiteSender.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/api/BrokenSiteSender.kt
@@ -100,7 +100,7 @@ class BrokenSiteSubmitter @Inject constructor(
                 REMOTE_CONFIG_ETAG to privacyConfig.privacyConfigData()?.eTag.orEmpty(),
                 ERROR_CODES_KEY to brokenSite.errorCodes,
                 HTTP_ERROR_CODES_KEY to brokenSite.httpErrorCodes,
-                PROTECTIONS_STATE to protectionsState.toBinaryString(),
+                PROTECTIONS_STATE to protectionsState.toString(),
             )
 
             val lastSentDay = brokenSiteLastSentReport.getLastSentDay(domain.orEmpty())

--- a/app/src/test/java/com/duckduckgo/app/brokensite/api/BrokenSiteSubmitterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/brokensite/api/BrokenSiteSubmitterTest.kt
@@ -116,7 +116,7 @@ class BrokenSiteSubmitterTest {
         verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture())
         val params = paramsCaptor.firstValue
 
-        assertEquals("0", params["protectionsState"])
+        assertEquals("false", params["protectionsState"])
     }
 
     @Test
@@ -133,7 +133,7 @@ class BrokenSiteSubmitterTest {
         verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture())
         val params = paramsCaptor.firstValue
 
-        assertEquals("0", params["protectionsState"])
+        assertEquals("false", params["protectionsState"])
     }
 
     @Test
@@ -150,7 +150,7 @@ class BrokenSiteSubmitterTest {
         verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture())
         val params = paramsCaptor.firstValue
 
-        assertEquals("0", params["protectionsState"])
+        assertEquals("false", params["protectionsState"])
     }
 
     @Test
@@ -169,7 +169,7 @@ class BrokenSiteSubmitterTest {
         verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture())
         val params = paramsCaptor.firstValue
 
-        assertEquals("0", params["protectionsState"])
+        assertEquals("false", params["protectionsState"])
     }
 
     @Test
@@ -186,7 +186,7 @@ class BrokenSiteSubmitterTest {
         verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture())
         val params = paramsCaptor.firstValue
 
-        assertEquals("1", params["protectionsState"])
+        assertEquals("true", params["protectionsState"])
     }
 
     @Test


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL:  https://app.asana.com/0/0/1205915950517978/f

### Description

Switching to true|false instead of 1|0 for cross-platform consistency. See the parent task https://app.asana.com/0/1201141132935289/1205644489547731


### Steps to test this PR

- [x] Submit the breakage form with protections on
- [x] Verify that the breakage form pixel param `protectionsState` is the string `true`
- [x] Submit the breakage form with protections off
- [x] Verify that the breakage form pixel param `protectionsState` is the string `false`

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
