### PR TITLE
Ensure we re-evaluate newly added feature flags

### DIFF
--- a/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesRemoteFeatureCodeGenerator.kt
+++ b/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesRemoteFeatureCodeGenerator.kt
@@ -311,6 +311,7 @@ class ContributesRemoteFeatureCodeGenerator : CodeGenerator {
                     )
                     .addProperty(createSharedPreferencesProperty(generatedPackage, featureName, module))
                     .addProperty(createFeatureNameProperty(featureName))
+                    .addFunction(createFeatureHashcode(module))
                     .addFunction(createStoreOverride(module))
                     .addFunctions(createToggleStoreImplementation(module))
                     .addFunction(createCompareAndSetHash())
@@ -406,6 +407,31 @@ class ContributesRemoteFeatureCodeGenerator : CodeGenerator {
             .build()
     }
 
+    private fun createFeatureHashcode(module: ModuleDescriptor): FunSpec {
+        return FunSpec.builder("hash")
+            .addModifiers(KModifier.OVERRIDE)
+            .addCode(
+                CodeBlock.of(
+                    """
+                        try {
+                            // try to hash with all sub-features
+                            val concatMethodNames = this.feature.get().javaClass
+                                .declaredMethods
+                                .map { it.name }
+                                .joinToString(separator = "")
+                            val hash = %T().writeUtf8(concatMethodNames).md5().hex()
+                            return hash
+                        } catch(e: Throwable) {
+                            // fallback to just featureName 
+                            return this.featureName
+                        }
+                    """.trimIndent(),
+                    okioBuffer.asClassName(module),
+                ),
+            )
+            .returns(String::class.asClassName().copy(nullable = true))
+            .build()
+    }
     private fun createStoreOverride(module: ModuleDescriptor): FunSpec {
         return FunSpec.builder("store")
             .addModifiers(KModifier.OVERRIDE)
@@ -416,7 +442,13 @@ class ContributesRemoteFeatureCodeGenerator : CodeGenerator {
                 if (featureName == this.featureName) {
                     val feature = parseJson(jsonString) ?: return false
                     
-                    if (compareAndSetHash(feature.hash)) return true
+                    // feature hash is the hash of the feature + hash coming from remote config
+                    // this way we evaluate either when remote config has changes OR when feature changes
+                    // when the feature.hash (remote config) is null we always re-evaluate
+                    if (feature.hash != null) {
+                        val _hash = hash() + feature.hash
+                        if (compareAndSetHash(_hash)) return true
+                    }
         
                     val exceptions = parseExceptions(feature)
                     exceptionStore.insertAll(exceptions)

--- a/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureToggles.kt
+++ b/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureToggles.kt
@@ -307,11 +307,11 @@ internal class ToggleImpl constructor(
             } ?: state
         }
 
-        val sortedRollout = state.rollout.sorted().filter { it in 0.0..100.0 }
-        if (sortedRollout.isEmpty()) return state
+        val scopedRolloutRange = state.rollout.filter { it in 0.0..100.0 }
+        if (scopedRolloutRange.isEmpty()) return state
 
         return state.copy(
-            enable = (state.rolloutThreshold ?: 0.0) <= sortedRollout.last(),
+            enable = (state.rolloutThreshold ?: 0.0) <= scopedRolloutRange.last(),
         )
     }
 }

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt
@@ -48,6 +48,7 @@ class ContributesRemoteFeatureCodeGeneratorTest {
 
     private val context: Context = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
     private lateinit var testFeature: TestTriggerFeature
+    private lateinit var anotherTestFeature: AnotherTestTriggerFeature
     private val appBuildConfig: AppBuildConfig = mock()
     private lateinit var variantManager: FakeVariantManager
     private lateinit var toggleStore: FakeToggleStore
@@ -65,6 +66,14 @@ class ContributesRemoteFeatureCodeGeneratorTest {
             appVariantProvider = { variantManager.getVariantKey() },
             forceDefaultVariant = { variantManager.saveVariants(emptyList()) },
         ).build().create(TestTriggerFeature::class.java)
+        anotherTestFeature = FeatureToggles.Builder(
+            toggleStore,
+            featureName = "testFeature",
+            appVersionProvider = { appBuildConfig.versionCode },
+            flavorNameProvider = { appBuildConfig.flavor.name },
+            appVariantProvider = { variantManager.getVariantKey() },
+            forceDefaultVariant = { variantManager.saveVariants(emptyList()) },
+        ).build().create(AnotherTestTriggerFeature::class.java)
     }
 
     @Test
