### PR TITLE
new DuckDuckGo directory in Downloads

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/install/AppInstallStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/install/AppInstallStore.kt
@@ -36,6 +36,8 @@ interface AppInstallStore : MainProcessLifecycleObserver {
 
     var newDefaultBrowserDialogCount: Int
 
+    var returningUserChecked: Boolean
+
     fun hasInstallTimestampRecorded(): Boolean
 }
 
@@ -60,6 +62,10 @@ class AppInstallSharedPreferences @Inject constructor(private val context: Conte
         get() = preferences.getInt(ROLE_MANAGER_BROWSER_DIALOG_KEY, 0)
         set(defaultBrowser) = preferences.edit { putInt(ROLE_MANAGER_BROWSER_DIALOG_KEY, defaultBrowser) }
 
+    override var returningUserChecked: Boolean
+        get() = preferences.getBoolean(KEY_RETURNING_USER, false)
+        set(checked) = preferences.edit { putBoolean(KEY_RETURNING_USER, checked) }
+
     override fun hasInstallTimestampRecorded(): Boolean = preferences.contains(KEY_TIMESTAMP_UTC)
 
     private val preferences: SharedPreferences by lazy { context.getSharedPreferences(FILENAME, Context.MODE_PRIVATE) }
@@ -78,6 +84,7 @@ class AppInstallSharedPreferences @Inject constructor(private val context: Conte
         const val KEY_TIMESTAMP_UTC = "INSTALL_TIMESTAMP_UTC"
         const val KEY_WIDGET_INSTALLED = "KEY_WIDGET_INSTALLED"
         const val KEY_DEFAULT_BROWSER = "KEY_DEFAULT_BROWSER"
+        const val KEY_RETURNING_USER = "KEY_RETURNING_USER"
         private const val ROLE_MANAGER_BROWSER_DIALOG_KEY = "ROLE_MANAGER_BROWSER_DIALOG_KEY"
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/reinstalls/DownloadsDirectoryManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/reinstalls/DownloadsDirectoryManager.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.reinstalls
+
+import android.os.Environment
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import java.io.File
+import javax.inject.Inject
+import timber.log.Timber
+
+interface DownloadsDirectoryManager {
+
+    fun getDownloadsDirectory(): File
+    fun createNewDirectory(directoryName: String)
+}
+
+@ContributesBinding(AppScope::class)
+class DownloadsDirectoryManagerImpl @Inject constructor() : DownloadsDirectoryManager {
+
+    override fun getDownloadsDirectory(): File {
+        val downloadDirectory = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+        if (!downloadDirectory.exists()) {
+            Timber.i("Download directory doesn't exist; trying to create it. %s", downloadDirectory.absolutePath)
+            downloadDirectory.mkdirs()
+        }
+        return downloadDirectory
+    }
+
+    override fun createNewDirectory(directoryName: String) {
+        val directory = File(getDownloadsDirectory(), directoryName)
+        val success = directory.mkdirs()
+        Timber.i("Directory creation success: %s", success)
+        if (!success) {
+            Timber.e("Directory creation failed")
+            kotlin.runCatching {
+                val directoryCreationSuccess = directory.createNewFile()
+                Timber.i("File creation success: %s", directoryCreationSuccess)
+            }.onFailure {
+                Timber.w("Failed to create file: %s", it.message)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/reinstalls/ReinstallAtbListener.kt
+++ b/app/src/main/java/com/duckduckgo/app/reinstalls/ReinstallAtbListener.kt
@@ -16,24 +16,51 @@
 
 package com.duckduckgo.app.reinstalls
 
+import android.os.Build
+import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.statistics.AtbInitializerListener
+import com.duckduckgo.app.statistics.store.StatisticsDataStore
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
 import javax.inject.Inject
+import timber.log.Timber
 
 @SingleInstanceIn(AppScope::class)
 @ContributesMultibinding(AppScope::class)
 class ReinstallAtbListener @Inject constructor(
     private val backupDataStore: BackupServiceDataStore,
+    private val statisticsDataStore: StatisticsDataStore,
+    private val appInstallStore: AppInstallStore,
+    private val appBuildConfig: AppBuildConfig,
+    private val downloadsDirectoryManager: DownloadsDirectoryManager,
 ) : AtbInitializerListener {
+
     override suspend fun beforeAtbInit() {
         backupDataStore.clearBackupPreferences()
+
+        if (appBuildConfig.sdkInt >= Build.VERSION_CODES.R && !appInstallStore.returningUserChecked) {
+            val downloadDirectory = downloadsDirectoryManager.getDownloadsDirectory()
+
+            val downloadFiles = downloadDirectory.list()?.asList() ?: emptyList()
+            val ddgDirectoryExists = downloadFiles.contains(DDG_DOWNLOADS_DIRECTORY)
+            if (ddgDirectoryExists) {
+                statisticsDataStore.variant = REINSTALL_VARIANT
+                Timber.i("Variant update for returning user")
+            } else {
+                downloadsDirectoryManager.createNewDirectory(DDG_DOWNLOADS_DIRECTORY)
+            }
+            appInstallStore.returningUserChecked = true
+        }
     }
 
     override fun beforeAtbInitTimeoutMillis(): Long = MAX_REINSTALL_WAIT_TIME_MS
 
     companion object {
         private const val MAX_REINSTALL_WAIT_TIME_MS = 1_500L
+
+        const val REINSTALL_VARIANT = "ru"
+        private const val DDG_DOWNLOADS_DIRECTORY = "DuckDuckGo"
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/reinstalls/ReinstallAtbListenerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/reinstalls/ReinstallAtbListenerTest.kt
@@ -16,26 +16,45 @@
 
 package com.duckduckgo.app.reinstalls
 
+import android.os.Build
+import com.duckduckgo.app.global.install.AppInstallStore
+import com.duckduckgo.app.reinstalls.ReinstallAtbListener.Companion.REINSTALL_VARIANT
+import com.duckduckgo.app.statistics.store.StatisticsDataStore
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.test.CoroutineTestRule
+import java.io.File
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 class ReinstallAtbListenerTest {
 
     private lateinit var testee: ReinstallAtbListener
 
     private val mockBackupDataStore: BackupServiceDataStore = mock()
+    private val mockStatisticsDataStore: StatisticsDataStore = mock()
+    private val mockAppInstallStore: AppInstallStore = mock()
+    private val mockAppBuildConfig: AppBuildConfig = mock()
+    private val mockDownloadsDirectoryManager: DownloadsDirectoryManager = mock()
 
     @get:Rule
     val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
 
     @Before
     fun before() {
-        testee = ReinstallAtbListener(mockBackupDataStore)
+        testee = ReinstallAtbListener(
+            mockBackupDataStore,
+            mockStatisticsDataStore,
+            mockAppInstallStore,
+            mockAppBuildConfig,
+            mockDownloadsDirectoryManager,
+        )
     }
 
     @Test
@@ -43,5 +62,66 @@ class ReinstallAtbListenerTest {
         testee.beforeAtbInit()
 
         verify(mockBackupDataStore).clearBackupPreferences()
+    }
+
+    @Test
+    fun whenAndroidVersionIs10OrLowerThenDontCheckForDownloadsDirectory() = runTest {
+        whenever(mockAppBuildConfig.sdkInt).thenReturn(Build.VERSION_CODES.Q)
+
+        testee.beforeAtbInit()
+
+        verify(mockDownloadsDirectoryManager, never()).getDownloadsDirectory()
+    }
+
+    @Test
+    fun whenReturningUserHasBeenAlreadyCheckedThenDontCheckForDownloadsDirectory() = runTest {
+        whenever(mockAppBuildConfig.sdkInt).thenReturn(Build.VERSION_CODES.R)
+        whenever(mockAppInstallStore.returningUserChecked).thenReturn(true)
+
+        testee.beforeAtbInit()
+
+        verify(mockDownloadsDirectoryManager, never()).getDownloadsDirectory()
+    }
+
+    @Test
+    fun whenDDGDirectoryIsFoundThenUpdateVariantForReturningUser() = runTest {
+        whenever(mockAppBuildConfig.sdkInt).thenReturn(Build.VERSION_CODES.R)
+        whenever(mockAppInstallStore.returningUserChecked).thenReturn(false)
+        val mockDownloadsDirectory: File = mock {
+            on { list() } doReturn arrayOf("DuckDuckGo")
+        }
+        whenever(mockDownloadsDirectoryManager.getDownloadsDirectory()).thenReturn(mockDownloadsDirectory)
+
+        testee.beforeAtbInit()
+
+        verify(mockStatisticsDataStore).variant = REINSTALL_VARIANT
+    }
+
+    @Test
+    fun whenDDGDirectoryIsNotFoundThenVariantForReturningUserIsNotSet() = runTest {
+        whenever(mockAppBuildConfig.sdkInt).thenReturn(Build.VERSION_CODES.R)
+        whenever(mockAppInstallStore.returningUserChecked).thenReturn(false)
+        val mockDownloadsDirectory: File = mock {
+            on { list() } doReturn emptyArray()
+        }
+        whenever(mockDownloadsDirectoryManager.getDownloadsDirectory()).thenReturn(mockDownloadsDirectory)
+
+        testee.beforeAtbInit()
+
+        verify(mockStatisticsDataStore, never()).variant = REINSTALL_VARIANT
+    }
+
+    @Test
+    fun whenDDGDirectoryIsNotFoundThenCreateIt() = runTest {
+        whenever(mockAppBuildConfig.sdkInt).thenReturn(Build.VERSION_CODES.R)
+        whenever(mockAppInstallStore.returningUserChecked).thenReturn(false)
+        val mockDownloadsDirectory: File = mock {
+            on { list() } doReturn emptyArray()
+        }
+        whenever(mockDownloadsDirectoryManager.getDownloadsDirectory()).thenReturn(mockDownloadsDirectory)
+
+        testee.beforeAtbInit()
+
+        verify(mockDownloadsDirectoryManager).createNewDirectory("DuckDuckGo")
     }
 }

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/VariantManagerImpl.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/VariantManagerImpl.kt
@@ -66,6 +66,10 @@ class VariantManagerImpl @Inject constructor(
             return
         }
 
+        if (currentVariantKey == REINSTALL_VARIANT) {
+            return
+        }
+
         if (currentVariantKey == null) {
             allocateNewVariant(activeVariants)
             return
@@ -140,6 +144,8 @@ class VariantManagerImpl @Inject constructor(
 
         // this will be returned when there are no other active experiments
         private val DEFAULT_VARIANT = Variant(key = "", filterBy = { noFilter() })
+
+        private const val REINSTALL_VARIANT = "ru"
 
         private val serpRegionToggleTargetCountries = listOf(
             "AU",

--- a/experiments/experiments-impl/src/test/java/com/duckduckgo/experiments/impl/ExperimentationVariantManagerTest.kt
+++ b/experiments/experiments-impl/src/test/java/com/duckduckgo/experiments/impl/ExperimentationVariantManagerTest.kt
@@ -103,6 +103,19 @@ class ExperimentationVariantManagerTest {
     }
 
     @Test
+    fun givenReturnUserVariantWhenVariantsConfigUpdatedThenNewVariantNoAllocated() {
+        val variantsConfig = listOf(VariantConfig("variant1", 1.0), VariantConfig("variant2", 1.0))
+        val testVariantEntity = ExperimentVariantEntity("variant1", 1.0)
+        whenever(mockExperimentVariantRepository.getActiveVariants()).thenReturn(listOf(testVariantEntity))
+        whenever(mockExperimentVariantRepository.getUserVariant()).thenReturn("ru")
+
+        testee.saveVariants(variantsConfig)
+
+        verify(mockExperimentVariantRepository, never()).updateVariant(any())
+        verify(mockRandomizer, never()).random(any())
+    }
+
+    @Test
     fun whenNoVariantsAvailableThenDefaultVariantIsAssigned() {
         whenever(mockExperimentVariantRepository.getActiveVariants()).thenReturn(emptyList())
         whenever(mockExperimentVariantRepository.getUserVariant()).thenReturn(null)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1206329522328638/f

### Description
Add implementation for creating a new DuckDuckGo directory in Downloads folder for Android 11 onwards

### Steps to test this PR

_User with Android version < 11_
- [x] Check you don't have `DuckDuckGo` directory in _Downloads_ folder
- Install from this branch
- Download an image giving storage permissions
- Close and open the app again
- [x] Check new `DuckDuckGo` directory has **NOT** been created in _Downloads_

**_Android version > 10_**
_Existing user_
- Make sure you have a previous install
- [x] Check you don't have `DuckDuckGo` directory in _Downloads_ folder
- Install from this branch
- [x] Check new `DuckDuckGo` directory has been created

_New user install_
- [x] Check you don't have `DuckDuckGo` directory in _Downloads_ folder
- Fresh install from branch
- [x] Check new `DuckDuckGo` directory has been created
- [x] Check 'ru' variant has not been assigned

_Returning user install_
- Fresh install from branch
- [x] Check you have `DuckDuckGo` directory in _Downloads_ folder
- Uninstall and install the app again from branch
- [x] Check `DuckDuckGo` directory is still in _Downloads_
- [x] Check 'ru' variant has been assigned

_Manual directory removal_
- Fresh install from branch
- [x] Check you have `DuckDuckGo` directory in _Downloads_ folder
- Remove `DuckDuckGo' directory manually from your device Downloads folder
- Open the app again
- Check new `DuckDuckGo` directory has **NOT** been created again in _Downloads_

### No UI changes
