### PR TITLE
Add CPM status to page load pixel

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/pageloadpixel/PageLoadedHandlerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/pageloadpixel/PageLoadedHandlerTest.kt
@@ -1,6 +1,7 @@
 package com.duckduckgo.app.browser.pageloadpixel
 
 import com.duckduckgo.app.pixels.remoteconfig.OptimizeTrackerEvaluationRCWrapper
+import com.duckduckgo.autoconsent.api.Autoconsent
 import com.duckduckgo.browser.api.WebViewVersionProvider
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.device.DeviceInfo
@@ -26,6 +27,7 @@ class PageLoadedHandlerTest {
     private val deviceInfo: DeviceInfo = mock()
     private val webViewVersionProvider: WebViewVersionProvider = mock()
     private val pageLoadedPixelDao: PageLoadedPixelDao = mock()
+    private val autoconsent: Autoconsent = mock()
     private val optimizeTrackerEvaluationRCWrapper = object : OptimizeTrackerEvaluationRCWrapper {
         override val enabled: Boolean
             get() = true
@@ -38,12 +40,14 @@ class PageLoadedHandlerTest {
         TestScope(),
         coroutinesTestRule.testDispatcherProvider,
         optimizeTrackerEvaluationRCWrapper,
+        autoconsent,
     )
 
     @Before
     fun before() {
         whenever(webViewVersionProvider.getMajorVersion()).thenReturn("1")
         whenever(deviceInfo.appVersion).thenReturn("1")
+        whenever(autoconsent.isAutoconsentEnabled()).thenReturn(true)
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/browser/pageloadpixel/PageLoadedHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pageloadpixel/PageLoadedHandler.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.browser.pageloadpixel
 
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.pixels.remoteconfig.OptimizeTrackerEvaluationRCWrapper
+import com.duckduckgo.autoconsent.api.Autoconsent
 import com.duckduckgo.browser.api.WebViewVersionProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.UriString
@@ -51,6 +52,7 @@ class RealPageLoadedHandler @Inject constructor(
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
     private val optimizeTrackerEvaluationRCWrapper: OptimizeTrackerEvaluationRCWrapper,
+    private val autoconsent: Autoconsent,
 ) : PageLoadedHandler {
 
     override operator fun invoke(url: String, start: Long, end: Long) {
@@ -62,6 +64,7 @@ class RealPageLoadedHandler @Inject constructor(
                         webviewVersion = webViewVersionProvider.getMajorVersion(),
                         appVersion = deviceInfo.appVersion,
                         trackerOptimizationEnabled = optimizeTrackerEvaluationRCWrapper.enabled,
+                        cpmEnabled = autoconsent.isAutoconsentEnabled(),
                     ),
                 )
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/pageloadpixel/PageLoadedOfflinePixelSender.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pageloadpixel/PageLoadedOfflinePixelSender.kt
@@ -29,6 +29,7 @@ import timber.log.Timber
 private const val ELAPSED_TIME = "elapsed_time"
 private const val WEBVIEW_VERSION = "webview_version"
 private const val TRACKER_OPTIMIZATION_ENABLED = "tracker_optimization_enabled"
+private const val CPM_ENABLED = "cpm_enabled"
 
 // This is used to ensure the app version we send is the one from the moment the page was loaded, and not then the pixel is fired later on
 private const val APP_VERSION = "app_version_when_page_loaded"
@@ -49,6 +50,7 @@ class PageLoadedOfflinePixelSender @Inject constructor(
                     ELAPSED_TIME to it.elapsedTime.toString(),
                     WEBVIEW_VERSION to it.webviewVersion,
                     TRACKER_OPTIMIZATION_ENABLED to it.trackerOptimizationEnabled.toString(),
+                    CPM_ENABLED to it.cpmEnabled.toString(),
                 )
 
                 val pixel = pixelSender.sendPixel(

--- a/app/src/main/java/com/duckduckgo/app/browser/pageloadpixel/PageLoadedPixelEntity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pageloadpixel/PageLoadedPixelEntity.kt
@@ -26,4 +26,5 @@ class PageLoadedPixelEntity(
     val elapsedTime: Long,
     val webviewVersion: String,
     val trackerOptimizationEnabled: Boolean,
+    val cpmEnabled: Boolean,
 )

--- a/app/src/main/java/com/duckduckgo/app/global/db/AppDatabase.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/db/AppDatabase.kt
@@ -68,7 +68,7 @@ import com.duckduckgo.savedsites.store.SavedSitesRelationsDao
 
 @Database(
     exportSchema = true,
-    version = 51,
+    version = 52,
     entities = [
         TdsTracker::class,
         TdsEntity::class,
@@ -635,6 +635,12 @@ class MigrationsProvider(val context: Context, val settingsDataStore: SettingsDa
         }
     }
 
+    private val MIGRATION_51_TO_52: Migration = object : Migration(51, 52) {
+        override fun migrate(database: SupportSQLiteDatabase) {
+            database.execSQL("ALTER TABLE `page_loaded_pixel_entity` ADD COLUMN `cpmEnabled` INTEGER NOT NULL DEFAULT 0")
+        }
+    }
+
     val BOOKMARKS_DB_ON_CREATE = object : RoomDatabase.Callback() {
         override fun onCreate(database: SupportSQLiteDatabase) {
             database.execSQL(
@@ -711,6 +717,7 @@ class MigrationsProvider(val context: Context, val settingsDataStore: SettingsDa
             MIGRATION_48_TO_49,
             MIGRATION_49_TO_50,
             MIGRATION_50_TO_51,
+            MIGRATION_51_TO_52,
         )
 
     @Deprecated(

--- a/autoconsent/autoconsent-api/src/main/java/com/duckduckgo/autoconsent/api/Autoconsent.kt
+++ b/autoconsent/autoconsent-api/src/main/java/com/duckduckgo/autoconsent/api/Autoconsent.kt
@@ -42,6 +42,11 @@ interface Autoconsent {
     fun isSettingEnabled(): Boolean
 
     /**
+     * @return `true` if autoconsent is enabled in remote config and enabled by the user, `false` otherwise.
+     */
+    fun isAutoconsentEnabled(): Boolean
+
+    /**
      * This method sends and opt out message to autoconsent on the given [WebView] instance to set the opt out mode.
      */
     fun setAutoconsentOptOut(webView: WebView)

--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/RealAutoconsent.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/RealAutoconsent.kt
@@ -45,7 +45,7 @@ class RealAutoconsent @Inject constructor(
     private lateinit var autoconsentJs: String
 
     override fun injectAutoconsent(webView: WebView, url: String) {
-        if (canBeInjected() && !urlInUserAllowList(url) && !isAnException(url)) {
+        if (isAutoconsentEnabled() && !urlInUserAllowList(url) && !isAnException(url)) {
             webView.evaluateJavascript("javascript:${getFunctionsJS()}", null)
         }
     }
@@ -63,6 +63,10 @@ class RealAutoconsent @Inject constructor(
 
     override fun isSettingEnabled(): Boolean {
         return settingsRepository.userSetting
+    }
+
+    override fun isAutoconsentEnabled(): Boolean {
+        return isEnabled() && isSettingEnabled()
     }
 
     override fun setAutoconsentOptOut(webView: WebView) {
@@ -96,10 +100,6 @@ class RealAutoconsent @Inject constructor(
 
     private fun matches(url: String): Boolean {
         return autoconsentExceptionsRepository.exceptions.any { UriString.sameOrSubdomain(url, it.domain) }
-    }
-
-    private fun canBeInjected(): Boolean {
-        return isEnabled() && settingsRepository.userSetting
     }
 
     private fun getFunctionsJS(): String {

--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/di/AutoconsentModule.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/di/AutoconsentModule.kt
@@ -39,6 +39,7 @@ import kotlinx.coroutines.CoroutineScope
 object AutoconsentModule {
 
     @Provides
+    @SingleInstanceIn(AppScope::class)
     fun provideAutoconsentSettingsRepository(context: Context, autoconsentFeature: AutoconsentFeature): AutoconsentSettingsRepository {
         return AutoconsentSettingsRepository.create(context, autoconsentFeature.onByDefault().isEnabled())
     }

--- a/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/ui/AutoconsentSettingsViewModelTest.kt
+++ b/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/ui/AutoconsentSettingsViewModelTest.kt
@@ -92,6 +92,10 @@ class AutoconsentSettingsViewModelTest {
 
         override fun isSettingEnabled(): Boolean = test
 
+        override fun isAutoconsentEnabled(): Boolean {
+            return isSettingEnabled()
+        }
+
         override fun setAutoconsentOptOut(webView: WebView) {
             // NO OP
         }

--- a/autoconsent/autoconsent-store/src/main/java/com/duckduckgo/autoconsent/store/AutoconsentSettingsDataStore.kt
+++ b/autoconsent/autoconsent-store/src/main/java/com/duckduckgo/autoconsent/store/AutoconsentSettingsDataStore.kt
@@ -27,17 +27,25 @@ interface AutoconsentSettingsDataStore {
 
 class RealAutoconsentSettingsDataStore constructor(
     private val context: Context,
-    private val onByDefault: Boolean,
+    onByDefault: Boolean,
 ) :
     AutoconsentSettingsDataStore {
 
     private val preferences: SharedPreferences by lazy { context.getSharedPreferences(FILENAME, Context.MODE_PRIVATE) }
+    private var internalUserSettings: Boolean
+
+    init {
+        internalUserSettings = preferences.getBoolean(AUTOCONSENT_USER_SETTING, onByDefault)
+    }
 
     override var userSetting: Boolean
-        get() = preferences.getBoolean(AUTOCONSENT_USER_SETTING, onByDefault)
+        get() = internalUserSettings
+
         set(value) {
             preferences.edit(commit = true) {
                 putBoolean(AUTOCONSENT_USER_SETTING, value)
+            }.also {
+                internalUserSettings = value
             }
         }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/0/1206446781259752/f 

### Description
Add CPM status information to page loaded pixel

### Steps to test this PR

_Feature 1_
- [x] Install the app
- [x] Open reddit.com
- [x] Go to settings and change the status of CPM
- [x] Open another page
- [x] Using database inspector, go to `page_loaded_pixel_entity` in app db and check that the last 2 pixels have the right value for CPM enabled

_Feature 2_
- [x] Install the app
- [x] Go to settings and change the status of CPM
- [x] Check that the status is updated on the settings screen when navigating back

### UI changes
No UI changes
