### PR TITLE
Enable desugaring of Java 8+ APIs

### DIFF
--- a/ad-click/ad-click-impl/build.gradle
+++ b/ad-click/ad-click-impl/build.gradle
@@ -27,6 +27,9 @@ android {
         generateDaggerFactories = true // default is false
     }
     namespace 'com.duckduckgo.adclick.impl'
+    compileOptions {
+        coreLibraryDesugaringEnabled = true
+    }
 }
 
 dependencies {
@@ -73,9 +76,6 @@ dependencies {
         // conflicts with mockito due to direct inclusion of byte buddy
         exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
     }
-
-    implementation "com.jakewharton.threetenabp:threetenabp:_"
-    testImplementation "org.threeten:threetenbp:_"
 
     implementation JakeWharton.timber
 

--- a/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/pixels/AdClickPixels.kt
+++ b/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/pixels/AdClickPixels.kt
@@ -24,9 +24,9 @@ import com.duckduckgo.adclick.impl.pixels.AdClickPixelParameters.AD_CLICK_PAGELO
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
+import java.time.Instant
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
-import org.threeten.bp.Instant
 
 interface AdClickPixels {
     fun fireAdClickActivePixel(exemption: Exemption?): Boolean

--- a/ad-click/ad-click-impl/src/test/java/com/duckduckgo/adclick/impl/pixels/RealAdClickPixelsTest.kt
+++ b/ad-click/ad-click-impl/src/test/java/com/duckduckgo/adclick/impl/pixels/RealAdClickPixelsTest.kt
@@ -23,6 +23,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.adclick.impl.Exemption
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.test.api.InMemorySharedPreferences
+import java.time.Instant
 import java.util.concurrent.TimeUnit
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -36,7 +37,6 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.threeten.bp.Instant
 
 @RunWith(AndroidJUnit4::class)
 class RealAdClickPixelsTest {

--- a/ad-click/ad-click-store/build.gradle
+++ b/ad-click/ad-click-store/build.gradle
@@ -22,6 +22,9 @@ plugins {
 
 android {
     namespace 'com.duckduckgo.adclick.store'
+    compileOptions {
+        coreLibraryDesugaringEnabled = true
+    }
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"
@@ -37,9 +40,6 @@ dependencies {
         // conflicts with mockito due to direct inclusion of byte buddy
         exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
     }
-
-    implementation "com.jakewharton.threetenabp:threetenabp:_"
-    testImplementation "org.threeten:threetenbp:_"
 
     implementation JakeWharton.timber
 

--- a/anrs/anrs-impl/build.gradle
+++ b/anrs/anrs-impl/build.gradle
@@ -40,7 +40,6 @@ dependencies {
     implementation AndroidX.room.rxJava2
     implementation AndroidX.room.ktx
     implementation AndroidX.room.rxJava2
-    implementation "com.jakewharton.threetenabp:threetenabp:_"
 
     testImplementation project(':common-test')
     testImplementation Testing.junit4
@@ -48,7 +47,6 @@ dependencies {
     testImplementation AndroidX.test.ext.junit
     testImplementation "org.mockito.kotlin:mockito-kotlin:_"
     testImplementation Testing.robolectric
-    testImplementation "org.threeten:threetenbp:_"
 }
 
 android {
@@ -56,4 +54,7 @@ android {
         generateDaggerFactories = true // default is false
     }
   namespace 'com.duckduckgo.app.anr'
+    compileOptions {
+        coreLibraryDesugaringEnabled = true
+    }
 }

--- a/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/ExceptionModels.kt
+++ b/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/ExceptionModels.kt
@@ -19,10 +19,10 @@ package com.duckduckgo.app.anr
 import com.duckduckgo.anrs.api.CrashLogger
 import com.duckduckgo.app.anrs.store.AnrEntity
 import com.duckduckgo.app.anrs.store.ExceptionEntity
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import logcat.asLog
 import okio.ByteString.Companion.encode
-import org.threeten.bp.LocalDateTime
-import org.threeten.bp.format.DateTimeFormatter
 
 internal data class ProcessThread(
     val name: String,

--- a/app-store/build.gradle
+++ b/app-store/build.gradle
@@ -28,10 +28,11 @@ dependencies {
     implementation KotlinX.coroutines.android
     implementation AndroidX.room.runtime
 
-    implementation "com.jakewharton.threetenabp:threetenabp:_"
-
     ksp AndroidX.room.compiler
 }
 android {
   namespace 'com.duckduckgo.app'
+    compileOptions {
+        coreLibraryDesugaringEnabled = true
+    }
 }

--- a/app-store/src/main/java/com/duckduckgo/app/trackerdetection/api/WebTrackersBlockedRepository.kt
+++ b/app-store/src/main/java/com/duckduckgo/app/trackerdetection/api/WebTrackersBlockedRepository.kt
@@ -18,8 +18,8 @@ package com.duckduckgo.app.trackerdetection.api
 
 import com.duckduckgo.app.trackerdetection.db.DatabaseDateFormatter
 import com.duckduckgo.app.trackerdetection.db.WebTrackerBlocked
+import java.time.LocalDateTime
 import kotlinx.coroutines.flow.Flow
-import org.threeten.bp.LocalDateTime
 
 interface WebTrackersBlockedRepository {
 

--- a/app-store/src/main/java/com/duckduckgo/app/trackerdetection/db/DatabaseDateFormatter.kt
+++ b/app-store/src/main/java/com/duckduckgo/app/trackerdetection/db/DatabaseDateFormatter.kt
@@ -16,8 +16,8 @@
 
 package com.duckduckgo.app.trackerdetection.db
 
-import org.threeten.bp.LocalDateTime
-import org.threeten.bp.format.DateTimeFormatter
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 internal class DatabaseDateFormatter {
 

--- a/app-store/src/main/java/com/duckduckgo/app/trackerdetection/db/WebTrackerBlocked.kt
+++ b/app-store/src/main/java/com/duckduckgo/app/trackerdetection/db/WebTrackerBlocked.kt
@@ -18,8 +18,8 @@ package com.duckduckgo.app.trackerdetection.db
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import org.threeten.bp.LocalDateTime
-import org.threeten.bp.format.DateTimeFormatter
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 @Entity(tableName = "web_trackers_blocked")
 data class WebTrackerBlocked(

--- a/app-tracking-protection/vpn-impl/build.gradle
+++ b/app-tracking-protection/vpn-impl/build.gradle
@@ -37,6 +37,9 @@ android {
         }
     }
     namespace 'com.duckduckgo.mobile.android.vpn'
+    compileOptions {
+        coreLibraryDesugaringEnabled = true
+    }
 }
 
 dependencies {
@@ -99,9 +102,6 @@ dependencies {
         // conflicts with mockito due to direct inclusion of byte buddy
         exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
     }
-
-    implementation "com.jakewharton.threetenabp:threetenabp:_"
-    testImplementation "org.threeten:threetenbp:_"
 
     implementation "com.squareup.logcat:logcat:_"
 

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/bugreport/VpnLastTrackersBlockedCollector.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/bugreport/VpnLastTrackersBlockedCollector.kt
@@ -25,10 +25,10 @@ import com.duckduckgo.mobile.android.vpn.stats.AppTrackerBlockingStatsRepository
 import com.squareup.anvil.annotations.ContributesMultibinding
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
+import java.time.LocalDateTime
 import javax.inject.Inject
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
-import org.threeten.bp.LocalDateTime
 
 @ContributesMultibinding(ActivityScope::class)
 class VpnLastTrackersBlockedCollector @Inject constructor(

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/cohort/CohortCalculator.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/cohort/CohortCalculator.kt
@@ -18,10 +18,10 @@ package com.duckduckgo.mobile.android.vpn.cohort
 
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+import java.time.temporal.IsoFields
 import javax.inject.Inject
-import org.threeten.bp.LocalDate
-import org.threeten.bp.temporal.ChronoUnit
-import org.threeten.bp.temporal.IsoFields
 
 interface CohortCalculator {
     fun calculateCohortForDate(localDate: LocalDate, now: LocalDate = LocalDate.now()): String

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/cohort/CohortStore.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/cohort/CohortStore.kt
@@ -32,11 +32,11 @@ import com.duckduckgo.mobile.android.vpn.service.VpnServiceCallbacks
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnStopReason
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import org.threeten.bp.LocalDate
-import org.threeten.bp.format.DateTimeFormatter
 
 interface CohortStore {
     /**

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/debug/SendTrackerDebugReceiver.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/debug/SendTrackerDebugReceiver.kt
@@ -31,12 +31,12 @@ import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnStopReason
 import com.duckduckgo.mobile.android.vpn.stats.AppTrackerBlockingStatsRepository
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
+import java.time.LocalDateTime
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import logcat.logcat
-import org.threeten.bp.LocalDateTime
 
 /**
  * This receiver allows sending fake trackers, to do so, in the command line:

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
@@ -23,11 +23,11 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 import java.util.*
 import javax.inject.Inject
-import org.threeten.bp.Instant
-import org.threeten.bp.ZoneOffset
-import org.threeten.bp.format.DateTimeFormatter
 
 interface DeviceShieldPixels {
     /** This pixel will be unique on a given day, no matter how many times we call this fun */

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/onboarding/VpnStore.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/onboarding/VpnStore.kt
@@ -22,9 +22,9 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
+import java.time.Instant
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
-import org.threeten.bp.Instant
 
 interface VpnStore {
     fun onboardingDidShow()

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/AppTPCompanyTrackersViewModel.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/AppTPCompanyTrackersViewModel.kt
@@ -31,13 +31,13 @@ import com.duckduckgo.mobile.android.vpn.model.VpnTrackerWithEntity
 import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixels
 import com.duckduckgo.mobile.android.vpn.stats.AppTrackerBlockingStatsRepository
 import com.duckduckgo.mobile.android.vpn.ui.tracker_activity.model.TrackingSignal
+import java.time.LocalDateTime
 import javax.inject.Inject
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.threeten.bp.LocalDateTime
 
 @ContributesViewModel(ActivityScope::class)
 class AppTPCompanyTrackersViewModel @Inject constructor(

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldActivityFeedViewModel.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldActivityFeedViewModel.kt
@@ -40,6 +40,7 @@ import com.duckduckgo.mobile.android.vpn.ui.tracker_activity.model.TrackerFeedIt
 import com.duckduckgo.mobile.android.vpn.ui.tracker_activity.model.TrackerFeedItem.TrackerDescriptionFeed
 import com.duckduckgo.mobile.android.vpn.ui.tracker_activity.model.TrackerFeedItem.TrackerLoadingSkeleton
 import java.lang.Integer.min
+import java.time.LocalDateTime
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import kotlin.coroutines.coroutineContext
@@ -48,7 +49,6 @@ import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.*
 import logcat.logcat
-import org.threeten.bp.LocalDateTime
 
 @ContributesViewModel(FragmentScope::class)
 class DeviceShieldActivityFeedViewModel @Inject constructor(

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/cohort/CohortPixelInterceptorTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/cohort/CohortPixelInterceptorTest.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.common.test.api.FakeChain
 import com.duckduckgo.common.test.api.InMemorySharedPreferences
 import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
 import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
+import java.time.LocalDate
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
@@ -32,7 +33,6 @@ import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import org.threeten.bp.LocalDate
 
 class CohortPixelInterceptorTest {
     @get:Rule

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/cohort/RealCohortCalculatorTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/cohort/RealCohortCalculatorTest.kt
@@ -16,11 +16,11 @@
 
 package com.duckduckgo.mobile.android.vpn.cohort
 
+import java.time.LocalDate
+import java.time.temporal.IsoFields
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
-import org.threeten.bp.LocalDate
-import org.threeten.bp.temporal.IsoFields
 
 class RealCohortCalculatorTest {
 

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/cohort/RealCohortStoreTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/cohort/RealCohortStoreTest.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.mobile.android.vpn.AppTpVpnFeature
 import com.duckduckgo.mobile.android.vpn.FakeVpnFeaturesRegistry
 import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
 import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
+import java.time.LocalDate
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
@@ -35,7 +36,6 @@ import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import org.threeten.bp.LocalDate
 
 class RealCohortStoreTest {
     @get:Rule

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/PrivacyReportViewModelTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/PrivacyReportViewModelTest.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.mobile.android.vpn.store.VpnDatabase
 import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerEntity
 import com.duckduckgo.mobile.android.vpn.ui.onboarding.VpnStore
 import com.duckduckgo.mobile.android.vpn.ui.report.PrivacyReportViewModel
+import java.time.LocalDateTime
 import kotlin.time.ExperimentalTime
 import kotlinx.coroutines.runBlocking
 import org.junit.After
@@ -42,7 +43,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
-import org.threeten.bp.LocalDateTime
 
 @ExperimentalTime
 @RunWith(AndroidJUnit4::class)

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/notification/DeviceShieldDailyNotificationFactoryTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/notification/DeviceShieldDailyNotificationFactoryTest.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.mobile.android.vpn.stats.RealAppTrackerBlockingStatsReposi
 import com.duckduckgo.mobile.android.vpn.store.VpnDatabase
 import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerEntity
 import com.duckduckgo.mobile.android.vpn.ui.notification.DeviceShieldNotificationFactory.DeviceShieldNotification
+import java.time.LocalDateTime
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.*
@@ -35,7 +36,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.threeten.bp.LocalDateTime
 
 @RunWith(AndroidJUnit4::class)
 class DeviceShieldDailyNotificationFactoryTest {

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/notification/DeviceShieldWeeklyNotificationFactoryTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/notification/DeviceShieldWeeklyNotificationFactoryTest.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.mobile.android.vpn.stats.RealAppTrackerBlockingStatsReposi
 import com.duckduckgo.mobile.android.vpn.store.VpnDatabase
 import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerEntity
 import com.duckduckgo.mobile.android.vpn.ui.notification.DeviceShieldNotificationFactory.DeviceShieldNotification
+import java.time.LocalDateTime
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.*
@@ -35,7 +36,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.threeten.bp.LocalDateTime
 
 @RunWith(AndroidJUnit4::class)
 class DeviceShieldWeeklyNotificationFactoryTest {

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/onboarding/SharedPreferencesVpnStoreTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/onboarding/SharedPreferencesVpnStoreTest.kt
@@ -20,6 +20,7 @@ import android.content.SharedPreferences
 import androidx.core.content.edit
 import com.duckduckgo.common.test.api.InMemorySharedPreferences
 import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
+import java.time.Instant
 import java.util.concurrent.TimeUnit
 import org.junit.Assert.*
 import org.junit.Before
@@ -27,7 +28,6 @@ import org.junit.Test
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import org.threeten.bp.Instant
 
 class SharedPreferencesVpnStoreTest {
 

--- a/app-tracking-protection/vpn-store/build.gradle
+++ b/app-tracking-protection/vpn-store/build.gradle
@@ -40,6 +40,9 @@ android {
             includeAndroidResources = true
         }
     }
+    compileOptions {
+        coreLibraryDesugaringEnabled = true
+    }
 }
 
 dependencies {
@@ -50,9 +53,6 @@ dependencies {
     implementation project(path: ':app-build-config-api')
 
     implementation AndroidX.core.ktx
-
-    implementation "com.jakewharton.threetenabp:threetenabp:_"
-    testImplementation "org.threeten:threetenbp:_"
 
     implementation "com.squareup.logcat:logcat:_"
 

--- a/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/stats/AppTrackerBlockingStatsRepository.kt
+++ b/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/stats/AppTrackerBlockingStatsRepository.kt
@@ -21,9 +21,9 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.formatters.time.DatabaseDateFormatter
 import com.duckduckgo.mobile.android.vpn.model.*
 import com.duckduckgo.mobile.android.vpn.store.VpnDatabase
+import java.time.LocalDateTime
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.flow.*
-import org.threeten.bp.LocalDateTime
 
 interface AppTrackerBlockingStatsRepository {
 

--- a/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/store/VpnDatabase.kt
+++ b/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/store/VpnDatabase.kt
@@ -25,8 +25,8 @@ import com.duckduckgo.mobile.android.vpn.trackers.*
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
-import org.threeten.bp.OffsetDateTime
-import org.threeten.bp.format.DateTimeFormatter
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
 
 @Database(
     exportSchema = true,

--- a/app-tracking-protection/vpn-store/src/test/java/com/duckduckgo/mobile/android/vpn/stats/AppTrackerBlockingStatsRepositoryTest.kt
+++ b/app-tracking-protection/vpn-store/src/test/java/com/duckduckgo/mobile/android/vpn/stats/AppTrackerBlockingStatsRepositoryTest.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.mobile.android.vpn.model.TrackingApp
 import com.duckduckgo.mobile.android.vpn.model.VpnTracker
 import com.duckduckgo.mobile.android.vpn.store.VpnDatabase
 import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerEntity
+import java.time.LocalDateTime
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
@@ -35,7 +36,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.threeten.bp.LocalDateTime
 
 @RunWith(AndroidJUnit4::class)
 class AppTrackerBlockingStatsRepositoryTest {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -348,10 +348,6 @@ dependencies {
     implementation "io.reactivex.rxjava2:rxandroid:_"
     implementation JakeWharton.timber
 
-    // ThreeTenABP
-    implementation "com.jakewharton.threetenabp:threetenabp:_"
-    testImplementation "org.threeten:threetenbp:_"
-
     // RxRelay
     implementation "com.jakewharton.rxrelay2:rxrelay:_"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,6 +65,7 @@ android {
         viewBinding = true
     }
     compileOptions {
+        coreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
@@ -442,6 +443,8 @@ dependencies {
     androidTestImplementation project(':common-test')
     testImplementation project(':common-test')
     lintChecks project(":lint-rules")
+
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
 }
 
 tasks.register('fastlaneVersionCode') {

--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/FirstPartyCookiesReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/FirstPartyCookiesReferenceTest.kt
@@ -43,6 +43,9 @@ import com.duckduckgo.privacy.config.impl.models.JsonPrivacyConfig
 import com.duckduckgo.privacy.config.impl.network.JSONObjectAdapter
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
 import java.util.Locale
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.coroutines.resume
@@ -58,9 +61,6 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import org.threeten.bp.Instant
-import org.threeten.bp.ZoneOffset
-import org.threeten.bp.temporal.ChronoUnit
 
 @RunWith(Parameterized::class)
 @SuppressLint("NoHardcodedCoroutineDispatcher")

--- a/app/src/androidTest/java/com/duckduckgo/cookies/impl/features/firstparty/RealFirstPartyCookiesModifierTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/cookies/impl/features/firstparty/RealFirstPartyCookiesModifierTest.kt
@@ -31,6 +31,10 @@ import com.duckduckgo.cookies.store.CookiesRepository
 import com.duckduckgo.cookies.store.FirstPartyCookiePolicyEntity
 import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 import java.util.Locale
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
@@ -43,10 +47,6 @@ import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.*
-import org.threeten.bp.Instant
-import org.threeten.bp.ZoneOffset
-import org.threeten.bp.format.DateTimeFormatter
-import org.threeten.bp.temporal.ChronoUnit
 
 @SuppressLint("NoHardcodedCoroutineDispatcher")
 class RealFirstPartyCookiesModifierTest {

--- a/app/src/internal/java/com/duckduckgo/app/flipper/plugins/PixelFlipperPlugin.kt
+++ b/app/src/internal/java/com/duckduckgo/app/flipper/plugins/PixelFlipperPlugin.kt
@@ -26,10 +26,10 @@ import dagger.Binds
 import dagger.Module
 import dagger.SingleInstanceIn
 import dagger.multibindings.IntoSet
+import java.time.LocalTime
 import javax.inject.Inject
 import okhttp3.Interceptor
 import okhttp3.Response
-import org.threeten.bp.LocalTime
 import timber.log.Timber
 
 @SingleInstanceIn(AppScope::class)

--- a/app/src/main/java/com/duckduckgo/app/downloads/DownloadsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/downloads/DownloadsViewModel.kt
@@ -37,6 +37,7 @@ import com.duckduckgo.downloads.api.DownloadsRepository
 import com.duckduckgo.downloads.api.model.DownloadItem
 import com.duckduckgo.downloads.store.DownloadStatus
 import java.io.File
+import java.time.LocalDateTime
 import javax.inject.Inject
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.channels.Channel
@@ -49,7 +50,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import org.threeten.bp.LocalDateTime
 
 @ContributesViewModel(ActivityScope::class)
 class DownloadsViewModel @Inject constructor(

--- a/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
@@ -27,7 +27,6 @@ import com.duckduckgo.app.referral.AppInstallationReferrerStateListener
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.di.DaggerMap
-import com.jakewharton.threetenabp.AndroidThreeTen
 import dagger.android.AndroidInjector
 import dagger.android.HasDaggerInjector
 import io.reactivex.exceptions.UndeliverableException
@@ -35,7 +34,6 @@ import io.reactivex.plugins.RxJavaPlugins
 import java.io.File
 import javax.inject.Inject
 import kotlinx.coroutines.*
-import org.threeten.bp.zone.ZoneRulesProvider
 import timber.log.Timber
 
 private const val VPN_PROCESS_NAME = "vpn"
@@ -78,7 +76,6 @@ open class DuckDuckGoApplication : HasDaggerInjector, MultiProcessApplication() 
         configureDependencyInjection()
         setupActivityLifecycleCallbacks()
         configureUncaughtExceptionHandlerBrowser()
-        initializeDateLibrary()
 
         // Deprecated, we need to move all these into AppLifecycleEventObserver
         ProcessLifecycleOwner.get().lifecycle.apply {
@@ -99,7 +96,6 @@ open class DuckDuckGoApplication : HasDaggerInjector, MultiProcessApplication() 
             Timber.d("Init for secondary process $shortProcessName with pid=${android.os.Process.myPid()}")
             configureDependencyInjection()
             configureUncaughtExceptionHandlerVpn()
-            initializeDateLibrary()
 
             // ProcessLifecycleOwner doesn't know about secondary processes, so the callbacks are our own callbacks and limited to onCreate which
             // is good enough.
@@ -185,14 +181,6 @@ open class DuckDuckGoApplication : HasDaggerInjector, MultiProcessApplication() 
             }
         }
         return dir
-    }
-
-    private fun initializeDateLibrary() {
-        AndroidThreeTen.init(this)
-        // Query the ZoneRulesProvider so that it is loaded on a background coroutine
-        GlobalScope.launch(dispatchers.io()) {
-            ZoneRulesProvider.getAvailableZoneIds()
-        }
     }
 
     /**

--- a/app/src/main/java/com/duckduckgo/app/privacy/cleanup/TrackersDbCleanerScheduler.kt
+++ b/app/src/main/java/com/duckduckgo/app/privacy/cleanup/TrackersDbCleanerScheduler.kt
@@ -35,10 +35,10 @@ import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoSet
+import java.time.LocalDateTime
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
-import org.threeten.bp.LocalDateTime
 import timber.log.Timber
 
 @Module

--- a/app/src/main/java/com/duckduckgo/app/survey/api/SurveyDownloader.kt
+++ b/app/src/main/java/com/duckduckgo/app/survey/api/SurveyDownloader.kt
@@ -26,10 +26,10 @@ import com.duckduckgo.autofill.api.email.EmailManager
 import com.duckduckgo.networkprotection.impl.cohort.NetpCohortStore
 import io.reactivex.Completable
 import java.io.IOException
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
 import java.util.*
 import javax.inject.Inject
-import org.threeten.bp.LocalDate
-import org.threeten.bp.temporal.ChronoUnit
 import retrofit2.Response
 import timber.log.Timber
 

--- a/app/src/test/java/com/duckduckgo/app/bookmarks/model/SavedSitesRepositoryTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/bookmarks/model/SavedSitesRepositoryTest.kt
@@ -41,6 +41,8 @@ import com.duckduckgo.savedsites.store.EntityType.BOOKMARK
 import com.duckduckgo.savedsites.store.Relation
 import com.duckduckgo.savedsites.store.SavedSitesEntitiesDao
 import com.duckduckgo.savedsites.store.SavedSitesRelationsDao
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNotNull
 import junit.framework.TestCase.assertNull
@@ -53,8 +55,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.threeten.bp.OffsetDateTime
-import org.threeten.bp.ZoneOffset
 
 @RunWith(AndroidJUnit4::class)
 class SavedSitesRepositoryTest {

--- a/app/src/test/java/com/duckduckgo/app/bookmarks/model/SyncSavedSitesRepositoryTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/bookmarks/model/SyncSavedSitesRepositoryTest.kt
@@ -53,6 +53,8 @@ import com.duckduckgo.savedsites.store.SavedSitesRelationsDao
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 import junit.framework.TestCase
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -62,8 +64,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.threeten.bp.OffsetDateTime
-import org.threeten.bp.ZoneOffset
 
 @RunWith(AndroidJUnit4::class)
 @OptIn(ExperimentalCoroutinesApi::class)

--- a/app/src/test/java/com/duckduckgo/app/downloads/DownloadsViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/downloads/DownloadsViewModelTest.kt
@@ -36,6 +36,8 @@ import com.duckduckgo.common.utils.formatters.time.TimeDiffFormatter
 import com.duckduckgo.downloads.api.DownloadsRepository
 import com.duckduckgo.downloads.api.model.DownloadItem
 import com.duckduckgo.downloads.store.DownloadStatus.FINISHED
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -47,7 +49,6 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.annotation.Config
-import org.threeten.bp.LocalDateTime
 
 @RunWith(AndroidJUnit4::class)
 @Config(manifest = Config.NONE)
@@ -135,7 +136,7 @@ class DownloadsViewModelTest {
     @Test
     fun whenMultipleDownloadsAndVisibilityChangedCalledWithValueFalseThenViewStateEmittedWithMultipleItemsAndHeaders() = runTest {
         val visible = false
-        val formatter = org.threeten.bp.format.DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")
+        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")
         val today = LocalDateTime.parse(TODAY, formatter)
         val yesterday = today.minusDays(1)
         val sometimeDuringPastWeek = today.minusDays(6)
@@ -371,7 +372,7 @@ private class FakeTimeDiffFormatter(
     today: String,
     private val realTimeDiffFormatter: RealTimeDiffFormatter,
 ) : TimeDiffFormatter by realTimeDiffFormatter {
-    private val formatter = org.threeten.bp.format.DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")
+    private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")
     private val formattedToday = LocalDateTime.parse(today, formatter)
 
     override fun formatTimePassed(endLocalDateTime: LocalDateTime, startLocalDateTime: LocalDateTime): String {

--- a/app/src/test/java/com/duckduckgo/app/survey/api/SurveyDownloaderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/survey/api/SurveyDownloaderTest.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.app.survey.model.Survey.Status.SCHEDULED
 import com.duckduckgo.autofill.api.email.EmailManager
 import com.duckduckgo.common.test.InstantSchedulersRule
 import com.duckduckgo.networkprotection.impl.cohort.NetpCohortStore
+import java.time.LocalDate
 import kotlinx.coroutines.test.runTest
 import okhttp3.ResponseBody
 import okhttp3.ResponseBody.Companion.toResponseBody
@@ -31,7 +32,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.*
-import org.threeten.bp.LocalDate
 import retrofit2.Call
 import retrofit2.Response
 

--- a/app/src/test/java/com/duckduckgo/app/sync/SavedSitesSyncDataProviderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/sync/SavedSitesSyncDataProviderTest.kt
@@ -50,6 +50,8 @@ import com.duckduckgo.savedsites.store.SavedSitesRelationsDao
 import com.duckduckgo.sync.api.SyncCrypto
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -58,8 +60,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.*
-import org.threeten.bp.OffsetDateTime
-import org.threeten.bp.ZoneOffset
 
 @RunWith(AndroidJUnit4::class)
 class SavedSitesSyncDataProviderTest {

--- a/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesLocalWinsPersisterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesLocalWinsPersisterTest.kt
@@ -38,13 +38,13 @@ import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDao
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDatabase
 import com.duckduckgo.savedsites.store.SavedSitesEntitiesDao
 import com.duckduckgo.savedsites.store.SavedSitesRelationsDao
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.threeten.bp.OffsetDateTime
-import org.threeten.bp.ZoneOffset
 
 @RunWith(AndroidJUnit4::class)
 class SavedSitesLocalWinsPersisterTest {

--- a/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesRemoteWinsPersisterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesRemoteWinsPersisterTest.kt
@@ -38,13 +38,13 @@ import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDao
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDatabase
 import com.duckduckgo.savedsites.store.SavedSitesEntitiesDao
 import com.duckduckgo.savedsites.store.SavedSitesRelationsDao
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.threeten.bp.OffsetDateTime
-import org.threeten.bp.ZoneOffset
 
 @RunWith(AndroidJUnit4::class)
 class SavedSitesRemoteWinsPersisterTest {

--- a/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesTimestampPersisterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesTimestampPersisterTest.kt
@@ -38,13 +38,13 @@ import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDao
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDatabase
 import com.duckduckgo.savedsites.store.SavedSitesEntitiesDao
 import com.duckduckgo.savedsites.store.SavedSitesRelationsDao
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.threeten.bp.OffsetDateTime
-import org.threeten.bp.ZoneOffset
 
 @RunWith(AndroidJUnit4::class)
 class SavedSitesTimestampPersisterTest {

--- a/autofill/autofill-impl/build.gradle
+++ b/autofill/autofill-impl/build.gradle
@@ -61,9 +61,6 @@ dependencies {
 
     implementation "net.zetetic:android-database-sqlcipher:_"
 
-    implementation "com.jakewharton.threetenabp:threetenabp:_"
-    testImplementation "org.threeten:threetenbp:_"
-
     // Testing dependencies
     testImplementation "org.mockito.kotlin:mockito-kotlin:_"
     testImplementation Testing.junit4
@@ -97,5 +94,8 @@ android {
         }
     }
     namespace 'com.duckduckgo.autofill.impl'
+    compileOptions {
+        coreLibraryDesugaringEnabled = true
+    }
 }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/SyncDateProvider.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/SyncDateProvider.kt
@@ -16,9 +16,9 @@
 
 package com.duckduckgo.autofill.sync
 
-import org.threeten.bp.OffsetDateTime
-import org.threeten.bp.ZoneOffset
-import org.threeten.bp.format.DateTimeFormatter
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 
 class SyncDateProvider {
     companion object {

--- a/broken-site/broken-site-impl/build.gradle
+++ b/broken-site/broken-site-impl/build.gradle
@@ -27,6 +27,9 @@ android {
         generateDaggerFactories = true // default is false
     }
     namespace 'com.duckduckgo.brokensite.impl'
+    compileOptions {
+        coreLibraryDesugaringEnabled = true
+    }
 }
 
 dependencies {
@@ -59,9 +62,6 @@ dependencies {
         // conflicts with mockito due to direct inclusion of byte buddy
         exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
     }
-
-    implementation "com.jakewharton.threetenabp:threetenabp:_"
-    testImplementation "org.threeten:threetenbp:_"
 
     implementation Google.dagger
     implementation JakeWharton.timber

--- a/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSiteReportRepository.kt
+++ b/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSiteReportRepository.kt
@@ -22,14 +22,14 @@ import com.duckduckgo.brokensite.store.BrokenSiteLastSentReportEntity
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.formatters.time.DatabaseDateFormatter
 import com.duckduckgo.common.utils.sha256
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.threeten.bp.Instant
-import org.threeten.bp.LocalDateTime
-import org.threeten.bp.OffsetDateTime
-import org.threeten.bp.ZoneOffset
-import org.threeten.bp.format.DateTimeFormatter
 
 interface BrokenSiteReportRepository {
     suspend fun getLastSentDay(hostname: String): String?

--- a/broken-site/broken-site-store/build.gradle
+++ b/broken-site/broken-site-store/build.gradle
@@ -35,9 +35,6 @@ dependencies {
     implementation project(path: ':common-utils')
     implementation project(':broken-site-api')
 
-    implementation "com.jakewharton.threetenabp:threetenabp:_"
-    testImplementation "org.threeten:threetenbp:_"
-
     testImplementation Testing.junit4
 }
 android {
@@ -52,4 +49,7 @@ android {
         test.assets.srcDirs += files("$projectDir/schemas".toString())
     }
     namespace 'com.duckduckgo.brokensite.store'
+    compileOptions {
+        coreLibraryDesugaringEnabled = true
+    }
 }

--- a/common/common-utils/build.gradle
+++ b/common/common-utils/build.gradle
@@ -33,6 +33,9 @@ android {
         }
     }
     namespace 'com.duckduckgo.common.utils'
+    compileOptions {
+        coreLibraryDesugaringEnabled = true
+    }
 }
 
 dependencies {
@@ -63,10 +66,6 @@ dependencies {
     implementation AndroidX.room.runtime
     implementation AndroidX.room.rxJava2
     ksp AndroidX.room.compiler
-
-    // ThreeTenABP
-    implementation "com.jakewharton.threetenabp:threetenabp:_"
-    testImplementation "org.threeten:threetenbp:_"
 
     // Testing dependencies
     testImplementation Testing.junit4

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/formatters/time/DatabaseDateFormatter.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/formatters/time/DatabaseDateFormatter.kt
@@ -16,13 +16,13 @@
 
 package com.duckduckgo.common.utils.formatters.time
 
-import org.threeten.bp.Duration
-import org.threeten.bp.Instant
-import org.threeten.bp.LocalDate
-import org.threeten.bp.LocalDateTime
-import org.threeten.bp.OffsetDateTime
-import org.threeten.bp.ZoneOffset
-import org.threeten.bp.format.DateTimeFormatter
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 
 class DatabaseDateFormatter {
 

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/formatters/time/TimeDiffFormatter.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/formatters/time/TimeDiffFormatter.kt
@@ -22,11 +22,11 @@ import com.duckduckgo.common.utils.formatters.time.model.TimePassed
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import java.text.SimpleDateFormat
+import java.time.Duration
+import java.time.LocalDateTime
 import java.util.*
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
-import org.threeten.bp.Duration
-import org.threeten.bp.LocalDateTime
 
 interface TimeDiffFormatter {
     fun formatTimePassedInDaysWeeksMonthsYears(

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/formatters/time/model/TimePassed.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/formatters/time/model/TimePassed.kt
@@ -19,7 +19,7 @@ package com.duckduckgo.common.utils.formatters.time.model
 import android.content.res.Resources
 import com.duckduckgo.common.utils.R
 import com.duckduckgo.common.utils.formatters.time.DatabaseDateFormatter
-import org.threeten.bp.LocalDateTime
+import java.time.LocalDateTime
 
 fun dateOfPreviousMidnight(): String {
     val midnight = LocalDateTime.now().toLocalDate().atStartOfDay()

--- a/common/common-utils/src/test/java/com/duckduckgo/common/utils/formatters/time/DatabaseDateFormatterTest.kt
+++ b/common/common-utils/src/test/java/com/duckduckgo/common/utils/formatters/time/DatabaseDateFormatterTest.kt
@@ -47,6 +47,7 @@ class DatabaseDateFormatterTest {
     @Test
     fun whenIso8601isParsedThenDateIsCorrect() {
         val now = OffsetDateTime.now(ZoneOffset.UTC)
+            .truncatedTo(ChronoUnit.MILLIS) // SystemClock returns time with higher precision on JVM
         val format = DatabaseDateFormatter.iso8601(now)
         val offsetDateMillis = DatabaseDateFormatter.millisIso8601(now)
         val formatted = DatabaseDateFormatter.parseMillisIso8601(offsetDateMillis)

--- a/common/common-utils/src/test/java/com/duckduckgo/common/utils/formatters/time/DatabaseDateFormatterTest.kt
+++ b/common/common-utils/src/test/java/com/duckduckgo/common/utils/formatters/time/DatabaseDateFormatterTest.kt
@@ -16,13 +16,13 @@
 
 package com.duckduckgo.common.utils.formatters.time
 
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import org.threeten.bp.Instant
-import org.threeten.bp.LocalDateTime
-import org.threeten.bp.OffsetDateTime
-import org.threeten.bp.ZoneOffset
-import org.threeten.bp.temporal.ChronoUnit
 
 class DatabaseDateFormatterTest {
 

--- a/downloads/downloads-impl/build.gradle
+++ b/downloads/downloads-impl/build.gradle
@@ -27,6 +27,9 @@ android {
         generateDaggerFactories = true // default is false
     }
     namespace 'com.duckduckgo.downloads.impl'
+    compileOptions {
+        coreLibraryDesugaringEnabled = true
+    }
 }
 
 dependencies {
@@ -62,9 +65,6 @@ dependencies {
         // conflicts with mockito due to direct inclusion of byte buddy
         exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
     }
-
-    implementation "com.jakewharton.threetenabp:threetenabp:_"
-    testImplementation "org.threeten:threetenbp:_"
 
     implementation JakeWharton.timber
 

--- a/downloads/downloads-store/build.gradle
+++ b/downloads/downloads-store/build.gradle
@@ -34,9 +34,6 @@ dependencies {
         exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
     }
 
-    implementation "com.jakewharton.threetenabp:threetenabp:_"
-    testImplementation "org.threeten:threetenbp:_"
-
     implementation JakeWharton.timber
 
     // Room
@@ -61,4 +58,7 @@ dependencies {
 
 android {
   namespace 'com.duckduckgo.downloads.store'
+    compileOptions {
+        coreLibraryDesugaringEnabled = true
+    }
 }

--- a/example-feature/example-feature-api-android/build.gradle
+++ b/example-feature/example-feature-api-android/build.gradle
@@ -23,6 +23,9 @@ apply from: "$rootProject.projectDir/gradle/android-library.gradle"
 
 android {
     namespace "com.duckduckgo.examplefeature.api"
+    compileOptions {
+        coreLibraryDesugaringEnabled = true
+    }
 }
 
 dependencies {

--- a/example-feature/example-feature-impl/build.gradle
+++ b/example-feature/example-feature-impl/build.gradle
@@ -62,5 +62,8 @@ android {
             includeAndroidResources = true
         }
     }
+    compileOptions {
+        coreLibraryDesugaringEnabled = true
+    }
 }
 

--- a/experiments/experiments-impl/build.gradle
+++ b/experiments/experiments-impl/build.gradle
@@ -70,7 +70,6 @@ dependencies {
     testImplementation "androidx.test:runner:_"
     testImplementation Testing.robolectric
     testImplementation CashApp.turbine
-    testImplementation "org.threeten:threetenbp:_"
 
     androidTestImplementation project(path: ':common-test')
     testImplementation project(path: ':common-test')

--- a/fingerprint-protection/fingerprint-protection-impl/build.gradle
+++ b/fingerprint-protection/fingerprint-protection-impl/build.gradle
@@ -27,6 +27,9 @@ android {
         generateDaggerFactories = true // default is false
     }
     namespace 'com.duckduckgo.fingerprintprotection.impl'
+    compileOptions {
+        coreLibraryDesugaringEnabled = true
+    }
 }
 
 dependencies {
@@ -74,9 +77,6 @@ dependencies {
         // conflicts with mockito due to direct inclusion of byte buddy
         exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
     }
-
-    implementation "com.jakewharton.threetenabp:threetenabp:_"
-    testImplementation "org.threeten:threetenbp:_"
 
     implementation JakeWharton.timber
 

--- a/fingerprint-protection/fingerprint-protection-store/build.gradle
+++ b/fingerprint-protection/fingerprint-protection-store/build.gradle
@@ -24,6 +24,9 @@ apply from: "$rootProject.projectDir/gradle/android-library.gradle"
 
 android {
     namespace 'com.duckduckgo.fingerprintprotection.store'
+    compileOptions {
+        coreLibraryDesugaringEnabled = true
+    }
 }
 
 dependencies {
@@ -37,9 +40,6 @@ dependencies {
         // conflicts with mockito due to direct inclusion of byte buddy
         exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
     }
-
-    implementation "com.jakewharton.threetenabp:threetenabp:_"
-    testImplementation "org.threeten:threetenbp:_"
 
     implementation JakeWharton.timber
 

--- a/network-protection/network-protection-impl/build.gradle
+++ b/network-protection/network-protection-impl/build.gradle
@@ -53,7 +53,6 @@ dependencies {
     implementation KotlinX.coroutines.core
     implementation Square.retrofit2.retrofit
     implementation Square.retrofit2.converter.moshi
-    implementation "com.jakewharton.threetenabp:threetenabp:_"
 
     // Lottie
     implementation "com.airbnb.android:lottie:_"
@@ -66,7 +65,6 @@ dependencies {
     testImplementation AndroidX.test.ext.junit
     testImplementation "org.mockito.kotlin:mockito-kotlin:_"
     testImplementation Testing.robolectric
-    testImplementation "org.threeten:threetenbp:_"
 
     // WorkManager
     implementation AndroidX.work.runtimeKtx
@@ -103,5 +101,8 @@ android {
     }
     defaultConfig {
         buildConfigField "String", "NETP_DEBUG_SERVER_TOKEN", "\"${NETP_DEBUG_SERVER_TOKEN}\""
+    }
+    compileOptions {
+        coreLibraryDesugaringEnabled = true
     }
 }

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/cohort/NetPCohortUpdater.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/cohort/NetPCohortUpdater.kt
@@ -23,11 +23,11 @@ import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnStopReason
 import com.duckduckgo.networkprotection.api.NetworkProtectionState
 import com.duckduckgo.networkprotection.impl.pixels.NetworkProtectionPixels
 import com.squareup.anvil.annotations.ContributesMultibinding
+import java.time.LocalDate
+import java.time.ZoneId
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import org.threeten.bp.LocalDate
-import org.threeten.bp.ZoneId
 
 @ContributesMultibinding(
     scope = VpnScope::class,

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/cohort/NetpCohortStore.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/cohort/NetpCohortStore.kt
@@ -23,9 +23,9 @@ import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
 import com.duckduckgo.networkprotection.impl.state.NetPFeatureRemover
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import javax.inject.Inject
-import org.threeten.bp.LocalDate
-import org.threeten.bp.format.DateTimeFormatter
 
 interface NetpCohortStore {
     var cohortLocalDate: LocalDate?

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/connectionclass/VpnLatencySampler.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/connectionclass/VpnLatencySampler.kt
@@ -31,12 +31,12 @@ import com.duckduckgo.networkprotection.impl.connectionclass.ConnectionQuality.U
 import com.duckduckgo.networkprotection.impl.pixels.NetworkProtectionPixels
 import com.duckduckgo.networkprotection.impl.store.NetworkProtectionRepository
 import com.squareup.anvil.annotations.ContributesMultibinding
+import java.time.Instant
 import java.util.concurrent.atomic.AtomicLong
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.*
 import logcat.logcat
-import org.threeten.bp.Instant
 
 @ContributesMultibinding(VpnScope::class)
 class VpnLatencySampler @Inject constructor(

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/pixels/NetworkProtectionPixels.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/pixels/NetworkProtectionPixels.kt
@@ -25,12 +25,12 @@ import com.duckduckgo.networkprotection.impl.cohort.NetpCohortStore
 import com.duckduckgo.networkprotection.impl.pixels.NetworkProtectionPixelNames.*
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 import javax.inject.Qualifier
-import org.threeten.bp.Instant
-import org.threeten.bp.ZoneId
-import org.threeten.bp.ZoneOffset
-import org.threeten.bp.format.DateTimeFormatter
 
 interface NetworkProtectionPixels {
     /**

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/pixels/WireguardHandshakeMonitor.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/pixels/WireguardHandshakeMonitor.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnStopReason
 import com.duckduckgo.networkprotection.api.NetworkProtectionState
 import com.duckduckgo.networkprotection.impl.WgProtocol
 import com.squareup.anvil.annotations.ContributesMultibinding
+import java.time.Instant
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.minutes
@@ -41,7 +42,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import logcat.LogPriority.WARN
 import logcat.logcat
-import org.threeten.bp.Instant
 
 @ContributesMultibinding(VpnScope::class)
 class WireguardHandshakeMonitor @Inject constructor(

--- a/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/cohort/NetPCohortUpdaterTest.kt
+++ b/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/cohort/NetPCohortUpdaterTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.networkprotection.impl.cohort
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.networkprotection.api.NetworkProtectionState
 import com.duckduckgo.networkprotection.impl.pixels.NetworkProtectionPixels
+import java.time.LocalDate
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
@@ -30,7 +31,6 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
-import org.threeten.bp.LocalDate
 
 class NetPCohortUpdaterTest {
     @get:Rule

--- a/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/cohort/NetpCohortPixelInterceptorTest.kt
+++ b/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/cohort/NetpCohortPixelInterceptorTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.networkprotection.impl.cohort
 
 import com.duckduckgo.common.test.api.FakeChain
+import java.time.LocalDate
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Before
@@ -24,7 +25,6 @@ import org.junit.Test
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.whenever
-import org.threeten.bp.LocalDate
 
 class NetpCohortPixelInterceptorTest {
     @Mock

--- a/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/pixels/RealNetworkProtectionPixelTest.kt
+++ b/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/pixels/RealNetworkProtectionPixelTest.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.common.test.api.InMemorySharedPreferences
 import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
 import com.duckduckgo.networkprotection.impl.cohort.NetpCohortStore
 import com.duckduckgo.networkprotection.impl.pixels.NetworkProtectionPixelNames.NETP_ENABLE_UNIQUE
+import java.time.LocalDate
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
@@ -29,7 +30,6 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.threeten.bp.LocalDate
 
 class RealNetworkProtectionPixelTest {
     @Mock

--- a/network-protection/network-protection-store/build.gradle
+++ b/network-protection/network-protection-store/build.gradle
@@ -26,8 +26,6 @@ dependencies {
     implementation project(':vpn-api')
     implementation project(path: ':common-utils')
 
-    implementation "com.jakewharton.threetenabp:threetenabp:_"
-
     implementation AndroidX.core.ktx
 
     // Room
@@ -43,4 +41,7 @@ dependencies {
 
 android {
     namespace 'com.duckduckgo.networkprotection.store'
+    compileOptions {
+        coreLibraryDesugaringEnabled = true
+    }
 }

--- a/privacy-config/privacy-config-impl/build.gradle
+++ b/privacy-config/privacy-config-impl/build.gradle
@@ -41,7 +41,6 @@ dependencies {
     implementation Google.android.material
     implementation AndroidX.constraintLayout
     implementation JakeWharton.timber
-    implementation "com.jakewharton.threetenabp:threetenabp:_"
 
     implementation KotlinX.coroutines.core
 
@@ -72,7 +71,6 @@ dependencies {
     testImplementation "androidx.test:runner:_"
     testImplementation Testing.robolectric
     testImplementation CashApp.turbine
-    testImplementation "org.threeten:threetenbp:_"
 
     androidTestImplementation project(path: ':common-test')
     testImplementation project(path: ':common-test')
@@ -88,5 +86,8 @@ android {
         }
     }
   namespace 'com.duckduckgo.privacy.config.impl'
+    compileOptions {
+        coreLibraryDesugaringEnabled = true
+    }
 }
 

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/PrivacyConfigPersister.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/PrivacyConfigPersister.kt
@@ -38,10 +38,10 @@ import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
 import dagger.Provides
 import dagger.SingleInstanceIn
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 import javax.inject.Qualifier
-import org.threeten.bp.LocalDateTime
-import org.threeten.bp.format.DateTimeFormatter
 import timber.log.Timber
 
 interface PrivacyConfigPersister {

--- a/remote-messaging/remote-messaging-impl/build.gradle
+++ b/remote-messaging/remote-messaging-impl/build.gradle
@@ -67,7 +67,6 @@ dependencies {
     testImplementation "androidx.test:runner:_"
     testImplementation Testing.robolectric
     testImplementation 'app.cash.turbine:turbine:_'
-    testImplementation "org.threeten:threetenbp:_"
     testImplementation (KotlinX.coroutines.test) {
         // https://github.com/Kotlin/kotlinx.coroutines/issues/2023
         // conflicts with mockito due to direct inclusion of byte buddy
@@ -85,4 +84,7 @@ android {
         }
     }
     namespace 'com.duckduckgo.remote.messaging.impl'
+    compileOptions {
+        coreLibraryDesugaringEnabled = true
+    }
 }

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/RealRemoteMessagingConfigProcessorTest.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/RealRemoteMessagingConfigProcessorTest.kt
@@ -24,6 +24,8 @@ import com.duckduckgo.remote.messaging.fixtures.RemoteMessagingConfigOM.aRemoteM
 import com.duckduckgo.remote.messaging.fixtures.messageActionPlugins
 import com.duckduckgo.remote.messaging.impl.mappers.RemoteMessagingConfigJsonMapper
 import com.duckduckgo.remote.messaging.store.RemoteMessagingConfigRepository
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import java.util.*
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
@@ -34,8 +36,6 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.threeten.bp.LocalDateTime
-import org.threeten.bp.format.DateTimeFormatter
 
 class RealRemoteMessagingConfigProcessorTest {
 

--- a/remote-messaging/remote-messaging-store/build.gradle
+++ b/remote-messaging/remote-messaging-store/build.gradle
@@ -34,14 +34,15 @@ android {
         test.assets.srcDirs += files("$projectDir/schemas".toString())
     }
     namespace 'com.duckduckgo.remote.messaging.store'
+    compileOptions {
+        coreLibraryDesugaringEnabled = true
+    }
 }
 
 dependencies {
     implementation AndroidX.room.ktx
     ksp AndroidX.room.compiler
-    implementation "com.jakewharton.threetenabp:threetenabp:_"
 
     testImplementation project(path: ':common-test')
-    testImplementation "org.threeten:threetenbp:_"
     testImplementation Testing.junit4
 }

--- a/remote-messaging/remote-messaging-store/src/main/java/com/duckduckgo/remote/messaging/store/DateFormatter.kt
+++ b/remote-messaging/remote-messaging-store/src/main/java/com/duckduckgo/remote/messaging/store/DateFormatter.kt
@@ -16,6 +16,6 @@
 
 package com.duckduckgo.remote.messaging.store
 
-import org.threeten.bp.format.DateTimeFormatter
+import java.time.format.DateTimeFormatter
 
 internal fun databaseTimestampFormatter() = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")

--- a/remote-messaging/remote-messaging-store/src/main/java/com/duckduckgo/remote/messaging/store/RemoteMessagingConfig.kt
+++ b/remote-messaging/remote-messaging-store/src/main/java/com/duckduckgo/remote/messaging/store/RemoteMessagingConfig.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.remote.messaging.store
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import org.threeten.bp.LocalDateTime
+import java.time.LocalDateTime
 
 @Entity(tableName = "remote_messaging")
 data class RemoteMessagingConfig(

--- a/remote-messaging/remote-messaging-store/src/test/java/com/duckduckgo/remote/messaging/store/LocalRemoteMessagingConfigRepositoryTest.kt
+++ b/remote-messaging/remote-messaging-store/src/test/java/com/duckduckgo/remote/messaging/store/LocalRemoteMessagingConfigRepositoryTest.kt
@@ -16,10 +16,10 @@
 
 package com.duckduckgo.remote.messaging.store
 
+import java.time.LocalDateTime
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import org.threeten.bp.LocalDateTime
 
 class LocalRemoteMessagingConfigRepositoryTest {
 

--- a/saved-sites/saved-sites-impl/build.gradle
+++ b/saved-sites/saved-sites-impl/build.gradle
@@ -56,9 +56,6 @@ dependencies {
     implementation AndroidX.room.ktx
     ksp AndroidX.room.compiler
 
-    implementation "com.jakewharton.threetenabp:threetenabp:_"
-    testImplementation "org.threeten:threetenbp:_"
-
     // Testing dependencies
     testImplementation project(path: ':common-test')
     testImplementation AndroidX.core
@@ -91,5 +88,8 @@ android {
         }
     }
     namespace 'com.duckduckgo.saved.sites.impl'
+    compileOptions {
+        coreLibraryDesugaringEnabled = true
+    }
 }
 

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/SavedSitesRepository.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/SavedSitesRepository.kt
@@ -35,11 +35,11 @@ import com.duckduckgo.savedsites.store.Relation
 import com.duckduckgo.savedsites.store.SavedSitesEntitiesDao
 import com.duckduckgo.savedsites.store.SavedSitesRelationsDao
 import io.reactivex.Single
+import java.time.OffsetDateTime
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
-import org.threeten.bp.OffsetDateTime
 import timber.log.Timber
 
 class RealSavedSitesRepository(

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/RealSyncSavedSitesRepository.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/RealSyncSavedSitesRepository.kt
@@ -28,8 +28,8 @@ import com.duckduckgo.savedsites.store.EntityType.FOLDER
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.Types
+import java.time.OffsetDateTime
 import java.util.*
-import org.threeten.bp.OffsetDateTime
 import timber.log.*
 
 class RealSyncSavedSitesRepository(

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SyncEntitiesExtension.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SyncEntitiesExtension.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.savedsites.impl.sync
 
 import com.duckduckgo.savedsites.api.models.*
 import com.duckduckgo.savedsites.store.*
-import org.threeten.bp.*
+import java.time.*
 
 fun Entity.mapToBookmark(relationId: String): SavedSite.Bookmark =
     SavedSite.Bookmark(this.entityId, this.title, this.url.orEmpty(), relationId, this.lastModified, deleted = this.deletedFlag())

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/algorithm/SavedSitesTimestampPersister.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/algorithm/SavedSitesTimestampPersister.kt
@@ -23,9 +23,9 @@ import com.duckduckgo.savedsites.api.models.SavedSite
 import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
 import com.duckduckgo.savedsites.impl.sync.SyncSavedSitesRepository
 import com.squareup.anvil.annotations.ContributesBinding
+import java.time.OffsetDateTime
 import javax.inject.Inject
 import javax.inject.Named
-import org.threeten.bp.OffsetDateTime
 import timber.log.Timber
 
 @ContributesBinding(AppScope::class)

--- a/saved-sites/saved-sites-impl/src/test/java/com/duckduckgo/savedsites/impl/sync/algorithm/SavedSitesSyncPersisterAlgorithmTest.kt
+++ b/saved-sites/saved-sites-impl/src/test/java/com/duckduckgo/savedsites/impl/sync/algorithm/SavedSitesSyncPersisterAlgorithmTest.kt
@@ -33,6 +33,8 @@ import com.duckduckgo.sync.api.engine.SyncableDataPersister.SyncConflictResoluti
 import com.duckduckgo.sync.api.engine.SyncableDataPersister.SyncConflictResolution.LOCAL_WINS
 import com.duckduckgo.sync.api.engine.SyncableDataPersister.SyncConflictResolution.REMOTE_WINS
 import com.duckduckgo.sync.api.engine.SyncableDataPersister.SyncConflictResolution.TIMESTAMP
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
 import org.junit.Before
@@ -43,8 +45,6 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
-import org.threeten.bp.OffsetDateTime
-import org.threeten.bp.ZoneOffset
 
 @RunWith(AndroidJUnit4::class)
 class SavedSitesSyncPersisterAlgorithmTest {

--- a/saved-sites/saved-sites-store/build.gradle
+++ b/saved-sites/saved-sites-store/build.gradle
@@ -32,6 +32,9 @@ android {
         }
     }
     namespace 'com.duckduckgo.saved.sites.store'
+    compileOptions {
+        coreLibraryDesugaringEnabled = true
+    }
 }
 
 dependencies {
@@ -48,8 +51,6 @@ dependencies {
 
     implementation project(path: ':saved-sites-api')
     implementation project(path: ':common-utils')
-
-    implementation "com.jakewharton.threetenabp:threetenabp:_"
 
     testImplementation Testing.junit4
     testImplementation Testing.robolectric

--- a/site-permissions/site-permissions-store/build.gradle
+++ b/site-permissions/site-permissions-store/build.gradle
@@ -34,6 +34,9 @@ android {
         androidTest.assets.srcDirs += files("$projectDir/schemas".toString())
     }
     namespace 'com.duckduckgo.site.permissions.store'
+    compileOptions {
+        coreLibraryDesugaringEnabled = true
+    }
 }
 
 dependencies {
@@ -41,10 +44,8 @@ dependencies {
     implementation project(path: ':common-utils')
     implementation project(path: ':feature-toggles-api')
     ksp AndroidX.room.compiler
-    implementation "com.jakewharton.threetenabp:threetenabp:_"
     implementation Google.dagger
 
     testImplementation project(path: ':common-test')
-    testImplementation "org.threeten:threetenbp:_"
     testImplementation Testing.junit4
 }

--- a/statistics/build.gradle
+++ b/statistics/build.gradle
@@ -60,9 +60,6 @@ dependencies {
     
     implementation AndroidX.core.ktx
 
-    implementation "com.jakewharton.threetenabp:threetenabp:_"
-    testImplementation "org.threeten:threetenbp:_"
-
     testImplementation Testing.junit4
     androidTestImplementation AndroidX.test.runner
     androidTestImplementation AndroidX.test.rules
@@ -73,4 +70,7 @@ android {
         generateDaggerFactories = true // default is false
     }
     namespace 'com.duckduckgo.app.statistics'
+    compileOptions {
+        coreLibraryDesugaringEnabled = true
+    }
 }

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/pixels/FeatureRetentionPixelSender.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/pixels/FeatureRetentionPixelSender.kt
@@ -27,12 +27,12 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesMultibinding
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import org.threeten.bp.Instant
-import org.threeten.bp.ZoneOffset
-import org.threeten.bp.format.DateTimeFormatter
 
 @ContributesMultibinding(AppScope::class)
 class FeatureRetentionPixelSender @Inject constructor(

--- a/sync/sync-impl/build.gradle
+++ b/sync/sync-impl/build.gradle
@@ -70,9 +70,6 @@ dependencies {
     implementation AndroidX.room.runtime
     implementation AndroidX.room.ktx
 
-    implementation "com.jakewharton.threetenabp:threetenabp:_"
-    testImplementation "org.threeten:threetenbp:_"
-
     // Testing dependencies
     testImplementation "org.mockito.kotlin:mockito-kotlin:_"
     testImplementation Testing.junit4
@@ -106,6 +103,9 @@ android {
         unitTests {
             includeAndroidResources = true
         }
+    }
+    compileOptions {
+        coreLibraryDesugaringEnabled = true
     }
 }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/engine/RealSyncEngine.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/engine/RealSyncEngine.kt
@@ -43,9 +43,9 @@ import com.duckduckgo.sync.store.model.SyncAttempt
 import com.duckduckgo.sync.store.model.SyncAttemptState.IN_PROGRESS
 import com.duckduckgo.sync.store.model.SyncAttemptState.SUCCESS
 import com.squareup.anvil.annotations.ContributesBinding
+import java.time.Duration
+import java.time.OffsetDateTime
 import javax.inject.Inject
-import org.threeten.bp.Duration
-import org.threeten.bp.OffsetDateTime
 import timber.log.Timber
 
 @ContributesBinding(scope = AppScope::class)

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/engine/SyncScheduler.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/engine/SyncScheduler.kt
@@ -22,9 +22,9 @@ import com.duckduckgo.sync.impl.engine.SyncOperation.EXECUTE
 import com.duckduckgo.sync.store.model.SyncAttemptState.FAIL
 import com.duckduckgo.sync.store.model.SyncAttemptState.IN_PROGRESS
 import com.squareup.anvil.annotations.ContributesBinding
+import java.time.Duration
+import java.time.OffsetDateTime
 import javax.inject.Inject
-import org.threeten.bp.Duration
-import org.threeten.bp.OffsetDateTime
 import timber.log.Timber
 
 interface SyncScheduler {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
@@ -27,10 +27,10 @@ import com.duckduckgo.sync.impl.stats.SyncStatsRepository
 import com.duckduckgo.sync.store.SharedPrefsProvider
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 import javax.inject.Inject
-import org.threeten.bp.Instant
-import org.threeten.bp.ZoneOffset
-import org.threeten.bp.format.DateTimeFormatter
 
 interface SyncPixels {
 

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/engine/SyncSchedulerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/engine/SyncSchedulerTest.kt
@@ -20,15 +20,15 @@ import com.duckduckgo.sync.store.model.SyncAttempt
 import com.duckduckgo.sync.store.model.SyncAttemptState.FAIL
 import com.duckduckgo.sync.store.model.SyncAttemptState.IN_PROGRESS
 import com.duckduckgo.sync.store.model.SyncAttemptState.SUCCESS
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 import junit.framework.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import org.threeten.bp.Instant
-import org.threeten.bp.ZoneOffset
-import org.threeten.bp.format.DateTimeFormatter
-import org.threeten.bp.temporal.ChronoUnit
 
 class SyncSchedulerTest {
 

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/stats/SyncStatsRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/stats/SyncStatsRepositoryTest.kt
@@ -20,15 +20,15 @@ import com.duckduckgo.sync.impl.engine.SyncStateRepository
 import com.duckduckgo.sync.store.model.SyncAttempt
 import com.duckduckgo.sync.store.model.SyncAttemptState.FAIL
 import com.duckduckgo.sync.store.model.SyncAttemptState.SUCCESS
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 import junit.framework.TestCase.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import org.threeten.bp.Instant
-import org.threeten.bp.ZoneOffset
-import org.threeten.bp.format.DateTimeFormatter
-import org.threeten.bp.temporal.ChronoUnit
 
 class SyncStatsRepositoryTest {
 

--- a/sync/sync-settings-impl/build.gradle
+++ b/sync/sync-settings-impl/build.gradle
@@ -49,9 +49,6 @@ dependencies {
     implementation AndroidX.room.ktx
     ksp AndroidX.room.compiler
 
-    implementation "com.jakewharton.threetenabp:threetenabp:_"
-    testImplementation "org.threeten:threetenbp:_"
-
     // Testing dependencies
     testImplementation "org.mockito.kotlin:mockito-kotlin:_"
     testImplementation Testing.junit4
@@ -86,5 +83,8 @@ android {
         }
     }
     namespace 'com.duckduckgo.sync.settings.impl'
+    compileOptions {
+        coreLibraryDesugaringEnabled = true
+    }
 }
 

--- a/sync/sync-settings-impl/src/main/java/com/duckduckgo/sync/settings/impl/SyncDateProvider.kt
+++ b/sync/sync-settings-impl/src/main/java/com/duckduckgo/sync/settings/impl/SyncDateProvider.kt
@@ -16,8 +16,8 @@
 
 package com.duckduckgo.sync.settings.impl
 
-import org.threeten.bp.*
-import org.threeten.bp.format.*
+import java.time.*
+import java.time.format.*
 
 class SyncDateProvider {
     companion object {

--- a/sync/sync-store/build.gradle
+++ b/sync/sync-store/build.gradle
@@ -32,6 +32,9 @@ android {
         }
     }
     namespace 'com.duckduckgo.sync.store'
+    compileOptions {
+        coreLibraryDesugaringEnabled = true
+    }
 }
 
 dependencies {
@@ -47,9 +50,6 @@ dependencies {
     implementation project(path: ':common-utils')
 
     ksp AndroidX.room.compiler
-
-    implementation "com.jakewharton.threetenabp:threetenabp:_"
-    testImplementation "org.threeten:threetenbp:_"
 
     testImplementation Testing.junit4
     testImplementation Testing.robolectric

--- a/sync/sync-store/src/main/java/com/duckduckgo/sync/store/model/SyncDatabaseModels.kt
+++ b/sync/sync-store/src/main/java/com/duckduckgo/sync/store/model/SyncDatabaseModels.kt
@@ -19,8 +19,8 @@ package com.duckduckgo.sync.store.model
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.duckduckgo.common.utils.formatters.time.DatabaseDateFormatter
-import org.threeten.bp.LocalDate
-import org.threeten.bp.ZoneOffset
+import java.time.LocalDate
+import java.time.ZoneOffset
 
 @Entity(
     tableName = "sync_attempts",

--- a/versions.properties
+++ b/versions.properties
@@ -119,10 +119,6 @@ version.robolectric=4.11.1
 
 version.com.facebook.shimmer..shimmer=0.5.0
 
-version.com.jakewharton.threetenabp..threetenabp=1.4.4
-
-version.org.threeten..threetenbp=1.6.5
-
 version.com.facebook.flipper..flipper=0.176.1
 
 version.com.facebook.soloader..soloader=0.10.5

--- a/versions.properties
+++ b/versions.properties
@@ -136,3 +136,5 @@ version.com.journeyapps..zxing-android-embedded=4.3.0
 version.com.google.zxing..core=3.3.0
 
 version.androidx.room.testing=2.4.3
+
+version.android.tools.desugar_jdk_libs=2.0.4


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/276630244458377/1206111990201349/f

### Description

This PR enables desugaring of Java 8+ APIs and migrates the code from org.threeten.bp library to java.time

### Steps to test this PR

- [x] All checks are green

### No UI changes

