### PR TITLE
Update autofill enabled toggle's subtitle to remove trailing period

### DIFF
--- a/autofill/autofill-impl/src/main/res/values-bg/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-bg/strings-autofill-impl.xml
@@ -116,7 +116,7 @@
     <string name="autofillManagementScreenTitle">Пароли</string>
     <string name="credentialManagementNoLoginsSavedTitle">Все още няма запазени пароли</string>
     <string name="credentialManagementAutofillToggleLabel">Запазване и автоматично попълване на паролите</string>
-    <string name="credentialManagementAutofillToggleSubtitle">Паролите се съхраняват сигурно на Вашето устройство.</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Паролите се съхраняват сигурно на Вашето устройство</string>
     <string name="saveLoginDialogSubtitle">Паролите се съхраняват сигурно на Вашето устройство.</string>
     <string name="autofillManagementAddLogin">Добавяне на парола</string>
     <string name="credentialManagementEditLoginTitleHint">Заглавие</string>

--- a/autofill/autofill-impl/src/main/res/values-cs/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-cs/strings-autofill-impl.xml
@@ -116,7 +116,7 @@
     <string name="autofillManagementScreenTitle">Hesla</string>
     <string name="credentialManagementNoLoginsSavedTitle">Zatím nemáš uložená žádná hesla</string>
     <string name="credentialManagementAutofillToggleLabel">Ukládání a automatické vyplňování hesel</string>
-    <string name="credentialManagementAutofillToggleSubtitle">Hesla se bezpečně ukládají do tvého zařízení.</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Hesla se bezpečně ukládají do tvého zařízení</string>
     <string name="saveLoginDialogSubtitle">Hesla se bezpečně ukládají do tvého zařízení.</string>
     <string name="autofillManagementAddLogin">Přidat heslo</string>
     <string name="credentialManagementEditLoginTitleHint">Název</string>

--- a/autofill/autofill-impl/src/main/res/values-da/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-da/strings-autofill-impl.xml
@@ -116,7 +116,7 @@
     <string name="autofillManagementScreenTitle">Adgangskoder</string>
     <string name="credentialManagementNoLoginsSavedTitle">Ingen adgangskoder gemt endnu</string>
     <string name="credentialManagementAutofillToggleLabel">Gem og udfyld adgangskoder automatisk</string>
-    <string name="credentialManagementAutofillToggleSubtitle">Adgangskoder gemmes sikkert på din enhed.</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Adgangskoder gemmes sikkert på din enhed</string>
     <string name="saveLoginDialogSubtitle">Adgangskoder gemmes sikkert på din enhed.</string>
     <string name="autofillManagementAddLogin">Tilføj adgangskode</string>
     <string name="credentialManagementEditLoginTitleHint">Titel</string>

--- a/autofill/autofill-impl/src/main/res/values-de/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-de/strings-autofill-impl.xml
@@ -116,7 +116,7 @@
     <string name="autofillManagementScreenTitle">Passwörter</string>
     <string name="credentialManagementNoLoginsSavedTitle">Noch keine Passwörter gespeichert</string>
     <string name="credentialManagementAutofillToggleLabel">Passwörter speichern und automatisch ausfüllen</string>
-    <string name="credentialManagementAutofillToggleSubtitle">Passwörter werden sicher auf deinem Gerät gespeichert.</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Passwörter werden sicher auf deinem Gerät gespeichert</string>
     <string name="saveLoginDialogSubtitle">Passwörter werden sicher auf deinem Gerät gespeichert.</string>
     <string name="autofillManagementAddLogin">Passwort hinzufügen</string>
     <string name="credentialManagementEditLoginTitleHint">Titel</string>

--- a/autofill/autofill-impl/src/main/res/values-el/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-el/strings-autofill-impl.xml
@@ -116,7 +116,7 @@
     <string name="autofillManagementScreenTitle">Κωδικοί πρόσβασης</string>
     <string name="credentialManagementNoLoginsSavedTitle">Δεν έχουν αποθηκευτεί ακόμα κωδικοί πρόσβασης</string>
     <string name="credentialManagementAutofillToggleLabel">Αποθήκευση και αυτόματη συμπλήρωση κωδικών πρόσβασης</string>
-    <string name="credentialManagementAutofillToggleSubtitle">Οι κωδικοί πρόσβασης αποθηκεύονται με ασφάλεια στη συσκευή σας.</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Οι κωδικοί πρόσβασης αποθηκεύονται με ασφάλεια στη συσκευή σας</string>
     <string name="saveLoginDialogSubtitle">Οι κωδικοί πρόσβασης αποθηκεύονται με ασφάλεια στη συσκευή σας.</string>
     <string name="autofillManagementAddLogin">Προσθήκη κωδικού πρόσβασης</string>
     <string name="credentialManagementEditLoginTitleHint">Τίτλος</string>

