### PR TITLE
Delay generation for specific VpnScope(d) sub-components

### DIFF
--- a/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesSubComponentCodeGenerator.kt
+++ b/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesSubComponentCodeGenerator.kt
@@ -178,7 +178,7 @@ class ContributesSubComponentCodeGenerator : CodeGenerator {
     }
 
     private fun FqName.subComponentAnnotation(module: ModuleDescriptor, delayGeneration: Boolean): AnnotationSpec {
-        return if (this == vpnScopeFqName || delayGeneration) {
+        return if (delayGeneration) {
             AnnotationSpec.builder(ContributesSubcomponent::class)
                 .addMember("scope = %T::class", this.asClassName(module))
                 .addMember("parentScope = %T::class", getParentScope(module).asClassName(module))
@@ -189,7 +189,7 @@ class ContributesSubComponentCodeGenerator : CodeGenerator {
     }
 
     private fun FqName.subComponentFactoryAnnotation(module: ModuleDescriptor, delayGeneration: Boolean): AnnotationSpec {
-        return if (this == vpnScopeFqName || delayGeneration) {
+        return if (delayGeneration) {
             AnnotationSpec.builder(ContributesSubcomponent.Factory::class).build()
         } else {
             AnnotationSpec.builder(Subcomponent.Factory::class).build()

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
@@ -71,7 +71,10 @@ import logcat.LogPriority.WARN
 import logcat.asLog
 import logcat.logcat
 
-@InjectWith(VpnScope::class)
+@InjectWith(
+    scope = VpnScope::class,
+    delayGeneration = true,
+)
 class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope(), VpnSocketProtector {
 
     private external fun jni_wait_for_tun_up(tunFd: Int): Int

--- a/app-tracking-protection/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/VpnInternalSettingsActivity.kt
+++ b/app-tracking-protection/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/VpnInternalSettingsActivity.kt
@@ -55,7 +55,10 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
 @ContributeToActivityStarter(LaunchVpnInternalScreenWithEmptyParams::class)
-@InjectWith(VpnScope::class)
+@InjectWith(
+    scope = VpnScope::class,
+    delayGeneration = true,
+)
 class VpnInternalSettingsActivity : DuckDuckGoActivity() {
 
     @Inject


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1205997010028981/f

### Description
Delay the sub-component generation only for the sub-components that need it. Not all of them

### Steps to test this PR
Builds and smoke test the VPN/AppTP