@@ -113,6 +122,227 @@ class ContributesRemoteFeatureCodeGeneratorTest {
         assertEquals(TriggerTestScope::class, annotation.scope)
         assertEquals(PrivacyFeaturePlugin::class, annotation.boundType)
         assertTrue(annotation.ignoreQualifier)
+    }
+
+    @Test
+    fun `re-evaluate feature state when feature hash is null`() {
+        val feature = generatedFeatureNewInstance()
+
+        val privacyPlugin = (feature as PrivacyFeaturePlugin)
+
+        assertTrue(
+            privacyPlugin.store(
+                "testFeature",
+                """
+                {
+                    "state": "disabled",
+                    "features": {
+                        "missingFeature": {
+                            "state": "enabled"
+                        },
+                        "fooFeature": {
+                            "state": "enabled"
+                        }
+                    }
+                }
+                """.trimIndent(),
+            ),
+        )
+        assertFalse(testFeature.self().isEnabled())
+        assertTrue(testFeature.fooFeature().isEnabled())
+
+        assertTrue(
+            privacyPlugin.store(
+                "testFeature",
+                """
+                {
+                    "state": "enabled",
+                    "features": {
+                        "missingFeature": {
+                            "state": "enabled"
+                        },
+                        "fooFeature": {
+                            "state": "disabled"
+                        }
+                    }
+                }
+                """.trimIndent(),
+            ),
+        )
+        assertTrue(testFeature.self().isEnabled())
+        assertFalse(testFeature.fooFeature().isEnabled())
+    }
+
+    @Test
+    fun `do not re-evaluate feature state if hash hasn't changed`() {
+        val feature = generatedFeatureNewInstance()
+
+        val privacyPlugin = (feature as PrivacyFeaturePlugin)
+
+        assertTrue(
+            privacyPlugin.store(
+                "testFeature",
+                """
+                {
+                    "hash": "1",
+                    "state": "disabled",
+                    "features": {
+                        "missingFeature": {
+                            "state": "enabled"
+                        },
+                        "fooFeature": {
+                            "state": "enabled"
+                        }
+                    }
+                }
+                """.trimIndent(),
+            ),
+        )
+        assertFalse(testFeature.self().isEnabled())
+        assertTrue(testFeature.fooFeature().isEnabled())
+
+        assertTrue(
+            privacyPlugin.store(
+                "testFeature",
+                """
+                {
+                    "hash": "1",
+                    "state": "enabled",
+                    "features": {
+                        "missingFeature": {
+                            "state": "enabled"
+                        },
+                        "fooFeature": {
+                            "state": "disabled"
+                        }
+                    }
+                }
+                """.trimIndent(),
+            ),
+        )
+        assertFalse(testFeature.self().isEnabled())
+        assertTrue(testFeature.fooFeature().isEnabled())
+    }
+
+    @Test
+    fun `re-evaluate feature state if hash changed`() {
+        val feature = generatedFeatureNewInstance()
+
+        val privacyPlugin = (feature as PrivacyFeaturePlugin)
+
+        assertTrue(
+            privacyPlugin.store(
+                "testFeature",
+                """
+                {
+                    "hash": "1",
+                    "state": "disabled",
+                    "features": {
+                        "missingFeature": {
+                            "state": "enabled"
+                        },
+                        "fooFeature": {
+                            "state": "enabled"
+                        }
+                    }
+                }
+                """.trimIndent(),
+            ),
+        )
+        assertFalse(testFeature.self().isEnabled())
+        assertTrue(testFeature.fooFeature().isEnabled())
+
+        assertTrue(
+            privacyPlugin.store(
+                "testFeature",
+                """
+                {
+                    "hash": "2",
+                    "state": "enabled",
+                    "features": {
+                        "missingFeature": {
+                            "state": "enabled"
+                        },
+                        "fooFeature": {
+                            "state": "disabled"
+                        }
+                    }
+                }
+                """.trimIndent(),
+            ),
+        )
+        assertTrue(testFeature.self().isEnabled())
+        assertFalse(testFeature.fooFeature().isEnabled())
+    }
+
+    @Test
+    fun `re-evaluate feature when already preset in remote config but just added to client`() {
+        fun createAnotherFooFeature(): Any {
+            return Class
+                .forName("com.duckduckgo.feature.toggles.codegen.AnotherTestTriggerFeature_RemoteFeature")
+                .getConstructor(
+                    FeatureExceptions.Store::class.java,
+                    FeatureSettings.Store::class.java,
+                    dagger.Lazy::class.java as Class<*>,
+                    AppBuildConfig::class.java,
+                    VariantManager::class.java,
+                    Context::class.java,
+                ).newInstance(
+                    FeatureExceptions.EMPTY_STORE,
+                    FeatureSettings.EMPTY_STORE,
+                    Lazy { anotherTestFeature },
+                    appBuildConfig,
+                    variantManager,
+                    context,
+                )
+        }
+
+        assertFalse(anotherTestFeature.newFooFeature().isEnabled())
+
+        assertTrue(
+            (generatedFeatureNewInstance() as PrivacyFeaturePlugin).store(
+                "testFeature",
+                """
+                {
+                    "hash": "1",
+                    "state": "disabled",
+                    "features": {
+                        "newFooFeature": {
+                            "state": "enabled"
+                        },
+                        "fooFeature": {
+                            "state": "enabled"
+                        }
+                    }
+                }
+                """.trimIndent(),
+            ),
+        )
+        assertFalse(testFeature.self().isEnabled())
+        assertTrue(testFeature.fooFeature().isEnabled())
+        assertFalse(anotherTestFeature.newFooFeature().isEnabled())
+
+        assertTrue(
+            (createAnotherFooFeature() as PrivacyFeaturePlugin).store(
+                "testFeature",
+                """
+                {
+                    "hash": "1",
+                    "state": "disabled",
+                    "features": {
+                        "newFooFeature": {
+                            "state": "enabled"
+                        },
+                        "fooFeature": {
+                            "state": "enabled"
+                        }
+                    }
+                }
+                """.trimIndent(),
+            ),
+        )
+
+        assertTrue(anotherTestFeature.newFooFeature().isEnabled())
     }
 
     @Test

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/TestTriggerFeature.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/TestTriggerFeature.kt
@@ -60,3 +60,18 @@ interface TestTriggerFeature {
     @Experiment
     fun experimentDisabledByDefault(): Toggle
 }
+
+@ContributesRemoteFeature(
+    scope = TriggerTestScope::class,
+    featureName = "testFeature",
+)
+interface AnotherTestTriggerFeature {
+    @DefaultValue(false)
+    fun self(): Toggle
+
+    @DefaultValue(false)
+    fun fooFeature(): Toggle
+
+    @DefaultValue(false)
+    fun newFooFeature(): Toggle
+}

--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeaturePlugin.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeaturePlugin.kt
@@ -41,4 +41,11 @@ interface PrivacyFeaturePlugin {
      * @return the [featureName] of this feature
      */
     val featureName: String
+
+    /**
+     * @return the hash that represents the feature.
+     * The has should change every time the feature changes, eg. new sub-feature is added/remove
+     * Default value is set to [null] for backwards compatibility
+     */
+    fun hash(): String? = null
 }

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/PrivacyConfigPersister.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/PrivacyConfigPersister.kt
@@ -142,7 +142,10 @@ class RealPrivacyConfigPersister @Inject constructor(
 
 @VisibleForTesting
 fun PluginPoint<PrivacyFeaturePlugin>.signature(): Int {
-    return this.getPlugins().sumOf { it.featureName.hashCode() }
+    return this.getPlugins().sumOf {
+        // use the hash() of the feature or featureName for backwards compat
+        it.hash()?.hashCode() ?: it.featureName.hashCode()
+    }
 }
 
 @Retention(AnnotationRetention.BINARY)

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/RealPrivacyConfigPersisterTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/RealPrivacyConfigPersisterTest.kt
@@ -109,8 +109,16 @@ class RealPrivacyConfigPersisterTest {
     }
 
     @Test
-    fun whenPluginPointSignatureThenReturnUniqueSignature() {
-        assertEquals(pluginPoint.signature(), pluginPoint.signature())
+    fun whenHashIsNullSignatureReturnsFeatureName() {
+        val expected = pluginPoint.getPlugins().sumOf { it.featureName.hashCode() }
+        assertEquals(expected, pluginPoint.signature())
+    }
+
+    @Test
+    fun whenHashIsNotNullSignatureReturnsHash() {
+        val pluginPoint = FakePrivacyFeaturePluginPoint(listOf(HashedFakePrivacyFeaturePlugin()))
+        val expected = pluginPoint.getPlugins().sumOf { it.hash().hashCode() }
+        assertEquals(expected, pluginPoint.signature())
     }
 
     @Test
@@ -230,7 +238,7 @@ class RealPrivacyConfigPersisterTest {
         }
     }
 
-    class FakePrivacyFeaturePlugin : PrivacyFeaturePlugin {
+    private class FakePrivacyFeaturePlugin : PrivacyFeaturePlugin {
         var count = 0
 
         override fun store(
@@ -243,6 +251,22 @@ class RealPrivacyConfigPersisterTest {
 
         override val featureName: String =
             PrivacyFeatureName.GpcFeatureName.value
+    }
+
+    private class HashedFakePrivacyFeaturePlugin : PrivacyFeaturePlugin {
+        var count = 0
+
+        override fun store(
+            featureName: String,
+            jsonString: String,
+        ): Boolean {
+            count++
+            return true
+        }
+
+        override val featureName: String = "HashedFakePrivacyFeaturePlugin"
+
+        override fun hash() = "HashedFakePrivacyFeaturePluginHash"
     }
 
     class FakePrivacyVariantManagerPlugin : PrivacyFeaturePlugin {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1206560594088721/f

### Description
We have an edge case where if a feature flag is present in the remote config before it's handled in the app, it will not be re-evaluated unless its `hash` changes.
This causes an issue in cases like the following example:
* release app version 1, that doesn't have any `testFlag` feature flag
* release to remote config a feature flag called `testFlag` rolled out to 99%
* app version 1 downloads the config that contains `testFlag` and ignores it as it doesn't know about it
* release app version 2 that contains and handles `testFlag`
* remote config is re-downloaded
* `testFlag` continues to be ignored because nothing has changed in it and its feature `hash` is the same
* to force a re-evaluation we'll need to eg. bump the rollout step

To overcome this, this PR adds a `PrivacyFeaturePlugin#hash()` method. This method should return the `hash` of privacy feature and the hash should change when eg. new sub-features (aka feature flags) are added.
The hash is used in two places:
* in the plugin `signature()`, called from the `persistPrivacyConfig` to decide whether the remote config should be persisted or not
* in the `PrivacyFeaturePlugin#store()` method (auto-generated for the feature flags). Previously the `store` method would only consider the remote config feature `hash`, but now combines both the remote feature `hash` and the own's feature `hash`. This way the feature is re-evaluated when either it changes remotely or locally 


Note: [Incidentally](https://github.com/duckduckgo/Android/pull/4175/commits/1c2f954b48c5aa5acc369acc910faf8b7668f784) this PR also removes the `rollout.steps` sorting that prohibited to reduce the rollout %. By removing it we allow to re reduce the rollout % for new users. Something that is desirable.

### Steps to test this PR
This PR added 2e2 tests that verify the functionality but this is also the equivalent manual test

_Test_
- [x] install from this branch and launch the app
- [x] go to app settings -> developer settings -> override privacy remote config URL
- [x] toggle "use custom URL" on and enter `https://jsonblob.com/api/jsonBlob/1126094951384629248`
- [x] tap on force reloading
- [x] Use AS (or Flipper) to see the contents of the share prefs `com.duckduckgo.feature.toggle.androidBrowserConfig`
- [x] take note of the `hash`
- [x] Apply the following patch and rebuild / re-install / re-launch the app
```kotlin
Index: app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt	(revision 5fe8bd5216708fbbe945832377600bc90233eb24)
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt	(date 1707729280159)
@@ -59,4 +59,7 @@
      */
     @Toggle.DefaultValue(false)
     fun optimizeTrackerEvaluation(): Toggle
+
+    @Toggle.DefaultValue(false)
+    fun testFlag(): Toggle
 }
```
- [x] verify the `androidBrowserConfig_testFlag` is now present in the `com.duckduckgo.feature.toggle.androidBrowserConfig` and its `enable` value is most likely `true` (`rolloutThreshold` < `98`)
- [x] Repeating this test in develop should fail the last step

