### PR TITLE
Fix pixels related to protections toggle on Broken Site screen

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/brokensite/view/SiteProtectionsToggle.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/view/SiteProtectionsToggle.kt
@@ -43,7 +43,9 @@ class SiteProtectionsToggle @JvmOverloads constructor(
 
     fun setOnProtectionsToggledListener(listener: (Boolean) -> Unit) {
         binding.protectionsSwitch.setOnCheckedChangeListener { _, isChecked ->
-            listener.invoke(isChecked)
+            if (isChecked != areProtectionsEnabled()) {
+                listener.invoke(isChecked)
+            }
         }
     }
 
@@ -79,5 +81,12 @@ class SiteProtectionsToggle @JvmOverloads constructor(
                 protectionsBannerMessageContainer.setBackgroundResource(R.drawable.background_site_protections_toggle_banner_alert)
             }
         }
+    }
+
+    private fun areProtectionsEnabled(): Boolean = when (state) {
+        SiteProtectionsState.ENABLED -> true
+        SiteProtectionsState.DISABLED,
+        SiteProtectionsState.DISABLED_BY_REMOTE_CONFIG,
+        -> false
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205947853089389/f

### Description

In the BrokenSiteViewModel, the onProtectionsToggled() method is invoked right after the view is initialized, which leads to sending m_broken_site_allowlist_remove pixel even though the user didn't interact with the protections toggle.

### Steps to test this PR

#### Pixels are not fired without user interaction with the protections toggle (this is the fix)
- [x] Go to the site breakage report screen
- [x] Verify that m_broken_site_allowlist_remove / m_broken_site_allowlist_add pixels weren't fired until you use the protections toggle.

#### Verify pixels are fired when toggling protections (existing behavior that shouldn't change)
 - [x] Go to the site breakage report screen
 - [x] Toggle protections off/on
 - [x] Verify that m_broken_site_allowlist_add pixel is fired on turning protections OFF
 - [x] Verify that m_broken_site_allowlist_remove pixel is fired on turning protections ON

### No UI changes
