### PR TITLE
ADS: onDialogCancelled callback added to alert dialogs

### DIFF
--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/dialog/CustomAlertDialogBuilder.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/dialog/CustomAlertDialogBuilder.kt
@@ -32,6 +32,7 @@ class CustomAlertDialogBuilder(val context: Context) : DaxAlertDialog {
         open fun onDialogDismissed() {}
         open fun onPositiveButtonClicked() {}
         open fun onNegativeButtonClicked() {}
+        open fun onDialogCancelled() {}
     }
 
     internal class DefaultEventListener : EventListener()
@@ -99,6 +100,7 @@ class CustomAlertDialogBuilder(val context: Context) : DaxAlertDialog {
             .apply {
                 setCancelable(false)
                 setOnDismissListener { listener.onDialogDismissed() }
+                setOnCancelListener { listener.onDialogCancelled() }
             }
         dialog = dialogBuilder.create()
         setViews(binding, dialog!!)

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/dialog/RadioListAlertDialogBuilder.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/dialog/RadioListAlertDialogBuilder.kt
@@ -36,6 +36,7 @@ class RadioListAlertDialogBuilder(val context: Context) : DaxAlertDialog {
     abstract class EventListener {
         open fun onDialogShown() {}
         open fun onDialogDismissed() {}
+        open fun onDialogCancelled() {}
         open fun onRadioItemSelected(selectedItem: Int) {}
         open fun onPositiveButtonClicked(selectedItem: Int) {}
         open fun onNegativeButtonClicked() {}
@@ -127,6 +128,7 @@ class RadioListAlertDialogBuilder(val context: Context) : DaxAlertDialog {
             .apply {
                 setCancelable(false)
                 setOnDismissListener { listener.onDialogDismissed() }
+                setOnCancelListener { listener.onDialogCancelled() }
             }
 
         dialog = dialogBuilder.create()

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/dialog/StackedAlertDialogBuilder.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/dialog/StackedAlertDialogBuilder.kt
@@ -34,6 +34,7 @@ class StackedAlertDialogBuilder(val context: Context) : DaxAlertDialog {
     abstract class EventListener {
         open fun onDialogShown() {}
         open fun onDialogDismissed() {}
+        open fun onDialogCancelled() {}
         open fun onButtonClicked(position: Int) {}
     }
 
@@ -99,6 +100,7 @@ class StackedAlertDialogBuilder(val context: Context) : DaxAlertDialog {
             .apply {
                 setCancelable(false)
                 setOnDismissListener { listener.onDialogDismissed() }
+                setOnCancelListener { listener.onDialogCancelled() }
             }
 
         dialog = dialogBuilder.create()

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/dialog/TextAlertDialogBuilder.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/dialog/TextAlertDialogBuilder.kt
@@ -110,11 +110,8 @@ class TextAlertDialogBuilder(val context: Context) : DaxAlertDialog {
             .setView(binding.root)
             .setCancelable(isCancellable)
             .apply {
-                if (isCancellable) {
-                    setOnCancelListener {
-                        listener.onDialogCancelled()
-                    }
-                }
+                setOnDismissListener { listener.onDialogDismissed() }
+                setOnCancelListener { listener.onDialogCancelled() }
             }
         dialog = dialogBuilder.create()
         setViews(binding, dialog!!)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1204448904099019/f

### Description
Add cancellable callback to Dax Alert dialogs

- [Android Component: TextAlertDialog](https://app.asana.com/0/0/1202943892847396/f)
[Android Component: StackedAlertDialog](https://app.asana.com/0/0/1202943892847397/f)
[Android Component: RadioListAlertDialog](https://app.asana.com/0/0/1202943892847398/f)
[Android Component: CustomAlertDialog](https://app.asana.com/0/0/1203508448986202/f)

### Steps to test this PR

- Install from branch
- Go to Settings > Design Preview
- Tap on DIALOGS tab
- Tap on "Text Alert Dialog Cancellable"
- [ ] Check you see "Dialog cancelled" when tapping outside the dialog
- [ ] Check you see "Dialog cancelled" when tapping back key
- [ ] Check you don't see "Dialog cancelled" when tapping any button

### No UI changes
