### PR TITLE
Extract applink logic from BrowserTabFragment

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -102,6 +102,7 @@ import com.duckduckgo.app.browser.BrowserTabViewModel.SavedSiteChangedViewState
 import com.duckduckgo.app.browser.R.string
 import com.duckduckgo.app.browser.WebViewErrorResponse.LOADING
 import com.duckduckgo.app.browser.WebViewErrorResponse.OMITTED
+import com.duckduckgo.app.browser.applinks.AppLinksLauncher
 import com.duckduckgo.app.browser.applinks.AppLinksSnackBarConfigurator
 import com.duckduckgo.app.browser.autocomplete.BrowserAutoCompleteSuggestionsAdapter
 import com.duckduckgo.app.browser.cookies.ThirdPartyCookieManager
@@ -460,6 +461,9 @@ class BrowserTabFragment :
 
     @Inject
     lateinit var appLinksSnackBarConfigurator: AppLinksSnackBarConfigurator
+
+    @Inject
+    lateinit var appLinksLauncher: AppLinksLauncher
 
     /**
      * We use this to monitor whether the user was seeing the in-context Email Protection signup prompt
@@ -1617,53 +1621,17 @@ class BrowserTabFragment :
     }
 
     private fun showAppLinkSnackBar(appLink: SpecialUrlDetector.UrlType.AppLink) {
-        appLinksSnackBar = appLinksSnackBarConfigurator.configureAppLinkSnackBar(
-            view = view,
-            appLink = appLink,
-            openAppLinkAction = { openAppLink(appLink) },
-        )
+        appLinksSnackBar = appLinksSnackBarConfigurator.configureAppLinkSnackBar(view = view, appLink = appLink, viewModel = viewModel)
         appLinksSnackBar?.show()
     }
 
     private fun openAppLink(appLink: SpecialUrlDetector.UrlType.AppLink) {
-        if (appLink.appIntent != null) {
-            appLink.appIntent!!.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-            try {
-                startActivityOrQuietlyFail(appLink.appIntent!!)
-            } catch (e: SecurityException) {
-                showToast(R.string.unableToOpenLink)
-            }
-        } else if (appLink.excludedComponents != null) {
-            val title = getString(R.string.appLinkIntentChooserTitle)
-            val chooserIntent = getChooserIntent(appLink.uriString, title, appLink.excludedComponents!!)
-            startActivityOrQuietlyFail(chooserIntent)
-        }
-        viewModel.clearPreviousUrl()
-    }
-
-    private fun startActivityOrQuietlyFail(intent: Intent) {
-        try {
-            startActivity(intent)
-        } catch (e: ActivityNotFoundException) {
-            Timber.w(e, "Activity not found")
-        }
+        appLinksLauncher.openAppLink(context = context, appLink = appLink, viewModel = viewModel)
     }
 
     private fun dismissAppLinkSnackBar() {
         appLinksSnackBar?.dismiss()
         appLinksSnackBar = null
-    }
-
-    private fun getChooserIntent(
-        url: String?,
-        title: String,
-        excludedComponents: List<ComponentName>,
-    ): Intent {
-        val urlIntent = Intent.parseUri(url, Intent.URI_ANDROID_APP_SCHEME)
-        urlIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-        val chooserIntent = Intent.createChooser(urlIntent, title)
-        chooserIntent.putExtra(Intent.EXTRA_EXCLUDE_COMPONENTS, excludedComponents.toTypedArray())
-        return chooserIntent
     }
 
     private fun openExternalDialog(

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -458,6 +458,9 @@ class BrowserTabFragment :
     @Inject
     lateinit var privacyProtectionsPopupFactory: PrivacyProtectionsPopupFactory
 
+    @Inject
+    lateinit var appLinksSnackBarConfigurator: AppLinksSnackBarConfigurator
+
     /**
      * We use this to monitor whether the user was seeing the in-context Email Protection signup prompt
      * This is needed because the activity stack will be cleared if an external link is opened in our browser
@@ -1614,11 +1617,10 @@ class BrowserTabFragment :
     }
 
     private fun showAppLinkSnackBar(appLink: SpecialUrlDetector.UrlType.AppLink) {
-        appLinksSnackBar = AppLinksSnackBarConfigurator().configureAppLinkSnackBar(
+        appLinksSnackBar = appLinksSnackBarConfigurator.configureAppLinkSnackBar(
             view = view,
             appLink = appLink,
             openAppLinkAction = { openAppLink(appLink) },
-            pixel = pixel,
         )
         appLinksSnackBar?.show()
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksLauncher.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksLauncher.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.applinks
+
+import android.content.ActivityNotFoundException
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.widget.Toast
+import androidx.annotation.RequiresApi
+import androidx.annotation.StringRes
+import com.duckduckgo.app.browser.BrowserTabViewModel
+import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType.AppLink
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+import timber.log.Timber
+
+interface AppLinksLauncher {
+    fun openAppLink(context: Context?, appLink: AppLink, viewModel: BrowserTabViewModel)
+}
+
+@ContributesBinding(AppScope::class)
+class DuckDuckGoAppLinksLauncher @Inject constructor(
+    private val appBuildConfig: AppBuildConfig,
+) : AppLinksLauncher {
+
+    @Suppress("NewApi")
+    override fun openAppLink(context: Context?, appLink: AppLink, viewModel: BrowserTabViewModel) {
+        if (context == null) return
+        appLink.appIntent?.let {
+            it.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            startActivityOrQuietlyFail(context, it)
+        } ?: run {
+            if (appLink.excludedComponents != null && appBuildConfig.sdkInt >= Build.VERSION_CODES.N) {
+                val title = context.getString(R.string.appLinkIntentChooserTitle)
+                val chooserIntent = getChooserIntent(appLink.uriString, title, appLink.excludedComponents!!)
+                startActivityOrQuietlyFail(context, chooserIntent)
+            }
+        }
+        viewModel.clearPreviousUrl()
+    }
+
+    @RequiresApi(Build.VERSION_CODES.N)
+    private fun getChooserIntent(url: String?, title: String, excludedComponents: List<ComponentName>): Intent {
+        val urlIntent = Intent.parseUri(url, Intent.URI_ANDROID_APP_SCHEME).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        }
+        return Intent.createChooser(urlIntent, title).apply {
+            putExtra(Intent.EXTRA_EXCLUDE_COMPONENTS, excludedComponents.toTypedArray())
+        }
+    }
+
+    private fun startActivityOrQuietlyFail(context: Context, intent: Intent) {
+        try {
+            context.startActivity(intent)
+        } catch (exception: ActivityNotFoundException) {
+            Timber.e(exception, "Activity not found")
+        } catch (exception: SecurityException) {
+            showToast(context, R.string.unableToOpenLink)
+        }
+    }
+
+    private fun showToast(context: Context, @StringRes messageId: Int, length: Int = Toast.LENGTH_LONG) {
+        Toast.makeText(context.applicationContext, messageId, length).show()
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksSnackBarConfigurator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksSnackBarConfigurator.kt
@@ -29,6 +29,7 @@ import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
+import timber.log.Timber
 
 interface AppLinksSnackBarConfigurator {
     fun configureAppLinkSnackBar(
@@ -83,7 +84,8 @@ class DuckDuckGoAppLinksSnackBarConfigurator @Inject constructor(private val pix
             val packageManager = context.packageManager
             val applicationInfo = packageManager.getApplicationInfo(packageName, 0)
             packageManager.getApplicationLabel(applicationInfo).toString()
-        } catch (e: PackageManager.NameNotFoundException) {
+        } catch (exception: PackageManager.NameNotFoundException) {
+            Timber.e(exception, "App name not found")
             null
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksSnackBarConfigurator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksSnackBarConfigurator.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.browser.applinks
 import android.content.Context
 import android.content.pm.PackageManager
 import android.view.View
+import com.duckduckgo.app.browser.BrowserTabViewModel
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType.AppLink
 import com.duckduckgo.app.pixels.AppPixelName
@@ -35,14 +36,17 @@ interface AppLinksSnackBarConfigurator {
     fun configureAppLinkSnackBar(
         view: View?,
         appLink: AppLink,
-        openAppLinkAction: () -> Unit,
+        viewModel: BrowserTabViewModel,
     ): Snackbar?
 }
 
 @ContributesBinding(AppScope::class)
-class DuckDuckGoAppLinksSnackBarConfigurator @Inject constructor(private val pixel: Pixel) : AppLinksSnackBarConfigurator {
+class DuckDuckGoAppLinksSnackBarConfigurator @Inject constructor(
+    private val appLinksLauncher: AppLinksLauncher,
+    private val pixel: Pixel,
+) : AppLinksSnackBarConfigurator {
 
-    override fun configureAppLinkSnackBar(view: View?, appLink: AppLink, openAppLinkAction: () -> Unit): Snackbar? {
+    override fun configureAppLinkSnackBar(view: View?, appLink: AppLink, viewModel: BrowserTabViewModel): Snackbar? {
         return view?.let {
             val context = it.context
             val (message, action) = getSnackBarContent(context, appLink) ?: return null
@@ -50,7 +54,7 @@ class DuckDuckGoAppLinksSnackBarConfigurator @Inject constructor(private val pix
             it.makeSnackbarWithNoBottomInset(message, Snackbar.LENGTH_LONG).apply {
                 setAction(action) {
                     pixel.fire(AppPixelName.APP_LINKS_SNACKBAR_OPEN_ACTION_PRESSED)
-                    openAppLinkAction()
+                    appLinksLauncher.openAppLink(context, appLink, viewModel)
                 }
                 addCallback(
                     object : BaseTransientBottomBar.BaseCallback<Snackbar>() {

--- a/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksSnackBarConfigurator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksSnackBarConfigurator.kt
@@ -24,12 +24,24 @@ import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType.AppLink
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.ui.view.makeSnackbarWithNoBottomInset
+import com.duckduckgo.di.scopes.AppScope
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
 
-class AppLinksSnackBarConfigurator {
+interface AppLinksSnackBarConfigurator {
+    fun configureAppLinkSnackBar(
+        view: View?,
+        appLink: AppLink,
+        openAppLinkAction: () -> Unit,
+    ): Snackbar?
+}
 
-    fun configureAppLinkSnackBar(view: View?, appLink: AppLink, openAppLinkAction: () -> Unit, pixel: Pixel): Snackbar? {
+@ContributesBinding(AppScope::class)
+class DuckDuckGoAppLinksSnackBarConfigurator @Inject constructor(private val pixel: Pixel) : AppLinksSnackBarConfigurator {
+
+    override fun configureAppLinkSnackBar(view: View?, appLink: AppLink, openAppLinkAction: () -> Unit): Snackbar? {
         return view?.let {
             val context = it.context
             val (message, action) = getSnackBarContent(context, appLink) ?: return null
@@ -39,12 +51,14 @@ class AppLinksSnackBarConfigurator {
                     pixel.fire(AppPixelName.APP_LINKS_SNACKBAR_OPEN_ACTION_PRESSED)
                     openAppLinkAction()
                 }
-                addCallback(object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
-                    override fun onShown(transientBottomBar: Snackbar?) {
-                        super.onShown(transientBottomBar)
-                        pixel.fire(AppPixelName.APP_LINKS_SNACKBAR_SHOWN)
-                    }
-                },)
+                addCallback(
+                    object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
+                        override fun onShown(transientBottomBar: Snackbar?) {
+                            super.onShown(transientBottomBar)
+                            pixel.fire(AppPixelName.APP_LINKS_SNACKBAR_SHOWN)
+                        }
+                    },
+                )
                 duration = DURATION
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksSnackBarConfigurator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksSnackBarConfigurator.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.applinks
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.view.View
+import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType.AppLink
+import com.duckduckgo.app.pixels.AppPixelName
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.common.ui.view.makeSnackbarWithNoBottomInset
+import com.google.android.material.snackbar.BaseTransientBottomBar
+import com.google.android.material.snackbar.Snackbar
+
+class AppLinksSnackBarConfigurator {
+
+    fun configureAppLinkSnackBar(view: View?, appLink: AppLink, openAppLinkAction: () -> Unit, pixel: Pixel): Snackbar? {
+        return view?.let {
+            val context = it.context
+            val (message, action) = getSnackBarContent(context, appLink) ?: return null
+
+            it.makeSnackbarWithNoBottomInset(message, Snackbar.LENGTH_LONG).apply {
+                setAction(action) {
+                    pixel.fire(AppPixelName.APP_LINKS_SNACKBAR_OPEN_ACTION_PRESSED)
+                    openAppLinkAction()
+                }
+                addCallback(object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
+                    override fun onShown(transientBottomBar: Snackbar?) {
+                        super.onShown(transientBottomBar)
+                        pixel.fire(AppPixelName.APP_LINKS_SNACKBAR_SHOWN)
+                    }
+                })
+                duration = DURATION
+            }
+        }
+    }
+
+    private fun getSnackBarContent(context: Context, appLink: AppLink): Pair<String, String>? {
+        val appIntent = appLink.appIntent
+        return if (appIntent != null) {
+            val packageName = appIntent.component?.packageName ?: return null
+            val message = context.getString(R.string.appLinkSnackBarMessage, getAppName(context, packageName))
+            val action = context.getString(R.string.appLinkSnackBarAction)
+            message to action
+        } else {
+            val message = context.getString(R.string.appLinkMultipleSnackBarMessage)
+            val action = context.getString(R.string.appLinkMultipleSnackBarAction)
+            message to action
+        }
+    }
+
+    private fun getAppName(context: Context, packageName: String): String? {
+        return try {
+            val packageManager = context.packageManager
+            val applicationInfo = packageManager.getApplicationInfo(packageName, 0)
+            packageManager.getApplicationLabel(applicationInfo).toString()
+        } catch (e: PackageManager.NameNotFoundException) {
+            null
+        }
+    }
+
+    companion object {
+        const val DURATION = 6000
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksSnackBarConfigurator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksSnackBarConfigurator.kt
@@ -44,7 +44,7 @@ class AppLinksSnackBarConfigurator {
                         super.onShown(transientBottomBar)
                         pixel.fire(AppPixelName.APP_LINKS_SNACKBAR_SHOWN)
                     }
-                })
+                },)
                 duration = DURATION
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksSnackBarConfigurator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksSnackBarConfigurator.kt
@@ -33,11 +33,7 @@ import javax.inject.Inject
 import timber.log.Timber
 
 interface AppLinksSnackBarConfigurator {
-    fun configureAppLinkSnackBar(
-        view: View?,
-        appLink: AppLink,
-        viewModel: BrowserTabViewModel,
-    ): Snackbar?
+    fun configureAppLinkSnackBar(view: View?, appLink: AppLink, viewModel: BrowserTabViewModel): Snackbar?
 }
 
 @ContributesBinding(AppScope::class)


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1206614754803818/f

### Description
This extracts and refactors the app link logic into two classes: `AppLinkSnackBarConfigurator` and `AppLinksLauncher`.

### Steps to test this PR
- [x] Go to https://maps.google.com
- [x] Verify that the snackbar is shown "You can open this link in Maps."
- [x] Verify that `m_app_links_snackbar_shown` pixel is sent
- [x] Click "Open in app"
- [x] Verify that `m_app_links_snackbar_open_action_pressed` pixel is sent
- [x] Verify that the app is opened
- [x] Go back
- [x] Tap the overflow menu and tap "Open in App"
- [x] Verify that the app is opened
