### PR TITLE
Calculate lint version automatically instead of hardcoding specific version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,14 +7,17 @@ buildscript {
         spotless = '6.1.2'
         anvil_version = '2.4.8'
         ksp_version = '1.9.20-1.0.14'
-        gradle_plugin = '8.1.2' // When updating, also update lint_version
-        lint_version = '31.1.2' // This value must always be gradle_plugin + 23
+        gradle_plugin = '8.1.2'
         min_sdk = 23
         target_sdk = 33
         compile_sdk = 34
         fladle_version = '0.17.4'
         kotlinter_version = '3.12.0'
         dokka_version = '1.8.20'
+
+        // Calculate lint_version (must always be gradle_plugin + 23)
+        def components = gradle_plugin.split('\\.')
+        lint_version = gradle_plugin.replaceFirst(components[0], (components[0].toInteger() + 23).toString())
     }
 
     repositories {


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1206001791999899/f 

### Description
Since lint version and gradle plugin version have a rule determining what the former should be based on the latter, might as well calculate this instead of having to update lint version independently.

### Steps to test this PR

QA optional