### PR TITLE
Add support for running A/B test on performance optimizations

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -52,6 +52,7 @@ import com.duckduckgo.app.browser.navigation.safeCopyBackForwardList
 import com.duckduckgo.app.browser.pageloadpixel.PageLoadedHandler
 import com.duckduckgo.app.browser.print.PrintInjector
 import com.duckduckgo.app.global.model.Site
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.autoconsent.api.Autoconsent
 import com.duckduckgo.autofill.api.BrowserAutofill
@@ -63,6 +64,7 @@ import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.common.utils.device.DeviceInfo
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.cookies.api.CookieManagerProvider
+import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.privacy.config.api.AmpLinks
 import com.duckduckgo.user.agent.api.UserAgentProvider
 import junit.framework.TestCase.assertEquals
@@ -119,6 +121,7 @@ class BrowserWebViewClientTest {
     private val deviceInfo: DeviceInfo = mock()
     private val pageLoadedHandler: PageLoadedHandler = mock()
     private val userAgentProvider: UserAgentProvider = mock()
+    private val androidBrowserConfigFeature: AndroidBrowserConfigFeature = mock()
 
     @UiThreadTest
     @Before
@@ -148,6 +151,7 @@ class BrowserWebViewClientTest {
             currentTimeProvider,
             pageLoadedHandler,
             userAgentProvider,
+            androidBrowserConfigFeature,
         )
         testee.webViewClientListener = listener
         whenever(webResourceRequest.url).thenReturn(Uri.EMPTY)
@@ -253,6 +257,9 @@ class BrowserWebViewClientTest {
     @Test
     fun whenShouldInterceptRequestThenEventSentToLoginDetector() {
         val webResourceRequest = mock<WebResourceRequest>()
+        val toggle: Toggle = mock()
+        whenever(androidBrowserConfigFeature.optimizeTrackerEvaluation()).thenReturn(toggle)
+        whenever(toggle.isEnabled()).thenReturn(true)
         testee.shouldInterceptRequest(webView, webResourceRequest)
         verify(loginDetector).onEvent(WebNavigationEvent.ShouldInterceptRequest(webView, webResourceRequest))
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/pageloadpixel/PageLoadedHandlerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/pageloadpixel/PageLoadedHandlerTest.kt
@@ -1,10 +1,9 @@
 package com.duckduckgo.app.browser.pageloadpixel
 
-import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.app.pixels.remoteconfig.OptimizeTrackerEvaluationRCWrapper
 import com.duckduckgo.browser.api.WebViewVersionProvider
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.device.DeviceInfo
-import com.duckduckgo.feature.toggles.api.Toggle
 import kotlinx.coroutines.test.TestScope
 import org.junit.Assert
 import org.junit.Before
@@ -27,8 +26,10 @@ class PageLoadedHandlerTest {
     private val deviceInfo: DeviceInfo = mock()
     private val webViewVersionProvider: WebViewVersionProvider = mock()
     private val pageLoadedPixelDao: PageLoadedPixelDao = mock()
-    private val androidBrowserConfigFeature: AndroidBrowserConfigFeature = mock()
-    private val toggle: Toggle = mock()
+    private val optimizeTrackerEvaluationRCWrapper = object : OptimizeTrackerEvaluationRCWrapper {
+        override val enabled: Boolean
+            get() = true
+    }
 
     private val testee = RealPageLoadedHandler(
         deviceInfo,
@@ -36,15 +37,13 @@ class PageLoadedHandlerTest {
         pageLoadedPixelDao,
         TestScope(),
         coroutinesTestRule.testDispatcherProvider,
-        androidBrowserConfigFeature,
+        optimizeTrackerEvaluationRCWrapper,
     )
 
     @Before
     fun before() {
         whenever(webViewVersionProvider.getMajorVersion()).thenReturn("1")
         whenever(deviceInfo.appVersion).thenReturn("1")
-        whenever(androidBrowserConfigFeature.optimizeTrackerEvaluation()).thenReturn(toggle)
-        whenever(toggle.isEnabled()).thenReturn(true)
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/pageloadpixel/PageLoadedHandlerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/pageloadpixel/PageLoadedHandlerTest.kt
@@ -1,8 +1,10 @@
 package com.duckduckgo.app.browser.pageloadpixel
 
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.browser.api.WebViewVersionProvider
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.device.DeviceInfo
+import com.duckduckgo.feature.toggles.api.Toggle
 import kotlinx.coroutines.test.TestScope
 import org.junit.Assert
 import org.junit.Before
@@ -25,18 +27,24 @@ class PageLoadedHandlerTest {
     private val deviceInfo: DeviceInfo = mock()
     private val webViewVersionProvider: WebViewVersionProvider = mock()
     private val pageLoadedPixelDao: PageLoadedPixelDao = mock()
+    private val androidBrowserConfigFeature: AndroidBrowserConfigFeature = mock()
+    private val toggle: Toggle = mock()
+
     private val testee = RealPageLoadedHandler(
         deviceInfo,
         webViewVersionProvider,
         pageLoadedPixelDao,
         TestScope(),
         coroutinesTestRule.testDispatcherProvider,
+        androidBrowserConfigFeature,
     )
 
     @Before
     fun before() {
         whenever(webViewVersionProvider.getMajorVersion()).thenReturn("1")
         whenever(deviceInfo.appVersion).thenReturn("1")
+        whenever(androidBrowserConfigFeature.optimizeTrackerEvaluation()).thenReturn(toggle)
+        whenever(toggle.isEnabled()).thenReturn(true)
     }
 
     @Test
@@ -45,6 +53,7 @@ class PageLoadedHandlerTest {
         val argumentCaptor = argumentCaptor<PageLoadedPixelEntity>()
         verify(pageLoadedPixelDao).add(argumentCaptor.capture())
         Assert.assertEquals(10L, argumentCaptor.firstValue.elapsedTime)
+        Assert.assertEquals(true, argumentCaptor.firstValue.trackerOptimizationEnabled)
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -52,7 +52,7 @@ import com.duckduckgo.app.browser.navigation.safeCopyBackForwardList
 import com.duckduckgo.app.browser.pageloadpixel.PageLoadedHandler
 import com.duckduckgo.app.browser.print.PrintInjector
 import com.duckduckgo.app.di.AppCoroutineScope
-import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.app.pixels.remoteconfig.OptimizeTrackerEvaluationRCWrapper
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.autoconsent.api.Autoconsent
 import com.duckduckgo.autofill.api.BrowserAutofill
@@ -95,7 +95,7 @@ class BrowserWebViewClient @Inject constructor(
     private val currentTimeProvider: CurrentTimeProvider,
     private val shouldSendPageLoadedPixel: PageLoadedHandler,
     private val userAgentProvider: UserAgentProvider,
-    private val browserConfigFeature: AndroidBrowserConfigFeature,
+    private val optimizeTrackerEvaluationRCWrapper: OptimizeTrackerEvaluationRCWrapper,
 ) : WebViewClient() {
 
     var webViewClientListener: WebViewClientListener? = null
@@ -357,7 +357,7 @@ class BrowserWebViewClient @Inject constructor(
                 loginDetector.onEvent(WebNavigationEvent.ShouldInterceptRequest(webView, request))
             }
             Timber.v("Intercepting resource ${request.url} type:${request.method} on page $documentUrl")
-            if (browserConfigFeature.self().isEnabled() && browserConfigFeature.optimizeTrackerEvaluation().isEnabled()) {
+            if (optimizeTrackerEvaluationRCWrapper.enabled) {
                 requestInterceptor.shouldIntercept(request, webView, documentUrl?.toUri(), webViewClientListener)
             } else {
                 requestInterceptor.shouldIntercept(request, webView, documentUrl, webViewClientListener)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -52,6 +52,7 @@ import com.duckduckgo.app.browser.navigation.safeCopyBackForwardList
 import com.duckduckgo.app.browser.pageloadpixel.PageLoadedHandler
 import com.duckduckgo.app.browser.print.PrintInjector
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.autoconsent.api.Autoconsent
 import com.duckduckgo.autofill.api.BrowserAutofill
@@ -94,6 +95,7 @@ class BrowserWebViewClient @Inject constructor(
     private val currentTimeProvider: CurrentTimeProvider,
     private val shouldSendPageLoadedPixel: PageLoadedHandler,
     private val userAgentProvider: UserAgentProvider,
+    private val browserConfigFeature: AndroidBrowserConfigFeature,
 ) : WebViewClient() {
 
     var webViewClientListener: WebViewClientListener? = null
@@ -350,12 +352,16 @@ class BrowserWebViewClient @Inject constructor(
         request: WebResourceRequest,
     ): WebResourceResponse? {
         return runBlocking {
-            val documentUrl = withContext(dispatcherProvider.main()) { webView.url }?.toUri()
+            val documentUrl = withContext(dispatcherProvider.main()) { webView.url }
             withContext(dispatcherProvider.main()) {
                 loginDetector.onEvent(WebNavigationEvent.ShouldInterceptRequest(webView, request))
             }
             Timber.v("Intercepting resource ${request.url} type:${request.method} on page $documentUrl")
-            requestInterceptor.shouldIntercept(request, webView, documentUrl, webViewClientListener)
+            if (browserConfigFeature.self().isEnabled() && browserConfigFeature.optimizeTrackerEvaluation().isEnabled()) {
+                requestInterceptor.shouldIntercept(request, webView, documentUrl?.toUri(), webViewClientListener)
+            } else {
+                requestInterceptor.shouldIntercept(request, webView, documentUrl, webViewClientListener)
+            }
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/pageloadpixel/PageLoadedHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pageloadpixel/PageLoadedHandler.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.browser.pageloadpixel
 
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.browser.api.WebViewVersionProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.UriString
@@ -50,6 +51,7 @@ class RealPageLoadedHandler @Inject constructor(
     private val pageLoadedPixelDao: PageLoadedPixelDao,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
+    private val browserConfigFeature: AndroidBrowserConfigFeature,
 ) : PageLoadedHandler {
 
     override operator fun invoke(url: String, start: Long, end: Long) {
@@ -60,9 +62,13 @@ class RealPageLoadedHandler @Inject constructor(
                         elapsedTime = end - start,
                         webviewVersion = webViewVersionProvider.getMajorVersion(),
                         appVersion = deviceInfo.appVersion,
+                        trackerOptimizationEnabled = shouldOptimizeTrackerEvaluation(),
                     ),
                 )
             }
         }
     }
+
+    private fun shouldOptimizeTrackerEvaluation() =
+        browserConfigFeature.self().isEnabled() && browserConfigFeature.optimizeTrackerEvaluation().isEnabled()
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/pageloadpixel/PageLoadedHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pageloadpixel/PageLoadedHandler.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.app.browser.pageloadpixel
 
 import com.duckduckgo.app.di.AppCoroutineScope
-import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.app.pixels.remoteconfig.OptimizeTrackerEvaluationRCWrapper
 import com.duckduckgo.browser.api.WebViewVersionProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.UriString
@@ -51,7 +51,7 @@ class RealPageLoadedHandler @Inject constructor(
     private val pageLoadedPixelDao: PageLoadedPixelDao,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
-    private val browserConfigFeature: AndroidBrowserConfigFeature,
+    private val optimizeTrackerEvaluationRCWrapper: OptimizeTrackerEvaluationRCWrapper,
 ) : PageLoadedHandler {
 
     override operator fun invoke(url: String, start: Long, end: Long) {
@@ -62,13 +62,10 @@ class RealPageLoadedHandler @Inject constructor(
                         elapsedTime = end - start,
                         webviewVersion = webViewVersionProvider.getMajorVersion(),
                         appVersion = deviceInfo.appVersion,
-                        trackerOptimizationEnabled = shouldOptimizeTrackerEvaluation(),
+                        trackerOptimizationEnabled = optimizeTrackerEvaluationRCWrapper.enabled,
                     ),
                 )
             }
         }
     }
-
-    private fun shouldOptimizeTrackerEvaluation() =
-        browserConfigFeature.self().isEnabled() && browserConfigFeature.optimizeTrackerEvaluation().isEnabled()
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/pageloadpixel/PageLoadedOfflinePixelSender.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pageloadpixel/PageLoadedOfflinePixelSender.kt
@@ -26,6 +26,7 @@ import javax.inject.Inject
 
 private const val ELAPSED_TIME = "elapsed_time"
 private const val WEBVIEW_VERSION = "webview_version"
+private const val TRACKER_OPTIMIZATION_ENABLED = "tracker_optimization_enabled"
 
 // This is used to ensure the app version we send is the one from the moment the page was loaded, and not then the pixel is fired later on
 private const val APP_VERSION = "app_version_when_page_loaded"
@@ -45,6 +46,7 @@ class PageLoadedOfflinePixelSender @Inject constructor(
                         APP_VERSION to it.appVersion,
                         ELAPSED_TIME to it.elapsedTime.toString(),
                         WEBVIEW_VERSION to it.webviewVersion,
+                        TRACKER_OPTIMIZATION_ENABLED to it.trackerOptimizationEnabled.toString(),
                     ),
                     mapOf(),
                 ).doOnComplete {

--- a/app/src/main/java/com/duckduckgo/app/browser/pageloadpixel/PageLoadedPixelEntity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pageloadpixel/PageLoadedPixelEntity.kt
@@ -25,4 +25,5 @@ class PageLoadedPixelEntity(
     val appVersion: String,
     val elapsedTime: Long,
     val webviewVersion: String,
+    val trackerOptimizationEnabled: Boolean,
 )

--- a/app/src/main/java/com/duckduckgo/app/global/db/AppDatabase.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/db/AppDatabase.kt
@@ -68,7 +68,7 @@ import com.duckduckgo.savedsites.store.SavedSitesRelationsDao
 
 @Database(
     exportSchema = true,
-    version = 50,
+    version = 51,
     entities = [
         TdsTracker::class,
         TdsEntity::class,
@@ -629,6 +629,12 @@ class MigrationsProvider(val context: Context, val settingsDataStore: SettingsDa
         }
     }
 
+    private val MIGRATION_50_TO_51: Migration = object : Migration(50, 51) {
+        override fun migrate(database: SupportSQLiteDatabase) {
+            database.execSQL("ALTER TABLE `page_loaded_pixel_entity` ADD COLUMN `trackerOptimizationEnabled` INTEGER NOT NULL DEFAULT 0")
+        }
+    }
+
     val BOOKMARKS_DB_ON_CREATE = object : RoomDatabase.Callback() {
         override fun onCreate(database: SupportSQLiteDatabase) {
             database.execSQL(
@@ -704,6 +710,7 @@ class MigrationsProvider(val context: Context, val settingsDataStore: SettingsDa
             MIGRATION_47_TO_48,
             MIGRATION_48_TO_49,
             MIGRATION_49_TO_50,
+            MIGRATION_50_TO_51,
         )
 
     @Deprecated(

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -51,4 +51,12 @@ interface AndroidBrowserConfigFeature {
      */
     @Toggle.DefaultValue(false)
     fun screenLock(): Toggle
+
+    /**
+     * @return `true` when the remote config has the global "optimizeTrackerEvaluation" androidBrowserConfig
+     * sub-feature flag enabled
+     * If the remote feature is not present defaults to `false`
+     */
+    @Toggle.DefaultValue(false)
+    fun optimizeTrackerEvaluation(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/OptimizeTrackerEvaluationRCWrapper.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/OptimizeTrackerEvaluationRCWrapper.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.pixels.remoteconfig
+
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface OptimizeTrackerEvaluationRCWrapper {
+    val enabled: Boolean
+}
+
+@ContributesBinding(AppScope::class)
+class RealOptimizeTrackerEvaluationRCWrapper @Inject constructor(
+    private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
+) : OptimizeTrackerEvaluationRCWrapper {
+    override val enabled by lazy { androidBrowserConfigFeature.optimizeTrackerEvaluation().isEnabled() }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/0/1206427492016652/f 

### Description
Read `optimizeTrackerEvaluation`, use it to decide whether or not to execute the optimized tracker logic and add its status to page loaded pixel

### Steps to test this PR

_Database migration_
- [ ] Install apk from https://github.com/duckduckgo/Android/pull/4104
- [ ] Update to this version
- [ ] Check the app starts normally

_Check pixels sent_
- [ ] Override remote config and enable optimizeTrackerEvaluation ([JSON Blob](https://jsonblob.com/1199388406986956800))
- [ ] Visit reddit.com
- [ ] Go to Grafana/Clickhouse (*) and look for a pixel with `trackerOptimizationEnabled` set to `1`. Alternatively, in a debug build, you can find the `page_loaded_pixel_entity` table in `app.db` and check the pixel there


_Check pixels sent_
- [ ] Override remote config and disable optimizeTrackerEvaluation ([JSON Blob](https://jsonblob.com/1199388406986956800))
- [ ] Visit reddit.com
- [ ] Go to Grafana/Clickhouse (*) and look for a pixel with `trackerOptimizationEnabled` set to `0`. Alternatively, in a debug build, you can find the `page_loaded_pixel_entity` table in `app.db` and check the pixel there

(*): Pixels aren't fired immediately, they might take up to 3 hours to appear




### UI changes
No UI changes
