### PR TITLE
Update content scope scripts to version 4.55.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -7404,6 +7404,7 @@
     }
 
     const MSG_WEB_SHARE = 'webShare';
+    const MSG_PERMISSIONS_QUERY = 'permissionsQuery';
 
     function canShare (data) {
         if (typeof data !== 'object') return false
@@ -7640,28 +7641,7 @@
                     this.onchange = null; // noop
                 }
             }
-            // Default subset based upon Firefox (the full list is pretty large right now and these are the common ones)
-            const defaultValidPermissionNames = [
-                'geolocation',
-                'notifications',
-                'push',
-                'persistent-storage',
-                'midi',
-                'accelerometer',
-                'ambient-light-sensor',
-                'background-sync',
-                'bluetooth',
-                'camera',
-                'clipboard',
-                'device-info',
-                'gyroscope',
-                'magnetometer',
-                'microphone',
-                'speaker'
-            ];
-            const validPermissionNames = settings.validPermissionNames || defaultValidPermissionNames;
-            const returnStatus = settings.permissionResponse || 'prompt';
-            permissions.query = new Proxy((query) => {
+            permissions.query = new Proxy(async (query) => {
                 this.addDebugFlag();
                 if (!query) {
                     throw new TypeError("Failed to execute 'query' on 'Permissions': 1 argument required, but only 0 present.")
@@ -7669,10 +7649,21 @@
                 if (!query.name) {
                     throw new TypeError("Failed to execute 'query' on 'Permissions': Failed to read the 'name' property from 'PermissionDescriptor': Required member is undefined.")
                 }
-                if (!validPermissionNames.includes(query.name)) {
+                if (!settings.supportedPermissions || !(query.name in settings.supportedPermissions)) {
                     throw new TypeError(`Failed to execute 'query' on 'Permissions': Failed to read the 'name' property from 'PermissionDescriptor': The provided value '${query.name}' is not a valid enum value of type PermissionName.`)
                 }
-                return Promise.resolve(new PermissionStatus(query.name, returnStatus))
+                const permSetting = settings.supportedPermissions[query.name];
+                const returnName = permSetting.name || query.name;
+                let returnStatus = settings.permissionResponse || 'prompt';
+                if (permSetting.native) {
+                    try {
+                        const response = await this.messaging.request(MSG_PERMISSIONS_QUERY, query);
+                        returnStatus = response.state || 'prompt';
+                    } catch (err) {
+                        // do nothing - keep returnStatus as-is
+                    }
+                }
+                return Promise.resolve(new PermissionStatus(returnName, returnStatus))
             }, {
                 get (target, name) {
                     return Reflect.get(target, name)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^6.4.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.0.1",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.54.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.55.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#3.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1699613603"
       },
@@ -69,7 +69,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#ddc9aef4a9753c0ff9ae19c3ae9139cca1448127",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#b121b2795fb689332c7dc85f3f17781e467b5ae6",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -268,9 +268,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.10.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.3.tgz",
-      "integrity": "sha512-XJavIpZqiXID5Yxnxv3RUDKTN5b81ddNC3ecsA0SoFXz/QU8OGBwZGMomiq0zw+uuqbL/krztv/DINAQ/EV4gg==",
+      "version": "20.10.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.4.tgz",
+      "integrity": "sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -1071,9 +1071,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.24.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.24.0.tgz",
-      "integrity": "sha512-ZpGR4Hy3+wBEzVEnHvstMvqpD/nABNelQn/z2r0fjVWGQsN3bpOLzQlqDxmb4CDZnXq5lpjnQ+mHQLAOpfM5iw==",
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.26.0.tgz",
+      "integrity": "sha512-dytTGoE2oHgbNV9nTzgBEPaqAWvcJNl66VZ0BkJqlvp71IjO8CxdBx/ykCNb47cLnCmCvRZ6ZR0tLkqvZCdVBQ==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^6.4.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.0.1",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.54.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.55.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#3.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1699613603"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1206156219234206/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [x] All tests must pass