### PR TITLE
Migrate from Autofill's bespoke activity launcher to GlobalActivityStarter

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -170,7 +170,8 @@ import com.duckduckgo.autoconsent.api.AutoconsentCallback
 import com.duckduckgo.autofill.api.AutofillCapabilityChecker
 import com.duckduckgo.autofill.api.AutofillEventListener
 import com.duckduckgo.autofill.api.AutofillFragmentResultsPlugin
-import com.duckduckgo.autofill.api.AutofillSettingsActivityLauncher
+import com.duckduckgo.autofill.api.AutofillScreens.AutofillSettingsScreenDirectlyViewCredentialsParams
+import com.duckduckgo.autofill.api.AutofillScreens.AutofillSettingsScreenShowSuggestionsForSiteParams
 import com.duckduckgo.autofill.api.BrowserAutofill
 import com.duckduckgo.autofill.api.Callback
 import com.duckduckgo.autofill.api.CredentialAutofillDialogFactory
@@ -335,9 +336,6 @@ class BrowserTabFragment :
     lateinit var browserAutofill: BrowserAutofill
 
     @Inject
-    lateinit var autofillSettingsLauncher: AutofillSettingsActivityLauncher
-
-    @Inject
     lateinit var faviconManager: FaviconManager
 
     @Inject
@@ -397,9 +395,6 @@ class BrowserTabFragment :
 
     @Inject
     lateinit var autoconsent: Autoconsent
-
-    @Inject
-    lateinit var autofillSettingsActivityLauncher: AutofillSettingsActivityLauncher
 
     @Inject
     lateinit var autofillCapabilityChecker: AutofillCapabilityChecker
@@ -2230,7 +2225,9 @@ class BrowserTabFragment :
             val snackbar = binding.browserLayout.makeSnackbarWithNoBottomInset(messageResourceId, Snackbar.LENGTH_LONG)
             if (includeShortcutToViewCredential) {
                 snackbar.setAction(R.string.autofillSnackbarAction) {
-                    context?.let { startActivity(autofillSettingsActivityLauncher.intentDirectlyViewCredentials(it, loginCredentials)) }
+                    context?.let {
+                        globalActivityStarter.start(it, AutofillSettingsScreenDirectlyViewCredentialsParams(loginCredentials))
+                    }
                 }
             }
             snackbar.show()
