### PR TITLE
Remove icon from location + DRM dialogs

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1433,9 +1433,6 @@ class BrowserTabFragment :
         } else {
             getString(R.string.preciseLocationSiteDialogSubtitle)
         }
-        lifecycleScope.launch {
-            faviconManager.loadToViewFromLocalWithPlaceholder(tabId, domain, binding.sitePermissionDialogFavicon)
-        }
 
         val dialog = MaterialAlertDialogBuilder(requireActivity())
             .setView(binding.root)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -86,6 +86,7 @@ import com.duckduckgo.app.browser.BrowserTabViewModel.FindInPageViewState
 import com.duckduckgo.app.browser.BrowserTabViewModel.GlobalLayoutViewState
 import com.duckduckgo.app.browser.BrowserTabViewModel.HighlightableButton
 import com.duckduckgo.app.browser.BrowserTabViewModel.LoadingViewState
+import com.duckduckgo.app.browser.BrowserTabViewModel.LocationPermission
 import com.duckduckgo.app.browser.BrowserTabViewModel.NavigationCommand
 import com.duckduckgo.app.browser.BrowserTabViewModel.OmnibarViewState
 import com.duckduckgo.app.browser.BrowserTabViewModel.PrivacyShieldViewState
@@ -1238,7 +1239,7 @@ class BrowserTabFragment :
             is Command.ShowWebContent -> webView?.show()
             is Command.CheckSystemLocationPermission -> checkSystemLocationPermission(it.domain, it.deniedForever)
             is Command.RequestSystemLocationPermission -> requestLocationPermissions()
-            is Command.AskDomainPermission -> askSiteLocationPermission(it.domain)
+            is Command.AskDomainPermission -> askSiteLocationPermission(it.locationPermission)
             is Command.RefreshUserAgent -> refreshUserAgent(it.url, it.isDesktop)
             is Command.AskToFireproofWebsite -> askToFireproofWebsite(requireContext(), it.fireproofWebsite)
             is Command.AskToAutomateFireproofWebsite -> askToAutomateFireproofWebsite(requireContext(), it.fireproofWebsite)
@@ -1418,7 +1419,7 @@ class BrowserTabFragment :
         )
     }
 
