### PR TITLE
Update autofill dialog copy, changing "logins" to "passwords"

### DIFF
--- a/autofill/autofill-impl/src/main/res/values-bg/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-bg/strings-autofill-impl.xml
@@ -23,14 +23,14 @@
     <string name="managementDisabledModeSubtitle">За защита на данните за вход е необходимо да зададете модел за заключване, ПИН код или биометрични данни.</string>
     <string name="managementDisabledModeTitle">Защитете устройството, за да можете да запазвате данни за вход</string>
 
-    <string name="saveLoginDialogButtonSave">Запазване на данните за вход</string>
+    <string name="saveLoginDialogButtonSave">Запазване на паролата</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Запазване на паролата</string>
     <string name="saveLoginDialogNotNow">Не записвай</string>
-    <string name="saveLoginDialogSubtitle">Данните за вход се съхраняват на сигурно място в менюто Данни за вход на Вашето устройство.</string>
-    <string name="saveLoginDialogTitle">Искате ли DuckDuckGo да запази данните за вход?</string>
+    <string name="saveLoginDialogSubtitle">Паролите се съхраняват на сигурно място в менюто Данни за вход на Вашето устройство.</string>
+    <string name="saveLoginDialogTitle">Искате ли DuckDuckGo да запази Вашата парола?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Повече опции</string>
 
-    <string name="useSavedLoginDialogTitle">Да се използват ли запазените данни за вход?</string>
+    <string name="useSavedLoginDialogTitle">Използване на запазена парола?</string>
     <string name="useSavedLoginDialogMissingUsernameButtonText" instruction="Placeholder is the name of a website">Парола за %1$s</string>
     <string name="useSavedLoginDialogMissingUsernameMissingDomainButtonText">Парола за сайта</string>
     <string name="useSavedLoginDialogGroupThisWebsite">От този уебсайт</string>
@@ -43,7 +43,7 @@
     <string name="updateLoginDialogButtonUpdateUsername">Актуализиране на потребителското име</string>
 
     <string name="updateLoginDialogTitleLine" instruction="Placeholder is the user&apos;s username for this site">Актуализиране на паролата за \n%1$s?</string>
-    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo ще актуализира запазените данни за вход във Вашето устройство.</string>
+    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo ще актуализира запазената парола във Вашето устройство.</string>
 
     <string name="autofillDialogCloseButtonContentDescription">Затваряне на диалоговия прозорец за автоматично попълване</string>
 

--- a/autofill/autofill-impl/src/main/res/values-cs/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-cs/strings-autofill-impl.xml
@@ -23,14 +23,14 @@
     <string name="managementDisabledModeSubtitle">Na ochranu přihlašovacích údajů se vyžaduje gesto zámku obrazovky, PIN nebo biometrické ověření.</string>
     <string name="managementDisabledModeTitle">Zabezpeč si zařízení, ať si můžeš ukládat přihlašovací údaje</string>
 
-    <string name="saveLoginDialogButtonSave">Uložit přihlašovací údaje</string>
+    <string name="saveLoginDialogButtonSave">Uložit heslo</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Uložit heslo</string>
     <string name="saveLoginDialogNotNow">Neukládat</string>
-    <string name="saveLoginDialogSubtitle">Přihlašovací údaje jsou bezpečně uložené v zařízení v nabídce Přihlášení.</string>
-    <string name="saveLoginDialogTitle">Má DuckDuckGo uložit přihlašovací údaje?</string>
+    <string name="saveLoginDialogSubtitle">Hesla jsou bezpečně uložená v zařízení v nabídce Přihlášení.</string>
+    <string name="saveLoginDialogTitle">Má DuckDuckGo uložit heslo?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Další možnosti</string>
 
-    <string name="useSavedLoginDialogTitle">Použít uložené přihlášení?</string>
+    <string name="useSavedLoginDialogTitle">Použít uložené heslo?</string>
     <string name="useSavedLoginDialogMissingUsernameButtonText" instruction="Placeholder is the name of a website">Heslo pro %1$s</string>
     <string name="useSavedLoginDialogMissingUsernameMissingDomainButtonText">Heslo pro web</string>
     <string name="useSavedLoginDialogGroupThisWebsite">Z této webové stránky</string>
@@ -43,7 +43,7 @@
     <string name="updateLoginDialogButtonUpdateUsername">Aktualizovat uživatelské jméno</string>
 
     <string name="updateLoginDialogTitleLine" instruction="Placeholder is the user&apos;s username for this site">Aktualizovat heslo pro \n%1$s?</string>
-    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo zaktualizuje toto uložené přihlášení ve tvém zařízení.</string>
+    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo aktualizuje tohle uložené heslo ve tvém zařízení.</string>
 
     <string name="autofillDialogCloseButtonContentDescription">Zavřít dialogové okno Automatické vyplňování</string>
 

--- a/autofill/autofill-impl/src/main/res/values-da/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-da/strings-autofill-impl.xml
@@ -23,14 +23,14 @@
     <string name="managementDisabledModeSubtitle">Der kræves et låsemønster, en pinkode eller biometri for at beskytte dine logins.</string>
     <string name="managementDisabledModeTitle">Beskyt din enhed for at gemme logins</string>
 
-    <string name="saveLoginDialogButtonSave">Gem login</string>
+    <string name="saveLoginDialogButtonSave">Gem adgangskode</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Gem adgangskode</string>
     <string name="saveLoginDialogNotNow">Gem ikke</string>
-    <string name="saveLoginDialogSubtitle">Logins gemmes sikkert på din enhed i menuen Logins.</string>
-    <string name="saveLoginDialogTitle">Skal DuckDuckGo gemme dit login?</string>
+    <string name="saveLoginDialogSubtitle">Adgangskoder gemmes sikkert på din enhed i menuen Logins.</string>
+    <string name="saveLoginDialogTitle">Skal DuckDuckGo gemme din adgangskode?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Flere muligheder</string>
 
-    <string name="useSavedLoginDialogTitle">Vil du bruge et gemt login?</string>
+    <string name="useSavedLoginDialogTitle">Brug en gemt adgangskode?</string>
     <string name="useSavedLoginDialogMissingUsernameButtonText" instruction="Placeholder is the name of a website">Adgangskode til %1$s</string>
     <string name="useSavedLoginDialogMissingUsernameMissingDomainButtonText">Adgangskode til websted</string>
     <string name="useSavedLoginDialogGroupThisWebsite">Fra dette websted</string>
@@ -43,7 +43,7 @@
     <string name="updateLoginDialogButtonUpdateUsername">Opdater brugernavn</string>
 
     <string name="updateLoginDialogTitleLine" instruction="Placeholder is the user&apos;s username for this site">Opdater adgangskode for \n%1$s?</string>
-    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo opdaterer dette gemte login på din enhed.</string>
+    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo opdaterer denne gemte adgangskode på din enhed.</string>
 
     <string name="autofillDialogCloseButtonContentDescription">Luk dialogboksen for automatisk udfyldning</string>
 

--- a/autofill/autofill-impl/src/main/res/values-de/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-de/strings-autofill-impl.xml
@@ -23,14 +23,14 @@
     <string name="managementDisabledModeSubtitle">Es sind ein Entsperrmuster, eine PIN oder biometrische Daten erforderlich, um deine Anmeldedaten zu schützen.</string>
     <string name="managementDisabledModeTitle">Sichere dein Gerät, um Anmeldungen zu speichern</string>
 
