### PR TITLE
Android version filter for experiments

### DIFF
--- a/experiments/experiments-api/src/main/java/com/duckduckgo/experiments/api/VariantConfig.kt
+++ b/experiments/experiments-api/src/main/java/com/duckduckgo/experiments/api/VariantConfig.kt
@@ -19,7 +19,7 @@ package com.duckduckgo.experiments.api
 data class VariantConfig(
     val variantKey: String,
     val weight: Double? = 0.0,
-    val filters: VariantFilters = VariantFilters(),
+    val filters: VariantFilters? = null,
 )
 
 data class VariantFilters(

--- a/experiments/experiments-api/src/main/java/com/duckduckgo/experiments/api/VariantConfig.kt
+++ b/experiments/experiments-api/src/main/java/com/duckduckgo/experiments/api/VariantConfig.kt
@@ -24,4 +24,5 @@ data class VariantConfig(
 
 data class VariantFilters(
     val locale: List<String>? = null,
+    val androidVersion: List<String>? = null,
 )

--- a/experiments/experiments-api/src/main/java/com/duckduckgo/experiments/api/VariantConfig.kt
+++ b/experiments/experiments-api/src/main/java/com/duckduckgo/experiments/api/VariantConfig.kt
@@ -19,10 +19,10 @@ package com.duckduckgo.experiments.api
 data class VariantConfig(
     val variantKey: String,
     val weight: Double? = 0.0,
-    val filters: VariantFilters? = null,
+    val filters: VariantFilters = VariantFilters(),
 )
 
 data class VariantFilters(
-    val locale: List<String>? = null,
-    val androidVersion: List<String>? = null,
+    val locale: List<String> = emptyList(),
+    val androidVersion: List<String> = emptyList(),
 )

--- a/experiments/experiments-impl/build.gradle
+++ b/experiments/experiments-impl/build.gradle
@@ -52,7 +52,7 @@ dependencies {
 
     implementation Square.retrofit2.converter.moshi
 
-    testImplementation (KotlinX.coroutines.test) {
+    testImplementation(KotlinX.coroutines.test) {
         // https://github.com/Kotlin/kotlinx.coroutines/issues/2023
         // conflicts with mockito due to direct inclusion of byte buddy
         exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
@@ -84,6 +84,16 @@ android {
             includeAndroidResources = true
         }
     }
-  namespace 'com.duckduckgo.experiments.impl'
+    defaultConfig {
+        javaCompileOptions {
+            annotationProcessorOptions {
+                arguments = ["room.schemaLocation": "$projectDir/schemas".toString()]
+            }
+        }
+    }
+    sourceSets {
+        test.assets.srcDirs += files("$projectDir/schemas".toString())
+    }
+    namespace 'com.duckduckgo.experiments.impl'
 }
 

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/ExperimentFiltersManager.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/ExperimentFiltersManager.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.experiments.impl
+
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.experiments.impl.store.ExperimentVariantEntity
+import com.squareup.anvil.annotations.ContributesBinding
+import java.util.Locale
+import javax.inject.Inject
+
+interface ExperimentFiltersManager {
+    fun addFilters(entity: ExperimentVariantEntity): (AppBuildConfig) -> Boolean
+}
+
+@ContributesBinding(AppScope::class)
+class ExperimentFiltersManagerImpl @Inject constructor(
+    private val appBuildConfig: AppBuildConfig,
+) : ExperimentFiltersManager {
+    override fun addFilters(entity: ExperimentVariantEntity): (AppBuildConfig) -> Boolean {
+        if (entity.key == "sc" || entity.key == "se") {
+            return { isSerpRegionToggleCountry() }
+        }
+
+        var matchesLocaleFilter = true
+        var matchesAndroidVersionFilter = true
+
+        if (entity.localeFilter.isNotEmpty()) {
+            val userLocale = Locale.getDefault()
+            matchesLocaleFilter = entity.localeFilter.contains(userLocale.toString())
+        }
+        if (entity.androidVersionFilter.isNotEmpty()) {
+            val userAndroidVersion = appBuildConfig.sdkInt.toString()
+            matchesAndroidVersionFilter = entity.androidVersionFilter.contains(userAndroidVersion)
+        }
+
+        return { matchesLocaleFilter && matchesAndroidVersionFilter }
+    }
+
+    private val serpRegionToggleTargetCountries = listOf(
+        "AU",
+        "AT",
+        "DK",
+        "FI",
+        "FR",
+        "DE",
+        "IT",
+        "IE",
+        "NZ",
+        "NO",
+        "ES",
+        "SE",
+        "GB",
+    )
+
+    private fun isSerpRegionToggleCountry(): Boolean {
+        val locale = Locale.getDefault()
+        return serpRegionToggleTargetCountries.contains(locale.country)
+    }
+}

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/ExperimentVariantRepository.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/ExperimentVariantRepository.kt
@@ -48,6 +48,7 @@ class ExperimentVariantRepositoryImpl @Inject constructor(
                     key = it.variantKey,
                     weight = it.weight,
                     localeFilter = it.filters?.locale.orEmpty(),
+                    androidVersionFilter = it.filters?.androidVersion.orEmpty(),
                 ),
             )
         }

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/ExperimentVariantRepository.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/ExperimentVariantRepository.kt
@@ -47,8 +47,8 @@ class ExperimentVariantRepositoryImpl @Inject constructor(
                 ExperimentVariantEntity(
                     key = it.variantKey,
                     weight = it.weight,
-                    localeFilter = it.filters.locale,
-                    androidVersionFilter = it.filters.androidVersion,
+                    localeFilter = it.filters?.locale.orEmpty(),
+                    androidVersionFilter = it.filters?.androidVersion.orEmpty(),
                 ),
             )
         }

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/ExperimentVariantRepository.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/ExperimentVariantRepository.kt
@@ -47,8 +47,8 @@ class ExperimentVariantRepositoryImpl @Inject constructor(
                 ExperimentVariantEntity(
                     key = it.variantKey,
                     weight = it.weight,
-                    localeFilter = it.filters?.locale.orEmpty(),
-                    androidVersionFilter = it.filters?.androidVersion.orEmpty(),
+                    localeFilter = it.filters.locale,
+                    androidVersionFilter = it.filters.androidVersion,
                 ),
             )
         }

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/VariantManagerImpl.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/VariantManagerImpl.kt
@@ -107,18 +107,14 @@ class VariantManagerImpl @Inject constructor(
 
         var matchesLocaleFilter = true
         var matchesAndroidVersionLocale = true
-        when {
-            entity.localeFilter.isNotEmpty() -> {
-                val userLocale = Locale.getDefault()
-                matchesLocaleFilter = entity.localeFilter.contains(userLocale.toString())
-            }
-            entity.androidVersionFilter.isNotEmpty() -> {
-                val userAndroidVersion = appBuildConfig.sdkInt.toString()
-                matchesAndroidVersionLocale = entity.androidVersionFilter.contains(userAndroidVersion)
-            }
-            else -> {
-                return { noFilter() }
-            }
+
+        if (entity.localeFilter.isNotEmpty()) {
+            val userLocale = Locale.getDefault()
+            matchesLocaleFilter = entity.localeFilter.contains(userLocale.toString())
+        }
+        if (entity.androidVersionFilter.isNotEmpty()) {
+            val userAndroidVersion = appBuildConfig.sdkInt.toString()
+            matchesAndroidVersionLocale = entity.androidVersionFilter.contains(userAndroidVersion)
         }
 
         return { matchesLocaleFilter && matchesAndroidVersionLocale }

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/VariantManagerImpl.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/VariantManagerImpl.kt
@@ -104,12 +104,24 @@ class VariantManagerImpl @Inject constructor(
         if (entity.key == "sc" || entity.key == "se") {
             return { isSerpRegionToggleCountry() }
         }
-        if (entity.localeFilter.isEmpty()) {
-            return { noFilter() }
+
+        var matchesLocaleFilter = true
+        var matchesAndroidVersionLocale = true
+        when {
+            entity.localeFilter.isNotEmpty() -> {
+                val userLocale = Locale.getDefault()
+                matchesLocaleFilter = entity.localeFilter.contains(userLocale.toString())
+            }
+            entity.androidVersionFilter.isNotEmpty() -> {
+                val userAndroidVersion = appBuildConfig.sdkInt.toString()
+                matchesAndroidVersionLocale = entity.androidVersionFilter.contains(userAndroidVersion)
+            }
+            else -> {
+                return { noFilter() }
+            }
         }
 
-        val userLocale = Locale.getDefault()
-        return { entity.localeFilter.contains(userLocale.toString()) }
+        return { matchesLocaleFilter && matchesAndroidVersionLocale }
     }
 
     private fun matchesReferrerVariant(key: String): Boolean {

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/VariantManagerImpl.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/VariantManagerImpl.kt
@@ -23,7 +23,6 @@ import com.duckduckgo.experiments.api.VariantConfig
 import com.duckduckgo.experiments.api.VariantManager
 import com.duckduckgo.experiments.impl.store.ExperimentVariantEntity
 import com.squareup.anvil.annotations.ContributesBinding
-import java.util.Locale
 import javax.inject.Inject
 import timber.log.Timber
 
@@ -33,6 +32,7 @@ class VariantManagerImpl @Inject constructor(
     private val indexRandomizer: IndexRandomizer,
     private val appBuildConfig: AppBuildConfig,
     private val experimentVariantRepository: ExperimentVariantRepository,
+    private val experimentFiltersManager: ExperimentFiltersManager,
 ) : VariantManager {
 
     override fun defaultVariantKey(): String {
@@ -93,31 +93,11 @@ class VariantManagerImpl @Inject constructor(
                 Variant(
                     key = entity.key,
                     weight = entity.weight ?: 0.0,
-                    filterBy = addFilters(entity),
+                    filterBy = experimentFiltersManager.addFilters(entity),
                 ),
             )
         }
         return activeVariants
-    }
-
-    private fun addFilters(entity: ExperimentVariantEntity): (AppBuildConfig) -> Boolean {
-        if (entity.key == "sc" || entity.key == "se") {
-            return { isSerpRegionToggleCountry() }
-        }
-
-        var matchesLocaleFilter = true
-        var matchesAndroidVersionLocale = true
-
-        if (entity.localeFilter.isNotEmpty()) {
-            val userLocale = Locale.getDefault()
-            matchesLocaleFilter = entity.localeFilter.contains(userLocale.toString())
-        }
-        if (entity.androidVersionFilter.isNotEmpty()) {
-            val userAndroidVersion = appBuildConfig.sdkInt.toString()
-            matchesAndroidVersionLocale = entity.androidVersionFilter.contains(userAndroidVersion)
-        }
-
-        return { matchesLocaleFilter && matchesAndroidVersionLocale }
     }
 
     private fun matchesReferrerVariant(key: String): Boolean {
@@ -155,27 +135,6 @@ class VariantManagerImpl @Inject constructor(
 
         private const val REINSTALL_VARIANT = "ru"
 
-        private val serpRegionToggleTargetCountries = listOf(
-            "AU",
-            "AT",
-            "DK",
-            "FI",
-            "FR",
-            "DE",
-            "IT",
-            "IE",
-            "NZ",
-            "NO",
-            "ES",
-            "SE",
-            "GB",
-        )
-
         private fun noFilter(): Boolean = true
-
-        private fun isSerpRegionToggleCountry(): Boolean {
-            val locale = Locale.getDefault()
-            return serpRegionToggleTargetCountries.contains(locale.country)
-        }
     }
 }

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/di/ExperimentsModule.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/di/ExperimentsModule.kt
@@ -19,9 +19,9 @@ package com.duckduckgo.experiments.impl.di
 import android.content.Context
 import androidx.room.Room
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.experiments.impl.store.ALL_MIGRATIONS
 import com.duckduckgo.experiments.impl.store.ExperimentVariantDao
 import com.duckduckgo.experiments.impl.store.ExperimentsDatabase
-import com.duckduckgo.experiments.impl.store.ExperimentsDatabase.Companion.ALL_MIGRATIONS
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
 import dagger.Provides
@@ -35,8 +35,8 @@ object ExperimentsModule {
     @SingleInstanceIn(AppScope::class)
     fun providesExperimentsDatabase(context: Context): ExperimentsDatabase {
         return Room.databaseBuilder(context, ExperimentsDatabase::class.java, "experiments.db")
-            .addMigrations(*ALL_MIGRATIONS)
             .fallbackToDestructiveMigration()
+            .addMigrations(*ALL_MIGRATIONS)
             .build()
     }
 

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/store/ExperimentsDatabase.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/store/ExperimentsDatabase.kt
@@ -20,10 +20,11 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     exportSchema = true,
-    version = 1,
+    version = 2,
     entities = [
         ExperimentVariantEntity::class,
     ],
@@ -35,8 +36,12 @@ import androidx.room.migration.Migration
 
 abstract class ExperimentsDatabase : RoomDatabase() {
     abstract fun experimentVariantsDao(): ExperimentVariantDao
+}
 
-    companion object {
-        val ALL_MIGRATIONS = emptyArray<Migration>()
+val MIGRATION_1_2 = object : Migration(1, 2) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE `experiment_variants` ADD COLUMN `androidVersionFilter` TEXT NOT NULL DEFAULT '[]'")
     }
 }
+
+val ALL_MIGRATIONS = arrayOf(MIGRATION_1_2)

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/store/VariantManagerEntity.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/store/VariantManagerEntity.kt
@@ -28,6 +28,7 @@ data class ExperimentVariantEntity(
     @PrimaryKey val key: String,
     val weight: Double?,
     val localeFilter: List<String> = emptyList(),
+    val androidVersionFilter: List<String> = emptyList(),
 )
 
 class StringListConverter {

--- a/experiments/experiments-impl/src/test/java/com/duckduckgo/experiments/impl/ExperimentFiltersManagerImplTest.kt
+++ b/experiments/experiments-impl/src/test/java/com/duckduckgo/experiments/impl/ExperimentFiltersManagerImplTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.experiments.impl
+
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.experiments.impl.store.ExperimentVariantEntity
+import java.util.Locale
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class ExperimentFiltersManagerImplTest {
+
+    private lateinit var testee: ExperimentFiltersManager
+
+    private val mockAppBuildConfig: AppBuildConfig = mock()
+
+    @Before
+    fun setup() {
+        testee = ExperimentFiltersManagerImpl(
+            mockAppBuildConfig,
+        )
+    }
+
+    @Test
+    fun whenVariantComplyWithLocaleFilterThenAddFiltersReturnsTrue() {
+        val locale = Locale("en", "US")
+        Locale.setDefault(locale)
+        val testEntity = addActiveVariant(localeFilter = listOf("en_US"))
+
+        assertTrue(testee.addFilters(testEntity).invoke(mockAppBuildConfig))
+    }
+
+    @Test
+    fun whenVariantDoesNotComplyWithLocaleFilterThenAddFiltersReturnsFalse() {
+        val locale = Locale("en", "US")
+        Locale.setDefault(locale)
+        val testEntity = addActiveVariant(localeFilter = listOf("de_DE"))
+
+        assertFalse(testee.addFilters(testEntity).invoke(mockAppBuildConfig))
+    }
+
+    @Test
+    fun whenVariantComplyWithAndroidVersionFilterThenAddFiltersReturnsTrue() {
+        whenever(mockAppBuildConfig.sdkInt).thenReturn(33)
+        val testEntity = addActiveVariant(androidVersionFilter = listOf("33", "34"))
+
+        assertTrue(testee.addFilters(testEntity).invoke(mockAppBuildConfig))
+    }
+
+    @Test
+    fun whenVariantDoesNotComplyWithAndroidVersionFilterThenAddFiltersReturnsFalse() {
+        whenever(mockAppBuildConfig.sdkInt).thenReturn(32)
+        val testEntity = addActiveVariant(androidVersionFilter = listOf("33", "34"))
+
+        assertFalse(testee.addFilters(testEntity).invoke(mockAppBuildConfig))
+    }
+
+    @Test
+    fun whenVariantComplyWithBothFiltersThenAddFiltersReturnsTrue() {
+        val locale = Locale("en", "US")
+        Locale.setDefault(locale)
+        whenever(mockAppBuildConfig.sdkInt).thenReturn(33)
+        val testEntity = addActiveVariant(localeFilter = listOf("en_US"), androidVersionFilter = listOf("33", "34"))
+
+        assertTrue(testee.addFilters(testEntity).invoke(mockAppBuildConfig))
+    }
+
+    @Test
+    fun whenVariantComplyWithLocaleFiltersAndDoesNotComplyWithAndroidVersionFilterThenAddFiltersReturnsFalse() {
+        val locale = Locale("en", "US")
+        Locale.setDefault(locale)
+        whenever(mockAppBuildConfig.sdkInt).thenReturn(32)
+        val testEntity = addActiveVariant(localeFilter = listOf("en_US"), androidVersionFilter = listOf("33", "34"))
+
+        assertFalse(testee.addFilters(testEntity).invoke(mockAppBuildConfig))
+    }
+
+    @Test
+    fun whenVariantComplyWithAndroidVersionFiltersAndDoesNotComplyWithLocaleFilterThenAddFiltersReturnsFalse() {
+        val locale = Locale("en", "US")
+        Locale.setDefault(locale)
+        whenever(mockAppBuildConfig.sdkInt).thenReturn(33)
+        val testEntity = addActiveVariant(localeFilter = listOf("de_DE"), androidVersionFilter = listOf("33", "34"))
+
+        assertFalse(testee.addFilters(testEntity).invoke(mockAppBuildConfig))
+    }
+
+    private fun addActiveVariant(
+        localeFilter: List<String> = listOf(),
+        androidVersionFilter: List<String> = listOf(),
+    ): ExperimentVariantEntity {
+        return ExperimentVariantEntity("key", 1.0, localeFilter, androidVersionFilter)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1206193424728741/f

### Description

### Steps to test this PR

- Change `const val PRIVACY_REMOTE_CONFIG_URL` to `https://www.jsonblob.com/api/1168612786158034944`
- There is a log in `VariantManagerImpl` _Line 136_ when a new variant allocation is made. This way, you can check if the variant has been allocated correctly

_Android version filter_
- Add the API version of your device you are testing with in the `filters` parameter.in the JSONBlob endpoint e.g.
<img width="545" alt="Screenshot 2023-12-21 at 11 57 51" src="https://github.com/duckduckgo/Android/assets/20798495/7399632e-e119-4499-9911-09fe89b888f9">

- Fresh install
- [x] Check the experimental variant is allocated correctly

_Android version filter doesn't match_
- Add a different API version from your device you are testing with in the `filters` parameter in the JSONBlob endpoint e.g.
<img width="545" alt="Screenshot 2023-12-21 at 11 57 51" src="https://github.com/duckduckgo/Android/assets/20798495/7399632e-e119-4499-9911-09fe89b888f9">

- Fresh install
- [x] Check the default variant is allocated

_No filters_
- Remove filters parameter or leave it empty
- Fresh install
- [x] Check the experimental variant is allocated correctly

_Filters combined 1_
- Add the API version of your device you are testing with in the `filters` parameter.in the JSONBlob endpoint e.g.
<img width="545" alt="Screenshot 2023-12-21 at 11 57 51" src="https://github.com/duckduckgo/Android/assets/20798495/7399632e-e119-4499-9911-09fe89b888f9">

- Add a different locale filter which doesn't match your testing device. _e.g._ `"locale": ["en_US"]`
- Fresh install
- [ ] Check the default variant is allocated

_Filters combined 2_
- Add the API version of your device you are testing with in the `filters` parameter.in the JSONBlob endpoint e.g.
<img width="545" alt="Screenshot 2023-12-21 at 11 57 51" src="https://github.com/duckduckgo/Android/assets/20798495/7399632e-e119-4499-9911-09fe89b888f9">

- Add the locale which matched your testing device.
- Fresh install
- [x] Check the experimental variant is allocated correctly

_Filters combined 3_
- Add a different API version from your device you are testing with in the `filters` parameter in the JSONBlob endpoint _e.g._
<img width="545" alt="Screenshot 2023-12-21 at 11 57 51" src="https://github.com/duckduckgo/Android/assets/20798495/7399632e-e119-4499-9911-09fe89b888f9">

- Add a different locale filter which doesn't match your testing device. _e.g._ `"locale": ["en_US"]`
- Fresh install
- [x] Check the default variant is allocated

---------------
Improved steps in this [comment](https://github.com/duckduckgo/Android/pull/4033#pullrequestreview-1829408345) by @marcosholgado 

### No UI changes
