### PR TITLE
Handle Samsung store links

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1627,8 +1627,12 @@ class BrowserTabFragment :
             val action: String?
 
             if (appLink.appIntent != null) {
-                val packageName = appLink.appIntent!!.component?.packageName ?: return
-                message = getString(R.string.appLinkSnackBarMessage, getAppName(packageName))
+                message = if (appLink.storePackage == null) {
+                    val packageName = appLink.appIntent!!.component?.packageName ?: return
+                    getString(R.string.appLinkSnackBarMessage, getAppName(packageName))
+                } else {
+                    getString(R.string.appLinkSnackBarMessage, getAppName(appLink.storePackage!!))
+                }
                 action = getString(R.string.appLinkSnackBarAction)
             } else {
                 message = getString(R.string.appLinkMultipleSnackBarMessage)

--- a/app/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
@@ -25,6 +25,7 @@ import android.content.pm.ResolveInfo
 import android.net.Uri
 import android.os.Build
 import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType
+import com.duckduckgo.app.browser.applinks.SamsungStoreLinkHandler
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.privacy.config.api.AmpLinkType
 import com.duckduckgo.privacy.config.api.AmpLinks
@@ -36,6 +37,7 @@ class SpecialUrlDetectorImpl(
     private val packageManager: PackageManager,
     private val ampLinks: AmpLinks,
     private val trackingParameters: TrackingParameters,
+    private val samsungStoreLinkHandler: SamsungStoreLinkHandler,
     private val appBuildConfig: AppBuildConfig,
 ) : SpecialUrlDetector {
 
@@ -71,6 +73,8 @@ class SpecialUrlDetectorImpl(
         trackingParameters.cleanTrackingParameters(initiatingUrl = initiatingUrl, url = uriString)?.let { cleanedUrl ->
             return UrlType.TrackingParameterLink(cleanedUrl = cleanedUrl)
         }
+
+        samsungStoreLinkHandler.handleSamsungStoreLink(uriString)?.let { return it }
 
         if (appBuildConfig.sdkInt >= Build.VERSION_CODES.N) {
             try {

--- a/app/src/main/java/com/duckduckgo/app/browser/applinks/SamsungStoreLinkHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/applinks/SamsungStoreLinkHandler.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.applinks
+
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.net.Uri
+import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+import timber.log.Timber
+
+interface SamsungStoreLinkHandler {
+    fun handleSamsungStoreLink(uriString: String): UrlType?
+}
+
+@ContributesBinding(AppScope::class)
+class DuckDuckGoSamsungStoreLinkHandler @Inject constructor() : SamsungStoreLinkHandler {
+
+    override fun handleSamsungStoreLink(uriString: String): UrlType? {
+        extractSamsungStoreAppPackageName(uriString)?.let { packageName ->
+            try {
+                val intent = Intent(Intent.ACTION_VIEW)
+                intent.data = Uri.parse("${SAMSUNG_STORE_APP_SCHEME}$packageName")
+                return UrlType.AppLink(appIntent = intent, uriString = uriString, storePackage = SAMSUNG_STORE_PACKAGE_NAME)
+            } catch (e: ActivityNotFoundException) {
+                Timber.w(e, "Samsung store not found")
+            }
+        }
+        return null
+    }
+
+    private fun extractSamsungStoreAppPackageName(uriString: String): String? {
+        return if (uriString.startsWith(SAMSUNG_STORE_URL_PREFIX)) {
+            try {
+                val uri = Uri.parse(uriString)
+                val pathSegments = uri.pathSegments
+                if (pathSegments.size > 1 && pathSegments[pathSegments.size - 2] == DETAIL_SEGMENT) {
+                    pathSegments.lastOrNull()?.takeIf { it.isNotEmpty() }
+                } else {
+                    null
+                }
+            } catch (e: Exception) {
+                Timber.w(e, "Failed to parse Samsung store URL")
+                null
+            }
+        } else {
+            null
+        }
+    }
+
+    companion object {
+        const val SAMSUNG_STORE_URL_PREFIX = "https://galaxystore.samsung.com/detail/"
+        const val SAMSUNG_STORE_APP_SCHEME = "samsungapps://ProductDetail/"
+        const val SAMSUNG_STORE_PACKAGE_NAME = "com.sec.android.app.samsungapps"
+        const val DETAIL_SEGMENT = "detail"
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.adclick.api.AdClickManager
 import com.duckduckgo.app.browser.*
 import com.duckduckgo.app.browser.addtohome.AddToHomeCapabilityDetector
 import com.duckduckgo.app.browser.addtohome.AddToHomeSystemCapabilityDetector
+import com.duckduckgo.app.browser.applinks.SamsungStoreLinkHandler
 import com.duckduckgo.app.browser.certificates.rootstore.TrustedCertificateStore
 import com.duckduckgo.app.browser.cookies.AppThirdPartyCookieManager
 import com.duckduckgo.app.browser.cookies.ThirdPartyCookieManager
@@ -174,8 +175,9 @@ class BrowserModule {
         packageManager: PackageManager,
         ampLinks: AmpLinks,
         trackingParameters: TrackingParameters,
+        samsungStoreLinkHandler: SamsungStoreLinkHandler,
         appBuildConfig: AppBuildConfig,
-    ): SpecialUrlDetector = SpecialUrlDetectorImpl(packageManager, ampLinks, trackingParameters, appBuildConfig)
+    ): SpecialUrlDetector = SpecialUrlDetectorImpl(packageManager, ampLinks, trackingParameters, samsungStoreLinkHandler, appBuildConfig)
 
     @Provides
     fun webViewRequestInterceptor(

--- a/app/src/test/java/com/duckduckgo/app/browser/SpecialUrlDetectorImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/SpecialUrlDetectorImplTest.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType.*
 import com.duckduckgo.app.browser.SpecialUrlDetectorImpl.Companion.EMAIL_MAX_LENGTH
 import com.duckduckgo.app.browser.SpecialUrlDetectorImpl.Companion.PHONE_MAX_LENGTH
 import com.duckduckgo.app.browser.SpecialUrlDetectorImpl.Companion.SMS_MAX_LENGTH
+import com.duckduckgo.app.browser.applinks.SamsungStoreLinkHandler
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.privacy.config.api.AmpLinkType
 import com.duckduckgo.privacy.config.api.AmpLinks
@@ -60,6 +61,9 @@ class SpecialUrlDetectorImplTest {
     lateinit var mockTrackingParameters: TrackingParameters
 
     @Mock
+    lateinit var mockSamsungStore: SamsungStoreLinkHandler
+
+    @Mock
     lateinit var appBuildConfig: AppBuildConfig
 
     @Before
@@ -69,6 +73,7 @@ class SpecialUrlDetectorImplTest {
             packageManager = mockPackageManager,
             ampLinks = mockAmpLinks,
             trackingParameters = mockTrackingParameters,
+            samsungStoreLinkHandler = mockSamsungStore,
             appBuildConfig = appBuildConfig,
         )
         whenever(mockPackageManager.queryIntentActivities(any(), anyInt())).thenReturn(emptyList())
@@ -373,6 +378,15 @@ class SpecialUrlDetectorImplTest {
             testee.determineType(initiatingUrl = "https://www.example.com", uri = "https://www.example.com/query.html?utm_example=something".toUri())
         assertEquals(expected, actual::class)
         assertEquals("https://www.example.com/query.html", (actual as TrackingParameterLink).cleanedUrl)
+    }
+
+    @Test
+    fun whenSamsungStoreLinkDetectedThenReturnResultFromSamsungStoreLinkHandler() {
+        val samsungStoreUrl = "https://galaxystore.samsung.com/detail/com.test.app"
+        val expected = AppLink(appIntent = Intent(), uriString = samsungStoreUrl, storePackage = "com.sec.android.app.samsungapps")
+        whenever(mockSamsungStore.handleSamsungStoreLink(samsungStoreUrl)).thenReturn(expected)
+        val actual = testee.determineType(samsungStoreUrl)
+        assertEquals(expected, actual)
     }
 
     private fun randomString(length: Int): String {

--- a/app/src/test/java/com/duckduckgo/app/browser/applinks/DuckDuckGoSamsungStoreLinkHandlerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/applinks/DuckDuckGoSamsungStoreLinkHandlerTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.applinks
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNull
+import junit.framework.TestCase.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DuckDuckGoSamsungStoreLinkHandlerTest {
+
+    private val handler = DuckDuckGoSamsungStoreLinkHandler()
+
+    @Test
+    fun whenValidSamsungStoreUrlThenAppLinkTypeIsReturned() {
+        val samsungStoreUrl = "https://galaxystore.samsung.com/detail/com.example.app"
+        val result = handler.handleSamsungStoreLink(samsungStoreUrl)
+
+        assertTrue(result is UrlType.AppLink)
+        assertEquals("samsungapps://ProductDetail/com.example.app", (result as UrlType.AppLink).appIntent?.data?.toString())
+        assertEquals("com.sec.android.app.samsungapps", result.storePackage)
+        assertEquals(samsungStoreUrl, result.uriString)
+    }
+
+    @Test
+    fun whenNonSamsungStoreUrlThenNullIsReturned() {
+        val nonSamsungStoreUrl = "https://example.com"
+        val result = handler.handleSamsungStoreLink(nonSamsungStoreUrl)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun whenMalformedUrlThenNullIsReturned() {
+        val malformedUrl = "https://galaxystore.samsung.com/detail/something/com.example.app"
+        val result = handler.handleSamsungStoreLink(malformedUrl)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun whenPackageIsMissingThenNullIsReturned() {
+        val malformedUrl = "https://galaxystore.samsung.com/detail/"
+        val result = handler.handleSamsungStoreLink(malformedUrl)
+
+        assertNull(result)
+    }
+}

--- a/browser-api/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
@@ -34,6 +34,7 @@ interface SpecialUrlDetector {
             val appIntent: Intent? = null,
             val excludedComponents: List<ComponentName>? = null,
             val uriString: String,
+            val storePackage: String? = null,
         ) : UrlType()
 
         class NonHttpAppLink(


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1206018177037542/f

### Description
Adds Samsung store app link handling.

### Steps to test this PR

**Note**: Requires a Samsung device to test.

_Snackbar_
- [ ] Got to `https://duckduckgo.com/?q=https%3A%2F%2Fgalaxystore.samsung.com%2Fdetail%2Fcom.samsung.android.privateshare`
- [ ] Click on the "Private Share" Galaxy Store listing in SERP
- [ ] Verify that the "You can open this link in Galaxy Store" Snackbar is shown
- [ ] Tap "Open in app"
- [ ] Verify that the Galaxy Store is opened for the "Private Share" app

_Menu_
- [ ] Push back to exit the Galaxy Store
- [ ] Open the overflow menu in the browser
- [ ] Tap "Open in App"
- [ ] Verify that the Galaxy Store is opened for the "Private Share" app

### UI changes
https://github.com/duckduckgo/Android/assets/3471025/b7907bdc-451c-45b0-9746-7b406c1d24b5

