### PR TITLE
Get translations for updated autofill terminology, preferring passwords over logins

### DIFF
--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -783,4 +783,9 @@
     <string name="imageCaptureCameraPermissionDeniedMessage">Сайтовете могат да използват камерата, само ако разрешите на DuckDuckGo да поиска достъп.</string>
     <string name="imageCaptureCameraPermissionDeniedPositiveButton">Отвори Настройки</string>
     <string name="imageCaptureCameraPermissionDeniedNegativeButton">Отмени</string>
+
+    <!-- Autofill -->
+    <string name="settingsAutofillLoginsSetting">Пароли</string>
+    <string name="autofillLoginSavedSnackbarMessage">Паролата е запазена</string>
+    <string name="autofillLoginUpdatedSnackbarMessage">Паролата е актуализирана</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -791,4 +791,9 @@
     <string name="imageCaptureCameraPermissionDeniedMessage">Weby můžou používat fotoaparát, jen když službě DuckDuckGo povolíš žádat o přístup.</string>
     <string name="imageCaptureCameraPermissionDeniedPositiveButton">Otevřít nastavení</string>
     <string name="imageCaptureCameraPermissionDeniedNegativeButton">Zrušit</string>
+
+    <!-- Autofill -->
+    <string name="settingsAutofillLoginsSetting">Hesla</string>
+    <string name="autofillLoginSavedSnackbarMessage">Heslo je uložené</string>
+    <string name="autofillLoginUpdatedSnackbarMessage">Heslo je aktualizované</string>
 </resources>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -783,4 +783,9 @@
     <string name="imageCaptureCameraPermissionDeniedMessage">Websteder kan kun bruge dit kamera, hvis du giver DuckDuckGo tilladelse til at bede om adgang.</string>
     <string name="imageCaptureCameraPermissionDeniedPositiveButton">Åbn indstillinger</string>
     <string name="imageCaptureCameraPermissionDeniedNegativeButton">Annuller</string>
+
+    <!-- Autofill -->
+    <string name="settingsAutofillLoginsSetting">Adgangskoder</string>
+    <string name="autofillLoginSavedSnackbarMessage">Adgangskode gemt</string>
+    <string name="autofillLoginUpdatedSnackbarMessage">Adgangskode opdateret</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -783,4 +783,9 @@
     <string name="imageCaptureCameraPermissionDeniedMessage">Websites können deine Kamera nur verwenden, wenn du DuckDuckGo erlaubst, um Zugriff zu bitten.</string>
     <string name="imageCaptureCameraPermissionDeniedPositiveButton">Einstellungen öffnen</string>
     <string name="imageCaptureCameraPermissionDeniedNegativeButton">Abbrechen</string>
+
+    <!-- Autofill -->
+    <string name="settingsAutofillLoginsSetting">Passwörter</string>
+    <string name="autofillLoginSavedSnackbarMessage">Passwort gespeichert</string>
+    <string name="autofillLoginUpdatedSnackbarMessage">Passwort aktualisiert</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -783,4 +783,9 @@
     <string name="imageCaptureCameraPermissionDeniedMessage">Οι ιστότοποι μπορούν να χρησιμοποιούν την κάμερά σας μόνο εάν επιτρέψετε στο DuckDuckGo να αιτηθεί πρόσβαση.</string>
     <string name="imageCaptureCameraPermissionDeniedPositiveButton">Άνοιγμα ρυθμίσεων</string>
     <string name="imageCaptureCameraPermissionDeniedNegativeButton">Ακύρωση</string>
+
+    <!-- Autofill -->
+    <string name="settingsAutofillLoginsSetting">Κωδικοί πρόσβασης</string>
+    <string name="autofillLoginSavedSnackbarMessage">Αποθηκευμένος κωδικός πρόσβασης</string>
+    <string name="autofillLoginUpdatedSnackbarMessage">Ο κωδικός πρόσβασης ενημερώθηκε</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -783,4 +783,9 @@
     <string name="imageCaptureCameraPermissionDeniedMessage">Los sitios solo pueden usar tu cámara si permites que DuckDuckGo solicite acceso.</string>
     <string name="imageCaptureCameraPermissionDeniedPositiveButton">Abrir configuración</string>
     <string name="imageCaptureCameraPermissionDeniedNegativeButton">Cancelar</string>
+
+    <!-- Autofill -->
+    <string name="settingsAutofillLoginsSetting">Contraseñas</string>
+    <string name="autofillLoginSavedSnackbarMessage">Contraseña guardada</string>
+    <string name="autofillLoginUpdatedSnackbarMessage">Contraseña actualizada</string>
 </resources>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -783,4 +783,9 @@
     <string name="imageCaptureCameraPermissionDeniedMessage">Saidid saavad sinu kaamerat kasutada ainult siis, kui lubad DuckDuckGo’l küsida sellele juurdepääsu.</string>
     <string name="imageCaptureCameraPermissionDeniedPositiveButton">Ava sätted</string>
     <string name="imageCaptureCameraPermissionDeniedNegativeButton">Loobu</string>
+
+    <!-- Autofill -->
+    <string name="settingsAutofillLoginsSetting">Paroolid</string>
+    <string name="autofillLoginSavedSnackbarMessage">Parool salvestatud</string>
+    <string name="autofillLoginUpdatedSnackbarMessage">Parool uuendatud</string>
 </resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -783,4 +783,9 @@
     <string name="imageCaptureCameraPermissionDeniedMessage">Sivustot voivat käyttää kameraa vain, jos sallit DuckDuckGon pyytää sen käyttöoikeutta.</string>
     <string name="imageCaptureCameraPermissionDeniedPositiveButton">Avaa asetukset</string>
     <string name="imageCaptureCameraPermissionDeniedNegativeButton">Peruuta</string>
+
+    <!-- Autofill -->
+    <string name="settingsAutofillLoginsSetting">Salasanat</string>
+    <string name="autofillLoginSavedSnackbarMessage">Salasana tallennettu</string>
+    <string name="autofillLoginUpdatedSnackbarMessage">Salasana päivitetty</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -783,4 +783,9 @@
     <string name="imageCaptureCameraPermissionDeniedMessage">Les sites ne peuvent utiliser votre appareil photo que si vous autorisez DuckDuckGo à demander l\'accès.</string>
     <string name="imageCaptureCameraPermissionDeniedPositiveButton">Ouvrir les paramètres</string>
     <string name="imageCaptureCameraPermissionDeniedNegativeButton">Annuler</string>
+
+    <!-- Autofill -->
+    <string name="settingsAutofillLoginsSetting">Mots de passe</string>
+    <string name="autofillLoginSavedSnackbarMessage">Le mot de passe a été enregistré</string>
+    <string name="autofillLoginUpdatedSnackbarMessage">Le mot de passe a été modifié</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -791,4 +791,9 @@
     <string name="imageCaptureCameraPermissionDeniedMessage">Stranice mogu koristiti tvoju kameru samo ako dopustiš DuckDuckGou da zatraži pristup.</string>
     <string name="imageCaptureCameraPermissionDeniedPositiveButton">Otvori postavke</string>
     <string name="imageCaptureCameraPermissionDeniedNegativeButton">Odustani</string>
+
+    <!-- Autofill -->
+    <string name="settingsAutofillLoginsSetting">Lozinke</string>
+    <string name="autofillLoginSavedSnackbarMessage">Lozinka je spremljena</string>
+    <string name="autofillLoginUpdatedSnackbarMessage">Lozinka je ažurirana</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -783,4 +783,9 @@
     <string name="imageCaptureCameraPermissionDeniedMessage">A webhelyek csak akkor használhatják a kamerát, ha engedélyezed, hogy a DuckDuckGo hozzáférést kérjen.</string>
     <string name="imageCaptureCameraPermissionDeniedPositiveButton">Beállítások megnyitása</string>
     <string name="imageCaptureCameraPermissionDeniedNegativeButton">Mégsem</string>
+
+    <!-- Autofill -->
+    <string name="settingsAutofillLoginsSetting">Jelszavak</string>
+    <string name="autofillLoginSavedSnackbarMessage">Jelszó mentve</string>
+    <string name="autofillLoginUpdatedSnackbarMessage">Jelszó frissítve</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -783,4 +783,9 @@
     <string name="imageCaptureCameraPermissionDeniedMessage">I siti possono utilizzare la fotocamera solo se consenti a DuckDuckGo di richiederne l\'accesso.</string>
     <string name="imageCaptureCameraPermissionDeniedPositiveButton">Apri Impostazioni</string>
     <string name="imageCaptureCameraPermissionDeniedNegativeButton">Annulla</string>
+
+    <!-- Autofill -->
+    <string name="settingsAutofillLoginsSetting">Password</string>
+    <string name="autofillLoginSavedSnackbarMessage">Password salvata</string>
+    <string name="autofillLoginUpdatedSnackbarMessage">Password aggiornata</string>
 </resources>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -791,4 +791,9 @@
     <string name="imageCaptureCameraPermissionDeniedMessage">Svetainės gali naudoti jūsų kamerą tik tada, jei leisite „DuckDuckGo“ prašyti prieigos.</string>
     <string name="imageCaptureCameraPermissionDeniedPositiveButton">Atidaryti nustatymus</string>
     <string name="imageCaptureCameraPermissionDeniedNegativeButton">Atšaukti</string>
+
+    <!-- Autofill -->
+    <string name="settingsAutofillLoginsSetting">Slaptažodžiai</string>
+    <string name="autofillLoginSavedSnackbarMessage">Slaptažodis išsaugotas</string>
+    <string name="autofillLoginUpdatedSnackbarMessage">Slaptažodis atnaujintas</string>
 </resources>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -787,4 +787,9 @@
     <string name="imageCaptureCameraPermissionDeniedMessage">Vietnes var izmantot tavu kameru tikai tad, ja tu atļauj DuckDuckGo prasīt piekļuvi.</string>
     <string name="imageCaptureCameraPermissionDeniedPositiveButton">Atvērt iestatījumus</string>
     <string name="imageCaptureCameraPermissionDeniedNegativeButton">Atcelt</string>
+
+    <!-- Autofill -->
+    <string name="settingsAutofillLoginsSetting">Paroles</string>
+    <string name="autofillLoginSavedSnackbarMessage">Parole saglabāta</string>
+    <string name="autofillLoginUpdatedSnackbarMessage">Parole atjaunināta</string>
 </resources>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -783,4 +783,9 @@
     <string name="imageCaptureCameraPermissionDeniedMessage">Nettsteder kan bare bruke kameraet ditt hvis du lar DuckDuckGo be om tilgang.</string>
     <string name="imageCaptureCameraPermissionDeniedPositiveButton">Åpne innstillinger</string>
     <string name="imageCaptureCameraPermissionDeniedNegativeButton">Avbryt</string>
+
+    <!-- Autofill -->
+    <string name="settingsAutofillLoginsSetting">Passord</string>
+    <string name="autofillLoginSavedSnackbarMessage">Passordet er lagret</string>
+    <string name="autofillLoginUpdatedSnackbarMessage">Passordet er oppdatert</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -783,4 +783,9 @@
     <string name="imageCaptureCameraPermissionDeniedMessage">Sites kunnen je camera alleen gebruiken als je DuckDuckGo toestaat om toegang te vragen.</string>
     <string name="imageCaptureCameraPermissionDeniedPositiveButton">Open Instellingen</string>
     <string name="imageCaptureCameraPermissionDeniedNegativeButton">Annuleren</string>
