### PR TITLE
Removes errors after a manual refresh

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -54,6 +54,8 @@ import com.duckduckgo.app.browser.BrowserTabViewModel.NavigationCommand
 import com.duckduckgo.app.browser.BrowserTabViewModel.NavigationCommand.Navigate
 import com.duckduckgo.app.browser.LongPressHandler.RequiredAction.DownloadFile
 import com.duckduckgo.app.browser.LongPressHandler.RequiredAction.OpenInNewTab
+import com.duckduckgo.app.browser.WebViewErrorResponse.LOADING
+import com.duckduckgo.app.browser.WebViewErrorResponse.OMITTED
 import com.duckduckgo.app.browser.addtohome.AddToHomeCapabilityDetector
 import com.duckduckgo.app.browser.applinks.AppLinksHandler
 import com.duckduckgo.app.browser.camera.CameraHardwareChecker
@@ -4552,6 +4554,15 @@ class BrowserTabViewModelTest {
         val params = buildFileChooserParams(arrayOf("application/pdf"))
         testee.showFileChooser(mockFileChooserCallback, params)
         assertCommandIssued<Command.ShowFileChooser>()
+    }
+
+    @Test
+    fun whenWebViewRefreshedThenBrowserErrorStateChangedToLoading() {
+        assertEquals(OMITTED, browserViewState().browserError)
+
+        testee.onWebViewRefreshed()
+
+        assertEquals(LOADING, browserViewState().browserError)
     }
 
     private fun aCredential(): LoginCredentials {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -93,6 +93,7 @@ import com.duckduckgo.app.browser.BrowserTabViewModel.OmnibarViewState
 import com.duckduckgo.app.browser.BrowserTabViewModel.PrivacyShieldViewState
 import com.duckduckgo.app.browser.BrowserTabViewModel.SavedSiteChangedViewState
 import com.duckduckgo.app.browser.DownloadConfirmationFragment.DownloadConfirmationDialogListener
+import com.duckduckgo.app.browser.WebViewErrorResponse.LOADING
 import com.duckduckgo.app.browser.WebViewErrorResponse.OMITTED
 import com.duckduckgo.app.browser.autocomplete.BrowserAutoCompleteSuggestionsAdapter
 import com.duckduckgo.app.browser.cookies.ThirdPartyCookieManager
@@ -1118,6 +1119,7 @@ class BrowserTabFragment :
     fun refresh() {
         webView?.reload()
         viewModel.onWebViewRefreshed()
+        viewModel.resetErrors()
     }
 
     private fun processCommand(it: Command?) {
@@ -3287,6 +3289,9 @@ class BrowserTabFragment :
                 lastSeenLoadingViewState = viewState
 
                 if (viewState.progress == MAX_PROGRESS) {
+                    if (lastSeenBrowserViewState?.browserError == LOADING) {
+                        showBrowser()
+                    }
                     webView?.setBottomMatchingBehaviourEnabled(true)
                 }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -55,6 +55,7 @@ import com.duckduckgo.app.browser.BrowserTabViewModel.HighlightableButton.Visibl
 import com.duckduckgo.app.browser.LongPressHandler.RequiredAction
 import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType.AppLink
 import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType.NonHttpAppLink
+import com.duckduckgo.app.browser.WebViewErrorResponse.LOADING
 import com.duckduckgo.app.browser.WebViewErrorResponse.OMITTED
 import com.duckduckgo.app.browser.addtohome.AddToHomeCapabilityDetector
 import com.duckduckgo.app.browser.applinks.AppLinksHandler
@@ -2889,7 +2890,12 @@ class BrowserTabViewModel @Inject constructor(
         }
     }
 
+    fun resetErrors() {
+        site?.resetErrors()
+    }
+
     fun onWebViewRefreshed() {
+        browserViewState.value = currentBrowserViewState().copy(browserError = LOADING)
         accessibilityViewState.value = currentAccessibilityViewState().copy(refreshWebView = false)
         canAutofillSelectCredentialsDialogCanAutomaticallyShow = true
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -502,5 +502,6 @@ enum class WebViewErrorResponse(@StringRes val errorId: Int) {
     BAD_URL(R.string.webViewErrorBadUrl),
     CONNECTION(R.string.webViewErrorNoConnection),
     OMITTED(R.string.webViewErrorNoConnection),
+    LOADING(R.string.webViewErrorNoConnection),
     SSL_PROTOCOL_ERROR(R.string.webViewErrorSslProtocol),
 }

--- a/app/src/main/java/com/duckduckgo/app/global/model/SiteMonitor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/model/SiteMonitor.kt
@@ -131,6 +131,11 @@ class SiteMonitor(
         return HttpsStatus.NONE
     }
 
+    override fun resetErrors() {
+        errorCodeEvents.clear()
+        httpErrorCodeEvents.clear()
+    }
+
     override fun surrogateDetected(surrogate: SurrogateResponse) {
         surrogates.add(surrogate)
     }

--- a/browser-api/src/main/java/com/duckduckgo/app/global/model/Site.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/global/model/Site.kt
@@ -61,6 +61,7 @@ interface Site {
     fun trackerDetected(event: TrackingEvent)
     fun onHttpErrorDetected(errorCode: Int)
     fun onErrorDetected(error: String)
+    fun resetErrors()
     fun updatePrivacyData(sitePrivacyData: SitePrivacyData)
     fun surrogateDetected(surrogate: SurrogateResponse)
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1206139108436193/f 

### Description
This task removes errors from a site after a manual refresh has been triggered. It also fixes the yeti screen stuck even after a successul refresh of the page. It doesn't add the pull to refresh capability though. Comming soon.

### Steps to test this PR

- [x] Go to www.pacopatata.es
- [x] Web shouldn't load
- [x] Filter logcat by epbf
- [x] Send a broken site report
- [x] Pixel should contain an errorDescription
- [x] Now go to https://client-cert-missing.badssl.com/
- [x] Send a broken site report
- [x] Pixel should not have an errorDescription but an httpErrorCode instead.
- [x] Go to cnn.com
- [x] Put the phone in airplane mode and refresh
- [x] You should see the yeti screen
- [x] Send a broken site report
- [x] Pixel should have an errorDescription
- [x] Remove airplane mode and refresh the page
- [x] Yeti screen should disappear
- [x] Send a broken site report
- [x] Pixel should not contain an errorDescription or httpErrorCode

