### PR TITLE
Remove ForcesDefaultVariantIfNull and make it default behavior

### DIFF
--- a/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureToggles.kt
+++ b/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureToggles.kt
@@ -243,7 +243,7 @@ internal class ToggleImpl constructor(
         if (isInternalAlwaysEnabled && flavorNameProvider.invoke().lowercase() == "internal") {
             return true
         }
-        // If there's not assigned variant yet and feature forces default variant, set default variant
+        // If there's not assigned variant yet and is an experiment feature, set default variant
         if (appVariantProvider.invoke() == null && isExperiment) {
             forceDefaultVariant.invoke()
         }

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/TestTriggerFeature.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/TestTriggerFeature.kt
@@ -19,7 +19,7 @@ package com.duckduckgo.feature.toggles.codegen
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.feature.toggles.api.Toggle.DefaultValue
-import com.duckduckgo.feature.toggles.api.Toggle.ForcesDefaultVariantIfNull
+import com.duckduckgo.feature.toggles.api.Toggle.Experiment
 import com.duckduckgo.feature.toggles.api.Toggle.InternalAlwaysEnabled
 
 abstract class TriggerTestScope private constructor()
@@ -34,6 +34,10 @@ interface TestTriggerFeature {
 
     @DefaultValue(false)
     fun fooFeature(): Toggle
+
+    @DefaultValue(false)
+    @Experiment
+    fun experimentFooFeature(): Toggle
 
     @DefaultValue(true)
     @InternalAlwaysEnabled
@@ -53,6 +57,6 @@ interface TestTriggerFeature {
     fun variantFeature(): Toggle
 
     @DefaultValue(false)
-    @ForcesDefaultVariantIfNull
-    fun variantFeatureForcesDefaultVariant(): Toggle
+    @Experiment
+    fun experimentDisabledByDefault(): Toggle
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1206058566871760/f

### Description
`ForcesDefaultVariantIfNull` was added with the intent to be used by experiments very close to the app creation.
However after discussing internally (see asana) this should be the default hardcoded behavior. And so the `ForcesDefaultVariantIfNull` annotation is not needed

### Steps to test this PR

_Test_
Repeat tests from https://github.com/duckduckgo/Android/pull/3758