### PR TITLE
Add export behavior to registered broadcast receivers

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/AndroidManifest.xml
+++ b/app-tracking-protection/vpn-impl/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SYSTEM_EXEMPTED" />
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
@@ -82,6 +83,7 @@
         <service
             android:name=".service.TrackerBlockingVpnService"
             android:exported="false"
+            android:foregroundServiceType="systemExempted"
             android:permission="android.permission.BIND_VPN_SERVICE"
             android:process=":vpn">
             <intent-filter>

--- a/app-tracking-protection/vpn-impl/src/main/AndroidManifest.xml
+++ b/app-tracking-protection/vpn-impl/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
     <application
         android:largeHeap="true"
         android:theme="@style/Theme.DuckDuckGo.Light">

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/apps/NewAppBroadcastReceiver.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/apps/NewAppBroadcastReceiver.kt
@@ -22,8 +22,8 @@ import android.content.Intent
 import android.content.IntentFilter
 import androidx.annotation.MainThread
 import androidx.annotation.WorkerThread
-import androidx.core.content.ContextCompat
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.extensions.registerExportedReceiver
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.di.scopes.VpnScope
 import com.duckduckgo.mobile.android.vpn.AppTpVpnFeature
@@ -82,7 +82,7 @@ class NewAppBroadcastReceiver @Inject constructor(
             addAction(Intent.ACTION_PACKAGE_ADDED)
             addDataScheme("package")
         }.run {
-            ContextCompat.registerReceiver(applicationContext, this@NewAppBroadcastReceiver, this, ContextCompat.RECEIVER_EXPORTED)
+            applicationContext.registerExportedReceiver(this@NewAppBroadcastReceiver, this)
         }
     }
 

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/apps/NewAppBroadcastReceiver.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/apps/NewAppBroadcastReceiver.kt
@@ -22,6 +22,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import androidx.annotation.MainThread
 import androidx.annotation.WorkerThread
+import androidx.core.content.ContextCompat
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.di.scopes.VpnScope
@@ -81,7 +82,7 @@ class NewAppBroadcastReceiver @Inject constructor(
             addAction(Intent.ACTION_PACKAGE_ADDED)
             addDataScheme("package")
         }.run {
-            applicationContext.registerReceiver(this@NewAppBroadcastReceiver, this)
+            ContextCompat.registerReceiver(applicationContext, this@NewAppBroadcastReceiver, this, ContextCompat.RECEIVER_EXPORTED)
         }
     }
 

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/debug/DeviceShieldNotificationsDebugReceiver.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/debug/DeviceShieldNotificationsDebugReceiver.kt
@@ -21,6 +21,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
@@ -49,7 +50,7 @@ class DeviceShieldNotificationsDebugReceiver(
 ) : BroadcastReceiver() {
 
     init {
-        context.registerReceiver(this, IntentFilter(intentAction))
+        ContextCompat.registerReceiver(context, this, IntentFilter(intentAction), ContextCompat.RECEIVER_NOT_EXPORTED)
     }
 
     override fun onReceive(

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/debug/DeviceShieldNotificationsDebugReceiver.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/debug/DeviceShieldNotificationsDebugReceiver.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.notification.checkPermissionAndNotify
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.mobile.android.vpn.ui.notification.*
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -117,7 +118,7 @@ class DeviceShieldNotificationsDebugReceiverRegister @Inject constructor(
                 }
 
                 notification?.let {
-                    notificationManagerCompat.notify(DeviceShieldNotificationScheduler.VPN_WEEKLY_NOTIFICATION_ID, it)
+                    notificationManagerCompat.checkPermissionAndNotify(context, DeviceShieldNotificationScheduler.VPN_WEEKLY_NOTIFICATION_ID, it)
                 }
             }
         }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/debug/DeviceShieldNotificationsDebugReceiver.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/debug/DeviceShieldNotificationsDebugReceiver.kt
