### PR TITLE
Fix DRM permission saving

### DIFF
--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
@@ -146,7 +146,7 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
         val sessionSetting = sitePermissionsRepository.getDrmForSession(domain)
         if (sessionSetting != null) {
             if (sessionSetting) {
-                systemPermissionGranted()
+                grantPermissions()
             } else {
                 denyPermissions()
             }
@@ -181,14 +181,14 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
         }
 
         binding.siteAllowAlwaysDrmPermission.setOnClickListener {
-            systemPermissionGranted()
+            grantPermissions()
             onSiteDrmPermissionSave(domain, SitePermissionAskSettingType.ALLOW_ALWAYS)
             dialog.dismiss()
         }
 
         binding.siteAllowOnceDrmPermission.setOnClickListener {
             sitePermissionsRepository.saveDrmForSession(domain, true)
-            systemPermissionGranted()
+            grantPermissions()
             dialog.dismiss()
         }
 
@@ -283,9 +283,13 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
         }
     }
 
-    private fun systemPermissionGranted() {
+    private fun grantPermissions() {
         val permissions = permissionsHandledAutomatically.toTypedArray() + permissionsHandledByUser
         sitePermissionRequest.grant(permissions)
+    }
+
+    private fun systemPermissionGranted() {
+        grantPermissions()
         permissionsHandledByUser.forEach {
             sitePermissionsRepository.sitePermissionGranted(siteURL, tabId, it)
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1206082649420187/f

### Description
* Fix bug where selecting Always Allow set DRM to Ask.
* Don't store session-based DRM permission

### Steps to test this PR
- [x] Go to https://permission.site/ (HTTPS) and click on "Encrypted Media (EME)" --> DRM consent prompt should appear
- [x] Select "Only for this Session"
- [x] Go to Settings --> Permissions --> Site Permissions and verify that the site does not appear there
- [x] Open a new tab, go to https://permission.site/ (HTTPS) and click on "Encrypted Media (EME)" --> DRM consent prompt should appear
- [x] Select "Always Allow"
- [x] Go to Settings --> Permissions --> Site Permissions and verify that DRM is set to "Allow"

