### PR TITLE
Autofill, support deleting all passwords, notifiy sync listener

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/SecureStoreBackedAutofillStore.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/SecureStoreBackedAutofillStore.kt
@@ -198,6 +198,7 @@ class SecureStoreBackedAutofillStore @Inject constructor(
         val idsToDelete = savedCredentials.mapNotNull { it.details.id }
         secureStorage.deleteWebSiteLoginDetailsWithCredentials(idsToDelete)
         Timber.i("Deleted %d credentials", idsToDelete.size)
+        syncCredentialsListener.onCredentialRemoved(idsToDelete)
         return savedCredentials.map { it.toLoginCredentials() }
     }
 
@@ -283,8 +284,8 @@ class SecureStoreBackedAutofillStore @Inject constructor(
         withContext(dispatcherProvider.io()) {
             val mappedCredentials = credentials.map { it.prepareForReinsertion() }
             secureStorage.addWebsiteLoginDetailsWithCredentials(mappedCredentials).also {
-                // TODO: INFORM syncCredentialsListener
-                // syncCredentialsListener.onCredentialAdded(it.details.id!!)
+                val ids = mappedCredentials.mapNotNull { it.details.id }
+                syncCredentialsListener.onCredentialsAdded(ids)
             }
         }
     }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/SyncCredentialsListener.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/SyncCredentialsListener.kt
@@ -29,11 +29,19 @@ class SyncCredentialsListener @Inject constructor(
         credentialsSyncMetadata.onEntityChanged(id)
     }
 
+    fun onCredentialsAdded(ids: List<Long>) {
+        credentialsSyncMetadata.onEntitiesChanged(ids)
+    }
+
     fun onCredentialUpdated(id: Long) {
         credentialsSyncMetadata.onEntityChanged(id)
     }
 
     fun onCredentialRemoved(id: Long) {
         credentialsSyncMetadata.onEntityRemoved(id)
+    }
+
+    fun onCredentialRemoved(ids: List<Long>) {
+        credentialsSyncMetadata.onEntitiesRemoved(ids)
     }
 }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/SecureStoreBackedAutofillStoreTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/SecureStoreBackedAutofillStoreTest.kt
@@ -484,7 +484,11 @@ class SecureStoreBackedAutofillStoreTest {
             autofillPrefsStore = autofillPrefsStore,
             dispatcherProvider = coroutineTestRule.testDispatcherProvider,
             autofillUrlMatcher = autofillUrlMatcher,
-            syncCredentialsListener = SyncCredentialsListener(CredentialsSyncMetadata(inMemoryAutofillDatabase().credentialsSyncDao())),
+            syncCredentialsListener = SyncCredentialsListener(
+                CredentialsSyncMetadata(inMemoryAutofillDatabase().credentialsSyncDao()),
+                coroutineTestRule.testDispatcherProvider,
+                coroutineTestRule.testScope,
+            ),
         )
     }
 

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/CredentialsSyncMetadataTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/CredentialsSyncMetadataTest.kt
@@ -167,6 +167,22 @@ internal class CredentialsSyncMetadataTest {
     }
 
     @Test
