### PR TITLE
Fix dialog permissions

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -240,6 +240,7 @@ import com.duckduckgo.site.permissions.api.SitePermissionsManager.SitePermission
 import com.duckduckgo.user.agent.api.UserAgentProvider
 import com.duckduckgo.voice.api.VoiceSearchLauncher
 import com.duckduckgo.voice.api.VoiceSearchLauncher.Source.BROWSER
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import java.io.File
@@ -1441,9 +1442,9 @@ class BrowserTabFragment :
             faviconManager.loadToViewFromLocalWithPlaceholder(tabId, domain, binding.sitePermissionDialogFavicon)
         }
 
-        val dialog = CustomAlertDialogBuilder(requireActivity())
-            .setView(binding)
-            .build()
+        val dialog = MaterialAlertDialogBuilder(requireActivity())
+            .setView(binding.root)
+            .create()
 
         binding.siteAllowAlwaysLocationPermission.setOnClickListener {
             viewModel.onSiteLocationPermissionSelected(domain, LocationPermissionType.ALLOW_ALWAYS)

--- a/app/src/main/res/layout/content_site_location_permission_dialog.xml
+++ b/app/src/main/res/layout/content_site_location_permission_dialog.xml
@@ -16,79 +16,86 @@
   ~ limitations under the License.
   -->
 
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:gravity="center"
-    android:orientation="vertical">
-
-    <FrameLayout
-        android:id="@+id/sitePermissionDialogFaviconContainer"
-        android:layout_width="@dimen/dialogImageSize"
-        android:layout_height="@dimen/dialogImageSize"
-        android:layout_marginBottom="@dimen/keyline_4"
-        android:background="@drawable/list_item_image_circular_background"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
-
-        <ImageView
-            android:id="@+id/sitePermissionDialogFavicon"
-            android:layout_width="22dp"
-            android:layout_height="22dp"
-            android:layout_gravity="center"
-            android:importantForAccessibility="no"
-            android:src="@drawable/ic_globe_gray_16dp"/>
-    </FrameLayout>
-
-    <com.duckduckgo.common.ui.view.text.DaxTextView
-        android:id="@+id/sitePermissionDialogTitle"
-        app:typography="h2"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/preciseLocationSiteDialogTitle"/>
-
-    <com.duckduckgo.common.ui.view.text.DaxTextView
-        android:id="@+id/sitePermissionDialogSubtitle"
-        app:typography="body1"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/keyline_2"
-        android:text="@string/preciseLocationSiteDialogSubtitle"/>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:app="http://schemas.android.com/apk/res-auto"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            style="@style/Widget.DuckDuckGo.Dialog.Content"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
     <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/keyline_5"
-        android:gravity="end"
-        android:orientation="vertical">
-
-        <com.duckduckgo.common.ui.view.button.DaxButtonGhost
-            android:id="@+id/siteAllowAlwaysLocationPermission"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/preciseLocationSiteDialogAllowAlways"/>
+            android:gravity="center"
+            android:orientation="vertical">
 
-        <com.duckduckgo.common.ui.view.button.DaxButtonGhost
-            android:id="@+id/siteAllowOnceLocationPermission"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/preciseLocationSiteDialogAllowOnce"/>
+        <FrameLayout
+                android:id="@+id/sitePermissionDialogFaviconContainer"
+                android:layout_width="@dimen/dialogImageSize"
+                android:layout_height="@dimen/dialogImageSize"
+                android:layout_marginBottom="@dimen/keyline_4"
+                android:background="@drawable/list_item_image_circular_background"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
 
-        <com.duckduckgo.common.ui.view.button.DaxButtonGhost
-            android:id="@+id/siteDenyOnceLocationPermission"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/preciseLocationSiteDialogDenyOnce"/>
+            <ImageView
+                    android:id="@+id/sitePermissionDialogFavicon"
+                    android:layout_width="22dp"
+                    android:layout_height="22dp"
+                    android:layout_gravity="center"
+                    android:importantForAccessibility="no"
+                    android:src="@drawable/ic_globe_gray_16dp"/>
+        </FrameLayout>
 
-        <com.duckduckgo.common.ui.view.button.DaxButtonGhost
-            android:id="@+id/siteDenyAlwaysLocationPermission"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/preciseLocationSiteDialogDenyAlways"/>
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/sitePermissionDialogTitle"
+                app:typography="h2"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/preciseLocationSiteDialogTitle"/>
+
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/sitePermissionDialogSubtitle"
+                app:typography="body1"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/keyline_2"
+                android:text="@string/preciseLocationSiteDialogSubtitle"/>
+
+        <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/keyline_5"
+                android:gravity="end"
+                android:orientation="vertical">
+
+            <com.duckduckgo.common.ui.view.button.DaxButtonGhost
+                    android:id="@+id/siteAllowAlwaysLocationPermission"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/preciseLocationSiteDialogAllowAlways"/>
+
+            <com.duckduckgo.common.ui.view.button.DaxButtonGhost
+                    android:id="@+id/siteAllowOnceLocationPermission"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/preciseLocationSiteDialogAllowOnce"/>
+
+            <com.duckduckgo.common.ui.view.button.DaxButtonGhost
+                    android:id="@+id/siteDenyOnceLocationPermission"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/preciseLocationSiteDialogDenyOnce"/>
+
+            <com.duckduckgo.common.ui.view.button.DaxButtonGhost
+                    android:id="@+id/siteDenyAlwaysLocationPermission"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/preciseLocationSiteDialogDenyAlways"/>
+
+        </LinearLayout>
 
     </LinearLayout>
 
-</LinearLayout>
+</ScrollView>

--- a/app/src/main/res/layout/content_system_location_permission_dialog.xml
+++ b/app/src/main/res/layout/content_system_location_permission_dialog.xml
@@ -16,66 +16,74 @@
   ~ limitations under the License.
   -->
 
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:gravity="center"
-    android:orientation="vertical">
-
-    <androidx.appcompat.widget.AppCompatImageView
-        android:id="@+id/faviconImage"
-        android:layout_width="@dimen/dialogImageSize"
-        android:layout_height="@dimen/dialogImageSize"
-        android:layout_gravity="center"
-        android:importantForAccessibility="no"
-        android:layout_marginBottom="@dimen/keyline_4"
-        app:srcCompat="@drawable/ic_dax_icon"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"/>
-
-    <com.duckduckgo.common.ui.view.text.DaxTextView
-        android:id="@+id/systemPermissionDialogTitle"
-        app:typography="h2"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/preciseLocationSystemDialogTitle"/>
-
-    <com.duckduckgo.common.ui.view.text.DaxTextView
-        android:id="@+id/systemPermissionDialogSubtitle"
-        app:typography="body1"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/keyline_2"
-        android:text="@string/preciseLocationSystemDialogSubtitle"/>
-
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:app="http://schemas.android.com/apk/res-auto"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior">
     <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/keyline_5"
-        android:gravity="end"
-        android:orientation="vertical">
-
-        <com.duckduckgo.common.ui.view.button.DaxButtonGhost
-            android:id="@+id/allowLocationPermission"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/preciseLocationSystemDialogAllow"/>
+            android:gravity="center"
+            android:orientation="vertical">
 
-        <com.duckduckgo.common.ui.view.button.DaxButtonGhost
-            android:id="@+id/denyLocationPermission"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/preciseLocationSystemDialogDeny"/>
+        <androidx.appcompat.widget.AppCompatImageView
+                android:id="@+id/faviconImage"
+                android:layout_width="@dimen/dialogImageSize"
+                android:layout_height="@dimen/dialogImageSize"
+                android:layout_gravity="center"
+                android:importantForAccessibility="no"
+                android:layout_marginBottom="@dimen/keyline_4"
+                app:srcCompat="@drawable/ic_dax_icon"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"/>
 
-        <com.duckduckgo.common.ui.view.button.DaxButtonGhost
-            android:id="@+id/neverAllowLocationPermission"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/preciseLocationSystemDialogNeverAllow"/>
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/systemPermissionDialogTitle"
+                app:typography="h2"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/preciseLocationSystemDialogTitle"/>
+
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/systemPermissionDialogSubtitle"
+                app:typography="body1"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/keyline_2"
+                android:text="@string/preciseLocationSystemDialogSubtitle"/>
+
+        <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/keyline_5"
+                android:gravity="end"
+                android:orientation="vertical">
+
+            <com.duckduckgo.common.ui.view.button.DaxButtonGhost
+                    android:id="@+id/allowLocationPermission"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textAlignment="textEnd"
+                    android:text="@string/preciseLocationSystemDialogAllow"/>
+
+            <com.duckduckgo.common.ui.view.button.DaxButtonGhost
+                    android:id="@+id/denyLocationPermission"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textAlignment="textEnd"
+                    android:text="@string/preciseLocationSystemDialogDeny"/>
+
+            <com.duckduckgo.common.ui.view.button.DaxButtonGhost
+                    android:id="@+id/neverAllowLocationPermission"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textAlignment="textEnd"
+                    android:text="@string/preciseLocationSystemDialogNeverAllow"/>
+
+        </LinearLayout>
 
     </LinearLayout>
 
-</LinearLayout>
+</ScrollView>

--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
@@ -29,7 +29,6 @@ import androidx.core.net.toUri
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.common.ui.view.addClickableLink
-import com.duckduckgo.common.ui.view.dialog.CustomAlertDialogBuilder
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.common.utils.DispatcherProvider
@@ -42,6 +41,7 @@ import com.duckduckgo.site.permissions.api.SitePermissionsManager.SitePermission
 import com.duckduckgo.site.permissions.impl.databinding.ContentSiteDrmPermissionDialogBinding
 import com.duckduckgo.site.permissions.store.sitepermissions.SitePermissionAskSettingType
 import com.duckduckgo.site.permissions.store.sitepermissions.SitePermissionsEntity
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.BaseTransientBottomBar.BaseCallback
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.snackbar.Snackbar.SnackbarLayout
@@ -155,9 +155,9 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
 
         // No session-based setting -> proceed to show dialog
         val binding = ContentSiteDrmPermissionDialogBinding.inflate(activity.layoutInflater)
-        val dialog = CustomAlertDialogBuilder(activity)
-            .setView(binding)
-            .build()
+        val dialog = MaterialAlertDialogBuilder(activity)
+            .setView(binding.root)
+            .create()
 
         val title = url.websiteFromGeoLocationsApiOrigin()
         binding.sitePermissionDialogTitle.text = activity.getString(R.string.drmSiteDialogTitle, title)

--- a/site-permissions/site-permissions-impl/src/main/res/layout/content_site_drm_permission_dialog.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/layout/content_site_drm_permission_dialog.xml
@@ -16,79 +16,86 @@
   ~ limitations under the License.
   -->
 
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:gravity="center"
-    android:orientation="vertical">
-
-    <FrameLayout
-        android:id="@+id/sitePermissionDialogFaviconContainer"
-        android:layout_width="@dimen/dialogImageSize"
-        android:layout_height="@dimen/dialogImageSize"
-        android:layout_marginBottom="@dimen/keyline_4"
-        android:background="@drawable/list_item_image_circular_background"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
-
-        <ImageView
-            android:id="@+id/sitePermissionDialogFavicon"
-            android:layout_width="22dp"
-            android:layout_height="22dp"
-            android:layout_gravity="center"
-            android:importantForAccessibility="no"
-            android:src="@drawable/ic_globe_gray_16dp"/>
-    </FrameLayout>
-
-    <com.duckduckgo.common.ui.view.text.DaxTextView
-        android:id="@+id/sitePermissionDialogTitle"
-        app:typography="h2"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/drmSiteDialogTitle"/>
-
-    <com.duckduckgo.common.ui.view.text.DaxTextView
-        android:id="@+id/sitePermissionDialogSubtitle"
-        app:typography="body1"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/keyline_2"
-        android:text="@string/drmSiteDialogSubtitle"/>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:app="http://schemas.android.com/apk/res-auto"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            style="@style/Widget.DuckDuckGo.Dialog.Content"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
     <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/keyline_5"
-        android:gravity="end"
-        android:orientation="vertical">
-
-        <com.duckduckgo.common.ui.view.button.DaxButtonGhost
-            android:id="@+id/siteAllowAlwaysDrmPermission"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/drmSiteDialogAllowAlways"/>
+            android:gravity="center"
+            android:orientation="vertical">
 
-        <com.duckduckgo.common.ui.view.button.DaxButtonGhost
-            android:id="@+id/siteAllowOnceDrmPermission"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/drmSiteDialogAllowOnce"/>
+        <FrameLayout
+                android:id="@+id/sitePermissionDialogFaviconContainer"
+                android:layout_width="@dimen/dialogImageSize"
+                android:layout_height="@dimen/dialogImageSize"
+                android:layout_marginBottom="@dimen/keyline_4"
+                android:background="@drawable/list_item_image_circular_background"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
 
-        <com.duckduckgo.common.ui.view.button.DaxButtonGhost
-            android:id="@+id/siteDenyOnceDrmPermission"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/drmSiteDialogDenyOnce"/>
+            <ImageView
+                    android:id="@+id/sitePermissionDialogFavicon"
+                    android:layout_width="22dp"
+                    android:layout_height="22dp"
+                    android:layout_gravity="center"
+                    android:importantForAccessibility="no"
+                    android:src="@drawable/ic_globe_gray_16dp"/>
+        </FrameLayout>
 
-        <com.duckduckgo.common.ui.view.button.DaxButtonGhost
-            android:id="@+id/siteDenyAlwaysDrmPermission"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/drmSiteDialogDenyAlways"/>
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/sitePermissionDialogTitle"
+                app:typography="h2"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/drmSiteDialogTitle"/>
+
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/sitePermissionDialogSubtitle"
+                app:typography="body1"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/keyline_2"
+                android:text="@string/drmSiteDialogSubtitle"/>
+
+        <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/keyline_5"
+                android:gravity="end"
+                android:orientation="vertical">
+
+            <com.duckduckgo.common.ui.view.button.DaxButtonGhost
+                    android:id="@+id/siteAllowAlwaysDrmPermission"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/drmSiteDialogAllowAlways"/>
+
+            <com.duckduckgo.common.ui.view.button.DaxButtonGhost
+                    android:id="@+id/siteAllowOnceDrmPermission"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/drmSiteDialogAllowOnce"/>
+
+            <com.duckduckgo.common.ui.view.button.DaxButtonGhost
+                    android:id="@+id/siteDenyOnceDrmPermission"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/drmSiteDialogDenyOnce"/>
+
+            <com.duckduckgo.common.ui.view.button.DaxButtonGhost
+                    android:id="@+id/siteDenyAlwaysDrmPermission"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/drmSiteDialogDenyAlways"/>
+
+        </LinearLayout>
 
     </LinearLayout>
 
-</LinearLayout>
+</ScrollView>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/0/1206009544951106/f 

### Description
This PR makes the EME and location dialogs scrollable and dismissible

### Steps to test this PR
* Test on a device/emulator with a small screen (e.g., Pixel 1)

_DRM_
- [x] Go to https://permission.site/ (HTTPS)
- [x] Click on "Encrypted Media (EME)" --> DRM consent prompt should appear
- [x] Verify that you can scroll through the dialog and see all 4 options
- [x] Click outside of the dialog
- [x] Verify dialog has been dismissed
- [x] Click on "Encrypted Media (EME)" --> DRM consent prompt should appear
- [x] Scroll to only for this session, EME should be green

_Location_
- [x] Go to https://permission.site/ (HTTPS) and click on Location
- [x] Accept the system permissions until you see the dialog with the 4 options
- [ ] ~Click outside the dialog~
- [ ] ~Verify dialog has been dismissed~
- [x] Click on Location again --> dialog should appear again
- [x] Click "Only for this session" --> dialog should dismiss
- [x] Location should now be green