### PR TITLE
Add reportFlow param to the broken site report pixel

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteActivity.kt
@@ -34,12 +34,14 @@ import com.duckduckgo.app.browser.databinding.ActivityBrokenSiteBinding
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.browser.api.WebViewVersionProvider
 import com.duckduckgo.browser.api.brokensite.BrokenSiteData
+import com.duckduckgo.browser.api.brokensite.BrokenSiteData.ReportFlow
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.view.dialog.DaxAlertDialog
 import com.duckduckgo.common.ui.view.dialog.RadioListAlertDialogBuilder
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.extensions.getSerializableExtra
 import com.duckduckgo.di.scopes.ActivityScope
 import com.google.android.material.snackbar.Snackbar
 import java.util.*
@@ -86,6 +88,7 @@ class BrokenSiteActivity : DuckDuckGoActivity() {
         val errorCodes = intent.getStringArrayExtra(ERROR_CODES).orEmpty()
         val httpErrorCodes = intent.getStringExtra(HTTP_ERROR_CODES).orEmpty()
         val isDesktopMode = intent.getBooleanExtra(IS_DESKTOP_MODE, false)
+        val reportFlow = intent.getSerializableExtra<ReportFlow>(REPORT_FLOW)!!
         viewModel.setInitialBrokenSite(
             url = url,
             blockedTrackers = blockedTrackers,
@@ -98,6 +101,7 @@ class BrokenSiteActivity : DuckDuckGoActivity() {
             errorCodes = errorCodes,
             httpErrorCodes = httpErrorCodes,
             isDesktopMode = isDesktopMode,
+            reportFlow = reportFlow,
         )
     }
 
@@ -243,6 +247,7 @@ class BrokenSiteActivity : DuckDuckGoActivity() {
         private const val ERROR_CODES = "ERROR_CODES"
         private const val HTTP_ERROR_CODES = "HTTP_ERROR_CODES"
         private const val IS_DESKTOP_MODE = "IS_DESKTOP_MODE"
+        private const val REPORT_FLOW = "report_flow"
 
         fun intent(
             context: Context,
@@ -260,6 +265,7 @@ class BrokenSiteActivity : DuckDuckGoActivity() {
             intent.putExtra(ERROR_CODES, data.errorCodes.toTypedArray())
             intent.putExtra(HTTP_ERROR_CODES, data.httpErrorCodes)
             intent.putExtra(IS_DESKTOP_MODE, data.isDesktopMode)
+            intent.putExtra(REPORT_FLOW, data.reportFlow)
             return intent
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteActivity.kt
@@ -88,7 +88,7 @@ class BrokenSiteActivity : DuckDuckGoActivity() {
         val errorCodes = intent.getStringArrayExtra(ERROR_CODES).orEmpty()
         val httpErrorCodes = intent.getStringExtra(HTTP_ERROR_CODES).orEmpty()
         val isDesktopMode = intent.getBooleanExtra(IS_DESKTOP_MODE, false)
-        val reportFlow = intent.getSerializableExtra<ReportFlow>(REPORT_FLOW)!!
+        val reportFlow = intent.getSerializableExtra<ReportFlow>(REPORT_FLOW)
         viewModel.setInitialBrokenSite(
             url = url,
             blockedTrackers = blockedTrackers,
@@ -247,7 +247,7 @@ class BrokenSiteActivity : DuckDuckGoActivity() {
         private const val ERROR_CODES = "ERROR_CODES"
         private const val HTTP_ERROR_CODES = "HTTP_ERROR_CODES"
         private const val IS_DESKTOP_MODE = "IS_DESKTOP_MODE"
-        private const val REPORT_FLOW = "report_flow"
+        private const val REPORT_FLOW = "REPORT_FLOW"
 
         fun intent(
             context: Context,

--- a/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteViewModel.kt
@@ -106,7 +106,7 @@ class BrokenSiteViewModel @Inject constructor(
     private var errorCodes: Array<out String> = emptyArray()
     private var httpErrorCodes: String = ""
     private var isDesktopMode: Boolean = false
-    private lateinit var reportFlow: ReportFlow
+    private var reportFlow: ReportFlow? = null
 
     var shuffledCategories = mutableListOf<BrokenSiteCategory>()
 
@@ -127,7 +127,7 @@ class BrokenSiteViewModel @Inject constructor(
         errorCodes: Array<out String>,
         httpErrorCodes: String,
         isDesktopMode: Boolean,
-        reportFlow: ReportFlow,
+        reportFlow: ReportFlow?,
     ) {
         this.url = url
         this.blockedTrackers = blockedTrackers
@@ -259,7 +259,7 @@ class BrokenSiteViewModel @Inject constructor(
             errorCodes = jsonStringListAdapter.toJson(errorCodes.toList()).toString(),
             httpErrorCodes = httpErrorCodes,
             loginSite = loginSite,
-            reportFlow = reportFlow.mapToBrokenSiteModelReportFlow(),
+            reportFlow = reportFlow?.mapToBrokenSiteModelReportFlow(),
         )
     }
 

--- a/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteViewModel.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.app.brokensite.api.BrokenSiteSender
 import com.duckduckgo.app.brokensite.model.BrokenSite
 import com.duckduckgo.app.brokensite.model.BrokenSiteCategory
 import com.duckduckgo.app.brokensite.model.BrokenSiteCategory.*
+import com.duckduckgo.app.brokensite.model.ReportFlow as BrokenSiteModelReportFlow
 import com.duckduckgo.app.brokensite.model.SiteProtectionsState
 import com.duckduckgo.app.brokensite.model.SiteProtectionsState.DISABLED
 import com.duckduckgo.app.brokensite.model.SiteProtectionsState.DISABLED_BY_REMOTE_CONFIG
@@ -34,6 +35,9 @@ import com.duckduckgo.app.global.SingleLiveEvent
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.browser.api.brokensite.BrokenSiteData.ReportFlow
+import com.duckduckgo.browser.api.brokensite.BrokenSiteData.ReportFlow.DASHBOARD
+import com.duckduckgo.browser.api.brokensite.BrokenSiteData.ReportFlow.MENU
 import com.duckduckgo.common.utils.extractDomain
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.feature.toggles.api.FeatureToggle
@@ -102,6 +106,7 @@ class BrokenSiteViewModel @Inject constructor(
     private var errorCodes: Array<out String> = emptyArray()
     private var httpErrorCodes: String = ""
     private var isDesktopMode: Boolean = false
+    private lateinit var reportFlow: ReportFlow
 
     var shuffledCategories = mutableListOf<BrokenSiteCategory>()
 
@@ -122,6 +127,7 @@ class BrokenSiteViewModel @Inject constructor(
         errorCodes: Array<out String>,
         httpErrorCodes: String,
         isDesktopMode: Boolean,
+        reportFlow: ReportFlow,
     ) {
         this.url = url
         this.blockedTrackers = blockedTrackers
@@ -134,6 +140,7 @@ class BrokenSiteViewModel @Inject constructor(
         this.errorCodes = errorCodes
         this.httpErrorCodes = httpErrorCodes
         this.isDesktopMode = isDesktopMode
+        this.reportFlow = reportFlow
 
         loadProtectionsState()
     }
@@ -252,6 +259,7 @@ class BrokenSiteViewModel @Inject constructor(
             errorCodes = jsonStringListAdapter.toJson(errorCodes.toList()).toString(),
             httpErrorCodes = httpErrorCodes,
             loginSite = loginSite,
+            reportFlow = reportFlow.mapToBrokenSiteModelReportFlow(),
         )
     }
 
@@ -263,4 +271,9 @@ class BrokenSiteViewModel @Inject constructor(
 
 private fun MutableLiveData<ViewState>.setProtectionsState(state: SiteProtectionsState?) {
     value = value!!.copy(protectionsState = state)
+}
+
+private fun ReportFlow.mapToBrokenSiteModelReportFlow(): BrokenSiteModelReportFlow = when (this) {
+    MENU -> BrokenSiteModelReportFlow.MENU
+    DASHBOARD -> BrokenSiteModelReportFlow.DASHBOARD
 }

--- a/app/src/main/java/com/duckduckgo/app/brokensite/api/BrokenSiteSender.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/api/BrokenSiteSender.kt
@@ -19,6 +19,9 @@ package com.duckduckgo.app.brokensite.api
 import android.net.Uri
 import androidx.core.net.toUri
 import com.duckduckgo.app.brokensite.model.BrokenSite
+import com.duckduckgo.app.brokensite.model.ReportFlow
+import com.duckduckgo.app.brokensite.model.ReportFlow.DASHBOARD
+import com.duckduckgo.app.brokensite.model.ReportFlow.MENU
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
@@ -101,6 +104,7 @@ class BrokenSiteSubmitter @Inject constructor(
                 ERROR_CODES_KEY to brokenSite.errorCodes,
                 HTTP_ERROR_CODES_KEY to brokenSite.httpErrorCodes,
                 PROTECTIONS_STATE to protectionsState.toString(),
+                REPORT_FLOW to brokenSite.reportFlow.toStringValue(),
             )
 
             val lastSentDay = brokenSiteLastSentReport.getLastSentDay(domain.orEmpty())
@@ -160,7 +164,13 @@ class BrokenSiteSubmitter @Inject constructor(
         private const val PROTECTIONS_STATE = "protectionsState"
         private const val LAST_SENT_DAY = "lastSentDay"
         private const val LOGIN_SITE = "loginSite"
+        private const val REPORT_FLOW = "reportFlow"
     }
 }
 
 fun Boolean.toBinaryString(): String = if (this) "1" else "0"
+
+private fun ReportFlow.toStringValue(): String = when (this) {
+    DASHBOARD -> "dashboard"
+    MENU -> "menu"
+}

--- a/app/src/main/java/com/duckduckgo/app/brokensite/api/BrokenSiteSender.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/api/BrokenSiteSender.kt
@@ -104,8 +104,11 @@ class BrokenSiteSubmitter @Inject constructor(
                 ERROR_CODES_KEY to brokenSite.errorCodes,
                 HTTP_ERROR_CODES_KEY to brokenSite.httpErrorCodes,
                 PROTECTIONS_STATE to protectionsState.toString(),
-                REPORT_FLOW to brokenSite.reportFlow.toStringValue(),
             )
+
+            brokenSite.reportFlow?.let { reportFlow ->
+                params[REPORT_FLOW] = reportFlow.toStringValue()
+            }
 
             val lastSentDay = brokenSiteLastSentReport.getLastSentDay(domain.orEmpty())
             if (lastSentDay != null) {

--- a/app/src/main/java/com/duckduckgo/app/brokensite/model/BrokenSite.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/model/BrokenSite.kt
@@ -35,7 +35,7 @@ data class BrokenSite(
     val errorCodes: String,
     val httpErrorCodes: String,
     val loginSite: String?,
-    val reportFlow: ReportFlow,
+    val reportFlow: ReportFlow?,
 )
 
 sealed class BrokenSiteCategory(

--- a/app/src/main/java/com/duckduckgo/app/brokensite/model/BrokenSite.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/model/BrokenSite.kt
@@ -35,6 +35,7 @@ data class BrokenSite(
     val errorCodes: String,
     val httpErrorCodes: String,
     val loginSite: String?,
+    val reportFlow: ReportFlow,
 )
 
 sealed class BrokenSiteCategory(
@@ -63,3 +64,5 @@ sealed class BrokenSiteCategory(
         const val OTHER_CATEGORY_KEY = "other"
     }
 }
+
+enum class ReportFlow { DASHBOARD, MENU }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -115,6 +115,7 @@ import com.duckduckgo.autofill.api.email.EmailManager
 import com.duckduckgo.autofill.api.passwordgeneration.AutomaticSavedLoginsMonitor
 import com.duckduckgo.autofill.impl.AutofillFireproofDialogSuppressor
 import com.duckduckgo.browser.api.brokensite.BrokenSiteData
+import com.duckduckgo.browser.api.brokensite.BrokenSiteData.ReportFlow.MENU
 import com.duckduckgo.common.utils.AppUrl
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.UriString
@@ -2129,7 +2130,7 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     fun onBrokenSiteSelected() {
-        command.value = BrokenSiteFeedback(BrokenSiteData.fromSite(site))
+        command.value = BrokenSiteFeedback(BrokenSiteData.fromSite(site, reportFlow = MENU))
     }
 
     fun onPrivacyProtectionMenuClicked() {

--- a/app/src/test/java/com/duckduckgo/app/brokensite/BrokenSiteDataTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/brokensite/BrokenSiteDataTest.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.app.trackerdetection.model.TrackerStatus
 import com.duckduckgo.app.trackerdetection.model.TrackerType
 import com.duckduckgo.app.trackerdetection.model.TrackingEvent
 import com.duckduckgo.browser.api.brokensite.BrokenSiteData
+import com.duckduckgo.browser.api.brokensite.BrokenSiteData.ReportFlow.MENU
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.privacy.config.api.ContentBlocking
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -47,7 +48,7 @@ class BrokenSiteDataTest {
 
     @Test
     fun whenSiteIsNullThenDataIsEmptyAndUpgradedIsFalse() {
-        val data = BrokenSiteData.fromSite(null)
+        val data = BrokenSiteData.fromSite(null, reportFlow = MENU)
         assertTrue(data.url.isEmpty())
         assertTrue(data.blockedTrackers.isEmpty())
         assertTrue(data.surrogates.isEmpty())
@@ -57,21 +58,21 @@ class BrokenSiteDataTest {
     @Test
     fun whenSiteExistsThenDataContainsUrl() {
         val site = buildSite(SITE_URL)
-        val data = BrokenSiteData.fromSite(site)
+        val data = BrokenSiteData.fromSite(site, reportFlow = MENU)
         assertEquals(SITE_URL, data.url)
     }
 
     @Test
     fun whenSiteUpgradedThenHttpsUpgradedIsTrue() {
         val site = buildSite(SITE_URL, httpsUpgraded = true)
-        val data = BrokenSiteData.fromSite(site)
+        val data = BrokenSiteData.fromSite(site, reportFlow = MENU)
         assertTrue(data.upgradedToHttps)
     }
 
     @Test
     fun whenSiteNotUpgradedThenHttpsUpgradedIsFalse() {
         val site = buildSite(SITE_URL, httpsUpgraded = false)
-        val data = BrokenSiteData.fromSite(site)
+        val data = BrokenSiteData.fromSite(site, reportFlow = MENU)
         assertFalse(data.upgradedToHttps)
     }
 
@@ -79,21 +80,21 @@ class BrokenSiteDataTest {
     fun whenUrlParametersRemovedThenUrlParametersRemovedIsTrue() {
         val site = buildSite(SITE_URL)
         site.urlParametersRemoved = true
-        val data = BrokenSiteData.fromSite(site)
+        val data = BrokenSiteData.fromSite(site, reportFlow = MENU)
         assertTrue(data.urlParametersRemoved)
     }
 
     @Test
     fun whenUrlParametersNotRemovedThenUrlParametersRemovedIsFalse() {
         val site = buildSite(SITE_URL)
-        val data = BrokenSiteData.fromSite(site)
+        val data = BrokenSiteData.fromSite(site, reportFlow = MENU)
         assertFalse(data.urlParametersRemoved)
     }
 
     @Test
     fun whenSiteHasNoTrackersThenBlockedTrackersIsEmpty() {
         val site = buildSite(SITE_URL)
-        val data = BrokenSiteData.fromSite(site)
+        val data = BrokenSiteData.fromSite(site, reportFlow = MENU)
         assertTrue(data.blockedTrackers.isEmpty())
     }
 
@@ -120,7 +121,7 @@ class BrokenSiteDataTest {
         )
         site.trackerDetected(event)
         site.trackerDetected(anotherEvent)
-        assertEquals("tracker.com", BrokenSiteData.fromSite(site).blockedTrackers)
+        assertEquals("tracker.com", BrokenSiteData.fromSite(site, reportFlow = MENU).blockedTrackers)
     }
 
     @Test
@@ -146,7 +147,7 @@ class BrokenSiteDataTest {
         )
         site.trackerDetected(event)
         site.trackerDetected(anotherEvent)
-        assertEquals("tracker.com", BrokenSiteData.fromSite(site).blockedTrackers)
+        assertEquals("tracker.com", BrokenSiteData.fromSite(site, reportFlow = MENU).blockedTrackers)
     }
 
     @Test
@@ -162,13 +163,13 @@ class BrokenSiteDataTest {
             type = TrackerType.OTHER,
         )
         site.trackerDetected(event)
-        assertEquals(".tracker.com", BrokenSiteData.fromSite(site).blockedTrackers)
+        assertEquals(".tracker.com", BrokenSiteData.fromSite(site, reportFlow = MENU).blockedTrackers)
     }
 
     @Test
     fun whenSiteHasNoSurrogatesThenSurrogatesIsEmpty() {
         val site = buildSite(SITE_URL)
-        val data = BrokenSiteData.fromSite(site)
+        val data = BrokenSiteData.fromSite(site, reportFlow = MENU)
         assertTrue(data.surrogates.isEmpty())
     }
 
@@ -179,7 +180,7 @@ class BrokenSiteDataTest {
         val site = buildSite(SITE_URL)
         site.surrogateDetected(surrogate)
         site.surrogateDetected(anotherSurrogate)
-        assertEquals("surrogate.com,anothersurrogate.com", BrokenSiteData.fromSite(site).surrogates)
+        assertEquals("surrogate.com,anothersurrogate.com", BrokenSiteData.fromSite(site, reportFlow = MENU).surrogates)
     }
 
     @Test
@@ -189,7 +190,7 @@ class BrokenSiteDataTest {
         val site = buildSite(SITE_URL)
         site.surrogateDetected(surrogate)
         site.surrogateDetected(anotherSurrogate)
-        assertEquals("surrogate.com", BrokenSiteData.fromSite(site).surrogates)
+        assertEquals("surrogate.com", BrokenSiteData.fromSite(site, reportFlow = MENU).surrogates)
     }
 
     private fun buildSite(

--- a/app/src/test/java/com/duckduckgo/app/brokensite/api/BrokenSiteSubmitterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/brokensite/api/BrokenSiteSubmitterTest.kt
@@ -271,6 +271,20 @@ class BrokenSiteSubmitterTest {
         assertEquals("dashboard", params["reportFlow"])
     }
 
+    @Test
+    fun whenReportFlowIsNullThenDoNotIncludeParam() {
+        val brokenSite = getBrokenSite()
+            .copy(reportFlow = null)
+
+        testee.submitBrokenSiteFeedback(brokenSite)
+
+        val paramsCaptor = argumentCaptor<Map<String, String>>()
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), any())
+        val params = paramsCaptor.firstValue
+
+        assertFalse("reportFlow" in params)
+    }
+
     private fun getBrokenSite(): BrokenSite {
         return BrokenSite(
             category = "category",

--- a/app/src/test/java/com/duckduckgo/app/brokensite/api/BrokenSiteSubmitterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/brokensite/api/BrokenSiteSubmitterTest.kt
@@ -206,7 +206,7 @@ class BrokenSiteSubmitterTest {
     }
 
     @Test
-    fun whenDeviceIsEnglishAndLoginReportThenIncludeLoginSite() {
+    fun whenDeviceIsEnglishThenIncludeLoginSite() {
         whenever(mockAppBuildConfig.deviceLocale).thenReturn(Locale.ENGLISH)
         whenever(mockContentBlocking.isAnException(any())).thenReturn(false)
         whenever(mockUserAllowListRepository.isDomainInUserAllowList(any())).thenReturn(false)
@@ -224,7 +224,7 @@ class BrokenSiteSubmitterTest {
     }
 
     @Test
-    fun whenDeviceIsNotEnglishAndLoginReportThenIncludeLoginSite() {
+    fun whenDeviceIsNotEnglishThenDoNotIncludeLoginSite() {
         whenever(mockAppBuildConfig.deviceLocale).thenReturn(Locale.FRANCE)
         whenever(mockContentBlocking.isAnException(any())).thenReturn(false)
         whenever(mockUserAllowListRepository.isDomainInUserAllowList(any())).thenReturn(false)

--- a/app/src/test/java/com/duckduckgo/app/brokensite/api/BrokenSiteSubmitterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/brokensite/api/BrokenSiteSubmitterTest.kt
@@ -3,7 +3,6 @@ package com.duckduckgo.app.brokensite.api
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.brokensite.BrokenSiteViewModel
 import com.duckduckgo.app.brokensite.model.BrokenSite
-import com.duckduckgo.app.brokensite.model.BrokenSiteCategory
 import com.duckduckgo.app.brokensite.model.ReportFlow
 import com.duckduckgo.app.pixels.AppPixelName.BROKEN_SITE_REPORT
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
@@ -212,7 +211,7 @@ class BrokenSiteSubmitterTest {
         whenever(mockContentBlocking.isAnException(any())).thenReturn(false)
         whenever(mockUserAllowListRepository.isDomainInUserAllowList(any())).thenReturn(false)
         whenever(mockUnprotectedTemporary.isAnException(any())).thenReturn(false)
-        val brokenSite = getBrokenSite(BrokenSiteCategory.LOGIN_CATEGORY_KEY)
+        val brokenSite = getBrokenSite()
 
         testee.submitBrokenSiteFeedback(brokenSite)
 
@@ -230,7 +229,7 @@ class BrokenSiteSubmitterTest {
         whenever(mockContentBlocking.isAnException(any())).thenReturn(false)
         whenever(mockUserAllowListRepository.isDomainInUserAllowList(any())).thenReturn(false)
         whenever(mockUnprotectedTemporary.isAnException(any())).thenReturn(false)
-        val brokenSite = getBrokenSite(BrokenSiteCategory.LOGIN_CATEGORY_KEY)
+        val brokenSite = getBrokenSite()
 
         testee.submitBrokenSiteFeedback(brokenSite)
 
@@ -242,7 +241,7 @@ class BrokenSiteSubmitterTest {
         assertFalse(params.containsKey("loginSite"))
     }
 
-    private fun getBrokenSite(category: String = "category"): BrokenSite {
+    private fun getBrokenSite(): BrokenSite {
         return BrokenSite(
             category = "category",
             description = "description",

--- a/app/src/test/java/com/duckduckgo/app/brokensite/api/BrokenSiteSubmitterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/brokensite/api/BrokenSiteSubmitterTest.kt
@@ -4,6 +4,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.brokensite.BrokenSiteViewModel
 import com.duckduckgo.app.brokensite.model.BrokenSite
 import com.duckduckgo.app.brokensite.model.BrokenSiteCategory
+import com.duckduckgo.app.brokensite.model.ReportFlow
 import com.duckduckgo.app.pixels.AppPixelName.BROKEN_SITE_REPORT
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.statistics.model.Atb
@@ -258,6 +259,7 @@ class BrokenSiteSubmitterTest {
             errorCodes = "",
             httpErrorCodes = "",
             loginSite = null,
+            reportFlow = ReportFlow.MENU,
         )
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/brokensite/api/BrokenSiteSubmitterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/brokensite/api/BrokenSiteSubmitterTest.kt
@@ -4,6 +4,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.brokensite.BrokenSiteViewModel
 import com.duckduckgo.app.brokensite.model.BrokenSite
 import com.duckduckgo.app.brokensite.model.ReportFlow
+import com.duckduckgo.app.brokensite.model.ReportFlow.DASHBOARD
+import com.duckduckgo.app.brokensite.model.ReportFlow.MENU
 import com.duckduckgo.app.pixels.AppPixelName.BROKEN_SITE_REPORT
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.statistics.model.Atb
@@ -239,6 +241,34 @@ class BrokenSiteSubmitterTest {
         val params = paramsCaptor.firstValue
 
         assertFalse(params.containsKey("loginSite"))
+    }
+
+    @Test
+    fun whenReportFlowIsMenuThenIncludeParam() {
+        val brokenSite = getBrokenSite()
+            .copy(reportFlow = MENU)
+
+        testee.submitBrokenSiteFeedback(brokenSite)
+
+        val paramsCaptor = argumentCaptor<Map<String, String>>()
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), any())
+        val params = paramsCaptor.firstValue
+
+        assertEquals("menu", params["reportFlow"])
+    }
+
+    @Test
+    fun whenReportFlowIsDashboardThenIncludeParam() {
+        val brokenSite = getBrokenSite()
+            .copy(reportFlow = DASHBOARD)
+
+        testee.submitBrokenSiteFeedback(brokenSite)
+
+        val paramsCaptor = argumentCaptor<Map<String, String>>()
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), any())
+        val params = paramsCaptor.firstValue
+
+        assertEquals("dashboard", params["reportFlow"])
     }
 
     private fun getBrokenSite(): BrokenSite {

--- a/app/src/test/java/com/duckduckgo/app/feedback/BrokenSiteViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/feedback/BrokenSiteViewModelTest.kt
@@ -24,10 +24,12 @@ import com.duckduckgo.app.brokensite.BrokenSiteViewModel.Command
 import com.duckduckgo.app.brokensite.api.BrokenSiteSender
 import com.duckduckgo.app.brokensite.model.BrokenSite
 import com.duckduckgo.app.brokensite.model.BrokenSiteCategory
+import com.duckduckgo.app.brokensite.model.ReportFlow
 import com.duckduckgo.app.brokensite.model.SiteProtectionsState
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.browser.api.brokensite.BrokenSiteData.ReportFlow.MENU
 import com.duckduckgo.common.test.InstantSchedulersRule
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.AmpLinkInfo
@@ -156,6 +158,7 @@ class BrokenSiteViewModelTest {
             errorCodes = emptyArray(),
             httpErrorCodes = "",
             isDesktopMode = false,
+            reportFlow = MENU,
         )
         selectAndAcceptCategory()
         testee.onSubmitPressed("webViewVersion", "description", "")
@@ -176,6 +179,7 @@ class BrokenSiteViewModelTest {
             errorCodes = "[]",
             httpErrorCodes = "",
             loginSite = "",
+            reportFlow = ReportFlow.MENU,
         )
 
         verify(mockPixel).fire(AppPixelName.BROKEN_SITE_REPORTED, mapOf("url" to url))
@@ -198,6 +202,7 @@ class BrokenSiteViewModelTest {
             errorCodes = emptyArray(),
             httpErrorCodes = "",
             isDesktopMode = false,
+            reportFlow = MENU,
         )
         selectAndAcceptCategory()
         testee.onSubmitPressed("webViewVersion", "description", "")
@@ -218,6 +223,7 @@ class BrokenSiteViewModelTest {
             errorCodes = "",
             httpErrorCodes = "",
             loginSite = "",
+            reportFlow = ReportFlow.MENU,
         )
 
         verify(mockPixel, never()).fire(AppPixelName.BROKEN_SITE_REPORTED, mapOf("url" to nullUrl))
@@ -241,6 +247,7 @@ class BrokenSiteViewModelTest {
             errorCodes = emptyArray(),
             httpErrorCodes = "",
             isDesktopMode = false,
+            reportFlow = MENU,
         )
         selectAndAcceptCategory()
         testee.onSubmitPressed("webViewVersion", "description", "")
@@ -261,6 +268,7 @@ class BrokenSiteViewModelTest {
             errorCodes = "[]",
             httpErrorCodes = "",
             loginSite = "",
+            reportFlow = ReportFlow.MENU,
         )
 
         verify(mockPixel).fire(AppPixelName.BROKEN_SITE_REPORTED, mapOf("url" to url))
@@ -284,6 +292,7 @@ class BrokenSiteViewModelTest {
             errorCodes = emptyArray(),
             httpErrorCodes = "",
             isDesktopMode = false,
+            reportFlow = MENU,
         )
         selectAndAcceptCategory()
         testee.onSubmitPressed("webViewVersion", "description", "")
@@ -304,6 +313,7 @@ class BrokenSiteViewModelTest {
             errorCodes = "[]",
             httpErrorCodes = "",
             loginSite = "",
+            reportFlow = ReportFlow.MENU,
         )
 
         verify(mockPixel).fire(AppPixelName.BROKEN_SITE_REPORTED, mapOf("url" to trackingUrl))
@@ -327,6 +337,7 @@ class BrokenSiteViewModelTest {
             errorCodes = emptyArray(),
             httpErrorCodes = "",
             isDesktopMode = false,
+            reportFlow = MENU,
         )
         selectAndAcceptCategory()
         testee.onSubmitPressed("webViewVersion", "description", "")
@@ -353,6 +364,7 @@ class BrokenSiteViewModelTest {
             errorCodes = emptyArray(),
             httpErrorCodes = "",
             isDesktopMode = true,
+            reportFlow = MENU,
         )
         selectAndAcceptCategory()
 
@@ -374,6 +386,7 @@ class BrokenSiteViewModelTest {
             errorCodes = emptyArray(),
             httpErrorCodes = "",
             isDesktopMode = false,
+            reportFlow = MENU,
         )
         selectAndAcceptCategory()
 
@@ -397,6 +410,7 @@ class BrokenSiteViewModelTest {
             errorCodes = emptyArray(),
             httpErrorCodes = "",
             isDesktopMode = false,
+            reportFlow = MENU,
         )
         selectAndAcceptCategory(categoryIndex)
 
@@ -419,6 +433,7 @@ class BrokenSiteViewModelTest {
             errorCodes = emptyArray(),
             httpErrorCodes = "",
             isDesktopMode = false,
+            reportFlow = MENU,
         )
         selectAndAcceptCategory(0)
         testee.onCategoryIndexChanged(1)
@@ -441,6 +456,7 @@ class BrokenSiteViewModelTest {
             errorCodes = emptyArray(),
             httpErrorCodes = "",
             isDesktopMode = false,
+            reportFlow = MENU,
         )
         testee.onCategoryIndexChanged(1)
         testee.onCategorySelectionCancelled()
@@ -464,6 +480,7 @@ class BrokenSiteViewModelTest {
             errorCodes = emptyArray(),
             httpErrorCodes = "",
             isDesktopMode = false,
+            reportFlow = MENU,
         )
         selectAndAcceptCategory(categoryIndex)
         testee.onSubmitPressed("webViewVersion", "description", "test")
@@ -484,6 +501,7 @@ class BrokenSiteViewModelTest {
             errorCodes = "[]",
             httpErrorCodes = "",
             loginSite = "test",
+            reportFlow = ReportFlow.MENU,
         )
 
         verify(mockPixel).fire(AppPixelName.BROKEN_SITE_REPORTED, mapOf("url" to url))
@@ -507,6 +525,7 @@ class BrokenSiteViewModelTest {
             errorCodes = emptyArray(),
             httpErrorCodes = "",
             isDesktopMode = false,
+            reportFlow = MENU,
         )
         selectAndAcceptCategory(categoryIndex)
         testee.onSubmitPressed("webViewVersion", "description", "test")
@@ -527,6 +546,7 @@ class BrokenSiteViewModelTest {
             errorCodes = "[]",
             httpErrorCodes = "",
             loginSite = "",
+            reportFlow = ReportFlow.MENU,
         )
 
         verify(mockPixel).fire(AppPixelName.BROKEN_SITE_REPORTED, mapOf("url" to url))
@@ -550,6 +570,7 @@ class BrokenSiteViewModelTest {
             errorCodes = emptyArray(),
             httpErrorCodes = "",
             isDesktopMode = false,
+            reportFlow = MENU,
         )
 
         testee.onProtectionsToggled(protectionsEnabled = false)
@@ -582,6 +603,7 @@ class BrokenSiteViewModelTest {
             errorCodes = emptyArray(),
             httpErrorCodes = "",
             isDesktopMode = false,
+            reportFlow = MENU,
         )
 
         assertEquals(SiteProtectionsState.DISABLED_BY_REMOTE_CONFIG, viewState.protectionsState)
@@ -607,6 +629,7 @@ class BrokenSiteViewModelTest {
             errorCodes = emptyArray(),
             httpErrorCodes = "",
             isDesktopMode = false,
+            reportFlow = MENU,
         )
 
         assertEquals(SiteProtectionsState.DISABLED_BY_REMOTE_CONFIG, viewState.protectionsState)
@@ -632,6 +655,7 @@ class BrokenSiteViewModelTest {
             errorCodes = emptyArray(),
             httpErrorCodes = "",
             isDesktopMode = false,
+            reportFlow = MENU,
         )
 
         assertEquals(SiteProtectionsState.DISABLED_BY_REMOTE_CONFIG, viewState.protectionsState)
@@ -656,6 +680,7 @@ class BrokenSiteViewModelTest {
             errorCodes = emptyArray(),
             httpErrorCodes = "",
             isDesktopMode = false,
+            reportFlow = MENU,
         )
 
         assertEquals(SiteProtectionsState.DISABLED, viewState.protectionsState)
@@ -680,6 +705,7 @@ class BrokenSiteViewModelTest {
             errorCodes = emptyArray(),
             httpErrorCodes = "",
             isDesktopMode = false,
+            reportFlow = MENU,
         )
 
         assertEquals(SiteProtectionsState.ENABLED, viewState.protectionsState)
@@ -699,6 +725,7 @@ class BrokenSiteViewModelTest {
             errorCodes = emptyArray(),
             httpErrorCodes = "",
             isDesktopMode = false,
+            reportFlow = MENU,
         )
 
         testee.onProtectionsToggled(protectionsEnabled = false)
@@ -719,6 +746,7 @@ class BrokenSiteViewModelTest {
             errorCodes = emptyArray(),
             httpErrorCodes = "",
             isDesktopMode = false,
+            reportFlow = MENU,
         )
 
         testee.onProtectionsToggled(protectionsEnabled = true)

--- a/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesMultipleReportReferenceTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesMultipleReportReferenceTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.referencetests.brokensites
 import com.duckduckgo.app.brokensite.BrokenSiteViewModel
 import com.duckduckgo.app.brokensite.api.BrokenSiteSubmitter
 import com.duckduckgo.app.brokensite.model.BrokenSite
+import com.duckduckgo.app.brokensite.model.ReportFlow
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.model.Atb
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -169,6 +170,7 @@ class BrokenSitesMultipleReportReferenceTest(private val testCase: MultipleRepor
                 errorCodes = "",
                 httpErrorCodes = "",
                 loginSite = null,
+                reportFlow = ReportFlow.MENU,
             )
 
             testee.submitBrokenSiteFeedback(brokenSite)

--- a/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesReferenceTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesReferenceTest.kt
@@ -20,6 +20,7 @@ import android.net.Uri
 import com.duckduckgo.app.brokensite.BrokenSiteViewModel
 import com.duckduckgo.app.brokensite.api.BrokenSiteSubmitter
 import com.duckduckgo.app.brokensite.model.BrokenSite
+import com.duckduckgo.app.brokensite.model.ReportFlow
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.statistics.model.Atb
@@ -27,6 +28,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.app.trackerdetection.db.TdsMetadataDao
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.browser.api.brokensite.BrokenSiteData.ReportFlow.MENU
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.test.FileUtilities
 import com.duckduckgo.experiments.api.VariantManager
@@ -156,6 +158,7 @@ class BrokenSitesReferenceTest(private val testCase: TestCase) {
             errorCodes = "",
             httpErrorCodes = "",
             loginSite = null,
+            reportFlow = ReportFlow.MENU,
         )
 
         testee.submitBrokenSiteFeedback(brokenSite)

--- a/browser-api/src/main/java/com/duckduckgo/browser/api/brokensite/BrokenSiteNav.kt
+++ b/browser-api/src/main/java/com/duckduckgo/browser/api/brokensite/BrokenSiteNav.kt
@@ -39,9 +39,12 @@ data class BrokenSiteData(
     val errorCodes: List<String>,
     val httpErrorCodes: String,
     val isDesktopMode: Boolean,
+    val reportFlow: ReportFlow,
 ) {
+    enum class ReportFlow { MENU, DASHBOARD }
+
     companion object {
-        fun fromSite(site: Site?): BrokenSiteData {
+        fun fromSite(site: Site?, reportFlow: ReportFlow): BrokenSiteData {
             val events = site?.trackingEvents
             val blockedTrackers = events?.filter { it.status == TrackerStatus.BLOCKED }
                 ?.map { Uri.parse(it.trackerUrl).baseHost.orEmpty() }
@@ -68,6 +71,7 @@ data class BrokenSiteData(
                 errorCodes = errorCodes,
                 httpErrorCodes = httErrorCodes,
                 isDesktopMode = isDesktopMode,
+                reportFlow = reportFlow,
             )
         }
     }

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/extensions/IntentExtensions.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/extensions/IntentExtensions.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.utils.extensions
+
+import android.content.Intent
+import android.os.Build
+import java.io.Serializable
+
+inline fun <reified T : Serializable> Intent.getSerializableExtra(name: String): T? =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        getSerializableExtra(name, T::class.java)
+    } else {
+        @Suppress("DEPRECATION")
+        getSerializableExtra(name) as? T
+    }

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModel.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModel.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.app.global.model.domain
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.browser.api.brokensite.BrokenSiteData
+import com.duckduckgo.browser.api.brokensite.BrokenSiteData.ReportFlow.DASHBOARD
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.privacy.dashboard.impl.pixels.PrivacyDashboardPixels.PRIVACY_DASHBOARD_ALLOWLIST_ADD
@@ -210,7 +211,7 @@ class PrivacyDashboardHybridViewModel @Inject constructor(
 
     fun onReportBrokenSiteSelected() {
         viewModelScope.launch(dispatcher.io()) {
-            val siteData = BrokenSiteData.fromSite(site.value)
+            val siteData = BrokenSiteData.fromSite(site.value, reportFlow = DASHBOARD)
             command.send(LaunchReportBrokenSite(siteData))
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1205957959864913/f

### Description

Add the reportFlow parameter to the broken site report pixel

### Steps to test this PR

#### Menu flow
- [x] Navigate to the site breakage report screen through menu -> Report Broken Site
- [x] Send report
- [x] Verify that `"reportFlow"="menu"` param is included in the `epbf` pixel.

#### Dashboard flow
- [x] Navigate to the site breakage report screen through Privacy Dashboard -> "Website not working?"
- [x] Send report
- [x] Verify that `"reportFlow"="dashboard"` param is included in the `epbf` pixel.


### No UI changes
