### PR TITLE
Sync: Improve lists mechanism - sync events

### DIFF
--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/RealSyncSavedSitesRepository.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/RealSyncSavedSitesRepository.kt
@@ -233,4 +233,8 @@ class RealSyncSavedSitesRepository(
         Timber.d("Sync-Bookmarks-Metadata: adding children response metadata for folders: $children")
         savedSitesSyncMetadataDao.confirmChildren(children)
     }
+
+    override fun removeMetadata() {
+        savedSitesSyncMetadataDao.removeAll()
+    }
 }

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSitesSyncPersister.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSitesSyncPersister.kt
@@ -74,6 +74,7 @@ class SavedSitesSyncPersister @Inject constructor(
         savedSitesSyncStore.startTimeStamp = "0"
         savedSitesFormFactorSyncMigration.onFormFactorFavouritesDisabled()
         savedSitesSyncState.onSyncDisabled()
+        savedSitesSyncRepository.removeMetadata()
     }
 
     fun process(

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SyncSavedSitesRepository.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SyncSavedSitesRepository.kt
@@ -127,4 +127,10 @@ interface SyncSavedSitesRepository {
      * @param folders list of folders to be stored
      */
     fun addResponseMetadata(folders: List<SyncSavedSitesResponseEntry>)
+
+    /**
+     * Deletes all existing metadata
+     * This is called when Sync is disabled so all previous metadata is removed
+     */
+    fun removeMetadata()
 }

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/store/SavedSitesSyncMetadataDao.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/store/SavedSitesSyncMetadataDao.kt
@@ -68,6 +68,6 @@ interface SavedSitesSyncMetadataDao {
 @Entity(tableName = "saved_sites_sync_meta")
 data class SavedSitesSyncMetadataEntity(
     @PrimaryKey val folderId: String,
-    var childrenResponse: String, // JSON representation of list of children confirmed by the BE
-    var childrenRequest: String, // JSON representation of list of children sent to the BE
+    var childrenResponse: String?, // JSON representation of list of children confirmed by the BE
+    var childrenRequest: String?, // JSON representation of list of children sent to the BE
 )


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/1157893581871903/1206091622490132

### Description
This PR enables the reaction to sync events for the metadata table.
When sync is disabled (logout or account deletion) we want to delete the content of the metadata table.

### Steps to test this PR

_Account logout_
- [ ] Add a few bookmarks and enable sync
- [ ] Verify that the “saved_sites_sync_metadata” table has content
- [ ] Go to Settings -> Turn Off Sync & Backup"
- [ ] Verify that the “saved_sites_sync_metadata” table is empty

_Account deletion_
- [ ] Add a few bookmarks and enable sync
- [ ] Verify that the “saved_sites_sync_metadata” table has content
- [ ] Go to Settings -> Turn Off and Delete Server Data"
- [ ] Verify that the “saved_sites_sync_metadata” table is empty