--- a/autofill/autofill-impl/src/main/res/values-es/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-es/strings-autofill-impl.xml
@@ -116,7 +116,7 @@
     <string name="autofillManagementScreenTitle">Contraseñas</string>
     <string name="credentialManagementNoLoginsSavedTitle">Aún no hay contraseñas guardadas</string>
     <string name="credentialManagementAutofillToggleLabel">Guardar y autocompletar contraseñas</string>
-    <string name="credentialManagementAutofillToggleSubtitle">Las contraseñas se almacenan de forma segura en tu dispositivo.</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Las contraseñas se almacenan de forma segura en tu dispositivo</string>
     <string name="saveLoginDialogSubtitle">Las contraseñas se almacenan de forma segura en tu dispositivo.</string>
     <string name="autofillManagementAddLogin">Añadir contraseña</string>
     <string name="credentialManagementEditLoginTitleHint">Título</string>

--- a/autofill/autofill-impl/src/main/res/values-et/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-et/strings-autofill-impl.xml
@@ -116,7 +116,7 @@
     <string name="autofillManagementScreenTitle">Paroolid</string>
     <string name="credentialManagementNoLoginsSavedTitle">Paroole ei ole veel salvestatud</string>
     <string name="credentialManagementAutofillToggleLabel">Paroolide salvestamine ja automaatne sisestamine</string>
-    <string name="credentialManagementAutofillToggleSubtitle">Paroolid salvestatakse turvaliselt sinu seadmesse.</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Paroole hoitakse turvaliselt sinu seadmes</string>
     <string name="saveLoginDialogSubtitle">Paroolid salvestatakse turvaliselt sinu seadmesse.</string>
     <string name="autofillManagementAddLogin">Parooli lisamine</string>
     <string name="credentialManagementEditLoginTitleHint">Pealkiri</string>

--- a/autofill/autofill-impl/src/main/res/values-fi/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-fi/strings-autofill-impl.xml
@@ -116,7 +116,7 @@
     <string name="autofillManagementScreenTitle">Salasanat</string>
     <string name="credentialManagementNoLoginsSavedTitle">Salasanoja ei ole vielä tallennettu</string>
     <string name="credentialManagementAutofillToggleLabel">Tallenna ja täytä salasanat automaattisesti</string>
-    <string name="credentialManagementAutofillToggleSubtitle">Salasanat tallennetaan laitteellesi turvallisesti.</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Salasanat tallennetaan laitteellesi turvallisesti</string>
     <string name="saveLoginDialogSubtitle">Salasanat tallennetaan laitteellesi turvallisesti.</string>
     <string name="autofillManagementAddLogin">Lisää salasana</string>
     <string name="credentialManagementEditLoginTitleHint">Otsikko</string>

--- a/autofill/autofill-impl/src/main/res/values-fr/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-fr/strings-autofill-impl.xml
@@ -116,7 +116,7 @@
     <string name="autofillManagementScreenTitle">Mots de passe</string>
     <string name="credentialManagementNoLoginsSavedTitle">Aucun mot de passe n\'a été enregistré</string>
     <string name="credentialManagementAutofillToggleLabel">Enregistrer et saisir automatiquement les mots de passe</string>
-    <string name="credentialManagementAutofillToggleSubtitle">Les mots de passe sont stockés en toute sécurité sur votre appareil.</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Les mots de passe sont stockés en toute sécurité sur votre appareil</string>
     <string name="saveLoginDialogSubtitle">Les mots de passe sont stockés en toute sécurité sur votre appareil.</string>
     <string name="autofillManagementAddLogin">Ajouter un mot de passe</string>
     <string name="credentialManagementEditLoginTitleHint">Titre</string>

--- a/autofill/autofill-impl/src/main/res/values-hr/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-hr/strings-autofill-impl.xml
@@ -116,7 +116,7 @@
     <string name="autofillManagementScreenTitle">Lozinke</string>
     <string name="credentialManagementNoLoginsSavedTitle">Još nema spremljenih lozinki</string>
     <string name="credentialManagementAutofillToggleLabel">Spremi i automatski popuni lozinke</string>
-    <string name="credentialManagementAutofillToggleSubtitle">Lozinke su sigurno pohranjene na tvom uređaju.</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Lozinke su sigurno pohranjene na tvom uređaju</string>
     <string name="saveLoginDialogSubtitle">Lozinke su sigurno pohranjene na tvom uređaju.</string>
     <string name="autofillManagementAddLogin">Dodaj lozinku</string>
     <string name="credentialManagementEditLoginTitleHint">Naslov</string>

