### PR TITLE
Close Privacy Dashboard after toggling protections on Broken Site screen

### DIFF
--- a/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModel.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModel.kt
@@ -21,7 +21,7 @@ import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.global.model.Site
-import com.duckduckgo.app.privacy.db.UserAllowListDao
+import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.browser.api.brokensite.BrokenSiteData
 import com.duckduckgo.di.scopes.ActivityScope
@@ -51,7 +51,7 @@ import timber.log.Timber
 
 @ContributesViewModel(ActivityScope::class)
 class PrivacyDashboardHybridViewModel @Inject constructor(
-    private val userAllowListDao: UserAllowListDao,
+    private val userAllowListRepository: UserAllowListRepository,
     private val pixel: Pixel,
     private val dispatcher: DispatcherProvider,
     private val siteViewStateMapper: SiteViewStateMapper,
@@ -258,10 +258,10 @@ class PrivacyDashboardHybridViewModel @Inject constructor(
             currentViewState().siteViewState.domain?.let { domain ->
                 val pixelParams = pixelParamMap()
                 if (enabled) {
-                    userAllowListDao.delete(domain)
+                    userAllowListRepository.removeDomainFromUserAllowList(domain)
                     pixel.fire(PRIVACY_DASHBOARD_ALLOWLIST_REMOVE, pixelParams)
                 } else {
-                    userAllowListDao.insert(domain)
+                    userAllowListRepository.addDomainToUserAllowList(domain)
                     pixel.fire(PRIVACY_DASHBOARD_ALLOWLIST_ADD, pixelParams)
                 }
             }

--- a/privacy-dashboard/privacy-dashboard-impl/src/test/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModelTest.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/test/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModelTest.kt
@@ -23,7 +23,7 @@ import app.cash.turbine.test
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.app.global.model.Site
 import com.duckduckgo.app.global.model.domain
-import com.duckduckgo.app.privacy.db.UserAllowListDao
+import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.feature.toggles.api.Toggle
@@ -58,7 +58,7 @@ class PrivacyDashboardHybridViewModelTest {
         whenever(this.sdkInt).thenReturn(VERSION_CODES.Q)
     }
 
-    private val userAllowListDao = mock<UserAllowListDao>()
+    private val userAllowListRepository = mock<UserAllowListRepository>()
 
     private val contentBlocking = mock<ContentBlocking>()
     private val unprotectedTemporary = mock<UnprotectedTemporary>()
@@ -68,7 +68,7 @@ class PrivacyDashboardHybridViewModelTest {
 
     private val testee: PrivacyDashboardHybridViewModel by lazy {
         PrivacyDashboardHybridViewModel(
-            userAllowListDao = userAllowListDao,
+            userAllowListRepository = userAllowListRepository,
             pixel = pixel,
             dispatcher = coroutineRule.testDispatcherProvider,
             siteViewStateMapper = AppSiteViewStateMapper(PublicKeyInfoMapper(androidQAppBuildConfig)),
@@ -137,7 +137,7 @@ class PrivacyDashboardHybridViewModelTest {
         testee.onSiteChanged(site)
         testee.onPrivacyProtectionsClicked(enabled = false)
 
-        verify(userAllowListDao).insert(site.domain!!)
+        verify(userAllowListRepository).addDomainToUserAllowList(site.domain!!)
     }
 
     private fun site(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1205916361591091/f

### Description
- Whenever protections are toggled we should close the Privacy Dashboard.

### Steps to test this PR

#### Privacy Dashboard is closed automatically after toggling protections on Broken Site screen
- [x] Navigate to the Privacy Dashboard
- [x] Go to the Broken Site screen ("Website not working?" -> "Report Broken site")
- [x] Toggle protections
- [x] Press back or submit report
- [x] Verify that after exiting Broken Site screen you landed on the page which reloads automatically

#### Privacy Dashboard is closed automatically after toggling protections (no behavior changes here)
- [x] Navigate to the Privacy Dashboard
- [x] Toggle protections
- [x] Verify that the screen closed itself after a slight delay (300ms) and the page reloaded automatically (maintaining existing behavior in this scenario)

### UI changes

https://github.com/duckduckgo/Android/assets/4212474/f3dbb21f-f4be-4590-8a47-9fc56db754f2