+
+    <!-- Autofill -->
+    <string name="settingsAutofillLoginsSetting">Wachtwoorden</string>
+    <string name="autofillLoginSavedSnackbarMessage">Wachtwoord opgeslagen</string>
+    <string name="autofillLoginUpdatedSnackbarMessage">Wachtwoord bijgewerkt</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -791,4 +791,9 @@
     <string name="imageCaptureCameraPermissionDeniedMessage">Witryny mogą korzystać z Twojej kamery tylko wtedy, gdy pozwolisz DuckDuckGo poprosić o dostęp.</string>
     <string name="imageCaptureCameraPermissionDeniedPositiveButton">Otwórz ustawienia</string>
     <string name="imageCaptureCameraPermissionDeniedNegativeButton">Anuluj</string>
+
+    <!-- Autofill -->
+    <string name="settingsAutofillLoginsSetting">Hasła</string>
+    <string name="autofillLoginSavedSnackbarMessage">Hasło zapisane</string>
+    <string name="autofillLoginUpdatedSnackbarMessage">Zaktualizowano hasło</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -783,4 +783,9 @@
     <string name="imageCaptureCameraPermissionDeniedMessage">Os sites só podem utilizar a tua câmara se autorizares o DuckDuckGo a pedir acesso.</string>
     <string name="imageCaptureCameraPermissionDeniedPositiveButton">Abrir Definições</string>
     <string name="imageCaptureCameraPermissionDeniedNegativeButton">Cancelar</string>
+
+    <!-- Autofill -->
+    <string name="settingsAutofillLoginsSetting">Palavras-passe</string>
+    <string name="autofillLoginSavedSnackbarMessage">Palavra-passe guardada</string>
+    <string name="autofillLoginUpdatedSnackbarMessage">Palavra-passe atualizada</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -787,4 +787,9 @@
     <string name="imageCaptureCameraPermissionDeniedMessage">Site-urile îți pot utiliza camera numai dacă permiți ca DuckDuckGo să solicite accesul.</string>
     <string name="imageCaptureCameraPermissionDeniedPositiveButton">Deschide Setări</string>
     <string name="imageCaptureCameraPermissionDeniedNegativeButton">Anulare</string>
+
+    <!-- Autofill -->
+    <string name="settingsAutofillLoginsSetting">Parole</string>
+    <string name="autofillLoginSavedSnackbarMessage">Parolă salvată</string>
+    <string name="autofillLoginUpdatedSnackbarMessage">Parolă actualizată</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -791,4 +791,9 @@
     <string name="imageCaptureCameraPermissionDeniedMessage">Если вы разрешите DuckDuckGo запрашивать доступ, сайты смогут использовать камеру.</string>
     <string name="imageCaptureCameraPermissionDeniedPositiveButton">Открыть Настройки</string>
     <string name="imageCaptureCameraPermissionDeniedNegativeButton">Отменить</string>
+
+    <!-- Autofill -->
+    <string name="settingsAutofillLoginsSetting">Пароли</string>
+    <string name="autofillLoginSavedSnackbarMessage">Пароль сохранен</string>
+    <string name="autofillLoginUpdatedSnackbarMessage">Пароль обновлен</string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -791,4 +791,9 @@
     <string name="imageCaptureCameraPermissionDeniedMessage">Lokality môžu používať váš fotoaparát len vtedy, ak povolíte aplikácii DuckDuckGo žiadať o prístup.</string>
     <string name="imageCaptureCameraPermissionDeniedPositiveButton">Otvoriť nastavenia</string>
     <string name="imageCaptureCameraPermissionDeniedNegativeButton">Zrušiť</string>
+
+    <!-- Autofill -->
+    <string name="settingsAutofillLoginsSetting">Heslo</string>
+    <string name="autofillLoginSavedSnackbarMessage">Uložené heslo</string>
+    <string name="autofillLoginUpdatedSnackbarMessage">Aktualizácia hesla</string>
 </resources>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -791,4 +791,9 @@
     <string name="imageCaptureCameraPermissionDeniedMessage">Spletna mesta lahko uporabljajo vašo kamero le, če dovolite, da DuckDuckGo zaprosi za dostop.</string>
     <string name="imageCaptureCameraPermissionDeniedPositiveButton">Odpri nastavitve</string>
     <string name="imageCaptureCameraPermissionDeniedNegativeButton">Prekliči</string>
+
+    <!-- Autofill -->
+    <string name="settingsAutofillLoginsSetting">Gesla</string>
+    <string name="autofillLoginSavedSnackbarMessage">Geslo je shranjeno</string>
+    <string name="autofillLoginUpdatedSnackbarMessage">Geslo je posodobljeno</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -783,4 +783,9 @@
     <string name="imageCaptureCameraPermissionDeniedMessage">Webbplatser kan endast använda din kamera om du tillåter DuckDuckGo att be om åtkomst.</string>
     <string name="imageCaptureCameraPermissionDeniedPositiveButton">Öppna inställningar</string>
     <string name="imageCaptureCameraPermissionDeniedNegativeButton">Avbryt</string>
+
+    <!-- Autofill -->
+    <string name="settingsAutofillLoginsSetting">Lösenord</string>
+    <string name="autofillLoginSavedSnackbarMessage">Lösenord sparat</string>
+    <string name="autofillLoginUpdatedSnackbarMessage">Lösenordet har uppdaterats</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -783,4 +783,9 @@
     <string name="imageCaptureCameraPermissionDeniedMessage">Siteler kameranızı yalnızca DuckDuckGo\'nun erişim istemesine izin verirseniz kullanabilir.</string>
     <string name="imageCaptureCameraPermissionDeniedPositiveButton">Ayarları Aç</string>
     <string name="imageCaptureCameraPermissionDeniedNegativeButton">Vazgeç</string>
+
+    <!-- Autofill -->
+    <string name="settingsAutofillLoginsSetting">Şifreler</string>
+    <string name="autofillLoginSavedSnackbarMessage">Şifre kaydedildi</string>
+    <string name="autofillLoginUpdatedSnackbarMessage">Şifre güncellendi</string>
 </resources>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -46,9 +46,4 @@
     <!-- DRM -->
     <string name="sitePermissionsSettingsDRM">DRM</string>
 
-    <!-- Autofill -->
-    <string name="settingsAutofillLoginsSetting">Passwords</string>
-    <string name="autofillLoginSavedSnackbarMessage">Password saved</string>
-    <string name="autofillLoginUpdatedSnackbarMessage">Password updated</string>
-
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -782,4 +782,9 @@
     <string name="imageCaptureCameraPermissionDeniedMessage">Sites can only use your camera if you allow DuckDuckGo to ask for access.</string>
     <string name="imageCaptureCameraPermissionDeniedPositiveButton">Open Settings</string>
     <string name="imageCaptureCameraPermissionDeniedNegativeButton">Cancel</string>
+
+    <!-- Autofill -->
+    <string name="settingsAutofillLoginsSetting">Passwords</string>
+    <string name="autofillLoginSavedSnackbarMessage">Password saved</string>
+    <string name="autofillLoginUpdatedSnackbarMessage">Password updated</string>
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-bg/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-bg/strings-autofill-impl.xml
@@ -17,7 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-
     <string name="managementDisabledModeCta"><b>Настройване в Настройки</b></string>
 
     <string name="saveLoginDialogButtonSave">Запазване на паролата</string>
@@ -62,6 +61,7 @@
 
     <string name="autofillDeleteLoginDialogCancel">Отмени</string>
     <string name="autofillDeleteLoginDialogDelete">Изтрий</string>
+
 
     <string name="autofillManagementUsernameCopied">Потребителското име е копирано</string>
     <string name="autofillManagementPasswordCopied">Паролата е копирана</string>
@@ -112,5 +112,25 @@
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogTitle">Ако излезете сега, Вашият Duck Address няма да бъде запазен</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogPositiveButton">Продължаване с настройката</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogNegativeButton">Изход от настройката</string>
+
+    <string name="autofillManagementScreenTitle">Пароли</string>
+    <string name="credentialManagementNoLoginsSavedTitle">Все още няма запазени пароли</string>
+    <string name="credentialManagementAutofillToggleLabel">Запазване и автоматично попълване на паролите</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Паролите се съхраняват сигурно на Вашето устройство.</string>
+    <string name="saveLoginDialogSubtitle">Паролите се съхраняват сигурно на Вашето устройство.</string>
+    <string name="autofillManagementAddLogin">Добавяне на парола</string>
+    <string name="credentialManagementEditLoginTitleHint">Заглавие</string>
+    <string name="autofillDeleteLoginDialogTitle">Сигурни ли сте, че искате да изтриете тази парола?</string>
+    <string name="autofillManagementDeletedConfirmation">Паролата е изтрита</string>
+    <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Последна актуализация %1$s</string>
+    <string name="autofillDisableAutofillPromptTitle">Искате ли да продължите да запазвате пароли?</string>
+    <string name="deviceNotSupportedSubtitle">За да съхраняваме сигурно паролите, трябва да ги криптираме и да ги запазим на Вашето устройство. Тъй като Вашето устройство не поддържа криптирано съхранение, запазването и автоматичното попълване на пароли е недостъпно.</string>
+    <string name="autofill_password_generation_offer_message">Паролите се съхраняват сигурно на Вашето устройство.</string>
+    <string name="autofillManagementSearchLogins">Търсене на пароли</string>
+    <string name="biometric_prompt_title">Паролите са заключени</string>
+    <string name="autofill_auth_text_for_access">Отключете устройството, за да получите достъп до паролите</string>
+    <string name="managementDisabledModeTitle">Защитете устройството, за да можете да запазвате пароли</string>
+    <string name="managementDisabledModeSubtitle">За защита на паролите е необходимо да зададете модел за заключване, ПИН код или биометрични данни.</string>
+    <string name="credentialManagementEditTitle">Редактиране на парола</string>
 
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-cs/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-cs/strings-autofill-impl.xml
@@ -17,7 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-
     <string name="managementDisabledModeCta"><b>Nastavit v Nastaveních</b></string>
 
     <string name="saveLoginDialogButtonSave">Uložit heslo</string>
@@ -62,6 +61,7 @@
 
     <string name="autofillDeleteLoginDialogCancel">Zrušit</string>
     <string name="autofillDeleteLoginDialogDelete">Smazat</string>
+
 
     <string name="autofillManagementUsernameCopied">Uživatelské jméno zkopírováno</string>
     <string name="autofillManagementPasswordCopied">Heslo zkopírováno</string>
@@ -112,5 +112,25 @@
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogTitle">Když teď odejdeš, tvoje adresa Duck Address se neuloží.</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogPositiveButton">Pokračovat v nastavení</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogNegativeButton">Ukončit nastavení</string>
+
+    <string name="autofillManagementScreenTitle">Hesla</string>
+    <string name="credentialManagementNoLoginsSavedTitle">Zatím nemáš uložená žádná hesla</string>
+    <string name="credentialManagementAutofillToggleLabel">Ukládání a automatické vyplňování hesel</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Hesla se bezpečně ukládají do tvého zařízení.</string>
+    <string name="saveLoginDialogSubtitle">Hesla se bezpečně ukládají do tvého zařízení.</string>
+    <string name="autofillManagementAddLogin">Přidat heslo</string>
+    <string name="credentialManagementEditLoginTitleHint">Název</string>
+    <string name="autofillDeleteLoginDialogTitle">Opravdu chceš smazat tohle heslo?</string>
+    <string name="autofillManagementDeletedConfirmation">Heslo smazáno</string>
+    <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Poslední aktualizace %1$s</string>
+    <string name="autofillDisableAutofillPromptTitle">Chceš dál ukládat hesla?</string>
+    <string name="deviceNotSupportedSubtitle">Abychom mohli hesla bezpečně ukládat, musíme je zašifrovat a uložit do tvého zařízení. Protože tvoje zařízení nepodporuje šifrované úložiště, hesla není možné ukládat ani automaticky vyplňovat.</string>
+    <string name="autofill_password_generation_offer_message">Hesla se bezpečně ukládají do tvého zařízení.</string>
+    <string name="autofillManagementSearchLogins">Prohledat hesla</string>
+    <string name="biometric_prompt_title">Hesla jsou uzamčená</string>
+    <string name="autofill_auth_text_for_access">Pro přístup k heslům zařízení odemkni</string>
+    <string name="managementDisabledModeTitle">Zabezpeč si zařízení, ať si můžeš ukládat hesla</string>
+    <string name="managementDisabledModeSubtitle">Na ochranu hesel se vyžaduje gesto zámku obrazovky, PIN nebo biometrické ověření.</string>
+    <string name="credentialManagementEditTitle">Upravit heslo</string>
 
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-da/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-da/strings-autofill-impl.xml
@@ -17,7 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-
     <string name="managementDisabledModeCta"><b>Konfigurer i Indstillinger</b></string>
 
     <string name="saveLoginDialogButtonSave">Gem adgangskode</string>