-    <string name="saveLoginDialogButtonSave">Anmeldedaten speichern</string>
+    <string name="saveLoginDialogButtonSave">Passwort speichern</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Passwort speichern</string>
     <string name="saveLoginDialogNotNow">Nicht speichern</string>
-    <string name="saveLoginDialogSubtitle">Anmeldedaten werden sicher auf deinem Gerät im Anmeldedaten-Menü gespeichert.</string>
-    <string name="saveLoginDialogTitle">Möchtest du, dass DuckDuckGo deine Anmeldedaten speichert?</string>
+    <string name="saveLoginDialogSubtitle">Passwörter werden sicher auf deinem Gerät im Anmeldedaten-Menü gespeichert.</string>
+    <string name="saveLoginDialogTitle">Möchtest du, dass DuckDuckGo dein Passwort speichert?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Weitere Optionen</string>
 
-    <string name="useSavedLoginDialogTitle">Gespeicherte Anmeldedaten verwenden?</string>
+    <string name="useSavedLoginDialogTitle">Gespeichertes Passwort verwenden?</string>
     <string name="useSavedLoginDialogMissingUsernameButtonText" instruction="Placeholder is the name of a website">Passwort für %1$s</string>
     <string name="useSavedLoginDialogMissingUsernameMissingDomainButtonText">Passwort für die Website</string>
     <string name="useSavedLoginDialogGroupThisWebsite">Von dieser Website</string>
@@ -43,7 +43,7 @@
     <string name="updateLoginDialogButtonUpdateUsername">Benutzernamen aktualisieren</string>
 
     <string name="updateLoginDialogTitleLine" instruction="Placeholder is the user&apos;s username for this site">Passwort für \n%1$s aktualisieren?</string>
-    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo aktualisiert diese gespeicherten Anmeldedaten auf deinem Gerät.</string>
+    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo aktualisiert dieses gespeicherte Passwort auf deinem Gerät.</string>
 
     <string name="autofillDialogCloseButtonContentDescription">Autovervollständigen-Dialog schließen</string>
 

--- a/autofill/autofill-impl/src/main/res/values-el/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-el/strings-autofill-impl.xml
@@ -23,14 +23,14 @@
     <string name="managementDisabledModeSubtitle">Για προστασία των «Συνδέσεών» σας απαιτείται μοτίβο κλειδώματος συσκευής, PIN ή βιομετρικά στοιχεία.</string>
     <string name="managementDisabledModeTitle">Ασφαλίστε τη συσκευή σας για να αποθηκεύετε τις «Συνδέσεις»</string>
 
-    <string name="saveLoginDialogButtonSave">Αποθήκευση σύνδεσης</string>
+    <string name="saveLoginDialogButtonSave">Αποθήκευση κωδικού πρόσβασης</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Αποθήκευση κωδικού πρόσβασης</string>
     <string name="saveLoginDialogNotNow">Να μην αποθηκευτεί</string>
-    <string name="saveLoginDialogSubtitle">Οι συνδέσεις αποθηκεύονται με ασφάλεια στη συσκευή σας στο μενού Συνδέσεις.</string>
-    <string name="saveLoginDialogTitle">Θέλετε να αποθηκεύσει το DuckDuckGo τη σύνδεσή σας;</string>
+    <string name="saveLoginDialogSubtitle">Οι κωδικοί πρόσβασης αποθηκεύονται με ασφάλεια στη συσκευή σας στο μενού Συνδέσεις.</string>
+    <string name="saveLoginDialogTitle">Θέλετε το DuckDuckGo να αποθηκεύσει τον κωδικό πρόσβασής σας;</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Περισσότερες επιλογές</string>
 
-    <string name="useSavedLoginDialogTitle">Χρήση αποθηκευμένων στοιχείων σύνδεσης;</string>
+    <string name="useSavedLoginDialogTitle">Χρήση αποθηκευμένου κωδικού πρόσβασης;</string>
     <string name="useSavedLoginDialogMissingUsernameButtonText" instruction="Placeholder is the name of a website">Κωδικός πρόσβασης για %1$s</string>
     <string name="useSavedLoginDialogMissingUsernameMissingDomainButtonText">Κωδικός πρόσβασης για τον ιστότοπο</string>
     <string name="useSavedLoginDialogGroupThisWebsite">Από αυτόν τον ιστότοπο</string>
@@ -43,7 +43,7 @@
     <string name="updateLoginDialogButtonUpdateUsername">Ενημέρωση ονόματος χρήστη</string>
 
     <string name="updateLoginDialogTitleLine" instruction="Placeholder is the user&apos;s username for this site">Ενημέρωση κωδικού πρόσβασης για \n%1$s;</string>
-    <string name="updateLoginUpdatePasswordExplanation">Το DuckDuckGo θα ενημερώσει αυτήν την αποθηκευμένη σύνδεση στη συσκευή σας.</string>
+    <string name="updateLoginUpdatePasswordExplanation">Το DuckDuckGo θα ενημερώσει αυτόν τον αποθηκευμένο κωδικό πρόσβασης στη συσκευή σας.</string>
 
     <string name="autofillDialogCloseButtonContentDescription">Κλείσιμο διαλόγου αυτόματης συμπλήρωσης</string>
 

--- a/autofill/autofill-impl/src/main/res/values-es/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-es/strings-autofill-impl.xml
@@ -23,14 +23,14 @@
     <string name="managementDisabledModeSubtitle">Se requiere un patrón de bloqueo del dispositivo, un PIN o datos biométricos para proteger tus inicios de sesión.</string>
     <string name="managementDisabledModeTitle">Protege tu dispositivo para guardar los inicios de sesión</string>
 
-    <string name="saveLoginDialogButtonSave">Guardar inicio de sesión</string>
+    <string name="saveLoginDialogButtonSave">Guardar contraseña</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Guardar contraseña</string>
     <string name="saveLoginDialogNotNow">No guardar</string>
-    <string name="saveLoginDialogSubtitle">Los inicios de sesión se almacenan de forma segura en tu dispositivo en el menú Inicios de sesión.</string>
-    <string name="saveLoginDialogTitle">¿Quieres que DuckDuckGo guarde tu inicio de sesión?</string>
+    <string name="saveLoginDialogSubtitle">Las contraseñas se almacenan de forma segura en tu dispositivo en el menú Inicios de sesión.</string>
+    <string name="saveLoginDialogTitle">¿Quieres que DuckDuckGo guarde tu contraseña?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Más opciones</string>
 
-    <string name="useSavedLoginDialogTitle">¿Usar un inicio de sesión guardado?</string>
+    <string name="useSavedLoginDialogTitle">¿Usar una contraseña guardada?</string>
     <string name="useSavedLoginDialogMissingUsernameButtonText" instruction="Placeholder is the name of a website">Contraseña para %1$s</string>
     <string name="useSavedLoginDialogMissingUsernameMissingDomainButtonText">Contraseña para el sitio</string>
     <string name="useSavedLoginDialogGroupThisWebsite">Desde este sitio web</string>
@@ -43,7 +43,7 @@
     <string name="updateLoginDialogButtonUpdateUsername">Actualizar nombre de usuario</string>
 
     <string name="updateLoginDialogTitleLine" instruction="Placeholder is the user&apos;s username for this site">¿Actualizar contraseña de \n%1$s?</string>