@@ -2238,7 +2235,7 @@ class BrowserTabFragment :
     }
 
     private fun launchAutofillManagementScreen() {
-        startActivity(autofillSettingsLauncher.intentAlsoShowSuggestionsForSite(requireContext(), webView?.url))
+        globalActivityStarter.start(requireContext(), AutofillSettingsScreenShowSuggestionsForSiteParams(webView?.url))
     }
 
     private fun showDialogHidingPrevious(

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
@@ -49,7 +49,7 @@ import com.duckduckgo.app.webtrackingprotection.WebTrackingProtectionScreenNoPar
 import com.duckduckgo.app.widget.AddWidgetLauncher
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.autoconsent.impl.ui.AutoconsentSettingsActivity
-import com.duckduckgo.autofill.api.AutofillSettingsActivityLauncher
+import com.duckduckgo.autofill.api.AutofillScreens.AutofillSettingsScreenNoParams
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.listitem.TwoLineListItem
@@ -90,9 +90,6 @@ class SettingsActivity : DuckDuckGoActivity() {
 
     @Inject
     lateinit var appBuildConfig: AppBuildConfig
-
-    @Inject
-    lateinit var autofillSettingsActivityLauncher: AutofillSettingsActivityLauncher
 
     @Inject
     lateinit var globalActivityStarter: GlobalActivityStarter
@@ -335,7 +332,7 @@ class SettingsActivity : DuckDuckGoActivity() {
 
     private fun launchAutofillSettings() {
         val options = ActivityOptions.makeSceneTransitionAnimation(this).toBundle()
-        startActivity(autofillSettingsActivityLauncher.intent(this), options)
+        globalActivityStarter.start(this, AutofillSettingsScreenNoParams, options)
     }
 
     private fun launchAccessibilitySettings() {

--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillScreens.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillScreens.kt
@@ -16,30 +16,27 @@
 
 package com.duckduckgo.autofill.api
 
-import android.content.Context
-import android.content.Intent
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
+import com.duckduckgo.navigation.api.GlobalActivityStarter.ActivityParams
 
-/**
- * Used to access an Intent which will launch the autofill settings activity
- * The activity is implemented in the impl module and is otherwise inaccessible from outside this module.
- */
-interface AutofillSettingsActivityLauncher {
+sealed interface AutofillScreens {
 
     /**
      * Launch the Autofill management activity, which will show the full list of available credentials
      */
-    fun intent(context: Context): Intent
+    object AutofillSettingsScreenNoParams : ActivityParams {
+        private fun readResolve(): Any = AutofillSettingsScreenNoParams
+    }
 
     /**
      * Launch the Autofill management activity, which will show suggestions for the current url and the full list of available credentials
+     * @param currentUrl The current URL the user is viewing. This is used to show suggestions for the current site if available.
      */
-    fun intentAlsoShowSuggestionsForSite(context: Context, currentUrl: String?): Intent
+    data class AutofillSettingsScreenShowSuggestionsForSiteParams(val currentUrl: String?) : ActivityParams
 
     /**
      * Launch the Autofill management activity, directly showing particular credentials
-     * @param context
      * @param loginCredentials jump directly into viewing mode for these credentials
      */
-    fun intentDirectlyViewCredentials(context: Context, loginCredentials: LoginCredentials): Intent
+    data class AutofillSettingsScreenDirectlyViewCredentialsParams(val loginCredentials: LoginCredentials) : ActivityParams
 }

--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/domain/app/LoginCredentials.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/domain/app/LoginCredentials.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.autofill.api.domain.app
 
 import android.os.Parcelable
+import java.io.Serializable
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -31,7 +32,7 @@ data class LoginCredentials(
     val domainTitle: String? = null,
     val notes: String? = null,
     val lastUpdatedMillis: Long? = null,
-) : Parcelable {
+) : Parcelable, Serializable {
     override fun toString(): String {
         return """
             LoginCredentials(

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillManagementActivity.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillManagementActivity.kt
@@ -16,8 +16,6 @@
 
 package com.duckduckgo.autofill.impl.ui.credential.management
 
-import android.content.Context
-import android.content.Intent
 import android.os.Bundle
 import android.view.WindowManager
 import androidx.core.view.isVisible
@@ -26,9 +24,12 @@ import androidx.fragment.app.commitNow
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.autofill.api.AutofillSettingsActivityLauncher
+import com.duckduckgo.autofill.api.AutofillScreens.AutofillSettingsScreenDirectlyViewCredentialsParams
+import com.duckduckgo.autofill.api.AutofillScreens.AutofillSettingsScreenNoParams
+import com.duckduckgo.autofill.api.AutofillScreens.AutofillSettingsScreenShowSuggestionsForSiteParams
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.impl.R
 import com.duckduckgo.autofill.impl.databinding.ActivityAutofillSettingsBinding
@@ -70,16 +71,16 @@ import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.view.showKeyboard
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.ActivityScope
-import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.navigation.api.getActivityParams
 import com.google.android.material.snackbar.Snackbar
-import com.squareup.anvil.annotations.ContributesTo
-import dagger.Module
-import dagger.Provides
 import javax.inject.Inject
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
 @InjectWith(ActivityScope::class)
+@ContributeToActivityStarter(AutofillSettingsScreenNoParams::class)
+@ContributeToActivityStarter(AutofillSettingsScreenShowSuggestionsForSiteParams::class)
+@ContributeToActivityStarter(AutofillSettingsScreenDirectlyViewCredentialsParams::class)
 class AutofillManagementActivity : DuckDuckGoActivity() {
 
     val binding: ActivityAutofillSettingsBinding by viewBinding()
@@ -102,8 +103,9 @@ class AutofillManagementActivity : DuckDuckGoActivity() {
 
     private fun sendLaunchPixel(savedInstanceState: Bundle?) {
         if (savedInstanceState == null) {
-            val launchedFromBrowser = intent.hasExtra(EXTRAS_SUGGESTIONS_FOR_URL)
-            val directLinkToCredentials = intent.hasExtra(EXTRAS_CREDENTIALS_TO_VIEW)
+            val mode = extractViewMode()
+            val launchedFromBrowser = (mode is ViewMode.ListModeWithSuggestions)
+            val directLinkToCredentials = mode is ViewMode.CredentialMode
             viewModel.sendLaunchPixel(launchedFromBrowser, directLinkToCredentials)
         }
     }
@@ -124,12 +126,10 @@ class AutofillManagementActivity : DuckDuckGoActivity() {
     }
 
     private fun setupInitialState() {
-        if (intent.hasExtra(EXTRAS_CREDENTIALS_TO_VIEW)) {
-            intent.getParcelableExtra<LoginCredentials>(EXTRAS_CREDENTIALS_TO_VIEW)?.let {
-                viewModel.onViewCredentials(it)
-            }
-        } else {
-            viewModel.onShowListMode()
+        when (val mode = extractViewMode()) {
+            is ViewMode.ListMode -> viewModel.onShowListMode()
+            is ViewMode.ListModeWithSuggestions -> viewModel.onShowListMode()
+            is ViewMode.CredentialMode -> viewModel.onViewCredentials(mode.loginCredentials)
         }
     }
 
@@ -212,7 +212,7 @@ class AutofillManagementActivity : DuckDuckGoActivity() {
 
     private fun showListMode() {
         resetToolbar()
-        val currentUrl = intent.getStringExtra(EXTRAS_SUGGESTIONS_FOR_URL)
+        val currentUrl = extractSuggestionsUrl()
         Timber.v("showListMode. currentUrl is %s", currentUrl)
 
         supportFragmentManager.commitNow {
@@ -251,7 +251,7 @@ class AutofillManagementActivity : DuckDuckGoActivity() {
     }
 
     private fun credentialModeLaunchedDirectly(): Boolean {
-        return intent.getParcelableExtra<LoginCredentials>(EXTRAS_CREDENTIALS_TO_VIEW) != null
+        return extractViewMode() is ViewMode.CredentialMode
     }
 
     private fun showLockMode() {
@@ -335,67 +335,43 @@ class AutofillManagementActivity : DuckDuckGoActivity() {
         }
     }
 
+    private fun extractViewMode(): ViewMode {
+        intent.getActivityParams(AutofillSettingsScreenShowSuggestionsForSiteParams::class.java)?.let {
+            return ViewMode.ListModeWithSuggestions(it.currentUrl)
+        }
+
+        intent.getActivityParams(AutofillSettingsScreenDirectlyViewCredentialsParams::class.java)?.let {
+            return ViewMode.CredentialMode(it.loginCredentials)
+        }
+
+        // default if nothing else matches
+        return ViewMode.ListMode
+    }
+
+    private fun extractSuggestionsUrl(): String? {
+        val viewMode = extractViewMode()
+        if (viewMode is ViewMode.ListModeWithSuggestions) {
+            return viewMode.currentUrl
+        }
+        return null
+    }
+
     companion object {
-        private const val EXTRAS_CREDENTIALS_TO_VIEW = "extras_credentials_to_view"
-        private const val EXTRAS_SUGGESTIONS_FOR_URL = "extras_suggestions_for_url"
         private const val TAG_LOCKED = "tag_fragment_locked"
         private const val TAG_DISABLED = "tag_fragment_disabled"
         private const val TAG_UNSUPPORTED = "tag_fragment_unsupported"
         private const val TAG_CREDENTIAL = "tag_fragment_credential"
         private const val TAG_ALL_CREDENTIALS = "tag_fragment_credentials_list"
-
-        /**
-         * Launch the Autofill management activity, with LoginCredentials to jump directly into viewing mode.
-         */
-        fun intentDirectViewMode(
-            context: Context,
-            loginCredentials: LoginCredentials,
-        ): Intent {
-            return Intent(context, AutofillManagementActivity::class.java).apply {
-                putExtra(EXTRAS_CREDENTIALS_TO_VIEW, loginCredentials)
-            }
-        }
-
-        fun intentShowSuggestion(
-            context: Context,
-            currentUrl: String?,
-        ): Intent {
-            return Intent(context, AutofillManagementActivity::class.java).apply {
-                putExtra(EXTRAS_SUGGESTIONS_FOR_URL, currentUrl)
-            }
-        }
-
-        fun intentDefaultList(context: Context): Intent = Intent(context, AutofillManagementActivity::class.java)
     }
-}
 
-private sealed interface CopiedToClipboardDataType {
-    object Username : CopiedToClipboardDataType
-    object Password : CopiedToClipboardDataType
-}
+    private sealed interface ViewMode {
+        data object ListMode : ViewMode
+        data class ListModeWithSuggestions(val currentUrl: String? = null) : ViewMode
+        data class CredentialMode(val loginCredentials: LoginCredentials) : ViewMode
+    }
 
-@ContributesTo(AppScope::class)
-@Module
-class AutofillSettingsModule {
-
-    @Provides
-    fun activityLauncher(): AutofillSettingsActivityLauncher {
-        return object : AutofillSettingsActivityLauncher {
-            override fun intent(context: Context): Intent = AutofillManagementActivity.intentDefaultList(context)
-
-            override fun intentAlsoShowSuggestionsForSite(
-                context: Context,
-                currentUrl: String?,
-            ): Intent {
-                return AutofillManagementActivity.intentShowSuggestion(context, currentUrl)
-            }
-
-            override fun intentDirectlyViewCredentials(
-                context: Context,
-                loginCredentials: LoginCredentials,
-            ): Intent {
-                return AutofillManagementActivity.intentDirectViewMode(context, loginCredentials)
-            }
-        }
+    private sealed interface CopiedToClipboardDataType {
+        object Username : CopiedToClipboardDataType
+        object Password : CopiedToClipboardDataType
     }
 }

--- a/autofill/autofill-internal/build.gradle
+++ b/autofill/autofill-internal/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation project(':autofill-impl')
     implementation project(':internal-features-api')
     implementation project(path: ':browser-api')
+    implementation project(path: ':navigation-api')
 
     anvil project(path: ':anvil-compiler')
     implementation project(path: ':anvil-annotations')

--- a/autofill/autofill-internal/src/main/java/com/duckduckgo/autofill/internal/AutofillInternalSettingsActivity.kt
+++ b/autofill/autofill-internal/src/main/java/com/duckduckgo/autofill/internal/AutofillInternalSettingsActivity.kt
@@ -25,11 +25,11 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.autofill.api.AutofillFeature
+import com.duckduckgo.autofill.api.AutofillScreens.AutofillSettingsScreenNoParams
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.api.email.EmailManager
 import com.duckduckgo.autofill.api.store.AutofillStore
 import com.duckduckgo.autofill.impl.email.incontext.store.EmailProtectionInContextDataStore
-import com.duckduckgo.autofill.impl.ui.credential.management.AutofillManagementActivity
 import com.duckduckgo.autofill.internal.R.string
 import com.duckduckgo.autofill.internal.databinding.ActivityAutofillInternalSettingsBinding
 import com.duckduckgo.browser.api.UserBrowserProperties
@@ -39,6 +39,7 @@ import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.navigation.api.GlobalActivityStarter
 import java.text.SimpleDateFormat
 import javax.inject.Inject
 import kotlinx.coroutines.flow.first
@@ -70,6 +71,9 @@ class AutofillInternalSettingsActivity : DuckDuckGoActivity() {
 
     @Inject
     lateinit var autofillFeature: AutofillFeature
+
+    @Inject
+    lateinit var globalActivityStarter: GlobalActivityStarter
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -149,7 +153,7 @@ class AutofillInternalSettingsActivity : DuckDuckGoActivity() {
         }
 
         binding.viewSavedLoginsButton.setClickListener {
-            startActivity(AutofillManagementActivity.intentDefaultList(this))
+            globalActivityStarter.start(this, AutofillSettingsScreenNoParams)
         }
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205232499768032/f 

### Description
Migrate from Autofill's bespoke Activity launcher mechanism (which pre-dated the existence of `GlobalActivityStarter`) to using `GlobalActivityStarter`.

### Steps to test this PR

Test using `internal` build type.

#### Launching Autofill management screen from snackbar confirmation button
- [x] Visit https://fill.dev/form/login-simple
- [x] Enter username and password (>= 4 chars) and login
- [x] Save the login when prompted
- [x] Tap on snackbar's **View** button
- [x] Verify you are taken directly to the newly created credential view
- [x] Tap the back button; verify you are returned immediately to the browser (i.e., you don't see the credential list screen)

#### Launching Autofill management screen from browser overflow
(You should still have a credential saved for fill.dev and be on fill.dev from the previous step)
- [x] Tap on overflow->Login
- [x] Verify you see fill.dev as a `Suggested` site

#### Launching Autofill management screen from settings
- [x] Visit Overflow->Settings
- [x] Tap on Logins
- [x] Verify you do not see fill.dev as a `Suggested` site