### PR TITLE
ADS: Dismiss dialog when action button is tapped in BottomSheet components

### DIFF
--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/dialog/ActionBottomSheetDialog.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/dialog/ActionBottomSheetDialog.kt
@@ -52,8 +52,14 @@ class ActionBottomSheetDialog(builder: Builder) : BottomSheetDialog(builder.cont
 
         setOnDismissListener { builder.listener.onBottomSheetDismissed() }
         setOnShowListener { builder.listener.onBottomSheetShown() }
-        binding.actionBottomSheetDialogPrimaryItem.setOnClickListener { builder.listener.onPrimaryItemClicked() }
-        binding.actionBottomSheetDialogSecondaryItem.setOnClickListener { builder.listener.onSecondaryItemClicked() }
+        binding.actionBottomSheetDialogPrimaryItem.setOnClickListener {
+            builder.listener.onPrimaryItemClicked()
+            hide()
+        }
+        binding.actionBottomSheetDialogSecondaryItem.setOnClickListener {
+            builder.listener.onSecondaryItemClicked()
+            hide()
+        }
 
         builder.titleText?.let {
             binding.actionBottomSheetDialogTitle.text = it

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/dialog/PromoBottomSheetDialog.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/dialog/PromoBottomSheetDialog.kt
@@ -50,8 +50,14 @@ class PromoBottomSheetDialog(builder: Builder) : BottomSheetDialog(builder.conte
 
         setOnDismissListener { builder.listener.onBottomSheetDismissed() }
         setOnShowListener { builder.listener.onBottomSheetShown() }
-        binding.bottomSheetPromoPrimaryButton.setOnClickListener { builder.listener.onPrimaryButtonClicked() }
-        binding.bottomSheetPromoSecondaryButton.setOnClickListener { builder.listener.onSecondaryButtonClicked() }
+        binding.bottomSheetPromoPrimaryButton.setOnClickListener {
+            builder.listener.onPrimaryButtonClicked()
+            hide()
+        }
+        binding.bottomSheetPromoSecondaryButton.setOnClickListener {
+            builder.listener.onSecondaryButtonClicked()
+            hide()
+        }
 
         builder.icon?.let {
             binding.bottomSheetPromoIcon.setImageResource(it)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1206057713910059/f

### Description
Hide bottom sheet dialog when an action button is tapped. This will affect to ADS components:

- ActionBottomSheetDialog
- PromoBottomSheetDialog

### Steps to test this PR

- Install from branch
- Go to Settings > ADS preview
- Go to DIALOGS Tab
- [ ] Check all action buttons in bottomSheet components hide the dialog

### No UI changes
