### PR TITLE
Sync: Modified After Behaviour

### DIFF
--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/algorithm/SavedSitesTimestampPersister.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/algorithm/SavedSitesTimestampPersister.kt
@@ -103,7 +103,7 @@ class SavedSitesTimestampPersister @Inject constructor(
 
 fun BookmarkFolder.modifiedAfter(after: String?): Boolean {
     return if (this.lastModified == null) {
-        true
+        false
     } else {
         if (after == null) {
             false
@@ -121,7 +121,7 @@ fun BookmarkFolder.isDeleted(): Boolean {
 
 fun SavedSite.modifiedAfter(after: String?): Boolean {
     return if (this.lastModified == null) {
-        true
+        false
     } else {
         if (after == null) {
             false


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/0/1174433894299346/1206474912857922/f

### Description
This PR changes the way we compare modifications. If the local object doesn’t
 have a modifedDate, we assume that any comparison will not return as modifiedAfter.

### Steps to test this PR

- [ ] Join account from device B
- [ ] Create account on device A
- [ ] Import bookmarks on device A
- [ ] Ensure you trigger sync (after importing sync is not automatically triggered)
- [ ] Go to device B
- [ ] Verify bookmarks from A exist