### PR TITLE
Fix issue that caused only 1st page loaded pixel to be sent

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/pageloadpixel/PageLoadedHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pageloadpixel/PageLoadedHandler.kt
@@ -32,7 +32,6 @@ private val sites = listOf(
     "bbc.com",
     "ebay.com",
     "espn.com",
-    "nytimes.com",
     "reddit.com",
     "twitch.tv",
     "twitter.com",

--- a/app/src/main/java/com/duckduckgo/app/browser/pageloadpixel/PageLoadedPixelDao.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pageloadpixel/PageLoadedPixelDao.kt
@@ -31,7 +31,7 @@ abstract class PageLoadedPixelDao {
     abstract fun all(): List<PageLoadedPixelEntity>
 
     @Delete
-    abstract fun delete(exceptionEntity: PageLoadedPixelEntity)
+    abstract fun delete(pageLoadedPixelEntity: PageLoadedPixelEntity)
 
     @Query("DELETE FROM page_loaded_pixel_entity")
     abstract fun deleteAll()


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/0/1206522173508080/f 

### Description
See title

### Steps to test this PR

_Test pixels sent_
- [ ] Install this version and open a few sites (more than 1)
- [ ] Wait for ~3h and check that (1) there's as many log entries for pixels fired as sites previously visited and (2) all entries are removed from the database. Alternatively, you can modify the code to avoid the 3h delay:
* Replace `fun scheduleOfflinePixels()` with:

```
rivate fun scheduleOfflinePixels() {
        Timber.v("Scheduling offline pixels to be sent")

        val constraints = Constraints.Builder()
            .setRequiredNetworkType(NetworkType.CONNECTED)
            .build()

        val request = PeriodicWorkRequestBuilder<OfflinePixelWorker>(SERVICE_INTERVAL, SERVICE_TIME_UNIT)
            .addTag(WORK_REQUEST_TAG)
            .setConstraints(constraints)
            .setInitialDelay(0, SECONDS)
            .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, BACKOFF_INTERVAL, BACKOFF_TIME_UNIT)
            .build()

        workManager.enqueueUniquePeriodicWork(WORK_REQUEST_TAG, ExistingPeriodicWorkPolicy.REPLACE, request)
    }
```

Pixels will be sent on next app launch

### UI changes
No UI changes
