### PR TITLE
Defer voice search JSON adapter creation until it's off main thread

### DIFF
--- a/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/di/VoiceSearchModule.kt
+++ b/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/di/VoiceSearchModule.kt
@@ -24,7 +24,6 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.voice.api.VoiceSearchStatusListener
 import com.duckduckgo.voice.impl.remoteconfig.RealVoiceSearchFeatureRepository
 import com.duckduckgo.voice.impl.remoteconfig.VoiceSearchFeatureRepository
-import com.duckduckgo.voice.impl.remoteconfig.VoiceSearchSetting
 import com.duckduckgo.voice.store.ALL_MIGRATIONS
 import com.duckduckgo.voice.store.RealVoiceSearchRepository
 import com.duckduckgo.voice.store.SharedPreferencesVoiceSearchDataStore
@@ -32,9 +31,6 @@ import com.duckduckgo.voice.store.VoiceSearchDataStore
 import com.duckduckgo.voice.store.VoiceSearchDatabase
 import com.duckduckgo.voice.store.VoiceSearchRepository
 import com.squareup.anvil.annotations.ContributesTo
-import com.squareup.moshi.JsonAdapter
-import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import dagger.Module
 import dagger.Provides
 import dagger.SingleInstanceIn
@@ -72,12 +68,5 @@ object VoiceSearchModule {
         dispatcherProvider: DispatcherProvider,
     ): VoiceSearchFeatureRepository {
         return RealVoiceSearchFeatureRepository(database, coroutineScope, dispatcherProvider)
-    }
-
-    @SingleInstanceIn(AppScope::class)
-    @Provides
-    fun provideVoiceSearchJsonAdapter(): JsonAdapter<VoiceSearchSetting> {
-        val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
-        return moshi.adapter(VoiceSearchSetting::class.java)
     }
 }

--- a/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/remoteconfig/VoiceSearchFeatureSettingStore.kt
+++ b/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/remoteconfig/VoiceSearchFeatureSettingStore.kt
@@ -21,18 +21,26 @@ import com.duckduckgo.feature.toggles.api.FeatureSettings
 import com.duckduckgo.feature.toggles.api.RemoteFeatureStoreNamed
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import javax.inject.Inject
 
 @ContributesBinding(AppScope::class)
 @RemoteFeatureStoreNamed(VoiceSearchFeature::class)
 class VoiceSearchFeatureSettingStore @Inject constructor(
     private val voiceSearchFeatureRepository: VoiceSearchFeatureRepository,
-    private val jsonAdapter: JsonAdapter<VoiceSearchSetting>,
 ) : FeatureSettings.Store {
+
+    private val jsonAdapter by lazy { buildJsonAdapter() }
 
     override fun store(jsonSettings: String) {
         jsonAdapter.fromJson(jsonSettings)?.let {
             voiceSearchFeatureRepository.updateAllExceptions(it.excludedManufacturers, it.minVersion)
         }
+    }
+
+    private fun buildJsonAdapter(): JsonAdapter<VoiceSearchSetting> {
+        val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+        return moshi.adapter(VoiceSearchSetting::class.java)
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205939214156691/f 

### Description
We saw some ANRs due to the way we were eagerly instantiating the JSON adapter on process lifecycle start.

This PR defers the creation until it's needed (which is on a worker thread).

### Steps to test this PR

- [x] Clean install
- [x] Ensure no problems parsing voice search remote config
