### PR TITLE
Experiment: Remove notifications prompt for Android 13+

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboarding/di/WelcomePageModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/di/WelcomePageModule.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import com.duckduckgo.app.global.DefaultRoleBrowserDialog
 import com.duckduckgo.app.global.RealDefaultRoleBrowserDialog
 import com.duckduckgo.app.global.install.AppInstallStore
+import com.duckduckgo.app.onboarding.ui.page.NotificationPermissionsFeatureToggles
 import com.duckduckgo.app.onboarding.ui.page.WelcomePageViewModelFactory
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
@@ -35,7 +36,8 @@ class WelcomePageModule {
         context: Context,
         pixel: Pixel,
         defaultRoleBrowserDialog: DefaultRoleBrowserDialog,
-    ) = WelcomePageViewModelFactory(appInstallStore, context, pixel, defaultRoleBrowserDialog)
+        notificationPermissionsFeatureToggles: NotificationPermissionsFeatureToggles,
+    ) = WelcomePageViewModelFactory(appInstallStore, context, pixel, defaultRoleBrowserDialog, notificationPermissionsFeatureToggles)
 
     @Provides
     fun defaultRoleBrowserDialog(

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/NotificationPermissionsFeatureToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/NotificationPermissionsFeatureToggles.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 DuckDuckGo
+ * Copyright (c) 2023 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,21 +16,20 @@
 
 package com.duckduckgo.app.onboarding.ui.page
 
-import android.content.Intent
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.Experiment
 
-object WelcomePageView {
-    sealed class Event {
-        object OnPrimaryCtaClicked : Event()
-        object OnDefaultBrowserSet : Event()
-        object OnDefaultBrowserNotSet : Event()
-        object OnNotificationPermissionsRequested : Event()
-    }
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "notificationPermissions",
+)
+interface NotificationPermissionsFeatureToggles {
+    @Toggle.DefaultValue(false)
+    fun self(): Toggle
 
-    sealed class State {
-        object Idle : State()
-        data class ShowDefaultBrowserDialog(val intent: Intent) : State()
-        object Finish : State()
-        object ShowWelcomeAnimation : State()
-        object ShowNotificationsPermissionsPrompt : State()
-    }
+    @Toggle.DefaultValue(false)
+    @Experiment
+    fun noPermissionsPrompt(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePage.kt
@@ -86,7 +86,6 @@ class WelcomePage : OnboardingPageFragment(R.layout.content_onboarding_welcome) 
         super.onViewCreated(view, savedInstanceState)
 
         configureDaxCta()
-        requestNotificationsPermissions()
         setSkipAnimationListener()
 
         lifecycleScope.launch {
@@ -95,15 +94,21 @@ class WelcomePage : OnboardingPageFragment(R.layout.content_onboarding_welcome) 
                 .flowOn(dispatcherProvider.io())
                 .collect(::render)
         }
+
+        requestNotificationsPermissions()
     }
 
-    @SuppressLint("InlinedApi")
     private fun requestNotificationsPermissions() {
         if (appBuildConfig.sdkInt >= android.os.Build.VERSION_CODES.TIRAMISU) {
-            requestPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
+            event(WelcomePageView.Event.OnNotificationPermissionsRequested)
         } else {
             scheduleWelcomeAnimation()
         }
+    }
+
+    @SuppressLint("InlinedApi")
+    private fun showNotificationsPermissionsPrompt() {
+        requestPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
     }
 
     private fun render(state: WelcomePageView.State) {
@@ -115,6 +120,8 @@ class WelcomePage : OnboardingPageFragment(R.layout.content_onboarding_welcome) 
             WelcomePageView.State.Finish -> {
                 onContinuePressed()
             }
+            WelcomePageView.State.ShowWelcomeAnimation -> scheduleWelcomeAnimation()
+            WelcomePageView.State.ShowNotificationsPermissionsPrompt -> showNotificationsPermissionsPrompt()
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModel.kt
@@ -24,7 +24,6 @@ import com.duckduckgo.app.global.DefaultRoleBrowserDialog
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
@@ -91,7 +90,6 @@ class WelcomePageViewModel(
     }
 
     private fun notificationPermissionsRequested(): Flow<WelcomePageView.State> = flow {
-        delay(3000)
         if (notificationPermissionsFeatureToggles.noPermissionsPrompt().isEnabled()) {
             emit(WelcomePageView.State.ShowWelcomeAnimation)
         } else {

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModel.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.app.global.DefaultRoleBrowserDialog
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
@@ -90,6 +91,7 @@ class WelcomePageViewModel(
     }
 
     private fun notificationPermissionsRequested(): Flow<WelcomePageView.State> = flow {
+        delay(3000)
         if (notificationPermissionsFeatureToggles.noPermissionsPrompt().isEnabled()) {
             emit(WelcomePageView.State.ShowWelcomeAnimation)
         } else {

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModel.kt
@@ -33,6 +33,7 @@ class WelcomePageViewModel(
     private val context: Context,
     private val pixel: Pixel,
     private val defaultRoleBrowserDialog: DefaultRoleBrowserDialog,
+    private val notificationPermissionsFeatureToggles: NotificationPermissionsFeatureToggles,
 ) : ViewModel() {
 
     fun reduce(event: WelcomePageView.Event): Flow<WelcomePageView.State> {
@@ -40,6 +41,7 @@ class WelcomePageViewModel(
             WelcomePageView.Event.OnPrimaryCtaClicked -> onPrimaryCtaClicked()
             WelcomePageView.Event.OnDefaultBrowserSet -> onDefaultBrowserSet()
             WelcomePageView.Event.OnDefaultBrowserNotSet -> onDefaultBrowserNotSet()
+            WelcomePageView.Event.OnNotificationPermissionsRequested -> notificationPermissionsRequested()
         }
     }
 
@@ -86,6 +88,14 @@ class WelcomePageViewModel(
 
         emit(WelcomePageView.State.Finish)
     }
+
+    private fun notificationPermissionsRequested(): Flow<WelcomePageView.State> = flow {
+        if (notificationPermissionsFeatureToggles.noPermissionsPrompt().isEnabled()) {
+            emit(WelcomePageView.State.ShowWelcomeAnimation)
+        } else {
+            emit(WelcomePageView.State.ShowNotificationsPermissionsPrompt)
+        }
+    }
 }
 
 @Suppress("UNCHECKED_CAST")
@@ -94,6 +104,7 @@ class WelcomePageViewModelFactory(
     private val context: Context,
     private val pixel: Pixel,
     private val defaultRoleBrowserDialog: DefaultRoleBrowserDialog,
+    private val notificationPermissionsFeatureToggles: NotificationPermissionsFeatureToggles,
 ) : ViewModelProvider.NewInstanceFactory() {
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -104,6 +115,7 @@ class WelcomePageViewModelFactory(
                     context,
                     pixel,
                     defaultRoleBrowserDialog,
+                    notificationPermissionsFeatureToggles,
                 )
                 else -> throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
             }

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModelTest.kt
@@ -61,6 +61,9 @@ class WelcomePageViewModelTest {
     @Mock
     private lateinit var defaultRoleBrowserDialog: DefaultRoleBrowserDialog
 
+    @Mock
+    private lateinit var mockNotificationPermissionsFeatureToggles: NotificationPermissionsFeatureToggles
+
     private val events = MutableSharedFlow<WelcomePageView.Event>(replay = 1)
 
     private lateinit var viewModel: WelcomePageViewModel
@@ -75,6 +78,7 @@ class WelcomePageViewModelTest {
             context = mock(),
             pixel = pixel,
             defaultRoleBrowserDialog = defaultRoleBrowserDialog,
+            notificationPermissionsFeatureToggles = mockNotificationPermissionsFeatureToggles,
         )
 
         viewEvents = events.flatMapLatest { viewModel.reduce(it) }

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModelTest.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.Toggle
 import kotlin.time.ExperimentalTime
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -37,6 +38,7 @@ import org.junit.Test
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -150,6 +152,30 @@ class WelcomePageViewModelTest {
                     Pixel.PixelParameter.DEFAULT_BROWSER_SET_FROM_ONBOARDING to true.toString(),
                 ),
             )
+        }
+    }
+
+    @Test
+    fun givenExperimentalVariantWhenOnNotificationPermissionsRequestedThenFireAndEmitWelcomeAnimation() = runTest {
+        val mockToggle: Toggle = mock { on { isEnabled() } doReturn true }
+        whenever(mockNotificationPermissionsFeatureToggles.noPermissionsPrompt()).thenReturn(mockToggle)
+
+        events.emit(WelcomePageView.Event.OnNotificationPermissionsRequested)
+
+        viewEvents.test {
+            assertTrue(awaitItem() == WelcomePageView.State.ShowWelcomeAnimation)
+        }
+    }
+
+    @Test
+    fun givenControlVariantWhenOnNotificationPermissionsRequestedThenFireAndEmitShowNotificationsPermissionsPrompt() = runTest {
+        val mockToggle: Toggle = mock { on { isEnabled() } doReturn false }
+        whenever(mockNotificationPermissionsFeatureToggles.noPermissionsPrompt()).thenReturn(mockToggle)
+
+        events.emit(WelcomePageView.Event.OnNotificationPermissionsRequested)
+
+        viewEvents.test {
+            assertTrue(awaitItem() == WelcomePageView.State.ShowNotificationsPermissionsPrompt)
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1206161927270269/f

### Description
Android experiment implementation where the experimental group won't see notifications permissions prompt when app is installed.

### Steps to test this PR
_Pre Steps_
- [x] Change const val `PRIVACY_REMOTE_CONFIG_URL` to `https://www.jsonblob.com/api/1168612786158034944`
- [x] There is a log in `VariantManagerImpl` _Line 136_ when a new variant allocation is made. This way, you can check if the variant has been allocated correctly
- [x] Before every test you need to delete the DuckDuckGo folder from downloads

_Experimental variant_
- [x] Change JSON blob to the one below in the variant `mg` and make sure you have `androidVersion` filter set to 33 and 34.
```
{
        "desc": "No notifications permissions prompt experimental group",
        "variantKey": "mg",
        "weight": 1,
        "filters": {
          "androidVersion": [
            "34",
            "33"
          ]
        }
}
```
- [x] Delete the DuckDuckGo folder from Downloads
- [x] Fresh install
- [x] Check experimental variant is assigned
- [x] Check you don't see notifications permissions prompt when first install

_Control variant_
- [x] Change JSON blob to the one below in the variant `mf` and make sure you have `androidVersion` filter set to 33 and 34.
```
{
        "desc": "No notifications permissions prompt experimental group",
        "variantKey": "mf",
        "weight": 1,
        "filters": {
          "androidVersion": [
            "34",
            "33"
          ]
        }
}
```
- [x] Delete the DuckDuckGo folder from Downloads
- [x] Fresh install
- [x] Check control variant is assigned
- [x] Check you see notifications permissions prompt when first install

### No UI changes