--- a/autofill/autofill-impl/src/main/res/values-hu/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-hu/strings-autofill-impl.xml
@@ -116,7 +116,7 @@
     <string name="autofillManagementScreenTitle">Jelszavak</string>
     <string name="credentialManagementNoLoginsSavedTitle">Még nincsenek mentett jelszavak</string>
     <string name="credentialManagementAutofillToggleLabel">Jelszavak mentése és automatikus kitöltése</string>
-    <string name="credentialManagementAutofillToggleSubtitle">A jelszavakat az eszközöd biztonságosan tárolja.</string>
+    <string name="credentialManagementAutofillToggleSubtitle">A jelszavakat az eszközöd biztonságosan tárolja</string>
     <string name="saveLoginDialogSubtitle">A jelszavakat az eszközöd biztonságosan tárolja.</string>
     <string name="autofillManagementAddLogin">Jelszó hozzáadása</string>
     <string name="credentialManagementEditLoginTitleHint">Cím</string>

--- a/autofill/autofill-impl/src/main/res/values-it/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-it/strings-autofill-impl.xml
@@ -116,7 +116,7 @@
     <string name="autofillManagementScreenTitle">Password</string>
     <string name="credentialManagementNoLoginsSavedTitle">Nessuna password ancora salvata</string>
     <string name="credentialManagementAutofillToggleLabel">Salva e compila automaticamente le password</string>
-    <string name="credentialManagementAutofillToggleSubtitle">Le password sono archiviate in modo sicuro sul tuo dispositivo.</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Le password sono archiviate in modo sicuro sul tuo dispositivo</string>
     <string name="saveLoginDialogSubtitle">Le password sono archiviate in modo sicuro sul tuo dispositivo.</string>
     <string name="autofillManagementAddLogin">Aggiungi password</string>
     <string name="credentialManagementEditLoginTitleHint">Titolo</string>

--- a/autofill/autofill-impl/src/main/res/values-lt/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-lt/strings-autofill-impl.xml
@@ -116,7 +116,7 @@
     <string name="autofillManagementScreenTitle">Slaptažodžiai</string>
     <string name="credentialManagementNoLoginsSavedTitle">Dar nėra išsaugotų slaptažodžių</string>
     <string name="credentialManagementAutofillToggleLabel">Išsaugokite ir automatiškai užpildykite slaptažodžius</string>
-    <string name="credentialManagementAutofillToggleSubtitle">Slaptažodžiai saugiai saugomi jūsų įrenginyje.</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Slaptažodžiai saugiai saugomi jūsų įrenginyje</string>
     <string name="saveLoginDialogSubtitle">Slaptažodžiai saugiai saugomi jūsų įrenginyje.</string>
     <string name="autofillManagementAddLogin">Pridėti slaptažodį</string>
     <string name="credentialManagementEditLoginTitleHint">Pavadinimas</string>

--- a/autofill/autofill-impl/src/main/res/values-lv/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-lv/strings-autofill-impl.xml
@@ -116,7 +116,7 @@
     <string name="autofillManagementScreenTitle">Paroles</string>
     <string name="credentialManagementNoLoginsSavedTitle">Vēl nav saglabāta neviena parole</string>
     <string name="credentialManagementAutofillToggleLabel">Saglabāt un automātiski aizpildīt paroles</string>
-    <string name="credentialManagementAutofillToggleSubtitle">Paroles tiek droši glabātas tavā ierīcē.</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Paroles tiek droši glabātas tavā ierīcē</string>
     <string name="saveLoginDialogSubtitle">Paroles tiek droši glabātas tavā ierīcē.</string>
     <string name="autofillManagementAddLogin">Pievienot paroli</string>
     <string name="credentialManagementEditLoginTitleHint">Nosaukums</string>

--- a/autofill/autofill-impl/src/main/res/values-nb/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-nb/strings-autofill-impl.xml
@@ -116,7 +116,7 @@
     <string name="autofillManagementScreenTitle">Passord</string>
     <string name="credentialManagementNoLoginsSavedTitle">Ingen passord er lagret ennå</string>
     <string name="credentialManagementAutofillToggleLabel">Lagre og fyll ut passord automatisk</string>
-    <string name="credentialManagementAutofillToggleSubtitle">Passord lagres på enheten din på en sikker måte.</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Passord lagres på enheten din på en sikker måte</string>
     <string name="saveLoginDialogSubtitle">Passord lagres på enheten din på en sikker måte.</string>
     <string name="autofillManagementAddLogin">Legg til passord</string>
     <string name="credentialManagementEditLoginTitleHint">Tittel</string>

