### PR TITLE
Add errors from provider and persister to daily stats

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/provider/CredentialsSyncDataProvider.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/provider/CredentialsSyncDataProvider.kt
@@ -40,6 +40,7 @@ class CredentialsSyncDataProvider @Inject constructor(
     private val dispatchers: DispatcherProvider,
     private val appBuildConfig: AppBuildConfig,
 ) : SyncableDataProvider {
+    override fun getType(): SyncableType = CREDENTIALS
 
     override fun getChanges(): SyncChangesRequest {
         if (appBuildConfig.isInternalBuild()) checkMainThread()

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSitesSyncDataProvider.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSitesSyncDataProvider.kt
@@ -41,6 +41,7 @@ class SavedSitesSyncDataProvider @Inject constructor(
     private val syncCrypto: SyncCrypto,
     private val savedSitesFormFactorSyncMigration: SavedSitesFormFactorSyncMigration,
 ) : SyncableDataProvider {
+    override fun getType(): SyncableType = BOOKMARKS
 
     override fun getChanges(): SyncChangesRequest {
         savedSitesSyncStore.startTimeStamp = DatabaseDateFormatter.iso8601()

--- a/sync/sync-api/src/main/java/com/duckduckgo/sync/api/engine/SyncableDataProvider.kt
+++ b/sync/sync-api/src/main/java/com/duckduckgo/sync/api/engine/SyncableDataProvider.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.sync.api.engine
 
 interface SyncableDataProvider {
+    fun getType(): SyncableType
 
     /**
      * Used by the SyncClient to get all the updates from each syncable feature

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/engine/RealSyncEngine.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/engine/RealSyncEngine.kt
@@ -37,11 +37,14 @@ import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.engine.SyncOperation.DISCARD
 import com.duckduckgo.sync.impl.engine.SyncOperation.EXECUTE
+import com.duckduckgo.sync.impl.error.SyncOperationErrorRecorder
 import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.store.SyncStore
 import com.duckduckgo.sync.store.model.SyncAttempt
 import com.duckduckgo.sync.store.model.SyncAttemptState.IN_PROGRESS
 import com.duckduckgo.sync.store.model.SyncAttemptState.SUCCESS
+import com.duckduckgo.sync.store.model.SyncOperationErrorType.DATA_PERSISTER_ERROR
+import com.duckduckgo.sync.store.model.SyncOperationErrorType.DATA_PROVIDER_ERROR
 import com.squareup.anvil.annotations.ContributesBinding
 import java.time.Duration
 import java.time.OffsetDateTime
@@ -55,6 +58,7 @@ class RealSyncEngine @Inject constructor(
     private val syncStateRepository: SyncStateRepository,
     private val syncPixels: SyncPixels,
     private val syncStore: SyncStore,
+    private val syncOperationErrorRecorder: SyncOperationErrorRecorder,
     private val providerPlugins: PluginPoint<SyncableDataProvider>,
     private val persisterPlugins: PluginPoint<SyncableDataPersister>,
 ) : SyncEngine {
@@ -211,9 +215,14 @@ class RealSyncEngine @Inject constructor(
     }
 
     private fun getChanges(): List<SyncChangesRequest> {
-        return providerPlugins.getPlugins().map {
+        return providerPlugins.getPlugins().mapNotNull {
             Timber.d("Sync-Engine: asking for changes in ${it.javaClass}")
-            it.getChanges()
+            kotlin.runCatching {
+                it.getChanges()
+            }.getOrElse { error ->
+                syncOperationErrorRecorder.record(it.getType().field, DATA_PROVIDER_ERROR)
+                null
+            }
         }
     }
 
@@ -222,19 +231,23 @@ class RealSyncEngine @Inject constructor(
         conflictResolution: SyncConflictResolution,
     ) {
         persisterPlugins.getPlugins().map {
-            when (val result = it.onSuccess(remoteChanges, conflictResolution)) {
-                is SyncMergeResult.Success -> {
-                    if (result.orphans) {
-                        Timber.d("Sync - Orphans present in this sync operation for feature ${remoteChanges.type.field}")
+            kotlin.runCatching {
+                when (val result = it.onSuccess(remoteChanges, conflictResolution)) {
+                    is SyncMergeResult.Success -> {
+                        if (result.orphans) {
+                            Timber.d("Sync - Orphans present in this sync operation for feature ${remoteChanges.type.field}")
+                        }
+                        if (result.timestampConflict) {
+                            Timber.d("Sync - Timestamp conflict present in this sync operation for feature ${remoteChanges.type.field}")
+                            syncPixels.fireTimestampConflictPixel(remoteChanges.type.field)
+                        }
                     }
-                    if (result.timestampConflict) {
-                        Timber.d("Sync - Timestamp conflict present in this sync operation for feature ${remoteChanges.type.field}")
-                        syncPixels.fireTimestampConflictPixel(remoteChanges.type.field)
+                    is SyncMergeResult.Error -> {
+                        Timber.d("Sync - Error while persisting data $result")
                     }
                 }
-                is SyncMergeResult.Error -> {
-                    Timber.d("Sync - Error while persisting data $result")
-                }
+            }.getOrElse { error ->
+                syncOperationErrorRecorder.record(remoteChanges.type.field, DATA_PERSISTER_ERROR)
             }
         }
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/error/SyncOperationErrorRecorder.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/error/SyncOperationErrorRecorder.kt
@@ -52,6 +52,6 @@ class RealSyncOperationErrorRecorder @Inject constructor(
         errorType: SyncOperationErrorType,
     ) {
         Timber.d("Sync-Error: Recording Operation Error $errorType for $feature")
-        repository.addError(errorType)
+        repository.addError(feature, errorType)
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/error/SyncOperationErrorRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/error/SyncOperationErrorRepository.kt
@@ -24,6 +24,9 @@ import com.duckduckgo.sync.store.model.SyncOperationError
 import com.duckduckgo.sync.store.model.SyncOperationErrorType
 import com.duckduckgo.sync.store.model.SyncOperationErrorType.DATA_DECRYPT
 import com.duckduckgo.sync.store.model.SyncOperationErrorType.DATA_ENCRYPT
+import com.duckduckgo.sync.store.model.SyncOperationErrorType.DATA_PERSISTER_ERROR
+import com.duckduckgo.sync.store.model.SyncOperationErrorType.DATA_PROVIDER_ERROR
+import java.util.Locale
 import javax.inject.Inject
 
 interface SyncOperationErrorRepository {
@@ -76,8 +79,11 @@ class RealSyncOperationErrorRepository @Inject constructor(private val dao: Sync
             val errorType = when (it.errorType) {
                 DATA_DECRYPT -> SyncPixelParameters.DATA_DECRYPT_ERROR
                 DATA_ENCRYPT -> SyncPixelParameters.DATA_ENCRYPT_ERROR
+                DATA_PROVIDER_ERROR -> SyncPixelParameters.DATA_PROVIDER_ERROR_PARAM
+                DATA_PERSISTER_ERROR -> SyncPixelParameters.DATA_PERSISTER_ERROR_PARAM
             }
-            SyncOperationErrorPixelData(errorType, it.count.toString())
+            val errorName = String.format(Locale.US, errorType, it.feature)
+            SyncOperationErrorPixelData(errorName, it.count.toString())
         }
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
@@ -161,6 +161,8 @@ object SyncPixelParameters {
     const val TOO_MANY_REQUESTS = "%s_too_many_requests_count"
     const val DATA_ENCRYPT_ERROR = "encrypt_error_count"
     const val DATA_DECRYPT_ERROR = "decrypt_error_count"
+    const val DATA_PERSISTER_ERROR_PARAM = "%s_persister_error_count"
+    const val DATA_PROVIDER_ERROR_PARAM = "%s_provider_error_count"
     const val ERROR_CODE = "code"
     const val ERROR_REASON = "reason"
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/engine/FakeSyncableDataProvider.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/engine/FakeSyncableDataProvider.kt
@@ -18,8 +18,15 @@ package com.duckduckgo.sync.impl.engine
 
 import com.duckduckgo.sync.api.engine.SyncChangesRequest
 import com.duckduckgo.sync.api.engine.SyncableDataProvider
+import com.duckduckgo.sync.api.engine.SyncableType
+import com.duckduckgo.sync.api.engine.SyncableType.BOOKMARKS
 
-class FakeSyncableDataProvider(private val fakeChanges: SyncChangesRequest) : SyncableDataProvider {
+class FakeSyncableDataProvider(
+    private val syncableType: SyncableType = BOOKMARKS,
+    private val fakeChanges: SyncChangesRequest,
+) : SyncableDataProvider {
+    override fun getType(): SyncableType = syncableType
+
     override fun getChanges(): SyncChangesRequest {
         return fakeChanges
     }

--- a/sync/sync-settings-impl/src/main/java/com/duckduckgo/sync/settings/impl/SettingsSyncDataProvider.kt
+++ b/sync/sync-settings-impl/src/main/java/com/duckduckgo/sync/settings/impl/SettingsSyncDataProvider.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.sync.api.SyncCrypto
 import com.duckduckgo.sync.api.engine.ModifiedSince
 import com.duckduckgo.sync.api.engine.SyncChangesRequest
 import com.duckduckgo.sync.api.engine.SyncableDataProvider
+import com.duckduckgo.sync.api.engine.SyncableType
 import com.duckduckgo.sync.api.engine.SyncableType.SETTINGS
 import com.duckduckgo.sync.settings.api.SyncableSetting
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -38,6 +39,8 @@ class SettingsSyncDataProvider @Inject constructor(
     val settingsSyncStore: SettingsSyncStore,
     val syncCrypto: SyncCrypto,
 ) : SyncableDataProvider {
+
+    override fun getType(): SyncableType = SETTINGS
     override fun getChanges(): SyncChangesRequest {
         val syncableSettings = syncableSettings.getPlugins()
         if (settingsSyncStore.serverModifiedSince == "0") {

--- a/sync/sync-store/src/main/java/com/duckduckgo/sync/store/model/SyncDatabaseModels.kt
+++ b/sync/sync-store/src/main/java/com/duckduckgo/sync/store/model/SyncDatabaseModels.kt
@@ -74,6 +74,8 @@ data class SyncOperationError(
 const val GENERIC_FEATURE = "Unknown"
 
 enum class SyncOperationErrorType {
+    DATA_PROVIDER_ERROR,
+    DATA_PERSISTER_ERROR,
     DATA_ENCRYPT,
     DATA_DECRYPT,
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1206158813217559/f 

### Description
Capture exceptions if they happen inside provider or persister implementation. And add an event to receive it in our daily stats.

### Steps to test this PR

_Feature 1_
- [x] Checkout, install, create a sync account
- [x] go to any part of the provider or persister and throw an exception (for example when encrypting data in the syncCrypto impl)
- [x] install again
- [x] Introduce a change so we execute the logic where the exception happens 
- [x] Ensure app doesn't crash
- [x] Ensure events are logged into the database

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