-    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo actualizará este inicio de sesión almacenado en tu dispositivo.</string>
+    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo actualizará esta contraseña almacenada en tu dispositivo.</string>
 
     <string name="autofillDialogCloseButtonContentDescription">Cerrar cuadro de diálogo de Autocompletar</string>
 

--- a/autofill/autofill-impl/src/main/res/values-et/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-et/strings-autofill-impl.xml
@@ -23,14 +23,14 @@
     <string name="managementDisabledModeSubtitle">Sisselogimise kaitsmiseks on vaja seadme lukustusmustrit, PIN-koodi või biomeetriat.</string>
     <string name="managementDisabledModeTitle">Sisselogimise salvestamiseks kaitske oma seadet</string>
 
-    <string name="saveLoginDialogButtonSave">Salvesta sisselogimisandmed</string>
+    <string name="saveLoginDialogButtonSave">Salvesta parool</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Salvesta parool</string>
     <string name="saveLoginDialogNotNow">Ära salvesta</string>
-    <string name="saveLoginDialogSubtitle">Logisid hoitakse turvaliselt sinu seadmes logide menüüs.</string>
-    <string name="saveLoginDialogTitle">Kas soovid, et DuckDuckGo salvestaks sinu sisselogimisandmed?</string>
+    <string name="saveLoginDialogSubtitle">Paroole hoitakse turvaliselt sinu seadmes sisselogimisandmete menüüs.</string>
+    <string name="saveLoginDialogTitle">Kas soovid, et DuckDuckGo salvestaks sinu parooli?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Veel valikuid</string>
 
-    <string name="useSavedLoginDialogTitle">Kas kasutada salvestatud sisselogimisandmeid?</string>
+    <string name="useSavedLoginDialogTitle">Kas kasutada salvestatud parooli?</string>
     <string name="useSavedLoginDialogMissingUsernameButtonText" instruction="Placeholder is the name of a website">Saidi %1$s parool</string>
     <string name="useSavedLoginDialogMissingUsernameMissingDomainButtonText">Saidi parool</string>
     <string name="useSavedLoginDialogGroupThisWebsite">Sellelt veebisaidilt</string>
@@ -43,7 +43,7 @@
     <string name="updateLoginDialogButtonUpdateUsername">Värskenda kasutajanime</string>
 
     <string name="updateLoginDialogTitleLine" instruction="Placeholder is the user&apos;s username for this site">Kas värskendada kasutajanime \n%1$s parooli?</string>
-    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo värskendab need salvestatud sisselogimisandmed sinu seadmes.</string>
+    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo värskendab selle salvestatud parooli sinu seadmes.</string>
 
     <string name="autofillDialogCloseButtonContentDescription">Sulge automaatse täitmise dialoog</string>
 

--- a/autofill/autofill-impl/src/main/res/values-fi/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-fi/strings-autofill-impl.xml
@@ -23,14 +23,14 @@
     <string name="managementDisabledModeSubtitle">Kirjautumistietojen suojaamiseen tarvitaan laitteen lukituskuvio, PIN-koodi tai biometriset tiedot.</string>
     <string name="managementDisabledModeTitle">Suojaa laitteesi kirjautumistietojen tallentamiseksi</string>
 
-    <string name="saveLoginDialogButtonSave">Tallenna kirjautumistiedot</string>
+    <string name="saveLoginDialogButtonSave">Tallenna salasana</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Tallenna salasana</string>
     <string name="saveLoginDialogNotNow">Älä tallenna</string>
-    <string name="saveLoginDialogSubtitle">Kirjautumistiedot tallennetaan turvallisesti laitteellesi kirjautumistiedot-valikkoon.</string>
-    <string name="saveLoginDialogTitle">Haluatko, että DuckDuckGo tallentaa kirjautumistietosi?</string>
+    <string name="saveLoginDialogSubtitle">Salasanat tallennetaan turvallisesti laitteellesi kirjautumistiedot-valikkoon.</string>
+    <string name="saveLoginDialogTitle">Haluatko, että DuckDuckGo tallentaa salasanasi?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Lisää vaihtoehtoja</string>
 
-    <string name="useSavedLoginDialogTitle">Käytä tallennettuja kirjautumistietoja?</string>
+    <string name="useSavedLoginDialogTitle">Käytetäänkö tallennettua salasanaa?</string>
     <string name="useSavedLoginDialogMissingUsernameButtonText" instruction="Placeholder is the name of a website">Sivuston %1$s salasana</string>
     <string name="useSavedLoginDialogMissingUsernameMissingDomainButtonText">Sivuston salasana</string>
     <string name="useSavedLoginDialogGroupThisWebsite">Tältä sivustolta</string>
@@ -43,7 +43,7 @@
     <string name="updateLoginDialogButtonUpdateUsername">Päivitä käyttäjätunnus</string>
 
     <string name="updateLoginDialogTitleLine" instruction="Placeholder is the user&apos;s username for this site">Päivitä käyttäjän \n%1$s salasana?</string>
-    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo päivittää tämän laitteellesi tallennetun kirjautumistiedon.</string>
+    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo päivittää tämän tallennetun salasanan laitteellesi.</string>
 
     <string name="autofillDialogCloseButtonContentDescription">Sulje automaattisen täytön valintaikkuna</string>
 

--- a/autofill/autofill-impl/src/main/res/values-fr/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-fr/strings-autofill-impl.xml
@@ -23,14 +23,14 @@
     <string name="managementDisabledModeSubtitle">Un schéma de verrouillage de l\'appareil, un code PIN ou des données biométriques sont nécessaires pour protéger vos identifiants.</string>
     <string name="managementDisabledModeTitle">Sécurisez votre appareil pour enregistrer des identifiants</string>
 
-    <string name="saveLoginDialogButtonSave">Enregistrer l\'identifiant</string>
+    <string name="saveLoginDialogButtonSave">Enregistrer le mot de passe</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Enregistrer le mot de passe</string>
     <string name="saveLoginDialogNotNow">Ne pas enregistrer</string>
-    <string name="saveLoginDialogSubtitle">Les identifiants de connexion sont stockés en toute sécurité sur votre appareil dans le menu Identifiants.</string>
-    <string name="saveLoginDialogTitle">Voulez-vous que DuckDuckGo enregistre votre identifiant ?</string>
+    <string name="saveLoginDialogSubtitle">Les mots de passe sont stockés en toute sécurité sur votre appareil dans le menu Identifiants.</string>
+    <string name="saveLoginDialogTitle">Voulez-vous que DuckDuckGo enregistre votre mot de passe ?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Plus d\'options</string>
 
-    <string name="useSavedLoginDialogTitle">Utiliser un identifiant enregistré ?</string>
+    <string name="useSavedLoginDialogTitle">Utiliser un mot de passe enregistré ?</string>
     <string name="useSavedLoginDialogMissingUsernameButtonText" instruction="Placeholder is the name of a website">Mot de passe pour %1$s</string>
     <string name="useSavedLoginDialogMissingUsernameMissingDomainButtonText">Mot de passe du site</string>
     <string name="useSavedLoginDialogGroupThisWebsite">À partir de ce site Web</string>
@@ -43,7 +43,7 @@
     <string name="updateLoginDialogButtonUpdateUsername">Modifier le nom d\'utilisateur</string>
 
     <string name="updateLoginDialogTitleLine" instruction="Placeholder is the user&apos;s username for this site">Mettre à jour le mot de passe pour \n%1$s ?</string>
