### PR TITLE
Bump ng to 1.6.9 to woraround TLS fragmented records

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -57,7 +57,7 @@ version.com.airbnb.android..lottie=5.2.0
 
 version.com.android.installreferrer..installreferrer=2.2
 
-version.com.duckduckgo.netguard..netguard-android=1.6.8
+version.com.duckduckgo.netguard..netguard-android=1.6.9
 
 version.com.duckduckgo.synccrypto..sync-crypto-android=0.3.0
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1205874074739543/f

### Description
Bump NG to 1.6.9 to workaround TLS fragmented records. See Asana for more info

### Steps to test this PR
Smoke test AppTP and VPN
