### PR TITLE
Bundle notifications experiment in privacy_config.json

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePage.kt
@@ -61,7 +61,7 @@ class WelcomePage : OnboardingPageFragment(R.layout.content_onboarding_welcome) 
         // displayed on top of the onboarding.
         if (view?.windowVisibility == View.VISIBLE) {
             // Nothing to do at this point with the result. Proceed with the welcome animation.
-            scheduleTypingAnimation()
+            scheduleWelcomeAnimation(ANIMATION_DELAY_AFTER_NOTIFICATIONS_PERMISSIONS_HANDLED)
         }
     }
 
@@ -74,7 +74,7 @@ class WelcomePage : OnboardingPageFragment(R.layout.content_onboarding_welcome) 
     private val events = MutableSharedFlow<WelcomePageView.Event>(replay = 0, extraBufferCapacity = 1)
 
     private val welcomePageViewModel: WelcomePageViewModel by lazy {
-        ViewModelProvider(this, viewModelFactory)[WelcomePageViewModel::class.java]
+        ViewModelProvider(this, viewModelFactory).get(WelcomePageViewModel::class.java)
     }
 
     private val binding: ContentOnboardingWelcomeBinding by viewBinding()
@@ -86,7 +86,6 @@ class WelcomePage : OnboardingPageFragment(R.layout.content_onboarding_welcome) 
         super.onViewCreated(view, savedInstanceState)
 
         configureDaxCta()
-        scheduleWelcomeAnimation()
         setSkipAnimationListener()
 
         lifecycleScope.launch {
@@ -95,16 +94,8 @@ class WelcomePage : OnboardingPageFragment(R.layout.content_onboarding_welcome) 
                 .flowOn(dispatcherProvider.io())
                 .collect(::render)
         }
-    }
 
-    private fun scheduleWelcomeAnimation() {
-        welcomeAnimation = ViewCompat.animate(binding.welcomeContent as View)
-            .alpha(MIN_ALPHA)
-            .setDuration(ANIMATION_DURATION)
-            .setStartDelay(ANIMATION_DELAY)
-            .withEndAction {
-                requestNotificationsPermissions()
-            }
+        requestNotificationsPermissions()
     }
 
     private fun requestNotificationsPermissions() {
@@ -115,27 +106,23 @@ class WelcomePage : OnboardingPageFragment(R.layout.content_onboarding_welcome) 
         }
     }
 
-    @SuppressLint("InlinedApi")
-    private fun showNotificationsPermissionsPrompt() {
-        if (appBuildConfig.sdkInt >= android.os.Build.VERSION_CODES.TIRAMISU) {
-            requestPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
-        }
-    }
-
     private fun render(state: WelcomePageView.State) {
         when (state) {
             WelcomePageView.State.Idle -> {}
             is WelcomePageView.State.ShowDefaultBrowserDialog -> {
                 showDefaultBrowserDialog(state.intent)
             }
-
             WelcomePageView.State.Finish -> {
                 onContinuePressed()
             }
-
-            WelcomePageView.State.ShowWelcomeAnimation -> scheduleTypingAnimation()
+            WelcomePageView.State.ShowWelcomeAnimation -> scheduleWelcomeAnimation()
             WelcomePageView.State.ShowNotificationsPermissionsPrompt -> showNotificationsPermissionsPrompt()
         }
+    }
+
+    @SuppressLint("InlinedApi")
+    private fun showNotificationsPermissionsPrompt() {
+        requestPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
     }
 
     private fun event(event: WelcomePageView.Event) {
@@ -201,20 +188,26 @@ class WelcomePage : OnboardingPageFragment(R.layout.content_onboarding_welcome) 
                 finishTypingAnimation()
             } else if (!welcomeAnimationFinished) {
                 welcomeAnimation?.cancel()
-                scheduleTypingAnimation()
+                scheduleWelcomeAnimation(0L)
             }
             welcomeAnimationFinished = true
         }
     }
 
