### PR TITLE
Detect scenarios where Autofill dialogs would overlap

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -205,6 +205,7 @@ import com.duckduckgo.autofill.api.EmailProtectionUserPromptListener
 import com.duckduckgo.autofill.api.ExistingCredentialMatchDetector
 import com.duckduckgo.autofill.api.UseGeneratedPasswordDialog
 import com.duckduckgo.autofill.api.credential.saving.DuckAddressLoginCreator
+import com.duckduckgo.autofill.api.dialog.AutofillOverlappingDialogDetector
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.api.domain.app.LoginTriggerType
 import com.duckduckgo.autofill.api.emailprotection.EmailInjector
@@ -435,6 +436,9 @@ class BrowserTabFragment :
 
     @Inject
     lateinit var externalCameraLauncher: UploadFromExternalCameraLauncher
+
+    @Inject
+    lateinit var autofillOverlappingDialogDetector: AutofillOverlappingDialogDetector
 
     /**
      * We use this to monitor whether the user was seeing the in-context Email Protection signup prompt
@@ -2318,10 +2322,12 @@ class BrowserTabFragment :
     ) {
         // want to ensure lifecycle is at least resumed before attempting to show dialog
         lifecycleScope.launchWhenResumed {
-            hideDialogWithTag(tag)
-
             val currentUrl = webView?.url
             val urlMatch = requiredUrl == null || requiredUrl == currentUrl
+
+            autofillOverlappingDialogDetector.detectOverlappingDialogs(childFragmentManager, tag, urlMatch)
+            hideDialogWithTag(tag)
+
             if (isActiveTab && urlMatch) {
                 Timber.i("Showing dialog (%s), hidden=%s, requiredUrl=%s, currentUrl=%s, tabId=%s", tag, isHidden, requiredUrl, currentUrl, tabId)
                 dialog.show(childFragmentManager, tag)

--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/dialog/AutofillOverlappingDialogDetector.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/dialog/AutofillOverlappingDialogDetector.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.api.dialog
+
+import androidx.fragment.app.FragmentManager
+
+/**
+ * This class is responsible for detecting overlapping Autofill dialog events.
+ *
+ * This is when an Autofill dialog is already showing and another one is triggered to show.
+ * If this happens, we want to detect that scenario and fire a pixel.
+ * * @param fragmentManager The FragmentManager to use to detect existing autofill dialogs
+ * @param tag The tag of the new dialog that is being shown, used in the pixel
+ * @param urlMatch Whether the URL of the new dialog matches the URL of the existing dialog, used in the pixel
+ */
+interface AutofillOverlappingDialogDetector {
+    fun detectOverlappingDialogs(
+        fragmentManager: FragmentManager,
+        tag: String,
+        urlMatch: Boolean,
+    )
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelInterceptor.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelInterceptor.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_DECLINE_PR
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_DECLINE_PROMPT_TO_DISABLE_AUTOFILL_SHOWN
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENABLE_AUTOFILL_TOGGLE_MANUALLY_DISABLED
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENABLE_AUTOFILL_TOGGLE_MANUALLY_ENABLED
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_OVERLAPPING_DIALOG
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_PASSWORD_GENERATION_ACCEPTED
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_PASSWORD_GENERATION_PROMPT_DISMISSED
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_PASSWORD_GENERATION_PROMPT_SHOWN
@@ -118,6 +119,8 @@ class AutofillPixelInterceptor @Inject constructor(
 
             MENU_ACTION_AUTOFILL_PRESSED,
             SETTINGS_AUTOFILL_MANAGEMENT_OPENED,
+
+            AUTOFILL_OVERLAPPING_DIALOG,
         )
     }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
@@ -85,6 +85,8 @@ enum class AutofillPixelNames(override val pixelName: String) : Pixel.PixelName 
     AUTOFILL_NEVER_SAVE_FOR_THIS_SITE_CONFIRMATION_PROMPT_DISPLAYED("m_autofill_settings_reset_excluded_displayed"),
     AUTOFILL_NEVER_SAVE_FOR_THIS_SITE_CONFIRMATION_PROMPT_CONFIRMED("m_autofill_settings_reset_excluded_confirmed"),
     AUTOFILL_NEVER_SAVE_FOR_THIS_SITE_CONFIRMATION_PROMPT_DISMISSED("m_autofill_settings_reset_excluded_dismissed"),