@@ -62,6 +61,7 @@
 
     <string name="autofillDeleteLoginDialogCancel">Annuller</string>
     <string name="autofillDeleteLoginDialogDelete">Slet</string>
+
 
     <string name="autofillManagementUsernameCopied">Brugernavn kopieret</string>
     <string name="autofillManagementPasswordCopied">Adgangskode kopieret</string>
@@ -112,5 +112,25 @@
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogTitle">Hvis du afslutter nu, vil din Duck Address ikke blive gemt</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogPositiveButton">Fortsæt opsætning</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogNegativeButton">Afslut opsætning</string>
+
+    <string name="autofillManagementScreenTitle">Adgangskoder</string>
+    <string name="credentialManagementNoLoginsSavedTitle">Ingen adgangskoder gemt endnu</string>
+    <string name="credentialManagementAutofillToggleLabel">Gem og udfyld adgangskoder automatisk</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Adgangskoder gemmes sikkert på din enhed.</string>
+    <string name="saveLoginDialogSubtitle">Adgangskoder gemmes sikkert på din enhed.</string>
+    <string name="autofillManagementAddLogin">Tilføj adgangskode</string>
+    <string name="credentialManagementEditLoginTitleHint">Titel</string>
+    <string name="autofillDeleteLoginDialogTitle">Er du sikker på, at du vil slette denne adgangskode?</string>
+    <string name="autofillManagementDeletedConfirmation">Adgangskode slettet</string>
+    <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Sidst opdateret %1$s</string>
+    <string name="autofillDisableAutofillPromptTitle">Vil du fortsætte med at gemme adgangskoder?</string>
+    <string name="deviceNotSupportedSubtitle">For at gemme adgangskoder sikkert skal vi kryptere og gemme dem på din enhed. Da din enhed ikke understøtter krypteret lagring, er det ikke muligt at gemme og udfylde adgangskoder automatisk.</string>
+    <string name="autofill_password_generation_offer_message">Adgangskoder gemmes sikkert på din enhed.</string>
+    <string name="autofillManagementSearchLogins">Søg adgangskoder</string>
+    <string name="biometric_prompt_title">Adgangskoder låst</string>
+    <string name="autofill_auth_text_for_access">Lås enheden op for at få adgang til adgangskoder</string>
+    <string name="managementDisabledModeTitle">Beskyt din enhed for at gemme adgangskoder</string>
+    <string name="managementDisabledModeSubtitle">Der kræves et låsemønster, en pinkode eller biometri for at beskytte dine adgangskoder.</string>
+    <string name="credentialManagementEditTitle">Rediger adgangskode</string>
 
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-de/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-de/strings-autofill-impl.xml
@@ -17,7 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-
     <string name="managementDisabledModeCta"><b>In den Einstellungen einrichten</b></string>
 
     <string name="saveLoginDialogButtonSave">Passwort speichern</string>
@@ -62,6 +61,7 @@
 
     <string name="autofillDeleteLoginDialogCancel">Abbrechen</string>
     <string name="autofillDeleteLoginDialogDelete">Löschen</string>
+
 
     <string name="autofillManagementUsernameCopied">Benutzername kopiert</string>
     <string name="autofillManagementPasswordCopied">Passwort kopiert</string>
@@ -112,5 +112,25 @@
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogTitle">Wenn du jetzt beendest, wird deine Duck Address nicht gespeichert</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogPositiveButton">Einrichtung fortsetzen</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogNegativeButton">Einrichtung beenden</string>
+
+    <string name="autofillManagementScreenTitle">Passwörter</string>
+    <string name="credentialManagementNoLoginsSavedTitle">Noch keine Passwörter gespeichert</string>
+    <string name="credentialManagementAutofillToggleLabel">Passwörter speichern und automatisch ausfüllen</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Passwörter werden sicher auf deinem Gerät gespeichert.</string>
+    <string name="saveLoginDialogSubtitle">Passwörter werden sicher auf deinem Gerät gespeichert.</string>
+    <string name="autofillManagementAddLogin">Passwort hinzufügen</string>
+    <string name="credentialManagementEditLoginTitleHint">Titel</string>
+    <string name="autofillDeleteLoginDialogTitle">Möchtest du dieses Passwort wirklich löschen?</string>
+    <string name="autofillManagementDeletedConfirmation">Passwort gelöscht</string>
+    <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Zuletzt aktualisiert %1$s</string>
+    <string name="autofillDisableAutofillPromptTitle">Möchtest du weiterhin Passwörter speichern?</string>
+    <string name="deviceNotSupportedSubtitle">Um Passwörter sicher zu speichern, müssen sie auf deinem Gerät verschlüsselt und gespeichert werden. Da dein Gerät keine verschlüsselte Speicherung unterstützt, ist das Speichern und automatische Ausfüllen von Passwörtern nicht möglich.</string>
+    <string name="autofill_password_generation_offer_message">Passwörter werden sicher auf deinem Gerät gespeichert.</string>
+    <string name="autofillManagementSearchLogins">Passwörter suchen</string>
+    <string name="biometric_prompt_title">Passwörter gesperrt</string>
+    <string name="autofill_auth_text_for_access">Gerät entsperren, um auf Passwörter zuzugreifen</string>
+    <string name="managementDisabledModeTitle">Sichere dein Gerät, um Passwörter zu speichern</string>
+    <string name="managementDisabledModeSubtitle">Es sind ein Muster, eine PIN oder biometrische Daten erforderlich, um deine Passwörter zu schützen.</string>
+    <string name="credentialManagementEditTitle">Passwort bearbeiten</string>
 
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-el/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-el/strings-autofill-impl.xml
@@ -17,7 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-
     <string name="managementDisabledModeCta"><b>Προσαρμογή στις Ρυθμίσεις</b></string>
 
     <string name="saveLoginDialogButtonSave">Αποθήκευση κωδικού πρόσβασης</string>
@@ -62,6 +61,7 @@
 
     <string name="autofillDeleteLoginDialogCancel">Ακύρωση</string>
     <string name="autofillDeleteLoginDialogDelete">Διαγραφή</string>
+
 
     <string name="autofillManagementUsernameCopied">Το όνομα χρήστη αντιγράφηκε</string>
     <string name="autofillManagementPasswordCopied">Ο κωδικός πρόσβασης αντιγράφηκε</string>
@@ -112,5 +112,25 @@
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogTitle">Εάν εξέλθετε τώρα, η Duck Address δεν θα αποθηκευτεί</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogPositiveButton">Συνέχιση εγκατάστασης</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogNegativeButton">Έξοδος από την εγκατάσταση</string>
+
+    <string name="autofillManagementScreenTitle">Κωδικοί πρόσβασης</string>
+    <string name="credentialManagementNoLoginsSavedTitle">Δεν έχουν αποθηκευτεί ακόμα κωδικοί πρόσβασης</string>
+    <string name="credentialManagementAutofillToggleLabel">Αποθήκευση και αυτόματη συμπλήρωση κωδικών πρόσβασης</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Οι κωδικοί πρόσβασης αποθηκεύονται με ασφάλεια στη συσκευή σας.</string>
+    <string name="saveLoginDialogSubtitle">Οι κωδικοί πρόσβασης αποθηκεύονται με ασφάλεια στη συσκευή σας.</string>
+    <string name="autofillManagementAddLogin">Προσθήκη κωδικού πρόσβασης</string>
+    <string name="credentialManagementEditLoginTitleHint">Τίτλος</string>
+    <string name="autofillDeleteLoginDialogTitle">Θέλετε σίγουρα να διαγράψετε αυτόν τον κωδικό πρόσβασης;</string>
+    <string name="autofillManagementDeletedConfirmation">Διαγραφή κωδικού πρόσβασης</string>
+    <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Τελευταία ενημέρωση %1$s</string>
+    <string name="autofillDisableAutofillPromptTitle">Θέλετε να συνεχίσετε να αποθηκεύετε κωδικούς πρόσβασης;</string>
+    <string name="deviceNotSupportedSubtitle">Για ασφαλή αποθήκευση των κωδικών πρόσβασής σας, πρέπει να τους κρυπτογραφήσουμε και να τους αποθηκεύσουμε στη συσκευή σας. Επειδή η συσκευή σας δεν υποστηρίζει κρυπτογραφημένη αποθήκευση, δεν είναι δυνατή η αποθήκευση και η αυτόματη συμπλήρωση κωδικών πρόσβασης.</string>
+    <string name="autofill_password_generation_offer_message">Οι κωδικοί πρόσβασης αποθηκεύονται με ασφάλεια στη συσκευή σας.</string>
+    <string name="autofillManagementSearchLogins">Αναζήτηση κωδικών πρόσβασης</string>
+    <string name="biometric_prompt_title">Κλειδωμένοι κωδικοί πρόσβασης</string>
+    <string name="autofill_auth_text_for_access">Ξεκλειδώστε τη συσκευή για πρόσβαση σε κωδικούς πρόσβασης</string>
+    <string name="managementDisabledModeTitle">Ασφαλίστε τη συσκευή σας για αποθήκευση κωδικών πρόσβασης</string>
+    <string name="managementDisabledModeSubtitle">Για προστασία των κωδικών πρόσβασής σας απαιτείται μοτίβο κλειδώματος συσκευής, PIN ή βιομετρικά στοιχεία.</string>
+    <string name="credentialManagementEditTitle">Επεξεργασία κωδικού πρόσβασης</string>
 
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-es/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-es/strings-autofill-impl.xml
@@ -17,7 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-
     <string name="managementDisabledModeCta"><b>Configurar en Ajustes</b></string>
 
     <string name="saveLoginDialogButtonSave">Guardar contraseña</string>
@@ -62,6 +61,7 @@
 
     <string name="autofillDeleteLoginDialogCancel">Cancelar</string>
     <string name="autofillDeleteLoginDialogDelete">Eliminar</string>
+
 
     <string name="autofillManagementUsernameCopied">Nombre de usuario copiado</string>
     <string name="autofillManagementPasswordCopied">Contraseña copiada</string>
