### PR TITLE
Hide browser layout when in home screen

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1021,6 +1021,7 @@ class BrowserTabFragment :
         dismissAppLinkSnackBar()
         errorSnackbar.dismiss()
         newBrowserTab.newTabLayout.show()
+        binding.browserLayout.gone()
         webViewContainer.gone()
         omnibar.appBarLayout.setExpanded(true)
         webView?.onPause()
@@ -1030,6 +1031,7 @@ class BrowserTabFragment :
 
     private fun showBrowser() {
         newBrowserTab.newTabLayout.gone()
+        binding.browserLayout.show()
         webViewContainer.show()
         webView?.show()
         webView?.onResume()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/1114857721287938/1206213247675490/f 

### Description
Fixes a bug where going to the home screen after being in the browser blocks the favorite UX and you can pull to refresh.

### Steps to test this PR

- [x] Add a favorite
- [x] Complete the onboarding
- [x] Open a new tab and click on the favorite you added
- [x] Wait until the website loads
- [x] Click the back button
- [x] You should not be able to pull to refresh
- [x] You should be able to click on the favorite and navigate to it

