### PR TITLE
Remove NYTimes from page loaded pixel allowlist

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/pageloadpixel/PageLoadedHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pageloadpixel/PageLoadedHandler.kt
@@ -32,7 +32,6 @@ private val sites = listOf(
     "bbc.com",
     "ebay.com",
     "espn.com",
-    "nytimes.com",
     "reddit.com",
     "twitch.tv",
     "twitter.com",


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/0/1206522179596625/f

### Description
See title

### Steps to test this PR
- [ ] Open nytimes.com
- [ ] Check no entry is added to `page_loaded_pixel_entity` in  app database


### UI changes
No UI changes
