### PR TITLE
Refactor permissions

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserChromeClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserChromeClientTest.kt
@@ -33,6 +33,7 @@ import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import com.duckduckgo.app.CoroutineTestRule
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.site.permissions.api.SitePermissionsManager
+import com.duckduckgo.site.permissions.api.SitePermissionsManager.SitePermissions
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
@@ -74,7 +75,7 @@ class BrowserChromeClientTest {
         mockFileChooserParams = mock()
         testee.webViewClientListener = mockWebViewClientListener
         webView = TestWebView(getInstrumentation().targetContext)
-        mockSitePermissionsManager.stub { onBlocking { getSitePermissionsForUserToHandle(any(), any()) }.thenReturn(arrayOf()) }
+        mockSitePermissionsManager.stub { onBlocking { getSitePermissions(any(), any()) }.thenReturn(SitePermissions(emptyList(), emptyList())) }
     }
 
     @Test
@@ -184,12 +185,15 @@ class BrowserChromeClientTest {
     @ExperimentalCoroutinesApi
     @Test
     fun whenOnMediaPermissionRequestIfDomainIsAllowToAskThenRequestPermission() = runTest {
-        val permissions = arrayOf(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID)
+        val permissions = SitePermissions(
+            userHandled = listOf(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID),
+            autoAccept = emptyList(),
+        )
         val mockPermission: PermissionRequest = mock()
         whenever(mockWebViewClientListener.getCurrentTabId()).thenReturn("id")
-        whenever(mockPermission.resources).thenReturn(permissions)
+        whenever(mockPermission.resources).thenReturn(arrayOf(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID))
         whenever(mockPermission.origin).thenReturn("https://open.spotify.com".toUri())
-        whenever(mockSitePermissionsManager.getSitePermissionsForUserToHandle(any(), any())).thenReturn(permissions)
+        whenever(mockSitePermissionsManager.getSitePermissions(any(), any())).thenReturn(permissions)
         testee.onPermissionRequest(mockPermission)
 
         verify(mockWebViewClientListener).onSitePermissionRequested(mockPermission, permissions)
@@ -198,12 +202,15 @@ class BrowserChromeClientTest {
     @ExperimentalCoroutinesApi
     @Test
     fun whenOnCameraPermissionRequestIfDomainIsAllowToAskThenRequestPermission() = runTest {
-        val permissions = arrayOf(PermissionRequest.RESOURCE_VIDEO_CAPTURE)
+        val permissions = SitePermissions(
+            userHandled = listOf(PermissionRequest.RESOURCE_VIDEO_CAPTURE),
+            autoAccept = emptyList(),
+        )
         val mockRequest: PermissionRequest = mock()
         whenever(mockWebViewClientListener.getCurrentTabId()).thenReturn("id")
-        whenever(mockRequest.resources).thenReturn(permissions)
+        whenever(mockRequest.resources).thenReturn(arrayOf(PermissionRequest.RESOURCE_VIDEO_CAPTURE))
         whenever(mockRequest.origin).thenReturn("https://www.example.com".toUri())
-        whenever(mockSitePermissionsManager.getSitePermissionsForUserToHandle(any(), any())).thenReturn(permissions)
+        whenever(mockSitePermissionsManager.getSitePermissions(any(), any())).thenReturn(permissions)
 
         testee.onPermissionRequest(mockRequest)
 
@@ -213,12 +220,15 @@ class BrowserChromeClientTest {
     @ExperimentalCoroutinesApi
     @Test
     fun whenOnMicPermissionRequestIfDomainIsAllowToAskThenRequestPermission() = runTest {
-        val permissions = arrayOf(PermissionRequest.RESOURCE_AUDIO_CAPTURE)
+        val permissions = SitePermissions(
+            userHandled = listOf(PermissionRequest.RESOURCE_VIDEO_CAPTURE),
+            autoAccept = emptyList(),
+        )
         val mockRequest: PermissionRequest = mock()
         whenever(mockWebViewClientListener.getCurrentTabId()).thenReturn("id")
-        whenever(mockRequest.resources).thenReturn(permissions)
+        whenever(mockRequest.resources).thenReturn(arrayOf(PermissionRequest.RESOURCE_VIDEO_CAPTURE))
         whenever(mockRequest.origin).thenReturn("https://www.example.com".toUri())
-        whenever(mockSitePermissionsManager.getSitePermissionsForUserToHandle(any(), any())).thenReturn(permissions)
+        whenever(mockSitePermissionsManager.getSitePermissions(any(), any())).thenReturn(permissions)
 
         testee.onPermissionRequest(mockRequest)
 
@@ -227,13 +237,13 @@ class BrowserChromeClientTest {
 
     @ExperimentalCoroutinesApi
     @Test
-    fun whenNotSitePermissionsAreRequestedThenCallonSitePermissionRequested() = runTest {
-        val permissions = arrayOf<String>()
+    fun whenNotSitePermissionsAreRequestedThenCallOnSitePermissionRequested() = runTest {
+        val permissions = SitePermissions(emptyList(), emptyList())
         val mockRequest: PermissionRequest = mock()
         whenever(mockWebViewClientListener.getCurrentTabId()).thenReturn("id")
-        whenever(mockRequest.resources).thenReturn(permissions)
+        whenever(mockRequest.resources).thenReturn(arrayOf())
         whenever(mockRequest.origin).thenReturn("https://www.example.com".toUri())
-        whenever(mockSitePermissionsManager.getSitePermissionsForUserToHandle(any(), any())).thenReturn(permissions)
+        whenever(mockSitePermissionsManager.getSitePermissions(any(), any())).thenReturn(permissions)
 
         testee.onPermissionRequest(mockRequest)
 

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -142,7 +142,6 @@ import com.duckduckgo.remote.messaging.api.RemoteMessagingRepository
 import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
 import com.duckduckgo.savedsites.api.models.SavedSite.Favorite
-import com.duckduckgo.site.permissions.api.SitePermissionsManager
 import com.duckduckgo.voice.api.VoiceSearchAvailability
 import com.duckduckgo.voice.api.VoiceSearchAvailabilityPixelLogger
 import dagger.Lazy
@@ -326,9 +325,6 @@ class BrowserTabViewModelTest {
     private lateinit var mockAdClickManager: AdClickManager
 
     @Mock
-    private lateinit var mockSitePermissionsManager: SitePermissionsManager
-
-    @Mock
     private lateinit var mockUserAllowListRepository: UserAllowListRepository
 
     @Mock
@@ -498,7 +494,6 @@ class BrowserTabViewModelTest {
             voiceSearchPixelLogger = voiceSearchPixelLogger,
             settingsDataStore = mockSettingsDataStore,
             adClickManager = mockAdClickManager,
-            sitePermissionsManager = mockSitePermissionsManager,
             autofillCapabilityChecker = autofillCapabilityChecker,
             autofillFireproofDialogSuppressor = autofillFireproofDialogSuppressor,
             automaticSavedLoginsMonitor = automaticSavedLoginsMonitor,

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -125,7 +125,6 @@ import com.duckduckgo.autofill.api.AutofillCapabilityChecker
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.api.email.EmailManager
 import com.duckduckgo.autofill.api.passwordgeneration.AutomaticSavedLoginsMonitor
-import com.duckduckgo.autofill.api.store.AutofillStore
 import com.duckduckgo.autofill.impl.AutofillFireproofDialogSuppressor
 import com.duckduckgo.downloads.api.DownloadStateListener
 import com.duckduckgo.downloads.api.FileDownloader
@@ -386,8 +385,6 @@ class BrowserTabViewModelTest {
 
     private val favoriteListFlow = Channel<List<Favorite>>()
 
-    private val mockAutofillStore: AutofillStore = mock()
-
     private val mockAppTheme: AppTheme = mock()
 
     private val autofillCapabilityChecker: FakeCapabilityChecker = FakeCapabilityChecker(enabled = false)
@@ -500,7 +497,6 @@ class BrowserTabViewModelTest {
             voiceSearchAvailability = voiceSearchAvailability,
             voiceSearchPixelLogger = voiceSearchPixelLogger,
             settingsDataStore = mockSettingsDataStore,
-            autofillStore = mockAutofillStore,
             adClickManager = mockAdClickManager,
             sitePermissionsManager = mockSitePermissionsManager,
             autofillCapabilityChecker = autofillCapabilityChecker,
@@ -4165,54 +4161,6 @@ class BrowserTabViewModelTest {
         assertTrue(testee.siteLiveData.value?.consentOptOutFailed!!)
         assertTrue(testee.siteLiveData.value?.consentSelfTestFailed!!)
         assertTrue(testee.siteLiveData.value?.consentCosmeticHide!!)
-    }
-
-    @Test
-    fun givenPermissionsAlreadyGrantedWhenWebsiteRequestsSitePermissionThenGrantItAutomatically() = runTest {
-        val request: PermissionRequest = mock()
-        val permissionsGranted = arrayOf(PermissionRequest.RESOURCE_AUDIO_CAPTURE, PermissionRequest.RESOURCE_VIDEO_CAPTURE)
-        whenever(mockSitePermissionsManager.getSitePermissionsGranted(any(), any(), any())).thenReturn(permissionsGranted)
-
-        givenSitePermissionsRequestFromDomain(request)
-
-        assertCommandIssued<Command.GrantSitePermissionRequest> {
-            assertEquals(this.request, request)
-            assertArrayEquals(this.sitePermissionsToGrant, permissionsGranted)
-        }
-    }
-
-    @Test
-    fun givenPermissionNeverGrantedWhenWebsiteRequestsSitePermissionThenGrantItAutomatically() = runTest {
-        val request: PermissionRequest = mock()
-        val permissionsGranted = arrayOf<String>()
-        val permissionsToAsk = arrayOf(PermissionRequest.RESOURCE_AUDIO_CAPTURE, PermissionRequest.RESOURCE_VIDEO_CAPTURE)
-        whenever(mockSitePermissionsManager.getSitePermissionsGranted(any(), any(), any())).thenReturn(permissionsGranted)
-
-        givenSitePermissionsRequestFromDomain(request)
-
-        assertCommandIssued<Command.ShowSitePermissionsDialog> {
-            assertEquals(this.request, request)
-            assertArrayEquals(this.permissionsToRequest, permissionsToAsk)
-        }
-    }
-
-    @Test
-    fun whenOnePermissionIsGrantedAndOtherNeedsToBeRequestedThenBothCommandsAreCalled() = runTest {
-        val request: PermissionRequest = mock()
-        val permissionsGranted = arrayOf(PermissionRequest.RESOURCE_AUDIO_CAPTURE)
-        val permissionsToAsk = arrayOf(PermissionRequest.RESOURCE_VIDEO_CAPTURE)
-        whenever(mockSitePermissionsManager.getSitePermissionsGranted(any(), any(), any())).thenReturn(permissionsGranted)
-
-        givenSitePermissionsRequestFromDomain(request)
-
-        assertCommandIssued<Command.GrantSitePermissionRequest> {
-            assertEquals(this.request, request)
-            assertArrayEquals(this.sitePermissionsToGrant, permissionsGranted)
-        }
-        assertCommandIssued<Command.ShowSitePermissionsDialog> {
-            assertEquals(this.request, request)
-            assertArrayEquals(this.permissionsToRequest, permissionsToAsk)
-        }
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserChromeClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserChromeClient.kt
@@ -26,16 +26,13 @@ import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.global.DefaultDispatcherProvider
 import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
-import com.duckduckgo.privacy.config.api.Drm
 import com.duckduckgo.site.permissions.api.SitePermissionsManager
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 class BrowserChromeClient @Inject constructor(
-    private val drm: Drm,
     private val appBuildConfig: AppBuildConfig,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val coroutineDispatcher: DispatcherProvider = DefaultDispatcherProvider(),
@@ -139,13 +136,11 @@ class BrowserChromeClient @Inject constructor(
     }
 
     override fun onPermissionRequest(request: PermissionRequest) {
-        appCoroutineScope.launch(coroutineDispatcher.io()) {
-            val permissionsAllowedToAsk = sitePermissionsManager.getSitePermissionsAllowedToAsk(request.origin.toString(), request.resources)
-            if (permissionsAllowedToAsk.isNotEmpty()) {
-                webViewClientListener?.onSitePermissionRequested(request, permissionsAllowedToAsk)
-            } else {
-                withContext(coroutineDispatcher.main()) {
-                    request.deny()
+        webViewClientListener?.getCurrentTabId()?.let { tabId ->
+            appCoroutineScope.launch(coroutineDispatcher.io()) {
+                val permissionsAllowedToAsk = sitePermissionsManager.getSitePermissionsForUserToHandle(tabId, request)
+                if (permissionsAllowedToAsk.isNotEmpty()) {
+                    webViewClientListener?.onSitePermissionRequested(request, permissionsAllowedToAsk)
                 }
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserChromeClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserChromeClient.kt
@@ -138,8 +138,8 @@ class BrowserChromeClient @Inject constructor(
     override fun onPermissionRequest(request: PermissionRequest) {
         webViewClientListener?.getCurrentTabId()?.let { tabId ->
             appCoroutineScope.launch(coroutineDispatcher.io()) {
-                val permissionsAllowedToAsk = sitePermissionsManager.getSitePermissionsForUserToHandle(tabId, request)
-                if (permissionsAllowedToAsk.isNotEmpty()) {
+                val permissionsAllowedToAsk = sitePermissionsManager.getSitePermissions(tabId, request)
+                if (permissionsAllowedToAsk.userHandled.isNotEmpty()) {
                     webViewClientListener?.onSitePermissionRequested(request, permissionsAllowedToAsk)
                 }
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -225,6 +225,7 @@ import com.duckduckgo.savedsites.api.models.SavedSite.Favorite
 import com.duckduckgo.savedsites.api.models.SavedSitesNames
 import com.duckduckgo.site.permissions.api.SitePermissionsDialogLauncher
 import com.duckduckgo.site.permissions.api.SitePermissionsGrantedListener
+import com.duckduckgo.site.permissions.api.SitePermissionsManager.SitePermissions
 import com.duckduckgo.user.agent.api.UserAgentProvider
 import com.duckduckgo.voice.api.VoiceSearchLauncher
 import com.duckduckgo.voice.api.VoiceSearchLauncher.Source.BROWSER
@@ -3640,7 +3641,7 @@ class BrowserTabFragment :
     }
 
     private fun showSitePermissionsDialog(
-        permissionsToRequest: Array<String>,
+        permissionsToRequest: SitePermissions,
         request: PermissionRequest,
     ) {
         if (!isActiveTab) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1273,7 +1273,6 @@ class BrowserTabFragment :
 
             is Command.PrintLink -> launchPrint(it.url, it.mediaSize)
             is Command.ShowSitePermissionsDialog -> showSitePermissionsDialog(it.permissionsToRequest, it.request)
-            is Command.GrantSitePermissionRequest -> grantSitePermissionRequest(it.sitePermissionsToGrant, it.request)
             is Command.ShowUserCredentialSavedOrUpdatedConfirmation -> showAuthenticationSavedOrUpdatedSnackbar(
                 loginCredentials = it.credentials,
                 messageResourceId = it.messageResourceId,
@@ -3652,13 +3651,6 @@ class BrowserTabFragment :
         activity?.let {
             sitePermissionsDialogLauncher.askForSitePermission(it, request.origin.toString(), tabId, permissionsToRequest, request, this)
         }
-    }
-
-    private fun grantSitePermissionRequest(
-        sitePermissionsToGrant: Array<String>,
-        request: PermissionRequest,
-    ) {
-        request.grant(sitePermissionsToGrant)
     }
 
     override fun continueDownload(pendingFileDownload: PendingFileDownload) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -129,7 +129,6 @@ import com.duckduckgo.savedsites.api.models.BookmarkFolder
 import com.duckduckgo.savedsites.api.models.SavedSite
 import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
 import com.duckduckgo.savedsites.api.models.SavedSite.Favorite
-import com.duckduckgo.site.permissions.api.SitePermissionsManager
 import com.duckduckgo.voice.api.VoiceSearchAvailability
 import com.duckduckgo.voice.api.VoiceSearchAvailabilityPixelLogger
 import com.jakewharton.rxrelay2.PublishRelay
@@ -188,7 +187,6 @@ class BrowserTabViewModel @Inject constructor(
     private val settingsDataStore: SettingsDataStore,
     private val autofillCapabilityChecker: AutofillCapabilityChecker,
     private val adClickManager: AdClickManager,
-    private val sitePermissionsManager: SitePermissionsManager,
     private val autofillFireproofDialogSuppressor: AutofillFireproofDialogSuppressor,
     private val automaticSavedLoginsMonitor: AutomaticSavedLoginsMonitor,
     private val surveyNotificationScheduler: SurveyNotificationScheduler,
@@ -1479,10 +1477,7 @@ class BrowserTabViewModel @Inject constructor(
         sitePermissionsAllowedToAsk: Array<String>,
     ) {
         viewModelScope.launch(dispatchers.io()) {
-            val sitePermissionsToAsk = sitePermissionsManager.getSitePermissionsForUserToHandle(tabId, request)
-            if (sitePermissionsToAsk.isNotEmpty()) {
-                command.postValue(ShowSitePermissionsDialog(sitePermissionsToAsk, request))
-            }
+            command.postValue(ShowSitePermissionsDialog(sitePermissionsAllowedToAsk, request))
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -129,6 +129,7 @@ import com.duckduckgo.savedsites.api.models.BookmarkFolder
 import com.duckduckgo.savedsites.api.models.SavedSite
 import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
 import com.duckduckgo.savedsites.api.models.SavedSite.Favorite
+import com.duckduckgo.site.permissions.api.SitePermissionsManager.SitePermissions
 import com.duckduckgo.voice.api.VoiceSearchAvailability
 import com.duckduckgo.voice.api.VoiceSearchAvailabilityPixelLogger
 import com.jakewharton.rxrelay2.PublishRelay
@@ -448,7 +449,7 @@ class BrowserTabViewModel @Inject constructor(
         class NavigateToHistory(val historyStackIndex: Int) : Command()
         object EmailSignEvent : Command()
         class ShowSitePermissionsDialog(
-            val permissionsToRequest: Array<String>,
+            val permissionsToRequest: SitePermissions,
             val request: PermissionRequest,
         ) : Command()
 
@@ -1474,7 +1475,7 @@ class BrowserTabViewModel @Inject constructor(
 
     override fun onSitePermissionRequested(
         request: PermissionRequest,
-        sitePermissionsAllowedToAsk: Array<String>,
+        sitePermissionsAllowedToAsk: SitePermissions,
     ) {
         viewModelScope.launch(dispatchers.io()) {
             command.postValue(ShowSitePermissionsDialog(sitePermissionsAllowedToAsk, request))

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
@@ -28,6 +28,7 @@ import android.webkit.WebChromeClient
 import com.duckduckgo.app.browser.model.BasicAuthenticationRequest
 import com.duckduckgo.app.surrogates.SurrogateResponse
 import com.duckduckgo.app.trackerdetection.model.TrackingEvent
+import com.duckduckgo.site.permissions.api.SitePermissionsManager.SitePermissions
 
 interface WebViewClientListener {
 
@@ -39,7 +40,7 @@ interface WebViewClientListener {
 
     fun onSitePermissionRequested(
         request: PermissionRequest,
-        sitePermissionsAllowedToAsk: Array<String>,
+        sitePermissionsAllowedToAsk: SitePermissions,
     )
 
     fun onSiteLocationPermissionRequested(

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
@@ -97,4 +97,6 @@ interface WebViewClientListener {
     fun onReceivedError(errorType: WebViewErrorResponse, url: String)
     fun recordErrorCode(error: String, url: String)
     fun recordHttpErrorCode(statusCode: Int, url: String)
+
+    fun getCurrentTabId(): String
 }

--- a/site-permissions/readme.md
+++ b/site-permissions/readme.md
@@ -4,6 +4,7 @@ Currently, it covers permissions for the microphone and camera.
 
 ## Who can help you better understand this feature?
 - Noelia Alcala
+- Marcos Holgado
 
 ## More information
 - [Asana: documentation](https://app.asana.com/0/72649045549333/1202390981544269/f)

--- a/site-permissions/site-permissions-api/src/main/java/com/duckduckgo/site/permissions/api/SitePermissionsDialogLauncher.kt
+++ b/site-permissions/site-permissions-api/src/main/java/com/duckduckgo/site/permissions/api/SitePermissionsDialogLauncher.kt
@@ -3,6 +3,7 @@ package com.duckduckgo.site.permissions.api
 import android.app.Activity
 import android.webkit.PermissionRequest
 import androidx.activity.result.ActivityResultCaller
+import com.duckduckgo.site.permissions.api.SitePermissionsManager.SitePermissions
 
 /** Public interface for requesting microphone and/or camera permissions when website requests it */
 interface SitePermissionsDialogLauncher {
@@ -22,8 +23,7 @@ interface SitePermissionsDialogLauncher {
      * @param activity where this method is called from
      * @param url URL taken from the permissions request object
      * @param tabId id from the tab where this method is called from
-     * @param permissionsRequested array of permissions that need to be asked filtered by user permissions settings. *Note: This could
-     * be different from `request.getResources()`
+     * @param permissionsRequested maps of permissions where keys are the type [PermissionsKey] and have a list of [String] as values.
      * @param request from onPermissionRequest callback in BrowserChromeClient. It is needed to grant site permissions.
      * @param permissionsGrantedListener interface that fragment or activity needs to implement to handle special cases when granting permissions
      */
@@ -31,7 +31,7 @@ interface SitePermissionsDialogLauncher {
         activity: Activity,
         url: String,
         tabId: String,
-        permissionsRequested: Array<String>,
+        permissionsRequested: SitePermissions,
         request: PermissionRequest,
         permissionsGrantedListener: SitePermissionsGrantedListener,
     )

--- a/site-permissions/site-permissions-api/src/main/java/com/duckduckgo/site/permissions/api/SitePermissionsManager.kt
+++ b/site-permissions/site-permissions-api/src/main/java/com/duckduckgo/site/permissions/api/SitePermissionsManager.kt
@@ -16,27 +16,18 @@
 
 package com.duckduckgo.site.permissions.api
 
+import android.webkit.PermissionRequest
+
 /** Public interface for managing site permissions data */
 interface SitePermissionsManager {
-
     /**
-     * Returns an array of already granted site permissions. That could be:
-     *     - Permission is always allowed for this website
-     *     - Permission has been granted within 24h for same site and same tab
+     * Returns an array of permissions that we support and the user has to manually handle
      *
-     * @param url unmodified URL taken from the URL bar (containing subdomains, query params etc...)
-     * @param tabId id from the tab where this method is called from
-     * @param resources array of permissions that have been requested by the website
+     * @param tabId the tab where the request was originated
+     * @param request original permission request
+     * @return array of strings with the permissions the user needs to handle
      */
-    suspend fun getSitePermissionsGranted(url: String, tabId: String, resources: Array<String>): Array<String>
-
-    /**
-     * Returns an array of permissions that we support and user didn't deny for given website
-     *
-     * @param url unmodified URL taken from the URL bar (containing subdomains, query params etc...)
-     * @param resources array of permissions that have been requested by the website
-     */
-    suspend fun getSitePermissionsAllowedToAsk(url: String, resources: Array<String>): Array<String>
+    suspend fun getSitePermissionsForUserToHandle(tabId: String, request: PermissionRequest): Array<String>
 
     /**
      * Deletes all site permissions but the ones that are fireproof

--- a/site-permissions/site-permissions-api/src/main/java/com/duckduckgo/site/permissions/api/SitePermissionsManager.kt
+++ b/site-permissions/site-permissions-api/src/main/java/com/duckduckgo/site/permissions/api/SitePermissionsManager.kt
@@ -25,9 +25,9 @@ interface SitePermissionsManager {
      *
      * @param tabId the tab where the request was originated
      * @param request original permission request
-     * @return array of strings with the permissions the user needs to handle
+     * @return map where keys are the type [PermissionsKey] and have a list of [String] as values
      */
-    suspend fun getSitePermissionsForUserToHandle(tabId: String, request: PermissionRequest): Array<String>
+    suspend fun getSitePermissions(tabId: String, request: PermissionRequest): SitePermissions
 
     /**
      * Deletes all site permissions but the ones that are fireproof
@@ -35,4 +35,9 @@ interface SitePermissionsManager {
      * @param fireproofDomains list of domains that are fireproof
      */
     suspend fun clearAllButFireproof(fireproofDomains: List<String>)
+
+    data class SitePermissions(
+        val autoAccept: List<String>,
+        val userHandled: List<String>,
+    )
 }

--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
@@ -38,6 +38,7 @@ import com.duckduckgo.mobile.android.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.mobile.android.ui.view.toPx
 import com.duckduckgo.site.permissions.api.SitePermissionsDialogLauncher
 import com.duckduckgo.site.permissions.api.SitePermissionsGrantedListener
+import com.duckduckgo.site.permissions.api.SitePermissionsManager.SitePermissions
 import com.duckduckgo.site.permissions.impl.databinding.ContentSiteDrmPermissionDialogBinding
 import com.duckduckgo.site.permissions.store.sitepermissions.SitePermissionAskSettingType
 import com.duckduckgo.site.permissions.store.sitepermissions.SitePermissionsEntity
@@ -61,6 +62,8 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
     private lateinit var activity: Activity
     private lateinit var permissionRequested: SitePermissionsRequestedType
     private lateinit var permissionsGrantedListener: SitePermissionsGrantedListener
+    private lateinit var permissionsHandledByUser: List<String>
+    private lateinit var permissionsHandledAutomatically: List<String>
     private var siteURL: String = ""
     private var tabId: String = ""
 
@@ -79,7 +82,7 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
         activity: Activity,
         url: String,
         tabId: String,
-        permissionsRequested: Array<String>,
+        permissionsRequested: SitePermissions,
         request: PermissionRequest,
         permissionsGrantedListener: SitePermissionsGrantedListener,
     ) {
@@ -88,21 +91,23 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
         this.tabId = tabId
         this.activity = activity
         this.permissionsGrantedListener = permissionsGrantedListener
+        permissionsHandledByUser = permissionsRequested.userHandled
+        permissionsHandledAutomatically = permissionsRequested.autoAccept
 
         when {
-            permissionsRequested.contains(PermissionRequest.RESOURCE_VIDEO_CAPTURE) && permissionsRequested.contains(
+            permissionsHandledByUser.contains(PermissionRequest.RESOURCE_VIDEO_CAPTURE) && permissionsHandledByUser.contains(
                 PermissionRequest.RESOURCE_AUDIO_CAPTURE,
             ) -> {
                 showSitePermissionsRationaleDialog(R.string.sitePermissionsMicAndCameraDialogTitle, url, this::askForMicAndCameraPermissions)
             }
-            permissionsRequested.contains(PermissionRequest.RESOURCE_AUDIO_CAPTURE) -> {
+            permissionsHandledByUser.contains(PermissionRequest.RESOURCE_AUDIO_CAPTURE) -> {
                 showSitePermissionsRationaleDialog(R.string.sitePermissionsMicDialogTitle, url, this::askForMicPermissions)
             }
-            permissionsRequested.contains(PermissionRequest.RESOURCE_VIDEO_CAPTURE) -> {
+            permissionsHandledByUser.contains(PermissionRequest.RESOURCE_VIDEO_CAPTURE) -> {
                 showSitePermissionsRationaleDialog(R.string.sitePermissionsCameraDialogTitle, url, this::askForCameraPermissions)
             }
-            permissionsRequested.contains(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID) -> {
-                showSiteDrmPermissionsDialog(activity, url, tabId, request)
+            permissionsHandledByUser.contains(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID) -> {
+                showSiteDrmPermissionsDialog(activity, url, tabId)
             }
         }
     }
@@ -123,7 +128,7 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
                     }
 
                     override fun onNegativeButtonClicked() {
-                        sitePermissionRequest.deny()
+                        denyPermissions()
                     }
                 },
             )
@@ -134,7 +139,6 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
         activity: Activity,
         url: String,
         tabId: String,
-        request: PermissionRequest,
     ) {
         val domain = url.extractDomain() ?: url
 
@@ -142,9 +146,9 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
         val sessionSetting = sitePermissionsRepository.getDrmForSession(domain)
         if (sessionSetting != null) {
             if (sessionSetting) {
-                request.grant(arrayOf(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID))
+                systemPermissionGranted()
             } else {
-                request.deny()
+                denyPermissions()
             }
             return
         }
@@ -161,7 +165,7 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
             DRM_LEARN_MORE_ANNOTATION,
             activity.getText(R.string.drmSiteDialogSubtitle),
         ) {
-            request.deny()
+            denyPermissions()
             dialog.dismiss()
             activity.startActivity(Intent(Intent.ACTION_VIEW, DRM_LEARN_MORE_URL))
         }
@@ -171,25 +175,25 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
         }
 
         binding.siteAllowAlwaysDrmPermission.setOnClickListener {
-            request.grant(arrayOf(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID))
+            systemPermissionGranted()
             onSiteDrmPermissionSave(domain, SitePermissionAskSettingType.ALLOW_ALWAYS)
             dialog.dismiss()
         }
 
         binding.siteAllowOnceDrmPermission.setOnClickListener {
             sitePermissionsRepository.saveDrmForSession(domain, true)
-            request.grant(arrayOf(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID))
+            systemPermissionGranted()
             dialog.dismiss()
         }
 
         binding.siteDenyOnceDrmPermission.setOnClickListener {
             sitePermissionsRepository.saveDrmForSession(domain, false)
-            request.deny()
+            denyPermissions()
             dialog.dismiss()
         }
 
         binding.siteDenyAlwaysDrmPermission.setOnClickListener {
-            request.deny()
+            denyPermissions()
             onSiteDrmPermissionSave(domain, SitePermissionAskSettingType.DENY_ALWAYS)
             dialog.dismiss()
         }
@@ -274,20 +278,10 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
     }
 
     private fun systemPermissionGranted() {
-        when (permissionRequested) {
-            SitePermissionsRequestedType.CAMERA -> {
-                sitePermissionRequest.grant(arrayOf(PermissionRequest.RESOURCE_VIDEO_CAPTURE))
-                sitePermissionsRepository.sitePermissionGranted(siteURL, tabId, PermissionRequest.RESOURCE_VIDEO_CAPTURE)
-            }
-            SitePermissionsRequestedType.AUDIO -> {
-                sitePermissionRequest.grant(arrayOf(PermissionRequest.RESOURCE_AUDIO_CAPTURE))
-                sitePermissionsRepository.sitePermissionGranted(siteURL, tabId, PermissionRequest.RESOURCE_AUDIO_CAPTURE)
-            }
-            SitePermissionsRequestedType.CAMERA_AND_AUDIO -> {
-                sitePermissionRequest.grant(arrayOf(PermissionRequest.RESOURCE_VIDEO_CAPTURE, PermissionRequest.RESOURCE_AUDIO_CAPTURE))
-                sitePermissionsRepository.sitePermissionGranted(siteURL, tabId, PermissionRequest.RESOURCE_VIDEO_CAPTURE)
-                sitePermissionsRepository.sitePermissionGranted(siteURL, tabId, PermissionRequest.RESOURCE_AUDIO_CAPTURE)
-            }
+        val permissions = permissionsHandledAutomatically.toTypedArray() + permissionsHandledByUser
+        sitePermissionRequest.grant(permissions)
+        permissionsHandledByUser.forEach {
+            sitePermissionsRepository.sitePermissionGranted(siteURL, tabId, it)
         }
         checkIfActionNeeded()
     }
@@ -339,7 +333,9 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
                         transientBottomBar: Snackbar?,
                         event: Int,
                     ) {
-                        if (event == BaseCallback.DISMISS_EVENT_TIMEOUT) { sitePermissionRequest.deny() }
+                        if (event == BaseCallback.DISMISS_EVENT_TIMEOUT) {
+                            denyPermissions()
+                        }
                     }
                 },
             )
@@ -347,8 +343,16 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
         }
     }
 
+    private fun denyPermissions() {
+        if (permissionsHandledAutomatically.isNotEmpty()) {
+            sitePermissionRequest.grant(permissionsHandledAutomatically.toTypedArray())
+        } else {
+            sitePermissionRequest.deny()
+        }
+    }
+
     private fun showSystemPermissionsDeniedDialog() {
-        sitePermissionRequest.deny()
+        denyPermissions()
         val titleRes = when (permissionRequested) {
             SitePermissionsRequestedType.CAMERA -> R.string.systemPermissionDialogCameraDeniedTitle
             SitePermissionsRequestedType.AUDIO -> R.string.systemPermissionDialogAudioDeniedTitle

--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsRepository.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsRepository.kt
@@ -20,7 +20,7 @@ import android.webkit.PermissionRequest
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.global.DispatcherProvider
 import com.duckduckgo.app.global.extractDomain
-import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.site.permissions.store.SitePermissionsPreferences
 import com.duckduckgo.site.permissions.store.sitepermissions.SitePermissionAskSettingType
 import com.duckduckgo.site.permissions.store.sitepermissions.SitePermissionsDao
@@ -53,7 +53,8 @@ interface SitePermissionsRepository {
     suspend fun savePermission(sitePermissionsEntity: SitePermissionsEntity)
 }
 
-@ContributesBinding(ActivityScope::class)
+// Cannot be a Singleton
+@ContributesBinding(AppScope::class)
 class SitePermissionsRepositoryImpl @Inject constructor(
     private val sitePermissionsDao: SitePermissionsDao,
     private val sitePermissionsAllowedDao: SitePermissionsAllowedDao,

--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/di/SitePermissionsModule.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/di/SitePermissionsModule.kt
@@ -17,12 +17,8 @@
 package com.duckduckgo.site.permissions.impl.di
 
 import android.content.Context
-import android.content.pm.PackageManager
 import androidx.room.Room
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.site.permissions.api.SitePermissionsManager
-import com.duckduckgo.site.permissions.impl.SitePermissionsManagerImpl
-import com.duckduckgo.site.permissions.impl.SitePermissionsRepositoryImpl
 import com.duckduckgo.site.permissions.store.ALL_MIGRATIONS
 import com.duckduckgo.site.permissions.store.SitePermissionsDatabase
 import com.duckduckgo.site.permissions.store.SitePermissionsPreferences
@@ -57,14 +53,6 @@ object SitePermissionsModule {
     @SingleInstanceIn(AppScope::class)
     fun providesSitePermissionsAllowedDao(sitePermissionsDatabase: SitePermissionsDatabase): SitePermissionsAllowedDao {
         return sitePermissionsDatabase.sitePermissionsAllowedDao()
-    }
-
-    @Provides
-    fun providesSitePermissionsManager(
-        sitePermissionsRepository: SitePermissionsRepositoryImpl,
-        packageManager: PackageManager,
-    ): SitePermissionsManager {
-        return SitePermissionsManagerImpl(packageManager, sitePermissionsRepository)
     }
 
     @Provides


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205815328063411/f 

### Description
This PR refactors permissions so the ones that can be accepted or denied automatically are done within the module rather than the fragment.

### Steps to test this PR

_Camera/mic deny_
- [x] Go to http://webcamera.io/
- [x] Deny the camera/mic permissions
- [x] Go to Settings --> Permissions --> Site Permissions
- [x] Verify webcamera.io is **not** under "Manage Sites"

_Camera/mic allow_
- [x] Go to http://webcamera.io/
- [x] Allow the camera/mic permissions
- [x] Go to Settings --> Permissions --> Site Permissions
- [x] Verify webcamera.io is under "Manage Sites" and is set to ask for all permissions

_Camera/mic allow within 24h_
- [x] Go to Settings --> Permissions --> Site Permissions
- [x] Tap on webcamera.io under "Manage Sites"
- [x] Set microphone permission to "Allow"
- [x] Reload the web on the same tab
- [x] Check all permissions are granted without prompt (camera should work)
- [x] Close the tab
- [x] Go to http://webcamera.io/ on a new tab
- [x] Deny the camera permission (this can trigger the website to re-ask for the permission several times)
- [x] Camera should not work.
- [x] Reload the site and this time accept the camera permission.
- [x] Camera should work.

_Camera/mic always allow_
- [x] Go to Settings --> Permissions --> Site Permissions
- [x] Tap on webcamera.io under "Manage Sites"
- [x] Set camera permission to "Allow"
- [x] Open a new tab
- [x] Go to http://webcamera.io/ and check permission is granted without prompt

_Camera/mic always deny
- [x] Go to Settings --> Permissions --> Site Permissions
- [x] Tap on webcamera.io under "Manage Sites"
- [x] Set camera permission to "Deny"
- [x] Go to http://webcamera.io/ and check permission is not granted (camera doesn't work and you are not asked)

_Session-based Consent_
- [x] Load https://shaka-player-demo.appspot.com/demo/ - DRM consent prompt should appear
- [x] Select  "Only for this Session"
- [x] Verify that you are able to play the 3rd video, Sintel (it's encrypted with Widevine)
- [x] Reload the page and verify that you are still able to play the video and no dialog appears
- [x] Open a new tab and go to https://shaka-player-demo.appspot.com/demo/
- [x] Consent prompt should appear - select "Deny for this Session"
- [x] Verify that the 3rd video, Sintel, is not available
- [x] Reload the page - video should still be unavailable and no consent prompt should appear

_Random tests_
- [x] Go to https://permission.site
- [x] If not already change to https
- [x] Click on microphone and allow, should be green.
- [x] Click on camera and deny, should be red
- [x] Click on camera and microphone
- [x] Should ask you about camera permission (mic was already accepted)
- [x] Deny and should be red
- [x] Click again, should ask for camera and allow. Should be green.

