### PR TITLE
Android: play() can only be initiated by a user gesture issue

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -219,16 +219,16 @@ class BrowserWebViewClientTest {
 
     @UiThreadTest
     @Test
-    fun whenOnPageStartedCalledForUrlWithAutoplayEnabledThenMediaPlaybackRequiresUserGestureIsFalse() {
-        whenever(mediaPlayback.isAutoplayEnabledForUrl(EXAMPLE_URL)).thenReturn(true)
+    fun whenOnPageStartedCalledForUrlWithUserGestureNotRequiredForUrlThenMediaPlaybackRequiresUserGestureIsFalse() {
+        whenever(mediaPlayback.doesMediaPlaybackRequireUserGestureForUrl(EXAMPLE_URL)).thenReturn(false)
         testee.onPageStarted(webView, EXAMPLE_URL, null)
         assertFalse(webView.settings.mediaPlaybackRequiresUserGesture)
     }
 
     @UiThreadTest
     @Test
-    fun whenOnPageStartedCalledForUrlWithAutoplayDisabledThenMediaPlaybackRequiresUserGestureIsTrue() {
-        whenever(mediaPlayback.isAutoplayEnabledForUrl(EXAMPLE_URL)).thenReturn(false)
+    fun whenOnPageStartedCalledForUrlWithUserGestureRequiredForUrlThenMediaPlaybackRequiresUserGestureIsTrue() {
+        whenever(mediaPlayback.doesMediaPlaybackRequireUserGestureForUrl(EXAMPLE_URL)).thenReturn(true)
         testee.onPageStarted(webView, EXAMPLE_URL, null)
         assertTrue(webView.settings.mediaPlaybackRequiresUserGesture)
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -47,6 +47,7 @@ import com.duckduckgo.app.browser.cookies.ThirdPartyCookieManager
 import com.duckduckgo.app.browser.httpauth.WebViewHttpAuthStore
 import com.duckduckgo.app.browser.logindetection.DOMLoginDetector
 import com.duckduckgo.app.browser.logindetection.WebNavigationEvent
+import com.duckduckgo.app.browser.mediaplayback.MediaPlayback
 import com.duckduckgo.app.browser.model.BasicAuthenticationRequest
 import com.duckduckgo.app.browser.navigation.safeCopyBackForwardList
 import com.duckduckgo.app.browser.pageloadpixel.PageLoadedHandler
@@ -117,6 +118,7 @@ class BrowserWebViewClientTest {
     private val currentTimeProvider: CurrentTimeProvider = mock()
     private val deviceInfo: DeviceInfo = mock()
     private val pageLoadedHandler: PageLoadedHandler = mock()
+    private val mediaPlayback: MediaPlayback = mock()
 
     @UiThreadTest
     @Before
@@ -145,6 +147,7 @@ class BrowserWebViewClientTest {
             jsPlugins,
             currentTimeProvider,
             pageLoadedHandler,
+            mediaPlayback,
         )
         testee.webViewClientListener = listener
         whenever(webResourceRequest.url).thenReturn(Uri.EMPTY)
@@ -212,6 +215,22 @@ class BrowserWebViewClientTest {
     fun whenOnPageStartedCalledThenInjectAutoconsentCalled() {
         testee.onPageStarted(webView, EXAMPLE_URL, null)
         verify(autoconsent).injectAutoconsent(webView, EXAMPLE_URL)
+    }
+
+    @UiThreadTest
+    @Test
+    fun whenOnPageStartedCalledForUrlWithAutoplayEnabledThenMediaPlaybackRequiresUserGestureIsFalse() {
+        whenever(mediaPlayback.isAutoplayEnabledForUrl(EXAMPLE_URL)).thenReturn(true)
+        testee.onPageStarted(webView, EXAMPLE_URL, null)
+        assertFalse(webView.settings.mediaPlaybackRequiresUserGesture)
+    }
+
+    @UiThreadTest
+    @Test
+    fun whenOnPageStartedCalledForUrlWithAutoplayDisabledThenMediaPlaybackRequiresUserGestureIsTrue() {
+        whenever(mediaPlayback.isAutoplayEnabledForUrl(EXAMPLE_URL)).thenReturn(false)
+        testee.onPageStarted(webView, EXAMPLE_URL, null)
+        assertTrue(webView.settings.mediaPlaybackRequiresUserGesture)
     }
 
     @UiThreadTest

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -47,6 +47,7 @@ import com.duckduckgo.app.browser.cookies.ThirdPartyCookieManager
 import com.duckduckgo.app.browser.httpauth.WebViewHttpAuthStore
 import com.duckduckgo.app.browser.logindetection.DOMLoginDetector
 import com.duckduckgo.app.browser.logindetection.WebNavigationEvent
+import com.duckduckgo.app.browser.mediaplayback.MediaPlayback
 import com.duckduckgo.app.browser.model.BasicAuthenticationRequest
 import com.duckduckgo.app.browser.navigation.safeCopyBackForwardList
 import com.duckduckgo.app.browser.pageloadpixel.PageLoadedHandler
@@ -92,6 +93,7 @@ class BrowserWebViewClient @Inject constructor(
     private val jsPlugins: PluginPoint<JsInjectorPlugin>,
     private val currentTimeProvider: CurrentTimeProvider,
     private val shouldSendPageLoadedPixel: PageLoadedHandler,
+    private val mediaPlayback: MediaPlayback,
 ) : WebViewClient() {
 
     var webViewClientListener: WebViewClientListener? = null
@@ -282,6 +284,7 @@ class BrowserWebViewClient @Inject constructor(
             if (it != "about:blank" && start == null) {
                 start = currentTimeProvider.getTimeInMillis()
             }
+            handleMediaPlayback(webView, it)
             autoconsent.injectAutoconsent(webView, url)
             adClickManager.detectAdDomain(url)
             requestInterceptor.onPageStarted(url)
@@ -300,6 +303,11 @@ class BrowserWebViewClient @Inject constructor(
             it.onPageStarted(webView, url, webViewClientListener?.getSite())
         }
         loginDetector.onEvent(WebNavigationEvent.OnPageStarted(webView))
+    }
+
+    private fun handleMediaPlayback(webView: WebView, url: String) {
+        // The default value for this flag is `true`.
+        webView.settings.mediaPlaybackRequiresUserGesture = !mediaPlayback.isAutoplayEnabledForUrl(url)
     }
 
     @UiThread

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -307,7 +307,7 @@ class BrowserWebViewClient @Inject constructor(
 
     private fun handleMediaPlayback(webView: WebView, url: String) {
         // The default value for this flag is `true`.
-        webView.settings.mediaPlaybackRequiresUserGesture = !mediaPlayback.isAutoplayEnabledForUrl(url)
+        webView.settings.mediaPlaybackRequiresUserGesture = mediaPlayback.doesMediaPlaybackRequireUserGestureForUrl(url)
     }
 
     @UiThread

--- a/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.browser.di
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.pm.PackageManager
+import androidx.room.Room
 import androidx.work.WorkManager
 import com.duckduckgo.adclick.api.AdClickManager
 import com.duckduckgo.app.browser.*
@@ -35,6 +36,9 @@ import com.duckduckgo.app.browser.favicon.FaviconPersister
 import com.duckduckgo.app.browser.favicon.FileBasedFaviconPersister
 import com.duckduckgo.app.browser.httpauth.WebViewHttpAuthStore
 import com.duckduckgo.app.browser.logindetection.*
+import com.duckduckgo.app.browser.mediaplayback.store.ALL_MIGRATIONS
+import com.duckduckgo.app.browser.mediaplayback.store.MediaPlaybackDao
+import com.duckduckgo.app.browser.mediaplayback.store.MediaPlaybackDatabase
 import com.duckduckgo.app.browser.pageloadpixel.PageLoadedPixelDao
 import com.duckduckgo.app.browser.session.WebViewSessionInMemoryStorage
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
@@ -303,5 +307,21 @@ class BrowserModule {
     @SingleInstanceIn(AppScope::class)
     fun providePageLoadedPixelDao(appDatabase: AppDatabase): PageLoadedPixelDao {
         return appDatabase.pageLoadedPixelDao()
+    }
+
+    @Provides
+    @SingleInstanceIn(AppScope::class)
+    fun provideMediaPlaybackDatabase(context: Context): MediaPlaybackDatabase {
+        return Room.databaseBuilder(context, MediaPlaybackDatabase::class.java, "media_playback.db")
+            .enableMultiInstanceInvalidation()
+            .fallbackToDestructiveMigration()
+            .addMigrations(*ALL_MIGRATIONS)
+            .build()
+    }
+
+    @Provides
+    @SingleInstanceIn(AppScope::class)
+    fun providesMediaPlaybackDao(mediaPlaybackDatabase: MediaPlaybackDatabase): MediaPlaybackDao {
+        return mediaPlaybackDatabase.mediaPlaybackDao()
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/mediaplayback/MediaPlayback.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/mediaplayback/MediaPlayback.kt
@@ -35,6 +35,6 @@ class RealMediaPlayback @Inject constructor(
 
     override fun doesMediaPlaybackRequireUserGestureForUrl(url: String): Boolean {
         val uri = url.toUri()
-        return !(mediaPlaybackFeature.self().isEnabled() && mediaPlaybackRepository.exceptions.any { it.domain == uri.baseHost })
+        return mediaPlaybackFeature.self().isEnabled() && mediaPlaybackRepository.exceptions.none { it.domain == uri.baseHost }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/mediaplayback/MediaPlayback.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/mediaplayback/MediaPlayback.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.mediaplayback
+
+import androidx.core.net.toUri
+import com.duckduckgo.app.browser.mediaplayback.store.MediaPlaybackRepository
+import com.duckduckgo.common.utils.baseHost
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface MediaPlayback {
+    fun isAutoplayEnabledForUrl(url: String): Boolean
+}
+
+@ContributesBinding(AppScope::class)
+class RealMediaPlayback @Inject constructor(
+    private val mediaPlaybackFeature: MediaPlaybackFeature,
+    private val mediaPlaybackRepository: MediaPlaybackRepository,
+) : MediaPlayback {
+
+    override fun isAutoplayEnabledForUrl(url: String): Boolean {
+        val uri = url.toUri()
+        return mediaPlaybackFeature.self()
+            .isEnabled() && mediaPlaybackRepository.exceptions.firstOrNull { it.domain == uri.baseHost } != null
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/mediaplayback/MediaPlayback.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/mediaplayback/MediaPlayback.kt
@@ -24,7 +24,7 @@ import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 
 interface MediaPlayback {
-    fun isAutoplayEnabledForUrl(url: String): Boolean
+    fun doesMediaPlaybackRequireUserGestureForUrl(url: String): Boolean
 }
 
 @ContributesBinding(AppScope::class)
@@ -33,9 +33,8 @@ class RealMediaPlayback @Inject constructor(
     private val mediaPlaybackRepository: MediaPlaybackRepository,
 ) : MediaPlayback {
 
-    override fun isAutoplayEnabledForUrl(url: String): Boolean {
+    override fun doesMediaPlaybackRequireUserGestureForUrl(url: String): Boolean {
         val uri = url.toUri()
-        return mediaPlaybackFeature.self()
-            .isEnabled() && mediaPlaybackRepository.exceptions.firstOrNull { it.domain == uri.baseHost } != null
+        return !(mediaPlaybackFeature.self().isEnabled() && mediaPlaybackRepository.exceptions.any { it.domain == uri.baseHost })
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/mediaplayback/MediaPlaybackFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/mediaplayback/MediaPlaybackFeature.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.mediaplayback
+
+import com.duckduckgo.feature.toggles.api.Toggle
+
+interface MediaPlaybackFeature {
+    @Toggle.DefaultValue(true)
+    fun self(): Toggle
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/mediaplayback/UnusedMediaPlaybackFeatureFeatureCodegenTrigger.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/mediaplayback/UnusedMediaPlaybackFeatureFeatureCodegenTrigger.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.mediaplayback
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.app.browser.mediaplayback.store.MediaPlaybackStore
+import com.duckduckgo.di.scopes.AppScope
+
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "mediaPlaybackRequiresUserGesture",
+    exceptionsStore = MediaPlaybackStore::class,
+    boundType = MediaPlaybackFeature::class,
+)
+@Suppress("unused")
+private interface UnusedMediaPlaybackFeatureFeatureCodegenTrigger

--- a/app/src/main/java/com/duckduckgo/app/browser/mediaplayback/store/MediaPlaybackDao.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/mediaplayback/store/MediaPlaybackDao.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.mediaplayback.store
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+
+@Dao
+abstract class MediaPlaybackDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract fun insertAll(domains: List<MediaPlaybackExceptionEntity>)
+
+    @Transaction
+    open fun updateAll(domains: List<MediaPlaybackExceptionEntity>) {
+        deleteAll()
+        insertAll(domains)
+    }
+
+    @Query("select * from media_playback_user_gesture_exceptions")
+    abstract fun getAll(): List<MediaPlaybackExceptionEntity>
+
+    @Query("delete from media_playback_user_gesture_exceptions")
+    abstract fun deleteAll()
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/mediaplayback/store/MediaPlaybackDatabase.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/mediaplayback/store/MediaPlaybackDatabase.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.mediaplayback.store
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+
+@Database(
+    exportSchema = true,
+    version = 1,
+    entities = [
+        MediaPlaybackExceptionEntity::class,
+    ],
+)
+abstract class MediaPlaybackDatabase : RoomDatabase() {
+    abstract fun mediaPlaybackDao(): MediaPlaybackDao
+}
+
+val ALL_MIGRATIONS = emptyArray<Migration>()

--- a/app/src/main/java/com/duckduckgo/app/browser/mediaplayback/store/MediaPlaybackExceptionEntity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/mediaplayback/store/MediaPlaybackExceptionEntity.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.mediaplayback.store
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.duckduckgo.feature.toggles.api.FeatureExceptions
+
+@Entity(tableName = "media_playback_user_gesture_exceptions")
+data class MediaPlaybackExceptionEntity(@PrimaryKey val domain: String)
+
+fun MediaPlaybackExceptionEntity.toFeatureException(): FeatureExceptions.FeatureException {
+    return FeatureExceptions.FeatureException(domain = this.domain, reason = null)
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/mediaplayback/store/MediaPlaybackRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/mediaplayback/store/MediaPlaybackRepository.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.mediaplayback.store
+
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.FeatureExceptions
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import java.util.concurrent.CopyOnWriteArrayList
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+interface MediaPlaybackRepository {
+    fun updateAll(exceptions: List<MediaPlaybackExceptionEntity>)
+    val exceptions: CopyOnWriteArrayList<FeatureExceptions.FeatureException>
+}
+
+@ContributesBinding(AppScope::class)
+@SingleInstanceIn(AppScope::class)
+class RealMediaPlaybackRepository @Inject constructor(
+    private val mediaPlaybackDao: MediaPlaybackDao,
+    @AppCoroutineScope appCoroutineScope: CoroutineScope,
+    dispatcherProvider: DispatcherProvider,
+) : MediaPlaybackRepository {
+
+    override val exceptions = CopyOnWriteArrayList<FeatureExceptions.FeatureException>()
+
+    init {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            loadToMemory()
+        }
+    }
+
+    override fun updateAll(exceptions: List<MediaPlaybackExceptionEntity>) {
+        mediaPlaybackDao.updateAll(exceptions)
+        loadToMemory()
+    }
+
+    private fun loadToMemory() {
+        exceptions.clear()
+        mediaPlaybackDao.getAll().map {
+            exceptions.add(it.toFeatureException())
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/mediaplayback/store/MediaPlaybackStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/mediaplayback/store/MediaPlaybackStore.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.mediaplayback.store
+
+import com.duckduckgo.app.browser.mediaplayback.MediaPlaybackFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.FeatureExceptions
+import com.duckduckgo.feature.toggles.api.RemoteFeatureStoreNamed
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+@ContributesBinding(AppScope::class)
+@RemoteFeatureStoreNamed(MediaPlaybackFeature::class)
+class MediaPlaybackStore @Inject constructor(
+    private val mediaPlaybackRepository: MediaPlaybackRepository,
+) : FeatureExceptions.Store {
+    override fun insertAll(exception: List<FeatureExceptions.FeatureException>) {
+        mediaPlaybackRepository.updateAll(
+            exception.map { MediaPlaybackExceptionEntity(domain = it.domain) },
+        )
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/browser/mediaplayback/store/RealMediaPlaybackRepositoryTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/mediaplayback/store/RealMediaPlaybackRepositoryTest.kt
@@ -1,0 +1,80 @@
+package com.duckduckgo.app.browser.mediaplayback.store
+
+import com.duckduckgo.common.test.CoroutineTestRule
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.ArgumentMatchers.anyList
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class RealMediaPlaybackRepositoryTest {
+    @get:Rule
+    var coroutineRule = CoroutineTestRule()
+
+    lateinit var testee: RealMediaPlaybackRepository
+
+    private val mockMediaPlaybackDatabase: MediaPlaybackDatabase = mock()
+    private val mockMediaPlaybackDao: MediaPlaybackDao = mock()
+
+    @Before
+    fun before() {
+        whenever(mockMediaPlaybackDatabase.mediaPlaybackDao()).thenReturn(mockMediaPlaybackDao)
+        initRepository()
+    }
+
+    @Test
+    fun whenRepositoryIsCreatedThenValuesLoadedIntoMemory() {
+        givenMediaPlaybackDaoContainsEntities()
+
+        initRepository()
+
+        assertEquals(mediaPlaybackExceptionEntity.toFeatureException(), testee.exceptions.first())
+    }
+
+    @Test
+    fun whenUpdateAllThenUpdateAllCalled() = runTest {
+        initRepository()
+
+        testee.updateAll(listOf())
+
+        verify(mockMediaPlaybackDao).updateAll(anyList())
+    }
+
+    @Test
+    fun whenUpdateAllThenPreviousValuesAreClearedAndNewValuesUpdated() = runTest {
+        givenMediaPlaybackDaoContainsEntities()
+
+        initRepository()
+        assertEquals(1, testee.exceptions.size)
+
+        reset(mockMediaPlaybackDao)
+
+        testee.updateAll(listOf())
+
+        assertEquals(0, testee.exceptions.size)
+    }
+
+    private fun initRepository() {
+        testee = RealMediaPlaybackRepository(
+            mockMediaPlaybackDao,
+            TestScope(),
+            coroutineRule.testDispatcherProvider,
+        )
+    }
+
+    private fun givenMediaPlaybackDaoContainsEntities() {
+        whenever(mockMediaPlaybackDao.getAll()).thenReturn(listOf(mediaPlaybackExceptionEntity))
+    }
+
+    companion object {
+        val mediaPlaybackExceptionEntity = MediaPlaybackExceptionEntity(
+            domain = "example.com",
+        )
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1206024383416124/f

### Description
Added feature flag to control autoplay. 

### Steps to test this PR

_Without the flag_
- [x] Install from this branch.
- [x] Navigate to https://clearmemorysolution.com/presentation
- [x] Notice the video doesn't play at all when you tap on it.

_With the flag enabled_
- [x] Override the privacy config url with https://www.jsonblob.com/api/1199734168438562816
- [x] Navigate to https://clearmemorysolution.com/presentation
- [x] Notice the video works when you tap on it.

_With the flag disabled_
- [x] Modify the privacy config at https://www.jsonblob.com/1199734168438562816 and disable `mediaPlaybackRequiresUserGesture`
- [x] Navigate to https://clearmemorysolution.com/presentation
- [x]  Notice the video works when you tap on it.
 
### NO UI changes

