### PR TITLE
Surface the last-used password first in Autofill dialog for filling passwords

### DIFF
--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/domain/app/LoginCredentials.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/domain/app/LoginCredentials.kt
@@ -32,12 +32,13 @@ data class LoginCredentials(
     val domainTitle: String? = null,
     val notes: String? = null,
     val lastUpdatedMillis: Long? = null,
+    val lastUsedMillis: Long? = null,
 ) : Parcelable, Serializable {
     override fun toString(): String {
         return """
             LoginCredentials(
                 id=$id, domain=$domain, username=$username, password=********, domainTitle=$domainTitle, 
-                lastUpdatedMillis=$lastUpdatedMillis, notesLength=${notes?.length ?: 0}
+                lastUpdatedMillis=$lastUpdatedMillis, lastUsedMillis=$lastUsedMillis, notesLength=${notes?.length ?: 0}
             )
         """.trimIndent()
     }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/securestorage/SecureStorage.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/securestorage/SecureStorage.kt
@@ -302,6 +302,7 @@ class RealSecureStorage @Inject constructor(
             notesIv = encryptedNotes?.iv,
             domainTitle = details.domainTitle,
             lastUpdatedInMillis = details.lastUpdatedMillis,
+            lastUsedInMillis = details.lastUsedInMillis,
         )
     }
 
@@ -319,6 +320,7 @@ class RealSecureStorage @Inject constructor(
             id = id,
             domainTitle = domainTitle,
             lastUpdatedMillis = lastUpdatedInMillis,
+            lastUsedInMillis = lastUsedInMillis,
         )
 
     // only encrypt when there's data

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/securestorage/SecureStorageModels.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/securestorage/SecureStorageModels.kt
@@ -46,6 +46,7 @@ data class WebsiteLoginDetailsWithCredentials(
  * [id] database id associated to the website login
  * [domainTitle] title associated to the login
  * [lastUpdatedMillis] time in milliseconds when the credential was last updated
+ * [lastUsedInMillis] time in milliseconds when the credential was last used to autofill
  */
 data class WebsiteLoginDetails(
     val domain: String?,
@@ -53,6 +54,7 @@ data class WebsiteLoginDetails(
     val id: Long? = null,
     val domainTitle: String? = null,
     val lastUpdatedMillis: Long? = null,
+    val lastUsedInMillis: Long? = null,
 ) {
     override fun toString(): String {
         return """

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/store/InternalAutofillStore.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/store/InternalAutofillStore.kt
@@ -103,9 +103,11 @@ interface InternalAutofillStore : AutofillStore {
     /**
      * Updates the given login credentials, replacing what was saved before for the credentials with the specified ID
      * @param credentials The ID of the given credentials must match a saved credential for it to be updated.
+     * @param refreshLastUpdatedTimestamp Whether to update the last-updated timestamp of the credential.
+     * Defaults to true. Set to false if you don't want the last-updated timestamp modified.
      * @return The saved credential if it saved successfully, otherwise null
      */
-    suspend fun updateCredentials(credentials: LoginCredentials): LoginCredentials?
+    suspend fun updateCredentials(credentials: LoginCredentials, refreshLastUpdatedTimestamp: Boolean = true): LoginCredentials?
 
     /**
      * Used to reinsert a credential that was previously deleted

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/selecting/AutofillSelectCredentialsSorter.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/selecting/AutofillSelectCredentialsSorter.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.ui.credential.selecting
+
+import com.duckduckgo.autofill.api.domain.app.LoginCredentials
+import com.duckduckgo.di.scopes.FragmentScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+import javax.inject.Named
+
+interface TimestampBasedLoginSorter : Comparator<LoginCredentials>
+
+@ContributesBinding(FragmentScope::class)
+@Named("LastUsedCredentialSorter")
+class LastUsedCredentialSorter @Inject constructor() : TimestampBasedLoginSorter {
+
+    /**
+     * This comparator sorts based on last-used timestamps.
+     *
+     * Null timestamps come first, then older timestamps are sorted before newer timestamps.
+     */
+    override fun compare(
+        o1: LoginCredentials?,
+        o2: LoginCredentials?,
+    ): Int {
+        // handle where one or both of the objects are null
+        if (o1 == null && o2 == null) return 0
+        if (o1 == null) return -1
+        if (o2 == null) return 1
+
+        // handle where one or both of the timestamps are null
+        val lastUsed1 = o1.lastUsedMillis
+        val lastUsed2 = o2.lastUsedMillis
+
+        if (lastUsed1 == null && lastUsed2 == null) return 0
+        if (lastUsed1 == null) return -1
+        if (lastUsed2 == null) return 1
+
+        return lastUsed1.compareTo(lastUsed2)
+    }
+}
+
+@ContributesBinding(FragmentScope::class)
+@Named("LastUpdatedCredentialSorter")
+class LastUpdatedCredentialSorter @Inject constructor() : TimestampBasedLoginSorter {
+
+    /**
+     * This comparator sorts based on last-updated timestamps.
+     *
+     * Null timestamps come first, then older timestamps are sorted before newer timestamps.
+     */
+    override fun compare(
+        o1: LoginCredentials?,
+        o2: LoginCredentials?,
+    ): Int {
+        // handle where one or both of the objects are null
+        if (o1 == null && o2 == null) return 0
+        if (o1 == null) return -1
+        if (o2 == null) return 1
+
+        // handle where one or both of the timestamps are null
+        val lastUpdated1 = o1.lastUpdatedMillis
+        val lastUpdated2 = o2.lastUpdatedMillis
+
+        if (lastUpdated1 == null && lastUpdated2 == null) return 0
+        if (lastUpdated1 == null) return -1
+        if (lastUpdated2 == null) return 1
+
+        return lastUpdated1.compareTo(lastUpdated2)
+    }
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/RealDuckAddressLoginCreatorTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/RealDuckAddressLoginCreatorTest.kt
@@ -112,11 +112,11 @@ class RealDuckAddressLoginCreatorTest {
     }
 
     private suspend fun verifyLoginSaved() = verify(autofillStore).saveCredentials(eq(URL), any())
-    private suspend fun verifyLoginUpdated() = verify(autofillStore).updateCredentials(any())
+    private suspend fun verifyLoginUpdated() = verify(autofillStore).updateCredentials(any(), any())
 
     private suspend fun verifyNotSavedOrUpdated() {
         verify(autofillStore, never()).saveCredentials(any(), any())
-        verify(autofillStore, never()).updateCredentials(any())
+        verify(autofillStore, never()).updateCredentials(any(), any())
     }
 
     private fun aLogin(id: Long? = null, username: String? = null, password: String? = null): LoginCredentials {

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/securestorage/RealSecureStorageTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/securestorage/RealSecureStorageTest.kt
@@ -73,6 +73,7 @@ class RealSecureStorageTest {
         notesIv = expectedEncryptedIv,
         domainTitle = "test",
         lastUpdatedInMillis = 1000L,
+        lastUsedInMillis = null,
     )
 
     @Before

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/passwordgeneration/ResultHandlerUseGeneratedPasswordTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/passwordgeneration/ResultHandlerUseGeneratedPasswordTest.kt
@@ -126,7 +126,7 @@ class ResultHandlerUseGeneratedPasswordTest {
         )
         testee.processResult(bundle, context, "tab-id-123", Fragment(), callback)
         verify(autofillStore, never()).saveCredentials(any(), any())
-        verify(autofillStore, never()).updateCredentials(any())
+        verify(autofillStore, never()).updateCredentials(any(), any())
     }
 
     @Test
@@ -143,7 +143,7 @@ class ResultHandlerUseGeneratedPasswordTest {
         )
         testee.processResult(bundle, context, "tab-id-123", Fragment(), callback)
         verify(autofillStore, never()).saveCredentials(any(), any())
-        verify(autofillStore).updateCredentials(any())
+        verify(autofillStore).updateCredentials(any(), any())
     }
 
     @Test
@@ -160,7 +160,7 @@ class ResultHandlerUseGeneratedPasswordTest {
         )
         testee.processResult(bundle, context, "tab-id-123", Fragment(), callback)
         verify(autofillStore, never()).saveCredentials(any(), any())
-        verify(autofillStore).updateCredentials(any())
+        verify(autofillStore).updateCredentials(any(), any())
     }
 
     @Test

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/selecting/LastUpdatedCredentialSorterTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/selecting/LastUpdatedCredentialSorterTest.kt
@@ -1,0 +1,81 @@
+package com.duckduckgo.autofill.impl.ui.credential.selecting
+
+import com.duckduckgo.autofill.api.domain.app.LoginCredentials
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LastUpdatedCredentialSorterTest {
+
+    private val testee = LastUpdatedCredentialSorter()
+
+    @Test
+    fun whenTimestampsAreEqualThen0Returned() {
+        val login1 = aLogin(lastUpdatedTimestamp = 1)
+        val login2 = aLogin(lastUpdatedTimestamp = 1)
+        val result = testee.compare(login1, login2)
+        assertEquals(0, result)
+    }
+
+    @Test
+    fun whenTimestampsAreBothNullThen0Returned() {
+        val login1 = aLogin(lastUpdatedTimestamp = null)
+        val login2 = aLogin(lastUpdatedTimestamp = null)
+        val result = testee.compare(login1, login2)
+        assertEquals(0, result)
+    }
+
+    @Test
+    fun whenLogin1TimestampIsLowerThenSortedBeforeOtherLogin() {
+        val login1 = aLogin(lastUpdatedTimestamp = 1)
+        val login2 = aLogin(lastUpdatedTimestamp = 2)
+        val result = testee.compare(login1, login2)
+        assertEquals(-1, result)
+    }
+
+    @Test
+    fun whenLogin1IsMissingATimestampThenSortedBeforeOtherLogin() {
+        val login1 = aLogin(lastUpdatedTimestamp = null)
+        val login2 = aLogin(lastUpdatedTimestamp = 1)
+        val result = testee.compare(login1, login2)
+        assertEquals(-1, result)
+    }
+
+    @Test
+    fun whenLogin2TimestampIsLowerThenSortedBeforeOtherLogin() {
+        val login1 = aLogin(lastUpdatedTimestamp = 2)
+        val login2 = aLogin(lastUpdatedTimestamp = 1)
+        val result = testee.compare(login1, login2)
+        assertEquals(1, result)
+    }
+
+    @Test
+    fun whenLogin2IsMissingATimestampThenSortedBeforeOtherLogin() {
+        val login1 = aLogin(lastUpdatedTimestamp = 1)
+        val login2 = aLogin(lastUpdatedTimestamp = null)
+        val result = testee.compare(login1, login2)
+        assertEquals(1, result)
+    }
+
+    @Test
+    fun whenLogin1IsNullThenSortedBeforeOtherLogin() {
+        val login2 = aLogin(lastUpdatedTimestamp = null)
+        val result = testee.compare(null, login2)
+        assertEquals(-1, result)
+    }
+
+    @Test
+    fun whenLogin2IsNullThenSortedBeforeOtherLogin() {
+        val login1 = aLogin(lastUpdatedTimestamp = null)
+        val result = testee.compare(login1, null)
+        assertEquals(1, result)
+    }
+
+    @Test
+    fun whenBothLoginsAreNullThenTreatedAsEquals() {
+        assertEquals(0, testee.compare(null, null))
+    }
+
+    private fun aLogin(lastUpdatedTimestamp: Long?): LoginCredentials {
+        return LoginCredentials(domain = "example.com", username = "user", password = "pass", lastUpdatedMillis = lastUpdatedTimestamp)
+    }
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/selecting/LastUsedCredentialSorterTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/selecting/LastUsedCredentialSorterTest.kt
@@ -1,0 +1,81 @@
+package com.duckduckgo.autofill.impl.ui.credential.selecting
+
+import com.duckduckgo.autofill.api.domain.app.LoginCredentials
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LastUsedCredentialSorterTest {
+
+    private val testee = LastUsedCredentialSorter()
+
+    @Test
+    fun whenTimestampsAreEqualThen0Returned() {
+        val login1 = aLogin(lastUsedTimestamp = 1)
+        val login2 = aLogin(lastUsedTimestamp = 1)
+        val result = testee.compare(login1, login2)
+        assertEquals(0, result)
+    }
+
+    @Test
+    fun whenTimestampsAreBothNullThen0Returned() {
+        val login1 = aLogin(lastUsedTimestamp = null)
+        val login2 = aLogin(lastUsedTimestamp = null)
+        val result = testee.compare(login1, login2)
+        assertEquals(0, result)
+    }
+
+    @Test
+    fun whenLogin1TimestampIsLowerThenSortedBeforeOtherLogin() {
+        val login1 = aLogin(lastUsedTimestamp = 1)
+        val login2 = aLogin(lastUsedTimestamp = 2)
+        val result = testee.compare(login1, login2)
+        assertEquals(-1, result)
+    }
+
+    @Test
+    fun whenLogin1IsMissingATimestampThenSortedBeforeOtherLogin() {
+        val login1 = aLogin(lastUsedTimestamp = null)
+        val login2 = aLogin(lastUsedTimestamp = 1)
+        val result = testee.compare(login1, login2)
+        assertEquals(-1, result)
+    }
+
+    @Test
+    fun whenLogin2TimestampIsLowerThenSortedBeforeOtherLogin() {
+        val login1 = aLogin(lastUsedTimestamp = 2)
+        val login2 = aLogin(lastUsedTimestamp = 1)
+        val result = testee.compare(login1, login2)
+        assertEquals(1, result)
+    }
+
+    @Test
+    fun whenLogin2IsMissingATimestampThenSortedBeforeOtherLogin() {
+        val login1 = aLogin(lastUsedTimestamp = 1)
+        val login2 = aLogin(lastUsedTimestamp = null)
+        val result = testee.compare(login1, login2)
+        assertEquals(1, result)
+    }
+
+    @Test
+    fun whenLogin1IsNullThenSortedBeforeOtherLogin() {
+        val login2 = aLogin(lastUsedTimestamp = null)
+        val result = testee.compare(null, login2)
+        assertEquals(-1, result)
+    }
+
+    @Test
+    fun whenLogin2IsNullThenSortedBeforeOtherLogin() {
+        val login1 = aLogin(lastUsedTimestamp = null)
+        val result = testee.compare(login1, null)
+        assertEquals(1, result)
+    }
+
+    @Test
+    fun whenBothLoginsAreNullThenTreatedAsEquals() {
+        assertEquals(0, testee.compare(null, null))
+    }
+
+    private fun aLogin(lastUsedTimestamp: Long?): LoginCredentials {
+        return LoginCredentials(domain = "example.com", username = "user", password = "pass", lastUsedMillis = lastUsedTimestamp)
+    }
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/selecting/ResultHandlerCredentialSelectionTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/selecting/ResultHandlerCredentialSelectionTest.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.autofill.api.ExistingCredentialMatchDetector
 import com.duckduckgo.autofill.api.ExistingCredentialMatchDetector.ContainsCredentialsResult.NoMatch
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.impl.deviceauth.FakeAuthenticator
+import com.duckduckgo.autofill.impl.store.InternalAutofillStore
 import com.duckduckgo.common.test.CoroutineTestRule
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
@@ -48,6 +49,7 @@ class ResultHandlerCredentialSelectionTest {
     private val appBuildConfig: AppBuildConfig = mock()
     private lateinit var deviceAuthenticator: FakeAuthenticator
     private lateinit var testee: ResultHandlerCredentialSelection
+    private val autofillStore: InternalAutofillStore = mock()
 
     @Before
     fun setup() = runTest {
@@ -156,6 +158,7 @@ class ResultHandlerCredentialSelectionTest {
             pixel = pixel,
             deviceAuthenticator = deviceAuthenticator,
             appBuildConfig = appBuildConfig,
+            autofillStore = autofillStore,
         )
     }
 }

--- a/autofill/autofill-store/src/main/java/com/duckduckgo/securestorage/store/db/SecureStorageDatabase.kt
+++ b/autofill/autofill-store/src/main/java/com/duckduckgo/securestorage/store/db/SecureStorageDatabase.kt
@@ -22,7 +22,7 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
-    version = 4,
+    version = 5,
     entities = [
         WebsiteLoginCredentialsEntity::class,
         NeverSavedSiteEntity::class,
@@ -52,6 +52,11 @@ val ALL_MIGRATIONS = arrayOf(
         override fun migrate(db: SupportSQLiteDatabase) {
             db.execSQL("CREATE TABLE IF NOT EXISTS `never_saved_sites` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `domain` TEXT)")
             db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_never_saved_sites_domain` ON `never_saved_sites` (`domain`)")
+        }
+    },
+    object : Migration(4, 5) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL("ALTER TABLE `website_login_credentials` ADD COLUMN `lastUsedInMillis` INTEGER")
         }
     },
 )

--- a/autofill/autofill-store/src/main/java/com/duckduckgo/securestorage/store/db/WebsiteLoginCredentialsEntity.kt
+++ b/autofill/autofill-store/src/main/java/com/duckduckgo/securestorage/store/db/WebsiteLoginCredentialsEntity.kt
@@ -30,4 +30,5 @@ data class WebsiteLoginCredentialsEntity(
     val notesIv: String?,
     val domainTitle: String?,
     val lastUpdatedInMillis: Long?,
+    val lastUsedInMillis: Long?,
 )

--- a/autofill/autofill-store/src/test/java/com.duckduckgo.autofill.store/RealSecureStorageRepositoryTest.kt
+++ b/autofill/autofill-store/src/test/java/com.duckduckgo.autofill.store/RealSecureStorageRepositoryTest.kt
@@ -203,6 +203,7 @@ class RealSecureStorageRepositoryTest {
         notesIv: String = "notesIv",
         domainTitle: String = "test",
         lastUpdatedInMillis: Long = 0L,
+        lastUsedInMillis: Long = 0L,
     ): WebsiteLoginCredentialsEntity {
         return WebsiteLoginCredentialsEntity(
             id = id,
@@ -214,6 +215,7 @@ class RealSecureStorageRepositoryTest {
             notesIv = notesIv,
             domainTitle = domainTitle,
             lastUpdatedInMillis = lastUpdatedInMillis,
+            lastUsedInMillis = lastUsedInMillis,
         )
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1206534334888412/f 

### Description
Adds `last-used` as a field for saved credentials so that it can used in the sort order when presenting a list of passwords to autofill into a form.


### Steps to test this PR


#### DB upgrade
- [ ] Install from `develop` and save a login
- [ ] Install from this branch, visit Passwords and ensure the login is still savedd


ℹ️ When instructions say to add a saved login, it means:
- visiting `Overflow -> Passwords`
- Adding a login using the ➕ button
- Ensure it both a username and a password

#### Testing new sort order (perfect matches)

- [ ] Add a saved login for `fill.dev` with username `A`
- [ ] Add a saved login for `fill.dev` with username `B`
- [ ] Add a saved login for `fill.dev` with username `C`
- [ ] Visit `https://fill.dev/form/login-simple`
- [ ] Verify that `C` will be the primary CTA (blue button) [ at this point, there are no last-used timestamps and so the last-modified will be used instead ]
- [ ] Choose to use `B`  (ℹ️  you can hit back instead of authenticating; by design this still counts as a selection and makes testing faster)
- [ ] Reload the login form
- [ ] Verify that `B` is now the primary CTA, then `C` is in the middle and `A` is at the bottom [ `B` is primary because it had a last-used timestamp and the others are sorted below it using their `last-modified` times ]
- [ ] This time, choose `A`
- [ ] Return to the login form (refresh is required)
- [ ]  Verify that `A` is now the primary CTA, then `B` is below and `C` is at the bottom [ `A` has the most recent last-used, `B` has the next most recent last-used and `C` is sorted last since it doesn't have any last-used value]

#### Testing sort order (imperfect matches)

- [ ] Add a saved login for `foo.fill.dev` with username `D`
- [ ] Add a saved login for `foo.fill.dev` with username `E`
- [ ] Reload the login form
- [ ] Verify that primary button is still `A` in the top "From This Website" section [ these are the URL-perfect matches ]
- [ ] Verify that `E` appears above `D` [ no last-used, so relying on last modified timestamps ]
- [ ] Choose to use `D`
- [ ] Return to the form (+ reload)
- [ ] Verify that primary CTA is still `A` [ exact URL matches rank higher than last-used from an imperfect match ]
- [ ] Verify that the order in the bottom group is now `D` above `E`


