### PR TITLE
Sync: Move login sync to io

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
@@ -36,10 +36,9 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import dagger.*
 import dagger.SingleInstanceIn
+import javax.inject.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import javax.inject.*
 import timber.log.Timber
 
 interface SyncAccountRepository {
@@ -70,7 +69,7 @@ class AppSyncAccountRepository @Inject constructor(
     private val syncEngine: SyncEngine,
     private val syncPixels: SyncPixels,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
-    private val dispatcherProvider: DispatcherProvider
+    private val dispatcherProvider: DispatcherProvider,
 ) : SyncAccountRepository {
 
     override fun createAccount(): Result<Boolean> {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.sync.impl
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.global.DefaultDispatcherProvider
 import com.duckduckgo.sync.TestSyncFixtures.accountCreatedFailDupUser
 import com.duckduckgo.sync.TestSyncFixtures.accountCreatedSuccess
 import com.duckduckgo.sync.TestSyncFixtures.accountKeys
@@ -58,6 +59,7 @@ import com.duckduckgo.sync.crypto.SyncLib
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.pixels.*
 import com.duckduckgo.sync.store.SyncStore
+import kotlinx.coroutines.test.TestScope
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -87,7 +89,8 @@ class AppSyncAccountRepositoryTest {
 
     @Before
     fun before() {
-        syncRepo = AppSyncAccountRepository(syncDeviceIds, nativeLib, syncApi, syncStore, syncEngine, syncPixels)
+        syncRepo =
+            AppSyncAccountRepository(syncDeviceIds, nativeLib, syncApi, syncStore, syncEngine, syncPixels, TestScope(), DefaultDispatcherProvider())
     }
 
     @Test


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1204909556811580/f 

### Description
This PR ensures that the UI login an account is not blocked until the first sync operation finishes.

### Steps to test this PR
- Import html file attached to Asana task
- Remove folder with 500 bookmarks to avoid object limit
- You’ll need two devices for this

_Login (this branch)_ 
- [x] With one device, create a sync account with the data described above
- [x] In the second device, log into the account previously created
- [x] Verify that the ‘Device Synced” screen appears almost immediately
- [x] Navigate to Bookmarks
- [x] Verify that bookmarks start appearing

For comparison, do the same operations from develop and verify that the “Device Synced” screen takes much longer to appear