### PR TITLE
Fix privacy dashboard closing when site is allow listed

### DIFF
--- a/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModel.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModel.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -194,6 +195,7 @@ class PrivacyDashboardHybridViewModel @Inject constructor(
                 // Checking if site was added to / removed from allowlist since the screen was initialized
                 site.userAllowList != site.domain in allowlistedDomains
             }
+            .drop(1)
             .onEach { allowlistChanged ->
                 // Closing the Privacy Dashboard screen
                 viewState.update { it?.copy(userChangedValues = allowlistChanged) }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1206017073615834/f

### Description
Fixes issue where privacy dashboard immediately closes when site is allow listed.

### Steps to test this PR

#### Privacy Dashboard is closed automatically after toggling protections on Broken Site screen
- [x] Navigate to the Privacy Dashboard
- [x] Go to the Broken Site screen ("Website not working?" -> "Report Broken site")
- [x] Toggle protections
- [x] Press back or submit report
- [x] Verify that after exiting Broken Site screen you landed on the page which reloads automatically

#### Privacy Dashboard is closed automatically after toggling protections (no behavior changes here)
- [x] Navigate to the Privacy Dashboard
- [x] Toggle protections
- [x] Verify that the screen closed itself after a slight delay (300ms) and the page reloaded automatically (maintaining existing behavior in this scenario)

#### Screen stays open for allow listed domains
- [x] Go to strava.com
- [x] Navigate to the Privacy Dashboard
- [x] Verify that protections are disabled and the screen doesn't close