@@ -112,5 +112,25 @@
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogTitle">Si sales ahora, no se guardará tu Duck Address</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogPositiveButton">Continuar con la configuración</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogNegativeButton">Salir de Configuración</string>
+
+    <string name="autofillManagementScreenTitle">Contraseñas</string>
+    <string name="credentialManagementNoLoginsSavedTitle">Aún no hay contraseñas guardadas</string>
+    <string name="credentialManagementAutofillToggleLabel">Guardar y autocompletar contraseñas</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Las contraseñas se almacenan de forma segura en tu dispositivo.</string>
+    <string name="saveLoginDialogSubtitle">Las contraseñas se almacenan de forma segura en tu dispositivo.</string>
+    <string name="autofillManagementAddLogin">Añadir contraseña</string>
+    <string name="credentialManagementEditLoginTitleHint">Título</string>
+    <string name="autofillDeleteLoginDialogTitle">¿Seguro de que quieres borrar esta contraseña?</string>
+    <string name="autofillManagementDeletedConfirmation">Contraseña borrada</string>
+    <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Última actualización %1$s</string>
+    <string name="autofillDisableAutofillPromptTitle">¿Quieres seguir guardando contraseñas?</string>
+    <string name="deviceNotSupportedSubtitle">Para almacenar las contraseñas de forma segura, necesitamos cifrarlas y almacenarlas en tu dispositivo. Debido a que tu dispositivo no admite almacenamiento cifrado, no es posible guardar ni autocompletar contraseñas.</string>
+    <string name="autofill_password_generation_offer_message">Las contraseñas se almacenan de forma segura en tu dispositivo.</string>
+    <string name="autofillManagementSearchLogins">Buscar contraseñas</string>
+    <string name="biometric_prompt_title">Contraseñas bloqueadas</string>
+    <string name="autofill_auth_text_for_access">Desbloquear dispositivo para acceder a contraseñas</string>
+    <string name="managementDisabledModeTitle">Protege tu dispositivo para guardar contraseñas</string>
+    <string name="managementDisabledModeSubtitle">Se requiere un patrón de bloqueo del dispositivo, un PIN o datos biométricos para proteger tus contraseñas.</string>
+    <string name="credentialManagementEditTitle">Editar contraseña</string>
 
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-et/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-et/strings-autofill-impl.xml
@@ -17,7 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-
     <string name="managementDisabledModeCta"><b>Seadista sätetes</b></string>
 
     <string name="saveLoginDialogButtonSave">Salvesta parool</string>
@@ -62,6 +61,7 @@
 
     <string name="autofillDeleteLoginDialogCancel">Loobu</string>
     <string name="autofillDeleteLoginDialogDelete">Kustuta</string>
+
 
     <string name="autofillManagementUsernameCopied">Kasutajanimi on kopeeritud</string>
     <string name="autofillManagementPasswordCopied">Parool on kopeeritud</string>
@@ -112,5 +112,25 @@
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogTitle">Kui sa praegu väljud, siis sinu Duck Addressi ei salvestata</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogPositiveButton">Jätka seadistamist</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogNegativeButton">Välju seadistusest</string>
+
+    <string name="autofillManagementScreenTitle">Paroolid</string>
+    <string name="credentialManagementNoLoginsSavedTitle">Paroole ei ole veel salvestatud</string>
+    <string name="credentialManagementAutofillToggleLabel">Paroolide salvestamine ja automaatne sisestamine</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Paroolid salvestatakse turvaliselt sinu seadmesse.</string>
+    <string name="saveLoginDialogSubtitle">Paroolid salvestatakse turvaliselt sinu seadmesse.</string>
+    <string name="autofillManagementAddLogin">Parooli lisamine</string>
+    <string name="credentialManagementEditLoginTitleHint">Pealkiri</string>
+    <string name="autofillDeleteLoginDialogTitle">Kas oled kindel, et soovid selle parooli kustutada?</string>
+    <string name="autofillManagementDeletedConfirmation">Parool on kustutatud</string>
+    <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Viimati uuendatud %1$s</string>
+    <string name="autofillDisableAutofillPromptTitle">Kas soovid jätkata paroolide salvestamist?</string>
+    <string name="deviceNotSupportedSubtitle">Paroolide turvaliseks salvestamiseks peame need krüptima ja sinu seadmesse salvestama. Kuna sinu seade ei toeta krüptitud salvestusruumi, ei ole paroolide salvestamine ja automaatne sisestamine võimalik.</string>
+    <string name="autofill_password_generation_offer_message">Paroolid salvestatakse turvaliselt sinu seadmesse.</string>
+    <string name="autofillManagementSearchLogins">Otsi paroole</string>
+    <string name="biometric_prompt_title">Paroolid lukustatud</string>
+    <string name="autofill_auth_text_for_access">Paroolidele juurdepääsuks ava seade</string>
+    <string name="managementDisabledModeTitle">Paroolide salvestamiseks muuda oma seade turvaliseks</string>
+    <string name="managementDisabledModeSubtitle">Paroolide kaitsmiseks on vaja seadme lukustusmustrit, PIN-koodi või biomeetriat.</string>
+    <string name="credentialManagementEditTitle">Parooli muutmine</string>
 
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-fi/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-fi/strings-autofill-impl.xml
@@ -17,7 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-
     <string name="managementDisabledModeCta"><b>Määritä Asetuksissa</b></string>
 
     <string name="saveLoginDialogButtonSave">Tallenna salasana</string>
@@ -62,6 +61,7 @@
 
     <string name="autofillDeleteLoginDialogCancel">Peruuta</string>
     <string name="autofillDeleteLoginDialogDelete">Poista</string>
+
 
     <string name="autofillManagementUsernameCopied">Käyttäjätunnus kopioitu</string>
     <string name="autofillManagementPasswordCopied">Salasana kopioitu</string>
@@ -112,5 +112,25 @@
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogTitle">Jos poistut nyt, Duck Address -osoitettasi ei tallenneta</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogPositiveButton">Jatka asennusta</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogNegativeButton">Poistu asennuksesta</string>
+
+    <string name="autofillManagementScreenTitle">Salasanat</string>
+    <string name="credentialManagementNoLoginsSavedTitle">Salasanoja ei ole vielä tallennettu</string>
+    <string name="credentialManagementAutofillToggleLabel">Tallenna ja täytä salasanat automaattisesti</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Salasanat tallennetaan laitteellesi turvallisesti.</string>
+    <string name="saveLoginDialogSubtitle">Salasanat tallennetaan laitteellesi turvallisesti.</string>
+    <string name="autofillManagementAddLogin">Lisää salasana</string>
+    <string name="credentialManagementEditLoginTitleHint">Otsikko</string>
+    <string name="autofillDeleteLoginDialogTitle">Haluatko varmasti poistaa tämän salasanan?</string>
+    <string name="autofillManagementDeletedConfirmation">Salasana poistettu</string>
+    <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Viimeksi päivitetty %1$s</string>
+    <string name="autofillDisableAutofillPromptTitle">Haluatko jatkaa salasanojen tallentamista?</string>
+    <string name="deviceNotSupportedSubtitle">Jotta salasanat voidaan tallentaa turvallisesti, meidän on salattava ja tallennettava ne laitteellesi. Koska laitteesi ei tue salattua tallennusta, salasanojen tallentaminen ja automaattinen täyttäminen ei ole mahdollista.</string>
+    <string name="autofill_password_generation_offer_message">Salasanat tallennetaan laitteellesi turvallisesti.</string>
+    <string name="autofillManagementSearchLogins">Etsi salasanoja</string>
+    <string name="biometric_prompt_title">Salasanat lukittu</string>
+    <string name="autofill_auth_text_for_access">Avaa laitteen lukitus päästäksesi salasanoihin</string>
+    <string name="managementDisabledModeTitle">Suojaa laitteesi salasanojen tallentamiseksi</string>
+    <string name="managementDisabledModeSubtitle">Salasanojen suojaamiseen tarvitaan laitteen lukituskuvio, PIN-koodi tai biometriset tiedot.</string>
+    <string name="credentialManagementEditTitle">Muokkaa salasanaa</string>
 
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-fr/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-fr/strings-autofill-impl.xml
@@ -17,7 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-
     <string name="managementDisabledModeCta"><b>Configurer dans les paramètres</b></string>
 
     <string name="saveLoginDialogButtonSave">Enregistrer le mot de passe</string>
@@ -62,6 +61,7 @@
 
     <string name="autofillDeleteLoginDialogCancel">Annuler</string>
     <string name="autofillDeleteLoginDialogDelete">Supprimer</string>
+
 
     <string name="autofillManagementUsernameCopied">Nom d\'utilisateur copié</string>
     <string name="autofillManagementPasswordCopied">Mot de passe copié</string>
@@ -112,5 +112,25 @@
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogTitle">Si vous quittez cette page maintenant, votre Duck Address ne sera pas enregistrée</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogPositiveButton">Poursuivre la configuration</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogNegativeButton">Quitter la configuration</string>
+
+    <string name="autofillManagementScreenTitle">Mots de passe</string>
+    <string name="credentialManagementNoLoginsSavedTitle">Aucun mot de passe n\'a été enregistré</string>
+    <string name="credentialManagementAutofillToggleLabel">Enregistrer et saisir automatiquement les mots de passe</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Les mots de passe sont stockés en toute sécurité sur votre appareil.</string>
+    <string name="saveLoginDialogSubtitle">Les mots de passe sont stockés en toute sécurité sur votre appareil.</string>
+    <string name="autofillManagementAddLogin">Ajouter un mot de passe</string>
+    <string name="credentialManagementEditLoginTitleHint">Titre</string>
+    <string name="autofillDeleteLoginDialogTitle">Voulez-vous vraiment supprimer ce mot de passe ?</string>
+    <string name="autofillManagementDeletedConfirmation">Le mot de passe a été supprimé</string>
+    <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Dernière modification : %1$s</string>
+    <string name="autofillDisableAutofillPromptTitle">Voulez-vous continuer à enregistrer vos mots de passe ?</string>
+    <string name="deviceNotSupportedSubtitle">Pour protéger vos mots de passe, nous devons les chiffrer et les stocker sur votre appareil. Étant donné que votre appareil ne prend pas en charge le stockage chiffré, l\'enregistrement et la saisie automatique des mots de passe ne sont pas possibles.</string>
+    <string name="autofill_password_generation_offer_message">Les mots de passe sont stockés en toute sécurité sur votre appareil.</string>
+    <string name="autofillManagementSearchLogins">Rechercher un mot de passe</string>
+    <string name="biometric_prompt_title">Mots de passe verrouillés</string>
+    <string name="autofill_auth_text_for_access">Déverrouiller l\'appareil pour accéder aux mots de passe</string>
+    <string name="managementDisabledModeTitle">Sécurisez votre appareil pour enregistrer vos mots de passe</string>
+    <string name="managementDisabledModeSubtitle">Un schéma de verrouillage de l\'appareil, un code PIN ou des données biométriques sont nécessaires pour protéger vos mots de passe.</string>
+    <string name="credentialManagementEditTitle">Modifier le mot de passe</string>
 
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-hr/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-hr/strings-autofill-impl.xml
@@ -17,7 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-
     <string name="managementDisabledModeCta"><b>Odredi u Postavkama</b></string>
 
     <string name="saveLoginDialogButtonSave">Spremi lozinku</string>
@@ -62,6 +61,7 @@
 
     <string name="autofillDeleteLoginDialogCancel">Odustani</string>
     <string name="autofillDeleteLoginDialogDelete">Izbriši</string>
+
 
     <string name="autofillManagementUsernameCopied">Korisničko ime je kopirano</string>
     <string name="autofillManagementPasswordCopied">Lozinka je kopirana</string>
