### PR TITLE
Update reference tests to version 1699613603

### DIFF
--- a/app/src/test/resources/reference_tests/brokensites/multiple_report_tests.json
+++ b/app/src/test/resources/reference_tests/brokensites/multiple_report_tests.json
@@ -15,6 +15,7 @@
                         "blocklistVersion": "abc123",
                         "remoteConfigEtag": "abd142",
                         "remoteConfigVersion": "1234",
+                        "protectionsEnabled": true,
                         "expectReportURLPrefix": "https://improving.duckduckgo.com/t/epbf",
                         "expectReportURLParams": [
                             {"name": "category", "value": "content"},
@@ -23,7 +24,8 @@
                             {"name": "tds", "value": "abc123"},
                             {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
                             {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"},
-                            {"name": "lastSentDay", "present": false}
+                            {"name": "lastSentDay", "present": false},
+                            {"name": "protectionsState", "value": "true"}
                         ]
                     },
                     {
@@ -36,6 +38,7 @@
                         "blocklistVersion": "abc123",
                         "remoteConfigEtag": "abd142",
                         "remoteConfigVersion": "1234",
+                        "protectionsEnabled": true,
                         "expectReportURLPrefix": "https://improving.duckduckgo.com/t/epbf",
                         "expectReportURLParams": [
                             {"name": "category", "value": "content"},
@@ -46,7 +49,8 @@
                             {"name": "remoteConfigVersion", "value": "1234"},
                             {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
                             {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"},
-                            {"name": "lastSentDay", "present": true, "matchesCurrentDay": true, "matches": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"}
+                            {"name": "lastSentDay", "present": true, "matchesCurrentDay": true, "matches": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"},
+                            {"name": "protectionsState", "value": "true"}
                         ]
                     },
                     {
@@ -59,6 +63,7 @@
                         "blocklistVersion": "abc123",
                         "remoteConfigEtag": "abd142",
                         "remoteConfigVersion": "1234",
+                        "protectionsEnabled": true,
                         "expectReportURLPrefix": "https://improving.duckduckgo.com/t/epbf",
                         "expectReportURLParams": [
                             {"name": "category", "value": "content"},
@@ -69,7 +74,8 @@
                             {"name": "remoteConfigVersion", "value": "1234"},
                             {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
                             {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"},
-                            {"name": "lastSentDay", "present": false}
+                            {"name": "lastSentDay", "present": false},
+                            {"name": "protectionsState", "value": "true"}
                         ]
                     },
                     {
@@ -82,6 +88,7 @@
                         "blocklistVersion": "abc123",
                         "remoteConfigEtag": "abd142",
                         "remoteConfigVersion": "1234",
+                        "protectionsEnabled": true,
                         "expectReportURLPrefix": "https://improving.duckduckgo.com/t/epbf",
                         "expectReportURLParams": [
                             {"name": "category", "value": "content"},
@@ -92,7 +99,8 @@
                             {"name": "remoteConfigVersion", "value": "1234"},
                             {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
                             {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"},
-                            {"name": "lastSentDay", "present": true, "matchesCurrentDay": true, "matches": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"}
+                            {"name": "lastSentDay", "present": true, "matchesCurrentDay": true, "matches": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"},
+                            {"name": "protectionsState", "value": "true"}
                         ]
                     },
                     {
@@ -105,6 +113,7 @@
                         "blocklistVersion": "abc123",
                         "remoteConfigEtag": "abd142",
                         "remoteConfigVersion": "1234",
+                        "protectionsEnabled": true,
                         "expectReportURLPrefix": "https://improving.duckduckgo.com/t/epbf",
                         "expectReportURLParams": [
                             {"name": "category", "value": "content"},
@@ -115,7 +124,8 @@
                             {"name": "remoteConfigVersion", "value": "1234"},
                             {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
                             {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"},
-                            {"name": "lastSentDay", "present": false}
+                            {"name": "lastSentDay", "present": false},
+                            {"name": "protectionsState", "value": "true"}
                         ]
                     }
                 ],

--- a/app/src/test/resources/reference_tests/brokensites/tests.json
+++ b/app/src/test/resources/reference_tests/brokensites/tests.json
@@ -13,6 +13,7 @@
                 "blocklistVersion": "abc123",
                 "remoteConfigEtag": "abd142",
                 "remoteConfigVersion": "1234",
+                "protectionsEnabled": true,
                 "expectReportURLPrefix": "https://improving.duckduckgo.com/t/epbf",
                 "expectReportURLParams": [
                     {"name": "category", "value": "content"},
@@ -20,9 +21,65 @@
                     {"name": "upgradedHttps", "value": "true"},
                     {"name": "tds", "value": "abc123"},
                     {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
-                    {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"}
+                    {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"},
+                    {"name": "protectionsState", "value": "true"}
                 ],
                 "exceptPlatforms": []
+            },
+            {
+                "name": "Protections disabled",
+                "siteURL": "https://example.test/",
+                "wasUpgraded": true,
+                "category": "content",
+                "blockedTrackers": ["bad.tracker.test", "tracking.test"],
+                "surrogates": ["surrogate.domain.test", "domain2.test"],
+                "atb": "v123-456g",
+                "blocklistVersion": "abc123",
+                "remoteConfigEtag": "abd142",
+                "remoteConfigVersion": "1234",
+                "protectionsEnabled": false,
+                "expectReportURLPrefix": "https://improving.duckduckgo.com/t/epbf",
+                "expectReportURLParams": [
+                    {"name": "category", "value": "content"},
+                    {"name": "siteUrl", "value": "https%3A%2F%2Fexample.test%2F"},
+                    {"name": "upgradedHttps", "value": "true"},
+                    {"name": "tds", "value": "abc123"},
+                    {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
+                    {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"},
+                    {"name": "protectionsState", "value": "false"}
+                ],
+                "exceptPlatforms": []
+            },
+            {
+                "name": "Protections force-enabled by the user",
+                "siteURL": "https://example.test/",
+                "wasUpgraded": true,
+                "category": "content",
+                "blockedTrackers": ["bad.tracker.test", "tracking.test"],
+                "surrogates": ["surrogate.domain.test", "domain2.test"],
+                "atb": "v123-456g",
+                "blocklistVersion": "abc123",
+                "remoteConfigEtag": "abd142",
+                "remoteConfigVersion": "1234",
+                "protectionsEnabled": false,
+                "denylisted": true,
+                "expectReportURLPrefix": "https://improving.duckduckgo.com/t/epbf",
+                "expectReportURLParams": [
+                    {"name": "category", "value": "content"},
+                    {"name": "siteUrl", "value": "https%3A%2F%2Fexample.test%2F"},
+                    {"name": "upgradedHttps", "value": "true"},
+                    {"name": "tds", "value": "abc123"},
+                    {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
+                    {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"},
+                    {"name": "protectionsState", "value": "true"}
+                ],
+                "exceptPlatforms": [
+                    "android-browser",
+                    "ios-browser",
+                    "macos-browser",
+                    "safari-extension",
+                    "windows-browser"
+                ]
             },
             {
                 "name": "Simple test with a common set of fields",
@@ -35,6 +92,7 @@
                 "blocklistVersion": "abc123",
                 "remoteConfigEtag": "abd142",
                 "remoteConfigVersion": "1234",
+                "protectionsEnabled": true,
                 "expectReportURLPrefix": "https://improving.duckduckgo.com/t/epbf",
                 "expectReportURLParams": [
                     {"name": "category", "value": "content"},
@@ -44,7 +102,8 @@
                     {"name": "remoteConfigEtag", "value": "abd142"},
                     {"name": "remoteConfigVersion", "value": "1234"},
                     {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
-                    {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"}
+                    {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"},
+                    {"name": "protectionsState", "value": "true"}
                 ],
                 "exceptPlatforms": [
                     "ios-browser"
@@ -61,6 +120,7 @@
                 "blocklistVersion": "W/\"cb62f38dda52e13f76c06147b7aea50c\"",
                 "remoteConfigEtag": "W/\"4acd4754aff66f5da1ea044580a60cd3\"",
                 "remoteConfigVersion": "1234",
+                "protectionsEnabled": true,
                 "expectReportURLPrefix": "https://improving.duckduckgo.com/t/epbf",
                 "expectReportURLParams": [
                     {"name": "category", "value": "content"},
@@ -70,7 +130,8 @@
                     {"name": "remoteConfigEtag", "value": "W%2F%224acd4754aff66f5da1ea044580a60cd3%22"},
                     {"name": "remoteConfigVersion", "value": "1234"},
                     {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
-                    {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"}
+                    {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"},
+                    {"name": "protectionsState", "value": "true"}
                 ],
                 "exceptPlatforms": [
                     "ios-browser"
@@ -87,6 +148,7 @@
                 "blocklistVersion": "\"cb62f38dda52e13f76c06147b7aea50c\"",
                 "remoteConfigEtag": "\"4acd4754aff66f5da1ea044580a60cd3\"",
                 "remoteConfigVersion": "1234",
+                "protectionsEnabled": true,
                 "expectReportURLPrefix": "https://improving.duckduckgo.com/t/epbf",
                 "expectReportURLParams": [
                     {"name": "category", "value": "content"},
@@ -96,7 +158,8 @@
                     {"name": "remoteConfigEtag", "value": "%224acd4754aff66f5da1ea044580a60cd3%22"},
                     {"name": "remoteConfigVersion", "value": "1234"},
                     {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
-                    {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"}
+                    {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"},
+                    {"name": "protectionsState", "value": "true"}
                 ],
                 "exceptPlatforms": [
                     "ios-browser"
@@ -111,6 +174,7 @@
                 "surrogates": [],
                 "atb": "v123-456g",
                 "blocklistVersion": "abc123",
+                "protectionsEnabled": true,
                 "expectReportURLPrefix": "https://improving.duckduckgo.com/t/epbf",
                 "expectReportURLParams": [
                     {"name": "category", "value": "paywall"},
@@ -118,7 +182,8 @@
                     {"name": "upgradedHttps", "value": "false"},
                     {"name": "tds", "value": "abc123"},
                     {"name": "blockedTrackers", "value": ""},
-                    {"name": "surrogates", "value": ""}
+                    {"name": "surrogates", "value": ""},
+                    {"name": "protectionsState", "value": "true"}
                 ],
                 "exceptPlatforms": []
             },
@@ -132,6 +197,7 @@
                 "atb": "v123-456g",
                 "blocklistVersion": "abc123",
                 "providedDescription": "This is+a&description./\nThat spans %20lines\"'. With \\emoji: 😀",
+                "protectionsEnabled": true,
                 "expectReportURLPrefix": "https://improving.duckduckgo.com/t/epbf",
                 "expectReportURLParams": [
                     {"name": "category", "value": "content"},
@@ -140,7 +206,8 @@
                     {"name": "upgradedHttps", "value": "true"},
                     {"name": "tds", "value": "abc123"},
                     {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
-                    {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"}
+                    {"name": "surrogates", "value": "surrogate.domain.test,domain2.test"},
+                    {"name": "protectionsState", "value": "true"}
                 ],
                 "exceptPlatforms": [
                     "ios-browser",
@@ -160,6 +227,7 @@
                 "model": "305 RAMAC",
                 "os": "12",
                 "gpcEnabled": true,
+                "protectionsEnabled": true,
                 "expectReportURLPrefix": "https://improving.duckduckgo.com/t/epbf",
                 "expectReportURLParams": [
                     {"name": "category", "value": "images"},
@@ -171,7 +239,8 @@
                     {"name": "manufacturer", "value": "IBM"},
                     {"name": "model", "value": "305 RAMAC"},
                     {"name": "os", "value": "12"},
-                    {"name": "gpc", "value": "true"}
+                    {"name": "gpc", "value": "true"},
+                    {"name": "protectionsState", "value": "true"}
                 ],
                 "exceptPlatforms": [
                     "web-extension",
@@ -193,6 +262,7 @@
                 "surrogates": ["surrogate.domain.test", "domain2.com", "nested.sub.domain3.com"],
                 "atb": "v123-456g",
                 "blocklistVersion": "abc123",
+                "protectionsEnabled": true,
                 "expectReportURLPrefix": "https://improving.duckduckgo.com/t/epbf",
                 "expectReportURLParams": [
                     {"name": "category", "value": "content"},
@@ -204,7 +274,8 @@
                     {"name": "noActionRequests", "value": "noaction1.test,sub.noaction2.test"},
                     {"name": "adAttributionRequests", "value": "adattr1.test,sub.adattr2.test"},
                     {"name": "ignoredByUserRequests", "value": "ignoreuser1.test,sub.ignoreuser2.test"},
-                    {"name": "surrogates", "value": "surrogate.domain.test,domain2.com,nested.sub.domain3.com"}
+                    {"name": "surrogates", "value": "surrogate.domain.test,domain2.com,nested.sub.domain3.com"},
+                    {"name": "protectionsState", "value": "true"}
                 ],
                 "exceptPlatforms": [
                     "android-browser",
@@ -227,6 +298,7 @@
                 "surrogates": [],
                 "atb": "v123-456g",
                 "blocklistVersion": "abc123",
+                "protectionsEnabled": true,
                 "expectReportURLPrefix": "https://improving.duckduckgo.com/t/epbf",
                 "expectReportURLParams": [
                     {"name": "category", "value": "content"},
@@ -238,7 +310,8 @@
                     {"name": "noActionRequests", "value": ""},
                     {"name": "adAttributionRequests", "value": ""},
                     {"name": "ignoredByUserRequests", "value": "ignoreuser1.test,sub.ignoreuser2.test"},
-                    {"name": "surrogates", "value": ""}
+                    {"name": "surrogates", "value": ""},
+                    {"name": "protectionsState", "value": "true"}
                 ],
                 "exceptPlatforms": [
                     "android-browser",
@@ -261,6 +334,7 @@
                 "surrogates": ["surrogate.domain.test", "domain2.com", "nested.sub.domain3.com"],
                 "atb": "v123-456g",
                 "blocklistVersion": "abc123",
+                "protectionsEnabled": true,
                 "expectReportURLPrefix": "https://improving.duckduckgo.com/t/epbf",
                 "expectReportURLParams": [
                     {"name": "category", "value": "content"},
@@ -269,7 +343,8 @@
                     {"name": "tds", "value": "abc123"},
                     {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
                     {"name": "surrogates", "value": "surrogate.domain.test,domain2.com,nested.sub.domain3.com"},
-                    {"name": "truncated", "value": "1"}
+                    {"name": "truncated", "value": "1"},
+                    {"name": "protectionsState", "value": "true"}
                 ],
                 "exceptPlatforms": [
                     "android-browser",
@@ -293,6 +368,7 @@
                 "surrogates": ["surrogate.domain.test", "domain2.com", "nested.sub.domain3.com"],
                 "atb": "v123-456g",
                 "blocklistVersion": "abc123",
+                "protectionsEnabled": true,
                 "expectReportURLPrefix": "https://improving.duckduckgo.com/t/epbf",
                 "expectReportURLParams": [
                     {"name": "category", "value": "content"},
@@ -302,7 +378,8 @@
                     {"name": "tds", "value": "abc123"},
                     {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
                     {"name": "surrogates", "value": "surrogate.domain.test,domain2.com,nested.sub.domain3.com"},
-                    {"name": "truncated", "value": "1"}
+                    {"name": "truncated", "value": "1"},
+                    {"name": "protectionsState", "value": "true"}
                 ],
                 "exceptPlatforms": [
                     "android-browser",
@@ -325,6 +402,7 @@
                 "surrogates": ["surrogate.domain.test", "domain2.com", "nested.sub.domain3.com"],
                 "atb": "v123-456g",
                 "blocklistVersion": "abc123",
+                "protectionsEnabled": true,
                 "expectReportURLPrefix": "https://improving.duckduckgo.com/t/epbf",
                 "expectReportURLParams": [
                     {"name": "category", "value": "content"},
@@ -333,7 +411,8 @@
                     {"name": "tds", "value": "abc123"},
                     {"name": "blockedTrackers", "value": "bad.tracker.test,tracking.test"},
                     {"name": "surrogates", "value": "surrogate.domain.test,domain2.com,nested.sub.domain3.com"},
-                    {"name": "truncated", "value": "1"}
+                    {"name": "truncated", "value": "1"},
+                    {"name": "protectionsState", "value": "true"}
                 ],
                 "exceptPlatforms": [
                     "android-browser",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#9.0.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.45.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.7.0",
-        "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1699439919"
+        "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1699613603"
       },
       "devDependencies": {
         "@rollup/plugin-json": "^4.1.0",
@@ -90,7 +90,7 @@
       }
     },
     "node_modules/@duckduckgo/privacy-reference-tests": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#7519c3d430e5dcef75b6128bfdadb0de3f463a49",
+      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#a3acc2194758bec0f01f57dd0c5f106de01a354e",
       "license": "Apache-2.0"
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#9.0.0",
     "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.45.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.7.0",
-    "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1699439919"
+    "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1699613603"
   }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1205935778872726/f 

 ----- 
- Automated reference tests dependency update

This PR updates the reference tests dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/0/1203766026095653/f for further information on what to do next.

- [x] All tests must pass