### PR TITLE
Support taking a new photo when prompted to upload an image

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/camera/CameraHardwareChecker.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/camera/CameraHardwareChecker.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.camera
+
+import android.content.Context
+import android.content.pm.PackageManager.FEATURE_CAMERA_ANY
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface CameraHardwareChecker {
+    fun hasCameraHardware(): Boolean
+}
+
+@ContributesBinding(AppScope::class)
+class RealCameraHardwareChecker @Inject constructor(
+    private val context: Context,
+) : CameraHardwareChecker {
+
+    override fun hasCameraHardware(): Boolean {
+        return with(context.packageManager) {
+            kotlin.runCatching { hasSystemFeature(FEATURE_CAMERA_ANY) }.getOrDefault(false)
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/camera/CameraHardwareChecker.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/camera/CameraHardwareChecker.kt
@@ -27,7 +27,7 @@ interface CameraHardwareChecker {
 }
 
 @ContributesBinding(AppScope::class)
-class RealCameraHardwareChecker @Inject constructor(
+class CameraHardwareCheckerImpl @Inject constructor(
     private val context: Context,
 ) : CameraHardwareChecker {
 

--- a/app/src/main/java/com/duckduckgo/app/browser/filechooser/camera/CameraCaptureResultHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/filechooser/camera/CameraCaptureResultHandler.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.filechooser.camera
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.provider.MediaStore
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.core.content.FileProvider
+import java.io.File
+import java.lang.IllegalStateException
+
+class RealCameraCaptureResultHandler : ActivityResultContract<Unit?, File?>() {
+
+    private var interimImageLocation: File? = null
+
+    override fun createIntent(
+        context: Context,
+        input: Unit?,
+    ): Intent {
+        val destinationForCapturedImage = destinationImageCaptureFile(context) ?: throw IllegalStateException("Unable to save images from camera")
+
+        return Intent(MediaStore.ACTION_IMAGE_CAPTURE).also { intent ->
+            destinationForCapturedImage.also { newFile ->
+                val safeUri = FileProvider.getUriForFile(context, "${context.packageName}.$PROVIDER_SUFFIX", newFile)
+                intent.putExtra(MediaStore.EXTRA_OUTPUT, safeUri)
+            }
+        }
+    }
+
+    private fun destinationImageCaptureFile(context: Context): File? {
+        val topLevelDirectory: File = context.externalCacheDir ?: return null
+        val cameraDataDir = File(topLevelDirectory, SUBDIRECTORY)
+        cameraDataDir.mkdirs()
+        val newFileName = "${System.currentTimeMillis()}.$IMAGE_FILE_EXTENSION"
+        return File(cameraDataDir, newFileName).also {
+            interimImageLocation = it
+        }
+    }
+
+    override fun parseResult(
+        resultCode: Int,
+        intent: Intent?,
+    ): File? {
+        if (resultCode != Activity.RESULT_OK) {
+            return null
+        }
+
+        return interimImageLocation
+    }
+
+    companion object {
+        private const val SUBDIRECTORY = "browser-uploads"
+        private const val PROVIDER_SUFFIX = "provider"
+        private const val IMAGE_FILE_EXTENSION = "jpg"
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/filechooser/camera/CameraCaptureResultHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/filechooser/camera/CameraCaptureResultHandler.kt
@@ -25,7 +25,7 @@ import androidx.core.content.FileProvider
 import java.io.File
 import java.lang.IllegalStateException
 
-class RealCameraCaptureResultHandler : ActivityResultContract<Unit?, File?>() {
+class CameraCaptureResultHandler : ActivityResultContract<Unit?, File?>() {
 
     private var interimImageLocation: File? = null
 

--- a/app/src/main/java/com/duckduckgo/app/browser/filechooser/camera/launcher/UploadFromExternalCameraLauncher.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/filechooser/camera/launcher/UploadFromExternalCameraLauncher.kt
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.filechooser.camera.launcher
+
+import android.Manifest
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
+import androidx.activity.result.ActivityResultCaller
+import androidx.activity.result.ActivityResultLauncher
+import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.filechooser.camera.RealCameraCaptureResultHandler
+import com.duckduckgo.app.browser.filechooser.camera.launcher.UploadFromExternalCameraLauncher.CameraImageCaptureResult
+import com.duckduckgo.app.browser.filechooser.camera.permission.ExternalCameraSystemPermissionsHelper
+import com.duckduckgo.app.browser.filechooser.camera.postprocess.CameraCaptureDelayedDeleter
+import com.duckduckgo.app.browser.filechooser.camera.postprocess.CameraCaptureImageMover
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.FragmentScope
+import com.squareup.anvil.annotations.ContributesBinding
+import java.io.File
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+/**
+ * Public API for launching the external camera app and capturing an image.
+ * This launcher will internally handle necessary camera permissions.
+ *
+ * [registerForResult] should be called once in [Activity.onCreate]
+ * [launch] should be called when it is time to launch the camera app.
+ */
+interface UploadFromExternalCameraLauncher {
+
+    /**
+     * Launches the external camera app to capture an image.
+     * Before calling launch, you must register a callback to receive the result, using [registerForResult].
+     */
+    fun launch()
+
+    /**
+     * Registers a callback to receive the result of the camera capture.
+     * This must be called before calling [launch].
+     *
+     * @param onResult will be called with the captured image or another result type if the capture failed.
+     */
+    fun registerForResult(
+        caller: ActivityResultCaller,
+        onResult: (CameraImageCaptureResult) -> Unit,
+    )
+
+    fun showPermissionRationaleDialog(activity: Activity)
+
+    /**
+     * Types of results that can be returned from the camera capture flow.
+     */
+    sealed interface CameraImageCaptureResult {
+
+        /**
+         * The image was captured successfully.
+         * The included [file] is the location of the captured image.
+         *
+         * Note, this file should be considered temporary and will be automatically deleted after a short period of time.
+         */
+        data class ImageCaptured(val file: File) : CameraImageCaptureResult
+
+        /**
+         * The user denied permission to access the camera.
+         */
+        data object CouldNotCapturePermissionDenied : CameraImageCaptureResult
+
+        /**
+         * No image was captured, most likely because the user cancelled the camera capture flow.
+         */
+        data object NoImageCaptured : CameraImageCaptureResult
+
+        /**
+         * No image was captured as unable to integrate with the system camera.
+         */
+        data object ErrorAccessingCamera : CameraImageCaptureResult
+    }
+}
+
+@ContributesBinding(FragmentScope::class)
+class PermissionAwareExternalCameraLauncher @Inject constructor(
+    private val permissionHelper: ExternalCameraSystemPermissionsHelper,
+    private val imageMover: CameraCaptureImageMover,
+    private val delayedDeleter: CameraCaptureDelayedDeleter,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val dispatchers: DispatcherProvider,
+) : UploadFromExternalCameraLauncher {
+
+    private lateinit var callback: (CameraImageCaptureResult) -> Unit
+    private lateinit var launcher: ActivityResultLauncher<Unit?>
+
+    override fun launch() {
+        if (permissionHelper.hasCameraPermissionsGranted()) {
+            Timber.d("camera permission already granted. launching camera now")
+            launchCamera()
+        } else {
+            // ask for permission
+            Timber.d("no camera permission yet, need to request camera permission before launching camera")
+            permissionHelper.requestPermission(Manifest.permission.CAMERA)
+        }
+    }
+
+    private fun launchCamera() {
+        try {
+            launcher.launch(null)
+        } catch (e: Exception) {
+            Timber.w(e, "exception launching camera")
+            callback.invoke(CameraImageCaptureResult.ErrorAccessingCamera)
+        }
+    }
+
+    override fun registerForResult(
+        caller: ActivityResultCaller,
+        onResult: (CameraImageCaptureResult) -> Unit,
+    ) {
+        callback = onResult
+        registerPermissionLauncher(caller)
+        launcher = caller.registerForActivityResult(RealCameraCaptureResultHandler()) { interimFile ->
+            if (interimFile == null) {
+                onResult(CameraImageCaptureResult.NoImageCaptured)
+            } else {
+                appCoroutineScope.launch(dispatchers.io()) {
+                    val finalImage = moveCapturedImageToFinalLocation(interimFile)
+                    onResult(CameraImageCaptureResult.ImageCaptured(finalImage))
+                }
+            }
+        }
+    }
+
+    override fun showPermissionRationaleDialog(activity: Activity) {
+        if (permissionHelper.isPermissionsRejectedForever(activity)) {
+            TextAlertDialogBuilder(activity)
+                .setTitle(R.string.imageCaptureCameraPermissionDeniedTitle)
+                .setMessage(R.string.imageCaptureCameraPermissionDeniedMessage)
+                .setPositiveButton(R.string.imageCaptureCameraPermissionDeniedPositiveButton)
+                .setNegativeButton(R.string.imageCaptureCameraPermissionDeniedNegativeButton)
+                .addEventListener(
+                    object : TextAlertDialogBuilder.EventListener() {
+                        override fun onPositiveButtonClicked() {
+                            val intent = Intent()
+                            intent.action = Settings.ACTION_APPLICATION_DETAILS_SETTINGS
+                            val uri = Uri.fromParts("package", activity.packageName, null)
+                            intent.data = uri
+                            activity.startActivity(intent)
+                        }
+                    },
+                )
+                .show()
+        }
+    }
+
+    private fun registerPermissionLauncher(caller: ActivityResultCaller) {
+        permissionHelper.registerPermissionLaunchers(caller, this::onResultSystemPermissionRequest)
+    }
+
+    private fun onResultSystemPermissionRequest(granted: Boolean) {
+        Timber.d("camera permission request received. granted=%s", granted)
+        if (granted) {
+            launchCamera()
+        } else {
+            callback(CameraImageCaptureResult.CouldNotCapturePermissionDenied)
+        }
+    }
+
+    private suspend fun moveCapturedImageToFinalLocation(interimFile: File): File {
+        return imageMover.moveInternal(interimFile).also { finalImage ->
+            delayedDeleter.scheduleDeletion(finalImage)
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/filechooser/camera/launcher/UploadFromExternalCameraLauncher.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/filechooser/camera/launcher/UploadFromExternalCameraLauncher.kt
@@ -24,7 +24,7 @@ import android.provider.Settings
 import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
 import com.duckduckgo.app.browser.R
-import com.duckduckgo.app.browser.filechooser.camera.RealCameraCaptureResultHandler
+import com.duckduckgo.app.browser.filechooser.camera.CameraCaptureResultHandler
 import com.duckduckgo.app.browser.filechooser.camera.launcher.UploadFromExternalCameraLauncher.CameraImageCaptureResult
 import com.duckduckgo.app.browser.filechooser.camera.permission.ExternalCameraSystemPermissionsHelper
 import com.duckduckgo.app.browser.filechooser.camera.postprocess.CameraCaptureDelayedDeleter
@@ -136,7 +136,7 @@ class PermissionAwareExternalCameraLauncher @Inject constructor(
     ) {
         callback = onResult
         registerPermissionLauncher(caller)
-        launcher = caller.registerForActivityResult(RealCameraCaptureResultHandler()) { interimFile ->
+        launcher = caller.registerForActivityResult(CameraCaptureResultHandler()) { interimFile ->
             if (interimFile == null) {
                 onResult(CameraImageCaptureResult.NoImageCaptured)
             } else {

--- a/app/src/main/java/com/duckduckgo/app/browser/filechooser/camera/permission/RealExternalCameraSystemPermissionsHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/filechooser/camera/permission/RealExternalCameraSystemPermissionsHelper.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.filechooser.camera.permission
+
+import android.Manifest
+import android.app.Activity
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.activity.result.ActivityResultCaller
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import com.duckduckgo.di.scopes.FragmentScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface ExternalCameraSystemPermissionsHelper {
+    fun hasCameraPermissionsGranted(): Boolean
+    fun registerPermissionLaunchers(
+        caller: ActivityResultCaller,
+        onResultPermissionRequest: (Boolean) -> Unit,
+    )
+    fun requestPermission(permission: String)
+    fun isPermissionsRejectedForever(activity: Activity): Boolean
+}
+
+@ContributesBinding(FragmentScope::class)
+class RealExternalCameraSystemPermissionsHelperImpl @Inject constructor(
+    private val context: Context,
+) : ExternalCameraSystemPermissionsHelper {
+
+    private lateinit var permissionLauncher: ActivityResultLauncher<String>
+    private var currentPermissionRequested: String? = null
+
+    override fun hasCameraPermissionsGranted(): Boolean =
+        ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED
+
+    override fun registerPermissionLaunchers(
+        caller: ActivityResultCaller,
+        onResultPermissionRequest: (Boolean) -> Unit,
+    ) {
+        permissionLauncher = caller.registerForActivityResult(RequestPermission()) {
+            onResultPermissionRequest.invoke(it)
+        }
+    }
+
+    override fun requestPermission(permission: String) {
+        if (this::permissionLauncher.isInitialized) {
+            currentPermissionRequested = permission
+            permissionLauncher.launch(permission)
+        } else {
+            throw IllegalAccessException("registerPermissionLaunchers() needs to be called before requestPermission()")
+        }
+    }
+
+    override fun isPermissionsRejectedForever(activity: Activity): Boolean =
+        currentPermissionRequested?.let { !ActivityCompat.shouldShowRequestPermissionRationale(activity, it) } ?: true
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/filechooser/camera/postprocess/CameraCaptureDelayedDeleter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/filechooser/camera/postprocess/CameraCaptureDelayedDeleter.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.filechooser.camera.postprocess
+
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.workDataOf
+import com.duckduckgo.di.scopes.FragmentScope
+import com.squareup.anvil.annotations.ContributesBinding
+import java.io.File
+import java.util.concurrent.TimeUnit.SECONDS
+import javax.inject.Inject
+
+interface CameraCaptureDelayedDeleter {
+    fun scheduleDeletion(file: File)
+}
+
+@ContributesBinding(FragmentScope::class)
+class WorkManagerCameraCaptureDelayedDeleter @Inject constructor(
+    private val workManager: WorkManager,
+) : CameraCaptureDelayedDeleter {
+
+    override fun scheduleDeletion(file: File) {
+        val workRequest = OneTimeWorkRequestBuilder<DeleteCameraCaptureWorker>()
+            .setInputData(
+                workDataOf(
+                    DeleteCameraCaptureWorker.KEY_FILE_URI to file.absolutePath,
+                ),
+            )
+            .setInitialDelay(INITIAL_DELAY_SECONDS, SECONDS)
+            .build()
+        workManager.enqueue(workRequest)
+    }
+
+    companion object {
+        private const val INITIAL_DELAY_SECONDS = 60L
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/filechooser/camera/postprocess/CameraCaptureImageMover.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/filechooser/camera/postprocess/CameraCaptureImageMover.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.filechooser.camera.postprocess
+
+import android.content.Context
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.FragmentScope
+import com.squareup.anvil.annotations.ContributesBinding
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import javax.inject.Inject
+import kotlinx.coroutines.withContext
+
+interface CameraCaptureImageMover {
+    suspend fun moveInternal(interimFile: File): File
+}
+
+@ContributesBinding(FragmentScope::class)
+class RealCameraCaptureImageMover @Inject constructor(
+    private val context: Context,
+    private val dispatchers: DispatcherProvider,
+) : CameraCaptureImageMover {
+
+    override suspend fun moveInternal(interimFile: File): File {
+        return withContext(dispatchers.io()) {
+            val newDestinationDirectory = File(context.cacheDir, SUBDIRECTORY_NAME)
+            newDestinationDirectory.mkdirs()
+            val newDestinationFile = File(newDestinationDirectory, interimFile.name)
+
+            FileInputStream(interimFile).use { inputStream ->
+                FileOutputStream(newDestinationFile).use { outputStream ->
+                    inputStream.copyTo(outputStream)
+                    interimFile.delete()
+                }
+            }
+
+            newDestinationFile
+        }
+    }
+
+    companion object {
+        private const val SUBDIRECTORY_NAME = "browser-uploads"
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/filechooser/camera/postprocess/DeleteCameraCaptureWorker.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/filechooser/camera/postprocess/DeleteCameraCaptureWorker.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.filechooser.camera.postprocess
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.duckduckgo.anvil.annotations.ContributesWorker
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import java.io.File
+import javax.inject.Inject
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+
+/**
+ * Images captured by the camera to be uploaded through the WebView shouldn't be kept forever.
+ * The URI for the image is passed to the WebView, but we don't know when it is safe to delete the file.
+ *
+ * This worker is responsible for deleting the file after a period of time.
+ *
+ * The typical use case is that:
+ * - the user chooses to upload an image on a website
+ * - user chooses to take a photo rather than use an existing image
+ * - the camera app is launched
+ * - a new file is created to store the image
+ * - we pass the URI of the file to the camera app
+ * - we schedule the file to be deleted using this worker
+ */
+@ContributesWorker(AppScope::class)
+class DeleteCameraCaptureWorker(
+    context: Context,
+    workerParameters: WorkerParameters,
+) :
+    CoroutineWorker(context, workerParameters) {
+
+    @Inject
+    lateinit var dispatchers: DispatcherProvider
+
+    override suspend fun doWork(): Result {
+        return withContext(dispatchers.io()) {
+            deleteFile()
+        }
+    }
+
+    private fun deleteFile(): Result {
+        val fileUri = inputData.getString(KEY_FILE_URI) ?: return Result.failure()
+
+        val file = File(fileUri)
+        if (!file.exists()) {
+            Timber.v("file doesn't exist; nothing to do here. file=%s", file.absolutePath)
+            return Result.success()
+        }
+
+        Timber.d("time to delete the temporary captured image file %s", file)
+
+        return if (file.delete()) {
+            Timber.d("Successfully deleted the file %s", file.absolutePath)
+            Result.success()
+        } else {
+            Timber.w("Failed to delete the file %s", file.absolutePath)
+
+            if (runAttemptCount < MAX_ATTEMPTS) {
+                Result.retry()
+            } else {
+                Result.failure()
+            }
+        }
+    }
+
+    companion object {
+        const val KEY_FILE_URI = "fileUri"
+        private const val MAX_ATTEMPTS = 10
+    }
+}

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -46,4 +46,14 @@
     <!-- DRM -->
     <string name="sitePermissionsSettingsDRM">DRM</string>
 
+    <string name="imageCaptureCameraUnavailable">Could not access camera</string>
+    <string name="imageCaptureCameraGalleryDisambiguationTitle">Upload an image</string>
+    <string name="imageCaptureCameraGalleryDisambiguationGalleryOption">Choose File</string>
+    <string name="imageCaptureCameraGalleryDisambiguationCameraOption">Take Photo</string>
+
+    <string name="imageCaptureCameraPermissionDeniedTitle">Allow DuckDuckGo to ask for camera access on this device</string>
+    <string name="imageCaptureCameraPermissionDeniedMessage">Sites can only use your camera if you allow DuckDuckGo to ask for access.</string>
+    <string name="imageCaptureCameraPermissionDeniedPositiveButton">Open Settings</string>
+    <string name="imageCaptureCameraPermissionDeniedNegativeButton">Cancel</string>
+
 </resources>

--- a/common/common-ui/src/main/res/drawable/ic_camera_24.xml
+++ b/common/common-ui/src/main/res/drawable/ic_camera_24.xml
@@ -1,0 +1,30 @@
+<!--
+  ~ Copyright (c) 2023 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M12,7C9.239,7 7,9.239 7,12C7,14.761 9.239,17 12,17C14.761,17 17,14.761 17,12C17,9.239 14.761,7 12,7ZM9,12C9,10.343 10.343,9 12,9C13.657,9 15,10.343 15,12C15,13.657 13.657,15 12,15C10.343,15 9,13.657 9,12Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M10.677,2C9.27,2 7.985,2.795 7.356,4.053C7.068,4.628 6.463,5 5.807,5C3.731,5 2,6.681 2,8.781V17C2,19.209 3.791,21 6,21H18C20.209,21 22,19.209 22,17V8.781C22,6.681 20.269,5 18.193,5C17.537,5 16.932,4.628 16.644,4.053C16.015,2.795 14.729,2 13.323,2H10.677ZM9.144,4.947C9.435,4.367 10.028,4 10.677,4H13.323C13.972,4 14.565,4.367 14.856,4.947C15.488,6.211 16.793,7 18.193,7C19.189,7 20,7.81 20,8.781V17C20,18.105 19.105,19 18,19H6C4.895,19 4,18.105 4,17V8.781C4,7.81 4.811,7 5.807,7C7.207,7 8.512,6.211 9.144,4.947Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"
+      android:fillType="evenOdd"/>
+</vector>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1206005059663926/f 

### Description
When encountering webpages which allow users to upload an image, currently the only option is to choose an existing image from the gallery.

With this PR, users will have the ability to choose between uploading an existing image from their gallery or taking a new photo from the camera and uploading that. 

Translations will follow separately.

### Steps to test this PR


#### Happy path, camera
- [x] Visit https://cdrussell.w3spaces.com and click the **Choose File** button
- [x] Choose **Take Photo**
- [x] Grant camera permission when prompted
- [x] Take a photo
- [x] Verify it appears on the demo webpage

#### Happy path, gallery
- [x] Visit https://cdrussell.w3spaces.com and click the **Choose File** button
- [x] Choose **Photo Library**
- [x] Verify you see the standard file chooser as you would just now in `develop` and that you can select an image (nothing has changed about this flow)

#### Alt path, cancel image capture
- [x] Visit https://cdrussell.w3spaces.com and click the **Choose File** button
- [x] Choose **Take Photo**
- [x] (assuming you still have camera permission from previous test; accept permission if needed)
- [x] When the camera app loads, cancel without taking an image
- [x] Choose **Take Photo** again to sense-check the flow can be repeated after cancellation

#### Alt path, refusing camera permission
- [x] Clear camera permissions if granted, manually or using `adb shell pm reset-permissions`
- [x] Visit https://cdrussell.w3spaces.com and click the **Choose File** button
- [x] Choose **Take Photo**
- [x] **Refuse** camera permission
- [x] Verify nothing else shown to user (just quietly returned to website with no dialogs showing)
- [x] Choose **Take Photo** again, and again refuse permission when prompted
- [x] Verify this time the permission rationale prompt shows explaining why we'd need this permission to do what the user is asking
- [x] Click on the **Open Settings** button and verify it takes you to the right place to alter system permissions for the app

#### Alt path, uploading a non-image file
- [x] Visit https://cdrussell.w3spaces.com/other.html
- [x] Tap the third button (`video/*` upload type)
- [x] Verify you are not given the option to use the camera (only supporting images at the moment)

### UI changes

<img width=50% src="https://github.com/duckduckgo/Android/assets/1336281/9b6c64d6-20cd-43aa-b0b0-2f039d96dcc7" />

<hr/>
<hr/>

<img width=50% src="https://github.com/duckduckgo/Android/assets/1336281/0905276b-80a9-4790-8a12-7859c3edafac" />