-    private fun scheduleTypingAnimation() {
-        typingAnimation = ViewCompat.animate(binding.daxDialogCta.daxCtaContainer)
-            .alpha(MAX_ALPHA)
+    private fun scheduleWelcomeAnimation(startDelay: Long = ANIMATION_DELAY) {
+        welcomeAnimation = ViewCompat.animate(binding.welcomeContent as View)
+            .alpha(MIN_ALPHA)
             .setDuration(ANIMATION_DURATION)
+            .setStartDelay(startDelay)
             .withEndAction {
-                welcomeAnimationFinished = true
-                binding.daxDialogCta.dialogTextCta.startTypingAnimation(ctaText)
-                setPrimaryCtaListenerAfterWelcomeAlphaAnimation()
+                typingAnimation = ViewCompat.animate(binding.daxDialogCta.daxCtaContainer)
+                    .alpha(MAX_ALPHA)
+                    .setDuration(ANIMATION_DURATION)
+                    .withEndAction {
+                        welcomeAnimationFinished = true
+                        binding.daxDialogCta.dialogTextCta.startTypingAnimation(ctaText)
+                        setPrimaryCtaListenerAfterWelcomeAlphaAnimation()
+                    }
             }
     }
 
@@ -231,8 +224,8 @@ class WelcomePage : OnboardingPageFragment(R.layout.content_onboarding_welcome) 
     companion object {
         private const val MIN_ALPHA = 0f
         private const val MAX_ALPHA = 1f
-        private const val ANIMATION_DURATION = 1200L
-        private const val ANIMATION_DELAY = 1800L
+        private const val ANIMATION_DURATION = 400L
+        private const val ANIMATION_DELAY = 1400L
         private const val ANIMATION_DELAY_AFTER_NOTIFICATIONS_PERMISSIONS_HANDLED = 800L
 
         private const val DEFAULT_BROWSER_ROLE_MANAGER_DIALOG = 101

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePage.kt
@@ -102,7 +102,7 @@ class WelcomePage : OnboardingPageFragment(R.layout.content_onboarding_welcome) 
         if (appBuildConfig.sdkInt >= android.os.Build.VERSION_CODES.TIRAMISU) {
             event(WelcomePageView.Event.OnNotificationPermissionsRequested)
         } else {
-            scheduleTypingAnimation()
+            scheduleWelcomeAnimation()
         }
     }
 

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/ExperimentVariantRepository.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/ExperimentVariantRepository.kt
@@ -19,6 +19,8 @@ package com.duckduckgo.experiments.impl
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.experiments.api.VariantConfig
+import com.duckduckgo.experiments.impl.VariantManagerImpl.Companion.DEFAULT_VARIANT
+import com.duckduckgo.experiments.impl.VariantManagerImpl.Companion.REINSTALL_VARIANT
 import com.duckduckgo.experiments.impl.store.ExperimentVariantDao
 import com.duckduckgo.experiments.impl.store.ExperimentVariantEntity
 import com.squareup.anvil.annotations.ContributesBinding
@@ -64,7 +66,13 @@ class ExperimentVariantRepositoryImpl @Inject constructor(
 
     override fun updateVariant(variantKey: String) {
         Timber.i("Updating variant for user: $variantKey")
-        store.variant = variantKey
+        if (updateVariantIsAllowed()) {
+            store.variant = variantKey
+        }
+    }
+
+    private fun updateVariantIsAllowed(): Boolean {
+        return store.variant != DEFAULT_VARIANT.key && store.variant != REINSTALL_VARIANT
     }
 
     override fun getAppReferrerVariant(): String? = store.referrerVariant

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/VariantManagerImpl.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/VariantManagerImpl.kt
@@ -131,9 +131,9 @@ class VariantManagerImpl @Inject constructor(
         const val RESERVED_EU_AUCTION_VARIANT = "ml"
 
         // this will be returned when there are no other active experiments
-        private val DEFAULT_VARIANT = Variant(key = "", filterBy = { noFilter() })
+        val DEFAULT_VARIANT = Variant(key = "", filterBy = { noFilter() })
 
-        private const val REINSTALL_VARIANT = "ru"
+        const val REINSTALL_VARIANT = "ru"
 
         private fun noFilter(): Boolean = true
     }

--- a/privacy-config/privacy-config-impl/src/main/res/raw/privacy_config.json
+++ b/privacy-config/privacy-config-impl/src/main/res/raw/privacy_config.json
@@ -947,7 +947,50 @@
                     "reason": "Site breakage"
                 }
             ]
+        },
+        "notificationPermissions": {
+            "state": "enabled",
+            "features": {
+                "noPermissionsPrompt": {
+                    "state": "enabled",
+                    "targets": [
+                        {
+                            "variantKey": "mg"
+                        }
+                    ]
+                }
+            }
         }
     },
-    "unprotectedTemporary": []
+    "unprotectedTemporary": [],
+    "experimentalVariants": {
+        "variants": [
+            {
+                "desc": "this is SERP don't remove",
+                "variantKey": "sc",
+                "weight": 0.0
+            },
+            {
+                "desc": "this is SERP don't remove",
+                "variantKey": "se",
+                "weight": 0.0
+            },
+            {
+                "desc": "Control group for notification permissions experiment",
+                "variantKey": "mf",
+                "weight": 1.0,
+                "filters": {
+                    "androidVersion": ["34", "33"]
+                }
+            },
+            {
+                "desc": "No notifications permissions prompt experimental group",
+                "variantKey": "mg",
+                "weight": 1.0,
+                "filters": {
+                    "androidVersion": ["34", "33"]
+                }
+            }
+        ]
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1206462881489059/f

### Description
Load experiment variants from local `privacy_config` to remove the welcome animation delay

### Steps to test this PR
_Pre Steps_
- [x] Change const val `PRIVACY_REMOTE_CONFIG_URL` to `https://www.jsonblob.com/api/1168612786158034944`
- [ ] There is a log in `VariantManagerImpl` _Line 86_ when a new variant allocation is made. This way, you can check if the variant has been allocated correctly
-  [ ] Before every test you need to delete the DuckDuckGo folder from downloads

_Experimental variant_
- [ ] Change `privacy_config.json` to the one below in the variant `mg` and make sure you have `androidVersion` filter set to 33 and 34.
```
{
        "desc": "No notifications permissions prompt experimental group",
        "variantKey": "mg",
        "weight": 1,
        "filters": {
          "androidVersion": [
            "34",
            "33"
          ]
        }
}
```
_Android >= 13_
- [ ] Delete the DuckDuckGo folder from Downloads
- [ ] Fresh install
- [ ] Check experimental variant is assigned
- [ ] Check you don't see notifications permissions prompt when first install

_Android < 13_
- [ ] Delete the DuckDuckGo folder from Downloads
- [ ] Fresh install
- [ ] Check experimental variant is assigned
- [ ] Check you don't see notifications permissions prompt when first install

_Control variant_
- [ ] Change `privacy_config.json` to the one below in the variant `mf` and make sure you have `androidVersion` filter set to 33 and 34.
```
{
        "desc": "No notifications permissions prompt experimental group",
        "variantKey": "mf",
        "weight": 1,
        "filters": {
          "androidVersion": [
            "34",
            "33"
          ]
        }
}
```
_Returning users_

- [ ] Make sure this is not a fresh install so you have DuckDuckGo directory in Downloads folder
- [ ] Install from branch
- [ ] Check `ru` variant is assigned to the user

### No UI changes
