### PR TITLE
Remove sending 'mnot' pixel when notifications disabled

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/di/NotificationModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/NotificationModule.kt
@@ -72,11 +72,13 @@ object NotificationModule {
     @SingleInstanceIn(AppScope::class)
     fun providesNotificationScheduler(
         workManager: WorkManager,
+        notificationManager: NotificationManagerCompat,
         clearDataNotification: ClearDataNotification,
         privacyProtectionNotification: PrivacyProtectionNotification,
     ): AndroidNotificationScheduler {
         return NotificationScheduler(
             workManager,
+            notificationManager,
             clearDataNotification,
             privacyProtectionNotification,
         )

--- a/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
@@ -59,16 +59,16 @@ class NotificationScheduler(
         if (privacyNotification.canShow()) {
             scheduleNotification(
                 OneTimeWorkRequestBuilder<PrivacyNotificationWorker>(),
-                5L,
-                TimeUnit.SECONDS,
+                PRIVACY_DELAY_DURATION_IN_DAYS,
+                TimeUnit.DAYS,
                 UNUSED_APP_WORK_REQUEST_TAG,
             )
         }
         if (clearDataNotification.canShow()) {
             scheduleNotification(
                 OneTimeWorkRequestBuilder<ClearDataNotificationWorker>(),
-                8L,
-                TimeUnit.SECONDS,
+                CLEAR_DATA_DELAY_DURATION_IN_DAYS,
+                TimeUnit.DAYS,
                 UNUSED_APP_WORK_REQUEST_TAG,
             )
         }

--- a/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/AndroidNotificationScheduler.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.notification
 
 import android.content.Context
 import androidx.annotation.WorkerThread
+import androidx.core.app.NotificationManagerCompat
 import androidx.work.*
 import com.duckduckgo.anvil.annotations.ContributesWorker
 import com.duckduckgo.app.notification.model.ClearDataNotification
@@ -37,6 +38,7 @@ interface AndroidNotificationScheduler {
 
 class NotificationScheduler(
     private val workManager: WorkManager,
+    private val notificationManager: NotificationManagerCompat,
     private val clearDataNotification: SchedulableNotification,
     private val privacyNotification: SchedulableNotification,
 ) : AndroidNotificationScheduler {
@@ -48,23 +50,25 @@ class NotificationScheduler(
     private suspend fun scheduleInactiveUserNotifications() {
         workManager.cancelAllWorkByTag(UNUSED_APP_WORK_REQUEST_TAG)
 
-        scheduleUnusedAppNotifications()
+        if (notificationManager.areNotificationsEnabled()) {
+            scheduleUnusedAppNotifications()
+        }
     }
 
     private suspend fun scheduleUnusedAppNotifications() {
         if (privacyNotification.canShow()) {
             scheduleNotification(
                 OneTimeWorkRequestBuilder<PrivacyNotificationWorker>(),
-                PRIVACY_DELAY_DURATION_IN_DAYS,
-                TimeUnit.DAYS,
+                5L,
+                TimeUnit.SECONDS,
                 UNUSED_APP_WORK_REQUEST_TAG,
             )
         }
         if (clearDataNotification.canShow()) {
             scheduleNotification(
                 OneTimeWorkRequestBuilder<ClearDataNotificationWorker>(),
-                CLEAR_DATA_DELAY_DURATION_IN_DAYS,
-                TimeUnit.DAYS,
+                8L,
+                TimeUnit.SECONDS,
                 UNUSED_APP_WORK_REQUEST_TAG,
             )
         }

--- a/app/src/test/java/com/duckduckgo/app/notification/AndroidSchedulerNotificationTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/notification/AndroidSchedulerNotificationTest.kt
@@ -33,6 +33,7 @@ package com.duckduckgo.app.notification
  */
 
 import android.util.Log
+import androidx.core.app.NotificationManagerCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.work.Configuration
@@ -58,21 +59,24 @@ class AndroidNotificationSchedulerTest {
     @get:Rule
     var coroutinesTestRule = CoroutineTestRule()
 
-    private val clearNotification: SchedulableNotification = mock()
-    private val privacyNotification: SchedulableNotification = mock()
+    private val mockClearNotification: SchedulableNotification = mock()
+    private val mockPrivacyNotification: SchedulableNotification = mock()
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
     private lateinit var workManager: WorkManager
+    private lateinit var notificationManager: NotificationManagerCompat
     private lateinit var testee: NotificationScheduler
 
     @Before
     fun before() {
         initializeWorkManager()
+        notificationManager = NotificationManagerCompat.from(context)
 
         testee = NotificationScheduler(
             workManager,
-            clearNotification,
-            privacyNotification,
+            notificationManager,
+            mockClearNotification,
+            mockPrivacyNotification,
         )
     }
 
@@ -89,8 +93,8 @@ class AndroidNotificationSchedulerTest {
 
     @Test
     fun whenPrivacyNotificationClearDataCanShowThenPrivacyNotificationIsScheduled() = runTest {
-        whenever(privacyNotification.canShow()).thenReturn(true)
-        whenever(clearNotification.canShow()).thenReturn(true)
+        whenever(mockPrivacyNotification.canShow()).thenReturn(true)
+        whenever(mockClearNotification.canShow()).thenReturn(true)
 
         testee.scheduleNextNotification()
 
@@ -99,8 +103,8 @@ class AndroidNotificationSchedulerTest {
 
     @Test
     fun whenPrivacyNotificationCanShowButClearDataCannotThenPrivacyNotificationIsScheduled() = runTest {
-        whenever(privacyNotification.canShow()).thenReturn(true)
-        whenever(clearNotification.canShow()).thenReturn(false)
+        whenever(mockPrivacyNotification.canShow()).thenReturn(true)
+        whenever(mockClearNotification.canShow()).thenReturn(false)
 
         testee.scheduleNextNotification()
 
@@ -109,8 +113,8 @@ class AndroidNotificationSchedulerTest {
 
     @Test
     fun whenPrivacyNotificationCannotShowAndClearNotificationCanShowThenClearNotificationIsScheduled() = runTest {
-        whenever(privacyNotification.canShow()).thenReturn(false)
-        whenever(clearNotification.canShow()).thenReturn(true)
+        whenever(mockPrivacyNotification.canShow()).thenReturn(false)
+        whenever(mockClearNotification.canShow()).thenReturn(true)
 
         testee.scheduleNextNotification()
 
@@ -119,8 +123,8 @@ class AndroidNotificationSchedulerTest {
 
     @Test
     fun whenPrivacyNotificationAndClearNotificationCannotShowThenNoNotificationScheduled() = runTest {
-        whenever(privacyNotification.canShow()).thenReturn(false)
-        whenever(clearNotification.canShow()).thenReturn(false)
+        whenever(mockPrivacyNotification.canShow()).thenReturn(false)
+        whenever(mockClearNotification.canShow()).thenReturn(false)
 
         testee.scheduleNextNotification()
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1206420860078750/f

### Description
Check if notifications permissions have been granted in order to send a pixel for engagement notification shown

### Steps to test this PR

_Pre steps_
- [ ] Change notification schedule to 10-20 SECONDS instead DAYS

_Allow notifications permissions_
- [ ] Fresh install from branch
- [ ] Allow notifications when prompt displays
- [ ] Check in logcat `mnot_s_%` pixels are fired

_Reject notifications permissions_
- [ ] Fresh install from branch
- [ ] Reject notifications permissions when prompt displays
- [ ] Check in logcat `mnot_s_%` pixels are **NOT** fired

### No UI changes
