### PR TITLE
Increase ability to run Android UI tests for Autofill by allowing device auth requirement to be bypassed (for UI testing builds only)

### DIFF
--- a/.maestro/autofill/0_all.yaml
+++ b/.maestro/autofill/0_all.yaml
@@ -1,6 +1,10 @@
 appId: com.duckduckgo.mobile.android
-name: Autofill - Run all tests
+name: "Autofill: Run all tests"
+tags:
+    - autofillNoAuthTests
 ---
+# Pre-requisite: the app is installed on an autofill-eligible device with a special build flag set to bypass device-authentication requirement
+
 - launchApp:
     clearState: true
 - runFlow: ../shared/onboarding.yaml
@@ -10,3 +14,6 @@ name: Autofill - Run all tests
 - runFlow: 2_autofill_reach_creds_management.yaml
 - runFlow: 3_autofill_manually_add_cred.yaml
 - runFlow: 4_search_logins.yaml
+- runFlow: 5_autofill_manually_updating_an_existing_credential.yaml
+- runFlow: 6_delete_logins.yaml
+- runFlow: 7_autofill_prompted_to_save_creds_on_form.yaml

--- a/.maestro/autofill/1_autofill_shown_in_overflow.yaml
+++ b/.maestro/autofill/1_autofill_shown_in_overflow.yaml
@@ -1,5 +1,8 @@
 appId: com.duckduckgo.mobile.android
+name: "Autofill: Autofill screen is reachable from overflow menu"
 ---
+# Pre-requisite: the user has cleared onboarding and is on the new tab page
+
 - tapOn:
       id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
 - assertVisible: "Passwords"

--- a/.maestro/autofill/2_autofill_reach_creds_management.yaml
+++ b/.maestro/autofill/2_autofill_reach_creds_management.yaml
@@ -1,5 +1,8 @@
 appId: com.duckduckgo.mobile.android
+name: "Autofill: Password manager screen when no passwords saved"
 ---
+# Pre-requisite: the user is viewing the password manager screen with no saved passwords, on an autofill-eligible device
+
 - assertVisible:
     text: "No passwords saved yet"
 - assertNotVisible:

--- a/.maestro/autofill/3_autofill_manually_add_cred.yaml
+++ b/.maestro/autofill/3_autofill_manually_add_cred.yaml
@@ -1,5 +1,8 @@
 appId: com.duckduckgo.mobile.android
+name: "Autofill: Manually add credentials"
 ---
+# Pre-requisite: the user is viewing the password manager screen with no saved passwords, on an autofill-eligible device
+
 - runScript: 3_script.js
 
 - repeat:

--- a/.maestro/autofill/4_search_logins.yaml
+++ b/.maestro/autofill/4_search_logins.yaml
@@ -1,5 +1,8 @@
 appId: com.duckduckgo.mobile.android
+name: "Autofill: Search credentials"
 ---
+# Pre-requisite: the user is viewing the password manager screen with some saved passwords added by a previous test step, on an autofill-eligible device
+
 - tapOn:
     id: searchLogins
 

--- a/.maestro/autofill/5_autofill_manually_updating_an_existing_credential.yaml
+++ b/.maestro/autofill/5_autofill_manually_updating_an_existing_credential.yaml
@@ -1,0 +1,25 @@
+appId: com.duckduckgo.mobile.android
+name: "Autofill: Manually updating an existing credential"
+---
+# Pre-requisite: the user is viewing the password manager screen with some saved passwords added by a previous test step, on an autofill-eligible device
+
+- tapOn:
+    id: "item_container"
+    index: "1"
+
+- tapOn: "More options"
+- tapOn: "Edit"
+
+- tapOn:
+    id: notesEditText
+
+- eraseText
+
+- inputText: "new note"
+
+- tapOn:
+    id: view_menu_save
+    retryTapIfNoChange: false
+
+- assertVisible: "new note"
+- tapOn: "Navigate up"