+    fun whenEntitiesRemovedThenUpdateDeletedAtIfExists() {
+        val loginId1 = 1L
+        val syncId1 = "syncId_1"
+        dao.insert(CredentialsSyncMetadataEntity(syncId = syncId1, localId = loginId1, null, null))
+
+        val loginId2 = 2L
+        val syncId2 = "syncId_2"
+        dao.insert(CredentialsSyncMetadataEntity(syncId = syncId2, localId = loginId2, null, null))
+
+        testee.onEntitiesRemoved(listOf(loginId1, loginId2))
+
+        assertNotNull(dao.getSyncMetadata(loginId1)!!.deleted_at)
+        assertNotNull(dao.getSyncMetadata(loginId2)!!.deleted_at)
+    }
+
+    @Test
     fun whenRemoveDeletedEntitiesThenDeleteEntitiesBeforeDate() {
         val loginId = 123L
         val syncId = "syncId"
@@ -222,10 +238,32 @@ internal class CredentialsSyncMetadataTest {
     }
 
     @Test
+    fun whenEntityChangedInAListThenUpdateModifiedAt() {
+        val loginId = 123L
+        val syncId = "syncId"
+        dao.insert(CredentialsSyncMetadataEntity(syncId = syncId, localId = loginId, null, null))
+
+        testee.onEntitiesChanged(listOf(loginId))
+
+        val result = dao.getSyncMetadata(loginId)!!
+        assertNotNull(result.modified_at)
+    }
+
+    @Test
     fun whenEntityChangedDoesNotExistThenInsertedWithModifiedAt() {
         val loginId = 123L
 
         testee.onEntityChanged(loginId)
+
+        val result = dao.getSyncMetadata(loginId)!!
+        assertNotNull(result.modified_at)
+    }
+
+    @Test
+    fun whenEntityChangedInAListDoesNotExistThenInsertedWithModifiedAt() {
+        val loginId = 123L
+
+        testee.onEntitiesChanged(listOf(loginId))
 
         val result = dao.getSyncMetadata(loginId)!!
         assertNotNull(result.modified_at)

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/SyncCredentialsListenerTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/SyncCredentialsListenerTest.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.sync
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.autofill.sync.SyncCredentialsListener.Companion.SYNC_CREDENTIALS_DELETE_DELAY
+import com.duckduckgo.common.test.CoroutineTestRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(AndroidJUnit4::class)
+class SyncCredentialsListenerTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val autofillDB = inMemoryAutofillDatabase()
+    private val syncMetatadaDao = autofillDB.credentialsSyncDao()
+
+    val testee = SyncCredentialsListener(
+        credentialsSyncMetadata = CredentialsSyncMetadata(syncMetatadaDao),
+        dispatcherProvider = coroutineRule.testDispatcherProvider,
+        appCoroutineScope = coroutineRule.testScope,
+    )
+
+    @After
+    fun after() {
+        autofillDB.close()
+    }
+
+    @Test
+    fun whenOnCredentialAddedThenNotifySyncMetadata() {
+        testee.onCredentialAdded(1)
+
+        syncMetatadaDao.getSyncMetadata(1)?.let {
+            assertEquals(1, it.localId)
+            assertNull(it.deleted_at)
+            assertNotNull(it.modified_at)
+        } ?: fail("Sync metadata not found")
+    }
+
+    @Test
+    fun whenAddingCredentialRecentlyRemovedThenCancelDeleteOperationAndDoNotUpdateMetadata() = runTest {
+        testee.onCredentialAdded(1)
+        val credential = syncMetatadaDao.getSyncMetadata(1)
+        testee.onCredentialRemoved(1)
+        testee.onCredentialAdded(1)
+        this.advanceTimeBy(SYNC_CREDENTIALS_DELETE_DELAY + 1)
+
+        syncMetatadaDao.getSyncMetadata(1)?.let {
+            assertEquals(credential, it)
+        } ?: fail("Sync metadata not found")
+    }
+
+    @Test
+    fun whenCredentialNotReinsertedThenNotifySyncMetadata() = runTest {
+        testee.onCredentialAdded(1)
+        testee.onCredentialRemoved(1)
+        this.advanceTimeBy(SYNC_CREDENTIALS_DELETE_DELAY + 1)
+
+        syncMetatadaDao.getSyncMetadata(1)?.let {
+            assertNotNull(it.deleted_at)
+        } ?: fail("Sync metadata not found")
+    }
+
+    @Test
+    fun whenMultipleCredentialsAddedThenNotifySyncMetadata() {
+        testee.onCredentialsAdded(listOf(1, 2, 3, 4, 5))
+
+        assertEquals(5, syncMetatadaDao.getAll().size)
+        syncMetatadaDao.getSyncMetadata(1)?.let {
+            assertEquals(1, it.localId)
+            assertNull(it.deleted_at)
+            assertNotNull(it.modified_at)
+        } ?: fail("Sync metadata not found")
+    }
+
+    @Test
+    fun whenReinsertingCredentialsRecentlyRemovedThenCancelDeleteOperationAndDoNotUpdateMetadata() = runTest {
+        testee.onCredentialsAdded(listOf(1, 2, 3, 4, 5))
+        val credentials = syncMetatadaDao.getAll()
+        assertEquals(5, credentials.size)
+
+        testee.onCredentialRemoved(listOf(1, 2, 3, 4, 5))
+        testee.onCredentialsAdded(listOf(1, 2, 3, 4, 5))
+        this.advanceTimeBy(SYNC_CREDENTIALS_DELETE_DELAY + 1)
+
+        assertEquals(5, syncMetatadaDao.getAll().size)
+        syncMetatadaDao.getAll().forEachIndexed { index, syncMetadataEntity ->
+            assertEquals(credentials[index], syncMetadataEntity)
+        }
+    }
+
+    @Test
+    fun whenCredentialsNotReinsertedThenNotifySyncMetadata() = runTest {
+        testee.onCredentialsAdded(listOf(1, 2, 3, 4, 5))
+
+        testee.onCredentialRemoved(listOf(1, 2, 3, 4, 5))
+        this.advanceTimeBy(SYNC_CREDENTIALS_DELETE_DELAY + 1)
+
+        syncMetatadaDao.getAll().forEach {
+            assertNotNull(it.deleted_at)
+        }
+    }
+}

--- a/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/CredentialsSyncMetadataDao.kt
+++ b/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/CredentialsSyncMetadataDao.kt
@@ -36,6 +36,9 @@ interface CredentialsSyncMetadataDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insert(entity: CredentialsSyncMetadataEntity): Long
 
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun insert(entities: List<CredentialsSyncMetadataEntity>)
+
     @Transaction
     fun initialize(entities: List<CredentialsSyncMetadataEntity>) {
         removeAll()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/0/1206350245635305/f 

### Description
Bulk notifies sync listener when delete-all is used.


### Steps to test this PR


#### Deleting entries
- [ ] Visit `Settings->Passwords`
- [ ] Add 2 or more saved passwords 
- [ ] Tap overflow and `Delete All`. confirm on the dialog and authenticate when prompted
- [ ] Check sync notified correctly and working as expected

#### Undoing deletion
- [ ] Repeat the above, this time tapping on the snackbar's UNDO button
- [ ] Check sync notified correctly and working as expected
- [ ] Ensure registry on credentials_sync_meta has `deleted_at` null