### PR TITLE
Add error state support to DaxTextInput

### DIFF
--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/themepreview/ui/component/textinput/ComponentTextInputFragment.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/themepreview/ui/component/textinput/ComponentTextInputFragment.kt
@@ -57,6 +57,7 @@ class ComponentTextInputFragment : Fragment() {
         binding.outlinedinputtext31.onAction { toastOnClick(it) }
         binding.outlinedinputtext32.onAction { toastOnClick(it) }
         binding.outlinedinputtext33.onAction { toastOnClick(it) }
+        binding.outlinedinputtext21.error = "This is an error"
     }
 
     private fun toastOnClick(action: Action) = when (action) {

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/text/DaxTextInput.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/text/DaxTextInput.kt
@@ -55,6 +55,7 @@ interface TextInput {
     var text: String
     var hint: String
     var isEditable: Boolean
+    var error: String?
 
     fun addTextChangedListener(textWatcher: TextWatcher)
     fun removeTextChangedListener(textWatcher: TextWatcher)
@@ -170,6 +171,12 @@ class DaxTextInput @JvmOverloads constructor(
         set(value) {
             binding.internalEditText.isEnabled = value
             handleIsEditableChangeForEndIcon(value)
+        }
+
+    override var error: String?
+        get() = binding.internalInputLayout.error.toString()
+        set(value) {
+            binding.internalInputLayout.error = value
         }
 
     fun showKeyboardDelayed() {

--- a/common/common-ui/src/main/res/layout/component_text_input_view.xml
+++ b/common/common-ui/src/main/res/layout/component_text_input_view.xml
@@ -163,6 +163,15 @@
             app:endIcon="@drawable/ic_copy"
             app:type="password" />
 
+        <com.duckduckgo.common.ui.view.text.DaxTextInput
+            android:id="@+id/outlinedinputtext21"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/keyline_3"
+            android:hint="Error"
+            android:text="This is an error"
+            app:editable="false"/>
+
     </LinearLayout>
 
 </androidx.core.widget.NestedScrollView>

--- a/common/common-ui/src/main/res/values/attrs-text-input.xml
+++ b/common/common-ui/src/main/res/values/attrs-text-input.xml
@@ -19,6 +19,7 @@
         <attr name="android:hint" />
         <attr name="android:text" />
         <attr name="android:minLines" />
+        <attr name="capitalizeKeyboard" format="boolean" />
         <attr name="clickable" format="boolean" />
         <attr name="editable" format="boolean" />
         <attr name="endIcon" format="reference" />

--- a/common/common-ui/src/main/res/values/widgets.xml
+++ b/common/common-ui/src/main/res/values/widgets.xml
@@ -330,6 +330,7 @@
         <item name="hintTextColor">@color/text_input_hint_color_selector</item>
         <item name="android:textColorHint">@color/text_input_hint_color_selector</item>
         <item name="android:theme">@style/Widget.DuckDuckGo.TextInputCursor</item>
+        <item name="errorIconDrawable">@null</item>
     </style>
 
     <style name="Widget.DuckDuckGo.TextInputText">

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/waitlist/NetPWaitlistRedeemCodeActivity.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/waitlist/NetPWaitlistRedeemCodeActivity.kt
@@ -19,7 +19,6 @@ package com.duckduckgo.networkprotection.impl.waitlist
 import android.os.Bundle
 import android.view.KeyEvent
 import android.view.inputmethod.EditorInfo
-import androidx.core.widget.doOnTextChanged
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -60,18 +59,20 @@ class NetPWaitlistRedeemCodeActivity : DuckDuckGoActivity() {
 
     private fun configureUiEventHandlers() {
         binding.redeemButton.setOnClickListener {
-            val code = binding.redeemCode.editText?.text.toString()
+            val code = binding.redeemCode.text
             it.hideKeyboard()
             viewModel.redeemCode(code)
         }
-        binding.redeemCode.editText?.doOnTextChanged { inputText, _, _, _ ->
+
+        binding.redeemCode.doOnTextChanged { inputText, _, _, _ ->
             binding.redeemCode.error = null
             binding.redeemButton.isEnabled = !inputText.isNullOrEmpty()
         }
-        binding.redeemCode.editText?.setOnEditorActionListener { textView, actionId, keyEvent ->
+
+        binding.redeemCode.setOnEditorActionListener { textView, actionId, keyEvent ->
             if (actionId == EditorInfo.IME_ACTION_GO || keyEvent?.keyCode == KeyEvent.KEYCODE_ENTER) {
                 if (binding.redeemButton.isEnabled) {
-                    val code = binding.redeemCode.editText?.text.toString()
+                    val code = binding.redeemCode.text
                     textView.hideKeyboard()
                     viewModel.redeemCode(code)
                 }

--- a/network-protection/network-protection-impl/src/main/res/layout/activity_netp_waitlist_redeem_code.xml
+++ b/network-protection/network-protection-impl/src/main/res/layout/activity_netp_waitlist_redeem_code.xml
@@ -55,7 +55,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/headerImage" />
 
-    <com.google.android.material.textfield.TextInputLayout
+    <com.duckduckgo.common.ui.view.text.DaxTextInput
         android:id="@+id/redeemCode"
         style="@style/Widget.DuckDuckGo.TextInput"
         android:layout_width="match_parent"
@@ -64,24 +64,14 @@
         android:layout_marginTop="24dp"
         android:layout_marginEnd="24dp"
         android:hint="@string/netpWaitlistCodeInvite"
-        android:textColorHint="?attr/daxColorSecondaryText"
-        app:errorIconTint="?attr/daxColorDestructive"
-        app:errorTextColor="?attr/daxColorDestructive"
-        app:errorIconDrawable="@null"
-        app:boxStrokeErrorColor="?attr/daxColorDestructive"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/statusTitle">
+        app:layout_constraintTop_toBottomOf="@+id/statusTitle"
+        app:type="single_line"
+        app:capitalizeKeyboard="true"
+        android:imeOptions="actionGo">
 
-        <com.google.android.material.textfield.TextInputEditText
-            style="@style/Widget.DuckDuckGo.TextInputText"
-            android:maxLines="1"
-            android:imeOptions="actionGo"
-            android:inputType="textCapCharacters"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
-
-    </com.google.android.material.textfield.TextInputLayout>
+    </com.duckduckgo.common.ui.view.text.DaxTextInput>
 
     <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
         android:id="@+id/redeemButton"


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1204338910522509/f 

### Description
Add error state support to DaxtextInput and use it in NetP waitlist

### Steps to test this PR

_Check error status_
- [ ] Go to NetP through settings
- [ ] Select I have an Invite Code
- [ ] Type a random bunch of characters
- [ ] Press the arrow/ok button on the keyboard
- [ ] Check that it submits the code and triggers the error state
- [ ] Check error state styling is correct


_Check single line and caps_
- [ ] Go to NetP through settings
- [ ] Select I have an Invite Code
- [ ] Type a random bunch of characters and check the field is single line
- [ ] Check the keyboard is launched with caps on

### UI changes

![output.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/xNBXzxGm7JvnNf4UHqZ9/665dcfca-cdd0-42ec-a188-fcedaf46d048.png)

