### PR TITLE
Removes the dependency of autofill-impl's gradle file on versioning.properties as it breaks incrementBuildNumber task

### DIFF
--- a/autofill/autofill-impl/build.gradle
+++ b/autofill/autofill-impl/build.gradle
@@ -21,7 +21,6 @@ plugins {
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"
-apply from: "$rootDir/versioning.gradle"
 
 ext {
     autofillDisableAuthRequirementBuildFlag = "autofill-disable-auth-requirement"
@@ -119,9 +118,3 @@ tasks.register('autofillTestLocal', Exec) {
     commandLine 'maestro', 'test', '--include-tags', 'autofillNoAuthTests', "$rootDir/.maestro"
     dependsOn 'installForAutofillTesting'
 }
-
-tasks.register('autofillTestCloud', Exec) {
-    commandLine 'maestro', 'cloud', '--include-tags', 'autofillNoAuthTests', "$rootDir/app/build/outputs/apk/internal/release/duckduckgo-${buildVersionName()}-internal-release.apk", "$rootDir/.maestro"
-    dependsOn 'installForAutofillTesting'
-}
-


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1206512928267585/f 

### Description

Remove `versioning.gradle` from being applied inside `autofill-impl`'s gradle (and the convenience function that used it). This was added to support a test convenience function, however, unintentionally meant that the `gradlew incrementBuildNumber` task was applied twice, and therefore broke when the nightly tried to call it (it ended up calling through to `:autofill-impl:incrementBuildNumber` which isn't intended.

### Steps to test this PR
QA optional

