### PR TITLE
Remove variant when updated generalised ATB

### DIFF
--- a/app/src/test/java/com/duckduckgo/app/statistics/api/StatisticsRequesterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/statistics/api/StatisticsRequesterTest.kt
@@ -71,6 +71,7 @@ class StatisticsRequesterTest {
     @Before
     fun before() {
         whenever(mockVariantManager.getVariantKey()).thenReturn("ma")
+        whenever(mockVariantManager.defaultVariantKey()).thenReturn("")
         whenever(mockService.atb(any(), any())).thenReturn(Observable.just(ATB))
         whenever(mockService.updateSearchAtb(any(), any(), any(), any())).thenReturn(Observable.just(Atb(NEW_ATB)))
         whenever(mockService.exti(any(), any())).thenReturn(Observable.just(mockResponseBody))
@@ -85,11 +86,27 @@ class StatisticsRequesterTest {
     }
 
     @Test
+    fun whenUpdateVersionPresentDuringRefreshSearchRetentionThenPreviousVariantIsReplacedWithDefaultVariant() {
+        configureStoredStatistics()
+        whenever(mockService.updateSearchAtb(any(), any(), any(), eq(0))).thenReturn(Observable.just(UPDATE_ATB))
+        testee.refreshSearchRetentionAtb()
+        verify(mockStatisticsStore).variant = ""
+    }
+
+    @Test
     fun whenUpdateVersionPresentDuringRefreshAppRetentionThenPreviousAtbIsReplacedWithUpdateVersion() {
         configureStoredStatistics()
         whenever(mockService.updateAppAtb(any(), any(), any(), eq(0))).thenReturn(Observable.just(UPDATE_ATB))
         testee.refreshAppRetentionAtb()
         verify(mockStatisticsStore).atb = Atb(UPDATE_ATB.updateVersion!!)
+    }
+
+    @Test
+    fun whenUpdateVersionPresentDuringRefreshAppRetentionThenPreviousVariantIsReplacedWithDefaultVariant() {
+        configureStoredStatistics()
+        whenever(mockService.updateAppAtb(any(), any(), any(), eq(0))).thenReturn(Observable.just(UPDATE_ATB))
+        testee.refreshAppRetentionAtb()
+        verify(mockStatisticsStore).variant = ""
     }
 
     @Test

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/api/StatisticsRequester.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/api/StatisticsRequester.kt
@@ -165,6 +165,7 @@ class StatisticsRequester @Inject constructor(
     private fun storeUpdateVersionIfPresent(retrievedAtb: Atb) {
         if (retrievedAtb.updateVersion != null) {
             store.atb = Atb(retrievedAtb.updateVersion)
+            store.variant = variantManager.defaultVariantKey()
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202552961248957/1205887954648090/f

### Description
Remove variant when receiving a generalised ATB from atb.js

### Steps to test this PR

- Ensure you have a variant allocated. e.g `ma`
- Ensure you have an old ATB value persisted. e.g `v230-5`
- Put a log in Line 169 on StatisticsRequester : e.g. `Timber.e("updatedVersion from atb.js: newATB=${retrievedAtb.updateVersion}, newVariant=${store.variant}")`

_app_use_
- Install from branch
- Open the app
- [ ] Check we received an updated version and the variant is an empty string now (in the log)

_search_
- Install from branch
- Perform a search
- [ ] Check we received an updated version and the variant is an empty string now (in the log)

### No UI changes
