### PR TITLE
Android: Add support to upload camera images for OnlyFans and Instagram

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -4544,10 +4544,10 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenOnShowFileChooserWithImageSpecificTypeThenExistingFileChooserCommandSent() {
+    fun whenOnShowFileChooserWithImageSpecificTypeThenImageOrCameraChooserCommandSent() {
         val params = buildFileChooserParams(arrayOf("image/png"))
         testee.showFileChooser(mockFileChooserCallback, params)
-        assertCommandIssued<Command.ShowFileChooser>()
+        assertCommandIssued<Command.ShowExistingImageOrCameraChooser>()
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1877,7 +1877,7 @@ class BrowserTabViewModel @Inject constructor(
         filePathCallback: ValueCallback<Array<Uri>>,
         fileChooserParams: FileChooserParams,
     ) {
-        if (fileChooserParams.acceptTypes.contains("image/*") && cameraHardwareChecker.hasCameraHardware()) {
+        if (fileChooserParams.acceptTypes.any { it.startsWith("image/") } && cameraHardwareChecker.hasCameraHardware()) {
             command.value = ShowExistingImageOrCameraChooser(filePathCallback, fileChooserParams)
         } else {
             command.value = ShowFileChooser(filePathCallback, fileChooserParams)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/0/1206243311279019/f

### Description
Updated the file chooser code to show the camera option when a mime type starting with `image/` is found.

### Steps to test this PR

- [ ] Install from this branch.
- [ ] Open the app and log in into a OnlyFans or Instagram account.
- [ ] Go to your account and try to change the profile photo.
- [ ] Notice you have the option to use the camera. (In the current version you can only choose an existing file).

### NO UI changes