-    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo mettra à jour cet identifiant enregistré sur votre appareil.</string>
+    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo mettra à jour ce mot de passe enregistré sur votre appareil.</string>
 
     <string name="autofillDialogCloseButtonContentDescription">Fermer la boîte de dialogue de saisie automatique</string>
 

--- a/autofill/autofill-impl/src/main/res/values-hr/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-hr/strings-autofill-impl.xml
@@ -23,14 +23,14 @@
     <string name="managementDisabledModeSubtitle">Uzorak za zaključavanje uređaja, PIN ili biometrija potrebni su za zaštitu vaših prijava.</string>
     <string name="managementDisabledModeTitle">Osigurajte svoj uređaj da biste spremili prijave</string>
 
-    <string name="saveLoginDialogButtonSave">Spremi prijavu</string>
+    <string name="saveLoginDialogButtonSave">Spremi lozinku</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Spremi lozinku</string>
     <string name="saveLoginDialogNotNow">Nemoj spremiti</string>
-    <string name="saveLoginDialogSubtitle">Prijave su sigurno pohranjene na tvom uređaju u izborniku Prijave.</string>
-    <string name="saveLoginDialogTitle">Želiš li da DuckDuckGo spremi tvoju prijavu?</string>
+    <string name="saveLoginDialogSubtitle">Lozinke su sigurno pohranjene na tvom uređaju u izborniku Prijava.</string>
+    <string name="saveLoginDialogTitle">Želiš li da DuckDuckGo spremi tvoju lozinku?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Dodatne mogućnosti</string>
 
-    <string name="useSavedLoginDialogTitle">Koristiti spremljene podatke za prijavu?</string>
+    <string name="useSavedLoginDialogTitle">Koristiti spremljenu lozinku?</string>
     <string name="useSavedLoginDialogMissingUsernameButtonText" instruction="Placeholder is the name of a website">Lozinka za %1$s</string>
     <string name="useSavedLoginDialogMissingUsernameMissingDomainButtonText">Lozinka za web lokaciju</string>
     <string name="useSavedLoginDialogGroupThisWebsite">S ove web lokacije</string>
@@ -43,7 +43,7 @@
     <string name="updateLoginDialogButtonUpdateUsername">Ažuriraj korisničko ime</string>
 
     <string name="updateLoginDialogTitleLine" instruction="Placeholder is the user&apos;s username for this site">Želiš li ažurirati lozinku za korisnika \n%1$s?</string>
-    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo će ažurirati ovu spremljenu prijavu na tvom uređaju.</string>
+    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo će ažurirati ovu pohranjenu lozinku na tvom uređaju.</string>
 
     <string name="autofillDialogCloseButtonContentDescription">Zatvori dijaloški okvir za automatsko popunjavanje</string>
 

--- a/autofill/autofill-impl/src/main/res/values-hu/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-hu/strings-autofill-impl.xml
@@ -23,14 +23,14 @@
     <string name="managementDisabledModeSubtitle">A bejelentkezések védelméhez az eszköz zárolási mintája, PIN-kód vagy biometrikus adatok szükségesek.</string>
     <string name="managementDisabledModeTitle">Tedd biztonságossá a készülékedet a bejelentkezések mentéséhez</string>
 
-    <string name="saveLoginDialogButtonSave">Bejelentkezés mentése</string>
+    <string name="saveLoginDialogButtonSave">Jelszó mentése</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Jelszó mentése</string>
     <string name="saveLoginDialogNotNow">Mentés mellőzése</string>
-    <string name="saveLoginDialogSubtitle">A rendszer biztonságosan tárolja az eszköz Bejelentkezés menüjében elérhető bejelentkezési adatokat.</string>
-    <string name="saveLoginDialogTitle">A DuckDuckGo mentse a bejelentkezést?</string>
+    <string name="saveLoginDialogSubtitle">A rendszer biztonságosan tárolja az eszköz Bejelentkezés menüjében elérhető jelszavakat.</string>
+    <string name="saveLoginDialogTitle">A DuckDuckGo mentse a jelszót?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">További lehetőségek</string>
 
-    <string name="useSavedLoginDialogTitle">Mentett bejelentkezés használata?</string>
+    <string name="useSavedLoginDialogTitle">Mentett jelszót használsz?</string>
     <string name="useSavedLoginDialogMissingUsernameButtonText" instruction="Placeholder is the name of a website">%1$s jelszava</string>
     <string name="useSavedLoginDialogMissingUsernameMissingDomainButtonText">Webhely jelszava</string>
     <string name="useSavedLoginDialogGroupThisWebsite">Erről a webhelyről</string>
@@ -43,7 +43,7 @@
     <string name="updateLoginDialogButtonUpdateUsername">Felhasználónév frissítése</string>
 
     <string name="updateLoginDialogTitleLine" instruction="Placeholder is the user&apos;s username for this site">Frissíted \n%1$s jelszavát?</string>
-    <string name="updateLoginUpdatePasswordExplanation">A DuckDuckGo frissíti az eszközödön ezt a tárolt bejelentkezést.</string>
+    <string name="updateLoginUpdatePasswordExplanation">A DuckDuckGo frissíti az eszközödön ezt a tárolt jelszót.</string>
 
     <string name="autofillDialogCloseButtonContentDescription">Automatikus kitöltési párbeszédablak bezárása</string>
 

--- a/autofill/autofill-impl/src/main/res/values-lt/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-lt/strings-autofill-impl.xml
@@ -23,14 +23,14 @@
     <string name="managementDisabledModeSubtitle">Prisijungimams apsaugoti reikia naudoti prietaiso užrakinimo šabloną, PIN kodą arba biometrinius duomenis.</string>
     <string name="managementDisabledModeTitle">Apsaugokite įrenginį, kad išsaugotumėte prisijungimus</string>
 
-    <string name="saveLoginDialogButtonSave">Išsaugoti prisijungimą</string>
+    <string name="saveLoginDialogButtonSave">Išsaugoti slaptažodį</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Išsaugoti slaptažodį</string>
     <string name="saveLoginDialogNotNow">Neišsaugokite</string>
-    <string name="saveLoginDialogSubtitle">Prisijungimai saugiai saugomi jūsų įrenginio meniu „Prisijungimai“.</string>
-    <string name="saveLoginDialogTitle">Ar norite, kad „DuckDuckGo“ išsaugotų jūsų prisijungimą?</string>
+    <string name="saveLoginDialogSubtitle">Slaptažodžiai saugiai saugomi jūsų įrenginio meniu „Prisijungimai“.</string>
+    <string name="saveLoginDialogTitle">Ar norite, kad „DuckDuckGo“ išsaugotų jūsų slaptažodį?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Daugiau parinkčių</string>
 
-    <string name="useSavedLoginDialogTitle">Naudoti išsaugotą prisijungimą?</string>
+    <string name="useSavedLoginDialogTitle">Naudoti išsaugotą slaptažodį?</string>
     <string name="useSavedLoginDialogMissingUsernameButtonText" instruction="Placeholder is the name of a website">„%1$s“ slaptažodis</string>
     <string name="useSavedLoginDialogMissingUsernameMissingDomainButtonText">Svetainės slaptažodis</string>
     <string name="useSavedLoginDialogGroupThisWebsite">Iš šios svetainės</string>
@@ -43,7 +43,7 @@
     <string name="updateLoginDialogButtonUpdateUsername">Atnaujinti naudotojo vardą</string>
 
     <string name="updateLoginDialogTitleLine" instruction="Placeholder is the user&apos;s username for this site">Atnaujinti \n%1$s slaptažodį?</string>
-    <string name="updateLoginUpdatePasswordExplanation">„DuckDuckGo“ atnaujins šį jūsų įrenginyje įrašytą prisijungimą.</string>
+    <string name="updateLoginUpdatePasswordExplanation">„DuckDuckGo“ atnaujins šį jūsų įrenginyje išsaugotą slaptažodį.</string>
 
     <string name="autofillDialogCloseButtonContentDescription">Uždaryti automatinio pildymo dialogo langą</string>
 

--- a/autofill/autofill-impl/src/main/res/values-lv/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-lv/strings-autofill-impl.xml
@@ -23,14 +23,14 @@
     <string name="managementDisabledModeSubtitle">Lai aizsargātu jūsu pieteikšanās datus, ir nepieciešama ierīces bloķēšanas figūra, PIN kods vai biometriskā aizsardzība.</string>
     <string name="managementDisabledModeTitle">Aizsargājiet savu ierīci, lai saglabātu pieteikšanās datus</string>
 
-    <string name="saveLoginDialogButtonSave">Saglabāt pieteikšanās datus</string>
+    <string name="saveLoginDialogButtonSave">Saglabāt paroli</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Saglabāt paroli</string>
     <string name="saveLoginDialogNotNow">Nesaglabāt</string>
-    <string name="saveLoginDialogSubtitle">Pieteikšanās dati tiek droši saglabāti tavā ierīcē, izvēlnē Pieteikšanās dati.</string>
-    <string name="saveLoginDialogTitle">Vai vēlies, lai DuckDuckGo saglabātu tavus pieteikšanās datus?</string>
+    <string name="saveLoginDialogSubtitle">Paroles tiek droši saglabātas tavā ierīcē, izvēlnē Pieteikšanās dati.</string>
+    <string name="saveLoginDialogTitle">Vai vēlies, lai DuckDuckGo saglabātu tavu paroli?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Citas iespējas</string>
 
-    <string name="useSavedLoginDialogTitle">Vai izmantot saglabātos pieteikšanās datus?</string>
+    <string name="useSavedLoginDialogTitle">Izmantot saglabāto paroli?</string>
     <string name="useSavedLoginDialogMissingUsernameButtonText" instruction="Placeholder is the name of a website">%1$s parole</string>
     <string name="useSavedLoginDialogMissingUsernameMissingDomainButtonText">Parole vietnei</string>
     <string name="useSavedLoginDialogGroupThisWebsite">No šīs vietnes</string>
@@ -43,7 +43,7 @@
     <string name="updateLoginDialogButtonUpdateUsername">Atjaunināt lietotājvārdu</string>
 
     <string name="updateLoginDialogTitleLine" instruction="Placeholder is the user&apos;s username for this site">Atjaunināt paroli lietotājvārdam \n%1$s?</string>
-    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo atjauninās šos saglabātos pieteikšanās datus tavā ierīcē.</string>
+    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo atjauninās tavā ierīcē saglabāto paroli.</string>
 
     <string name="autofillDialogCloseButtonContentDescription">Aizvērt automātiskās aizpildes dialoglodziņu</string>
 

--- a/autofill/autofill-impl/src/main/res/values-nb/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-nb/strings-autofill-impl.xml
@@ -23,14 +23,14 @@
     <string name="managementDisabledModeSubtitle">Du trenger låsemønster, PIN-kode eller biometri på enheten for å beskytte påloggingene dine.</string>
     <string name="managementDisabledModeTitle">Sikre enheten din for å lagre pålogginger</string>
 
-    <string name="saveLoginDialogButtonSave">Lagre påloggingen</string>
+    <string name="saveLoginDialogButtonSave">Lagre passordet</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Lagre passordet</string>
     <string name="saveLoginDialogNotNow">Ikke lagre</string>
-    <string name="saveLoginDialogSubtitle">Pålogginger lagres trygt på enheten din i påloggingsmenyen.</string>
-    <string name="saveLoginDialogTitle">Vil du at DuckDuckGo skal lagre påloggingen din?</string>
+    <string name="saveLoginDialogSubtitle">Passord lagres trygt på enheten din i påloggingsmenyen.</string>
+    <string name="saveLoginDialogTitle">Vil du at DuckDuckGo skal lagre passordet ditt?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Flere alternativer</string>
 
-    <string name="useSavedLoginDialogTitle">Vil du bruke en lagret pålogging?</string>
+    <string name="useSavedLoginDialogTitle">Vil du bruke et lagret passord?</string>
     <string name="useSavedLoginDialogMissingUsernameButtonText" instruction="Placeholder is the name of a website">Passord for %1$s</string>
     <string name="useSavedLoginDialogMissingUsernameMissingDomainButtonText">Passord for nettstedet</string>
     <string name="useSavedLoginDialogGroupThisWebsite">Fra dette nettstedet</string>
@@ -43,7 +43,7 @@
     <string name="updateLoginDialogButtonUpdateUsername">Oppdater brukernavn</string>
 
     <string name="updateLoginDialogTitleLine" instruction="Placeholder is the user&apos;s username for this site">Vil du oppdatere passordet for \n%1$s?</string>
-    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo oppdaterer denne lagrede påloggingen på enheten din.</string>
+    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo oppdaterer dette lagrede passordet på enheten din.</string>
 
     <string name="autofillDialogCloseButtonContentDescription">Lukk Autofyll-dialogboksen</string>
 

--- a/autofill/autofill-impl/src/main/res/values-nl/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-nl/strings-autofill-impl.xml
@@ -23,14 +23,14 @@
     <string name="managementDisabledModeSubtitle">Een vergrendelingspatroon, pincode of biometrische gegevens zijn noodzakelijk om je aanmeldgegevens te beschermen.</string>
     <string name="managementDisabledModeTitle">Beveilig je apparaat om aanmeldgegevens op te slaan</string>
 
-    <string name="saveLoginDialogButtonSave">Login opslaan</string>
+    <string name="saveLoginDialogButtonSave">Wachtwoord opslaan</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Wachtwoord opslaan</string>
     <string name="saveLoginDialogNotNow">Niet opslaan</string>
-    <string name="saveLoginDialogSubtitle">Aanmeldgegevens worden veilig opgeslagen op je apparaat in het menu \'Aanmeldingen\'.</string>
-    <string name="saveLoginDialogTitle">Wil je dat DuckDuckGo je login opslaat?</string>
+    <string name="saveLoginDialogSubtitle">Wachtwoorden worden veilig opgeslagen op je apparaat in het menu \'Aanmeldingen\'.</string>
+    <string name="saveLoginDialogTitle">Wil je dat DuckDuckGo je wachtwoord opslaat?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Meer opties</string>
 
-    <string name="useSavedLoginDialogTitle">Opgeslagen aanmeldgegevens gebruiken?</string>
+    <string name="useSavedLoginDialogTitle">Een opgeslagen wachtwoord gebruiken?</string>
     <string name="useSavedLoginDialogMissingUsernameButtonText" instruction="Placeholder is the name of a website">Wachtwoord voor %1$s</string>
     <string name="useSavedLoginDialogMissingUsernameMissingDomainButtonText">Wachtwoord voor website</string>
     <string name="useSavedLoginDialogGroupThisWebsite">Van deze website</string>
@@ -43,7 +43,7 @@
     <string name="updateLoginDialogButtonUpdateUsername">Gebruikersnaam bijwerken</string>
 
     <string name="updateLoginDialogTitleLine" instruction="Placeholder is the user&apos;s username for this site">Wachtwoord bijwerken voor \n%1$s?</string>
-    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo werkt deze opgeslagen aanmeldgegevens op je apparaat bij.</string>
+    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo werkt dit opgeslagen wachtwoord op je apparaat bij.</string>
 
     <string name="autofillDialogCloseButtonContentDescription">Dialoogvenster Automatisch invullen sluiten</string>
 

--- a/autofill/autofill-impl/src/main/res/values-pl/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-pl/strings-autofill-impl.xml
@@ -23,14 +23,14 @@
     <string name="managementDisabledModeSubtitle">Aby chronić dane logowania, korzystaj z blokady urządzenia za pomocą wzoru, kodu PIN lub danych biometrycznych.</string>
     <string name="managementDisabledModeTitle">Zabezpiecz urządzenie, aby chronić dane logowania</string>
 
-    <string name="saveLoginDialogButtonSave">Zapisz logowanie</string>
+    <string name="saveLoginDialogButtonSave">Zapisz hasło</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Zapisz hasło</string>
     <string name="saveLoginDialogNotNow">Nie zapisuj</string>
-    <string name="saveLoginDialogSubtitle">Loginy są bezpiecznie przechowywane na Twoim urządzeniu w menu Loginy.</string>
-    <string name="saveLoginDialogTitle">Czy chcesz zapisać dane logowania w DuckDuckGo?</string>
+    <string name="saveLoginDialogSubtitle">Hasła są bezpiecznie przechowywane na Twoim urządzeniu w menu Loginy.</string>
+    <string name="saveLoginDialogTitle">Czy chcesz zapisać hasło w DuckDuckGo?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Więcej opcji</string>
 
-    <string name="useSavedLoginDialogTitle">Czy chcesz użyć zapisanego loginu?</string>
+    <string name="useSavedLoginDialogTitle">Użyć zapisanego hasła?</string>
     <string name="useSavedLoginDialogMissingUsernameButtonText" instruction="Placeholder is the name of a website">Hasło do witryny %1$s</string>
     <string name="useSavedLoginDialogMissingUsernameMissingDomainButtonText">Hasło do witryny</string>
     <string name="useSavedLoginDialogGroupThisWebsite">Z tej strony</string>
@@ -43,7 +43,7 @@
     <string name="updateLoginDialogButtonUpdateUsername">Zaktualizuj nazwę użytkownika</string>
 
     <string name="updateLoginDialogTitleLine" instruction="Placeholder is the user&apos;s username for this site">Zaktualizować hasło \n%1$s?</string>
-    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo zaktualizuje ten zapisany login na Twoim urządzeniu.</string>
+    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo zaktualizuje to zapisane hasło na Twoim urządzeniu.</string>
 
     <string name="autofillDialogCloseButtonContentDescription">Zamknij okno dialogowe autouzupełniania</string>
 

--- a/autofill/autofill-impl/src/main/res/values-pt/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-pt/strings-autofill-impl.xml
@@ -23,14 +23,14 @@
     <string name="managementDisabledModeSubtitle">É necessário um padrão de bloqueio de dispositivo, PIN ou biometria para proteger os teus inícios de sessão.</string>
     <string name="managementDisabledModeTitle">Proteger o dispositivo para guardar inícios de sessão</string>
 
-    <string name="saveLoginDialogButtonSave">Guardar início de sessão</string>
+    <string name="saveLoginDialogButtonSave">Guardar palavra-passe</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Guardar palavra-passe</string>
     <string name="saveLoginDialogNotNow">Não guardar</string>
-    <string name="saveLoginDialogSubtitle">Os dados de início de sessão são armazenados de forma segura no teu dispositivo no menu Inícios de sessão.</string>
-    <string name="saveLoginDialogTitle">Queres que o DuckDuckGo guarde o teu início de sessão?</string>
+    <string name="saveLoginDialogSubtitle">As palavras-passe são armazenadas de forma segura no teu dispositivo no menu Inícios de sessão.</string>
+    <string name="saveLoginDialogTitle">Queres que o DuckDuckGo guarde a tua palavra-passe?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Mais opções</string>
 
-    <string name="useSavedLoginDialogTitle">Utilizar um início de sessão guardado?</string>
+    <string name="useSavedLoginDialogTitle">Usar uma palavra-passe guardada?</string>
     <string name="useSavedLoginDialogMissingUsernameButtonText" instruction="Placeholder is the name of a website">Palavra-passe de %1$s</string>
     <string name="useSavedLoginDialogMissingUsernameMissingDomainButtonText">Palavra-passe do site</string>
     <string name="useSavedLoginDialogGroupThisWebsite">Deste site</string>
@@ -43,7 +43,7 @@
     <string name="updateLoginDialogButtonUpdateUsername">Atualizar nome de utilizador</string>
 
     <string name="updateLoginDialogTitleLine" instruction="Placeholder is the user&apos;s username for this site">Atualizar palavra-passe de \n%1$s?</string>
-    <string name="updateLoginUpdatePasswordExplanation">O DuckDuckGo vai atualizar este início de sessão armazenado no teu dispositivo.</string>
+    <string name="updateLoginUpdatePasswordExplanation">O DuckDuckGo vai atualizar esta palavra-passe armazenada no teu dispositivo.</string>
 
     <string name="autofillDialogCloseButtonContentDescription">Fechar caixa de diálogo de preenchimento automático</string>
 

--- a/autofill/autofill-impl/src/main/res/values-ro/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-ro/strings-autofill-impl.xml
@@ -23,14 +23,14 @@
     <string name="managementDisabledModeSubtitle">Este necesar un model de blocare a dispozitivului, un cod PIN sau date biometrice pentru a-ți proteja conectările.</string>
     <string name="managementDisabledModeTitle">Securizează-ți dispozitivul pentru a salva conectările</string>
 
-    <string name="saveLoginDialogButtonSave">Salvează autentificarea</string>
+    <string name="saveLoginDialogButtonSave">Salvează parola</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Salvează parola</string>
     <string name="saveLoginDialogNotNow">Nu salva</string>
-    <string name="saveLoginDialogSubtitle">Conexiunile sunt stocate în siguranță pe dispozitivul dvs. în meniul Conectări.</string>
-    <string name="saveLoginDialogTitle">Vrei ca DuckDuckGo să îți salveze datele de conectare?</string>
+    <string name="saveLoginDialogSubtitle">Parolele sunt stocate în siguranță pe dispozitivul dvs. în meniul Autentificări.</string>
+    <string name="saveLoginDialogTitle">Dorești ca DuckDuckGo să-ți salveze parola?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Mai multe opțiuni</string>
 
-    <string name="useSavedLoginDialogTitle">Folosești datele de conectare salvate?</string>
+    <string name="useSavedLoginDialogTitle">Folosești o parolă salvată?</string>
     <string name="useSavedLoginDialogMissingUsernameButtonText" instruction="Placeholder is the name of a website">Parola pentru %1$s</string>
     <string name="useSavedLoginDialogMissingUsernameMissingDomainButtonText">Parola pentru site</string>
     <string name="useSavedLoginDialogGroupThisWebsite">De pe acest site web</string>
@@ -43,7 +43,7 @@
     <string name="updateLoginDialogButtonUpdateUsername">Actualizează numele de utilizator</string>
 
     <string name="updateLoginDialogTitleLine" instruction="Placeholder is the user&apos;s username for this site">Actualizezi parola pentru \n%1$s?</string>
-    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo va actualiza aceste date de conectare stocate pe dispozitivul tău.</string>
+    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo va actualiza această parolă stocată pe dispozitivul tău.</string>
 
     <string name="autofillDialogCloseButtonContentDescription">Închide dialogul de completare automată</string>
 

--- a/autofill/autofill-impl/src/main/res/values-ru/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-ru/strings-autofill-impl.xml
@@ -23,14 +23,14 @@
     <string name="managementDisabledModeSubtitle">Для защиты логинов требуются биометрические данные, графический ключ или ПИН-код.</string>
     <string name="managementDisabledModeTitle">Защитите свое устройство, чтобы сохранять логины</string>
 
-    <string name="saveLoginDialogButtonSave">Сохранить логин</string>
+    <string name="saveLoginDialogButtonSave">Сохранить пароль</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Сохранить пароль</string>
     <string name="saveLoginDialogNotNow">Не сохранять</string>
-    <string name="saveLoginDialogSubtitle">Учетные данные надежно хранятся на вашем устройстве в меню «Логины».</string>
-    <string name="saveLoginDialogTitle">Хотите, чтобы DuckDuckGo сохранил логин?</string>
+    <string name="saveLoginDialogSubtitle">Пароли надежно хранятся на вашем устройстве в меню «Логины».</string>
+    <string name="saveLoginDialogTitle">Хотите, чтобы DuckDuckGo сохранил ваш пароль?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Другие параметры</string>
 
-    <string name="useSavedLoginDialogTitle">Использовать сохраненный логин?</string>
+    <string name="useSavedLoginDialogTitle">Использовать сохраненный пароль?</string>
     <string name="useSavedLoginDialogMissingUsernameButtonText" instruction="Placeholder is the name of a website">Пароль для %1$s</string>
     <string name="useSavedLoginDialogMissingUsernameMissingDomainButtonText">Пароль для сайта</string>
     <string name="useSavedLoginDialogGroupThisWebsite">С этого сайта</string>
@@ -43,7 +43,7 @@
     <string name="updateLoginDialogButtonUpdateUsername">Обновить имя пользователя</string>
 
     <string name="updateLoginDialogTitleLine" instruction="Placeholder is the user&apos;s username for this site">Обновить пароль \n%1$s?</string>
-    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo обновит логин, сохраненный на вашем устройстве.</string>
+    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo обновит пароль, сохраненный на вашем устройстве.</string>
 
     <string name="autofillDialogCloseButtonContentDescription">Закрыть диалоговое окно автозаполнения</string>
 

--- a/autofill/autofill-impl/src/main/res/values-sk/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-sk/strings-autofill-impl.xml
@@ -23,14 +23,14 @@
     <string name="managementDisabledModeSubtitle">Na ochranu vašich prihlasovacích údajov sa vyžaduje vzor uzamknutia zariadenia, kód PIN alebo biometrické údaje.</string>
     <string name="managementDisabledModeTitle">Zabezpečte svoje zariadenie a uložte prihlasovacie údaje</string>
 
-    <string name="saveLoginDialogButtonSave">Uložiť prihlasovacie údaje</string>
+    <string name="saveLoginDialogButtonSave">Uložiť heslo</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Uložiť heslo</string>
     <string name="saveLoginDialogNotNow">Neukladať</string>
-    <string name="saveLoginDialogSubtitle">Prihlasovacie údaje sú bezpečne uložené v zariadení v ponuke Prihlásenia.</string>
-    <string name="saveLoginDialogTitle">Chcete, aby DuckDuckGo uložil vaše prihlasovacie údaje?</string>
+    <string name="saveLoginDialogSubtitle">Heslá sú bezpečne uložené na vašom zariadení v ponuke Prihlásenia.</string>
+    <string name="saveLoginDialogTitle">Chcete, aby DuckDuckGo uložil vaše heslo?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Ďalšie možnosti</string>
 
-    <string name="useSavedLoginDialogTitle">Použiť uložené prihlasovacie údaje?</string>
+    <string name="useSavedLoginDialogTitle">Použiť uložené heslo?</string>
     <string name="useSavedLoginDialogMissingUsernameButtonText" instruction="Placeholder is the name of a website">Heslo pre %1$s</string>
     <string name="useSavedLoginDialogMissingUsernameMissingDomainButtonText">Heslo pre lokalitu</string>
     <string name="useSavedLoginDialogGroupThisWebsite">Z tejto webovej lokality</string>
@@ -43,7 +43,7 @@
     <string name="updateLoginDialogButtonUpdateUsername">Aktualizovať používateľské meno</string>
 
     <string name="updateLoginDialogTitleLine" instruction="Placeholder is the user&apos;s username for this site">Aktualizovať heslo pre \n%1$s?</string>
-    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo bude aktualizovať tieto uložené prihlasovacie údaje vo vašom zariadení.</string>
+    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo aktualizuje toto uložené heslo vo vašom zariadení.</string>
 
     <string name="autofillDialogCloseButtonContentDescription">Zavrieť dialógové okno automatického vypĺňania</string>
 

--- a/autofill/autofill-impl/src/main/res/values-sl/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-sl/strings-autofill-impl.xml
@@ -23,14 +23,14 @@
     <string name="managementDisabledModeSubtitle">Za zaščito prijav je potreben vzorec za zaklepanje naprave, koda PIN ali biometrični podatki.</string>
     <string name="managementDisabledModeTitle">Zavarujte svojo napravo, če želite shraniti prijave</string>
 
-    <string name="saveLoginDialogButtonSave">Shrani prijavo</string>
+    <string name="saveLoginDialogButtonSave">Shrani geslo</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Shrani geslo</string>
     <string name="saveLoginDialogNotNow">Ne shrani</string>
-    <string name="saveLoginDialogSubtitle">Prijave so varno shranjene v vaši napravi v meniju Prijave.</string>
-    <string name="saveLoginDialogTitle">Ali želite, da DuckDuckGo shrani vašo prijavo?</string>
+    <string name="saveLoginDialogSubtitle">Gesla so varno shranjena v napravi v meniju Prijave.</string>
+    <string name="saveLoginDialogTitle">Ali želite, da DuckDuckGo shrani vaše geslo?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Več možnosti</string>
 
-    <string name="useSavedLoginDialogTitle">Želite uporabiti shranjene podatke za prijavo?</string>
+    <string name="useSavedLoginDialogTitle">Želite uporabiti shranjeno geslo?</string>
     <string name="useSavedLoginDialogMissingUsernameButtonText" instruction="Placeholder is the name of a website">Geslo za spletno mesto %1$s</string>
     <string name="useSavedLoginDialogMissingUsernameMissingDomainButtonText">Geslo za spletno mesto</string>
     <string name="useSavedLoginDialogGroupThisWebsite">S tega spletnega mesta</string>
@@ -43,7 +43,7 @@
     <string name="updateLoginDialogButtonUpdateUsername">Posodobi uporabniško ime</string>
 
     <string name="updateLoginDialogTitleLine" instruction="Placeholder is the user&apos;s username for this site">Želite posodobiti geslo za \n%1$s?</string>
-    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo bo posodobil to shranjeno prijavo v vaši napravi.</string>
+    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo bo posodobil to shranjeno geslo v vaši napravi.</string>
 
     <string name="autofillDialogCloseButtonContentDescription">Zapri pogovorno okno za samodejno izpolnjevanje</string>
 

