### PR TITLE
Convert null usernames to empty strings in getAutofillData response

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/AutofillJavascriptInterface.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/AutofillJavascriptInterface.kt
@@ -223,12 +223,23 @@ class AutofillStoredBackJavascriptInterface @Inject constructor(
         val dedupedCredentials = loginDeduplicator.deduplicate(url, credentials)
         Timber.v("Original autofill credentials list size: %d, after de-duping: %d", credentials.size, dedupedCredentials.size)
 
-        if (dedupedCredentials.isEmpty()) {
+        val finalCredentialList = ensureUsernamesNotNull(dedupedCredentials)
+
+        if (finalCredentialList.isEmpty()) {
             callback?.noCredentialsAvailable(url)
         } else {
-            callback?.onCredentialsAvailableToInject(url, dedupedCredentials, triggerType)
+            callback?.onCredentialsAvailableToInject(url, finalCredentialList, triggerType)
         }
     }
+
+    private fun ensureUsernamesNotNull(credentials: List<LoginCredentials>) =
+        credentials.map {
+            if (it.username == null) {
+                it.copy(username = "")
+            } else {
+                it
+            }
+        }
 
     private fun convertTriggerType(trigger: SupportedAutofillTriggerType): LoginTriggerType {
         return when (trigger) {

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/AutofillStoredBackJavascriptInterfaceTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/AutofillStoredBackJavascriptInterfaceTest.kt
@@ -151,6 +151,23 @@ class AutofillStoredBackJavascriptInterfaceTest {
     }
 
     @Test
+    fun whenGetAutofillDataCalledWithCredentialsAvailableWithNullUsernameUsernameConvertedToEmptyString() = runTest {
+        setupRequestForSubTypePassword()
+        whenever(autofillStore.getCredentials(any())).thenReturn(
+            listOf(
+                loginCredential(username = null, password = "foo"),
+                loginCredential(username = null, password = "bar"),
+                loginCredential(username = "foo", password = "bar"),
+            ),
+        )
+        initiateGetAutofillDataRequest()
+        assertCredentialsAvailable()
+
+        // ensure the list of credentials now has two entries with empty string username (one for each null username)
+        assertCredentialsContains({ it.username }, "", "")
+    }
+
+    @Test
     fun whenRequestSpecifiesSubtypeUsernameAndNoEntriesThenNoCredentialsCallbackInvoked() = runTest {
         setupRequestForSubTypeUsername()
         whenever(autofillStore.getCredentials(any())).thenReturn(emptyList())


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1206230587783134/f 

### Description
Converts null usernames to empty strings in response to autofill `getAutofillData` requests from the JS layer. This is to keep the response aligned with the expected schema.


### Steps to test this PR

**QA optional**. If you want to test more... follow the below:


- [ ] Open `Settings->Passwords`
- [ ] Manually add the following passwords using the ➕ button

`username=<LEAVE EMPTY>`, `password=bar`, `URL=fill.dev`

- [ ] Visit https://fill.dev/form/login-simple
- [ ] Verify there is **no** key icon on the username field
- [ ] Verify the key **is** visible on the password field
- [ ] Tap on the password field, verify you are prompted to autofill the saved password

