### PR TITLE
Update content scope scripts to version 4.48.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -714,9 +714,10 @@
         return new OriginalCustomEvent(eventName, eventDetail)
     }
 
-    function sendMessage (messageType, options) {
+    /** @deprecated */
+    function legacySendMessage (messageType, options) {
         // FF & Chrome
-        return originalWindowDispatchEvent(createCustomEvent('sendMessageProxy' + messageSecret, { detail: { messageType, options } }))
+        return originalWindowDispatchEvent && originalWindowDispatchEvent(createCustomEvent('sendMessageProxy' + messageSecret, { detail: { messageType, options } }))
         // TBD other platforms
     }
 
@@ -2849,7 +2850,7 @@
                 params = msg.params?.youTubeCTLAddedFlag;
             }
 
-            sendMessage(msg.method, params);
+            legacySendMessage(msg.method, params);
         }
 
         /**
@@ -2876,7 +2877,7 @@
                 params = req.params?.videoURL;
             }
 
-            sendMessage(req.method, params);
+            legacySendMessage(req.method, params);
 
             return new this.globals.Promise((resolve) => {
                 this._subscribe(comparator, (msgRes, unsubscribe) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^5.1.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.46.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.48.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.7.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1699613603"
       },
@@ -69,7 +69,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#4000215c763e1b25a0237e072c404a6d1cc47122",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#03c22270d58ac392cbc495b1119dd4afec0a381c",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^5.1.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.46.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.48.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#1.7.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1699613603"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1205946016107233/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass