### PR TITLE
Address Bar Spoofing Tests + Remediation

### DIFF
--- a/.maestro/security_tests/0_all.yaml
+++ b/.maestro/security_tests/0_all.yaml
@@ -1,0 +1,14 @@
+appId: com.duckduckgo.mobile.android
+tags:
+    - securityTest
+---
+- launchApp:
+    clearState: true
+- runFlow: ../shared/onboarding.yaml
+- runFlow: ./1_-_AddressBarSpoof,_basicauth.yaml
+- runFlow: ./2_-_AddressBarSpoof,_aboutblank.yaml
+- runFlow: ./3_-_AddressBarSpoof,_appschemes.yaml
+- runFlow: ./4_-_AddressBarSpoof,_b64_html.yaml
+- runFlow: ./5_-_AddressBarSpoof,_downloadpath.yaml
+- runFlow: ./6_-_AddressBarSpoof,_formaction.yaml
+- runFlow: ./7_-_AddressBarSpoof,_pagerewrite.yaml

--- a/.maestro/security_tests/1_-_AddressBarSpoof,_basicauth.yaml
+++ b/.maestro/security_tests/1_-_AddressBarSpoof,_basicauth.yaml
@@ -1,0 +1,36 @@
+appId: com.duckduckgo.mobile.android
+tags:
+    - securityTest
+---
+- doubleTapOn:
+    id: "omnibarTextInput"
+- pressKey: Backspace
+# Test 1 - using \u2028 character
+- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-basicauth-2028.html"
+- pressKey: Enter
+- tapOn: "run"
+- assertVisible: "Example Domain"
+- copyTextFrom:
+    id: "omnibarTextInput"
+- assertTrue: ${maestro.copiedText.indexOf("https://www.google.com") != 0}
+- tapOn:
+    id: "omnibarTextInput"
+# Test 2 - using \u2029 character
+- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-basicauth-2029.html"
+- pressKey: Enter
+- tapOn: "run"
+- assertVisible: "Example Domain"
+- copyTextFrom:
+    id: "omnibarTextInput"
+- assertTrue: ${maestro.copiedText.indexOf("https://www.google.com") != 0}
+- tapOn:
+    id: "omnibarTextInput"
+# Test 3 - using repeated " " space character
+- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-basicauth-whitespace.html"
+- pressKey: Enter
+- tapOn: "run"
+- assertVisible: "Example Domain"
+- copyTextFrom:
+    id: "omnibarTextInput"
+- assertTrue: ${maestro.copiedText.indexOf("https://www.google.com") != 0}
+- pressKey: Back

--- a/.maestro/security_tests/2_-_AddressBarSpoof,_aboutblank.yaml
+++ b/.maestro/security_tests/2_-_AddressBarSpoof,_aboutblank.yaml
@@ -1,0 +1,17 @@
+appId: com.duckduckgo.mobile.android
+tags:
+    - securityTest
+---
+- doubleTapOn:
+    id: "omnibarTextInput"
+- pressKey: Backspace
+- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-about-blank-rewrite.html"
+- pressKey: Enter
+- tapOn: "Start"
+# This test is expected to load "about:blank" then duckduckgo.com, not remain on the current page with spoofed content.
+- extendedWaitUntil:
+    notVisible: "Not DDG."  # Spoofed content not visible
+    timeout: 10000
+- copyTextFrom:
+    id: "omnibarTextInput"
+- assertTrue: ${maestro.copiedText == "about:blank" || maestro.copiedText == "https://duckduckgo.com/"}

--- a/.maestro/security_tests/3_-_AddressBarSpoof,_appschemes.yaml
+++ b/.maestro/security_tests/3_-_AddressBarSpoof,_appschemes.yaml
@@ -1,0 +1,26 @@
+appId: com.duckduckgo.mobile.android
+tags:
+    - securityTest
+---
+# Test 1
+- doubleTapOn:
+    id: "omnibarTextInput"
+- pressKey: Backspace
+- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-application-scheme.html"
+- pressKey: Enter
+- tapOn: "Start"
+# This test should reject trying to load
+# This test is expected to load duckduckgo.com, not remain on the current page with spoofed content.
+- assertVisible: "Privacy, simplified." # DuckDuckGo home page
+- copyTextFrom:
+    id: "omnibarTextInput"
+- assertTrue: ${maestro.copiedText == "https://duckduckgo.com/"} # DuckDuckGo home page
+- tapOn:
+    id: "omnibarTextInput"
+# Test 2
+- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-unsupported-scheme.html"
+- pressKey: Enter
+- tapOn: "Start"
+- copyTextFrom:
+    id: "omnibarTextInput"
+- assertTrue: ${maestro.copiedText == "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-unsupported-scheme.html"}