+
+    AUTOFILL_OVERLAPPING_DIALOG("m_autofill_overlapping_dialog"),
 }
 
 object AutofillPixelParameters {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/DefaultAutofillOverlappingDialogDetector.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/DefaultAutofillOverlappingDialogDetector.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.ui
+
+import androidx.fragment.app.FragmentManager
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.autofill.api.CredentialAutofillPickerDialog
+import com.duckduckgo.autofill.api.CredentialSavePickerDialog
+import com.duckduckgo.autofill.api.CredentialUpdateExistingCredentialsDialog
+import com.duckduckgo.autofill.api.EmailProtectionChooseEmailDialog
+import com.duckduckgo.autofill.api.EmailProtectionInContextSignUpDialog
+import com.duckduckgo.autofill.api.UseGeneratedPasswordDialog
+import com.duckduckgo.autofill.api.dialog.AutofillOverlappingDialogDetector
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames
+import com.duckduckgo.di.scopes.FragmentScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+import timber.log.Timber
+
+@ContributesBinding(FragmentScope::class)
+class DefaultAutofillOverlappingDialogDetector @Inject constructor(
+    private val pixel: Pixel,
+) : AutofillOverlappingDialogDetector {
+
+    override fun detectOverlappingDialogs(
+        fragmentManager: FragmentManager,
+        tag: String,
+        urlMatch: Boolean,
+    ) {
+        val existingTags = detectVisibleFragments(fragmentManager)
+        val formattedTags = existingTags.joinToString(",")
+        Timber.v("Found %d existing autofill tags: [ %s ]", existingTags.size, formattedTags)
+
+        if (existingTags.isNotEmpty()) {
+            pixel.fire(
+                AutofillPixelNames.AUTOFILL_OVERLAPPING_DIALOG,
+                mapOf(
+                    KEY_URL_MATCH to urlMatch.toString(),
+                    KEY_NEW_DIALOG_TAG to tag,
+                    KEY_EXISTING_DIALOG_TAGS to formattedTags,
+                ),
+            )
+        }
+    }
+
+    private fun detectVisibleFragments(fragmentManager: FragmentManager): List<String> =
+        autofillTags.mapNotNull { tag ->
+            if (fragmentManager.findFragmentByTag(tag) != null) tag else null
+        }
+
+    companion object {
+        private val autofillTags = listOf(
+            CredentialSavePickerDialog.TAG,
+            CredentialUpdateExistingCredentialsDialog.TAG,
+            UseGeneratedPasswordDialog.TAG,
+            CredentialAutofillPickerDialog.TAG,
+            EmailProtectionChooseEmailDialog.TAG,
+            EmailProtectionInContextSignUpDialog.TAG,
+        )
+
+        private const val KEY_URL_MATCH = "urlMatch"
+        private const val KEY_NEW_DIALOG_TAG = "newDialogTag"
+        private const val KEY_EXISTING_DIALOG_TAGS = "existingDialogTags"
+    }
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/DefaultAutofillOverlappingDialogDetectorTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/DefaultAutofillOverlappingDialogDetectorTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.ui
+
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.autofill.api.CredentialSavePickerDialog
+import com.duckduckgo.autofill.api.UseGeneratedPasswordDialog
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_OVERLAPPING_DIALOG
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+
+class DefaultAutofillOverlappingDialogDetectorTest {
+
+    private val pixel: Pixel = mock()
+    private val fragmentManager: FragmentManager = mock()
+
+    private val testee: DefaultAutofillOverlappingDialogDetector = DefaultAutofillOverlappingDialogDetector(pixel)
+
+    @Test
+    fun whenNoFragmentsShowingThenNoPixelSent() {
+        whenever(fragmentManager.findFragmentByTag(any())).thenReturn(null)
+        testee.detectOverlappingDialogs(fragmentManager, NEW_DIALOG_TAG, urlMatch = true)
+        verifyNoInteractions(pixel)
+    }
+
+    @Test
+    fun whenSingleFragmentShowingThenIncludedInPixelSent() {
+        val urlMatch = true
+        val existingTags = listOf(CredentialSavePickerDialog.TAG)
+        configureFragmentShowing(existingTags)
+
+        testee.detectOverlappingDialogs(fragmentManager, NEW_DIALOG_TAG, urlMatch)
+        verifyOverlapPixelSent(NEW_DIALOG_TAG, existingTags.joinToString(","), urlMatch)
+    }
+
+    @Test
+    fun whenMultipleFragmentsShowingThenAllIncludedInPixelSent() {
+        val urlMatch = true
+        val existingTags = listOf(CredentialSavePickerDialog.TAG, UseGeneratedPasswordDialog.TAG)
+        configureFragmentShowing(existingTags)
+
+        testee.detectOverlappingDialogs(fragmentManager, NEW_DIALOG_TAG, urlMatch)
+        verifyOverlapPixelSent(NEW_DIALOG_TAG, existingTags.joinToString(","), urlMatch)
+    }
+
+    @Test
+    fun whenNotAUrlMatchThenPixelParamSetCorrectly() {
+        val urlMatch = false
+        val existingTags = listOf(CredentialSavePickerDialog.TAG)
+        configureFragmentShowing(existingTags)
+
+        testee.detectOverlappingDialogs(fragmentManager, NEW_DIALOG_TAG, urlMatch)
+        verifyOverlapPixelSent(NEW_DIALOG_TAG, existingTags.joinToString(","), urlMatch)
+    }
+
+    private fun verifyOverlapPixelSent(
+        newDialogTag: String,
+        existingTags: String,
+        urlMatch: Boolean,
+    ) {
+        val expectedMap = mapOf(
+            "urlMatch" to urlMatch.toString(),
+            "newDialogTag" to newDialogTag,
+            "existingDialogTags" to existingTags,
+        )
+        verify(pixel).fire(eq(AUTOFILL_OVERLAPPING_DIALOG), eq(expectedMap), any())
+    }
+
+    private fun configureFragmentShowing(tags: List<String>) {
+        tags.forEach { tag ->
+            whenever(fragmentManager.findFragmentByTag(tag)).thenReturn(DUMMY_FRAGMENT)
+        }
+    }
+
+    companion object {
+        private val DUMMY_FRAGMENT = Fragment()
+        private const val NEW_DIALOG_TAG = "dummy-tag-to-show"
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/0/1206318827324908/f 

### Description
Adds temporary logic to detect scenarios where we are trying to show an Autofill dialog and there is already one showing. We are trying to run down a theory that perhaps this is leading to an anomaly.

This code will be removed again in the near future.

### Steps to test this PR

Testing this requires using Chrome DevTools to trigger arbitrary JS. 

#### Connecting to Chrome DevTools
- [x] Launch Chrome on your desktop, and enter `chrome://inspect/#devices` into the url bar
- [x] Connect to the WebView using the blue `inspect` button. e.g., 

<img src=https://github.com/duckduckgo/Android/assets/1336281/0362af46-a742-4c1f-bbbc-9bba55f02410 width=50% />


#### Testing overlapping dialogs
- [x] Clean install `internal` build type from this branch
- [x] Visit https://fill.dev/form/login-simple. Enter username and password (> 4 chars) and Login
- [x] Do not dismiss the save password prompt that shows
- [x] Hop over to Chrome DevTools, and in the `Console` window paste the following: `BrowserAutofill.storeFormData("{\"credentials\":{\"username\":\"foo\",\"password\":\"dummy-password\"},\"trigger\":\"formSubmission\"}")`
- [x] Verify in logcat that you see logs like these: 
    - `Found 1 existing autofill tags: [ CredentialAutofillPickerDialog ]` 
    - `Pixel sent: m_autofill_overlapping_dialog with params: {urlMatch=true, newDialogTag=CredentialSavePickerDialog, existingDialogTags=CredentialAutofillPickerDialog} {}`