-    private fun askSiteLocationPermission(domain: String) {
+    private fun askSiteLocationPermission(locationPermission: LocationPermission) {
         if (!isActiveTab) {
             Timber.v("Will not launch a dialog for an inactive tab")
             return
@@ -1426,6 +1427,7 @@ class BrowserTabFragment :
 
         val binding = ContentSiteLocationPermissionDialogBinding.inflate(layoutInflater)
 
+        val domain = locationPermission.origin
         val title = domain.websiteFromGeoLocationsApiOrigin()
         binding.sitePermissionDialogTitle.text = getString(R.string.preciseLocationSiteDialogTitle, title)
         binding.sitePermissionDialogSubtitle.text = if (title == DDG_DOMAIN) {
@@ -1436,6 +1438,10 @@ class BrowserTabFragment :
 
         val dialog = MaterialAlertDialogBuilder(requireActivity())
             .setView(binding.root)
+            .setOnCancelListener {
+                // Called when user clicks outside the dialog - deny to be safe
+                locationPermission.callback.invoke(locationPermission.origin, false, false)
+            }
             .create()
 
         binding.siteAllowAlwaysLocationPermission.setOnClickListener {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -431,7 +431,7 @@ class BrowserTabViewModel @Inject constructor(
             val deniedForever: Boolean,
         ) : Command()
 
-        class AskDomainPermission(val domain: String) : Command()
+        class AskDomainPermission(val locationPermission: LocationPermission) : Command()
         object RequestSystemLocationPermission : Command()
         class RefreshUserAgent(
             val url: String?,
@@ -1670,7 +1670,7 @@ class BrowserTabViewModel @Inject constructor(
                 }
 
                 LocationPermissionType.ALLOW_ONCE -> {
-                    command.postValue(AskDomainPermission(locationPermission.origin))
+                    command.postValue(AskDomainPermission(locationPermission))
                 }
 
                 LocationPermissionType.DENY_ALWAYS -> {
@@ -1678,7 +1678,7 @@ class BrowserTabViewModel @Inject constructor(
                 }
 
                 LocationPermissionType.DENY_ONCE -> {
-                    command.postValue(AskDomainPermission(locationPermission.origin))
+                    command.postValue(AskDomainPermission(locationPermission))
                 }
             }
         }
@@ -1719,7 +1719,7 @@ class BrowserTabViewModel @Inject constructor(
             viewModelScope.launch {
                 val permissionEntity = locationPermissionsRepository.getDomainPermission(locationPermission.origin)
                 if (permissionEntity == null) {
-                    command.postValue(AskDomainPermission(locationPermission.origin))
+                    command.postValue(AskDomainPermission(locationPermission))
                 } else {
                     reactToSitePermission(permissionEntity.permission)
                 }

--- a/app/src/main/res/layout/content_site_location_permission_dialog.xml
+++ b/app/src/main/res/layout/content_site_location_permission_dialog.xml
@@ -29,25 +29,6 @@
             android:gravity="center"
             android:orientation="vertical">
 
-        <FrameLayout
-                android:id="@+id/sitePermissionDialogFaviconContainer"
-                android:layout_width="@dimen/dialogImageSize"
-                android:layout_height="@dimen/dialogImageSize"
-                android:layout_marginBottom="@dimen/keyline_4"
-                android:background="@drawable/list_item_image_circular_background"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent">
-
-            <ImageView
-                    android:id="@+id/sitePermissionDialogFavicon"
-                    android:layout_width="22dp"
-                    android:layout_height="22dp"
-                    android:layout_gravity="center"
-                    android:importantForAccessibility="no"
-                    android:src="@drawable/ic_globe_gray_16dp"/>
-        </FrameLayout>
-
         <com.duckduckgo.common.ui.view.text.DaxTextView
                 android:id="@+id/sitePermissionDialogTitle"
                 app:typography="h2"

--- a/app/src/main/res/layout/content_system_location_permission_dialog.xml
+++ b/app/src/main/res/layout/content_system_location_permission_dialog.xml
@@ -27,18 +27,6 @@
             android:gravity="center"
             android:orientation="vertical">
 
-        <androidx.appcompat.widget.AppCompatImageView
-                android:id="@+id/faviconImage"
-                android:layout_width="@dimen/dialogImageSize"
-                android:layout_height="@dimen/dialogImageSize"
-                android:layout_gravity="center"
-                android:importantForAccessibility="no"
-                android:layout_marginBottom="@dimen/keyline_4"
-                app:srcCompat="@drawable/ic_dax_icon"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"/>
-
         <com.duckduckgo.common.ui.view.text.DaxTextView
                 android:id="@+id/systemPermissionDialogTitle"
                 app:typography="h2"

--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
@@ -26,7 +26,6 @@ import android.webkit.PermissionRequest
 import androidx.activity.result.ActivityResultCaller
 import androidx.annotation.StringRes
 import androidx.core.net.toUri
-import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.common.ui.view.addClickableLink
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
@@ -67,9 +66,6 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
     private var siteURL: String = ""
     private var tabId: String = ""
 
-    @Inject
-    lateinit var faviconManager: FaviconManager
-
     override fun registerPermissionLauncher(caller: ActivityResultCaller) {
         systemPermissionsHelper.registerPermissionLaunchers(
             caller,
@@ -107,7 +103,7 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
                 showSitePermissionsRationaleDialog(R.string.sitePermissionsCameraDialogTitle, url, this::askForCameraPermissions)
             }
             permissionsHandledByUser.contains(PermissionRequest.RESOURCE_PROTECTED_MEDIA_ID) -> {
-                showSiteDrmPermissionsDialog(activity, url, tabId)
+                showSiteDrmPermissionsDialog(activity, url)
             }
         }
     }
@@ -138,7 +134,6 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
     private fun showSiteDrmPermissionsDialog(
         activity: Activity,
         url: String,
-        tabId: String,
     ) {
         val domain = url.extractDomain() ?: url
 
@@ -168,10 +163,6 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
             denyPermissions()
             dialog.dismiss()
             activity.startActivity(Intent(Intent.ACTION_VIEW, DRM_LEARN_MORE_URL))
-        }
-
-        appCoroutineScope.launch(dispatcher.main()) {
-            faviconManager.loadToViewFromLocalWithPlaceholder(tabId, url, binding.sitePermissionDialogFavicon)
         }
 
         binding.siteAllowAlwaysDrmPermission.setOnClickListener {

--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
@@ -152,6 +152,10 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
         val binding = ContentSiteDrmPermissionDialogBinding.inflate(activity.layoutInflater)
         val dialog = MaterialAlertDialogBuilder(activity)
             .setView(binding.root)
+            .setOnCancelListener {
+                // Called when user clicks outside the dialog - deny to be safe
+                denyPermissions()
+            }
             .create()
 
         val title = url.websiteFromGeoLocationsApiOrigin()

--- a/site-permissions/site-permissions-impl/src/main/res/layout/content_site_drm_permission_dialog.xml
+++ b/site-permissions/site-permissions-impl/src/main/res/layout/content_site_drm_permission_dialog.xml
@@ -29,25 +29,6 @@
             android:gravity="center"
             android:orientation="vertical">
 
-        <FrameLayout
-                android:id="@+id/sitePermissionDialogFaviconContainer"
-                android:layout_width="@dimen/dialogImageSize"
-                android:layout_height="@dimen/dialogImageSize"
-                android:layout_marginBottom="@dimen/keyline_4"
-                android:background="@drawable/list_item_image_circular_background"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent">
-
-            <ImageView
-                    android:id="@+id/sitePermissionDialogFavicon"
-                    android:layout_width="22dp"
-                    android:layout_height="22dp"
-                    android:layout_gravity="center"
-                    android:importantForAccessibility="no"
-                    android:src="@drawable/ic_globe_gray_16dp"/>
-        </FrameLayout>
-
         <com.duckduckgo.common.ui.view.text.DaxTextView
                 android:id="@+id/sitePermissionDialogTitle"
                 app:typography="h2"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1206052137816789/f

### Description
* Remove icon from location + DRM dialogs
* Deny permission if user clicks outside the dialog

### Steps to test this PR
- [ ] Go to https://permission.site/ (HTTPS) and click on Location
- [ ] Verify the dialog has no icon. Select "Enable" and then select "while using the app" when the system dialog appears
- [ ] Verify that the 3rd (and final) location dialog also has no icon
- [ ] Click outside the dialog - Location should turn red (indicating permission was denied)
- [ ] Click on Location again - verify the dialog shows up again
- [ ] Click on "Encrypted Media (EME)" --> DRM consent prompt should appear
- [ ] Verify the dialog has no icon
- [ ] Click outside the dialog - EME should turn red
- [ ] Click on EME again and verify the dialog shows up again