### PR TITLE
Sync: Add a Favourite triggers Sync

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModel.kt
@@ -336,7 +336,7 @@ class BookmarksViewModel @Inject constructor(
 
     fun addFavorite(bookmark: Bookmark) {
         viewModelScope.launch(dispatcherProvider.io()) {
-            savedSitesRepository.insertFavorite(bookmark.id, bookmark.url, bookmark.title, bookmark.lastModified)
+            savedSitesRepository.insertFavorite(bookmark.id, bookmark.url, bookmark.title)
         }
     }
 

--- a/app/src/test/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModelTest.kt
@@ -382,7 +382,7 @@ class BookmarksViewModelTest {
     fun whenAddFavoriteCalledThenInsertFavorite() {
         testee.addFavorite(bookmark)
 
-        verify(savedSitesRepository).insertFavorite(bookmark.id, bookmark.url, bookmark.title, bookmark.lastModified)
+        verify(savedSitesRepository).insertFavorite(bookmark.id, bookmark.url, bookmark.title)
     }
 
     @Test

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/SavedSitesRepository.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/SavedSitesRepository.kt
@@ -405,7 +405,7 @@ class RealSavedSitesRepository(
 
         if (updateFavorite) {
             if (bookmark.isFavorite) {
-                insertFavorite(bookmark.id, bookmark.url, bookmark.title, bookmark.lastModified)
+                insertFavorite(bookmark.id, bookmark.url, bookmark.title)
             } else {
                 deleteFavorite(
                     Favorite(


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1206579231041835/f

### Description
This PR fixes the issue that adding a favourite doesn’t immediately trigger Sync
The modified date wasn’t correct, so we fixed that.

### Steps to test this PR

_From develop_
- [ ] Create a sync account
- [ ] add a bookmark
- [ ] don't interact with bottom sheet
- [ ] Then go to bookmarks screen.
- [ ] Add bookmark as favorite:
- [ ] overlflow menu → add as favorite
- [ ] or, overflow menu → edit → add as favorite
❌ neither operation triggers sync (sync is triggered, but bookmarks says no changed)

_From this branch_
- [ ] Create a sync account
- [ ] add a bookmark
- [ ] don't interact with bottom sheet
- [ ] Then go to bookmarks screen.
- [ ] Add bookmark as favorite:
- [ ] overlflow menu → add as favorite
- [ ] or, overflow menu → edit → add as favorite
- [ ] Sync is triggered, favourites folder and entity have changed