### PR TITLE
Update content scope scripts to version 4.61.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/README.md
+++ b/node_modules/@duckduckgo/content-scope-scripts/README.md
@@ -70,15 +70,16 @@ In the built output you will see these dramatic differences in the bundled code 
 To handle the difference in scope injection we expose multiple utilities which behave differently per browser in src/utils.js and `ContentFeature` base class. for Firefox the code exposed handles [xrays correctly](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Sharing_objects_with_page_scripts) without needing the features to be authored differently.
 
 - `ContentFeature.defineProperty()`
-    - defineProperty(object, propertyName, descriptor) behaves the same as Object.defineProperty(object, propertyName, descriptor)
+    - `defineProperty(object, propertyName, descriptor)` behaves the same as `Object.defineProperty(object, propertyName, descriptor)`
     - The difference is for Firefox we export the relevant functions so it can go across the xray
+    - Use this method if `Object.getOwnPropertyDescriptors(object).propertyName` should to exist in the supporting browser.
 - `ContentFeature.wrapProperty(object, propertyName, descriptor)`
-    - a simple wrapper around defineProperty() that ignores non-existing properties and retains unspecified descriptor keys.
+    - A simple wrapper around `defineProperty()` that ignores non-existing properties and retains unspecified descriptor keys.
     - Example usage: `this.wrapProperty('Navigator.prototype.userAgent', { get: () => 'fakeUA' })`
 - `ContentFeature.wrapMethod(object, propertyName, wrapperFn)`
-    - overrides a native method. wrapperFn() will be called in place of the original method. The original method will be passed as the first argument.
+    - Overrides a native method. wrapperFn() will be called in place of the original method. The original method will be passed as the first argument.
     - Example usage:
-    ```
+    ```JavaScript
     this.wrapMethod(Permissions.prototype, 'query', async function (originalFn, queryObject) {
         if (queryObject.name === 'blocked-permission') {
             return {
@@ -90,12 +91,25 @@ To handle the difference in scope injection we expose multiple utilities which b
         return await nativeImpl.call(this, queryObject)
     })
     ```
-
-- DDGProxy
-    - Behaves a lot like new window.Proxy with a few differences:
-        - has an overload function to actually apply the function to the native property.
+- `DDGProxy`
+    - Behaves a lot like `new window.Proxy` with a few differences:
+        - has an `overload` method to actually apply the function to the native property.
         - Stores the native original property in _native such that it can be called elsewhere if needed without going through the proxy.
-- DDGReflect
+        - Triggers `addDebugFlag` if get/apply is called.
+        - Sends debugging messaging if debug is enabled.
+        - Allows for remotely disabling the override based on script URL via `shouldExemptMethod`.
+        - Fixes `value.toString()` to appear like it was defined natively.
+    - Example usage:
+    ```JavaScript
+    const historyMethodProxy = new DDGProxy(this, History.prototype, 'pushState', {
+        apply (target, thisArg, args) {
+            applyRules(activeRules)
+            return DDGReflect.apply(target, thisArg, args)
+        }
+    })
+    historyMethodProxy.overload()
+    ```
+- `DDGReflect`
     - Calls into wrappedJSObject.Reflect for Firefox but otherwise exactly the same as [window.Reflect](Sources/BrowserServicesKit/UserScript/ContentScopeUserScript.swift) 
 
 ### Testing Locally

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -8695,11 +8695,13 @@
      * @param {string} locale UI locale
      */
     function getConfig (locale) {
-        const locales = JSON.parse(localesJSON);
-        const fbStrings = locales[locale]['facebook.json'];
-        const ytStrings = locales[locale]['youtube.json'];
+        const allLocales = JSON.parse(localesJSON);
+        const localeStrings = allLocales[locale] || allLocales.en;
 
-        const sharedStrings = locales[locale]['shared.json'];
+        const fbStrings = localeStrings['facebook.json'];
+        const ytStrings = localeStrings['youtube.json'];
+        const sharedStrings = localeStrings['shared.json'];
+
         const config = {
             'Facebook, Inc.': {
                 informationalModal: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^9.7.2",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.1.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.59.2",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.61.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#3.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1703196979"
       },
@@ -69,7 +69,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#38ee7284bac7fa12d822fcaf0677ea3969d15fb1",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#063b560e59a50e03d9b00b88a7fcb2ed2b562395",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -268,9 +268,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.11.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.6.tgz",
-      "integrity": "sha512-+EOokTnksGVgip2PbYbr3xnR7kZigh4LbybAfBAw5BpnQ+FqBYUsvCEjYd70IXKlbohQ64mzEYmMtlWUY8q//Q==",
+      "version": "20.11.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.16.tgz",
+      "integrity": "sha512-gKb0enTmRCzXSSUJDq6/sPcqrfCv2mkkG6Jt/clpn5eiCbKTY+SgZUxo+p8ZKMof5dCp9vHQUAB7wOUTod22wQ==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -464,9 +464,9 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.16.0.tgz",
-      "integrity": "sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
+      "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
@@ -606,9 +606,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
-      "integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
+      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
       "dev": true,
       "engines": {
         "node": ">= 4"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^9.7.2",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.1.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.59.2",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#4.61.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#3.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1703196979"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1206550824714055/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass