### PR TITLE
try-catch encrypt decrypt and pixel

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCrypto.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCrypto.kt
@@ -19,7 +19,9 @@ package com.duckduckgo.sync.impl
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.api.SyncCrypto
 import com.duckduckgo.sync.crypto.SyncLib
+import com.duckduckgo.sync.impl.error.SyncOperationErrorRecorder
 import com.duckduckgo.sync.store.SyncStore
+import com.duckduckgo.sync.store.model.SyncOperationErrorType
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 
@@ -27,11 +29,19 @@ import javax.inject.Inject
 class RealSyncCrypto @Inject constructor(
     private val nativeLib: SyncLib,
     private val syncStore: SyncStore,
+    private val syncOperationErrorRecorder: SyncOperationErrorRecorder,
 ) : SyncCrypto {
     override fun encrypt(text: String): String {
-        val encryptResult = nativeLib.encryptData(text, syncStore.secretKey.orEmpty())
+        val encryptResult = kotlin.runCatching {
+            nativeLib.encryptData(text, syncStore.secretKey.orEmpty())
+        }.getOrElse {
+            syncOperationErrorRecorder.record(SyncOperationErrorType.DATA_ENCRYPT)
+            throw it
+        }
+
         return if (encryptResult.result != 0L) {
-            ""
+            syncOperationErrorRecorder.record(SyncOperationErrorType.DATA_ENCRYPT)
+            throw Exception("Failed to encrypt data")
         } else {
             encryptResult.encryptedData
         }
@@ -39,9 +49,16 @@ class RealSyncCrypto @Inject constructor(
 
     override fun decrypt(data: String): String {
         if (data.isEmpty()) return data
-        val decryptResult = nativeLib.decryptData(data, syncStore.secretKey.orEmpty())
+        val decryptResult = kotlin.runCatching {
+            nativeLib.decryptData(data, syncStore.secretKey.orEmpty())
+        }.getOrElse {
+            syncOperationErrorRecorder.record(SyncOperationErrorType.DATA_DECRYPT)
+            throw it
+        }
+
         return if (decryptResult.result != 0L) {
-            ""
+            syncOperationErrorRecorder.record(SyncOperationErrorType.DATA_DECRYPT)
+            throw Exception("Failed to decrypt data")
         } else {
             decryptResult.decryptedData
         }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/di/SyncModule.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/di/SyncModule.kt
@@ -28,7 +28,9 @@ import com.duckduckgo.sync.impl.QREncoder
 import com.duckduckgo.sync.impl.engine.AppSyncStateRepository
 import com.duckduckgo.sync.impl.engine.SyncStateRepository
 import com.duckduckgo.sync.impl.error.RealSyncApiErrorRepository
+import com.duckduckgo.sync.impl.error.RealSyncOperationErrorRepository
 import com.duckduckgo.sync.impl.error.SyncApiErrorRepository
+import com.duckduckgo.sync.impl.error.SyncOperationErrorRepository
 import com.duckduckgo.sync.impl.internal.AppSyncInternalEnvDataStore
 import com.duckduckgo.sync.impl.internal.SyncInternalEnvDataStore
 import com.duckduckgo.sync.impl.stats.RealSyncStatsRepository
@@ -107,11 +109,17 @@ object SyncStoreModule {
     }
 
     @Provides
+    fun provideSyncOperationErrorRepository(syncDatabase: SyncDatabase): SyncOperationErrorRepository {
+        return RealSyncOperationErrorRepository(syncDatabase.syncOperationErrorsDao())
+    }
+
+    @Provides
     @SingleInstanceIn(AppScope::class)
     fun provideSyncStatsRepository(
         syncStateRepository: SyncStateRepository,
         syncApiErrorRepository: SyncApiErrorRepository,
+        syncOperationErrorRepository: SyncOperationErrorRepository,
     ): SyncStatsRepository {
-        return RealSyncStatsRepository(syncStateRepository, syncApiErrorRepository)
+        return RealSyncStatsRepository(syncStateRepository, syncApiErrorRepository, syncOperationErrorRepository)
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/error/SyncOperationErrorRecorder.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/error/SyncOperationErrorRecorder.kt
@@ -28,6 +28,11 @@ interface SyncOperationErrorRecorder {
     fun record(
         errorType: SyncOperationErrorType,
     )
+
+    fun record(
+        feature: String,
+        errorType: SyncOperationErrorType,
+    )
 }
 
 @ContributesBinding(AppScope::class)
@@ -39,6 +44,14 @@ class RealSyncOperationErrorRecorder @Inject constructor(
         errorType: SyncOperationErrorType,
     ) {
         Timber.d("Sync-Error: Recording Operation Error $errorType")
+        repository.addError(errorType)
+    }
+
+    override fun record(
+        feature: String,
+        errorType: SyncOperationErrorType,
+    ) {
+        Timber.d("Sync-Error: Recording Operation Error $errorType for $feature")
         repository.addError(errorType)
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/error/SyncOperationErrorRecorder.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/error/SyncOperationErrorRecorder.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.error
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.store.model.SyncOperationErrorType
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+import timber.log.Timber
+
+interface SyncOperationErrorRecorder {
+
+    fun record(
+        errorType: SyncOperationErrorType,
+    )
+}
+
+@ContributesBinding(AppScope::class)
+class RealSyncOperationErrorRecorder @Inject constructor(
+    private val syncPixels: SyncPixels,
+    private val repository: SyncOperationErrorRepository,
+) : SyncOperationErrorRecorder {
+    override fun record(
+        errorType: SyncOperationErrorType,
+    ) {
+        Timber.d("Sync-Error: Recording Operation Error $errorType")
+        repository.addError(errorType)
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/error/SyncOperationErrorRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/error/SyncOperationErrorRepository.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.error
+
+import com.duckduckgo.common.utils.formatters.time.DatabaseDateFormatter
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters
+import com.duckduckgo.sync.store.dao.SyncOperationErrorDao
+import com.duckduckgo.sync.store.model.SyncOperationError
+import com.duckduckgo.sync.store.model.SyncOperationErrorType
+import com.duckduckgo.sync.store.model.SyncOperationErrorType.DATA_DECRYPT
+import com.duckduckgo.sync.store.model.SyncOperationErrorType.DATA_ENCRYPT
+import javax.inject.Inject
+
+interface SyncOperationErrorRepository {
+    fun addError(
+        apiError: SyncOperationErrorType,
+    )
+
+    fun getErrorsByDate(date: String): List<SyncOperationErrorPixelData>
+}
+
+data class SyncOperationErrorPixelData(
+    val name: String,
+    val count: String,
+)
+
+class RealSyncOperationErrorRepository @Inject constructor(private val dao: SyncOperationErrorDao) : SyncOperationErrorRepository {
+    override fun addError(
+        apiError: SyncOperationErrorType,
+    ) {
+        val today = DatabaseDateFormatter.getUtcIsoLocalDate()
+        val todaysError = dao.errorByDate(apiError.name, today)
+        if (todaysError == null) {
+            dao.insert(SyncOperationError(errorType = apiError, count = 1, date = today))
+        } else {
+            dao.incrementCount(apiError.name, today)
+        }
+    }
+
+    override fun getErrorsByDate(date: String): List<SyncOperationErrorPixelData> {
+        return dao.errorsByDate(date).map {
+            val errorType = when (it.errorType) {
+                DATA_DECRYPT -> SyncPixelParameters.DATA_DECRYPT_ERROR
+                DATA_ENCRYPT -> SyncPixelParameters.DATA_ENCRYPT_ERROR
+            }
+            SyncOperationErrorPixelData(errorType, it.count.toString())
+        }
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
@@ -61,6 +61,10 @@ interface SyncPixels {
     fun fireSyncAccountErrorPixel(
         result: Error,
     )
+
+    fun fireEncryptFailurePixel()
+
+    fun fireDecryptFailurePixel()
 }
 
 @ContributesBinding(AppScope::class)
@@ -80,7 +84,7 @@ class RealSyncPixels @Inject constructor(
         val payload = mapOf(
             SyncPixelParameters.COUNT to dailyStats.attempts,
             SyncPixelParameters.DATE to dailyStats.date,
-        ).plus(dailyStats.apiErrorStats)
+        ).plus(dailyStats.apiErrorStats).plus(dailyStats.operationErrorStats)
         tryToFireDailyPixel(SYNC_DAILY_PIXEL, payload)
     }
 
@@ -110,6 +114,14 @@ class RealSyncPixels @Inject constructor(
                 SyncPixelParameters.ERROR_REASON to result.reason,
             ),
         )
+    }
+
+    override fun fireEncryptFailurePixel() {
+        tryToFireDailyPixel(SyncPixelName.SYNC_ENCRYPT_FAILURE)
+    }
+
+    override fun fireDecryptFailurePixel() {
+        tryToFireDailyPixel(SyncPixelName.SYNC_DECRYPT_FAILURE)
     }
 
     private fun tryToFireDailyPixel(
@@ -148,6 +160,8 @@ enum class SyncPixelName(override val pixelName: String) : Pixel.PixelName {
     SYNC_SIGNUP_DIRECT("m_sync_signup_direct"),
     SYNC_SIGNUP_CONNECT("m_sync_signup_connect"),
     SYNC_ACCOUNT_FAILURE("m_sync_account_failure"),
+    SYNC_ENCRYPT_FAILURE("m_sync_encrypt_failure"),
+    SYNC_DECRYPT_FAILURE("m_sync_decrypt_failure"),
 }
 
 object SyncPixelParameters {
@@ -157,6 +171,8 @@ object SyncPixelParameters {
     const val REQUEST_SIZE_LIMIT_EXCEEDED_COUNT = "%s_request_size_limit_exceeded_count"
     const val VALIDATION_ERROR_COUNT = "%s_validation_error"
     const val TOO_MANY_REQUESTS = "%s_too_many_requests_count"
+    const val DATA_ENCRYPT_ERROR = "encrypt_error_count"
+    const val DATA_DECRYPT_ERROR = "decrypt_error_count"
     const val ERROR_CODE = "code"
     const val ERROR_REASON = "reason"
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
@@ -61,10 +61,6 @@ interface SyncPixels {
     fun fireSyncAccountErrorPixel(
         result: Error,
     )
-
-    fun fireEncryptFailurePixel()
-
-    fun fireDecryptFailurePixel()
 }
 
 @ContributesBinding(AppScope::class)
@@ -114,14 +110,6 @@ class RealSyncPixels @Inject constructor(
                 SyncPixelParameters.ERROR_REASON to result.reason,
             ),
         )
-    }
-
-    override fun fireEncryptFailurePixel() {
-        tryToFireDailyPixel(SyncPixelName.SYNC_ENCRYPT_FAILURE)
-    }
-
-    override fun fireDecryptFailurePixel() {
-        tryToFireDailyPixel(SyncPixelName.SYNC_DECRYPT_FAILURE)
     }
 
     private fun tryToFireDailyPixel(

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/stats/SyncStatsRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/stats/SyncStatsRepository.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.sync.impl.stats
 import com.duckduckgo.common.utils.formatters.time.DatabaseDateFormatter
 import com.duckduckgo.sync.impl.engine.SyncStateRepository
 import com.duckduckgo.sync.impl.error.SyncApiErrorRepository
+import com.duckduckgo.sync.impl.error.SyncOperationErrorRepository
 import com.duckduckgo.sync.store.model.SyncAttempt
 import javax.inject.Inject
 
@@ -38,11 +39,13 @@ data class DailyStats(
     val attempts: String,
     val date: String,
     val apiErrorStats: Map<String, String> = emptyMap(),
+    val operationErrorStats: Map<String, String> = emptyMap(),
 )
 
 class RealSyncStatsRepository @Inject constructor(
     private val syncStateRepository: SyncStateRepository,
     private val syncApiErrorRepository: SyncApiErrorRepository,
+    private val syncOperationErrorRepository: SyncOperationErrorRepository,
 ) : SyncStatsRepository {
     override fun getYesterdayDailyStats(): DailyStats {
         val yesterday = DatabaseDateFormatter.getUtcIsoLocalDate(1)
@@ -50,6 +53,7 @@ class RealSyncStatsRepository @Inject constructor(
             it.yesterday()
         }.size
         val apiErrorMap = syncApiErrorRepository.getErrorsByDate(yesterday).associate { it.name to it.count }
-        return DailyStats(count.toString(), yesterday, apiErrorMap)
+        val operationErrorMap = syncOperationErrorRepository.getErrorsByDate(yesterday).associate { it.name to it.count }
+        return DailyStats(count.toString(), yesterday, apiErrorMap, operationErrorMap)
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/error/SyncOperationErrorRecorderTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/error/SyncOperationErrorRecorderTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.error
+
+import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.store.model.SyncOperationErrorType
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+internal class SyncOperationErrorRecorderTest {
+
+    private val syncPixels: SyncPixels = mock()
+    private val repository: SyncOperationErrorRepository = mock()
+
+    private val recorder = RealSyncOperationErrorRecorder(syncPixels, repository)
+
+    @Test
+    fun wheneverEncryptErrorReportedThenRepositoryAddsError() {
+        val error = SyncOperationErrorType.DATA_ENCRYPT
+
+        recorder.record(error)
+
+        verify(repository).addError(error)
+    }
+
+    @Test
+    fun wheneverDecryptErrorReportedThenRepositoryAddsError() {
+        val error = SyncOperationErrorType.DATA_DECRYPT
+
+        recorder.record(error)
+
+        verify(repository).addError(error)
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/error/SyncOperationErrorRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/error/SyncOperationErrorRepositoryTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.error
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.common.utils.formatters.time.DatabaseDateFormatter
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters
+import com.duckduckgo.sync.store.SyncDatabase
+import com.duckduckgo.sync.store.model.SyncOperationErrorType
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import org.junit.After
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SyncOperationErrorRepositoryTest {
+
+    @get:Rule
+    @Suppress("unused")
+    var instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+    private val db = Room.inMemoryDatabaseBuilder(context, SyncDatabase::class.java)
+        .allowMainThreadQueries()
+        .build()
+
+    private val dao = db.syncOperationErrorsDao()
+
+    private val testee = RealSyncOperationErrorRepository(dao)
+
+    @After
+    fun after() {
+        db.close()
+    }
+
+    @Test
+    fun whenOperationErrorAddedAndNotPresentThenNewEntryAdded() {
+        val errorType = SyncOperationErrorType.DATA_ENCRYPT
+        val date = DatabaseDateFormatter.getUtcIsoLocalDate()
+
+        testee.addError(errorType)
+
+        val error = dao.errorByDate(errorType.name, date)
+
+        Assert.assertTrue(error != null)
+        Assert.assertTrue(error!!.count == 1)
+    }
+
+    @Test
+    fun whenOperationErrorAddedAndPresentThenCountUpdated() {
+        val errorType = SyncOperationErrorType.DATA_ENCRYPT
+        val date = DatabaseDateFormatter.getUtcIsoLocalDate()
+
+        testee.addError(errorType)
+        testee.addError(errorType)
+
+        val error = dao.errorByDate(errorType.name, date)
+
+        Assert.assertTrue(error != null)
+        Assert.assertTrue(error!!.count == 2)
+    }
+
+    @Test
+    fun whenNoErrorsStoredThenGettingErrorsReturnsEmpty() {
+        val date = DatabaseDateFormatter.getUtcIsoLocalDate()
+
+        val errors = testee.getErrorsByDate(date)
+
+        Assert.assertTrue(errors.isEmpty())
+    }
+
+    @Test
+    fun whenNoErrorsStoredFromYesterdayThenGettingErrorsFromYesterdayReturnsEmpty() {
+        val errorType = SyncOperationErrorType.DATA_ENCRYPT
+        val yesterday = LocalDate.now().minusDays(1).format(DateTimeFormatter.ISO_LOCAL_DATE)
+
+        testee.addError(errorType)
+
+        val errors = testee.getErrorsByDate(yesterday)
+
+        Assert.assertTrue(errors.isEmpty())
+    }
+
+    @Test
+    fun whenErrorsStoredThenGettingErrorsReturnsData() {
+        val errorType = SyncOperationErrorType.DATA_ENCRYPT
+        val today = DatabaseDateFormatter.getUtcIsoLocalDate()
+
+        testee.addError(errorType)
+
+        val errors = testee.getErrorsByDate(today)
+        Assert.assertTrue(errors.isNotEmpty())
+
+        val error = errors.first()
+        Assert.assertTrue(error.name == SyncPixelParameters.DATA_ENCRYPT_ERROR)
+        Assert.assertTrue(error.count == "1")
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/error/SyncOperationErrorRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/error/SyncOperationErrorRepositoryTest.kt
@@ -23,6 +23,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.common.utils.formatters.time.DatabaseDateFormatter
 import com.duckduckgo.sync.impl.pixels.SyncPixelParameters
 import com.duckduckgo.sync.store.SyncDatabase
+import com.duckduckgo.sync.store.model.GENERIC_FEATURE
 import com.duckduckgo.sync.store.model.SyncOperationErrorType
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -60,7 +61,7 @@ class SyncOperationErrorRepositoryTest {
 
         testee.addError(errorType)
 
-        val error = dao.errorByDate(errorType.name, date)
+        val error = dao.featureErrorByDate(GENERIC_FEATURE, errorType.name, date)
 
         Assert.assertTrue(error != null)
         Assert.assertTrue(error!!.count == 1)
@@ -74,7 +75,7 @@ class SyncOperationErrorRepositoryTest {
         testee.addError(errorType)
         testee.addError(errorType)
 
-        val error = dao.errorByDate(errorType.name, date)
+        val error = dao.featureErrorByDate(GENERIC_FEATURE, errorType.name, date)
 
         Assert.assertTrue(error != null)
         Assert.assertTrue(error!!.count == 2)

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/pixels/SyncPixelsTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/pixels/SyncPixelsTest.kt
@@ -78,7 +78,7 @@ class SyncPixelsTest {
         val payload = mapOf(
             SyncPixelParameters.COUNT to dailyStats.attempts,
             SyncPixelParameters.DATE to dailyStats.date,
-        ).plus(dailyStats.apiErrorStats)
+        ).plus(dailyStats.apiErrorStats).plus(dailyStats.operationErrorStats)
 
         verify(pixel, times(1)).fire(SyncPixelName.SYNC_DAILY_PIXEL, payload)
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/stats/SyncStatsRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/stats/SyncStatsRepositoryTest.kt
@@ -19,6 +19,9 @@ package com.duckduckgo.sync.impl.stats
 import com.duckduckgo.sync.impl.engine.SyncStateRepository
 import com.duckduckgo.sync.impl.error.SyncApiErrorPixelData
 import com.duckduckgo.sync.impl.error.SyncApiErrorRepository
+import com.duckduckgo.sync.impl.error.SyncOperationErrorPixelData
+import com.duckduckgo.sync.impl.error.SyncOperationErrorRepository
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters
 import com.duckduckgo.sync.store.model.SyncAttempt
 import com.duckduckgo.sync.store.model.SyncAttemptState.FAIL
 import com.duckduckgo.sync.store.model.SyncAttemptState.SUCCESS
@@ -37,22 +40,26 @@ class SyncStatsRepositoryTest {
 
     private var syncStateRepository: SyncStateRepository = mock()
     private var syncApiErrorRepository: SyncApiErrorRepository = mock()
+    private var syncOperationErrorRepository: SyncOperationErrorRepository = mock()
 
     private lateinit var repository: SyncStatsRepository
 
     @Before
     fun setup() {
-        repository = RealSyncStatsRepository(syncStateRepository, syncApiErrorRepository)
+        repository = RealSyncStatsRepository(syncStateRepository, syncApiErrorRepository, syncOperationErrorRepository)
     }
 
     @Test
     fun whenNoAttemptsThenDailyStatsIsEmpty() {
         whenever(syncStateRepository.attempts()).thenReturn(emptyList())
         whenever(syncApiErrorRepository.getErrorsByDate(any())).thenReturn(emptyList())
+        whenever(syncOperationErrorRepository.getErrorsByDate(any())).thenReturn(emptyList())
 
         val stats = repository.getYesterdayDailyStats()
 
         assertTrue(stats.attempts == "0")
+        assertTrue(stats.apiErrorStats.isEmpty())
+        assertTrue(stats.operationErrorStats.isEmpty())
     }
 
     @Test
@@ -60,13 +67,14 @@ class SyncStatsRepositoryTest {
         val lastSyncTimestamp = timestamp(Instant.now().minus(5, ChronoUnit.DAYS))
         val lastSync = SyncAttempt(timestamp = lastSyncTimestamp, state = SUCCESS)
         whenever(syncStateRepository.attempts()).thenReturn(listOf(lastSync))
-
         whenever(syncApiErrorRepository.getErrorsByDate(any())).thenReturn(emptyList())
+        whenever(syncOperationErrorRepository.getErrorsByDate(any())).thenReturn(emptyList())
 
         val stats = repository.getYesterdayDailyStats()
 
         assertTrue(stats.attempts == "0")
         assertTrue(stats.apiErrorStats.isEmpty())
+        assertTrue(stats.operationErrorStats.isEmpty())
     }
 
     @Test
@@ -78,11 +86,16 @@ class SyncStatsRepositoryTest {
         val apiErrors = listOf(SyncApiErrorPixelData(name = "bookmark_object_limit_exceeded", count = "1"))
         whenever(syncApiErrorRepository.getErrorsByDate(any())).thenReturn(apiErrors)
 
+        val operationErrors = listOf(SyncOperationErrorPixelData(name = SyncPixelParameters.DATA_ENCRYPT_ERROR, count = "1"))
+        whenever(syncOperationErrorRepository.getErrorsByDate(any())).thenReturn(operationErrors)
+
         val stats = repository.getYesterdayDailyStats()
 
         assertTrue(stats.attempts == "1")
         assertTrue(stats.apiErrorStats.isNotEmpty())
         assertTrue(stats.apiErrorStats["bookmark_object_limit_exceeded"] == "1")
+        assertTrue(stats.operationErrorStats.isNotEmpty())
+        assertTrue(stats.operationErrorStats[SyncPixelParameters.DATA_ENCRYPT_ERROR] == "1")
     }
 
     @Test
@@ -92,11 +105,13 @@ class SyncStatsRepositoryTest {
         whenever(syncStateRepository.attempts()).thenReturn(listOf(lastSync))
 
         whenever(syncApiErrorRepository.getErrorsByDate(any())).thenReturn(emptyList())
+        whenever(syncOperationErrorRepository.getErrorsByDate(any())).thenReturn(emptyList())
 
         val stats = repository.getYesterdayDailyStats()
 
         assertTrue(stats.attempts == "0")
         assertTrue(stats.apiErrorStats.isEmpty())
+        assertTrue(stats.operationErrorStats.isEmpty())
     }
 
     @Test
@@ -108,11 +123,16 @@ class SyncStatsRepositoryTest {
         val apiErrors = listOf(SyncApiErrorPixelData(name = "bookmark_object_limit_exceeded", count = "1"))
         whenever(syncApiErrorRepository.getErrorsByDate(any())).thenReturn(apiErrors)
 
+        val operationErrors = listOf(SyncOperationErrorPixelData(name = SyncPixelParameters.DATA_ENCRYPT_ERROR, count = "1"))
+        whenever(syncOperationErrorRepository.getErrorsByDate(any())).thenReturn(operationErrors)
+
         val stats = repository.getYesterdayDailyStats()
 
         assertTrue(stats.attempts == "1")
         assertTrue(stats.apiErrorStats.isNotEmpty())
         assertTrue(stats.apiErrorStats["bookmark_object_limit_exceeded"] == "1")
+        assertTrue(stats.operationErrorStats.isNotEmpty())
+        assertTrue(stats.operationErrorStats[SyncPixelParameters.DATA_ENCRYPT_ERROR] == "1")
     }
 
     @Test
@@ -122,11 +142,13 @@ class SyncStatsRepositoryTest {
 
         whenever(syncStateRepository.attempts()).thenReturn(listOf(lastSync))
         whenever(syncApiErrorRepository.getErrorsByDate(any())).thenReturn(emptyList())
+        whenever(syncOperationErrorRepository.getErrorsByDate(any())).thenReturn(emptyList())
 
         val stats = repository.getYesterdayDailyStats()
 
         assertTrue(stats.attempts == "1")
         assertTrue(stats.apiErrorStats.isEmpty())
+        assertTrue(stats.operationErrorStats.isEmpty())
     }
 
     @Test
@@ -141,11 +163,13 @@ class SyncStatsRepositoryTest {
 
         whenever(syncStateRepository.attempts()).thenReturn(listOf(first, second, third, fourth, fifth, sixth))
         whenever(syncApiErrorRepository.getErrorsByDate(any())).thenReturn(emptyList())
+        whenever(syncOperationErrorRepository.getErrorsByDate(any())).thenReturn(emptyList())
 
         val stats = repository.getYesterdayDailyStats()
 
         assertTrue(stats.attempts == "6")
         assertTrue(stats.apiErrorStats.isEmpty())
+        assertTrue(stats.operationErrorStats.isEmpty())
     }
 
     private fun timestamp(instant: Instant): String {

--- a/sync/sync-store/src/main/java/com/duckduckgo/sync/store/SyncDatabase.kt
+++ b/sync/sync-store/src/main/java/com/duckduckgo/sync/store/SyncDatabase.kt
@@ -22,17 +22,21 @@ import androidx.room.TypeConverter
 import androidx.room.TypeConverters
 import com.duckduckgo.sync.store.dao.SyncApiErrorDao
 import com.duckduckgo.sync.store.dao.SyncAttemptDao
+import com.duckduckgo.sync.store.dao.SyncOperationErrorDao
 import com.duckduckgo.sync.store.model.SyncApiError
 import com.duckduckgo.sync.store.model.SyncApiErrorType
 import com.duckduckgo.sync.store.model.SyncAttempt
 import com.duckduckgo.sync.store.model.SyncAttemptState
+import com.duckduckgo.sync.store.model.SyncOperationError
+import com.duckduckgo.sync.store.model.SyncOperationErrorType
 
 @Database(
     exportSchema = true,
-    version = 2,
+    version = 3,
     entities = [
         SyncAttempt::class,
         SyncApiError::class,
+        SyncOperationError::class,
     ],
 )
 @TypeConverters(SyncTypeConverters::class)
@@ -42,6 +46,8 @@ abstract class SyncDatabase : RoomDatabase() {
     abstract fun syncAttemptsDao(): SyncAttemptDao
 
     abstract fun syncApiErrorsDao(): SyncApiErrorDao
+
+    abstract fun syncOperationErrorsDao(): SyncOperationErrorDao
 }
 
 object SyncTypeConverters {
@@ -67,6 +73,16 @@ object SyncTypeConverters {
 
     @TypeConverter
     fun fromSyncApiErrorType(errorType: SyncApiErrorType): String {
+        return errorType.name
+    }
+
+    @TypeConverter
+    fun toSyncOperationErrorType(errorType: String): SyncOperationErrorType {
+        return SyncOperationErrorType.valueOf(errorType)
+    }
+
+    @TypeConverter
+    fun fromSyncOperationErrorType(errorType: SyncOperationErrorType): String {
         return errorType.name
     }
 }

--- a/sync/sync-store/src/main/java/com/duckduckgo/sync/store/SyncDatabase.kt
+++ b/sync/sync-store/src/main/java/com/duckduckgo/sync/store/SyncDatabase.kt
@@ -40,7 +40,6 @@ import com.duckduckgo.sync.store.model.SyncOperationErrorType
     ],
 )
 @TypeConverters(SyncTypeConverters::class)
-
 abstract class SyncDatabase : RoomDatabase() {
 
     abstract fun syncAttemptsDao(): SyncAttemptDao

--- a/sync/sync-store/src/main/java/com/duckduckgo/sync/store/dao/SyncOperationErrorDao.kt
+++ b/sync/sync-store/src/main/java/com/duckduckgo/sync/store/dao/SyncOperationErrorDao.kt
@@ -30,11 +30,11 @@ interface SyncOperationErrorDao {
     @Query("SELECT * FROM sync_operation_errors WHERE date = :date")
     fun errorsByDate(date: String): List<SyncOperationError>
 
-    @Query("UPDATE sync_operation_errors SET count = count + 1 WHERE errorType = :error AND date = :date")
-    fun incrementCount(error: String, date: String)
+    @Query("UPDATE sync_operation_errors SET count = count + 1 WHERE feature = :feature AND errorType = :error AND date = :date")
+    fun incrementCount(feature: String, error: String, date: String)
 
-    @Query("SELECT * FROM sync_operation_errors WHERE errorType = :error AND date = :date LIMIT 1")
-    fun errorByDate(error: String, date: String): SyncOperationError?
+    @Query("SELECT * FROM sync_operation_errors WHERE feature = :feature AND errorType = :error AND date = :date LIMIT 1")
+    fun featureErrorByDate(feature: String, error: String, date: String): SyncOperationError?
 
     @Query("SELECT * FROM sync_operation_errors ORDER BY id DESC")
     fun allErrors(): List<SyncOperationError>

--- a/sync/sync-store/src/main/java/com/duckduckgo/sync/store/dao/SyncOperationErrorDao.kt
+++ b/sync/sync-store/src/main/java/com/duckduckgo/sync/store/dao/SyncOperationErrorDao.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.store.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.duckduckgo.sync.store.model.SyncOperationError
+
+@Dao
+interface SyncOperationErrorDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun insert(error: SyncOperationError)
+
+    @Query("SELECT * FROM sync_operation_errors WHERE date = :date")
+    fun errorsByDate(date: String): List<SyncOperationError>
+
+    @Query("UPDATE sync_operation_errors SET count = count + 1 WHERE errorType = :error AND date = :date")
+    fun incrementCount(error: String, date: String)
+
+    @Query("SELECT * FROM sync_operation_errors WHERE errorType = :error AND date = :date LIMIT 1")
+    fun errorByDate(error: String, date: String): SyncOperationError?
+
+    @Query("SELECT * FROM sync_operation_errors ORDER BY id DESC")
+    fun allErrors(): List<SyncOperationError>
+}

--- a/sync/sync-store/src/main/java/com/duckduckgo/sync/store/model/SyncDatabaseModels.kt
+++ b/sync/sync-store/src/main/java/com/duckduckgo/sync/store/model/SyncDatabaseModels.kt
@@ -59,3 +59,18 @@ enum class SyncApiErrorType {
     VALIDATION_ERROR,
     TOO_MANY_REQUESTS,
 }
+
+@Entity(
+    tableName = "sync_operation_errors",
+)
+data class SyncOperationError(
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    val errorType: SyncOperationErrorType,
+    val count: Int,
+    val date: String = "", // YYYY-MM-dd format
+)
+
+enum class SyncOperationErrorType {
+    DATA_ENCRYPT,
+    DATA_DECRYPT,
+}

--- a/sync/sync-store/src/main/java/com/duckduckgo/sync/store/model/SyncDatabaseModels.kt
+++ b/sync/sync-store/src/main/java/com/duckduckgo/sync/store/model/SyncDatabaseModels.kt
@@ -65,10 +65,13 @@ enum class SyncApiErrorType {
 )
 data class SyncOperationError(
     @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    val feature: String = GENERIC_FEATURE,
     val errorType: SyncOperationErrorType,
     val count: Int,
     val date: String = "", // YYYY-MM-dd format
 )
+
+const val GENERIC_FEATURE = "Unknown"
 
 enum class SyncOperationErrorType {
     DATA_ENCRYPT,


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1205581521828305/f 

### Description
This PR brings back the Encrypy / Decrypt pixel.
Instead of launching it when it happens, we are sending the stats in the daily pixel.

### Steps to test this PR
- In RealSyncCrypto, make sure that encrypting always calls:
`syncOperationErrorRecorder.record(SyncOperationErrorType.DATA_ENCRYPT)`
- In RealSyncCrypto, make sure that decrypting always calls:
`syncOperationErrorRecorder.record(SyncOperationErrorType.DATA_DECRYPT)` 
- Change getYesterdayDailyStats in RealSyncStatsRepository to return today’s data

_Daily Pixel_
- [ ] Enable sync and add some bookmarks
- [ ] Verify that `sync_operation_errors` table has encrypting errors
- [ ] Delete `com.duckduckgo.sync.pixels.v1.xml` using the Device Explorer
- [ ] Close the app and open it again
- [ ] Verify that `m_sync_success_rate_daily` is sent with the encrypting / decrypting errors