--- a/.maestro/security_tests/4_-_AddressBarSpoof,_b64_html.yaml
+++ b/.maestro/security_tests/4_-_AddressBarSpoof,_b64_html.yaml
@@ -1,0 +1,18 @@
+appId: com.duckduckgo.mobile.android
+tags:
+    - securityTest
+---
+# Test 1
+- doubleTapOn:
+    id: "omnibarTextInput"
+- pressKey: Backspace
+- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-open-b64-html.html"
+- pressKey: Enter
+- tapOn: "Start"
+# This test is expected to open a new tab with empty origin ("about:blank") and then prompt to open the link in another app
+- assertVisible: "Open in another app"
+- tapOn: "Cancel"
+- copyTextFrom:
+    id: "omnibarTextInput"
+- assertTrue: ${maestro.copiedText == "about:blank"}
+- pressKey: Back

--- a/.maestro/security_tests/5_-_AddressBarSpoof,_downloadpath.yaml
+++ b/.maestro/security_tests/5_-_AddressBarSpoof,_downloadpath.yaml
@@ -1,0 +1,30 @@
+appId: com.duckduckgo.mobile.android
+tags:
+    - securityTest
+---
+# Test 1
+- doubleTapOn:
+    id: "omnibarTextInput"
+- pressKey: Backspace
+- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-js-download-url.html"
+- pressKey: Enter
+- tapOn: "Start"
+# Download Acceptance Flow:
+- extendedWaitUntil:
+    visible: "Save to Downloads"
+    timeout: 10000
+- tapOn: "Save to Downloads"
+- copyTextFrom:
+    id: "omnibarTextInput"
+- assertTrue: ${maestro.copiedText == "Search or type URL"} # Downloads should occur in empty origin.
+- pressKey: Back
+# Download Cancel Flow:
+- tapOn: "Start"
+- extendedWaitUntil:
+    visible: "Cancel"  
+    timeout: 10000
+- tapOn: "Cancel"
+# Should redirect back to the last page.
+- copyTextFrom:
+    id: "omnibarTextInput"
+- assertTrue: ${maestro.copiedText == "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-js-download-url.html"} 

--- a/.maestro/security_tests/6_-_AddressBarSpoof,_formaction.yaml
+++ b/.maestro/security_tests/6_-_AddressBarSpoof,_formaction.yaml
@@ -1,0 +1,15 @@
+appId: com.duckduckgo.mobile.android
+tags:
+    - securityTest
+---
+# Test 1
+- doubleTapOn:
+    id: "omnibarTextInput"
+- pressKey: Backspace
+- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-form-action.html"
+- pressKey: Enter
+- tapOn: "run"
+# Should do nothing - the navigation should be prevented.
+- copyTextFrom:
+    id: "omnibarTextInput"
+- assertTrue: ${maestro.copiedText == "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-form-action.html"}

--- a/.maestro/security_tests/7_-_AddressBarSpoof,_pagerewrite.yaml
+++ b/.maestro/security_tests/7_-_AddressBarSpoof,_pagerewrite.yaml
@@ -1,0 +1,16 @@
+appId: com.duckduckgo.mobile.android
+tags:
+    - securityTest
+---
+# Test 1
+- doubleTapOn:
+    id: "omnibarTextInput"
+- pressKey: Backspace
+- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-js-page-rewrite.html"
+- pressKey: Enter
+- tapOn: "Start"
+# Now check the address bar hasn't been updated too early resulting in spoofed content
+- copyTextFrom:
+    id: "omnibarTextInput"
+- assertTrue: ${maestro.copiedText == "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-js-page-rewrite.html"}
+- assertNotVisible: "DDG." 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1424,6 +1424,9 @@ class BrowserTabViewModel @Inject constructor(
 
         return if (duckDuckGoUrlDetector.isDuckDuckGoQueryUrl(url)) {
             duckDuckGoUrlDetector.extractQuery(url) ?: url
+        } else if (url.contains("@")) {
+            // Strip out the basic auth credentials from the address bar to prevent spoofing
+            url.split("@")[1]
         } else {
             url
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/72649045549333/1205794884403778/f

### Description
The browser implementation of the address bar updating functionality is currently vulnerable to an Address Bar Spoofing vulnerability. In this PR I integrate all of our known address bar spoofing tests, including a fix for the basic auth address bar spoofing issues where someone can hide the domain portion of the address bar by prepending fake basic auth credentials to the domain. 

In the fix, I simply strip the username/password fields from the address bar which forces the browser to prompt for username/password. This is consistent with our other browser implementations on macOS and iOS.

### Steps to test this PR

_Security Tests_
- [ ] run `maestro test .maestro/security_tests/0_all.yaml` 
- [ ] ensure all tests are passing 

_Basic Auth_
- [ ] visit a page that actually requires basic auth: https://duckduckgo.com:fakepass@notarootkit.com
- [ ] check that username/password are stripped from address bar
- [ ] check that the username/password prompt is still raised 
- [ ] visit a page that doesn't require basic auth: https://duckduckgo.com:fakepass@example.com
- [ ] check that username/password are stripped from the address bar
- [ ] no username/password prompt is raised.
