### PR TITLE
Fix new tab threading issue and external dialog not showing

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1640,7 +1640,15 @@ class BrowserTabFragment :
                     }
 
                     fallbackUrl != null -> {
-                        webView?.loadUrl(fallbackUrl, headers)
+                        webView?.let { webView ->
+                            if (viewModel.linkOpenedInNewTab()) {
+                                webView.post {
+                                    webView.loadUrl(fallbackUrl, headers)
+                                }
+                            } else {
+                                webView.loadUrl(fallbackUrl, headers)
+                            }
+                        }
                     }
 
                     else -> {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1636,7 +1636,7 @@ class BrowserTabFragment :
                 when {
                     fallbackIntent != null -> {
                         val fallbackActivities = pm.queryIntentActivities(fallbackIntent, 0)
-                        launchDialogForIntent(it, pm, fallbackIntent, fallbackActivities, useFirstActivityFound)
+                        launchDialogForIntent(it, pm, fallbackIntent, fallbackActivities, useFirstActivityFound, viewModel.linkOpenedInNewTab())
                     }
 
                     fallbackUrl != null -> {
@@ -1656,7 +1656,7 @@ class BrowserTabFragment :
                     }
                 }
             } else {
-                launchDialogForIntent(it, pm, intent, activities, useFirstActivityFound)
+                launchDialogForIntent(it, pm, intent, activities, useFirstActivityFound, viewModel.linkOpenedInNewTab())
             }
         }
     }
@@ -1667,8 +1667,9 @@ class BrowserTabFragment :
         intent: Intent,
         activities: List<ResolveInfo>,
         useFirstActivityFound: Boolean,
+        isOpenedInNewTab: Boolean,
     ) {
-        if (!isActiveTab) {
+        if (!isActiveTab && !isOpenedInNewTab) {
             Timber.v("Will not launch a dialog for an inactive tab")
             return
         }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1205967799812886/f

### Description
- Fixes a crash when an app intent fallback URL opens in a new tab.
- Fixes an issue where the "Open in another app" dialog is not shown.

### Steps to test this PR
_With Amazon app not installed_
- [x] Go to https://best.lovetoknow.com/product-reviews/40-products-under-30-that-should-already-be-your-cart-112498
- [x] Scroll down and click "FIND ON AMAZON"
- [x] Verify that Amazon opens in a new tab

_With Amazon app installed_
- [x] Go to https://best.lovetoknow.com/product-reviews/40-products-under-30-that-should-already-be-your-cart-112498
- [x] Scroll down and click "FIND ON AMAZON"
- [x] Verify that the "Open in another app" dialog is shown
- [x] Tap "Open"
- [x] Verify that the Amazon app is opened
