### PR TITLE
Add flag to set fullbackup to false

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,6 +33,7 @@
     <application
         android:name="com.duckduckgo.app.global.DuckDuckGoApplication"
         android:backupAgent="com.duckduckgo.app.backup.agent.impl.DuckDuckGoBackupAgent"
+        android:fullBackupOnly="false"
         android:icon="${appIcon}"
         android:label="@string/appName"
         android:networkSecurityConfig="@xml/network_security_config"
@@ -41,6 +42,8 @@
         android:theme="@style/Theme.DuckDuckGo.Light"
         android:requestLegacyExternalStorage="true"
         tools:ignore="GoogleAppIndexingWarning">
+        <meta-data android:name="com.google.android.backup.api_key"
+                   android:value="unused" />
         <meta-data
             android:name="android.webkit.WebView.MetricsOptOut"
             android:value="true" />


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1206133268245246/f 

### Description
Adds the fullBackupOnly set to false to hopefully avoid some devices to do a full backup instead of a key-value.

### Steps to test this PR

- [x] Download the `test_cloud_backup.sh` script attached in the task and give it execution permissions (or run `chmod -R 777 test_cloud_backup.sh`)
- [x] Add a log in the `getVariantKey()` method inside `VariantManagerImpl` to show the value of the variant we are returning.
- [x] Build the app and go throw the welcome screen
- [x] In the console execute `./test_cloud_backup.sh com.duckduckgo.mobile.android.debug`
- [x] If it fails check that you have backups enabled on your phone.
- [x] Once it succeds the app would have been re-installed, open it again manually.
- [x] You should see in the logs the variant changes to `ru`