@@ -112,5 +112,25 @@
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogTitle">Ako izađeš sada, tvoja adresa Duck Address neće biti spremljena</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogPositiveButton">Nastavi s postavljanjem</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogNegativeButton">Izađi iz postavljanja</string>
+
+    <string name="autofillManagementScreenTitle">Lozinke</string>
+    <string name="credentialManagementNoLoginsSavedTitle">Još nema spremljenih lozinki</string>
+    <string name="credentialManagementAutofillToggleLabel">Spremi i automatski popuni lozinke</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Lozinke su sigurno pohranjene na tvom uređaju.</string>
+    <string name="saveLoginDialogSubtitle">Lozinke su sigurno pohranjene na tvom uređaju.</string>
+    <string name="autofillManagementAddLogin">Dodaj lozinku</string>
+    <string name="credentialManagementEditLoginTitleHint">Naslov</string>
+    <string name="autofillDeleteLoginDialogTitle">Sigurno želiš izbrisati ovu lozinku?</string>
+    <string name="autofillManagementDeletedConfirmation">Lozinka je izbrisana</string>
+    <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Posljednje ažuriranje: %1$s</string>
+    <string name="autofillDisableAutofillPromptTitle">Želiš li nastaviti spremati lozinke?</string>
+    <string name="deviceNotSupportedSubtitle">Kako bismo sigurno pohranili lozinke, moramo ih šifrirati i pohraniti na tvom uređaju. Budući da tvoj uređaj ne podržava šifriranu pohranu, spremanje i automatsko popunjavanje lozinki nije dostupno.</string>
+    <string name="autofill_password_generation_offer_message">Lozinke su sigurno pohranjene na tvom uređaju.</string>
+    <string name="autofillManagementSearchLogins">Pretraživanje lozinki</string>
+    <string name="biometric_prompt_title">Lozinke su zaključane</string>
+    <string name="autofill_auth_text_for_access">Otključaj uređaj za pristup lozinkama</string>
+    <string name="managementDisabledModeTitle">Osiguraj svoj uređaj za spremanje lozinki</string>
+    <string name="managementDisabledModeSubtitle">Uzorak za zaključavanje uređaja, PIN ili biometrija potrebni su za zaštitu tvojih lozinki.</string>
+    <string name="credentialManagementEditTitle">Uredi lozinku</string>
 
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-hu/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-hu/strings-autofill-impl.xml
@@ -17,7 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-
     <string name="managementDisabledModeCta"><b>Beállítás a Beállításokban</b></string>
 
     <string name="saveLoginDialogButtonSave">Jelszó mentése</string>
@@ -62,6 +61,7 @@
 
     <string name="autofillDeleteLoginDialogCancel">Mégsem</string>
     <string name="autofillDeleteLoginDialogDelete">Törlés</string>
+
 
     <string name="autofillManagementUsernameCopied">Felhasználónév másolva</string>
     <string name="autofillManagementPasswordCopied">Jelszó másolva</string>
@@ -112,5 +112,25 @@
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogTitle">Ha most kilépsz, a Duck-címed nem lesz mentve</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogPositiveButton">Beállítás folytatása</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogNegativeButton">Kilépés a beállításokból</string>
+
+    <string name="autofillManagementScreenTitle">Jelszavak</string>
+    <string name="credentialManagementNoLoginsSavedTitle">Még nincsenek mentett jelszavak</string>
+    <string name="credentialManagementAutofillToggleLabel">Jelszavak mentése és automatikus kitöltése</string>
+    <string name="credentialManagementAutofillToggleSubtitle">A jelszavakat az eszközöd biztonságosan tárolja.</string>
+    <string name="saveLoginDialogSubtitle">A jelszavakat az eszközöd biztonságosan tárolja.</string>
+    <string name="autofillManagementAddLogin">Jelszó hozzáadása</string>
+    <string name="credentialManagementEditLoginTitleHint">Cím</string>
+    <string name="autofillDeleteLoginDialogTitle">Biztosan törlöd ezt a jelszót?</string>
+    <string name="autofillManagementDeletedConfirmation">Jelszó törölve</string>
+    <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Utolsó frissítés: %1$s</string>
+    <string name="autofillDisableAutofillPromptTitle">Továbbra is szeretnéd menteni a jelszavakat?</string>
+    <string name="deviceNotSupportedSubtitle">A jelszavak biztonságos tárolásához az eszközödön kell titkosítanunk és tárolnunk azokat. Mivel az eszközöd nem támogatja a titkosított tárhelyet, a jelszavak mentése és automatikus kitöltése nem érhető el.</string>
+    <string name="autofill_password_generation_offer_message">A jelszavakat az eszközöd biztonságosan tárolja.</string>
+    <string name="autofillManagementSearchLogins">Jelszavak keresése</string>
+    <string name="biometric_prompt_title">Jelszavak zárolva</string>
+    <string name="autofill_auth_text_for_access">Oldd fel az eszközt a jelszavakhoz való hozzáféréshez</string>
+    <string name="managementDisabledModeTitle">Zárd le az eszközt a jelszavak mentéséhez</string>
+    <string name="managementDisabledModeSubtitle">A jelszavak védelméhez az eszköz zárolási mintája, PIN-kód vagy biometrikus adatok szükségesek.</string>
+    <string name="credentialManagementEditTitle">Jelszó szerkesztése</string>
 
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-it/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-it/strings-autofill-impl.xml
@@ -17,7 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-
     <string name="managementDisabledModeCta"><b>Configura in Impostazioni</b></string>
 
     <string name="saveLoginDialogButtonSave">Salva password</string>
@@ -62,6 +61,7 @@
 
     <string name="autofillDeleteLoginDialogCancel">Annulla</string>
     <string name="autofillDeleteLoginDialogDelete">Cancella</string>
+
 
     <string name="autofillManagementUsernameCopied">Nome utente copiato</string>
     <string name="autofillManagementPasswordCopied">Password copiata</string>
@@ -112,5 +112,25 @@
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogTitle">Se esci ora, il tuo Duck Address non verrà salvato</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogPositiveButton">Prosegui la configurazione</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogNegativeButton">Esci dalla configurazione</string>
+
+    <string name="autofillManagementScreenTitle">Password</string>
+    <string name="credentialManagementNoLoginsSavedTitle">Nessuna password ancora salvata</string>
+    <string name="credentialManagementAutofillToggleLabel">Salva e compila automaticamente le password</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Le password sono archiviate in modo sicuro sul tuo dispositivo.</string>
+    <string name="saveLoginDialogSubtitle">Le password sono archiviate in modo sicuro sul tuo dispositivo.</string>
+    <string name="autofillManagementAddLogin">Aggiungi password</string>
+    <string name="credentialManagementEditLoginTitleHint">Titolo</string>
+    <string name="autofillDeleteLoginDialogTitle">Eliminare questa password?</string>
+    <string name="autofillManagementDeletedConfirmation">Password eliminata</string>
+    <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Ultimo aggiornamento %1$s</string>
+    <string name="autofillDisableAutofillPromptTitle">Continuare a salvare le password?</string>
+    <string name="deviceNotSupportedSubtitle">Per archiviare le password in modo sicuro, dobbiamo crittografarle e archiviarle sul tuo dispositivo. Poiché il dispositivo non supporta l\'archiviazione crittografata, il salvataggio e la compilazione automatica delle password non è disponibile.</string>
+    <string name="autofill_password_generation_offer_message">Le password sono archiviate in modo sicuro sul tuo dispositivo.</string>
+    <string name="autofillManagementSearchLogins">Cerca password</string>
+    <string name="biometric_prompt_title">Password bloccate</string>
+    <string name="autofill_auth_text_for_access">Sblocca il dispositivo per accedere alle password</string>
+    <string name="managementDisabledModeTitle">Proteggi il tuo dispositivo per salvare le password</string>
+    <string name="managementDisabledModeSubtitle">Per proteggere le password sono necessari una sequenza di blocco del dispositivo, un PIN o dati biometrici.</string>
+    <string name="credentialManagementEditTitle">Modifica password</string>
 
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-lt/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-lt/strings-autofill-impl.xml
@@ -17,7 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-
     <string name="managementDisabledModeCta"><b>Nustatyti nustatymuose</b></string>
 
     <string name="saveLoginDialogButtonSave">Išsaugoti slaptažodį</string>
@@ -62,6 +61,7 @@
 
     <string name="autofillDeleteLoginDialogCancel">Atšaukti</string>
     <string name="autofillDeleteLoginDialogDelete">Trinti</string>
+
 
     <string name="autofillManagementUsernameCopied">Naudotojo vardas nukopijuotas</string>
     <string name="autofillManagementPasswordCopied">Slaptažodis nukopijuotas</string>
@@ -112,5 +112,25 @@
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogTitle">Jei išeisite dabar, jūsų „Duck Address“ nebus išsaugotas</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogPositiveButton">Tęsti sąranką</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogNegativeButton">Išeiti iš sąrankos</string>
+
+    <string name="autofillManagementScreenTitle">Slaptažodžiai</string>
+    <string name="credentialManagementNoLoginsSavedTitle">Dar nėra išsaugotų slaptažodžių</string>
+    <string name="credentialManagementAutofillToggleLabel">Išsaugokite ir automatiškai užpildykite slaptažodžius</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Slaptažodžiai saugiai saugomi jūsų įrenginyje.</string>
+    <string name="saveLoginDialogSubtitle">Slaptažodžiai saugiai saugomi jūsų įrenginyje.</string>
+    <string name="autofillManagementAddLogin">Pridėti slaptažodį</string>
+    <string name="credentialManagementEditLoginTitleHint">Pavadinimas</string>
+    <string name="autofillDeleteLoginDialogTitle">Ar tikrai norite ištrinti šį slaptažodį?</string>
+    <string name="autofillManagementDeletedConfirmation">Slaptažodis ištrintas</string>
+    <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Paskutinį kartą atnaujinta %1$s</string>
+    <string name="autofillDisableAutofillPromptTitle">Ar norite toliau saugoti slaptažodžius?</string>
+    <string name="deviceNotSupportedSubtitle">Kad saugiai laikytume slaptažodžius, turime juos užšifruoti ir išsaugoti jūsų įrenginyje. Kadangi jūsų įrenginys nepalaiko šifruoto saugojimo, slaptažodžių išsaugojimas ir automatinis užpildymas negalimas.</string>
+    <string name="autofill_password_generation_offer_message">Slaptažodžiai saugiai saugomi jūsų įrenginyje.</string>
+    <string name="autofillManagementSearchLogins">Ieškoti slaptažodžių</string>
+    <string name="biometric_prompt_title">Slaptažodžiai užrakinti</string>
+    <string name="autofill_auth_text_for_access">Atrakinkite įrenginį, kad galėtumėte pasiekti slaptažodžius</string>
+    <string name="managementDisabledModeTitle">Apsaugokite savo įrenginį, kad išsaugotumėte slaptažodžius</string>
+    <string name="managementDisabledModeSubtitle">Slaptažodžiams apsaugoti reikia naudoti įrenginio užrakinimo šabloną, PIN kodą arba biometrinius duomenis.</string>
+    <string name="credentialManagementEditTitle">Redaguoti slaptažodį</string>
 
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-lv/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-lv/strings-autofill-impl.xml
@@ -17,7 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-
     <string name="managementDisabledModeCta"><b>Iestati sadaļā Iestatījumi</b></string>
 
     <string name="saveLoginDialogButtonSave">Saglabāt paroli</string>
@@ -62,6 +61,7 @@
 
     <string name="autofillDeleteLoginDialogCancel">Atcelt</string>
     <string name="autofillDeleteLoginDialogDelete">Dzēst</string>
+
 
     <string name="autofillManagementUsernameCopied">Lietotājvārds nokopēts</string>
     <string name="autofillManagementPasswordCopied">Parole nokopēta</string>
@@ -112,5 +112,25 @@
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogTitle">Ja tagad iziesi, tava Duck adrese netiks saglabāta</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogPositiveButton">Turpināt iestatīšanu</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogNegativeButton">Iziet no iestatīšanas</string>
+
+    <string name="autofillManagementScreenTitle">Paroles</string>
+    <string name="credentialManagementNoLoginsSavedTitle">Vēl nav saglabāta neviena parole</string>
+    <string name="credentialManagementAutofillToggleLabel">Saglabāt un automātiski aizpildīt paroles</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Paroles tiek droši glabātas tavā ierīcē.</string>
+    <string name="saveLoginDialogSubtitle">Paroles tiek droši glabātas tavā ierīcē.</string>
+    <string name="autofillManagementAddLogin">Pievienot paroli</string>
+    <string name="credentialManagementEditLoginTitleHint">Nosaukums</string>
+    <string name="autofillDeleteLoginDialogTitle">Vai tiešām vēlies dzēst šo paroli?</string>
+    <string name="autofillManagementDeletedConfirmation">Parole dzēsta</string>
+    <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Pēdējoreiz atjaunināts %1$s</string>
+    <string name="autofillDisableAutofillPromptTitle">Vai vēlaties turpināt saglabāt paroles?</string>
+    <string name="deviceNotSupportedSubtitle">Lai droši glabātu pieteikšanās datus, mums tie ir jāšifrē un jāsaglabā tavā ierīcē. Tā kā tava ierīce neatbalsta šifrētu datu glabāšanu, paroļu saglabāšana un automātiskā aizpildīšana nav pieejama.</string>
+    <string name="autofill_password_generation_offer_message">Paroles tiek droši glabātas tavā ierīcē.</string>
+    <string name="autofillManagementSearchLogins">Meklēt paroles</string>
+    <string name="biometric_prompt_title">Paroles ir bloķētas</string>
+    <string name="autofill_auth_text_for_access">Atbloķē ierīci, lai piekļūtu parolēm</string>
+    <string name="managementDisabledModeTitle">Aizsargā savu ierīci, lai saglabātu paroles</string>
+    <string name="managementDisabledModeSubtitle">Lai aizsargātu tavus pieteikšanās datus, ir nepieciešama ierīces bloķēšanas figūra, PIN kods vai biometriskā aizsardzība.</string>
+    <string name="credentialManagementEditTitle">Paroles rediģēšana</string>
 
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-nb/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-nb/strings-autofill-impl.xml
@@ -17,7 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-
     <string name="managementDisabledModeCta"><b>Konfigurer i Innstillinger</b></string>
 
     <string name="saveLoginDialogButtonSave">Lagre passordet</string>
@@ -62,6 +61,7 @@
 
     <string name="autofillDeleteLoginDialogCancel">Avbryt</string>
     <string name="autofillDeleteLoginDialogDelete">Slett</string>
+
 
     <string name="autofillManagementUsernameCopied">Brukernavnet er kopiert</string>
     <string name="autofillManagementPasswordCopied">Passordet er kopiert</string>
@@ -112,5 +112,25 @@
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogTitle">Hvis du avslutter nå, blir ikke din Duck Address lagret</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogPositiveButton">Fortsett oppsett</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogNegativeButton">Avslutt oppsett</string>
+
+    <string name="autofillManagementScreenTitle">Passord</string>
+    <string name="credentialManagementNoLoginsSavedTitle">Ingen passord er lagret ennå</string>
+    <string name="credentialManagementAutofillToggleLabel">Lagre og fyll ut passord automatisk</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Passord lagres på enheten din på en sikker måte.</string>
+    <string name="saveLoginDialogSubtitle">Passord lagres på enheten din på en sikker måte.</string>
+    <string name="autofillManagementAddLogin">Legg til passord</string>
+    <string name="credentialManagementEditLoginTitleHint">Tittel</string>
+    <string name="autofillDeleteLoginDialogTitle">Er du sikker på at du vil slette dette passordet?</string>
+    <string name="autofillManagementDeletedConfirmation">Passordet er slettet</string>
+    <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Sist oppdatert %1$s</string>
+    <string name="autofillDisableAutofillPromptTitle">Vil du fortsette å lagre passord?</string>
+    <string name="deviceNotSupportedSubtitle">For å kunne lagre passord på en sikker måte må vi kryptere dem og lagre dem på enheten din. Siden enheten din ikke støtter kryptert lagring, er det ikke mulig å lagre og fylle ut passord automatisk.</string>
+    <string name="autofill_password_generation_offer_message">Passord lagres på enheten din på en sikker måte.</string>
+    <string name="autofillManagementSearchLogins">Søk i passord</string>
+    <string name="biometric_prompt_title">Passordene er låst</string>
+    <string name="autofill_auth_text_for_access">Lås opp enheten for å få tilgang til passord</string>
+    <string name="managementDisabledModeTitle">Sikre enheten din for å lagre passord</string>
+    <string name="managementDisabledModeSubtitle">Det kreves et låsemønster, en PIN-kode eller biometri for å beskytte passordene dine.</string>
+    <string name="credentialManagementEditTitle">Rediger passordet</string>
 
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-nl/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-nl/strings-autofill-impl.xml
@@ -17,7 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-
     <string name="managementDisabledModeCta"><b>Instellen in Instellingen</b></string>
 
     <string name="saveLoginDialogButtonSave">Wachtwoord opslaan</string>
@@ -62,6 +61,7 @@
 
     <string name="autofillDeleteLoginDialogCancel">Annuleren</string>
     <string name="autofillDeleteLoginDialogDelete">Verwijderen</string>
+
 
     <string name="autofillManagementUsernameCopied">Gebruikersnaam gekopieerd</string>
     <string name="autofillManagementPasswordCopied">Wachtwoord gekopieerd</string>
@@ -112,5 +112,25 @@
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogTitle">Als je nu afsluit, wordt je Duck Address niet opgeslagen</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogPositiveButton">Doorgaan met instellen</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogNegativeButton">Instellen beëindigen</string>
+
+    <string name="autofillManagementScreenTitle">Wachtwoorden</string>
+    <string name="credentialManagementNoLoginsSavedTitle">Nog geen wachtwoorden opgeslagen</string>
+    <string name="credentialManagementAutofillToggleLabel">Wachtwoorden opslaan en automatisch invullen</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Wachtwoorden worden veilig opgeslagen op je apparaat.</string>
+    <string name="saveLoginDialogSubtitle">Wachtwoorden worden veilig opgeslagen op je apparaat.</string>
+    <string name="autofillManagementAddLogin">Wachtwoord toevoegen</string>
+    <string name="credentialManagementEditLoginTitleHint">Titel</string>
+    <string name="autofillDeleteLoginDialogTitle">Weet je zeker dat je dit wachtwoord wilt verwijderen?</string>
+    <string name="autofillManagementDeletedConfirmation">Wachtwoord verwijderd</string>
+    <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Laatst bijgewerkt op %1$s</string>
+    <string name="autofillDisableAutofillPromptTitle">Wil je wachtwoorden blijven opslaan?</string>
+    <string name="deviceNotSupportedSubtitle">Om wachtwoorden veilig op te slaan, moeten we ze versleutelen en opslaan op je apparaat. Omdat je apparaat geen versleutelde opslag ondersteunt, kunnen wachtwoorden niet worden opgeslagen en automatisch worden aangevuld.</string>
+    <string name="autofill_password_generation_offer_message">Wachtwoorden worden veilig opgeslagen op je apparaat.</string>
+    <string name="autofillManagementSearchLogins">Wachtwoorden zoeken</string>
+    <string name="biometric_prompt_title">Wachtwoorden vergrendeld</string>
+    <string name="autofill_auth_text_for_access">Ontgrendel het apparaat om toegang te krijgen tot wachtwoorden</string>
+    <string name="managementDisabledModeTitle">Beveilig je apparaat om wachtwoorden op te slaan</string>
+    <string name="managementDisabledModeSubtitle">Je hebt een vergrendelingspatroon, pincode of biometrische gegevens nodig om je aanmeldgegevens te beschermen.</string>
+    <string name="credentialManagementEditTitle">Wachtwoord bewerken</string>
 
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-pl/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-pl/strings-autofill-impl.xml
@@ -17,7 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-
     <string name="managementDisabledModeCta"><b>Dostosuj ustawienia</b></string>
 
     <string name="saveLoginDialogButtonSave">Zapisz hasło</string>
@@ -62,6 +61,7 @@
 
     <string name="autofillDeleteLoginDialogCancel">Anuluj</string>
     <string name="autofillDeleteLoginDialogDelete">Usuń</string>
+
 
     <string name="autofillManagementUsernameCopied">Skopiowano nazwę użytkownika</string>
     <string name="autofillManagementPasswordCopied">Skopiowano hasło</string>
@@ -112,5 +112,25 @@
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogTitle">Jeśli teraz wyjdziesz, Twój Duck Address nie zostanie zapisany</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogPositiveButton">Kontynuuj konfigurację</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogNegativeButton">Wyjdź z konfiguracji</string>
+
+    <string name="autofillManagementScreenTitle">Hasła</string>
+    <string name="credentialManagementNoLoginsSavedTitle">Nie zapisano jeszcze żadnych haseł</string>
+    <string name="credentialManagementAutofillToggleLabel">Zapisuj i automatycznie uzupełniaj hasła</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Hasła są bezpiecznie przechowywane na Twoim urządzeniu.</string>
+    <string name="saveLoginDialogSubtitle">Hasła są bezpiecznie przechowywane na Twoim urządzeniu.</string>
+    <string name="autofillManagementAddLogin">Dodaj hasło</string>
+    <string name="credentialManagementEditLoginTitleHint">Tytuł</string>
+    <string name="autofillDeleteLoginDialogTitle">Czy na pewno chcesz usunąć to hasło?</string>
+    <string name="autofillManagementDeletedConfirmation">Hasło usunięte</string>
+    <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Ostatnia aktualizacja %1$s</string>
+    <string name="autofillDisableAutofillPromptTitle">Czy chcesz nadal zapisywać hasła?</string>
+    <string name="deviceNotSupportedSubtitle">Aby bezpiecznie przechowywać hasła, musimy je zaszyfrować i zapisać na Twoim urządzeniu. Ponieważ Twoje urządzenie nie obsługuje szyfrowanego przechowywania, zapisywanie i automatyczne wypełnianie haseł jest niedostępne.</string>
+    <string name="autofill_password_generation_offer_message">Hasła są bezpiecznie przechowywane na Twoim urządzeniu.</string>
+    <string name="autofillManagementSearchLogins">Wyszukaj hasła</string>
+    <string name="biometric_prompt_title">Zablokowane hasła</string>
+    <string name="autofill_auth_text_for_access">Odblokuj urządzenie, aby uzyskać dostęp do haseł</string>
+    <string name="managementDisabledModeTitle">Zabezpiecz urządzenie, aby zapisywać hasła</string>
+    <string name="managementDisabledModeSubtitle">Aby chronić hasła, korzystaj z blokady urządzenia za pomocą wzoru, kodu PIN lub danych biometrycznych.</string>
+    <string name="credentialManagementEditTitle">Edytuj hasło</string>
 
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-pt/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-pt/strings-autofill-impl.xml
@@ -17,7 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-
     <string name="managementDisabledModeCta"><b>Configura nas Definições</b></string>
 
     <string name="saveLoginDialogButtonSave">Guardar palavra-passe</string>
@@ -62,6 +61,7 @@
 
     <string name="autofillDeleteLoginDialogCancel">Cancelar</string>
     <string name="autofillDeleteLoginDialogDelete">Eliminar</string>
+
 
     <string name="autofillManagementUsernameCopied">Nome de utilizador copiado</string>
     <string name="autofillManagementPasswordCopied">Palavra-passe copiada</string>
