### PR TITLE
Send pixel when page reload is triggered by pull-to-refresh

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2332,6 +2332,7 @@ class BrowserTabFragment :
 
         binding.swipeRefreshContainer.setOnRefreshListener {
             onRefreshRequested()
+            pixel.fire(AppPixelName.BROWSER_PULL_TO_REFRESH)
         }
 
         binding.swipeRefreshContainer.setCanChildScrollUpCallback {

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -39,6 +39,7 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
 
     BROWSER_MENU_ALLOWLIST_ADD("mb_wla"),
     BROWSER_MENU_ALLOWLIST_REMOVE("mb_wlr"),
+    BROWSER_PULL_TO_REFRESH("m_browser_pull_to_refresh"),
 
     DEFAULT_BROWSER_SET("m_db_s"),
     DEFAULT_BROWSER_NOT_SET("m_db_ns"),


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1206145818662390/f

### Description

This PR adds new pixel to measure pull-to-refresh usage. We already have similar one for the refresh button in the options menu.

### Steps to test this PR

- [x] Open any webpage
- [x] Trigger page reload using pull-to-refresh
- [x] Verify that the m_browser_pull_to_refresh pixel is fired

### No UI changes
