### PR TITLE
Android: Add support for the capture field

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -4593,6 +4593,34 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenOnShowFileChooserWithImageWildcardedTypeOnlyAndCaptureEnabledThenShowImageCameraCommandSent() {
+        val params = buildFileChooserParams(acceptTypes = arrayOf("image/*"), captureEnabled = true)
+
+        testee.showFileChooser(mockFileChooserCallback, params)
+
+        assertCommandIssued<Command.ShowImageCamera>()
+    }
+
+    @Test
+    fun whenOnShowFileChooserWithVideoWildcardedTypeOnlyAndCaptureEnabledThenShowFileChooserCommandSent() {
+        val params = buildFileChooserParams(acceptTypes = arrayOf("video/*"), captureEnabled = true)
+
+        testee.showFileChooser(mockFileChooserCallback, params)
+
+        assertCommandIssued<Command.ShowFileChooser>()
+    }
+
+    @Test
+    fun whenOnShowFileChooserWithImageWildcardedTypeOnlyAndCaptureEnabledButCameraHardwareUnavailableThenShowFileChooserCommandSent() {
+        whenever(cameraHardwareChecker.hasCameraHardware()).thenReturn(false)
+        val params = buildFileChooserParams(acceptTypes = arrayOf("image/*"), captureEnabled = true)
+
+        testee.showFileChooser(mockFileChooserCallback, params)
+
+        assertCommandIssued<Command.ShowFileChooser>()
+    }
+
+    @Test
     fun whenWebViewRefreshedThenBrowserErrorStateIsOmitted() {
         testee.onWebViewRefreshed()
 
@@ -4878,11 +4906,11 @@ class BrowserTabViewModelTest {
         return nav
     }
 
-    private fun buildFileChooserParams(acceptTypes: Array<String>): FileChooserParams {
+    private fun buildFileChooserParams(acceptTypes: Array<String>, captureEnabled: Boolean = false): FileChooserParams {
         return object : FileChooserParams() {
             override fun getAcceptTypes(): Array<String> = acceptTypes
             override fun getMode(): Int = 0
-            override fun isCaptureEnabled(): Boolean = false
+            override fun isCaptureEnabled(): Boolean = captureEnabled
             override fun getTitle(): CharSequence? = null
             override fun getFilenameHint(): String? = null
             override fun createIntent(): Intent = Intent()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1219,6 +1219,7 @@ class BrowserTabFragment :
             is Command.CopyLink -> clipboardManager.setPrimaryClip(ClipData.newPlainText(null, it.url))
             is Command.ShowFileChooser -> launchFilePicker(it.filePathCallback, it.fileChooserParams)
             is Command.ShowExistingImageOrCameraChooser -> launchImageOrCameraChooser(it.fileChooserParams, it.filePathCallback)
+            is Command.ShowImageCamera -> launchCameraCapture(it.filePathCallback)
 
             is Command.AddHomeShortcut -> {
                 context?.let { context ->


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/1163321984198618/1206248386427115/f

### Description
Added support for the capture field used in conjunction with the image accept type.
We start the camera (not the file chooser) when the `capture` is enabled, camera is available and only "image" is accepted.

### Steps to test this PR

_Capture enabled with "image" only_
- [x] Install from this branch
- [x] Open https://jsbin.com/luzihukope/1/edit?html,js,output
- [x] Tap on Browse
- [x] See the camera opens to take a picture
- [x] Take a picture and notice the filename has the `.jpg` extension

_Capture enabled with "image" and other types_
- [x] Open https://jsbin.com/depemibobo/1/edit?html,js,output
- [x] Tap on Browse
- [x] See the bottomsheet with 2 options: `Choose File` and `Take Photo`

_Capture not enabled_
- [x] Open https://jsbin.com/zinipufosu/1/edit?html,js,output
- [x] Tap on Browse
- [x] See the bottomsheet with 2 options: `Choose File` and `Take Photo`

### NO UI changes