--- a/autofill/autofill-impl/src/main/res/values-nl/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-nl/strings-autofill-impl.xml
@@ -116,7 +116,7 @@
     <string name="autofillManagementScreenTitle">Wachtwoorden</string>
     <string name="credentialManagementNoLoginsSavedTitle">Nog geen wachtwoorden opgeslagen</string>
     <string name="credentialManagementAutofillToggleLabel">Wachtwoorden opslaan en automatisch invullen</string>
-    <string name="credentialManagementAutofillToggleSubtitle">Wachtwoorden worden veilig opgeslagen op je apparaat.</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Wachtwoorden worden veilig opgeslagen op je apparaat</string>
     <string name="saveLoginDialogSubtitle">Wachtwoorden worden veilig opgeslagen op je apparaat.</string>
     <string name="autofillManagementAddLogin">Wachtwoord toevoegen</string>
     <string name="credentialManagementEditLoginTitleHint">Titel</string>

--- a/autofill/autofill-impl/src/main/res/values-pl/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-pl/strings-autofill-impl.xml
@@ -116,7 +116,7 @@
     <string name="autofillManagementScreenTitle">Hasła</string>
     <string name="credentialManagementNoLoginsSavedTitle">Nie zapisano jeszcze żadnych haseł</string>
     <string name="credentialManagementAutofillToggleLabel">Zapisuj i automatycznie uzupełniaj hasła</string>
-    <string name="credentialManagementAutofillToggleSubtitle">Hasła są bezpiecznie przechowywane na Twoim urządzeniu.</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Hasła są bezpiecznie przechowywane na Twoim urządzeniu</string>
     <string name="saveLoginDialogSubtitle">Hasła są bezpiecznie przechowywane na Twoim urządzeniu.</string>
     <string name="autofillManagementAddLogin">Dodaj hasło</string>
     <string name="credentialManagementEditLoginTitleHint">Tytuł</string>

--- a/autofill/autofill-impl/src/main/res/values-pt/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-pt/strings-autofill-impl.xml
@@ -116,7 +116,7 @@
     <string name="autofillManagementScreenTitle">Palavras-passe</string>
     <string name="credentialManagementNoLoginsSavedTitle">Ainda não há palavras-passe guardadas</string>
     <string name="credentialManagementAutofillToggleLabel">Guardar e preencher palavras-passe automaticamente</string>
-    <string name="credentialManagementAutofillToggleSubtitle">As palavras-passe são armazenadas com segurança no teu dispositivo.</string>
+    <string name="credentialManagementAutofillToggleSubtitle">As palavras-passe são armazenadas com segurança no teu dispositivo</string>
     <string name="saveLoginDialogSubtitle">As palavras-passe são armazenadas com segurança no teu dispositivo.</string>
     <string name="autofillManagementAddLogin">Adicionar palavra-passe</string>
     <string name="credentialManagementEditLoginTitleHint">Título</string>

--- a/autofill/autofill-impl/src/main/res/values-ro/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-ro/strings-autofill-impl.xml
@@ -116,7 +116,7 @@
     <string name="autofillManagementScreenTitle">Parole</string>
     <string name="credentialManagementNoLoginsSavedTitle">Nici o parolă nu a fost salvată încă</string>
     <string name="credentialManagementAutofillToggleLabel">Salvează și completează automat parolele</string>
-    <string name="credentialManagementAutofillToggleSubtitle">Parolele sunt stocate în siguranță pe dispozitivul tău.</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Parolele sunt stocate în siguranță pe dispozitivul tău</string>
     <string name="saveLoginDialogSubtitle">Parolele sunt stocate în siguranță pe dispozitivul tău.</string>
     <string name="autofillManagementAddLogin">Adaugă parola</string>
     <string name="credentialManagementEditLoginTitleHint">Titlu</string>

--- a/autofill/autofill-impl/src/main/res/values-ru/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-ru/strings-autofill-impl.xml
@@ -116,7 +116,7 @@
     <string name="autofillManagementScreenTitle">Пароли</string>
     <string name="credentialManagementNoLoginsSavedTitle">Сохраненных паролей пока нет</string>
     <string name="credentialManagementAutofillToggleLabel">Хранение и автозаполнение паролей</string>
-    <string name="credentialManagementAutofillToggleSubtitle">Пароли надежно хранятся на вашем устройстве.</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Пароли надежно защищены и хранятся на вашем устройстве</string>
     <string name="saveLoginDialogSubtitle">Пароли надежно защищены и хранятся на вашем устройстве.</string>
     <string name="autofillManagementAddLogin">Добавление пароля</string>
     <string name="credentialManagementEditLoginTitleHint">Название</string>

