### PR TITLE
Attempt to fix test failing due to exceeding 10s timeout

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -172,14 +172,14 @@ class BrowserWebViewClientTest {
 
     @UiThreadTest
     @Test
-    fun whenOnPageStartedCalledThenEventSentToLoginDetector() = runTest {
+    fun whenOnPageStartedCalledThenEventSentToLoginDetector() {
         testee.onPageStarted(webView, EXAMPLE_URL, null)
         verify(loginDetector).onEvent(WebNavigationEvent.OnPageStarted(webView))
     }
 
     @UiThreadTest
     @Test
-    fun whenOnPageStartedCalledThenInjectJsCode() = runTest {
+    fun whenOnPageStartedCalledThenInjectJsCode() {
         assertEquals(0, jsPlugins.plugin.countStarted)
         testee.onPageStarted(webView, EXAMPLE_URL, null)
         assertEquals(1, jsPlugins.plugin.countStarted)
@@ -195,7 +195,7 @@ class BrowserWebViewClientTest {
 
     @UiThreadTest
     @Test
-    fun whenOnPageStartedCalledThenInjectAutoconsentCalled() = runTest {
+    fun whenOnPageStartedCalledThenInjectAutoconsentCalled() {
         testee.onPageStarted(webView, EXAMPLE_URL, null)
         verify(autoconsent).injectAutoconsent(webView, EXAMPLE_URL)
     }
@@ -436,7 +436,7 @@ class BrowserWebViewClientTest {
     }
 
     @Test
-    fun whenAmpLinkDetectedAndIsForMainFrameThenReturnTrueAndLoadExtractedUrl() = runTest {
+    fun whenAmpLinkDetectedAndIsForMainFrameThenReturnTrueAndLoadExtractedUrl() {
         whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any()))
             .thenReturn(SpecialUrlDetector.UrlType.ExtractedAmpLink(EXAMPLE_URL))
         whenever(webResourceRequest.isForMainFrame).thenReturn(true)
@@ -447,7 +447,7 @@ class BrowserWebViewClientTest {
     }
 
     @Test
-    fun whenAmpLinkDetectedAndIsNotForMainFrameThenReturnFalse() = runTest {
+    fun whenAmpLinkDetectedAndIsNotForMainFrameThenReturnFalse() {
         whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any()))
             .thenReturn(SpecialUrlDetector.UrlType.ExtractedAmpLink(EXAMPLE_URL))
         whenever(webResourceRequest.isForMainFrame).thenReturn(false)
@@ -482,7 +482,7 @@ class BrowserWebViewClientTest {
     }
 
     @Test
-    fun whenTrackingParametersDetectedAndIsForMainFrameThenReturnTrueAndLoadCleanedUrl() = runTest {
+    fun whenTrackingParametersDetectedAndIsForMainFrameThenReturnTrueAndLoadCleanedUrl() {
         whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any()))
             .thenReturn(SpecialUrlDetector.UrlType.TrackingParameterLink(EXAMPLE_URL))
         whenever(webResourceRequest.isForMainFrame).thenReturn(true)
@@ -499,7 +499,7 @@ class BrowserWebViewClientTest {
     }
 
     @Test
-    fun whenTrackingParametersDetectedAndIsNotForMainFrameThenReturnFalse() = runTest {
+    fun whenTrackingParametersDetectedAndIsNotForMainFrameThenReturnFalse() {
         whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any()))
             .thenReturn(SpecialUrlDetector.UrlType.TrackingParameterLink(EXAMPLE_URL))
         whenever(webResourceRequest.isForMainFrame).thenReturn(false)
@@ -525,13 +525,13 @@ class BrowserWebViewClientTest {
     }
 
     @Test
-    fun whenTrackingParametersDetectedAndIsForMainFrameAndIsAppLinkAndAppLinkIsHandledAndIsOpenedInNewTabThenReturnTrueAndLoadCleanedUrl() = runTest {
+    fun whenTrackingParametersDetectedAndIsForMainFrameAndIsAppLinkAndAppLinkIsHandledAndIsOpenedInNewTabThenReturnTrueAndLoadCleanedUrl() {
         whenever(listener.linkOpenedInNewTab()).thenReturn(true)
         whenTrackingParametersDetectedAndIsForMainFrameAndIsAppLinkAndAppLinkIsHandledThenReturnTrueAndLoadCleanedUrl()
     }
 
     @Test
-    fun whenTrackingParametersDetectedAndIsForMainFrameAndIsAppLinkAndAppLinkIsNotHandledThenReturnFalseAndLoadCleanedUrl() = runTest {
+    fun whenTrackingParametersDetectedAndIsForMainFrameAndIsAppLinkAndAppLinkIsNotHandledThenReturnFalseAndLoadCleanedUrl() {
         whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any()))
             .thenReturn(SpecialUrlDetector.UrlType.TrackingParameterLink(EXAMPLE_URL))
         val appLink = SpecialUrlDetector.UrlType.AppLink(uriString = EXAMPLE_URL)
@@ -552,7 +552,7 @@ class BrowserWebViewClientTest {
     }
 
     @Test
-    fun whenTrackingParametersDetectedAndIsForMainFrameAndIsExtractedAmpLinkThenReturnTrueAndLoadExtractedUrl() = runTest {
+    fun whenTrackingParametersDetectedAndIsForMainFrameAndIsExtractedAmpLinkThenReturnTrueAndLoadExtractedUrl() {
         whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any()))
             .thenReturn(SpecialUrlDetector.UrlType.TrackingParameterLink(EXAMPLE_URL))
         val ampLink = SpecialUrlDetector.UrlType.ExtractedAmpLink(extractedUrl = EXAMPLE_URL)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/0/1205977462737331/f 

### Description
Attempt at fixing the timeout occasionally experienced because of the new 10s `runTest` execution timeout.

While reviewing the failing tests, two things sprung to mind:
- `whenTrackingParametersDetectedAndIsForMainFrameAndIsAppLinkAndAppLinkIsHandledThenReturnTrueAndLoadCleanedUrl` is suspect, because it's a test, but it's also called from inside another test. This would result in a nested `runTest`. This isn't fixed in this PR yet (if the tests pass, will defer changing it)
- there are many tests which mock a `WebView` which is a slow operation (over 1.5s on my fast local setup). 
    - Feasible this could result in tripping the 10s threshold on CI. 
    - But also, none of the tests seem to require `runTest` anyway

### Steps to test this PR

_Feature 1_
- [ ] CI passes
