### PR TITLE
Fix bookmarks import and export bug

### DIFF
--- a/app/src/test/java/com/duckduckgo/app/bookmarks/model/SavedSitesRepositoryTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/bookmarks/model/SavedSitesRepositoryTest.kt
@@ -92,10 +92,7 @@ class SavedSitesRepositoryTest {
 
     @Test
     fun whenNoDataThenFolderContentisEmpty() = runTest {
-        repository.getFolderContentSync(SavedSitesNames.BOOKMARKS_ROOT).let { result ->
-            assert(result.first.isEmpty())
-            assert(result.second.isEmpty())
-        }
+        assert(repository.getFolderContentSync(SavedSitesNames.BOOKMARKS_ROOT).isEmpty())
     }
 
     @Test
@@ -107,10 +104,7 @@ class SavedSitesRepositoryTest {
         val relation = givenFolderWithContent(SavedSitesNames.BOOKMARKS_ROOT, entities)
         savedSitesRelationsDao.insertList(relation)
 
-        repository.getFolderContentSync(SavedSitesNames.BOOKMARKS_ROOT).let { result ->
-            assert(result.first.size == totalBookmarks)
-            assert(result.second.isEmpty())
-        }
+        assert(repository.getFolderContentSync(SavedSitesNames.BOOKMARKS_ROOT).size == totalBookmarks)
     }
 
     @Test
@@ -128,8 +122,7 @@ class SavedSitesRepositoryTest {
         savedSitesRelationsDao.insertList(relation)
 
         repository.getFolderContentSync(SavedSitesNames.BOOKMARKS_ROOT).let { result ->
-            assert(result.first.size == totalBookmarks)
-            assert(result.second.size == totalFolders)
+            assert(result.size == totalBookmarks + totalFolders)
         }
     }
 
@@ -147,10 +140,7 @@ class SavedSitesRepositoryTest {
         val relation = givenFolderWithContent(SavedSitesNames.BOOKMARKS_ROOT, entities.plus(folders))
         savedSitesRelationsDao.insertList(relation)
 
-        repository.getFolderContentSync("12").let { result ->
-            assert(result.first.isEmpty())
-            assert(result.second.isEmpty())
-        }
+        assert(repository.getFolderContentSync("12").isEmpty())
     }
 
     @Test
@@ -481,9 +471,8 @@ class SavedSitesRepositoryTest {
     fun whenBookmarkAddedToRootThenGetFolderReturnsRootFolder() = runTest {
         val bookmark = repository.insertBookmark(title = "name", url = "foo.com")
         repository.getFolderContentSync(bookmark.parentId).let { result ->
-            Assert.assertTrue(result.first.size == 1)
-            Assert.assertTrue(result.first.first().id == bookmark.id)
-            Assert.assertTrue(result.second.isEmpty())
+            Assert.assertTrue(result.size == 1)
+            Assert.assertTrue((result.first() as Bookmark).id == bookmark.id)
         }
     }
 
@@ -526,8 +515,7 @@ class SavedSitesRepositoryTest {
         repository.updateBookmark(bookmarkTwo.copy(parentId = folder.id), bookmarkTwo.parentId)
 
         repository.getFolderContentSync(folder.id).let { result ->
-            Assert.assertTrue(result.first.size == 2)
-            Assert.assertTrue(result.second.isEmpty())
+            Assert.assertTrue(result.size == 2)
         }
     }
 
@@ -548,9 +536,8 @@ class SavedSitesRepositoryTest {
         repository.insert(BookmarkFolder(id = "folder3", name = "folder2", lastModified = "timestamp", parentId = "folder2"))
 
         repository.getFolderContentSync(folder.id).let { result ->
-            Assert.assertTrue(result.first.size == 2)
-            Assert.assertTrue(result.second.size == 1)
-            Assert.assertEquals(result.second.first().id, "folder3")
+            Assert.assertTrue(result.size == 3)
+            Assert.assertEquals((result[2] as BookmarkFolder).id, "folder3")
         }
     }
 
@@ -562,15 +549,11 @@ class SavedSitesRepositoryTest {
         val folderTwo =
             repository.insert(BookmarkFolder(id = "folder2", name = "folder2", lastModified = "timestamp", parentId = SavedSitesNames.BOOKMARKS_ROOT))
 
-        repository.getFolderContentSync(SavedSitesNames.BOOKMARKS_ROOT).let { result ->
-            assertEquals(listOf(bookmark), result.first)
-        }
+        assertEquals(bookmark, repository.getFolderContentSync(SavedSitesNames.BOOKMARKS_ROOT).first())
 
         val updatedBookmark = bookmark.copy(parentId = folderTwo.id)
         repository.updateBookmark(updatedBookmark, bookmark.parentId)
-        repository.getFolderContentSync(SavedSitesNames.BOOKMARKS_ROOT).let { updatedResult ->
-            assertTrue(updatedResult.first.isEmpty())
-        }
+        assertTrue(repository.getFolderContentSync(SavedSitesNames.BOOKMARKS_ROOT).filterNot { it is BookmarkFolder }.isEmpty())
     }
 
     @Test
@@ -835,15 +818,11 @@ class SavedSitesRepositoryTest {
 
         givenFolderWithEntities(parentFolder.id, totalBookmarks, totalFolders)
 
-        repository.getFolderContentSync(parentFolder.id).let { result ->
-
-            assert(result.first.size == 10)
-            assert(result.second.size == 3)
-        }
+        assert(repository.getFolderContentSync(parentFolder.id).size == 13)
 
         repository.getFolderContentSync(SavedSitesNames.BOOKMARKS_ROOT).let { result ->
 
-            val folder = result.second.first()
+            val folder = result.first() as BookmarkFolder
 
             assert(folder.numBookmarks == 10)
             assert(folder.numFolders == 3)

--- a/app/src/test/java/com/duckduckgo/app/bookmarks/service/SavedSitesExporterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/bookmarks/service/SavedSitesExporterTest.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.savedsites.api.models.BookmarkFolder
 import com.duckduckgo.savedsites.api.models.FolderBranch
+import com.duckduckgo.savedsites.api.models.FolderTreeItem
 import com.duckduckgo.savedsites.api.models.SavedSite
 import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
 import com.duckduckgo.savedsites.api.models.SavedSitesNames
@@ -34,7 +35,6 @@ import com.duckduckgo.savedsites.api.models.TreeNode
 import com.duckduckgo.savedsites.api.service.ExportSavedSitesResult
 import com.duckduckgo.savedsites.impl.RealFavoritesDelegate
 import com.duckduckgo.savedsites.impl.RealSavedSitesRepository
-import com.duckduckgo.savedsites.impl.service.FolderTreeItem
 import com.duckduckgo.savedsites.impl.service.RealSavedSitesExporter
 import com.duckduckgo.savedsites.impl.service.RealSavedSitesParser
 import com.duckduckgo.savedsites.store.SavedSitesEntitiesDao

--- a/app/src/testInternal/java/com/duckduckgo/app/bookmarks/model/SavedSitesParserTest.kt
+++ b/app/src/testInternal/java/com/duckduckgo/app/bookmarks/model/SavedSitesParserTest.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.test.FileUtilities
 import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.savedsites.api.models.BookmarkFolder
+import com.duckduckgo.savedsites.api.models.FolderTreeItem
 import com.duckduckgo.savedsites.api.models.SavedSite
 import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
 import com.duckduckgo.savedsites.api.models.SavedSite.Favorite
@@ -33,7 +34,6 @@ import com.duckduckgo.savedsites.api.models.SavedSitesNames
 import com.duckduckgo.savedsites.api.models.TreeNode
 import com.duckduckgo.savedsites.impl.RealFavoritesDelegate
 import com.duckduckgo.savedsites.impl.RealSavedSitesRepository
-import com.duckduckgo.savedsites.impl.service.FolderTreeItem
 import com.duckduckgo.savedsites.impl.service.RealSavedSitesParser
 import com.duckduckgo.savedsites.store.SavedSitesEntitiesDao
 import com.duckduckgo.savedsites.store.SavedSitesRelationsDao

--- a/app/src/testInternal/java/com/duckduckgo/app/bookmarks/model/SavedSitesParserTest.kt
+++ b/app/src/testInternal/java/com/duckduckgo/app/bookmarks/model/SavedSitesParserTest.kt
@@ -25,7 +25,9 @@ import com.duckduckgo.app.sync.FakeDisplayModeSettingsRepository
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.test.FileUtilities
 import com.duckduckgo.savedsites.api.SavedSitesRepository
+import com.duckduckgo.savedsites.api.models.BookmarkFolder
 import com.duckduckgo.savedsites.api.models.SavedSite
+import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
 import com.duckduckgo.savedsites.api.models.SavedSite.Favorite
 import com.duckduckgo.savedsites.api.models.SavedSitesNames
 import com.duckduckgo.savedsites.api.models.TreeNode
@@ -160,16 +162,16 @@ class SavedSitesParserTest {
         val inputStream = FileUtilities.loadResource(javaClass.classLoader!!, "bookmarks/bookmarks_firefox.html")
         val document = Jsoup.parse(inputStream, Charsets.UTF_8.name(), "duckduckgo.com")
 
-        val bookmarks = parser.parseHtml(document, repository)
+        val bookmarks = parser.parseHtml(document, repository).filterIsInstance<Bookmark>()
 
         Assert.assertEquals(17, bookmarks.size)
 
         val firstBookmark = bookmarks.first()
-        Assert.assertEquals("https://support.mozilla.org/en-US/products/firefox", firstBookmark.url)
+        Assert.assertEquals("https://support.mozilla.org/en-US/products/firefox", (firstBookmark as Bookmark).url)
         Assert.assertEquals("Get Help", firstBookmark.title)
 
         val lastBookmark = bookmarks.last()
-        Assert.assertEquals("https://www.mozilla.org/en-US/firefox/central/", lastBookmark.url)
+        Assert.assertEquals("https://www.mozilla.org/en-US/firefox/central/", (lastBookmark as Bookmark).url)
         Assert.assertEquals("Getting Started", lastBookmark.title)
     }
 
@@ -178,19 +180,19 @@ class SavedSitesParserTest {
         val inputStream = FileUtilities.loadResource(javaClass.classLoader!!, "bookmarks/bookmarks_brave.html")
         val document = Jsoup.parse(inputStream, Charsets.UTF_8.name(), "duckduckgo.com")
 
-        val bookmarks = parser.parseHtml(document, repository)
+        val bookmarks = parser.parseHtml(document, repository).filterIsInstance<Bookmark>()
 
         Assert.assertEquals(12, bookmarks.size)
 
         val firstBookmark = bookmarks.first()
         Assert.assertEquals(
             "https://www.theguardian.com/international",
-            firstBookmark.url,
+            (firstBookmark as Bookmark).url,
         )
         Assert.assertEquals("News, sport and opinion from the Guardian's global edition | The Guardian", firstBookmark.title)
 
         val lastBookmark = bookmarks.last()
-        Assert.assertEquals("https://www.macrumors.com/", lastBookmark.url)
+        Assert.assertEquals("https://www.macrumors.com/", (lastBookmark as Bookmark).url)
         Assert.assertEquals("MacRumors: Apple News and Rumors", lastBookmark.title)
     }
 
@@ -199,19 +201,19 @@ class SavedSitesParserTest {
         val inputStream = FileUtilities.loadResource(javaClass.classLoader!!, "bookmarks/bookmarks_chrome.html")
         val document = Jsoup.parse(inputStream, Charsets.UTF_8.name(), "duckduckgo.com")
 
-        val bookmarks = parser.parseHtml(document, repository)
+        val bookmarks = parser.parseHtml(document, repository).filterIsInstance<Bookmark>()
 
         Assert.assertEquals(12, bookmarks.size)
 
         val firstBookmark = bookmarks.first()
         Assert.assertEquals(
             "https://www.theguardian.com/international",
-            firstBookmark.url,
+            (firstBookmark as Bookmark).url,
         )
         Assert.assertEquals("News, sport and opinion from the Guardian's global edition | The Guardian", firstBookmark.title)
 
         val lastBookmark = bookmarks.last()
-        Assert.assertEquals("https://www.macrumors.com/", lastBookmark.url)
+        Assert.assertEquals("https://www.macrumors.com/", (lastBookmark as Bookmark).url)
         Assert.assertEquals("MacRumors: Apple News and Rumors", lastBookmark.title)
     }
 
@@ -220,21 +222,20 @@ class SavedSitesParserTest {
         val inputStream = FileUtilities.loadResource(javaClass.classLoader!!, "bookmarks/bookmarks_ddg_android.html")
         val document = Jsoup.parse(inputStream, Charsets.UTF_8.name(), "duckduckgo.com")
 
-        val bookmarks = parser.parseHtml(document, repository)
+        val bookmarks = parser.parseHtml(document, repository).filterNot { it is BookmarkFolder }
 
         Assert.assertEquals(13, bookmarks.size)
 
         val firstBookmark = bookmarks.first()
         Assert.assertEquals(
             "https://www.theguardian.com/international",
-            firstBookmark.url,
+            (firstBookmark as Bookmark).url,
         )
         Assert.assertEquals("News, sport and opinion from the Guardian's global edition | The Guardian", firstBookmark.title)
 
         val lastBookmark = bookmarks.last()
-        Assert.assertEquals("https://www.apple.com/uk/", lastBookmark.url)
+        Assert.assertEquals("https://www.apple.com/uk/", (lastBookmark as Favorite).url)
         Assert.assertEquals("Apple (United Kingdom)", lastBookmark.title)
-        Assert.assertTrue(lastBookmark is Favorite)
     }
 
     @Test
@@ -242,19 +243,19 @@ class SavedSitesParserTest {
         val inputStream = FileUtilities.loadResource(javaClass.classLoader!!, "bookmarks/bookmarks_ddg_macos.html")
         val document = Jsoup.parse(inputStream, Charsets.UTF_8.name(), "duckduckgo.com")
 
-        val bookmarks = parser.parseHtml(document, repository)
+        val bookmarks = parser.parseHtml(document, repository).filterIsInstance<Bookmark>()
 
         Assert.assertEquals(13, bookmarks.size)
 
         val firstBookmark = bookmarks.first()
         Assert.assertEquals(
             "https://www.theguardian.com/international",
-            firstBookmark.url,
+            (firstBookmark as Bookmark).url,
         )
         Assert.assertEquals("News, sport and opinion from the Guardian's global edition | The Guardian", firstBookmark.title)
 
         val lastBookmark = bookmarks.last()
-        Assert.assertEquals("https://www.apple.com/uk/", lastBookmark.url)
+        Assert.assertEquals("https://www.apple.com/uk/", (lastBookmark as Bookmark).url)
         Assert.assertEquals("Apple (United Kingdom)", lastBookmark.title)
     }
 
@@ -263,19 +264,19 @@ class SavedSitesParserTest {
         val inputStream = FileUtilities.loadResource(javaClass.classLoader!!, "bookmarks/bookmarks_safari.html")
         val document = Jsoup.parse(inputStream, Charsets.UTF_8.name(), "duckduckgo.com")
 
-        val bookmarks = parser.parseHtml(document, repository)
+        val bookmarks = parser.parseHtml(document, repository).filterIsInstance<Bookmark>()
 
         Assert.assertEquals(14, bookmarks.size)
 
         val firstBookmark = bookmarks.first()
         Assert.assertEquals(
             "https://www.apple.com/uk",
-            firstBookmark.url,
+            (firstBookmark as Bookmark).url,
         )
         Assert.assertEquals("Apple", firstBookmark.title)
 
         val lastBookmark = bookmarks.last()
-        Assert.assertEquals("https://www.macrumors.com/", lastBookmark.url)
+        Assert.assertEquals("https://www.macrumors.com/", (lastBookmark as Bookmark).url)
         Assert.assertEquals("MacRumors: Apple News and Rumors", lastBookmark.title)
     }
 

--- a/saved-sites/saved-sites-api/src/main/java/com/duckduckgo/savedsites/api/SavedSitesRepository.kt
+++ b/saved-sites/saved-sites-api/src/main/java/com/duckduckgo/savedsites/api/SavedSitesRepository.kt
@@ -44,7 +44,7 @@ interface SavedSitesRepository {
      * @param folderId the id of the folder.
      * @return [Pair] of [Bookmark] and [BookmarkFolder] inside a folder
      */
-    fun getFolderContentSync(folderId: String): Pair<List<Bookmark>, List<BookmarkFolder>>
+    fun getFolderContentSync(folderId: String): List<Any>
 
     /**
      * Returns complete list of [BookmarkFolderItem] inside a folder. This method traverses all folders.

--- a/saved-sites/saved-sites-api/src/main/java/com/duckduckgo/savedsites/api/SavedSitesRepository.kt
+++ b/saved-sites/saved-sites-api/src/main/java/com/duckduckgo/savedsites/api/SavedSitesRepository.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.savedsites.api
 import com.duckduckgo.savedsites.api.models.BookmarkFolder
 import com.duckduckgo.savedsites.api.models.BookmarkFolderItem
 import com.duckduckgo.savedsites.api.models.FolderBranch
+import com.duckduckgo.savedsites.api.models.FolderTreeItem
 import com.duckduckgo.savedsites.api.models.SavedSite
 import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
 import com.duckduckgo.savedsites.api.models.SavedSite.Favorite
@@ -42,9 +43,9 @@ interface SavedSitesRepository {
     /**
      * Returns all [Bookmark] and [BookmarkFolder] inside a folder
      * @param folderId the id of the folder.
-     * @return [Pair] of [Bookmark] and [BookmarkFolder] inside a folder
+     * @return [FolderTreeItem]s inside a folder
      */
-    fun getFolderContentSync(folderId: String): List<Any>
+    fun getFolderTreeItems(folderId: String): List<FolderTreeItem>
 
     /**
      * Returns complete list of [BookmarkFolderItem] inside a folder. This method traverses all folders.

--- a/saved-sites/saved-sites-api/src/main/java/com/duckduckgo/savedsites/api/models/Models.kt
+++ b/saved-sites/saved-sites-api/src/main/java/com/duckduckgo/savedsites/api/models/Models.kt
@@ -94,3 +94,14 @@ object SavedSitesNames {
     const val BOOKMARKS_NAME = "Bookmarks"
     const val BOOMARKS_ROOT_ID = 0L
 }
+
+/**
+ * Used to build up a folder tree of [Bookmark]s and [BookmarkFolder]s
+ */
+data class FolderTreeItem(
+    val id: String,
+    val name: String,
+    val parentId: String,
+    val url: String?,
+    val depth: Int = 0,
+)

--- a/saved-sites/saved-sites-api/src/main/java/com/duckduckgo/savedsites/api/service/SavedSitesImporter.kt
+++ b/saved-sites/saved-sites-api/src/main/java/com/duckduckgo/savedsites/api/service/SavedSitesImporter.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.savedsites.api.service
 
 import android.net.Uri
-import com.duckduckgo.savedsites.api.models.SavedSite
 
 /**
  * Class that takes care of importing [SavedSites]
@@ -34,6 +33,6 @@ interface SavedSitesImporter {
 }
 
 sealed class ImportSavedSitesResult {
-    data class Success(val savedSites: List<SavedSite>) : ImportSavedSitesResult()
+    data class Success(val savedSites: List<Any>) : ImportSavedSitesResult()
     data class Error(val exception: Exception) : ImportSavedSitesResult()
 }

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/SavedSitesRepository.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/SavedSitesRepository.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.savedsites.api.models.BookmarkFolder
 import com.duckduckgo.savedsites.api.models.BookmarkFolderItem
 import com.duckduckgo.savedsites.api.models.FolderBranch
+import com.duckduckgo.savedsites.api.models.FolderTreeItem
 import com.duckduckgo.savedsites.api.models.SavedSite
 import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
 import com.duckduckgo.savedsites.api.models.SavedSite.Favorite
@@ -66,15 +67,17 @@ class RealSavedSitesRepository(
             .flowOn(dispatcherProvider.io())
     }
 
-    override fun getFolderContentSync(folderId: String): List<Any> {
+    override fun getFolderTreeItems(folderId: String): List<FolderTreeItem> {
         val entities = savedSitesEntitiesDao.entitiesInFolderSync(folderId)
-        val combinedList = mutableListOf<Any>()
+        val combinedList = mutableListOf<FolderTreeItem>()
 
         entities.forEach { entity ->
             if (entity.type == FOLDER) {
-                combinedList.add(entity.mapToBookmarkFolder(folderId))
+                val item = entity.mapToBookmarkFolder(folderId)
+                combinedList.add(FolderTreeItem(item.id, item.name, item.parentId, null))
             } else {
-                combinedList.add(entity.mapToBookmark(folderId))
+                val item = entity.mapToBookmark(folderId)
+                combinedList.add(FolderTreeItem(item.id, item.title, item.parentId, item.url))
             }
         }
         return combinedList

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/SavedSitesRepository.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/SavedSitesRepository.kt
@@ -66,14 +66,18 @@ class RealSavedSitesRepository(
             .flowOn(dispatcherProvider.io())
     }
 
-    override fun getFolderContentSync(folderId: String): Pair<List<Bookmark>, List<BookmarkFolder>> {
+    override fun getFolderContentSync(folderId: String): List<Any> {
         val entities = savedSitesEntitiesDao.entitiesInFolderSync(folderId)
-        val bookmarks = mutableListOf<Bookmark>()
-        val folders = mutableListOf<BookmarkFolder>()
+        val combinedList = mutableListOf<Any>()
+
         entities.forEach { entity ->
-            mapEntity(entity, folderId, bookmarks, folders)
+            if (entity.type == FOLDER) {
+                combinedList.add(entity.mapToBookmarkFolder(folderId))
+            } else {
+                combinedList.add(entity.mapToBookmark(folderId))
+            }
         }
-        return Pair(bookmarks.distinct(), folders.distinct())
+        return combinedList
     }
 
     private fun mapEntity(

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/SavedSitesRepository.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/SavedSitesRepository.kt
@@ -83,29 +83,6 @@ class RealSavedSitesRepository(
     private fun mapEntity(
         entity: Entity,
         folderId: String,
-        bookmarks: MutableList<Bookmark>,
-        folders: MutableList<BookmarkFolder>,
-    ) {
-        if (entity.type == FOLDER) {
-            val numFolders = savedSitesRelationsDao.countEntitiesInFolder(entity.entityId, FOLDER)
-            val numBookmarks = savedSitesRelationsDao.countEntitiesInFolder(entity.entityId, BOOKMARK)
-            folders.add(BookmarkFolder(entity.entityId, entity.title, folderId, numBookmarks, numFolders, entity.lastModified, entity.deletedFlag()))
-        } else {
-            bookmarks.add(
-                Bookmark(
-                    id = entity.entityId,
-                    title = entity.title,
-                    url = entity.url.orEmpty(),
-                    parentId = folderId,
-                    lastModified = entity.lastModified,
-                ),
-            )
-        }
-    }
-
-    private fun mapEntity(
-        entity: Entity,
-        folderId: String,
         bookmarks: MutableList<Any>,
     ) {
         if (entity.type == FOLDER) {

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/service/SavedSitesImporter.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/service/SavedSitesImporter.kt
@@ -20,12 +20,14 @@ import android.content.ContentResolver
 import android.net.Uri
 import com.duckduckgo.common.utils.formatters.time.DatabaseDateFormatter
 import com.duckduckgo.savedsites.api.SavedSitesRepository
+import com.duckduckgo.savedsites.api.models.BookmarkFolder
 import com.duckduckgo.savedsites.api.models.SavedSite
 import com.duckduckgo.savedsites.api.models.SavedSitesNames
 import com.duckduckgo.savedsites.api.service.ImportSavedSitesResult
 import com.duckduckgo.savedsites.api.service.SavedSitesImporter
 import com.duckduckgo.savedsites.store.Entity
 import com.duckduckgo.savedsites.store.EntityType.BOOKMARK
+import com.duckduckgo.savedsites.store.EntityType.FOLDER
 import com.duckduckgo.savedsites.store.Relation
 import com.duckduckgo.savedsites.store.SavedSitesEntitiesDao
 import com.duckduckgo.savedsites.store.SavedSitesRelationsDao
@@ -67,39 +69,53 @@ class RealSavedSitesImporter(
                 savedSitesParser.parseHtml(document, savedSitesRepository)
             }
 
-            savedSites.filterIsInstance<SavedSite.Bookmark>().map { bookmark ->
-                Pair(
-                    Relation(folderId = bookmark.parentId, entityId = bookmark.id),
-                    Entity(bookmark.id, title = bookmark.title, url = bookmark.url, type = BOOKMARK),
-                )
+            val bookmarks = savedSites.filterIsInstance<SavedSite.Bookmark>()
+            val bookmarksAndFolders = savedSites.filterNot { it is SavedSite.Favorite }
+
+            bookmarksAndFolders.map { item ->
+                when (item) {
+                    is SavedSite.Bookmark -> {
+                        Pair(
+                            Relation(folderId = item.parentId, entityId = item.id),
+                            Entity(item.id, title = item.title, url = item.url, type = BOOKMARK),
+                        )
+                    }
+                    is BookmarkFolder -> {
+                        Pair(
+                            Relation(folderId = item.parentId, entityId = item.id),
+                            Entity(item.id, title = item.name, url = null, type = FOLDER),
+                        )
+                    }
+                    else -> {
+                        Pair(null, null)
+                    }
+                }
             }.also { pairs ->
                 pairs.asSequence().chunked(IMPORT_BATCH_SIZE).forEach { chunk ->
-                    savedSitesRelationsDao.insertList(chunk.map { it.first })
-                    savedSitesEntitiesDao.insertList(chunk.map { it.second })
+                    savedSitesRelationsDao.insertList(chunk.mapNotNull { it.first })
+                    savedSitesEntitiesDao.insertList(chunk.mapNotNull { it.second })
                 }
             }
 
-            savedSites.filterIsInstance<SavedSite.Favorite>().filter { it.url.isNotEmpty() }.map { favorite ->
-                Pair(
-                    Relation(folderId = SavedSitesNames.FAVORITES_ROOT, entityId = favorite.id),
-                    Entity(favorite.id, title = favorite.title, url = favorite.url, type = BOOKMARK),
-                )
-            }.also { pairs ->
-                pairs.asSequence().chunked(IMPORT_BATCH_SIZE).forEach { chunk ->
-                    savedSitesRelationsDao.insertList(chunk.map { it.first })
-                    savedSitesEntitiesDao.insertList(chunk.map { it.second })
+            savedSites.filterIsInstance<SavedSite.Favorite>().map { favorite ->
+                val matchingBookmark = bookmarks.find { bookmark ->
+                    bookmark.url == favorite.url
                 }
-            }
-
-            savedSites.filterIsInstance<SavedSite.Favorite>().filter { it.url.isNotEmpty() }.map { favorite ->
-                Pair(
-                    Relation(folderId = SavedSitesNames.BOOKMARKS_ROOT, entityId = favorite.id),
-                    Entity(favorite.id, title = favorite.title, url = favorite.url, type = BOOKMARK),
-                )
+                if (matchingBookmark != null) {
+                    Pair(
+                        Relation(folderId = SavedSitesNames.FAVORITES_ROOT, entityId = matchingBookmark.id),
+                        null,
+                    )
+                } else {
+                    Pair(
+                        Relation(folderId = SavedSitesNames.FAVORITES_ROOT, entityId = favorite.id),
+                        Entity(favorite.id, title = favorite.title, url = favorite.url, type = BOOKMARK),
+                    )
+                }
             }.also { pairs ->
                 pairs.asSequence().chunked(IMPORT_BATCH_SIZE).forEach { chunk ->
                     savedSitesRelationsDao.insertList(chunk.map { it.first })
-                    savedSitesEntitiesDao.insertList(chunk.map { it.second })
+                    savedSitesEntitiesDao.insertList(chunk.mapNotNull { it.second })
                 }
             }
 

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/service/SavedSitesParser.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/service/SavedSitesParser.kt
@@ -34,7 +34,7 @@ interface SavedSitesParser {
     suspend fun parseHtml(
         document: Document,
         savedSitesRepository: SavedSitesRepository,
-    ): List<SavedSite>
+    ): List<Any>
 }
 
 class RealSavedSitesParser : SavedSitesParser {
@@ -125,7 +125,7 @@ class RealSavedSitesParser : SavedSitesParser {
     override suspend fun parseHtml(
         document: Document,
         savedSitesRepository: SavedSitesRepository,
-    ): List<SavedSite> {
+    ): List<Any> {
         val body = document.select("body").first() ?: return emptyList()
         val children = body.childNodes()
             .filterIsInstance<Element>()
@@ -143,9 +143,9 @@ class RealSavedSitesParser : SavedSitesParser {
         documentElement: Element,
         parentId: String,
         savedSitesRepository: SavedSitesRepository,
-        savedSites: MutableList<SavedSite>,
+        savedSites: MutableList<Any>,
         inFavorite: Boolean,
-    ): List<SavedSite> {
+    ): List<Any> {
         var favorites = 0
 
         documentElement.select("DL").first()?.let { itemBlock ->
@@ -177,7 +177,7 @@ class RealSavedSitesParser : SavedSitesParser {
                             if (existingFolder != null) {
                                 parseElement(element, existingFolder.id, savedSitesRepository, savedSites, false)
                             } else {
-                                savedSitesRepository.insert(bookmarkFolder)
+                                savedSites.add(bookmarkFolder)
                                 parseElement(element, bookmarkFolder.id, savedSitesRepository, savedSites, false)
                             }
                         }

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/algorithm/SavedSitesSyncPersisterAlgorithm.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/algorithm/SavedSitesSyncPersisterAlgorithm.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.savedsites.api.*
 import com.duckduckgo.savedsites.api.models.*
 import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
 import com.duckduckgo.savedsites.api.models.SavedSite.Favorite
+import com.duckduckgo.savedsites.api.models.SavedSitesNames.BOOKMARKS_ROOT
 import com.duckduckgo.savedsites.api.models.SavedSitesNames.FAVORITES_DESKTOP_ROOT
 import com.duckduckgo.savedsites.api.models.SavedSitesNames.FAVORITES_MOBILE_ROOT
 import com.duckduckgo.savedsites.api.models.SavedSitesNames.FAVORITES_ROOT
@@ -117,6 +118,11 @@ class RealSavedSitesSyncPersisterAlgorithm @Inject constructor(
                 )
                 processIds.add(favoriteFolder)
             }
+        }
+
+        // Bookmarks Root
+        if (allResponseIds.contains(BOOKMARKS_ROOT)) {
+            processBookmarksRootFolder(bookmarks.entries)
         }
 
         // there are two types of orphans
@@ -234,6 +240,18 @@ class RealSavedSitesSyncPersisterAlgorithm @Inject constructor(
             REMOTE_WINS -> remoteWinsStrategy.processFavouritesFolder(favoriteFolder, favourites)
             LOCAL_WINS -> localWinsStrategy.processFavouritesFolder(favoriteFolder, favourites)
             TIMESTAMP -> timestampStrategy.processFavouritesFolder(favoriteFolder, favourites)
+        }
+    }
+
+    private fun processBookmarksRootFolder(entries: List<SyncSavedSitesResponseEntry>) {
+        Timber.i("Sync-Bookmarks: processing bookmarks root folder")
+        val rootEntry = entries.find { it.id == BOOKMARKS_ROOT } ?: return
+        val rootContent = rootEntry.folder?.children ?: emptyList()
+        if (rootContent.isNotEmpty()) {
+            val rootFolder = savedSitesRepository.getFolder(BOOKMARKS_ROOT)
+            if (rootFolder != null) {
+                syncSavedSitesRepository.replaceBookmarkFolder(rootFolder, rootContent)
+            }
         }
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205538580267653/f

### Description
Fixes two issues:
- Favorited bookmarks are no longer duplicated on import
- Bookmark/folder order is respected for import and export

### Steps to test this PR
- [ ] Create some folders and bookmarks
- [ ] Make some of the bookmarks favorites (Be sure to add a favorite to a subfolder)
- [ ] Rearrange the folders / bookmarks
- [ ] Export bookmarks
- [ ] Delete everything
- [ ] Import bookmarks
- [ ] Verify that the imported items match the exported list