@@ -112,5 +112,25 @@
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogTitle">Se saíres agora, o teu Duck Address não será guardado</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogPositiveButton">Continuar configuração</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogNegativeButton">Sair da instalação</string>
+
+    <string name="autofillManagementScreenTitle">Palavras-passe</string>
+    <string name="credentialManagementNoLoginsSavedTitle">Ainda não há palavras-passe guardadas</string>
+    <string name="credentialManagementAutofillToggleLabel">Guardar e preencher palavras-passe automaticamente</string>
+    <string name="credentialManagementAutofillToggleSubtitle">As palavras-passe são armazenadas com segurança no teu dispositivo.</string>
+    <string name="saveLoginDialogSubtitle">As palavras-passe são armazenadas com segurança no teu dispositivo.</string>
+    <string name="autofillManagementAddLogin">Adicionar palavra-passe</string>
+    <string name="credentialManagementEditLoginTitleHint">Título</string>
+    <string name="autofillDeleteLoginDialogTitle">Tens a certeza de que pretendes eliminar esta palavra-passe?</string>
+    <string name="autofillManagementDeletedConfirmation">Palavra-passe eliminada</string>
+    <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Última atualização a %1$s</string>
+    <string name="autofillDisableAutofillPromptTitle">Pretendes continuar a guardar palavras-passe?</string>
+    <string name="deviceNotSupportedSubtitle">Para armazenar palavras-passe com segurança, é necessário encriptar e armazená-las no teu dispositivo. Uma vez que o teu dispositivo não suporta armazenamento encriptado, as opções de guardar e preencher automaticamente palavras-passe estão indisponíveis.</string>
+    <string name="autofill_password_generation_offer_message">As palavras-passe são armazenadas com segurança no teu dispositivo.</string>
+    <string name="autofillManagementSearchLogins">Pesquisar palavras-passe</string>
+    <string name="biometric_prompt_title">Palavras-passe bloqueadas</string>
+    <string name="autofill_auth_text_for_access">Desbloquear dispositivo para aceder às palavras-passe</string>
+    <string name="managementDisabledModeTitle">Proteger o dispositivo para guardar palavras-passe</string>
+    <string name="managementDisabledModeSubtitle">É necessário um padrão de bloqueio de dispositivo, PIN ou biometria para proteger as tuas palavras-passe.</string>
+    <string name="credentialManagementEditTitle">Editar palavra-passe</string>
 
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-ro/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-ro/strings-autofill-impl.xml
@@ -17,7 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-
     <string name="managementDisabledModeCta"><b>Configurează în Setări</b></string>
 
     <string name="saveLoginDialogButtonSave">Salvează parola</string>
@@ -62,6 +61,7 @@
 
     <string name="autofillDeleteLoginDialogCancel">Anulare</string>
     <string name="autofillDeleteLoginDialogDelete">Ștergere</string>
+
 
     <string name="autofillManagementUsernameCopied">Numele de utilizator a fost copiat</string>
     <string name="autofillManagementPasswordCopied">Parolă copiată</string>
@@ -112,5 +112,25 @@
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogTitle">Dacă ieșiți acum, Duck Address nu va fi salvată</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogPositiveButton">Continuă configurarea</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogNegativeButton">Ieși din configurare</string>
+
+    <string name="autofillManagementScreenTitle">Parole</string>
+    <string name="credentialManagementNoLoginsSavedTitle">Nici o parolă nu a fost salvată încă</string>
+    <string name="credentialManagementAutofillToggleLabel">Salvează și completează automat parolele</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Parolele sunt stocate în siguranță pe dispozitivul tău.</string>
+    <string name="saveLoginDialogSubtitle">Parolele sunt stocate în siguranță pe dispozitivul tău.</string>
+    <string name="autofillManagementAddLogin">Adaugă parola</string>
+    <string name="credentialManagementEditLoginTitleHint">Titlu</string>
+    <string name="autofillDeleteLoginDialogTitle">Sigur dorești să ștergi această parolă?</string>
+    <string name="autofillManagementDeletedConfirmation">Parolă ștearsă</string>
+    <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Ultima actualizare %1$s</string>
+    <string name="autofillDisableAutofillPromptTitle">Dorești să continui să salvezi parolele?</string>
+    <string name="deviceNotSupportedSubtitle">Pentru a stoca parolele în siguranță, trebuie să le criptăm și să le stocăm pe dispozitivul tău. Deoarece dispozitivul tău nu acceptă stocarea criptată, salvarea și completarea automată a parolelor nu este disponibilă.</string>
+    <string name="autofill_password_generation_offer_message">Parolele sunt stocate în siguranță pe dispozitivul tău.</string>
+    <string name="autofillManagementSearchLogins">Caută parole</string>
+    <string name="biometric_prompt_title">Parole blocate</string>
+    <string name="autofill_auth_text_for_access">Deblochează dispozitivul pentru a accesa parolele</string>
+    <string name="managementDisabledModeTitle">Securizează-ți dispozitivul pentru a salva parolele</string>
+    <string name="managementDisabledModeSubtitle">Este necesar un model de blocare a dispozitivului, un cod PIN sau date biometrice pentru a-ți proteja parolele.</string>
+    <string name="credentialManagementEditTitle">Editează parola</string>
 
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-ru/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-ru/strings-autofill-impl.xml
@@ -17,7 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-
     <string name="managementDisabledModeCta"><b>Откройте «Настройки»</b></string>
 
     <string name="saveLoginDialogButtonSave">Сохранить пароль</string>
@@ -62,6 +61,7 @@
 
     <string name="autofillDeleteLoginDialogCancel">Отменить</string>
     <string name="autofillDeleteLoginDialogDelete">Удалить</string>
+
 
     <string name="autofillManagementUsernameCopied">Имя пользователя скопировано</string>
     <string name="autofillManagementPasswordCopied">Пароль скопирован</string>
@@ -112,5 +112,25 @@
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogTitle">Если вы прервете настройку, ваш адрес Duck Address не сохранится</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogPositiveButton">Продолжить настройку</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogNegativeButton">Выйти из настройки</string>
+
+    <string name="autofillManagementScreenTitle">Пароли</string>
+    <string name="credentialManagementNoLoginsSavedTitle">Сохраненных паролей пока нет</string>
+    <string name="credentialManagementAutofillToggleLabel">Хранение и автозаполнение паролей</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Пароли надежно хранятся на вашем устройстве.</string>
+    <string name="saveLoginDialogSubtitle">Пароли надежно защищены и хранятся на вашем устройстве.</string>
+    <string name="autofillManagementAddLogin">Добавление пароля</string>
+    <string name="credentialManagementEditLoginTitleHint">Название</string>
+    <string name="autofillDeleteLoginDialogTitle">Вы точно хотите удалить этот пароль?</string>
+    <string name="autofillManagementDeletedConfirmation">Пароль удален</string>
+    <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Последнее обновление: %1$s</string>
+    <string name="autofillDisableAutofillPromptTitle">Продолжить сохранять пароли?</string>
+    <string name="deviceNotSupportedSubtitle">Чтобы надежно защитить пароли, нам нужно зашифровать и сохранить их на вашем устройстве. Однако оно не поддерживает хранение зашифрованной информации, и поэтому функция сохранения и автозаполнения паролей недоступна.</string>
+    <string name="autofill_password_generation_offer_message">Пароли надежно защищены и хранятся на вашем устройстве.</string>
+    <string name="autofillManagementSearchLogins">Найти пароль</string>
+    <string name="biometric_prompt_title">Пароли заблокированы</string>
+    <string name="autofill_auth_text_for_access">Разблокируйте устройство, чтобы получить доступ к паролям</string>
+    <string name="managementDisabledModeTitle">Защита устройства и паролей</string>
+    <string name="managementDisabledModeSubtitle">Для защиты паролей требуются биометрические данные, графический ключ или ПИН-код.</string>
+    <string name="credentialManagementEditTitle">Редактирование пароля</string>
 
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-sk/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-sk/strings-autofill-impl.xml
@@ -17,7 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-
     <string name="managementDisabledModeCta"><b>Nastaviť v Nastaveniach</b></string>
 
     <string name="saveLoginDialogButtonSave">Uložiť heslo</string>
@@ -62,6 +61,7 @@
 
     <string name="autofillDeleteLoginDialogCancel">Zrušiť</string>
     <string name="autofillDeleteLoginDialogDelete">Odstrániť</string>
+
 
     <string name="autofillManagementUsernameCopied">Meno používateľa bolo skopírované</string>
     <string name="autofillManagementPasswordCopied">Heslo bolo skopírované</string>
@@ -112,5 +112,25 @@
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogTitle">Ak teraz skončíte, vaša adresa Duck sa neuloží.</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogPositiveButton">Pokračovať v nastavovaní</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogNegativeButton">Odísť z nastavení</string>
+
+    <string name="autofillManagementScreenTitle">Heslá</string>
+    <string name="credentialManagementNoLoginsSavedTitle">Zatiaľ nie sú uložené žiadne heslá</string>
+    <string name="credentialManagementAutofillToggleLabel">Ukladať a automaticky dopĺňať heslá</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Heslá sú bezpečne uložené vo vašom zariadení.</string>
+    <string name="saveLoginDialogSubtitle">Heslá sú zabezpečeným spôsobom uložené vo vašom zariadení.</string>
+    <string name="autofillManagementAddLogin">Pridať heslo</string>
+    <string name="credentialManagementEditLoginTitleHint">Názov</string>
+    <string name="autofillDeleteLoginDialogTitle">Naozaj chcete odstrániť toto heslo?</string>
+    <string name="autofillManagementDeletedConfirmation">Heslo bolo odstránené</string>
+    <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Naposledy aktualizované %1$s</string>
+    <string name="autofillDisableAutofillPromptTitle">Chcete pokračovať v ukladaní hesiel?</string>
+    <string name="deviceNotSupportedSubtitle">Na uloženie hesiel zabezpečeným spôsobom ich musíme zašifrovať a uložiť vo vašom zariadení. Keďže vaše zariadenie nepodporuje šifrované ukladanie, ukladanie a automatické vypĺňanie hesiel nie je dostupné.</string>
+    <string name="autofill_password_generation_offer_message">Heslá sú zabezpečeným spôsobom uložené vo vašom zariadení.</string>
+    <string name="autofillManagementSearchLogins">Vyhľadávanie hesiel</string>
+    <string name="biometric_prompt_title">Uzamknuté heslá</string>
+    <string name="autofill_auth_text_for_access">Ak chcete získať prístup k heslám, odomknite zariadenie</string>
+    <string name="managementDisabledModeTitle">Zabezpečte svoje zariadenie na uloženie hesiel</string>
+    <string name="managementDisabledModeSubtitle">Na ochranu vašich prihlasovacích údajov sa vyžaduje vzor uzamknutia zariadenia, kód PIN alebo biometrické údaje.</string>
+    <string name="credentialManagementEditTitle">Upraviť heslo</string>
 
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-sl/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-sl/strings-autofill-impl.xml
@@ -17,7 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-
     <string name="managementDisabledModeCta"><b>Nastavitev v nastavitvah</b></string>
 
     <string name="saveLoginDialogButtonSave">Shrani geslo</string>
@@ -62,6 +61,7 @@
 
     <string name="autofillDeleteLoginDialogCancel">Prekliči</string>
     <string name="autofillDeleteLoginDialogDelete">Izbriši</string>
+
 
     <string name="autofillManagementUsernameCopied">Uporabniško ime je bilo kopirano</string>
     <string name="autofillManagementPasswordCopied">Geslo je bilo kopirano</string>
