### PR TITLE
Update content scope scripts to version 4.59.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^9.1.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.0.3",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.59.1",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.59.2",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#3.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1703196979"
       },
@@ -59,9 +59,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-9.1.0.tgz",
-      "integrity": "sha512-zjuYu+Wb/8cscFrjSttA4uMjxwcRAzPcHmou5vgbYAfEV7qdsAPMvuai2REke199BmoI7OK2khtsLq7LGqkDzQ=="
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-9.2.0.tgz",
+      "integrity": "sha512-O5CR35by6A2i15pSDOzUN47RYxbw0EhZNYGyuQb7oIKBCSoiYqBqV3qayV5Idr0fQzz1fFSFVhT4a9vPikHf2g=="
     },
     "node_modules/@duckduckgo/autofill": {
       "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#b972bc0ab6ee1d57a0a18a197dcc31e40ae6ac57",
@@ -69,7 +69,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#0b68b0d404d8d4f32296cd84fa160b18b0aeaf44",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#38ee7284bac7fa12d822fcaf0677ea3969d15fb1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -143,9 +143,9 @@
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.21",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.21.tgz",
-      "integrity": "sha512-SRfKmRe1KvYnxjEMtxEr+J4HIeMX5YBg/qhRHpxEIGjhX1rshcHlnFUE9K0GazhVKWM7B+nARSkV8LuvJdJ5/g==",
+      "version": "0.3.22",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.22.tgz",
+      "integrity": "sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==",
       "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -268,9 +268,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.11.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.0.tgz",
-      "integrity": "sha512-o9bjXmDNcF7GbM4CNQpmi+TutCgap/K3w1JyKgxAjqx41zp9qlIAVFi0IhCNsJcXolEqLWhbFbEeL0PvYm4pcQ==",
+      "version": "20.11.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.6.tgz",
+      "integrity": "sha512-+EOokTnksGVgip2PbYbr3xnR7kZigh4LbybAfBAw5BpnQ+FqBYUsvCEjYd70IXKlbohQ64mzEYmMtlWUY8q//Q==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -1071,9 +1071,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.26.0.tgz",
-      "integrity": "sha512-dytTGoE2oHgbNV9nTzgBEPaqAWvcJNl66VZ0BkJqlvp71IjO8CxdBx/ykCNb47cLnCmCvRZ6ZR0tLkqvZCdVBQ==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.27.0.tgz",
+      "integrity": "sha512-bi1HRwVRskAjheeYl291n3JC4GgO/Ty4z1nVs5AAsmonJulGxpSektecnNedrwK9C7vpvVtcX3cw00VSLt7U2A==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^9.1.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.0.3",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.59.1",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.59.2",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#3.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1703196979"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1206447940396946/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [x] All tests must pass