### PR TITLE
Stop using NonCancellable when launching coroutines

### DIFF
--- a/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/GlobalUncaughtExceptionHandler.kt
+++ b/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/GlobalUncaughtExceptionHandler.kt
@@ -29,7 +29,6 @@ import java.io.InterruptedIOException
 import javax.inject.Inject
 import javax.inject.Qualifier
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
 import logcat.LogPriority
 import logcat.asLog
@@ -70,7 +69,7 @@ class GlobalUncaughtExceptionHandler @Inject constructor(
         thread: Thread?,
         originalException: Throwable?,
     ) {
-        appCoroutineScope.launch(dispatcherProvider.io() + NonCancellable) {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
             try {
                 originalException?.let {
                     crashLogger.logCrash(

--- a/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModel.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.app.bookmarks.ui.EditSavedSiteDialogFragment.EditSavedSite
 import com.duckduckgo.app.bookmarks.ui.bookmarkfolders.AddBookmarkFolderDialogFragment.AddBookmarkFolderListener
 import com.duckduckgo.app.bookmarks.ui.bookmarkfolders.EditBookmarkFolderDialogFragment.EditBookmarkFolderListener
 import com.duckduckgo.app.browser.favicon.FaviconManager
+import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.global.SingleLiveEvent
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -42,7 +43,7 @@ import com.duckduckgo.savedsites.api.service.SavedSitesManager
 import com.duckduckgo.sync.api.engine.SyncEngine
 import com.duckduckgo.sync.api.engine.SyncEngine.SyncTrigger.FEATURE_READ
 import javax.inject.Inject
-import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
@@ -57,6 +58,7 @@ class BookmarksViewModel @Inject constructor(
     private val pixel: Pixel,
     private val syncEngine: SyncEngine,
     private val dispatcherProvider: DispatcherProvider,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
 ) : EditSavedSiteListener, AddBookmarkFolderListener, EditBookmarkFolderListener, DeleteBookmarkListener, ViewModel() {
 
     data class ViewState(
@@ -136,7 +138,7 @@ class BookmarksViewModel @Inject constructor(
     }
 
     private fun delete(savedSite: SavedSite) {
-        viewModelScope.launch(dispatcherProvider.io() + NonCancellable) {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
             if (savedSite is Bookmark) {
                 faviconManager.deletePersistedFavicon(savedSite.url)
             }
@@ -250,7 +252,7 @@ class BookmarksViewModel @Inject constructor(
     }
 
     private fun delete(bookmarkFolder: BookmarkFolder) {
-        viewModelScope.launch(dispatcherProvider.io() + NonCancellable) {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
             savedSitesRepository.deleteFolderBranch(bookmarkFolder)
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2839,7 +2839,7 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     private fun delete(savedSite: SavedSite) {
-        viewModelScope.launch(dispatchers.io() + NonCancellable) {
+        appCoroutineScope.launch(dispatchers.io()) {
             if (savedSite is Bookmark) {
                 faviconManager.deletePersistedFavicon(savedSite.url)
             }

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.app.autocomplete.api.AutoComplete
 import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteResult
 import com.duckduckgo.app.bookmarks.ui.EditSavedSiteDialogFragment
 import com.duckduckgo.app.browser.favorites.FavoritesQuickAccessAdapter
+import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.global.SingleLiveEvent
 import com.duckduckgo.app.onboarding.store.AppStage
 import com.duckduckgo.app.onboarding.store.UserStageStore
@@ -45,8 +46,8 @@ import io.reactivex.disposables.Disposable
 import io.reactivex.schedulers.Schedulers
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOn
@@ -70,6 +71,7 @@ class SystemSearchViewModel @Inject constructor(
     private val savedSitesRepository: SavedSitesRepository,
     private val appSettingsPreferencesStore: SettingsDataStore,
     private val dispatchers: DispatcherProvider,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
 ) : ViewModel(), EditSavedSiteDialogFragment.EditSavedSiteListener {
 
     data class OnboardingViewState(
@@ -348,7 +350,7 @@ class SystemSearchViewModel @Inject constructor(
     fun deleteSavedSiteSnackbarDismissed(savedSite: SavedSite) {
         when (savedSite) {
             is SavedSite.Favorite -> {
-                viewModelScope.launch(dispatchers.io() + NonCancellable) {
+                appCoroutineScope.launch(dispatchers.io()) {
                     savedSitesRepository.delete(savedSite)
                 }
             }

--- a/app/src/test/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModelTest.kt
@@ -85,6 +85,7 @@ class BookmarksViewModelTest {
             pixel,
             syncEngine,
             coroutineRule.testDispatcherProvider,
+            coroutineRule.testScope,
         )
         model.viewState.observeForever(viewStateObserver)
         model.command.observeForever(commandObserver)

--- a/app/src/test/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
@@ -37,6 +37,7 @@ import com.duckduckgo.common.test.InstantSchedulersRule
 import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.savedsites.api.models.SavedSite.Favorite
 import io.reactivex.Observable
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.*
 import org.junit.*
@@ -44,6 +45,7 @@ import org.junit.Assert.*
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.*
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @Suppress("EXPERIMENTAL_API_USAGE")
 class SystemSearchViewModelTest {
 
@@ -84,6 +86,7 @@ class SystemSearchViewModelTest {
             mocksavedSitesRepository,
             mockSettingsStore,
             coroutineRule.testDispatcherProvider,
+            coroutineRule.testScope,
         )
         testee.command.observeForever(commandObserver)
     }
@@ -348,6 +351,7 @@ class SystemSearchViewModelTest {
             mocksavedSitesRepository,
             mockSettingsStore,
             coroutineRule.testDispatcherProvider,
+            coroutineRule.testScope,
         )
 
         val viewState = testee.resultsViewState.value as QuickAccessItems
@@ -371,6 +375,7 @@ class SystemSearchViewModelTest {
             mocksavedSitesRepository,
             mockSettingsStore,
             coroutineRule.testDispatcherProvider,
+            coroutineRule.testScope,
         )
 
         val viewState = testee.resultsViewState.value as QuickAccessItems
@@ -412,6 +417,7 @@ class SystemSearchViewModelTest {
             mocksavedSitesRepository,
             mockSettingsStore,
             coroutineRule.testDispatcherProvider,
+            coroutineRule.testScope,
         )
 
         val viewState = testee.resultsViewState.value as SystemSearchViewModel.Suggestions.QuickAccessItems

--- a/lint-rules/src/main/java/com/duckduckgo/lint/NonCancellableDetector.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/NonCancellableDetector.kt
@@ -27,6 +27,7 @@ import com.android.tools.lint.detector.api.SourceCodeScanner
 import com.intellij.psi.PsiMethod
 import org.jetbrains.uast.UCallExpression
 import org.jetbrains.uast.UExpression
+import org.jetbrains.uast.ULambdaExpression
 import java.util.EnumSet
 
 /*
@@ -73,6 +74,7 @@ class NonCancellableDetector : Detector(), SourceCodeScanner {
     }
 
     private fun isNonCancellable(argument: UExpression): Boolean {
+        if(argument is ULambdaExpression) return false
         // Check if the argument is NonCancellable
         return argument.asSourceString().contains("NonCancellable")
     }

--- a/lint-rules/src/main/java/com/duckduckgo/lint/NonCancellableDetector.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/NonCancellableDetector.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint
+
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.intellij.psi.PsiMethod
+import org.jetbrains.uast.UCallExpression
+import org.jetbrains.uast.UExpression
+import java.util.EnumSet
+
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class NonCancellableDetector : Detector(), SourceCodeScanner {
+
+    override fun getApplicableMethodNames(): List<String>? {
+        return listOf("launch", "launchIn", "launchWhen", "async", "produce")
+    }
+
+    override fun visitMethodCall(
+        context: JavaContext,
+        node: UCallExpression,
+        method: PsiMethod
+    ) {
+        val methodName = method.name
+        if (methodName == "launch" || methodName == "launchIn" || methodName == "launchWhen" || methodName == "async" || methodName == "produce") {
+            val arguments = node.valueArguments.takeUnless { it.isEmpty() } ?: return
+            arguments.forEach { argument ->
+                if (isNonCancellable(argument)) {
+                    context.report(
+                        ISSUE_NON_CANCELLABLE,
+                        node,
+                        context.getLocation(node),
+                        "Avoid using NonCancellable when launching a coroutine."
+                    )
+                }
+            }
+        }
+    }
+
+    private fun isNonCancellable(argument: UExpression): Boolean {
+        // Check if the argument is NonCancellable
+        return argument.asSourceString().contains("NonCancellable")
+    }
+
+    companion object {
+        val ISSUE_NON_CANCELLABLE = Issue.create(
+            id = "NonCancellableUsage",
+            briefDescription = "Avoid using NonCancellable when launching a coroutine.",
+            explanation = "NonCancellable should not be used when launching coroutines. Use AppCoroutineScope instead.",
+            category = Category.CORRECTNESS,
+            priority = 6,
+            severity = Severity.ERROR,
+            implementation = Implementation(
+                NonCancellableDetector::class.java,
+                EnumSet.of(Scope.JAVA_FILE, Scope.TEST_SOURCES)
+            )
+        )
+    }
+}

--- a/lint-rules/src/main/java/com/duckduckgo/lint/registry/DuckDuckGoIssueRegistry.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/registry/DuckDuckGoIssueRegistry.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.lint.registry
 
+import com.duckduckgo.lint.NonCancellableDetector.Companion.ISSUE_NON_CANCELLABLE
 import com.android.tools.lint.client.api.IssueRegistry
 import com.android.tools.lint.client.api.Vendor
 import com.android.tools.lint.detector.api.CURRENT_API
@@ -30,7 +31,6 @@ import com.duckduckgo.lint.NoSingletonDetector.Companion.NO_SINGLETON_ISSUE
 import com.duckduckgo.lint.NoSystemLoadLibraryDetector.Companion.NO_SYSTEM_LOAD_LIBRARY
 import com.duckduckgo.lint.strings.MissingInstructionDetector.Companion.MISSING_INSTRUCTION
 import com.duckduckgo.lint.strings.PlaceholderDetector.Companion.PLACEHOLDER_MISSING_POSITION
-import com.duckduckgo.lint.ui.ColorAttributeInXmlDetector
 import com.duckduckgo.lint.ui.ColorAttributeInXmlDetector.Companion.INVALID_COLOR_ATTRIBUTE
 import com.duckduckgo.lint.ui.DaxButtonStylingDetector.Companion.INVALID_DAX_BUTTON_PROPERTY
 import com.duckduckgo.lint.ui.DaxTextViewStylingDetector.Companion.INVALID_DAX_TEXT_VIEW_PROPERTY
@@ -41,8 +41,6 @@ import com.duckduckgo.lint.ui.NoAlertDialogDetector.Companion.NO_DESIGN_SYSTEM_D
 import com.duckduckgo.lint.ui.NoBottomSheetDialogDetector.Companion.NO_BOTTOM_SHEET
 import com.duckduckgo.lint.ui.NoStyleAppliedToDesignSystemComponentDetector.Companion.STYLE_IN_DESIGN_SYSTEM_COMPONENT
 import com.duckduckgo.lint.ui.SkeletonViewBackgroundDetector.Companion.INVALID_SKELETON_VIEW_BACKGROUND
-import com.duckduckgo.lint.ui.WrongStyleDetector
-import com.duckduckgo.lint.ui.WrongStyleDetector.Companion
 import com.duckduckgo.lint.ui.WrongStyleDetector.Companion.WRONG_STYLE_NAME
 import com.duckduckgo.lint.ui.WrongStyleDetector.Companion.WRONG_STYLE_PARAMETER
 
@@ -60,6 +58,7 @@ class DuckDuckGoIssueRegistry : IssueRegistry() {
             PLACEHOLDER_MISSING_POSITION,
             NO_RETROFIT_CREATE_CALL,
             NO_ROBOLECTRIC_TEST_RUNNER_ISSUE,
+            ISSUE_NON_CANCELLABLE,
 
             // Android Design System
             DEPRECATED_WIDGET_IN_XML,

--- a/lint-rules/src/test/java/com/duckduckgo/lint/NonCancellableDetectorTest.kt
+++ b/lint-rules/src/test/java/com/duckduckgo/lint/NonCancellableDetectorTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint
+
+import com.android.tools.lint.checks.infrastructure.TestFile
+import com.android.tools.lint.checks.infrastructure.TestFiles
+import com.android.tools.lint.checks.infrastructure.TestLintTask
+import com.android.tools.lint.checks.infrastructure.TestMode
+import com.duckduckgo.lint.NoHardcodedCoroutineDispatcherDetector.Companion
+import com.duckduckgo.lint.NonCancellableDetector.Companion.ISSUE_NON_CANCELLABLE
+import org.junit.Assert.*
+import org.junit.Test
+
+class NonCancellableDetectorTest {
+
+    @Test
+    fun whenUsedInsideWithContextThenDetectedAsAViolation() {
+        val callSite = """
+              package com.duckduckgo.lint
+              import kotlinx.coroutines.CustomScope
+                
+                class Duck {
+                    private val scope = CustomScope()
+                    fun quack() {
+                       scope.launch(NonCancellable) { }                 
+                    }
+                }
+            """
+
+        assertLintError(listOf(TestFiles.kotlin(callSite).indented(), TestFiles.kt(classDefinitions)),
+            """
+                src/com/duckduckgo/lint/Duck.kt:7: Error: Avoid using NonCancellable when launching a coroutine. [NonCancellableUsage]
+                         scope.launch(NonCancellable) { }                 
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                1 errors, 0 warnings
+            """)
+    }
+
+    @Test
+    fun whenUsedInsideWithContextThenDetectedAsAViolation1() {
+        val callSite = """
+              package com.duckduckgo.lint
+              import kotlinx.coroutines.CustomScope
+                
+                class Duck {
+                    private val scope = CustomScope()
+                    fun quack() {
+                       scope.launch(dispatcherProvider.io() + NonCancellable) { }                 
+                    }
+                }
+            """
+
+        assertLintError(listOf(TestFiles.kotlin(callSite).indented(), TestFiles.kt(classDefinitions)),
+            """
+                src/com/duckduckgo/lint/Duck.kt:7: Error: Avoid using NonCancellable when launching a coroutine. [NonCancellableUsage]
+                         scope.launch(dispatcherProvider.io() + NonCancellable) { }                 
+                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                1 errors, 0 warnings
+            """)
+    }
+
+    private val classDefinitions = """
+package kotlinx.coroutines
+
+import kotlin.coroutines.CoroutineContext
+
+class CustomScope {
+    fun launch(
+        context: CoroutineContext
+    ): Job {
+        return Job()
+    }
+}
+        """
+
+    private fun assertLintError(files: List<TestFile>, expectedError: String) {
+        TestLintTask.lint()
+            .files(*files.toTypedArray())
+            .issues(ISSUE_NON_CANCELLABLE)
+            .testModes(TestMode.DEFAULT)
+            .run()
+            .expectContains(expectedError)
+    }
+
+    companion object {
+        private const val expectedError = "dafas"
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205269597285007/f 

### Description
Replaces usages of NonCancellable when launching a coroutine.
Replaced by AppCoroutineScope.

### Steps to test this PR

_Smoke test_
- [ ] Global crash handler
- [x] Deleting bookmarks and favorites
- [ ] 

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