@@ -112,5 +112,25 @@
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogTitle">Če zaprete zdaj, vaš naslov Duck Address ne bo shranjen</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogPositiveButton">Nadaljujte nastavitev</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogNegativeButton">Izhod iz nastavitev</string>
+
+    <string name="autofillManagementScreenTitle">Gesla</string>
+    <string name="credentialManagementNoLoginsSavedTitle">Nobeno geslo še ni shranjeno</string>
+    <string name="credentialManagementAutofillToggleLabel">Shranite in samodejno izpolnite gesla</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Gesla so varno shranjena v vaši napravi.</string>
+    <string name="saveLoginDialogSubtitle">Gesla so varno shranjena v vaši napravi.</string>
+    <string name="autofillManagementAddLogin">Dodajte geslo</string>
+    <string name="credentialManagementEditLoginTitleHint">Naslov</string>
+    <string name="autofillDeleteLoginDialogTitle">Ali ste prepričani, da želite izbrisati to geslo?</string>
+    <string name="autofillManagementDeletedConfirmation">Geslo je izbrisano</string>
+    <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Nazadnje posodobljeno dne %1$s</string>
+    <string name="autofillDisableAutofillPromptTitle">Ali želite še naprej shranjevati gesla?</string>
+    <string name="deviceNotSupportedSubtitle">Za varno shranjevanje gesel jih moramo šifrirati in shraniti v vaši napravi. Ker vaša naprava ne podpira šifriranega shranjevanja, shranjevanje in samodejno izpolnjevanje gesel nista na voljo.</string>
+    <string name="autofill_password_generation_offer_message">Gesla so varno shranjena v vaši napravi.</string>
+    <string name="autofillManagementSearchLogins">Iskanje gesel</string>
+    <string name="biometric_prompt_title">Gesla so zaklenjena</string>
+    <string name="autofill_auth_text_for_access">Če želite dostopati do gesel, odklenite napravo</string>
+    <string name="managementDisabledModeTitle">Zaščitite svojo napravo, da shranite gesla</string>
+    <string name="managementDisabledModeSubtitle">Za zaščito gesel je potreben vzorec za zaklepanje naprave, koda PIN ali biometrični podatki.</string>
+    <string name="credentialManagementEditTitle">Uredite geslo</string>
 
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-sv/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-sv/strings-autofill-impl.xml
@@ -17,7 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-
     <string name="managementDisabledModeCta"><b>Konfigurera i Inställningar</b></string>
 
     <string name="saveLoginDialogButtonSave">Spara lösenord</string>
@@ -62,6 +61,7 @@
 
     <string name="autofillDeleteLoginDialogCancel">Avbryt</string>
     <string name="autofillDeleteLoginDialogDelete">Ta bort</string>
+
 
     <string name="autofillManagementUsernameCopied">Användarnamn kopierat</string>
     <string name="autofillManagementPasswordCopied">Lösenord kopierat</string>
@@ -112,5 +112,25 @@
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogTitle">Om du avslutar nu kommer din Duck Address inte att sparas</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogPositiveButton">Fortsätt inställningen</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogNegativeButton">Avsluta inställningen</string>
+
+    <string name="autofillManagementScreenTitle">Lösenord</string>
+    <string name="credentialManagementNoLoginsSavedTitle">Inga lösenord sparade ännu</string>
+    <string name="credentialManagementAutofillToggleLabel">Spara och fyll i lösenord automatiskt</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Lösenord lagras säkert på din enhet.</string>
+    <string name="saveLoginDialogSubtitle">Lösenord lagras säkert på din enhet.</string>
+    <string name="autofillManagementAddLogin">Lägg till lösenord</string>
+    <string name="credentialManagementEditLoginTitleHint">Rubrik</string>
+    <string name="autofillDeleteLoginDialogTitle">Är du säker på att du vill radera detta lösenord?</string>
+    <string name="autofillManagementDeletedConfirmation">Lösenordet har raderats</string>
+    <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Uppdaterades senast %1$s</string>
+    <string name="autofillDisableAutofillPromptTitle">Vill du fortsätta spara lösenord?</string>
+    <string name="deviceNotSupportedSubtitle">Vi måste kryptera och spara dina lösenord för att lagra dem säkert på din enhet. Eftersom din enhet inte stöder krypterad lagring går det inte att spara eller automatiskt fylla i lösenord.</string>
+    <string name="autofill_password_generation_offer_message">Lösenord lagras säkert på din enhet.</string>
+    <string name="autofillManagementSearchLogins">Sök lösenord</string>
+    <string name="biometric_prompt_title">Lösenord låsta</string>
+    <string name="autofill_auth_text_for_access">Lås upp enheten för att komma åt lösenord</string>
+    <string name="managementDisabledModeTitle">Säkra din enhet för att spara lösenord</string>
+    <string name="managementDisabledModeSubtitle">För att skydda dina lösenord krävs ett enhetslåsmönster, en PIN-kod eller biometri.</string>
+    <string name="credentialManagementEditTitle">Redigera lösenord</string>
 
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-tr/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-tr/strings-autofill-impl.xml
@@ -17,7 +17,6 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-
     <string name="managementDisabledModeCta"><b>Ayarlarda Ayarlama</b></string>
 
     <string name="saveLoginDialogButtonSave">Şifreyi Kaydet</string>
@@ -62,6 +61,7 @@
 
     <string name="autofillDeleteLoginDialogCancel">Vazgeç</string>
     <string name="autofillDeleteLoginDialogDelete">Sil</string>
+
 
     <string name="autofillManagementUsernameCopied">Kullanıcı adı kopyalandı</string>
     <string name="autofillManagementPasswordCopied">Şifre kopyalandı</string>
@@ -112,5 +112,25 @@
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogTitle">Şimdi çıkış yaparsanız Duck Address kaydedilmez.</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogPositiveButton">Kuruluma Devam Et</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogNegativeButton">Kurulumdan Çık</string>
+
+    <string name="autofillManagementScreenTitle">Şifreler</string>
+    <string name="credentialManagementNoLoginsSavedTitle">Henüz şifre kaydedilmedi</string>
+    <string name="credentialManagementAutofillToggleLabel">Şifreleri kaydedin ve otomatik doldurun</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Şifreler cihazınızda güvenli bir şekilde saklanır.</string>
+    <string name="saveLoginDialogSubtitle">Şifreler cihazınızda güvenli bir şekilde saklanır.</string>
+    <string name="autofillManagementAddLogin">Şifre Ekle</string>
+    <string name="credentialManagementEditLoginTitleHint">Title</string>
+    <string name="autofillDeleteLoginDialogTitle">Bu şifreyi silmek istediğinizden emin misiniz?</string>
+    <string name="autofillManagementDeletedConfirmation">Şifre silindi</string>
+    <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Son güncelleme %1$s</string>
+    <string name="autofillDisableAutofillPromptTitle">Şifreleri kaydetmeye devam etmek istiyor musunuz?</string>
+    <string name="deviceNotSupportedSubtitle">Şifreleri güvenli bir şekilde saklamak için bunları şifrelememiz ve cihazınızda depolamamız gerekir. Cihazınız şifreli depolamayı desteklemediğinden, şifreleri kaydetmek ve otomatik doldurmak mümkün değildir.</string>
+    <string name="autofill_password_generation_offer_message">Şifreler cihazınızda güvenli bir şekilde saklanır.</string>
+    <string name="autofillManagementSearchLogins">Şifreleri ara</string>
+    <string name="biometric_prompt_title">Şifreler Kilitli</string>
+    <string name="autofill_auth_text_for_access">Şifrelere erişmek için cihazın kilidini açın</string>
+    <string name="managementDisabledModeTitle">Şifreleri kaydetmek için cihazınızın güvenliğini sağlayın</string>
+    <string name="managementDisabledModeSubtitle">Şifrelerinizin güvenliğini sağlamak için bir cihaz kilidi deseni, PIN veya biyometrik veri gereklidir.</string>
+    <string name="credentialManagementEditTitle">Şifreyi Düzenle</string>
 
 </resources>

--- a/autofill/autofill-impl/src/main/res/values/donottranslate.xml
+++ b/autofill/autofill-impl/src/main/res/values/donottranslate.xml
@@ -18,24 +18,4 @@
     <string name="credentials_limit_warning"><b>Sync Paused</b>\nLogins limit exceeded. Delete some to resume syncing.\n\n<annotation type="manage_logins">Manage Logins</annotation></string>
     <string name="credentials_limit_warning_notif"><b>Passwords Sync is Paused</b>\nYou have exceeded the passwords sync limit. Try deleting some passwords. Until this is resolved your passwords will not be backed up.</string>
 
-    <string name="autofillManagementScreenTitle">Passwords</string>
-    <string name="credentialManagementNoLoginsSavedTitle">No passwords saved yet</string>
-    <string name="credentialManagementAutofillToggleLabel">Save and autofill passwords</string>
-    <string name="credentialManagementAutofillToggleSubtitle">Passwords are stored securely on your device.</string>
-    <string name="saveLoginDialogSubtitle">Passwords are stored securely on your device.</string>
-    <string name="autofillManagementAddLogin">Add Password</string>
-    <string name="credentialManagementEditLoginTitleHint">Title</string>
-    <string name="autofillDeleteLoginDialogTitle">Are you sure you want to delete this password?</string>
-    <string name="autofillManagementDeletedConfirmation">Password deleted</string>
-    <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Last updated %1$s</string>
-    <string name="autofillDisableAutofillPromptTitle">Do you want to keep saving passwords?</string>
-    <string name="deviceNotSupportedSubtitle">To store passwords securely, we need to encrypt and store them on your device. Because your device does not support encrypted storage, saving and autofilling passwords is unavailable.</string>
-    <string name="autofill_password_generation_offer_message">Passwords are stored securely on your device.</string>
-    <string name="autofillManagementSearchLogins">Search passwords</string>
-    <string name="biometric_prompt_title">Passwords Locked</string>
-    <string name="autofill_auth_text_for_access">Unlock device to access passwords</string>
-    <string name="managementDisabledModeTitle">Secure your device to save passwords</string>
-    <string name="managementDisabledModeSubtitle">A device lock pattern, PIN, or biometrics is required to protect your passwords.</string>
-    <string name="credentialManagementEditTitle">Edit Password</string>
-
 </resources>

--- a/autofill/autofill-impl/src/main/res/values/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values/strings-autofill-impl.xml
@@ -113,4 +113,24 @@
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogPositiveButton">Continue Setup</string>
     <string name="autofillEmailProtectionInContextSignUpConfirmExitDialogNegativeButton">Exit Setup</string>
 
+    <string name="autofillManagementScreenTitle">Passwords</string>
+    <string name="credentialManagementNoLoginsSavedTitle">No passwords saved yet</string>
+    <string name="credentialManagementAutofillToggleLabel">Save and autofill passwords</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Passwords are stored securely on your device.</string>
+    <string name="saveLoginDialogSubtitle">Passwords are stored securely on your device.</string>
+    <string name="autofillManagementAddLogin">Add Password</string>
+    <string name="credentialManagementEditLoginTitleHint">Title</string>
+    <string name="autofillDeleteLoginDialogTitle">Are you sure you want to delete this password?</string>
+    <string name="autofillManagementDeletedConfirmation">Password deleted</string>
+    <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Last updated %1$s</string>
+    <string name="autofillDisableAutofillPromptTitle">Do you want to keep saving passwords?</string>
+    <string name="deviceNotSupportedSubtitle">To store passwords securely, we need to encrypt and store them on your device. Because your device does not support encrypted storage, saving and autofilling passwords is unavailable.</string>
+    <string name="autofill_password_generation_offer_message">Passwords are stored securely on your device.</string>
+    <string name="autofillManagementSearchLogins">Search passwords</string>
+    <string name="biometric_prompt_title">Passwords Locked</string>
+    <string name="autofill_auth_text_for_access">Unlock device to access passwords</string>
+    <string name="managementDisabledModeTitle">Secure your device to save passwords</string>
+    <string name="managementDisabledModeSubtitle">A device lock pattern, PIN, or biometrics is required to protect your passwords.</string>
+    <string name="credentialManagementEditTitle">Edit Password</string>
+
 </resources>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1206179833327111/f 

### Description
Translations for the updated autofill copy, preferring `passwords` over `logins` for general terminology.

### Steps to test this PR
QA optional.

- [x] CI should pass