--- a/autofill/autofill-impl/src/main/res/values-sv/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-sv/strings-autofill-impl.xml
@@ -23,14 +23,14 @@
     <string name="managementDisabledModeSubtitle">För att skydda dina inloggningar krävs ett enhetslåsmönster, en PIN-kod eller biometri.</string>
     <string name="managementDisabledModeTitle">Säkra din enhet för att spara inloggningar</string>
 
-    <string name="saveLoginDialogButtonSave">Spara inloggning</string>
+    <string name="saveLoginDialogButtonSave">Spara lösenord</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Spara lösenord</string>
     <string name="saveLoginDialogNotNow">Spara inte</string>
-    <string name="saveLoginDialogSubtitle">Inloggningar lagras säkert på din enhet i menyn Inloggningar.</string>
-    <string name="saveLoginDialogTitle">Vill du att DuckDuckGo ska spara din inloggning?</string>
+    <string name="saveLoginDialogSubtitle">Lösenord lagras säkert på din enhet i menyn Inloggningar.</string>
+    <string name="saveLoginDialogTitle">Vill du att DuckDuckGo ska spara ditt lösenord?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Fler alternativ</string>
 
-    <string name="useSavedLoginDialogTitle">Använd sparad inloggning?</string>
+    <string name="useSavedLoginDialogTitle">Vill du använda ett sparat lösenord?</string>
     <string name="useSavedLoginDialogMissingUsernameButtonText" instruction="Placeholder is the name of a website">Lösenord för %1$s</string>
     <string name="useSavedLoginDialogMissingUsernameMissingDomainButtonText">Lösenord för webbplatsen</string>
     <string name="useSavedLoginDialogGroupThisWebsite">Från den här webbplatsen</string>
@@ -43,7 +43,7 @@
     <string name="updateLoginDialogButtonUpdateUsername">Uppdatera användarnamn</string>
 
     <string name="updateLoginDialogTitleLine" instruction="Placeholder is the user&apos;s username for this site">Uppdatera lösenordet för \n%1$s?</string>
-    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo uppdaterar den här lagrade inloggningen på din enhet.</string>
+    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo kommer att uppdatera det lagrade lösenordet på din enhet.</string>
 
     <string name="autofillDialogCloseButtonContentDescription">Stäng dialogrutan för automatisk ifyllning</string>
 

--- a/autofill/autofill-impl/src/main/res/values-tr/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-tr/strings-autofill-impl.xml
@@ -23,14 +23,14 @@
     <string name="managementDisabledModeSubtitle">Giriş bilgilerinizin güvenliğini sağlamak için bir cihaz kilidi deseni, PIN veya biyometrik veri gereklidir.</string>
     <string name="managementDisabledModeTitle">Giriş bilgilerini kaydetmek için cihazınızın güvenliğini sağlayın</string>
 
-    <string name="saveLoginDialogButtonSave">Girişi Kaydet</string>
+    <string name="saveLoginDialogButtonSave">Şifre Kaydet</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Şifre Kaydet</string>
     <string name="saveLoginDialogNotNow">Kaydetme</string>
-    <string name="saveLoginDialogSubtitle">Giriş bilgileri cihazınızdaki Giriş Bilgileri menüsünde güvenli bir şekilde saklanır.</string>
-    <string name="saveLoginDialogTitle">DuckDuckGo\'nun Girişinizi kaydetmesini istiyor musunuz?</string>
+    <string name="saveLoginDialogSubtitle">Şifreler cihazınızdaki Oturum Açma menüsünde güvenli bir şekilde saklanır.</string>
+    <string name="saveLoginDialogTitle">DuckDuckGo\'nun şifrenizi kaydetmesini istiyor musunuz?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">Diğer Seçenekler</string>
 
-    <string name="useSavedLoginDialogTitle">Kayıtlı Giriş kullanılsın mı?</string>
+    <string name="useSavedLoginDialogTitle">Kayıtlı bir şifre mi kullanıyorsunuz?</string>
     <string name="useSavedLoginDialogMissingUsernameButtonText" instruction="Placeholder is the name of a website">%1$s şifresi</string>
     <string name="useSavedLoginDialogMissingUsernameMissingDomainButtonText">Site şifresi</string>
     <string name="useSavedLoginDialogGroupThisWebsite">Bu Web Sitesinden</string>
@@ -43,7 +43,7 @@
     <string name="updateLoginDialogButtonUpdateUsername">Kullanıcı Adını Güncelle</string>
 
     <string name="updateLoginDialogTitleLine" instruction="Placeholder is the user&apos;s username for this site">%1$s için şifre güncellensin mi?</string>
-    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo, cihazınızdaki bu kayıtlı Giriş bilgisini güncelleyecektir.</string>
+    <string name="updateLoginUpdatePasswordExplanation">DuckDuckGo bu kayıtlı şifreyi cihazınızda güncelleyecektir.</string>
 
     <string name="autofillDialogCloseButtonContentDescription">Otomatik Doldurma İletişim Kutusunu Kapat</string>
 

--- a/autofill/autofill-impl/src/main/res/values/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values/strings-autofill-impl.xml
@@ -23,14 +23,14 @@
     <string name="managementDisabledModeSubtitle">A device lock pattern, PIN, or biometrics is required to protect your Logins.</string>
     <string name="managementDisabledModeTitle">Secure your device to save Logins</string>
 
-    <string name="saveLoginDialogButtonSave">Save Login</string>
+    <string name="saveLoginDialogButtonSave">Save Password</string>
     <string name="saveLoginMissingUsernameDialogButtonSave">Save Password</string>
     <string name="saveLoginDialogNotNow">Don\'t Save</string>
-    <string name="saveLoginDialogSubtitle">Logins are stored securely on your device in the Logins menu.</string>
-    <string name="saveLoginDialogTitle">Do you want DuckDuckGo to save your Login?</string>
+    <string name="saveLoginDialogSubtitle">Passwords are stored securely on your device in the Logins menu.</string>
+    <string name="saveLoginDialogTitle">Do you want DuckDuckGo to save your password?</string>
     <string name="saveLoginDialogMoreOptionsButtonLabel">More Options</string>
 
-    <string name="useSavedLoginDialogTitle">Use a saved Login?</string>
+    <string name="useSavedLoginDialogTitle">Use a saved password?</string>
     <string name="useSavedLoginDialogMissingUsernameButtonText" instruction="Placeholder is the name of a website">Password for %1$s</string>
     <string name="useSavedLoginDialogMissingUsernameMissingDomainButtonText">Password for site</string>
     <string name="useSavedLoginDialogGroupThisWebsite">From This Website</string>
@@ -43,7 +43,7 @@
     <string name="updateLoginDialogButtonUpdateUsername">Update Username</string>
 
     <string name="updateLoginDialogTitleLine" instruction="Placeholder is the user's username for this site">Update password for \n%1$s?</string>
-    <string name="updateLoginUpdatePasswordExplanation" >DuckDuckGo will update this stored Login on your device.</string>
+    <string name="updateLoginUpdatePasswordExplanation" >DuckDuckGo will update this stored password on your device.</string>
 
     <string name="autofillDialogCloseButtonContentDescription">Close Autofill Dialog</string>
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/0/1205900373687630/f 

### Description
Updates copy, preferring to use terminology "password" instead of "login" in the autofill dialogs.

Includes translations.

### Steps to test this PR
- QA optional