--- a/autofill/autofill-impl/src/main/res/values-sk/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-sk/strings-autofill-impl.xml
@@ -116,7 +116,7 @@
     <string name="autofillManagementScreenTitle">Heslá</string>
     <string name="credentialManagementNoLoginsSavedTitle">Zatiaľ nie sú uložené žiadne heslá</string>
     <string name="credentialManagementAutofillToggleLabel">Ukladať a automaticky dopĺňať heslá</string>
-    <string name="credentialManagementAutofillToggleSubtitle">Heslá sú bezpečne uložené vo vašom zariadení.</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Heslá sú zabezpečeným spôsobom uložené vo vašom zariadení</string>
     <string name="saveLoginDialogSubtitle">Heslá sú zabezpečeným spôsobom uložené vo vašom zariadení.</string>
     <string name="autofillManagementAddLogin">Pridať heslo</string>
     <string name="credentialManagementEditLoginTitleHint">Názov</string>

--- a/autofill/autofill-impl/src/main/res/values-sl/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-sl/strings-autofill-impl.xml
@@ -116,7 +116,7 @@
     <string name="autofillManagementScreenTitle">Gesla</string>
     <string name="credentialManagementNoLoginsSavedTitle">Nobeno geslo še ni shranjeno</string>
     <string name="credentialManagementAutofillToggleLabel">Shranite in samodejno izpolnite gesla</string>
-    <string name="credentialManagementAutofillToggleSubtitle">Gesla so varno shranjena v vaši napravi.</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Gesla so varno shranjena v vaši napravi</string>
     <string name="saveLoginDialogSubtitle">Gesla so varno shranjena v vaši napravi.</string>
     <string name="autofillManagementAddLogin">Dodajte geslo</string>
     <string name="credentialManagementEditLoginTitleHint">Naslov</string>

--- a/autofill/autofill-impl/src/main/res/values-sv/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-sv/strings-autofill-impl.xml
@@ -116,7 +116,7 @@
     <string name="autofillManagementScreenTitle">Lösenord</string>
     <string name="credentialManagementNoLoginsSavedTitle">Inga lösenord sparade ännu</string>
     <string name="credentialManagementAutofillToggleLabel">Spara och fyll i lösenord automatiskt</string>
-    <string name="credentialManagementAutofillToggleSubtitle">Lösenord lagras säkert på din enhet.</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Lösenord lagras säkert på din enhet</string>
     <string name="saveLoginDialogSubtitle">Lösenord lagras säkert på din enhet.</string>
     <string name="autofillManagementAddLogin">Lägg till lösenord</string>
     <string name="credentialManagementEditLoginTitleHint">Rubrik</string>

--- a/autofill/autofill-impl/src/main/res/values-tr/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-tr/strings-autofill-impl.xml
@@ -116,7 +116,7 @@
     <string name="autofillManagementScreenTitle">Şifreler</string>
     <string name="credentialManagementNoLoginsSavedTitle">Henüz şifre kaydedilmedi</string>
     <string name="credentialManagementAutofillToggleLabel">Şifreleri kaydedin ve otomatik doldurun</string>
-    <string name="credentialManagementAutofillToggleSubtitle">Şifreler cihazınızda güvenli bir şekilde saklanır.</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Şifreler cihazınızda güvenli bir şekilde saklanır</string>
     <string name="saveLoginDialogSubtitle">Şifreler cihazınızda güvenli bir şekilde saklanır.</string>
     <string name="autofillManagementAddLogin">Şifre Ekle</string>
     <string name="credentialManagementEditLoginTitleHint">Title</string>

--- a/autofill/autofill-impl/src/main/res/values/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values/strings-autofill-impl.xml
@@ -116,7 +116,7 @@
     <string name="autofillManagementScreenTitle">Passwords</string>
     <string name="credentialManagementNoLoginsSavedTitle">No passwords saved yet</string>
     <string name="credentialManagementAutofillToggleLabel">Save and autofill passwords</string>
-    <string name="credentialManagementAutofillToggleSubtitle">Passwords are stored securely on your device.</string>
+    <string name="credentialManagementAutofillToggleSubtitle">Passwords are stored securely on your device</string>
     <string name="saveLoginDialogSubtitle">Passwords are stored securely on your device.</string>
     <string name="autofillManagementAddLogin">Add Password</string>
     <string name="credentialManagementEditLoginTitleHint">Title</string>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1206199606526279/f 

### Description
Removes a trailing `.` from an autofill string in password management screen.