--- a/.maestro/autofill/6_delete_logins.yaml
+++ b/.maestro/autofill/6_delete_logins.yaml
@@ -1,0 +1,30 @@
+appId: com.duckduckgo.mobile.android
+name: "Autofill: Delete credentials"
+---
+# Pre-requisite: the user is viewing the password manager screen with some saved passwords added by a previous test step, on an autofill-eligible device
+
+- tapOn:
+    id: "item_container"
+    index: 1
+- tapOn: "More options"
+- tapOn: "Delete"
+- tapOn: "Delete"
+
+- tapOn:
+      id: "item_container"
+      index: 1
+- tapOn: "More options"
+- tapOn: "Delete"
+- tapOn: "Delete"
+
+- tapOn:
+    id: "item_container"
+    index: 1
+- tapOn: "More options"
+- tapOn: "Delete"
+- tapOn: "Delete"
+
+- assertVisible:
+    text: "No passwords saved yet"
+
+- tapOn: "Navigate up"

--- a/.maestro/autofill/7_autofill_prompted_to_save_creds_on_form.yaml
+++ b/.maestro/autofill/7_autofill_prompted_to_save_creds_on_form.yaml
@@ -1,0 +1,41 @@
+appId: com.duckduckgo.mobile.android
+name: "Autofill: Prompted to save and update credentials on web form"
+---
+# Pre-requisite: the user is viewing the new tab screen, on an autofill-eligible device
+
+- tapOn:
+    text: "search or type URL"
+- eraseText
+- inputText: "fill.dev/form/login-simple"
+- pressKey: enter
+
+- tapOn:
+    text: "Got it"
+    optional: true
+
+- tapOn:
+    id: "username"
+- inputText: "user"
+- tapOn:
+    id: "password"
+- inputText: "password1"
+- tapOn:
+    text: "Login"
+- assertVisible: "Save Password"
+- tapOn: "Save Password"
+- pressKey: back
+- tapOn: "Close Autofill Dialog"
+- tapOn:
+    id: "password"
+- inputText: "password2"
+- tapOn:
+    text: "Login"
+- assertVisible: "Update Password"
+- tapOn: "Update Password"
+- tapOn:
+    id: "browserMenu"
+- tapOn: "Passwords"
+- tapOn: "user"
+- tapOn:
+    id: "internal_password_icon"
+- assertVisible: "password2"

