### PR TITLE
Fix okhttp3 NullPointerException

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -75,7 +75,7 @@ version.com.nhaarman.mockitokotlin2..mockito-kotlin=2.2.0
 
 version.google.android.material=1.7.0
 
-version.google.dagger=2.46.1
+version.google.dagger=2.48.1
 
 version.jakewharton.rxrelay2=2.0.0
 
@@ -93,7 +93,7 @@ version.mockito=4.4.0
 
 version.moshi=1.8.0
 
-version.okhttp3=4.11.0
+version.okhttp3=4.12.0
 
 version.net.zetetic..android-database-sqlcipher=4.5.1
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205409122994449/f

### Description
Fixes a NullPointerException in okhttp due to certificate corruption.

Changes:
- `version.google.dagger`=`2.46.1` → `2.48.1`
- `version.okhttp3`=`4.11.0` → `4.12.0`

### Steps to test this PR
- [ ] Smoke test
