### PR TITLE
Update downloadPath security test to match new test case result.

### DIFF
--- a/.maestro/security_tests/5_-_AddressBarSpoof,_downloadpath.yaml
+++ b/.maestro/security_tests/5_-_AddressBarSpoof,_downloadpath.yaml
@@ -30,4 +30,4 @@ tags:
 # Should redirect back to the last page.
 - copyTextFrom:
     id: "omnibarTextInput"
-- assertTrue: ${maestro.copiedText == "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-js-download-url.html"} 
+- assertTrue: ${maestro.copiedText.indexOf("https://staticcdn.duckduckgo.com") == -1} 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL:  https://app.asana.com/0/414730916066338/1206201528208884/f

### Description
The e2e tests were failing due to us relying on a third party site to perform a redirect for us. This was moved to privacy-test-pages in this commit: https://github.com/duckduckgo/privacy-test-pages/commit/f56ef132715362eba1a08449fa168f394aec216e. To accommodate for the new redirector, the test needs to be updated as well since the browser behaved slightly differently under the previous redirector.

### Steps to test this PR
maestro test

E2E test result: https://github.com/duckduckgo/Android/actions/runs/7286394253