@@ -21,12 +21,12 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import androidx.core.app.NotificationManagerCompat
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.extensions.registerNotExportedReceiver
 import com.duckduckgo.common.utils.notification.checkPermissionAndNotify
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.mobile.android.vpn.ui.notification.*
@@ -51,7 +51,7 @@ class DeviceShieldNotificationsDebugReceiver(
 ) : BroadcastReceiver() {
 
     init {
-        ContextCompat.registerReceiver(context, this, IntentFilter(intentAction), ContextCompat.RECEIVER_NOT_EXPORTED)
+        context.registerNotExportedReceiver(this, IntentFilter(intentAction))
     }
 
     override fun onReceive(

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/debug/SendTrackerDebugReceiver.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/debug/SendTrackerDebugReceiver.kt
@@ -20,6 +20,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import androidx.core.content.ContextCompat
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.formatters.time.DatabaseDateFormatter
@@ -66,7 +67,7 @@ class SendTrackerDebugReceiver @Inject constructor(
         }
 
         logcat { "Debug receiver SendTrackerDebugReceiver registered" }
-        context.registerReceiver(this, IntentFilter(INTENT_ACTION))
+        ContextCompat.registerReceiver(context, this, IntentFilter(INTENT_ACTION), ContextCompat.RECEIVER_NOT_EXPORTED)
     }
 
     private fun unregister() {

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/debug/SendTrackerDebugReceiver.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/debug/SendTrackerDebugReceiver.kt
@@ -20,9 +20,9 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import androidx.core.content.ContextCompat
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.extensions.registerNotExportedReceiver
 import com.duckduckgo.common.utils.formatters.time.DatabaseDateFormatter
 import com.duckduckgo.di.scopes.VpnScope
 import com.duckduckgo.mobile.android.vpn.model.TrackingApp
@@ -67,7 +67,7 @@ class SendTrackerDebugReceiver @Inject constructor(
         }
 
         logcat { "Debug receiver SendTrackerDebugReceiver registered" }
-        ContextCompat.registerReceiver(context, this, IntentFilter(INTENT_ACTION), ContextCompat.RECEIVER_NOT_EXPORTED)
+        context.registerNotExportedReceiver(this, IntentFilter(INTENT_ACTION))
     }
 
     private fun unregister() {

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/RestartReceiver.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/RestartReceiver.kt
@@ -20,6 +20,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import androidx.core.content.ContextCompat
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.appbuildconfig.api.isInternalBuild
@@ -56,7 +57,7 @@ class RestartReceiver @Inject constructor(
         if (appBuildConfig.isInternalBuild()) {
             logcat { "Starting vpn-service receiver" }
             unregister()
-            context.registerReceiver(this, IntentFilter("vpn-service"))
+            ContextCompat.registerReceiver(context, this, IntentFilter("vpn-service"), ContextCompat.RECEIVER_NOT_EXPORTED)
         }
     }
 

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/RestartReceiver.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/RestartReceiver.kt
@@ -20,11 +20,11 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import androidx.core.content.ContextCompat
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.appbuildconfig.api.isInternalBuild
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.extensions.registerNotExportedReceiver
 import com.duckduckgo.di.scopes.VpnScope
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -57,7 +57,7 @@ class RestartReceiver @Inject constructor(
         if (appBuildConfig.isInternalBuild()) {
             logcat { "Starting vpn-service receiver" }
             unregister()
-            ContextCompat.registerReceiver(context, this, IntentFilter("vpn-service"), ContextCompat.RECEIVER_NOT_EXPORTED)
+            context.registerNotExportedReceiver(this, IntentFilter("vpn-service"))
         }
     }
 

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/VpnTrackerNotificationUpdates.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/VpnTrackerNotificationUpdates.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import androidx.core.app.NotificationManagerCompat
 import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.notification.checkPermissionAndNotify
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.di.scopes.VpnScope
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnStopReason
@@ -71,6 +72,6 @@ class VpnTrackerNotificationUpdates @Inject constructor(
         vpnNotification: VpnEnabledNotificationContentPlugin.VpnEnabledNotificationContent,
     ) {
         val notification = VpnEnabledNotificationBuilder.buildVpnEnabledUpdateNotification(context, vpnNotification)
-        notificationManager.notify(TrackerBlockingVpnService.VPN_FOREGROUND_SERVICE_ID, notification)
+        notificationManager.checkPermissionAndNotify(context, TrackerBlockingVpnService.VPN_FOREGROUND_SERVICE_ID, notification)
     }
 }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/alwayson/AlwaysOnLockDownDetector.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/alwayson/AlwaysOnLockDownDetector.kt
@@ -22,6 +22,7 @@ import android.text.SpannableStringBuilder
 import androidx.core.app.NotificationManagerCompat
 import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.notification.checkPermissionAndNotify
 import com.duckduckgo.di.scopes.VpnScope
 import com.duckduckgo.mobile.android.app.tracking.AppTrackingProtection
 import com.duckduckgo.mobile.android.app.tracking.ui.AppTrackingProtectionScreens.AppTrackerActivityWithEmptyParams
@@ -95,7 +96,7 @@ class AlwaysOnLockDownDetector @Inject constructor(
             notification,
             intent,
         ).also {
-            notificationManagerCompat.notify(notificationId, it)
+            notificationManagerCompat.checkPermissionAndNotify(context, notificationId, it)
         }
     }
 

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/notification/AppTPReminderNotificationScheduler.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/notification/AppTPReminderNotificationScheduler.kt
@@ -26,6 +26,7 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.notification.checkPermissionAndNotify
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.di.scopes.VpnScope
 import com.duckduckgo.mobile.android.app.tracking.AppTrackingProtection
