### PR TITLE
Add additional configChanges to stop Activities being destroyed when bluetooth keyboard (dis)connects

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -229,7 +229,7 @@
 
         <activity
             android:name=".BrowserActivity"
-            android:configChanges="keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout"
+            android:configChanges="keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|navigation|keyboard"
             android:exported="true"
             android:label="@string/appDescription"
             android:launchMode="singleTask"
@@ -324,7 +324,7 @@
             android:parentActivityName=".BrowserActivity" />
         <activity
             android:name="com.duckduckgo.app.survey.ui.SurveyActivity"
-            android:configChanges="keyboardHidden|orientation|screenSize"
+            android:configChanges="keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|navigation|keyboard"
             android:exported="false"
             android:label="@string/surveyActivityTitle"
             android:parentActivityName=".BrowserActivity"

--- a/autofill/autofill-impl/src/main/AndroidManifest.xml
+++ b/autofill/autofill-impl/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <application>
         <activity
             android:name=".email.incontext.EmailProtectionInContextSignupActivity"
-            android:configChanges="keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout"
+            android:configChanges="keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|navigation|keyboard"
             android:exported="false" />
         <activity
             android:name=".ui.credential.management.AutofillManagementActivity"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/414730916066338/1206189169008466/f 

### Description
The default side-effect of a config change is for activities to be destroyed and re-created. However, this is a jarring UX for the browser so there are a number of config changes we exclude from this process, which prevents the Activities from being destroyed.

When a bluetooth keyboard connects/disconnects, that might trigger `keyboard|navigation` config changes. At the moment, that means the current page tab is destroyed and recreated / reloaded when the keyboard (dis)connects.

This PR excludes those events from trigger activity death, like we do for many other config changes.

### Steps to test this PR

- QA optional

If you do have a bluetooth keyboard to hand, you can load up a page in the browser and connect or disconnet the keyboard; ensure the page doesn't reload.