### PR TITLE
Fix moto g shortlist of devices for AppTP

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
@@ -218,5 +218,7 @@ enum class DeviceShieldPixelNames(override val pixelName: String, val enqueue: B
     VPN_SNOOZE_STARTED_DAILY("m_vpn_ev_snooze_started_d", enqueue = true),
     VPN_SNOOZE_ENDED("m_vpn_ev_snooze_ended_c", enqueue = true),
     VPN_SNOOZE_ENDED_DAILY("m_vpn_ev_snooze_ended_d", enqueue = true),
+
+    VPN_MOTO_G_FIX_DAILY("m_vpn_ev_moto_g_fix_d", enqueue = true),
     ;
 }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
@@ -349,6 +349,8 @@ interface DeviceShieldPixels {
 
     fun reportVpnSnoozedStarted()
     fun reportVpnSnoozedEnded()
+
+    fun reportMotoGFix()
 }
 
 @ContributesBinding(AppScope::class)
@@ -745,6 +747,10 @@ class RealDeviceShieldPixels @Inject constructor(
     override fun reportVpnSnoozedEnded() {
         tryToFireDailyPixel(DeviceShieldPixelNames.VPN_SNOOZE_ENDED_DAILY)
         firePixel(DeviceShieldPixelNames.VPN_SNOOZE_ENDED)
+    }
+
+    override fun reportMotoGFix() {
+        tryToFireDailyPixel(DeviceShieldPixelNames.VPN_MOTO_G_FIX_DAILY)
     }
 
     private fun suddenKill() {

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/VpnPixelParamRemovalPlugin.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/VpnPixelParamRemovalPlugin.kt
@@ -30,6 +30,7 @@ class VpnPixelParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin
             NETP_PIXEL_PREFIX to PixelParameter.removeAtb(),
             VPN_PIXEL_PREFIX to PixelParameter.removeAtb(),
             "m_atp_unprotected_apps_bucket_" to PixelParameter.removeAll(),
+            "m_vpn_ev_moto_g_fix_" to PixelParameter.removeAll(),
         )
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1203410036713941/f

### Description
Try out a fix for a subset of moto g devices for which AppTP doesn't work properly.

### Steps to test this PR
Check the configurations in the table below and verify the outcome, where

TLS blocking means
* DnsChangeCallback is never registered
* When AppTP only is enabled, `VpnTunnelConfig` never configures a DNS
* When VPN is enabled (irregardless of AppTP), VPN DNS is always configured
* Tracker attempts are blocked when AppTP is enabled
* 
DNS blocking
* DnsChangeCallback is registered
* Network changes (WIFI<>CELL) are detected and DNS is reconfigured (you can check this with DNS leak test app)
* Tracker attempts are blocked when AppTP is enabled



| moto g | private DNS | apptp | netp | Outcome        |
|--------|-------------|-------|------|----------------|
| -      | -           | -     | -    | -              |
| -      | -           | -     | X    | TLS blocking   |
| -      | -           | X     | -    | TLS blocking   |
| -      | -           | X     | X    | TLS blocking   |
| -      | X           | -     | -    | -              |
| -      | X           | -     | X    | TLS blocking   |
| -      | X           | X     |      | TLS blocking   |
| -      | X           | X     | X    | TLS blocking   |
| X      | -           | -     | -    | -              |
| X      | -           | -     | X    | TLS blocking   |
| X      | -           | X     | -    | DNS blocking   |
| X      | -           | X     | X    | TLS blocking   |
| X      | X           | -     | -    | -              |
| X      | X           | -     | X    | TLS blocking   |
| X      | X           | X     | -    | TLS blocking   |
| X      | X           | X     | X    | TLS blocking   |

