### PR TITLE
Add web content debugging to internal builds

### DIFF
--- a/app/src/internal/java/com/duckduckgo/app/browser/webview/InternalWebContentDebugging.kt
+++ b/app/src/internal/java/com/duckduckgo/app/browser/webview/InternalWebContentDebugging.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.webview
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+@ContributesBinding(
+    scope = ActivityScope::class,
+    replaces = [RealWebContentDebugging::class],
+)
+class InternalWebContentDebugging @Inject constructor(
+    private val webContentDebuggingFeature: WebContentDebuggingFeature,
+) : WebContentDebugging {
+    override fun isEnabled(): Boolean {
+        return webContentDebuggingFeature.webContentDebugging().isEnabled()
+    }
+}
+
+@ContributesRemoteFeature(
+    scope = ActivityScope::class,
+    featureName = "InternalWebContentDebuggingFlag",
+)
+interface WebContentDebuggingFeature {
+    @Toggle.DefaultValue(false)
+    fun self(): Toggle
+
+    @Toggle.DefaultValue(false)
+    fun webContentDebugging(): Toggle
+}

--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/DevSettingsActivity.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/DevSettingsActivity.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.R.layout
 import com.duckduckgo.app.browser.databinding.ActivityDevSettingsBinding
+import com.duckduckgo.app.browser.webview.WebContentDebuggingFeature
 import com.duckduckgo.app.dev.settings.DevSettingsViewModel.Command
 import com.duckduckgo.app.dev.settings.db.UAOverride
 import com.duckduckgo.app.dev.settings.privacy.TrackerDataDevReceiver.Companion.DOWNLOAD_TDS_INTENT_ACTION
@@ -39,12 +40,17 @@ import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.menu.PopupMenu
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.privacy.config.internal.PrivacyConfigInternalSettingsActivity
+import javax.inject.Inject
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
 @InjectWith(ActivityScope::class)
 class DevSettingsActivity : DuckDuckGoActivity() {
+
+    @Inject
+    lateinit var webContentDebuggingFeature: WebContentDebuggingFeature
 
     private val binding: ActivityDevSettingsBinding by viewBinding()
 
@@ -81,6 +87,9 @@ class DevSettingsActivity : DuckDuckGoActivity() {
     }
 
     private fun configureUiEventHandlers() {
+        binding.enableWebContentDebugging.quietlySetIsChecked(webContentDebuggingFeature.webContentDebugging().isEnabled()) { _, isChecked ->
+            webContentDebuggingFeature.webContentDebugging().setEnabled(Toggle.State(enable = isChecked))
+        }
         binding.triggerAnr.setOnClickListener {
             Handler(Looper.getMainLooper()).post {
                 Thread.sleep(10000)

--- a/app/src/internal/res/layout/activity_dev_settings.xml
+++ b/app/src/internal/res/layout/activity_dev_settings.xml
@@ -58,6 +58,15 @@
                 app:showSwitch="true" />
 
             <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+                    android:id="@+id/enableWebContentDebugging"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:primaryText="@string/devEnableWebContentDebuggingTitle"
+                    app:secondaryText="@string/devEnableWebContentDebuggingByline"
+                    app:showSwitch="true"
+            />
+
+            <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
                 android:id="@+id/triggerAnr"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/app/src/internal/res/values/donottranslate.xml
+++ b/app/src/internal/res/values/donottranslate.xml
@@ -31,6 +31,8 @@
     <string name="devSettingsClearSavedSitesSubtitle">Click here to clear all bookmarks, folders and favorites</string>
     <string name="devSettingsClearSavedSitesConfirmation">Saved sites cleared</string>
     <string name="devSettingsUseSandBoxSurvey">Use Sandbox Survey</string>
+    <string name="devEnableWebContentDebuggingTitle">Web Content Debugging</string>
+    <string name="devEnableWebContentDebuggingByline">Enable WebView debugging in Chrome DevTools</string>
 
     <string name="devSettingsScreenUserAgentSection">User Agent</string>
     <string name="devSettingsScreenUserAgentOverride">Override UserAgent</string>

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -133,6 +133,7 @@ import com.duckduckgo.app.browser.ui.dialogs.LaunchInExternalAppOptions
 import com.duckduckgo.app.browser.urlextraction.DOMUrlExtractor
 import com.duckduckgo.app.browser.urlextraction.UrlExtractingWebView
 import com.duckduckgo.app.browser.urlextraction.UrlExtractingWebViewClient
+import com.duckduckgo.app.browser.webview.WebContentDebugging
 import com.duckduckgo.app.cta.ui.*
 import com.duckduckgo.app.cta.ui.DaxDialogCta.*
 import com.duckduckgo.app.di.AppCoroutineScope
@@ -416,6 +417,9 @@ class BrowserTabFragment :
 
     @Inject
     lateinit var systemAutofillUsageMonitor: SystemAutofillUsageMonitor
+
+    @Inject
+    lateinit var webContentDebugging: WebContentDebugging
 
     /**
      * We use this to monitor whether the user was seeing the in-context Email Protection signup prompt
@@ -2124,9 +2128,7 @@ class BrowserTabFragment :
             )
         }
 
-        if (appBuildConfig.isDebug) {
-            WebView.setWebContentsDebuggingEnabled(true)
-        }
+        WebView.setWebContentsDebuggingEnabled(webContentDebugging.isEnabled())
     }
 
     private fun configureWebViewForAutofill(it: DuckDuckGoWebView) {

--- a/app/src/main/java/com/duckduckgo/app/browser/webview/WebContentDebugging.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/webview/WebContentDebugging.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.webview
+
+import com.duckduckgo.di.scopes.ActivityScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface WebContentDebugging {
+    fun isEnabled(): Boolean { return false }
+}
+
+@ContributesBinding(ActivityScope::class)
+class RealWebContentDebugging @Inject constructor() : WebContentDebugging


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1205969526566822/f

### Description
Add web content debugging to internal builds

### Steps to test this PR

_Test Internal Build_
- [x] install from this branch internal build
- [x] open app and `chrome://inspect` in chrome (with device attached to computer)
- [x] verify dev tools can't connect with device
- [x] go to DDG app settings -> dev settings and enable `Web Content Debugging`
- [x] close and re-launch the app
- [x] verify dev tools connect with device (if not refresh chrome tools)


_Test Play Build_
- [x] install from this branch play build
- [x] open app and `chrome://inspect` in chrome (with device attached to computer)
- [x] verify dev tools can't connect with device

