### PR TITLE
Update content scope scripts to version 4.59.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^6.4.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.0.2",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.58.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.59.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#3.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1703196979"
       },
@@ -69,7 +69,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#414f24b9190b14cb197200e3657db30e48f2cab3",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#bb027f14bec7fbb1a85d308139e7a66686da160e",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^6.4.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.0.2",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.58.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.59.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#3.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1703196979"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1206293582077378/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass