### PR TITLE
Revert Fix `get_server_name` crash when TLS record fragmentation

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -57,7 +57,7 @@ version.com.airbnb.android..lottie=5.2.0
 
 version.com.android.installreferrer..installreferrer=2.2
 
-version.com.duckduckgo.netguard..netguard-android=1.6.9
+version.com.duckduckgo.netguard..netguard-android=1.6.10
 
 version.com.duckduckgo.synccrypto..sync-crypto-android=0.3.0
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1206049262682135/f

### Description
Revert Fix `get_server_name` crash when TLS record fragmentation

### Steps to test this PR
Smoke tests for AppTP and VPN, fresh install and app update
