### PR TITLE
Add internal dev setting to allow debug autofill JS to be selected on the fly

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/email/EmailInjectorJsTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/email/EmailInjectorJsTest.kt
@@ -20,8 +20,8 @@ import android.webkit.WebView
 import androidx.test.annotation.UiThreadTest
 import androidx.test.filters.SdkSuppress
 import androidx.test.platform.app.InstrumentationRegistry
-import com.duckduckgo.app.autofill.FileBasedJavascriptInjector
-import com.duckduckgo.app.autofill.JavascriptInjector
+import com.duckduckgo.app.autofill.DefaultEmailProtectionJavascriptInjector
+import com.duckduckgo.app.autofill.EmailProtectionJavascriptInjector
 import com.duckduckgo.app.browser.DuckDuckGoUrlDetectorImpl
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.autofill.api.Autofill
@@ -41,7 +41,7 @@ class EmailInjectorJsTest {
     private val mockDispatcherProvider: DispatcherProvider = mock()
     private val mockAutofillFeature: AutofillFeature = mock()
     private val mockAutofill: Autofill = mock()
-    private val javascriptInjector: JavascriptInjector = FileBasedJavascriptInjector()
+    private val javascriptInjector: EmailProtectionJavascriptInjector = DefaultEmailProtectionJavascriptInjector()
 
     lateinit var testee: EmailInjectorJs
 

--- a/app/src/main/java/com/duckduckgo/app/autofill/DefaultEmailProtectionJavascriptInjector.kt
+++ b/app/src/main/java/com/duckduckgo/app/autofill/DefaultEmailProtectionJavascriptInjector.kt
@@ -21,25 +21,13 @@ import com.duckduckgo.app.browser.R
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
-import java.io.BufferedReader
 import javax.inject.Inject
 
 @SingleInstanceIn(AppScope::class)
 @ContributesBinding(AppScope::class)
-class FileBasedJavascriptInjector @Inject constructor() : JavascriptInjector {
-    private lateinit var functions: String
+class DefaultEmailProtectionJavascriptInjector @Inject constructor() : EmailProtectionJavascriptInjector {
     private lateinit var aliasFunctions: String
     private lateinit var signOutFunctions: String
-
-    override fun getFunctionsJS(): String {
-        if (!this::functions.isInitialized) {
-            // this can be enabled to see more verbose output from the autofill JS; useful for debugging autofill-related issues
-            val debugMode = false
-
-            functions = loadJs(if (debugMode) "autofill-debug.js" else "autofill.js")
-        }
-        return functions
-    }
 
     override fun getAliasFunctions(
         context: Context,
@@ -58,11 +46,5 @@ class FileBasedJavascriptInjector @Inject constructor() : JavascriptInjector {
             signOutFunctions = context.resources.openRawResource(R.raw.signout_autofill).bufferedReader().use { it.readText() }
         }
         return signOutFunctions
-    }
-
-    private fun loadJs(resourceName: String): String = readResource(resourceName).use { it?.readText() }.orEmpty()
-
-    private fun readResource(resourceName: String): BufferedReader? {
-        return javaClass.classLoader?.getResource(resourceName)?.openStream()?.bufferedReader()
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/email/EmailInjectorJs.kt
+++ b/app/src/main/java/com/duckduckgo/app/email/EmailInjectorJs.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.app.email
 
 import android.webkit.WebView
 import androidx.annotation.UiThread
-import com.duckduckgo.app.autofill.JavascriptInjector
+import com.duckduckgo.app.autofill.EmailProtectionJavascriptInjector
 import com.duckduckgo.app.browser.DuckDuckGoUrlDetector
 import com.duckduckgo.app.email.EmailJavascriptInterface.Companion.JAVASCRIPT_INTERFACE_NAME
 import com.duckduckgo.autofill.api.Autofill
@@ -36,7 +36,7 @@ class EmailInjectorJs @Inject constructor(
     private val urlDetector: DuckDuckGoUrlDetector,
     private val dispatcherProvider: DispatcherProvider,
     private val autofillFeature: AutofillFeature,
-    private val javaScriptInjector: JavascriptInjector,
+    private val emailProtectionJavascriptInjector: EmailProtectionJavascriptInjector,
     private val autofill: Autofill,
 ) : EmailInjector {
 
@@ -68,7 +68,7 @@ class EmailInjectorJs @Inject constructor(
     ) {
         url?.let {
             if (isFeatureEnabled() && !autofill.isAnException(url)) {
-                webView.evaluateJavascript("javascript:${javaScriptInjector.getAliasFunctions(webView.context, alias)}", null)
+                webView.evaluateJavascript("javascript:${emailProtectionJavascriptInjector.getAliasFunctions(webView.context, alias)}", null)
             }
         }
     }
@@ -80,7 +80,7 @@ class EmailInjectorJs @Inject constructor(
     ) {
         url?.let {
             if (isFeatureEnabled() && isDuckDuckGoUrl(url) && !emailManager.isSignedIn()) {
-                webView.evaluateJavascript("javascript:${javaScriptInjector.getSignOutFunctions(webView.context)}", null)
+                webView.evaluateJavascript("javascript:${emailProtectionJavascriptInjector.getSignOutFunctions(webView.context)}", null)
             }
         }
     }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/configuration/AutofillJavascriptEnvironmentConfiguration.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/configuration/AutofillJavascriptEnvironmentConfiguration.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.configuration
+
+import com.duckduckgo.autofill.impl.configuration.AutofillJavascriptEnvironmentConfiguration.AutofillJsConfigType
+import com.duckduckgo.autofill.impl.configuration.AutofillJavascriptEnvironmentConfiguration.AutofillJsConfigType.Debug
+import com.duckduckgo.autofill.impl.configuration.AutofillJavascriptEnvironmentConfiguration.AutofillJsConfigType.Production
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+interface AutofillJavascriptEnvironmentConfiguration {
+
+    fun useProductionConfig()
+    fun useDebugConfig()
+    fun getConfigType(): AutofillJsConfigType
+
+    sealed interface AutofillJsConfigType {
+        data object Production : AutofillJsConfigType
+        data object Debug : AutofillJsConfigType
+    }
+}
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class DefaultAutofillJavascriptEnvironmentConfiguration @Inject constructor() : AutofillJavascriptEnvironmentConfiguration {
+
+    private var configType: AutofillJsConfigType = Production
+
+    override fun useProductionConfig() {
+        configType = Production
+    }
+
+    override fun useDebugConfig() {
+        configType = Debug
+    }
+
+    override fun getConfigType(): AutofillJsConfigType = configType
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/configuration/AutofillJavascriptLoader.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/configuration/AutofillJavascriptLoader.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.configuration
+
+import com.duckduckgo.autofill.impl.configuration.AutofillJavascriptEnvironmentConfiguration.AutofillJsConfigType
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import java.io.BufferedReader
+import javax.inject.Inject
+import kotlinx.coroutines.withContext
+
+interface AutofillJavascriptLoader {
+    suspend fun getAutofillJavascript(): String
+}
+
+@ContributesBinding(AppScope::class)
+class DefaultAutofillJavascriptLoader @Inject constructor(
+    private val filenameProvider: AutofillJavascriptEnvironmentConfiguration,
+    private val dispatchers: DispatcherProvider,
+) : AutofillJavascriptLoader {
+
+    private val productionJavascript: String by lazy { loadJs(AUTOFILL_JS_FILENAME) }
+    private val debugJavascript: String by lazy { loadJs(AUTOFILL_JS_DEBUG_FILENAME) }
+
+    override suspend fun getAutofillJavascript(): String {
+        return withContext(dispatchers.io()) {
+            when (filenameProvider.getConfigType()) {
+                AutofillJsConfigType.Production -> productionJavascript
+                AutofillJsConfigType.Debug -> debugJavascript
+            }
+        }
+    }
+
+    private fun loadJs(resourceName: String): String = readResource(resourceName).use { it?.readText() }.orEmpty()
+
+    private fun readResource(resourceName: String): BufferedReader? {
+        return javaClass.classLoader?.getResource(resourceName)?.openStream()?.bufferedReader()
+    }
+
+    companion object {
+        const val AUTOFILL_JS_FILENAME = "autofill.js"
+        const val AUTOFILL_JS_DEBUG_FILENAME = "autofill-debug.js"
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/configuration/InlineBrowserAutofillConfigurator.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/configuration/InlineBrowserAutofillConfigurator.kt
@@ -16,7 +16,6 @@
 package com.duckduckgo.autofill.impl.configuration
 
 import android.webkit.WebView
-import com.duckduckgo.app.autofill.JavascriptInjector
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.autofill.api.AutofillCapabilityChecker
 import com.duckduckgo.autofill.api.BrowserAutofill.Configurator
@@ -33,10 +32,10 @@ import timber.log.Timber
 @ContributesBinding(AppScope::class)
 class InlineBrowserAutofillConfigurator @Inject constructor(
     private val autofillRuntimeConfigProvider: AutofillRuntimeConfigProvider,
-    private val javascriptInjector: JavascriptInjector,
     @AppCoroutineScope private val coroutineScope: CoroutineScope,
     private val dispatchers: DispatcherProvider = DefaultDispatcherProvider(),
     private val autofillCapabilityChecker: AutofillCapabilityChecker,
+    private val autofillJavascriptLoader: AutofillJavascriptLoader,
 ) : Configurator {
     override fun configureAutofillForCurrentPage(
         webView: WebView,
@@ -46,7 +45,7 @@ class InlineBrowserAutofillConfigurator @Inject constructor(
             if (canJsBeInjected(url)) {
                 Timber.v("Injecting autofill JS into WebView for %s", url)
 
-                val rawJs = javascriptInjector.getFunctionsJS()
+                val rawJs = autofillJavascriptLoader.getAutofillJavascript()
                 val formatted = autofillRuntimeConfigProvider.getRuntimeConfiguration(rawJs, url)
 
                 withContext(dispatchers.main()) {

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/configuration/InlineBrowserAutofillConfiguratorTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/configuration/InlineBrowserAutofillConfiguratorTest.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.autofill.impl.configuration
 
 import android.webkit.WebView
-import com.duckduckgo.app.autofill.JavascriptInjector
 import com.duckduckgo.autofill.api.AutofillCapabilityChecker
 import com.duckduckgo.common.test.CoroutineTestRule
 import kotlinx.coroutines.test.TestScope
@@ -38,21 +37,21 @@ class InlineBrowserAutofillConfiguratorTest {
     private lateinit var inlineBrowserAutofillConfigurator: InlineBrowserAutofillConfigurator
 
     private val autofillRuntimeConfigProvider: AutofillRuntimeConfigProvider = mock()
-    private val javascriptInjector: JavascriptInjector = mock()
     private val webView: WebView = mock()
     private val autofillCapabilityChecker: AutofillCapabilityChecker = mock()
+    private val autofillJavascriptLoader: AutofillJavascriptLoader = mock()
 
     @Before
     fun before() = runTest {
-        whenever(javascriptInjector.getFunctionsJS()).thenReturn("")
+        whenever(autofillJavascriptLoader.getAutofillJavascript()).thenReturn("")
         whenever(autofillRuntimeConfigProvider.getRuntimeConfiguration(any(), any())).thenReturn("")
 
         inlineBrowserAutofillConfigurator = InlineBrowserAutofillConfigurator(
             autofillRuntimeConfigProvider,
-            javascriptInjector,
             TestScope(),
             coroutineRule.testDispatcherProvider,
             autofillCapabilityChecker,
+            autofillJavascriptLoader,
         )
     }
 

--- a/autofill/autofill-internal/src/main/res/layout/activity_autofill_internal_settings.xml
+++ b/autofill/autofill-internal/src/main/res/layout/activity_autofill_internal_settings.xml
@@ -177,6 +177,23 @@
             app:primaryText="@string/autofillDevSettingsNeverSavedSitesCountTitle"
             />
 
+        <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+            android:id="@+id/autofillConfigSectionTitle"
+            android:layout_width="match_parent"
+            android:layout_marginTop="20dp"
+            android:layout_height="wrap_content"
+            app:primaryText="@string/autofillDevSettingsConfigSectionTitle" />
+
+        <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+            android:id="@+id/changeAutofillJsConfigButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:primaryText="@string/autofillDevSettingsConfigDebugTitle"
+            app:secondaryText="@string/autofillDevSettingsConfigDebugSubtitle" />
 
     </LinearLayout>
 </androidx.core.widget.NestedScrollView>

--- a/autofill/autofill-internal/src/main/res/values/donottranslate.xml
+++ b/autofill/autofill-internal/src/main/res/values/donottranslate.xml
@@ -53,6 +53,12 @@
     <string name="autofillDevSettingsClearLoginsSubtitle" instruction="%1$d is number of saved logins">Number of saved logins: %1$d</string>
     <string name="autofillDevSettingsViewSavedLogins">View saved logins</string>
 
+    <string name="autofillDevSettingsConfigSectionTitle">Autofill.js Configuration</string>
+    <string name="autofillDevSettingsConfigDebugTitle" instruction="Placeholder will specify if using debug or production version">Configuration Type: %1$s</string>
+    <string name="autofillDevSettingsConfigDebugSubtitle">Tap to change</string>
+    <string name="autofillDevSettingsConfigDebugOptionProduction">Production</string>
+    <string name="autofillDevSettingsConfigDebugOptionDebug">Debug</string>
+
     <string name="autofillDevSettingsAddSampleLogins">Add a few sample logins</string>
     <string name="autofillDevSettingsAddSampleLoginsSubtitle">Adds a few logins for https://fill.dev</string>
     <string name="autofillDevSettingsAddSampleLoginsSameSubdomain">Add duplicate logins (same domain)</string>

--- a/browser-api/src/main/java/com/duckduckgo/app/autofill/EmailProtectionJavascriptInjector.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/autofill/EmailProtectionJavascriptInjector.kt
@@ -18,8 +18,7 @@ package com.duckduckgo.app.autofill
 
 import android.content.Context
 
-interface JavascriptInjector {
-    fun getFunctionsJS(): String
+interface EmailProtectionJavascriptInjector {
 
     fun getAliasFunctions(
         context: Context,


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/1203115518054842/1206299001940948/f 

### Description
Adds a dev setting supporting switching between normal production `Autofill.js` usage to a debug version. This is to make autofill-related things easier to debug, especially for the javascript engineers.

### Steps to test this PR

- [x] Install from this branch
- [x] Add logcat filter: `message~:"CONSOLE"`
- [x] Open `Settings` -> `Autofill Dev Settings`, scroll to the bottom 
- [x] Verify default config shows as `Production` type
- [x] Tap on `Configuration Type: Production` and change it to `Debug`
- [x] Visit https://fill.dev/form/login-simple
- [x] Verify you you see a bunch of logs like `INFO:CONSOLE` printed out (which only happens in debug)
- [x] Kill the app and restart, loading that same page
- [x] Verify you don't see any of those logs (as the switch to use `Debug` is in-memory only)


### UI changes
![Screenshot_20240109_105157](https://github.com/duckduckgo/Android/assets/1336281/634e6163-016a-4558-89dd-b1a6b0568322)
