### PR TITLE
Sync: Timestamp and Orphans as daily stats

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/engine/RealSyncEngine.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/engine/RealSyncEngine.kt
@@ -45,6 +45,8 @@ import com.duckduckgo.sync.store.model.SyncAttemptState.IN_PROGRESS
 import com.duckduckgo.sync.store.model.SyncAttemptState.SUCCESS
 import com.duckduckgo.sync.store.model.SyncOperationErrorType.DATA_PERSISTER_ERROR
 import com.duckduckgo.sync.store.model.SyncOperationErrorType.DATA_PROVIDER_ERROR
+import com.duckduckgo.sync.store.model.SyncOperationErrorType.ORPHANS_PRESENT
+import com.duckduckgo.sync.store.model.SyncOperationErrorType.TIMESTAMP_CONFLICT
 import com.squareup.anvil.annotations.ContributesBinding
 import java.time.Duration
 import java.time.OffsetDateTime
@@ -236,10 +238,11 @@ class RealSyncEngine @Inject constructor(
                     is SyncMergeResult.Success -> {
                         if (result.orphans) {
                             Timber.d("Sync - Orphans present in this sync operation for feature ${remoteChanges.type.field}")
+                            syncOperationErrorRecorder.record(remoteChanges.type.field, ORPHANS_PRESENT)
                         }
                         if (result.timestampConflict) {
                             Timber.d("Sync - Timestamp conflict present in this sync operation for feature ${remoteChanges.type.field}")
-                            syncPixels.fireTimestampConflictPixel(remoteChanges.type.field)
+                            syncOperationErrorRecorder.record(remoteChanges.type.field, TIMESTAMP_CONFLICT)
                         }
                     }
                     is SyncMergeResult.Error -> {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/error/SyncOperationErrorRecorder.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/error/SyncOperationErrorRecorder.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.sync.impl.error
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.store.model.SyncOperationErrorType
+import com.duckduckgo.sync.store.model.SyncOperationErrorType.TIMESTAMP_CONFLICT
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 import timber.log.Timber
@@ -52,6 +53,10 @@ class RealSyncOperationErrorRecorder @Inject constructor(
         errorType: SyncOperationErrorType,
     ) {
         Timber.d("Sync-Error: Recording Operation Error $errorType for $feature")
+        if (errorType == TIMESTAMP_CONFLICT) {
+            syncPixels.fireTimestampConflictPixel(feature)
+        }
+
         repository.addError(feature, errorType)
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/error/SyncOperationErrorRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/error/SyncOperationErrorRepository.kt
@@ -26,6 +26,8 @@ import com.duckduckgo.sync.store.model.SyncOperationErrorType.DATA_DECRYPT
 import com.duckduckgo.sync.store.model.SyncOperationErrorType.DATA_ENCRYPT
 import com.duckduckgo.sync.store.model.SyncOperationErrorType.DATA_PERSISTER_ERROR
 import com.duckduckgo.sync.store.model.SyncOperationErrorType.DATA_PROVIDER_ERROR
+import com.duckduckgo.sync.store.model.SyncOperationErrorType.ORPHANS_PRESENT
+import com.duckduckgo.sync.store.model.SyncOperationErrorType.TIMESTAMP_CONFLICT
 import java.util.Locale
 import javax.inject.Inject
 
@@ -81,6 +83,8 @@ class RealSyncOperationErrorRepository @Inject constructor(private val dao: Sync
                 DATA_ENCRYPT -> SyncPixelParameters.DATA_ENCRYPT_ERROR
                 DATA_PROVIDER_ERROR -> SyncPixelParameters.DATA_PROVIDER_ERROR_PARAM
                 DATA_PERSISTER_ERROR -> SyncPixelParameters.DATA_PERSISTER_ERROR_PARAM
+                TIMESTAMP_CONFLICT -> SyncPixelParameters.TIMESTAMP_CONFLICT
+                ORPHANS_PRESENT -> SyncPixelParameters.ORPHANS_PRESENT
             }
             val errorName = String.format(Locale.US, errorType, it.feature)
             SyncOperationErrorPixelData(errorName, it.count.toString())

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
@@ -163,6 +163,8 @@ object SyncPixelParameters {
     const val DATA_DECRYPT_ERROR = "decrypt_error_count"
     const val DATA_PERSISTER_ERROR_PARAM = "%s_persister_error_count"
     const val DATA_PROVIDER_ERROR_PARAM = "%s_provider_error_count"
+    const val TIMESTAMP_CONFLICT = "%s_local_timestamp_resolution_triggered"
+    const val ORPHANS_PRESENT = "%s_orphans_present"
     const val ERROR_CODE = "code"
     const val ERROR_REASON = "reason"
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/engine/SyncEngineTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/engine/SyncEngineTest.kt
@@ -40,6 +40,8 @@ import com.duckduckgo.sync.store.model.SyncAttempt
 import com.duckduckgo.sync.store.model.SyncAttemptState.FAIL
 import com.duckduckgo.sync.store.model.SyncAttemptState.IN_PROGRESS
 import com.duckduckgo.sync.store.model.SyncAttemptState.SUCCESS
+import com.duckduckgo.sync.store.model.SyncOperationErrorType.ORPHANS_PRESENT
+import com.duckduckgo.sync.store.model.SyncOperationErrorType.TIMESTAMP_CONFLICT
 import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
@@ -495,7 +497,20 @@ internal class SyncEngineTest {
 
         verify(syncApiClient).patch(any())
         verify(syncPixels).fireDailyPixel()
-        verify(syncPixels).fireTimestampConflictPixel(any())
+        verify(syncOperationErrorRecorder).record(BOOKMARKS.field, TIMESTAMP_CONFLICT)
+        verify(syncStateRepository).updateSyncState(SUCCESS)
+    }
+
+    @Test
+    fun whenSyncTriggeredWithChangesAndPatchRemoteSucceedsWithOrphansThenStateIsUpdatedAndPixelIsFired() {
+        givenLocalChangesWithOrphansPresent()
+        givenPatchSuccess()
+
+        syncEngine.triggerSync(APP_OPEN)
+
+        verify(syncApiClient).patch(any())
+        verify(syncPixels).fireDailyPixel()
+        verify(syncOperationErrorRecorder).record(BOOKMARKS.field, ORPHANS_PRESENT)
         verify(syncStateRepository).updateSyncState(SUCCESS)
     }
 
@@ -522,6 +537,16 @@ internal class SyncEngineTest {
         val fakeProviderPlugin = FakeSyncableDataProvider(fakeChanges = localChanges)
         whenever(persisterPlugins.getPlugins()).thenReturn(listOf(FakeSyncableDataPersister(timestampConflict = true)))
             .thenReturn(listOf(FakeSyncableDataPersister(timestampConflict = true)))
+        whenever(providerPlugins.getPlugins()).thenReturn(listOf(fakeProviderPlugin))
+            .thenReturn(listOf(FakeSyncableDataProvider(fakeChanges = SyncChangesRequest.empty())))
+    }
+
+    private fun givenLocalChangesWithOrphansPresent() {
+        val updatesJSON = FileUtilities.loadText(javaClass.classLoader!!, "data_sync_sent_bookmarks.json")
+        val localChanges = SyncChangesRequest(BOOKMARKS, updatesJSON, ModifiedSince.Timestamp("2021-01-01T00:00:00.000Z"))
+        val fakeProviderPlugin = FakeSyncableDataProvider(fakeChanges = localChanges)
+        whenever(persisterPlugins.getPlugins()).thenReturn(listOf(FakeSyncableDataPersister(orphans = true)))
+            .thenReturn(listOf(FakeSyncableDataPersister(orphans = true)))
         whenever(providerPlugins.getPlugins()).thenReturn(listOf(fakeProviderPlugin))
             .thenReturn(listOf(FakeSyncableDataProvider(fakeChanges = SyncChangesRequest.empty())))
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/error/SyncOperationErrorRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/error/SyncOperationErrorRepositoryTest.kt
@@ -24,6 +24,9 @@ import com.duckduckgo.common.utils.formatters.time.DatabaseDateFormatter
 import com.duckduckgo.sync.api.engine.SyncableType
 import com.duckduckgo.sync.impl.pixels.SyncPixelParameters
 import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.DATA_PERSISTER_ERROR_PARAM
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.DATA_PROVIDER_ERROR_PARAM
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.ORPHANS_PRESENT
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.TIMESTAMP_CONFLICT
 import com.duckduckgo.sync.store.SyncDatabase
 import com.duckduckgo.sync.store.model.GENERIC_FEATURE
 import com.duckduckgo.sync.store.model.SyncOperationErrorType
@@ -148,6 +151,57 @@ class SyncOperationErrorRepositoryTest {
 
         val error = errors.first()
         val expectedErrorName = String.format(Locale.US, DATA_PERSISTER_ERROR_PARAM, feature.field)
+        Assert.assertTrue(error.name == expectedErrorName)
+        Assert.assertTrue(error.count == "1")
+    }
+
+    @Test
+    fun whenProviderErrorsStoredThenGettingErrorsReturnsData() {
+        val feature = SyncableType.BOOKMARKS
+        val errorType = SyncOperationErrorType.DATA_PROVIDER_ERROR
+        val today = DatabaseDateFormatter.getUtcIsoLocalDate()
+
+        testee.addError(feature.field, errorType)
+
+        val errors = testee.getErrorsByDate(today)
+        Assert.assertTrue(errors.isNotEmpty())
+
+        val error = errors.first()
+        val expectedErrorName = String.format(Locale.US, DATA_PROVIDER_ERROR_PARAM, feature.field)
+        Assert.assertTrue(error.name == expectedErrorName)
+        Assert.assertTrue(error.count == "1")
+    }
+
+    @Test
+    fun whenTimestampErrorsStoredThenGettingErrorsReturnsData() {
+        val feature = SyncableType.BOOKMARKS
+        val errorType = SyncOperationErrorType.TIMESTAMP_CONFLICT
+        val today = DatabaseDateFormatter.getUtcIsoLocalDate()
+
+        testee.addError(feature.field, errorType)
+
+        val errors = testee.getErrorsByDate(today)
+        Assert.assertTrue(errors.isNotEmpty())
+
+        val error = errors.first()
+        val expectedErrorName = String.format(Locale.US, TIMESTAMP_CONFLICT, feature.field)
+        Assert.assertTrue(error.name == expectedErrorName)
+        Assert.assertTrue(error.count == "1")
+    }
+
+    @Test
+    fun whenOrphansErrorsStoredThenGettingErrorsReturnsData() {
+        val feature = SyncableType.BOOKMARKS
+        val errorType = SyncOperationErrorType.ORPHANS_PRESENT
+        val today = DatabaseDateFormatter.getUtcIsoLocalDate()
+
+        testee.addError(feature.field, errorType)
+
+        val errors = testee.getErrorsByDate(today)
+        Assert.assertTrue(errors.isNotEmpty())
+
+        val error = errors.first()
+        val expectedErrorName = String.format(Locale.US, ORPHANS_PRESENT, feature.field)
         Assert.assertTrue(error.name == expectedErrorName)
         Assert.assertTrue(error.count == "1")
     }

--- a/sync/sync-store/src/main/java/com/duckduckgo/sync/store/model/SyncDatabaseModels.kt
+++ b/sync/sync-store/src/main/java/com/duckduckgo/sync/store/model/SyncDatabaseModels.kt
@@ -78,4 +78,6 @@ enum class SyncOperationErrorType {
     DATA_PERSISTER_ERROR,
     DATA_ENCRYPT,
     DATA_DECRYPT,
+    TIMESTAMP_CONFLICT,
+    ORPHANS_PRESENT,
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/0/1206402944085410/f

### Description
Add timestamp and orphans conflict to daily pixel

### Steps to test this PR

_Timestamp conflict_
- [ ] Enable sync and force a sync operation that returns timestamp conflict
- [ ] You can do this by modifying a Persister and make it return the flag
- [ ] Change the SyncStatsRepository to return today’s data
- [ ] Delete the sync pixel store, so that the pixel is sent
- [ ] Trigger sync
- [ ] Verify daily pixel contains timestamp parameter

_Orphans present_
- [ ] Enable sync and force a sync operation that returns orphan
- [ ] You can do this by modifying a Persister and make it return the flag
- [ ] Change the SyncStatsRepository to return today’s data
- [ ] Delete the sync pixel store, so that the pixel is sent
- [ ] Trigger sync
- [ ] Verify daily pixel contains orphans parameter