@@ -179,7 +180,8 @@ class AppTPReminderNotificationScheduler @Inject constructor(
         vpnReminderNotificationContentPluginPoint.getHighestPriorityPluginForType(DISABLED)?.let {
             it.getContent()?.let { content ->
                 logcat { "Showing disabled notification from $it" }
-                notificationManager.notify(
+                notificationManager.checkPermissionAndNotify(
+                    context,
                     TrackerBlockingVpnService.VPN_REMINDER_NOTIFICATION_ID,
                     vpnReminderNotificationBuilder.buildReminderNotification(content),
                 )
@@ -191,7 +193,8 @@ class AppTPReminderNotificationScheduler @Inject constructor(
         vpnReminderNotificationContentPluginPoint.getHighestPriorityPluginForType(REVOKED)?.let {
             it.getContent()?.let { content ->
                 logcat { "Showing revoked notification from $it" }
-                notificationManager.notify(
+                notificationManager.checkPermissionAndNotify(
+                    context,
                     TrackerBlockingVpnService.VPN_REMINDER_NOTIFICATION_ID,
                     vpnReminderNotificationBuilder.buildReminderNotification(content),
                 )

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/service/RestartReceiverTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/service/RestartReceiverTest.kt
@@ -56,7 +56,7 @@ class RestartReceiverTest {
         receiver.onVpnStarted(coroutineRule.testScope)
 
         verify(context).unregisterReceiver(any())
-        verify(context).registerReceiver(any(), any())
+        verify(context).registerReceiver(any(), any(), isNull(), isNull(), any())
     }
 
     @Test
@@ -66,7 +66,7 @@ class RestartReceiverTest {
         receiver.onVpnStarted(coroutineRule.testScope)
 
         verify(context, never()).unregisterReceiver(any())
-        verify(context, never()).registerReceiver(any(), any())
+        verify(context, never()).registerReceiver(any(), any(), isNull(), isNull(), any())
     }
 
     @Test
@@ -76,7 +76,7 @@ class RestartReceiverTest {
         receiver.onVpnStopped(coroutineRule.testScope, VpnStateMonitor.VpnStopReason.SELF_STOP())
 
         verify(context).unregisterReceiver(any())
-        verify(context, never()).registerReceiver(any(), any())
+        verify(context, never()).registerReceiver(any(), any(), isNull(), isNull(), any())
     }
 
     @Test
@@ -86,6 +86,6 @@ class RestartReceiverTest {
         receiver.onVpnStopped(coroutineRule.testScope, VpnStateMonitor.VpnStopReason.SELF_STOP())
 
         verify(context).unregisterReceiver(any())
-        verify(context, never()).registerReceiver(any(), any())
+        verify(context, never()).registerReceiver(any(), any(), isNull(), isNull(), any())
     }
 }

--- a/app-tracking-protection/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/InternalFeatureReceiver.kt
+++ b/app-tracking-protection/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/InternalFeatureReceiver.kt
@@ -20,6 +20,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import androidx.core.content.ContextCompat
 
 /**
  * Abstract class to create generic receivers for internal features accessible through
@@ -44,7 +45,7 @@ abstract class InternalFeatureReceiver(
 
     fun register() {
         unregister()
-        context.registerReceiver(this, IntentFilter(intentAction()))
+        ContextCompat.registerReceiver(context, this, IntentFilter(intentAction()), ContextCompat.RECEIVER_NOT_EXPORTED)
     }
 
     fun unregister() {

--- a/app-tracking-protection/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/InternalFeatureReceiver.kt
+++ b/app-tracking-protection/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/InternalFeatureReceiver.kt
@@ -20,7 +20,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import androidx.core.content.ContextCompat
+import com.duckduckgo.common.utils.extensions.registerNotExportedReceiver
 
 /**
  * Abstract class to create generic receivers for internal features accessible through
@@ -45,7 +45,7 @@ abstract class InternalFeatureReceiver(
 
     fun register() {
         unregister()
-        ContextCompat.registerReceiver(context, this, IntentFilter(intentAction()), ContextCompat.RECEIVER_NOT_EXPORTED)
+        context.registerNotExportedReceiver(this, IntentFilter(intentAction()))
     }
 
     fun unregister() {

--- a/app-tracking-protection/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/rules/ExceptionRulesDebugReceiver.kt
+++ b/app-tracking-protection/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/rules/ExceptionRulesDebugReceiver.kt
@@ -20,6 +20,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import androidx.core.content.ContextCompat
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.VpnScope
 import com.duckduckgo.mobile.android.vpn.service.VpnServiceCallbacks
@@ -48,7 +49,7 @@ class ExceptionRulesDebugReceiver(
 
     init {
         kotlin.runCatching { context.unregisterReceiver(this) }
-        context.registerReceiver(this, IntentFilter(intentAction))
+        ContextCompat.registerReceiver(context, this, IntentFilter(intentAction), ContextCompat.RECEIVER_NOT_EXPORTED)
     }
 
     override fun onReceive(

--- a/app-tracking-protection/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/rules/ExceptionRulesDebugReceiver.kt
+++ b/app-tracking-protection/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/rules/ExceptionRulesDebugReceiver.kt
@@ -20,8 +20,8 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import androidx.core.content.ContextCompat
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.extensions.registerNotExportedReceiver
 import com.duckduckgo.di.scopes.VpnScope
 import com.duckduckgo.mobile.android.vpn.service.VpnServiceCallbacks
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnStopReason
@@ -49,7 +49,7 @@ class ExceptionRulesDebugReceiver(
 
     init {
         kotlin.runCatching { context.unregisterReceiver(this) }
-        ContextCompat.registerReceiver(context, this, IntentFilter(intentAction), ContextCompat.RECEIVER_NOT_EXPORTED)
+        context.registerNotExportedReceiver(this, IntentFilter(intentAction))
     }
 
     override fun onReceive(

--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/privacy/TrackerDataDevReceiver.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/privacy/TrackerDataDevReceiver.kt
@@ -19,9 +19,11 @@ package com.duckduckgo.app.dev.settings.privacy
 import android.annotation.SuppressLint
 import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.Context.RECEIVER_NOT_EXPORTED
 import android.content.Intent
 import android.content.IntentFilter
 import android.widget.Toast
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.trackerdetection.api.TrackerDataDownloader
@@ -39,7 +41,7 @@ class TrackerDataDevReceiver(
     private val receiver: (Intent) -> Unit,
 ) : BroadcastReceiver() {
     init {
-        context.registerReceiver(this, IntentFilter(intentAction))
+        ContextCompat.registerReceiver(context, this, IntentFilter(intentAction), ContextCompat.RECEIVER_NOT_EXPORTED)
     }
 
     override fun onReceive(

--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/privacy/TrackerDataDevReceiver.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/privacy/TrackerDataDevReceiver.kt
@@ -19,15 +19,14 @@ package com.duckduckgo.app.dev.settings.privacy
 import android.annotation.SuppressLint
 import android.content.BroadcastReceiver
 import android.content.Context
-import android.content.Context.RECEIVER_NOT_EXPORTED
 import android.content.Intent
 import android.content.IntentFilter
 import android.widget.Toast
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.trackerdetection.api.TrackerDataDownloader
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.common.utils.extensions.registerNotExportedReceiver
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesMultibinding
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -41,7 +40,7 @@ class TrackerDataDevReceiver(
     private val receiver: (Intent) -> Unit,
 ) : BroadcastReceiver() {
     init {
-        ContextCompat.registerReceiver(context, this, IntentFilter(intentAction), ContextCompat.RECEIVER_NOT_EXPORTED)
+        context.registerNotExportedReceiver(this, IntentFilter(intentAction))
     }
 
     override fun onReceive(

--- a/app/src/main/java/com/duckduckgo/app/notification/AppNotificationSender.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/AppNotificationSender.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.app.notification.db.NotificationDao
 import com.duckduckgo.app.notification.model.Notification
 import com.duckduckgo.app.notification.model.SchedulableNotification
 import com.duckduckgo.app.notification.model.SchedulableNotificationPlugin
+import com.duckduckgo.common.utils.notification.checkPermissionAndNotify
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import timber.log.Timber
 
@@ -54,7 +55,7 @@ class AppNotificationSender(
         val cancelIntent = NotificationHandlerService.pendingCancelNotificationHandlerIntent(context, notification.javaClass)
         val systemNotification = factory.createNotification(specification, launchIntent, cancelIntent)
         notificationDao.insert(Notification(notification.id))
-        manager.notify(specification.systemId, systemNotification)
+        manager.checkPermissionAndNotify(context, specification.systemId, systemNotification)
 
         notificationPlugin.onNotificationShown()
     }

--- a/app/src/main/java/com/duckduckgo/app/widget/WidgetAddedReceiver.kt
+++ b/app/src/main/java/com/duckduckgo/app/widget/WidgetAddedReceiver.kt
@@ -22,11 +22,11 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.os.Build
 import android.widget.Toast
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.widget.AppWidgetManagerAddWidgetLauncher.Companion.ACTION_ADD_WIDGET
+import com.duckduckgo.common.utils.extensions.registerNotExportedReceiver
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
@@ -47,7 +47,7 @@ class WidgetAddedReceiver @Inject constructor(
 
     override fun onCreate(owner: LifecycleOwner) {
         super.onCreate(owner)
-        ContextCompat.registerReceiver(context, this, IntentFilter(ACTION_ADD_WIDGET), ContextCompat.RECEIVER_NOT_EXPORTED)
+        context.registerNotExportedReceiver(this, IntentFilter(ACTION_ADD_WIDGET))
     }
 
     override fun onDestroy(owner: LifecycleOwner) {

--- a/app/src/main/java/com/duckduckgo/app/widget/WidgetAddedReceiver.kt
+++ b/app/src/main/java/com/duckduckgo/app/widget/WidgetAddedReceiver.kt
@@ -22,6 +22,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.os.Build
 import android.widget.Toast
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
@@ -46,7 +47,7 @@ class WidgetAddedReceiver @Inject constructor(
 
     override fun onCreate(owner: LifecycleOwner) {
         super.onCreate(owner)
-        context.registerReceiver(this, IntentFilter(ACTION_ADD_WIDGET))
+        ContextCompat.registerReceiver(context, this, IntentFilter(ACTION_ADD_WIDGET), ContextCompat.RECEIVER_NOT_EXPORTED)
     }
 
     override fun onDestroy(owner: LifecycleOwner) {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsSyncFeatureListener.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsSyncFeatureListener.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.autofill.sync
 
 import android.content.Context
 import androidx.core.app.NotificationManagerCompat
+import com.duckduckgo.common.utils.notification.checkPermissionAndNotify
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.api.engine.FeatureSyncError
 import com.duckduckgo.sync.api.engine.FeatureSyncError.COLLECTION_LIMIT_REACHED
@@ -65,7 +66,8 @@ class AppCredentialsSyncFeatureListener @Inject constructor(
     }
 
     private fun triggerNotification() {
-        notificationManager.notify(
+        notificationManager.checkPermissionAndNotify(
+            context,
             SYNC_PAUSED_CREDENTIALS_NOTIFICATION_ID,
             notificationBuilder.buildRateLimitNotification(context),
         )

--- a/common/common-utils/src/main/AndroidManifest.xml
+++ b/common/common-utils/src/main/AndroidManifest.xml
@@ -22,5 +22,6 @@
         android:targetPackage="com.duckduckgo.common.utils"
         android:label="Test for common"
         />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
 </manifest>

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/extensions/ContextExtensions.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/extensions/ContextExtensions.kt
@@ -16,9 +16,12 @@
 
 package com.duckduckgo.common.utils.extensions
 
+import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.IntentFilter
 import android.os.PowerManager
 import android.provider.Settings
+import androidx.core.content.ContextCompat
 import timber.log.Timber
 
 fun Context.isPrivateDnsActive(): Boolean {
@@ -45,4 +48,18 @@ fun Context.isIgnoringBatteryOptimizations(): Boolean {
             powerManager.isIgnoringBatteryOptimizations(packageName)
         } ?: false
     }.getOrDefault(false)
+}
+
+fun Context.registerNotExportedReceiver(
+    receiver: BroadcastReceiver,
+    intentFilter: IntentFilter,
+) {
+    ContextCompat.registerReceiver(this, receiver, intentFilter, ContextCompat.RECEIVER_NOT_EXPORTED)
+}
+
+fun Context.registerExportedReceiver(
+    receiver: BroadcastReceiver,
+    intentFilter: IntentFilter,
+) {
+    ContextCompat.registerReceiver(this, receiver, intentFilter, ContextCompat.RECEIVER_EXPORTED)
 }

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/notification/NotificationUtils.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/notification/NotificationUtils.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.utils.notification
+
+import android.Manifest.permission.POST_NOTIFICATIONS
+import android.app.Notification
+import android.content.Context
+import android.content.pm.PackageManager.PERMISSION_GRANTED
+import androidx.core.app.ActivityCompat
+import androidx.core.app.NotificationManagerCompat
+
+fun NotificationManagerCompat.checkPermissionAndNotify(
+    context: Context,
+    id: Int,
+    notification: Notification,
+) {
+    if (ActivityCompat.checkSelfPermission(context, POST_NOTIFICATIONS) == PERMISSION_GRANTED) {
+        notify(id, notification)
+    }
+}

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DefaultFileDownloadNotificationManager.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DefaultFileDownloadNotificationManager.kt
@@ -28,6 +28,7 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.FileProvider
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.browser.api.BrowserLifecycleObserver
+import com.duckduckgo.common.utils.notification.checkPermissionAndNotify
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.downloads.api.FileDownloadNotificationManager
 import com.squareup.anvil.annotations.ContributesBinding
@@ -100,8 +101,8 @@ class DefaultFileDownloadNotificationManager @Inject constructor(
         }
 
         notificationManager.apply {
-            notify(downloadId.toInt(), notification)
-            notify(SUMMARY_ID, summary)
+            checkPermissionAndNotify(applicationContext, downloadId.toInt(), notification)
+            checkPermissionAndNotify(applicationContext, SUMMARY_ID, summary)
             groupNotificationsCounter.atomicUpdateAndGet { it.plus(downloadId to filename) }
         }
     }
@@ -128,7 +129,7 @@ class DefaultFileDownloadNotificationManager @Inject constructor(
 
         // we don't want to post any notification while the DDG application is closing
         if (applicationClosing.get()) return
-        notificationManager.notify(downloadId.toInt(), notification)
+        notificationManager.checkPermissionAndNotify(applicationContext, downloadId.toInt(), notification)
     }
 
     @AnyThread
@@ -158,7 +159,7 @@ class DefaultFileDownloadNotificationManager @Inject constructor(
 
         // we don't want to post any notification while the DDG application is closing
         if (applicationClosing.get()) return
-        notificationManager.notify(downloadId.toInt(), notification)
+        notificationManager.checkPermissionAndNotify(applicationContext, downloadId.toInt(), notification)
     }
 
     @AnyThread

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/FileDownloadNotificationActionReceiver.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/FileDownloadNotificationActionReceiver.kt
@@ -21,12 +21,12 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.Environment
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.extensions.registerNotExportedReceiver
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.downloads.api.*
 import com.duckduckgo.downloads.impl.pixels.DownloadsPixelName
@@ -56,7 +56,7 @@ class FileDownloadNotificationActionReceiver @Inject constructor(
     override fun onCreate(owner: LifecycleOwner) {
         super.onCreate(owner)
         Timber.v("Registering file download notification action receiver")
-        ContextCompat.registerReceiver(context, this, IntentFilter(INTENT_DOWNLOADS_NOTIFICATION_ACTION), ContextCompat.RECEIVER_NOT_EXPORTED)
+        context.registerNotExportedReceiver(this, IntentFilter(INTENT_DOWNLOADS_NOTIFICATION_ACTION))
 
         // When the app process is killed and restarted, this onCreate method is called and we take the opportunity
         // to clean up the pending downloads that were in progress and will be no longer downloading.

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/FileDownloadNotificationActionReceiver.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/FileDownloadNotificationActionReceiver.kt
@@ -21,6 +21,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.Environment
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
@@ -55,7 +56,7 @@ class FileDownloadNotificationActionReceiver @Inject constructor(
     override fun onCreate(owner: LifecycleOwner) {
         super.onCreate(owner)
         Timber.v("Registering file download notification action receiver")
-        context.registerReceiver(this, IntentFilter(INTENT_DOWNLOADS_NOTIFICATION_ACTION))
+        ContextCompat.registerReceiver(context, this, IntentFilter(INTENT_DOWNLOADS_NOTIFICATION_ACTION), ContextCompat.RECEIVER_NOT_EXPORTED)
 
         // When the app process is killed and restarted, this onCreate method is called and we take the opportunity
         // to clean up the pending downloads that were in progress and will be no longer downloading.

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/notification/NetPDisabledNotificationScheduler.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/notification/NetPDisabledNotificationScheduler.kt
@@ -22,6 +22,7 @@ import android.content.pm.PackageManager
 import androidx.core.app.NotificationManagerCompat
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.notification.checkPermissionAndNotify
 import com.duckduckgo.di.scopes.VpnScope
 import com.duckduckgo.mobile.android.vpn.service.VpnServiceCallbacks
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnStopReason
@@ -108,7 +109,8 @@ class NetPDisabledNotificationScheduler @Inject constructor(
         coroutineScope.launch(dispatcherProvider.io()) {
             if (triggerAtMillis != 0L) {
                 if (!netPSettingsLocalConfig.vpnNotificationAlerts().isEnabled()) return@launch
-                notificationManager.notify(
+                notificationManager.checkPermissionAndNotify(
+                    context,
                     NETP_REMINDER_NOTIFICATION_ID,
                     netPDisabledNotificationBuilder.buildSnoozeNotification(context, triggerAtMillis),
                 )
@@ -122,7 +124,8 @@ class NetPDisabledNotificationScheduler @Inject constructor(
         coroutineScope.launch(dispatcherProvider.io()) {
             logcat { "Showing disabled notification for NetP" }
             if (!netPSettingsLocalConfig.vpnNotificationAlerts().isEnabled()) return@launch
-            notificationManager.notify(
+            notificationManager.checkPermissionAndNotify(
+                context,
                 NETP_REMINDER_NOTIFICATION_ID,
                 netPDisabledNotificationBuilder.buildDisabledNotification(context),
             )
@@ -141,7 +144,8 @@ class NetPDisabledNotificationScheduler @Inject constructor(
         coroutineScope.launch(dispatcherProvider.io()) {
             logcat { "Showing disabled by vpn notification for NetP" }
             if (!netPSettingsLocalConfig.vpnNotificationAlerts().isEnabled()) return@launch
-            notificationManager.notify(
+            notificationManager.checkPermissionAndNotify(
+                context,
                 NETP_REMINDER_NOTIFICATION_ID,
                 netPDisabledNotificationBuilder.buildDisabledByVpnNotification(context),
             )

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/timezone/NetPTimezoneMonitor.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/timezone/NetPTimezoneMonitor.kt
@@ -20,7 +20,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import androidx.core.content.ContextCompat
+import com.duckduckgo.common.utils.extensions.registerNotExportedReceiver
 import com.duckduckgo.di.scopes.VpnScope
 import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
 import com.duckduckgo.mobile.android.vpn.service.VpnServiceCallbacks
@@ -77,7 +77,7 @@ class NetPTimezoneMonitor @Inject constructor(
         IntentFilter().apply {
             addAction(Intent.ACTION_TIMEZONE_CHANGED)
         }.run {
-            ContextCompat.registerReceiver(context, this@NetPTimezoneMonitor, this, ContextCompat.RECEIVER_NOT_EXPORTED)
+            context.registerNotExportedReceiver(this@NetPTimezoneMonitor, this)
         }
     }
 

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/timezone/NetPTimezoneMonitor.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/timezone/NetPTimezoneMonitor.kt
@@ -20,6 +20,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import androidx.core.content.ContextCompat
 import com.duckduckgo.di.scopes.VpnScope
 import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
 import com.duckduckgo.mobile.android.vpn.service.VpnServiceCallbacks
@@ -76,7 +77,7 @@ class NetPTimezoneMonitor @Inject constructor(
         IntentFilter().apply {
             addAction(Intent.ACTION_TIMEZONE_CHANGED)
         }.run {
-            context.registerReceiver(this@NetPTimezoneMonitor, this)
+            ContextCompat.registerReceiver(context, this@NetPTimezoneMonitor, this, ContextCompat.RECEIVER_NOT_EXPORTED)
         }
     }
 

--- a/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/feature/InternalFeatureReceiver.kt
+++ b/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/feature/InternalFeatureReceiver.kt
@@ -20,6 +20,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import androidx.core.content.ContextCompat
 
 /**
  * Abstract class to create generic receivers for internal features accessible through
@@ -44,7 +45,7 @@ abstract class InternalFeatureReceiver(
 
     fun register() {
         unregister()
-        context.registerReceiver(this, IntentFilter(intentAction()))
+        ContextCompat.registerReceiver(context, this, IntentFilter(intentAction()), ContextCompat.RECEIVER_NOT_EXPORTED)
     }
 
     fun unregister() {

--- a/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/feature/InternalFeatureReceiver.kt
+++ b/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/feature/InternalFeatureReceiver.kt
@@ -20,7 +20,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import androidx.core.content.ContextCompat
+import com.duckduckgo.common.utils.extensions.registerNotExportedReceiver
 
 /**
  * Abstract class to create generic receivers for internal features accessible through
@@ -45,7 +45,7 @@ abstract class InternalFeatureReceiver(
 
     fun register() {
         unregister()
-        ContextCompat.registerReceiver(context, this, IntentFilter(intentAction()), ContextCompat.RECEIVER_NOT_EXPORTED)
+        context.registerNotExportedReceiver(this, IntentFilter(intentAction()))
     }
 
     fun unregister() {

--- a/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/feature/snooze/VpnCallStateReceiver.kt
+++ b/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/feature/snooze/VpnCallStateReceiver.kt
@@ -20,6 +20,7 @@ import android.annotation.SuppressLint
 import android.content.*
 import android.telephony.PhoneStateListener
 import android.telephony.TelephonyManager
+import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.anvil.annotations.InjectWith
@@ -75,7 +76,10 @@ class VpnCallStateReceiver @Inject constructor(
     private val _listener: PhoneStateListener =
         object : PhoneStateListener() {
             @Deprecated("Deprecated in Java")
-            override fun onCallStateChanged(state: Int, phoneNumber: String?) {
+            override fun onCallStateChanged(
+                state: Int,
+                phoneNumber: String?,
+            ) {
                 appCoroutineScope.launch(dispatcherProvider.io()) {
                     logcat { "Call state: $state" }
                     if (state == TelephonyManager.CALL_STATE_IDLE) {
@@ -128,12 +132,14 @@ class VpnCallStateReceiver @Inject constructor(
                     registerListener()
                 }
             }
+
             ACTION_UNREGISTER_STATE_CALL_LISTENER -> {
                 logcat { "ACTION_UNREGISTER_STATE_CALL_LISTENER" }
                 goAsync(pendingResult) {
                     unregisterListener()
                 }
             }
+
             else -> {
                 logcat { "Unknown action ${intent.action}" }
             }
@@ -155,12 +161,14 @@ class VpnCallStateReceiver @Inject constructor(
     private fun register() {
         unregister()
         logcat { "Registering vpn call state receiver" }
-        context.registerReceiver(
+        ContextCompat.registerReceiver(
+            context,
             this,
             IntentFilter().apply {
                 addAction(ACTION_REGISTER_STATE_CALL_LISTENER)
                 addAction(ACTION_UNREGISTER_STATE_CALL_LISTENER)
             },
+            ContextCompat.RECEIVER_NOT_EXPORTED,
         )
     }
 

--- a/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/feature/snooze/VpnCallStateReceiver.kt
+++ b/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/feature/snooze/VpnCallStateReceiver.kt
@@ -20,7 +20,6 @@ import android.annotation.SuppressLint
 import android.content.*
 import android.telephony.PhoneStateListener
 import android.telephony.TelephonyManager
-import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.anvil.annotations.InjectWith
@@ -28,6 +27,7 @@ import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.di.ProcessName
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.extensions.registerNotExportedReceiver
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.di.scopes.ReceiverScope
 import com.duckduckgo.mobile.android.vpn.Vpn
@@ -161,14 +161,12 @@ class VpnCallStateReceiver @Inject constructor(
     private fun register() {
         unregister()
         logcat { "Registering vpn call state receiver" }
-        ContextCompat.registerReceiver(
-            context,
+        context.registerNotExportedReceiver(
             this,
             IntentFilter().apply {
                 addAction(ACTION_REGISTER_STATE_CALL_LISTENER)
                 addAction(ACTION_UNREGISTER_STATE_CALL_LISTENER)
             },
-            ContextCompat.RECEIVER_NOT_EXPORTED,
         )
     }
 

--- a/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/rekey/DebugRekeyReceiver.kt
+++ b/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/rekey/DebugRekeyReceiver.kt
@@ -21,6 +21,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import androidx.core.content.ContextCompat
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.di.ProcessName
 import com.duckduckgo.di.scopes.VpnScope
@@ -61,6 +62,7 @@ class DebugRekeyReceiver @Inject constructor(
                     rekeyer.forceRekey()
                 }
             }
+
             else -> {
                 logcat(LogPriority.WARN) { "Unknown action" }
                 pendingResult?.finish()
@@ -72,7 +74,10 @@ class DebugRekeyReceiver @Inject constructor(
         register()
     }
 
-    override fun onVpnStopped(coroutineScope: CoroutineScope, vpnStopReason: VpnStateMonitor.VpnStopReason) {
+    override fun onVpnStopped(
+        coroutineScope: CoroutineScope,
+        vpnStopReason: VpnStateMonitor.VpnStopReason,
+    ) {
         logcat { "Unregistering debug re-keying receiver" }
         unregister()
     }
@@ -81,11 +86,13 @@ class DebugRekeyReceiver @Inject constructor(
     private fun register() {
         unregister()
         logcat { "Registering debug re-keying receiver" }
-        context.registerReceiver(
+        ContextCompat.registerReceiver(
+            context,
             this,
             IntentFilter().apply {
                 addAction(ACTION_FORCE_REKEY)
             },
+            ContextCompat.RECEIVER_NOT_EXPORTED,
         )
     }
 

--- a/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/rekey/DebugRekeyReceiver.kt
+++ b/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/rekey/DebugRekeyReceiver.kt
@@ -21,9 +21,9 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import androidx.core.content.ContextCompat
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.di.ProcessName
+import com.duckduckgo.common.utils.extensions.registerNotExportedReceiver
 import com.duckduckgo.di.scopes.VpnScope
 import com.duckduckgo.mobile.android.vpn.service.VpnServiceCallbacks
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor
@@ -86,13 +86,11 @@ class DebugRekeyReceiver @Inject constructor(
     private fun register() {
         unregister()
         logcat { "Registering debug re-keying receiver" }
-        ContextCompat.registerReceiver(
-            context,
+        context.registerNotExportedReceiver(
             this,
             IntentFilter().apply {
                 addAction(ACTION_FORCE_REKEY)
             },
-            ContextCompat.RECEIVER_NOT_EXPORTED,
         )
     }
 

--- a/network-protection/network-protection-subscription-internal/src/main/java/com/duckduckgo/networkprotection/subscription/notification/NetpAccessRevokedNotificationScheduler.kt
+++ b/network-protection/network-protection-subscription-internal/src/main/java/com/duckduckgo/networkprotection/subscription/notification/NetpAccessRevokedNotificationScheduler.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.networkprotection.subscription.notification
 import android.content.Context
 import androidx.core.app.NotificationManagerCompat
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.notification.checkPermissionAndNotify
 import com.duckduckgo.di.scopes.VpnScope
 import com.duckduckgo.mobile.android.vpn.service.VpnServiceCallbacks
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnStopReason
@@ -49,7 +50,8 @@ class NetpAccessRevokedNotificationScheduler @Inject constructor(
 
     override fun onVpnStartFailed(coroutineScope: CoroutineScope) {
         if (networkProtectionRepository.vpnAccessRevoked) {
-            notificationManager.notify(
+            notificationManager.checkPermissionAndNotify(
+                context,
                 NetPDisabledNotificationScheduler.NETP_REMINDER_NOTIFICATION_ID,
                 netpAccessRevokedNotificationBuilder.buildVpnAccessRevokedNotification(context),
             )

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSitesSyncFeatureListener.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSitesSyncFeatureListener.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.savedsites.impl.sync
 
 import android.content.Context
 import androidx.core.app.NotificationManagerCompat
+import com.duckduckgo.common.utils.notification.checkPermissionAndNotify
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.api.engine.FeatureSyncError
 import com.duckduckgo.sync.api.engine.FeatureSyncError.COLLECTION_LIMIT_REACHED
@@ -65,7 +66,8 @@ class AppSavedSitesSyncFeatureListener @Inject constructor(
     }
 
     private fun triggerNotification() {
-        notificationManager.notify(
+        notificationManager.checkPermissionAndNotify(
+            context,
             SYNC_PAUSED_SAVED_SITES_NOTIFICATION_ID,
             notificationBuilder.buildRateLimitNotification(context),
         )

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeatureToggle.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeatureToggle.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.appbuildconfig.api.isInternalBuild
 import com.duckduckgo.common.utils.DefaultDispatcherProvider
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.notification.checkPermissionAndNotify
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
@@ -135,7 +136,8 @@ class SyncRemoteFeatureToggle @Inject constructor(
 
     private fun triggerNotification() {
         val showSync = showSync()
-        notificationManager.notify(
+        notificationManager.checkPermissionAndNotify(
+            context,
             SYNC_PAUSED_NOTIFICATION_ID,
             syncNotificationBuilder.buildSyncPausedNotification(context, addNavigationIntent = showSync),
         )

--- a/versions.properties
+++ b/versions.properties
@@ -23,7 +23,7 @@ version.androidx.localbroadcastmanager=1.1.0
 
 version.androidx.recyclerview=1.3.2
 
-version.androidx.core=1.8.0
+version.androidx.core=1.9.0
 
 version.androidx.fragment=1.5.2
 

--- a/versions.properties
+++ b/versions.properties
@@ -23,7 +23,7 @@ version.androidx.localbroadcastmanager=1.1.0
 
 version.androidx.recyclerview=1.3.2
 
-version.androidx.core=1.9.0
+version.androidx.core=1.12.0
 
 version.androidx.fragment=1.5.2
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/0/1206033184335184/f 

### Description
See attached task description

### Steps to test this PR
Smoke test app, espcially the affected features mentioned in task description) verify that no `"java.lang.SecurityException: com.duckduckgo.mobile.android.debug: One of RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED should be specified when a receiver isn't being registered exclusively for system broadcasts"` is logged
