### PR TITLE
Cancel previous always on monitor on VPN start

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
@@ -298,6 +298,8 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope(), V
             logcat { "VPN log: NEW network ${vpnNetworkStack.name}" }
         }
         dnsChangeCallback.unregister()
+        // cancel previous monitor
+        alwaysOnStateJob.cancel()
 
         vpnServiceStateStatsDao.insert(createVpnState(state = ENABLING))
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1206608309382825/f

### Description
Cancel always on previous monitor on VPN start

### Steps to test this PR

_Test_
- [x] install from this branch and enable AppTP
- [x] verify`state: VpnServiceStateStats(...)` logcat prints periodically, the frequency should decrease
- [x] add an app to the exclusion list to force a VPN re-configuration
- [x] verify`state: VpnServiceStateStats(...)` logcat prints periodically, at the initial frequency