--- a/autofill/autofill-impl/build.gradle
+++ b/autofill/autofill-impl/build.gradle
@@ -21,6 +21,11 @@ plugins {
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"
+apply from: "$rootDir/versioning.gradle"
+
+ext {
+    autofillDisableAuthRequirementBuildFlag = "autofill-disable-auth-requirement"
+}
 
 dependencies {
     implementation project(path: ':app-build-config-api')
@@ -97,5 +102,26 @@ android {
     compileOptions {
         coreLibraryDesugaringEnabled = true
     }
+    defaultConfig {
+        if (project.hasProperty("$autofillDisableAuthRequirementBuildFlag")) {
+            buildConfigField "boolean", "AUTH_REQUIRED", "false"
+        } else {
+            buildConfigField "boolean", "AUTH_REQUIRED", "true"
+        }
+    }
+}
+
+tasks.register('installForAutofillTesting', Exec) {
+    commandLine "$rootDir/gradlew", ':app:installInternalRelease', "-P$autofillDisableAuthRequirementBuildFlag"
+}
+
+tasks.register('autofillTestLocal', Exec) {
+    commandLine 'maestro', 'test', '--include-tags', 'autofillNoAuthTests', "$rootDir/.maestro"
+    dependsOn 'installForAutofillTesting'
+}
+
+tasks.register('autofillTestCloud', Exec) {
+    commandLine 'maestro', 'cloud', '--include-tags', 'autofillNoAuthTests', "$rootDir/app/build/outputs/apk/internal/release/duckduckgo-${buildVersionName()}-internal-release.apk", "$rootDir/.maestro"
+    dependsOn 'installForAutofillTesting'
 }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/AutofillGlobalCapabilityChecker.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/AutofillGlobalCapabilityChecker.kt
@@ -45,7 +45,9 @@ class AutofillGlobalCapabilityCheckerImpl @Inject constructor(
     override suspend fun isSecureAutofillAvailable(): Boolean {
         return withContext(dispatcherProvider.io()) {
             if (!autofillStore.autofillAvailable) return@withContext false
-            if (!deviceAuthenticator.hasValidDeviceAuthentication()) return@withContext false
+            if (deviceAuthenticator.isAuthenticationRequiredForAutofill() && !deviceAuthenticator.hasValidDeviceAuthentication()) {
+                return@withContext false
+            }
             return@withContext true
         }
     }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/deviceauth/DeviceAuthenticator.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/deviceauth/DeviceAuthenticator.kt
@@ -21,6 +21,7 @@ import androidx.annotation.UiThread
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.autofill.impl.BuildConfig
 import com.duckduckgo.autofill.impl.R
 import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator.AuthConfiguration
 import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator.AuthResult
@@ -55,6 +56,15 @@ interface DeviceAuthenticator {
         config: AuthConfiguration = AuthConfiguration(),
         onResult: (AuthResult) -> Unit,
     )
+
+    /**
+     * Returns true if the user has to authenticate to use autofill. This is always true in production.
+     *
+     * When running some specific UI tests, this can be set to false with a build flag to allow us to have increased test coverage.
+     */
+    fun isAuthenticationRequiredForAutofill(): Boolean {
+        return BuildConfig.AUTH_REQUIRED
+    }
 
     sealed class AuthResult {
         object Success : AuthResult()
@@ -93,7 +103,7 @@ class RealDeviceAuthenticator @Inject constructor(
         config: AuthConfiguration,
         onResult: (AuthResult) -> Unit,
     ) {
-        if (config.requireUserAction || autofillAuthGracePeriod.isAuthRequired()) {
+        if (isAuthenticationRequiredForAutofill() && (config.requireUserAction || autofillAuthGracePeriod.isAuthRequired())) {
             authLauncher.launch(
                 featureTitleText = config.displayTitleResource,
                 featureAuthText = config.displayTextResource,
@@ -111,7 +121,7 @@ class RealDeviceAuthenticator @Inject constructor(
         config: AuthConfiguration,
         onResult: (AuthResult) -> Unit,
     ) {
-        if (config.requireUserAction || autofillAuthGracePeriod.isAuthRequired()) {
+        if (isAuthenticationRequiredForAutofill() && (config.requireUserAction || autofillAuthGracePeriod.isAuthRequired())) {
             authLauncher.launch(
                 featureTitleText = config.displayTitleResource,
                 featureAuthText = config.displayTextResource,

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillManagementActivity.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillManagementActivity.kt
@@ -96,7 +96,11 @@ class AutofillManagementActivity : DuckDuckGoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+
+        if (deviceAuthenticator.isAuthenticationRequiredForAutofill()) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
+
         setContentView(binding.root)
         setupToolbar(binding.toolbar)
         observeViewModel()

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModel.kt
@@ -252,7 +252,7 @@ class AutofillSettingsViewModel @Inject constructor(
             return
         }
 
-        if (!deviceAuthenticator.hasValidDeviceAuthentication()) {
+        if (deviceAuthenticator.isAuthenticationRequiredForAutofill() && !deviceAuthenticator.hasValidDeviceAuthentication()) {
             Timber.d("Can't show device auth as there is no valid device authentication")
             disabled()
             return

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/AutofillGlobalCapabilityCheckerImplSecureStorageAvailableTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/AutofillGlobalCapabilityCheckerImplSecureStorageAvailableTest.kt
@@ -101,6 +101,7 @@ class AutofillGlobalCapabilityCheckerImplSecureStorageAvailableTest(
     }
 
     private fun configureDeviceAuthValid(isValid: Boolean) {
+        whenever(deviceAuthenticator.isAuthenticationRequiredForAutofill()).thenReturn(true)
         whenever(deviceAuthenticator.hasValidDeviceAuthentication()).thenReturn(isValid)
     }
 

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModelTest.kt
@@ -114,6 +114,7 @@ class AutofillSettingsViewModelTest {
         runTest {
             whenever(mockStore.getAllCredentials()).thenReturn(emptyFlow())
             whenever(neverSavedSiteRepository.neverSaveListCount()).thenReturn(emptyFlow())
+            whenever(deviceAuthenticator.isAuthenticationRequiredForAutofill()).thenReturn(true)
         }
     }
 

--- a/versioning.gradle
+++ b/versioning.gradle
@@ -9,7 +9,7 @@ ext {
 
     getVersionName = {
         def props = new Properties()
-        file("version/version.properties").withInputStream { props.load(it) }
+        file("$rootDir/app/version/version.properties").withInputStream { props.load(it) }
         return props.getProperty("VERSION")
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/1203822806345703/1206452714902883/f 

### Description

Since we require a device-level authentication mechanism (e.g., PIN/Password/Pattern etc...) to be in place to fully use `Autofill`, there are many parts of `Autofill` that we can't currently write UI tests for.

This PR allows setting a build flag when building the APK that will remove that limitation and will be set only for when running autofill UI tests. There are no changes to production behaviour.

**New build flag:** `autofill-disable-auth-requirement`
**Usage example:** `./gradlew assembleIR -Pautofill-disable-auth-requirement`

Under the hood, this will set a boolean which can be interrogated by `autofill-impl`'s `BuildConfig`.

This PR also introduces more maestro tests and convenience methods to run them:
- `./gradlew autofillTestLocal`  -- builds APK with the flag, installs it, then runs the full suite of autofill UI tests **locally**
- `./gradlew autofillTestCloud` -- builds APK with the flag, then runs the full suite of autofill UI tests in **Maestro Cloud**

Note, this PR does not define a GH action to automate the execution of the new autofill tests. I want to run them manually for a bit to test how reliable they are first. Will make any adjustments as needed, then create a follow-up PR to define a GHA workflow for them.

### Steps to test this PR

#### Production Behaviour

- [x] Disable device-level auth from system settings (e.g., `Settings -> Security -> Screen lock`)
- [x] Install using `./gradlew installInternalRelease`
- [x] Visit `Settings -> Passwords` in our app
- [x] Verify you are prompted to `Secure your device`
- [x] Visit https://fill.dev/form/login-simple. Enter username and password (>= 4 characters) and hit `Login`
- [x] Verify you are **not** prompted to save
- [x] Enable device-level auth from system settings (e.g., `Settings -> Security -> Screen lock`)
- [x] Visit `Settings -> Passwords` in our app
- [x] Verify you are **not** prompted to `Secure your device`
- [x] Visit https://fill.dev/form/login-simple. Enter username and password (>= 4 characters) and hit `Login`
- [x] Verify you **are** prompted to save. 
- [x] Save and navigate back to the login form. Agree to autofill, and verify you are prompted to authenticate.
- [x] Background the app (e.g., device `Home` button), then bring it back to foreground again. Go to `Settings -> Passwords` and verify you **are** prompted to authenticate before you can access passwords

#### UI Testing Behaviour
- [x] Install using `./gradlew installInternalRelease -Pautofill-disable-auth-requirement`
- [x] Visit `Settings -> Passwords` in our app. Verify you are **not** prompted to authenticate
- [x] Visit https://fill.dev/form/login-simple and choose to autofill the saved password when prompted. Verify you are **not** required to authenticate.
- [x] Disable device-level auth from system settings (e.g., `Settings -> Security -> Screen lock`)
- [x] Visit `Settings -> Passwords` in our app.
- [x] Verify you are **not** prompted to authenticate
- [x] Verify you are **not** prompted to `Secure your device`
