### PR TITLE
load privacy plugins data into memory just for main process

### DIFF
--- a/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/di/AdClickModule.kt
+++ b/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/di/AdClickModule.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.adclick.store.AdClickDatabase.Companion.ALL_MIGRATIONS
 import com.duckduckgo.adclick.store.AdClickFeatureToggleRepository
 import com.duckduckgo.adclick.store.RealAdClickAttributionRepository
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.di.IsMainProcess
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesTo
@@ -51,8 +52,9 @@ class AdClickModule {
         database: AdClickDatabase,
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
         dispatcherProvider: DispatcherProvider,
+        @IsMainProcess isMainProcess: Boolean,
     ): AdClickAttributionRepository {
-        return RealAdClickAttributionRepository(database, appCoroutineScope, dispatcherProvider)
+        return RealAdClickAttributionRepository(database, appCoroutineScope, dispatcherProvider, isMainProcess)
     }
 
     @SingleInstanceIn(AppScope::class)

--- a/ad-click/ad-click-store/src/main/java/com/duckduckgo/adclick/store/AdClickAttributionRepository.kt
+++ b/ad-click/ad-click-store/src/main/java/com/duckduckgo/adclick/store/AdClickAttributionRepository.kt
@@ -38,6 +38,7 @@ class RealAdClickAttributionRepository(
     val database: AdClickDatabase,
     coroutineScope: CoroutineScope,
     dispatcherProvider: DispatcherProvider,
+    isMainProcess: Boolean,
 ) : AdClickAttributionRepository {
 
     private val adClickAttributionDao: AdClickDao = database.adClickDao()
@@ -49,7 +50,9 @@ class RealAdClickAttributionRepository(
 
     init {
         coroutineScope.launch(dispatcherProvider.io()) {
-            loadToMemory()
+            if (isMainProcess) {
+                loadToMemory()
+            }
         }
     }
 

--- a/ad-click/ad-click-store/src/test/java/com/duckduckgo/adclick/store/RealAdClickAttributionRepositoryTest.kt
+++ b/ad-click/ad-click-store/src/test/java/com/duckduckgo/adclick/store/RealAdClickAttributionRepositoryTest.kt
@@ -48,6 +48,7 @@ class RealAdClickAttributionRepositoryTest {
             database = mockDatabase,
             coroutineScope = TestScope(),
             dispatcherProvider = coroutineRule.testDispatcherProvider,
+            isMainProcess = true,
         )
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/mediaplayback/store/MediaPlaybackRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/mediaplayback/store/MediaPlaybackRepository.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.browser.mediaplayback.store
 
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.di.IsMainProcess
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.FeatureExceptions
@@ -38,13 +39,16 @@ class RealMediaPlaybackRepository @Inject constructor(
     private val mediaPlaybackDao: MediaPlaybackDao,
     @AppCoroutineScope appCoroutineScope: CoroutineScope,
     dispatcherProvider: DispatcherProvider,
+    @IsMainProcess isMainProcess: Boolean,
 ) : MediaPlaybackRepository {
 
     override val exceptions = CopyOnWriteArrayList<FeatureExceptions.FeatureException>()
 
     init {
         appCoroutineScope.launch(dispatcherProvider.io()) {
-            loadToMemory()
+            if (isMainProcess) {
+                loadToMemory()
+            }
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/di/ApplicationModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/ApplicationModule.kt
@@ -51,4 +51,11 @@ object ProcessNameModule {
             "main"
         }
     }
+
+    @SingleInstanceIn(AppScope::class)
+    @Provides
+    @IsMainProcess
+    fun providerIsMainProcess(@ProcessName processName: String): Boolean {
+        return processName == "main"
+    }
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/mediaplayback/store/RealMediaPlaybackRepositoryTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/mediaplayback/store/RealMediaPlaybackRepositoryTest.kt
@@ -65,6 +65,7 @@ class RealMediaPlaybackRepositoryTest {
             mockMediaPlaybackDao,
             TestScope(),
             coroutineRule.testDispatcherProvider,
+            isMainProcess = true,
         )
     }
 

--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/di/AutoconsentModule.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/di/AutoconsentModule.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.autoconsent.impl.di
 import android.content.Context
 import androidx.room.Room
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.di.IsMainProcess
 import com.duckduckgo.autoconsent.impl.remoteconfig.AutoconsentExceptionsRepository
 import com.duckduckgo.autoconsent.impl.remoteconfig.AutoconsentFeature
 import com.duckduckgo.autoconsent.impl.remoteconfig.AutoconsentFeatureSettingsRepository
@@ -58,8 +59,9 @@ object AutoconsentModule {
         database: AutoconsentDatabase,
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
         dispatcherProvider: DispatcherProvider,
+        @IsMainProcess isMainProcess: Boolean,
     ): AutoconsentExceptionsRepository {
-        return RealAutoconsentExceptionsRepository(appCoroutineScope, dispatcherProvider, database)
+        return RealAutoconsentExceptionsRepository(appCoroutineScope, dispatcherProvider, database, isMainProcess)
     }
 
     @SingleInstanceIn(AppScope::class)

--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/remoteconfig/AutoconsentExceptionsRepository.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/remoteconfig/AutoconsentExceptionsRepository.kt
@@ -33,13 +33,18 @@ class RealAutoconsentExceptionsRepository(
     coroutineScope: CoroutineScope,
     dispatcherProvider: DispatcherProvider,
     val database: AutoconsentDatabase,
+    isMainProcess: Boolean,
 ) : AutoconsentExceptionsRepository {
 
     private val dao = database.autoconsentDao()
     override val exceptions = CopyOnWriteArrayList<FeatureException>()
 
     init {
-        coroutineScope.launch(dispatcherProvider.io()) { loadToMemory() }
+        coroutineScope.launch(dispatcherProvider.io()) {
+            if (isMainProcess) {
+                loadToMemory()
+            }
+        }
     }
 
     override fun insertAllExceptions(exceptions: List<FeatureException>) {

--- a/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/remoteconfig/RealAutoconsentExceptionsRepositoryTest.kt
+++ b/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/remoteconfig/RealAutoconsentExceptionsRepositoryTest.kt
@@ -52,14 +52,14 @@ class RealAutoconsentExceptionsRepositoryTest {
     fun whenRepositoryIsCreatedThenExceptionsLoadedIntoMemory() {
         givenDaoContainsExceptions()
 
-        repository = RealAutoconsentExceptionsRepository(TestScope(), coroutineRule.testDispatcherProvider, mockDatabase)
+        repository = RealAutoconsentExceptionsRepository(TestScope(), coroutineRule.testDispatcherProvider, mockDatabase, isMainProcess = true)
 
         assertEquals(exception.toFeatureException(), repository.exceptions.first())
     }
 
     @Test
     fun whenUpdateAllThenUpdateAllCalled() = runTest {
-        repository = RealAutoconsentExceptionsRepository(TestScope(), coroutineRule.testDispatcherProvider, mockDatabase)
+        repository = RealAutoconsentExceptionsRepository(TestScope(), coroutineRule.testDispatcherProvider, mockDatabase, isMainProcess = true)
 
         repository.insertAllExceptions(listOf())
 
@@ -69,7 +69,7 @@ class RealAutoconsentExceptionsRepositoryTest {
     @Test
     fun whenUpdateAllThenPreviousExceptionsAreCleared() = runTest {
         givenDaoContainsExceptions()
-        repository = RealAutoconsentExceptionsRepository(TestScope(), coroutineRule.testDispatcherProvider, mockDatabase)
+        repository = RealAutoconsentExceptionsRepository(TestScope(), coroutineRule.testDispatcherProvider, mockDatabase, isMainProcess = true)
 
         assertEquals(1, repository.exceptions.size)
         reset(mockDao)

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/di/AutofillModule.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/di/AutofillModule.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import androidx.room.Room
 import com.duckduckgo.anvil.annotations.ContributesPluginPoint
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.di.IsMainProcess
 import com.duckduckgo.autofill.api.AutofillFeature
 import com.duckduckgo.autofill.api.AutofillFragmentResultsPlugin
 import com.duckduckgo.autofill.api.InternalTestUserChecker
@@ -112,8 +113,9 @@ class AutofillModule {
         database: AutofillDatabase,
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
         dispatcherProvider: DispatcherProvider,
+        @IsMainProcess isMainProcess: Boolean,
     ): AutofillFeatureRepository {
-        return RealAutofillFeatureRepository(database, appCoroutineScope, dispatcherProvider)
+        return RealAutofillFeatureRepository(database, appCoroutineScope, dispatcherProvider, isMainProcess)
     }
 
     @SingleInstanceIn(AppScope::class)
@@ -122,8 +124,9 @@ class AutofillModule {
         database: EmailProtectionInContextDatabase,
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
         dispatcherProvider: DispatcherProvider,
+        @IsMainProcess isMainProcess: Boolean,
     ): EmailProtectionInContextFeatureRepository {
-        return RealEmailProtectionInContextFeatureRepository(database, appCoroutineScope, dispatcherProvider)
+        return RealEmailProtectionInContextFeatureRepository(database, appCoroutineScope, dispatcherProvider, isMainProcess)
     }
 
     @Provides

--- a/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/feature/AutofillFeatureRepository.kt
+++ b/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/feature/AutofillFeatureRepository.kt
@@ -35,13 +35,18 @@ class RealAutofillFeatureRepository(
     val database: AutofillDatabase,
     coroutineScope: CoroutineScope,
     dispatcherProvider: DispatcherProvider,
+    isMainProcess: Boolean,
 ) : AutofillFeatureRepository {
 
     private val autofillDao: AutofillDao = database.autofillDao()
     override val exceptions = CopyOnWriteArrayList<FeatureException>()
 
     init {
-        coroutineScope.launch(dispatcherProvider.io()) { loadToMemory() }
+        coroutineScope.launch(dispatcherProvider.io()) {
+            if (isMainProcess) {
+                loadToMemory()
+            }
+        }
     }
 
     override fun updateAllExceptions(exceptions: List<AutofillExceptionEntity>) {

--- a/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/feature/email/incontext/EmailProtectionInContextFeatureRepository.kt
+++ b/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/feature/email/incontext/EmailProtectionInContextFeatureRepository.kt
@@ -30,13 +30,18 @@ class RealEmailProtectionInContextFeatureRepository(
     val database: EmailProtectionInContextDatabase,
     coroutineScope: CoroutineScope,
     dispatcherProvider: DispatcherProvider,
+    isMainProcess: Boolean,
 ) : EmailProtectionInContextFeatureRepository {
 
     private val dao = database.emailInContextDao()
     override val exceptions = CopyOnWriteArrayList<String>()
 
     init {
-        coroutineScope.launch(dispatcherProvider.io()) { loadToMemory() }
+        coroutineScope.launch(dispatcherProvider.io()) {
+            if (isMainProcess) {
+                loadToMemory()
+            }
+        }
     }
 
     override fun updateAllExceptions(exceptions: List<EmailInContextExceptionEntity>) {

--- a/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/di/CookiesModule.kt
+++ b/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/di/CookiesModule.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.cookies.impl.di
 import android.content.Context
 import androidx.room.Room
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.di.IsMainProcess
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.cookies.store.ALL_MIGRATIONS
 import com.duckduckgo.cookies.store.CookiesDatabase
@@ -56,8 +57,9 @@ object CookiesModule {
         database: CookiesDatabase,
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
         dispatcherProvider: DispatcherProvider,
+        @IsMainProcess isMainProcess: Boolean,
     ): CookiesRepository {
-        return RealCookieRepository(database, appCoroutineScope, dispatcherProvider)
+        return RealCookieRepository(database, appCoroutineScope, dispatcherProvider, isMainProcess)
     }
 
     @SingleInstanceIn(AppScope::class)
@@ -78,7 +80,8 @@ object CookiesModule {
         database: CookiesDatabase,
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
         dispatcherProvider: DispatcherProvider,
+        @IsMainProcess isMainProcess: Boolean,
     ): ContentScopeScriptsCookieRepository {
-        return RealContentScopeScriptsCookieRepository(database, appCoroutineScope, dispatcherProvider)
+        return RealContentScopeScriptsCookieRepository(database, appCoroutineScope, dispatcherProvider, isMainProcess)
     }
 }

--- a/cookies/cookies-store/src/main/java/com/duckduckgo/cookies/store/CookiesRepository.kt
+++ b/cookies/cookies-store/src/main/java/com/duckduckgo/cookies/store/CookiesRepository.kt
@@ -32,6 +32,7 @@ class RealCookieRepository constructor(
     val database: CookiesDatabase,
     coroutineScope: CoroutineScope,
     dispatcherProvider: DispatcherProvider,
+    isMainProcess: Boolean,
 ) : CookiesRepository {
 
     private val cookiesDao: CookiesDao = database.cookiesDao()
@@ -41,7 +42,9 @@ class RealCookieRepository constructor(
 
     init {
         coroutineScope.launch(dispatcherProvider.io()) {
-            loadToMemory()
+            if (isMainProcess) {
+                loadToMemory()
+            }
         }
     }
 

--- a/cookies/cookies-store/src/main/java/com/duckduckgo/cookies/store/contentscopescripts/ContentScopeScriptsCookieRepository.kt
+++ b/cookies/cookies-store/src/main/java/com/duckduckgo/cookies/store/contentscopescripts/ContentScopeScriptsCookieRepository.kt
@@ -30,9 +30,10 @@ interface ContentScopeScriptsCookieRepository {
 }
 
 class RealContentScopeScriptsCookieRepository constructor(
-    private val database: CookiesDatabase,
+    database: CookiesDatabase,
     coroutineScope: CoroutineScope,
-    private val dispatcherProvider: DispatcherProvider,
+    dispatcherProvider: DispatcherProvider,
+    isMainProcess: Boolean,
 ) : ContentScopeScriptsCookieRepository {
 
     private val contentScopeScriptsCookieDao: ContentScopeScriptsCookieDao = database.contentScopeScriptsCookieDao()
@@ -40,7 +41,9 @@ class RealContentScopeScriptsCookieRepository constructor(
 
     init {
         coroutineScope.launch(dispatcherProvider.io()) {
-            loadToMemory()
+            if (isMainProcess) {
+                loadToMemory()
+            }
         }
     }
 

--- a/cookies/cookies-store/src/test/java/com/duckduckgo/cookies/store/RealCookieRepositoryTest.kt
+++ b/cookies/cookies-store/src/test/java/com/duckduckgo/cookies/store/RealCookieRepositoryTest.kt
@@ -52,6 +52,7 @@ class RealCookieRepositoryTest {
             mockDatabase,
             TestScope(),
             coroutineRule.testDispatcherProvider,
+            true,
         )
 
         assertEquals(cookieExceptionEntity.toFeatureException(), testee.exceptions.first())
@@ -67,6 +68,7 @@ class RealCookieRepositoryTest {
             mockDatabase,
             TestScope(),
             coroutineRule.testDispatcherProvider,
+            true,
         )
 
         assertEquals(DEFAULT_THRESHOLD, testee.firstPartyCookiePolicy.threshold)
@@ -81,6 +83,7 @@ class RealCookieRepositoryTest {
             mockDatabase,
             TestScope(),
             coroutineRule.testDispatcherProvider,
+            true,
         )
 
         testee.updateAll(listOf(), policy)
@@ -96,6 +99,7 @@ class RealCookieRepositoryTest {
             mockDatabase,
             TestScope(),
             coroutineRule.testDispatcherProvider,
+            true,
         )
         assertEquals(1, testee.exceptions.size)
         assertEquals(THRESHOLD, testee.firstPartyCookiePolicy.threshold)

--- a/di/src/main/java/com/duckduckgo/app/di/IsMainProcess.kt
+++ b/di/src/main/java/com/duckduckgo/app/di/IsMainProcess.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.di
+
+import javax.inject.Qualifier
+
+@Retention(AnnotationRetention.BINARY)
+@Qualifier
+annotation class IsMainProcess

--- a/element-hiding/element-hiding-impl/src/main/java/com/duckduckgo/elementhiding/impl/di/ElementHidingModule.kt
+++ b/element-hiding/element-hiding-impl/src/main/java/com/duckduckgo/elementhiding/impl/di/ElementHidingModule.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.elementhiding.impl.di
 import android.content.Context
 import androidx.room.Room
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.di.IsMainProcess
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.elementhiding.store.ALL_MIGRATIONS
@@ -51,7 +52,8 @@ object ElementHidingModule {
         database: ElementHidingDatabase,
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
         dispatcherProvider: DispatcherProvider,
+        @IsMainProcess isMainProcess: Boolean,
     ): ElementHidingRepository {
-        return RealElementHidingRepository(database, appCoroutineScope, dispatcherProvider)
+        return RealElementHidingRepository(database, appCoroutineScope, dispatcherProvider, isMainProcess)
     }
 }

--- a/element-hiding/element-hiding-store/src/main/java/com/duckduckgo/elementhiding/store/ElementHidingRepository.kt
+++ b/element-hiding/element-hiding-store/src/main/java/com/duckduckgo/elementhiding/store/ElementHidingRepository.kt
@@ -31,6 +31,7 @@ class RealElementHidingRepository constructor(
     val database: ElementHidingDatabase,
     val coroutineScope: CoroutineScope,
     val dispatcherProvider: DispatcherProvider,
+    isMainProcess: Boolean,
 ) : ElementHidingRepository {
 
     private val elementHidingDao: ElementHidingDao = database.elementHidingDao()
@@ -38,7 +39,9 @@ class RealElementHidingRepository constructor(
 
     init {
         coroutineScope.launch(dispatcherProvider.io()) {
-            loadToMemory()
+            if (isMainProcess) {
+                loadToMemory()
+            }
         }
     }
 

--- a/element-hiding/element-hiding-store/src/test/java/com/duckduckgo/elementhiding/store/ElementHidingRepositoryTest.kt
+++ b/element-hiding/element-hiding-store/src/test/java/com/duckduckgo/elementhiding/store/ElementHidingRepositoryTest.kt
@@ -49,6 +49,7 @@ class ElementHidingRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    true,
                 )
 
             verify(mockElementHidingDao).get()
@@ -64,6 +65,7 @@ class ElementHidingRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    true,
                 )
 
             verify(mockElementHidingDao).get()
@@ -78,6 +80,7 @@ class ElementHidingRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    true,
                 )
 
             testee.updateAll(elementHidingEntity)

--- a/fingerprint-protection/fingerprint-protection-impl/src/main/java/com/duckduckgo/fingerprintprotection/impl/di/FingerprintProtectionModule.kt
+++ b/fingerprint-protection/fingerprint-protection-impl/src/main/java/com/duckduckgo/fingerprintprotection/impl/di/FingerprintProtectionModule.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.fingerprintprotection.impl.di
 import android.content.Context
 import androidx.room.Room
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.di.IsMainProcess
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.fingerprintprotection.store.ALL_MIGRATIONS
@@ -60,8 +61,9 @@ object FingerprintProtectionModule {
         database: FingerprintProtectionDatabase,
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
         dispatcherProvider: DispatcherProvider,
+        @IsMainProcess isMainProcess: Boolean,
     ): FingerprintingBatteryRepository {
-        return RealFingerprintingBatteryRepository(database, appCoroutineScope, dispatcherProvider)
+        return RealFingerprintingBatteryRepository(database, appCoroutineScope, dispatcherProvider, isMainProcess)
     }
 
     @SingleInstanceIn(AppScope::class)
@@ -70,8 +72,9 @@ object FingerprintProtectionModule {
         database: FingerprintProtectionDatabase,
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
         dispatcherProvider: DispatcherProvider,
+        @IsMainProcess isMainProcess: Boolean,
     ): FingerprintingCanvasRepository {
-        return RealFingerprintingCanvasRepository(database, appCoroutineScope, dispatcherProvider)
+        return RealFingerprintingCanvasRepository(database, appCoroutineScope, dispatcherProvider, isMainProcess)
     }
 
     @SingleInstanceIn(AppScope::class)
@@ -80,8 +83,9 @@ object FingerprintProtectionModule {
         database: FingerprintProtectionDatabase,
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
         dispatcherProvider: DispatcherProvider,
+        @IsMainProcess isMainProcess: Boolean,
     ): FingerprintingHardwareRepository {
-        return RealFingerprintingHardwareRepository(database, appCoroutineScope, dispatcherProvider)
+        return RealFingerprintingHardwareRepository(database, appCoroutineScope, dispatcherProvider, isMainProcess)
     }
 
     @SingleInstanceIn(AppScope::class)
@@ -90,8 +94,9 @@ object FingerprintProtectionModule {
         database: FingerprintProtectionDatabase,
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
         dispatcherProvider: DispatcherProvider,
+        @IsMainProcess isMainProcess: Boolean,
     ): FingerprintingScreenSizeRepository {
-        return RealFingerprintingScreenSizeRepository(database, appCoroutineScope, dispatcherProvider)
+        return RealFingerprintingScreenSizeRepository(database, appCoroutineScope, dispatcherProvider, isMainProcess)
     }
 
     @SingleInstanceIn(AppScope::class)
@@ -100,8 +105,9 @@ object FingerprintProtectionModule {
         database: FingerprintProtectionDatabase,
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
         dispatcherProvider: DispatcherProvider,
+        @IsMainProcess isMainProcess: Boolean,
     ): FingerprintingTemporaryStorageRepository {
-        return RealFingerprintingTemporaryStorageRepository(database, appCoroutineScope, dispatcherProvider)
+        return RealFingerprintingTemporaryStorageRepository(database, appCoroutineScope, dispatcherProvider, isMainProcess)
     }
 
     @SingleInstanceIn(AppScope::class)

--- a/fingerprint-protection/fingerprint-protection-store/src/main/java/com/duckduckgo/fingerprintprotection/store/features/fingerprintingbattery/FingerprintingBatteryRepository.kt
+++ b/fingerprint-protection/fingerprint-protection-store/src/main/java/com/duckduckgo/fingerprintprotection/store/features/fingerprintingbattery/FingerprintingBatteryRepository.kt
@@ -33,6 +33,7 @@ class RealFingerprintingBatteryRepository constructor(
     val database: FingerprintProtectionDatabase,
     val coroutineScope: CoroutineScope,
     val dispatcherProvider: DispatcherProvider,
+    isMainProcess: Boolean,
 ) : FingerprintingBatteryRepository {
 
     private val fingerprintingBatteryDao: FingerprintingBatteryDao = database.fingerprintingBatteryDao()
@@ -40,7 +41,9 @@ class RealFingerprintingBatteryRepository constructor(
 
     init {
         coroutineScope.launch(dispatcherProvider.io()) {
-            loadToMemory()
+            if (isMainProcess) {
+                loadToMemory()
+            }
         }
     }
 

--- a/fingerprint-protection/fingerprint-protection-store/src/main/java/com/duckduckgo/fingerprintprotection/store/features/fingerprintingcanvas/FingerprintingCanvasRepository.kt
+++ b/fingerprint-protection/fingerprint-protection-store/src/main/java/com/duckduckgo/fingerprintprotection/store/features/fingerprintingcanvas/FingerprintingCanvasRepository.kt
@@ -29,10 +29,11 @@ interface FingerprintingCanvasRepository {
     var fingerprintingCanvasEntity: FingerprintingCanvasEntity
 }
 
-class RealFingerprintingCanvasRepository constructor(
+class RealFingerprintingCanvasRepository(
     val database: FingerprintProtectionDatabase,
     val coroutineScope: CoroutineScope,
     val dispatcherProvider: DispatcherProvider,
+    isMainProcess: Boolean,
 ) : FingerprintingCanvasRepository {
 
     private val fingerprintingCanvasDao: FingerprintingCanvasDao = database.fingerprintingCanvasDao()
@@ -40,7 +41,9 @@ class RealFingerprintingCanvasRepository constructor(
 
     init {
         coroutineScope.launch(dispatcherProvider.io()) {
-            loadToMemory()
+            if (isMainProcess) {
+                loadToMemory()
+            }
         }
     }
 

--- a/fingerprint-protection/fingerprint-protection-store/src/main/java/com/duckduckgo/fingerprintprotection/store/features/fingerprintinghardware/FingerprintingHardwareRepository.kt
+++ b/fingerprint-protection/fingerprint-protection-store/src/main/java/com/duckduckgo/fingerprintprotection/store/features/fingerprintinghardware/FingerprintingHardwareRepository.kt
@@ -33,6 +33,7 @@ class RealFingerprintingHardwareRepository constructor(
     val database: FingerprintProtectionDatabase,
     val coroutineScope: CoroutineScope,
     val dispatcherProvider: DispatcherProvider,
+    isMainProcess: Boolean,
 ) : FingerprintingHardwareRepository {
 
     private val fingerprintingHardwareDao: FingerprintingHardwareDao = database.fingerprintingHardwareDao()
@@ -40,7 +41,9 @@ class RealFingerprintingHardwareRepository constructor(
 
     init {
         coroutineScope.launch(dispatcherProvider.io()) {
-            loadToMemory()
+            if (isMainProcess) {
+                loadToMemory()
+            }
         }
     }
 

--- a/fingerprint-protection/fingerprint-protection-store/src/main/java/com/duckduckgo/fingerprintprotection/store/features/fingerprintingscreensize/FingerprintingScreenSizeRepository.kt
+++ b/fingerprint-protection/fingerprint-protection-store/src/main/java/com/duckduckgo/fingerprintprotection/store/features/fingerprintingscreensize/FingerprintingScreenSizeRepository.kt
@@ -33,6 +33,7 @@ class RealFingerprintingScreenSizeRepository constructor(
     val database: FingerprintProtectionDatabase,
     val coroutineScope: CoroutineScope,
     val dispatcherProvider: DispatcherProvider,
+    isMainProcess: Boolean,
 ) : FingerprintingScreenSizeRepository {
 
     private val fingerprintingScreenSizeDao: FingerprintingScreenSizeDao = database.fingerprintingScreenSizeDao()
@@ -40,7 +41,9 @@ class RealFingerprintingScreenSizeRepository constructor(
 
     init {
         coroutineScope.launch(dispatcherProvider.io()) {
-            loadToMemory()
+            if (isMainProcess) {
+                loadToMemory()
+            }
         }
     }
 

--- a/fingerprint-protection/fingerprint-protection-store/src/main/java/com/duckduckgo/fingerprintprotection/store/features/fingerprintingtemporarystorage/FingerprintingTemporaryStorageRepository.kt
+++ b/fingerprint-protection/fingerprint-protection-store/src/main/java/com/duckduckgo/fingerprintprotection/store/features/fingerprintingtemporarystorage/FingerprintingTemporaryStorageRepository.kt
@@ -33,6 +33,7 @@ class RealFingerprintingTemporaryStorageRepository constructor(
     val database: FingerprintProtectionDatabase,
     val coroutineScope: CoroutineScope,
     val dispatcherProvider: DispatcherProvider,
+    isMainProcess: Boolean,
 ) : FingerprintingTemporaryStorageRepository {
 
     private val fingerprintingTemporaryStorageDao: FingerprintingTemporaryStorageDao = database.fingerprintingTemporaryStorageDao()
@@ -40,7 +41,9 @@ class RealFingerprintingTemporaryStorageRepository constructor(
 
     init {
         coroutineScope.launch(dispatcherProvider.io()) {
-            loadToMemory()
+            if (isMainProcess) {
+                loadToMemory()
+            }
         }
     }
 

--- a/fingerprint-protection/fingerprint-protection-store/src/test/java/com/duckduckgo/fingerprintprotection/store/features/fingerprintingbattery/RealFingerprintingBatteryRepositoryTest.kt
+++ b/fingerprint-protection/fingerprint-protection-store/src/test/java/com/duckduckgo/fingerprintprotection/store/features/fingerprintingbattery/RealFingerprintingBatteryRepositoryTest.kt
@@ -51,6 +51,7 @@ class RealFingerprintingBatteryRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    true,
                 )
 
             verify(mockFingerprintingBatteryDao).get()
@@ -66,6 +67,7 @@ class RealFingerprintingBatteryRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    true,
                 )
 
             verify(mockFingerprintingBatteryDao).get()
@@ -80,6 +82,7 @@ class RealFingerprintingBatteryRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    true,
                 )
 
             testee.updateAll(fingerprintingBatteryEntity)

--- a/fingerprint-protection/fingerprint-protection-store/src/test/java/com/duckduckgo/fingerprintprotection/store/features/fingerprintingcanvas/RealFingerprintingCanvasRepositoryTest.kt
+++ b/fingerprint-protection/fingerprint-protection-store/src/test/java/com/duckduckgo/fingerprintprotection/store/features/fingerprintingcanvas/RealFingerprintingCanvasRepositoryTest.kt
@@ -51,6 +51,7 @@ class RealFingerprintingCanvasRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    isMainProcess = true,
                 )
 
             verify(mockFingerprintingCanvasDao).get()
@@ -66,6 +67,7 @@ class RealFingerprintingCanvasRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    isMainProcess = true,
                 )
 
             verify(mockFingerprintingCanvasDao).get()
@@ -80,6 +82,7 @@ class RealFingerprintingCanvasRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    isMainProcess = true,
                 )
 
             testee.updateAll(fingerprintingCanvasEntity)

--- a/fingerprint-protection/fingerprint-protection-store/src/test/java/com/duckduckgo/fingerprintprotection/store/features/fingerprintinghardware/RealFingerprintingHardwareRepositoryTest.kt
+++ b/fingerprint-protection/fingerprint-protection-store/src/test/java/com/duckduckgo/fingerprintprotection/store/features/fingerprintinghardware/RealFingerprintingHardwareRepositoryTest.kt
@@ -51,6 +51,7 @@ class RealFingerprintingHardwareRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    true,
                 )
 
             verify(mockFingerprintingHardwareDao).get()
@@ -66,6 +67,7 @@ class RealFingerprintingHardwareRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    true,
                 )
 
             verify(mockFingerprintingHardwareDao).get()
@@ -80,6 +82,7 @@ class RealFingerprintingHardwareRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    true,
                 )
 
             testee.updateAll(fingerprintingHardwareEntity)

--- a/fingerprint-protection/fingerprint-protection-store/src/test/java/com/duckduckgo/fingerprintprotection/store/features/fingerprintingscreensize/RealFingerprintingScreenSizeRepositoryTest.kt
+++ b/fingerprint-protection/fingerprint-protection-store/src/test/java/com/duckduckgo/fingerprintprotection/store/features/fingerprintingscreensize/RealFingerprintingScreenSizeRepositoryTest.kt
@@ -51,6 +51,7 @@ class RealFingerprintingScreenSizeRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    true,
                 )
 
             verify(mockFingerprintingScreenSizeDao).get()
@@ -66,6 +67,7 @@ class RealFingerprintingScreenSizeRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    true,
                 )
 
             verify(mockFingerprintingScreenSizeDao).get()
@@ -80,6 +82,7 @@ class RealFingerprintingScreenSizeRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    true,
                 )
 
             testee.updateAll(fingerprintingScreenSizeEntity)

--- a/fingerprint-protection/fingerprint-protection-store/src/test/java/com/duckduckgo/fingerprintprotection/store/features/fingerprintingtemporarystorage/RealFingerprintingTemporaryStorageRepositoryTest.kt
+++ b/fingerprint-protection/fingerprint-protection-store/src/test/java/com/duckduckgo/fingerprintprotection/store/features/fingerprintingtemporarystorage/RealFingerprintingTemporaryStorageRepositoryTest.kt
@@ -51,6 +51,7 @@ class RealFingerprintingTemporaryStorageRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    true,
                 )
 
             verify(mockFingerprintingTemporaryStorageDao).get()
@@ -66,6 +67,7 @@ class RealFingerprintingTemporaryStorageRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    true,
                 )
 
             verify(mockFingerprintingTemporaryStorageDao).get()
@@ -80,6 +82,7 @@ class RealFingerprintingTemporaryStorageRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    true,
                 )
 
             testee.updateAll(fingerprintingTemporaryStorageEntity)

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/di/PrivacyConfigModule.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/di/PrivacyConfigModule.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.room.Room
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.di.IsMainProcess
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.privacy.config.store.ALL_MIGRATIONS
@@ -88,8 +89,9 @@ object DatabaseModule {
         database: PrivacyConfigDatabase,
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
         dispatcherProvider: DispatcherProvider,
+        @IsMainProcess isMainProcess: Boolean,
     ): TrackerAllowlistRepository {
-        return RealTrackerAllowlistRepository(database, appCoroutineScope, dispatcherProvider)
+        return RealTrackerAllowlistRepository(database, appCoroutineScope, dispatcherProvider, isMainProcess)
     }
 
     @SingleInstanceIn(AppScope::class)
@@ -98,8 +100,9 @@ object DatabaseModule {
         database: PrivacyConfigDatabase,
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
         dispatcherProvider: DispatcherProvider,
+        @IsMainProcess isMainProcess: Boolean,
     ): ContentBlockingRepository {
-        return RealContentBlockingRepository(database, appCoroutineScope, dispatcherProvider)
+        return RealContentBlockingRepository(database, appCoroutineScope, dispatcherProvider, isMainProcess)
     }
 
     @SingleInstanceIn(AppScope::class)
@@ -121,8 +124,9 @@ object DatabaseModule {
         database: PrivacyConfigDatabase,
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
         dispatcherProvider: DispatcherProvider,
+        @IsMainProcess isMainProcess: Boolean,
     ): GpcRepository {
-        return RealGpcRepository(gpcDataStore, database, appCoroutineScope, dispatcherProvider)
+        return RealGpcRepository(gpcDataStore, database, appCoroutineScope, dispatcherProvider, isMainProcess)
     }
 
     @SingleInstanceIn(AppScope::class)
@@ -131,8 +135,9 @@ object DatabaseModule {
         database: PrivacyConfigDatabase,
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
         dispatcherProvider: DispatcherProvider,
+        @IsMainProcess isMainProcess: Boolean,
     ): HttpsRepository {
-        return RealHttpsRepository(database, appCoroutineScope, dispatcherProvider)
+        return RealHttpsRepository(database, appCoroutineScope, dispatcherProvider, isMainProcess)
     }
 
     @SingleInstanceIn(AppScope::class)
@@ -141,8 +146,9 @@ object DatabaseModule {
         database: PrivacyConfigDatabase,
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
         dispatcherProvider: DispatcherProvider,
+        @IsMainProcess isMainProcess: Boolean,
     ): UnprotectedTemporaryRepository {
-        return RealUnprotectedTemporaryRepository(database, appCoroutineScope, dispatcherProvider)
+        return RealUnprotectedTemporaryRepository(database, appCoroutineScope, dispatcherProvider, isMainProcess)
     }
 
     @SingleInstanceIn(AppScope::class)
@@ -157,8 +163,9 @@ object DatabaseModule {
         database: PrivacyConfigDatabase,
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
         dispatcherProvider: DispatcherProvider,
+        @IsMainProcess isMainProcess: Boolean,
     ): DrmRepository {
-        return RealDrmRepository(database, appCoroutineScope, dispatcherProvider)
+        return RealDrmRepository(database, appCoroutineScope, dispatcherProvider, isMainProcess)
     }
 
     @SingleInstanceIn(AppScope::class)
@@ -167,8 +174,9 @@ object DatabaseModule {
         database: PrivacyConfigDatabase,
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
         dispatcherProvider: DispatcherProvider,
+        @IsMainProcess isMainProcess: Boolean,
     ): AmpLinksRepository {
-        return RealAmpLinksRepository(database, appCoroutineScope, dispatcherProvider)
+        return RealAmpLinksRepository(database, appCoroutineScope, dispatcherProvider, isMainProcess)
     }
 
     @SingleInstanceIn(AppScope::class)
@@ -177,8 +185,9 @@ object DatabaseModule {
         database: PrivacyConfigDatabase,
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
         dispatcherProvider: DispatcherProvider,
+        @IsMainProcess isMainProcess: Boolean,
     ): TrackingParametersRepository {
-        return RealTrackingParametersRepository(database, appCoroutineScope, dispatcherProvider)
+        return RealTrackingParametersRepository(database, appCoroutineScope, dispatcherProvider, isMainProcess)
     }
 
     @SingleInstanceIn(AppScope::class)
@@ -187,7 +196,8 @@ object DatabaseModule {
         database: PrivacyConfigDatabase,
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
         dispatcherProvider: DispatcherProvider,
+        @IsMainProcess isMainProcess: Boolean,
     ): UserAgentRepository {
-        return RealUserAgentRepository(database, appCoroutineScope, dispatcherProvider)
+        return RealUserAgentRepository(database, appCoroutineScope, dispatcherProvider, isMainProcess)
     }
 }

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/RealPrivacyConfigPersisterTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/RealPrivacyConfigPersisterTest.kt
@@ -105,6 +105,7 @@ class RealPrivacyConfigPersisterTest {
                 db,
                 TestScope(),
                 coroutineRule.testDispatcherProvider,
+                isMainProcess = true,
             )
     }
 

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/ReferenceTestUtilities.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/ReferenceTestUtilities.kt
@@ -57,12 +57,12 @@ class ReferenceTestUtilities(
 
     var privacyRepository: PrivacyConfigRepository = RealPrivacyConfigRepository(db)
     var privacyFeatureTogglesRepository: PrivacyFeatureTogglesRepository = mock()
-    var unprotectedTemporaryRepository: UnprotectedTemporaryRepository = RealUnprotectedTemporaryRepository(db, TestScope(), dispatcherProvider)
-    var contentBlockingRepository: ContentBlockingRepository = RealContentBlockingRepository(db, TestScope(), dispatcherProvider)
-    var httpsRepository: HttpsRepository = RealHttpsRepository(db, TestScope(), dispatcherProvider)
-    var drmRepository: DrmRepository = RealDrmRepository(db, TestScope(), dispatcherProvider)
-    var gpcRepository: GpcRepository = RealGpcRepository(mock(), db, TestScope(), dispatcherProvider)
-    var trackerAllowlistRepository: TrackerAllowlistRepository = RealTrackerAllowlistRepository(db, TestScope(), dispatcherProvider)
+    var unprotectedTemporaryRepository: UnprotectedTemporaryRepository = RealUnprotectedTemporaryRepository(db, TestScope(), dispatcherProvider, true)
+    var contentBlockingRepository: ContentBlockingRepository = RealContentBlockingRepository(db, TestScope(), dispatcherProvider, true)
+    var httpsRepository: HttpsRepository = RealHttpsRepository(db, TestScope(), dispatcherProvider, true)
+    var drmRepository: DrmRepository = RealDrmRepository(db, TestScope(), dispatcherProvider, true)
+    var gpcRepository: GpcRepository = RealGpcRepository(mock(), db, TestScope(), dispatcherProvider, true)
+    var trackerAllowlistRepository: TrackerAllowlistRepository = RealTrackerAllowlistRepository(db, TestScope(), dispatcherProvider, true)
 
     // Add your plugin to this list in order for it to be tested against some basic reference tests
     private fun getPrivacyFeaturePlugins(): List<PrivacyFeaturePlugin> {

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/amplinks/AmpLinksRepository.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/amplinks/AmpLinksRepository.kt
@@ -34,6 +34,7 @@ class RealAmpLinksRepository(
     val database: PrivacyConfigDatabase,
     coroutineScope: CoroutineScope,
     dispatcherProvider: DispatcherProvider,
+    isMainProcess: Boolean,
 ) : AmpLinksRepository {
 
     private val ampLinksDao: AmpLinksDao = database.ampLinksDao()
@@ -44,7 +45,9 @@ class RealAmpLinksRepository(
 
     init {
         coroutineScope.launch(dispatcherProvider.io()) {
-            loadToMemory()
+            if (isMainProcess) {
+                loadToMemory()
+            }
         }
     }
 

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/contentblocking/ContentBlockingRepository.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/contentblocking/ContentBlockingRepository.kt
@@ -34,13 +34,18 @@ class RealContentBlockingRepository(
     val database: PrivacyConfigDatabase,
     coroutineScope: CoroutineScope,
     dispatcherProvider: DispatcherProvider,
+    isMainProcess: Boolean,
 ) : ContentBlockingRepository {
 
     private val contentBlockingDao: ContentBlockingDao = database.contentBlockingDao()
     override val exceptions = CopyOnWriteArrayList<FeatureException>()
 
     init {
-        coroutineScope.launch(dispatcherProvider.io()) { loadToMemory() }
+        coroutineScope.launch(dispatcherProvider.io()) {
+            if (isMainProcess) {
+                loadToMemory()
+            }
+        }
     }
 
     override fun updateAll(exceptions: List<ContentBlockingExceptionEntity>) {

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/drm/DrmRepository.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/drm/DrmRepository.kt
@@ -34,6 +34,7 @@ class RealDrmRepository(
     val database: PrivacyConfigDatabase,
     coroutineScope: CoroutineScope,
     dispatcherProvider: DispatcherProvider,
+    isMainProcess: Boolean,
 ) :
     DrmRepository {
 
@@ -42,7 +43,9 @@ class RealDrmRepository(
 
     init {
         coroutineScope.launch(dispatcherProvider.io()) {
-            loadToMemory()
+            if (isMainProcess) {
+                loadToMemory()
+            }
         }
     }
 

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/gpc/GpcRepository.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/gpc/GpcRepository.kt
@@ -49,6 +49,7 @@ class RealGpcRepository(
     val database: PrivacyConfigDatabase,
     coroutineScope: CoroutineScope,
     dispatcherProvider: DispatcherProvider,
+    isMainProcess: Boolean,
 ) : GpcRepository {
 
     private val gpcExceptionsDao: GpcExceptionsDao = database.gpcExceptionsDao()
@@ -59,7 +60,11 @@ class RealGpcRepository(
     override var gpcContentScopeConfig: String = emptyJson
 
     init {
-        coroutineScope.launch(dispatcherProvider.io()) { loadToMemory() }
+        coroutineScope.launch(dispatcherProvider.io()) {
+            if (isMainProcess) {
+                loadToMemory()
+            }
+        }
     }
 
     override fun updateAll(

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/https/HttpsRepository.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/https/HttpsRepository.kt
@@ -34,13 +34,18 @@ class RealHttpsRepository(
     val database: PrivacyConfigDatabase,
     coroutineScope: CoroutineScope,
     dispatcherProvider: DispatcherProvider,
+    isMainProcess: Boolean,
 ) : HttpsRepository {
 
     private val httpsDao: HttpsDao = database.httpsDao()
     override val exceptions = CopyOnWriteArrayList<FeatureException>()
 
     init {
-        coroutineScope.launch(dispatcherProvider.io()) { loadToMemory() }
+        coroutineScope.launch(dispatcherProvider.io()) {
+            if (isMainProcess) {
+                loadToMemory()
+            }
+        }
     }
 
     override fun updateAll(exceptions: List<HttpsExceptionEntity>) {

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/trackerallowlist/TrackerAllowlistRepository.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/trackerallowlist/TrackerAllowlistRepository.kt
@@ -32,13 +32,18 @@ class RealTrackerAllowlistRepository(
     database: PrivacyConfigDatabase,
     coroutineScope: CoroutineScope,
     dispatcherProvider: DispatcherProvider,
+    isMainProcess: Boolean,
 ) : TrackerAllowlistRepository {
 
     private val trackerAllowlistDao: TrackerAllowlistDao = database.trackerAllowlistDao()
     override val exceptions = CopyOnWriteArrayList<TrackerAllowlistEntity>()
 
     init {
-        coroutineScope.launch(dispatcherProvider.io()) { loadToMemory() }
+        coroutineScope.launch(dispatcherProvider.io()) {
+            if (isMainProcess) {
+                loadToMemory()
+            }
+        }
     }
 
     override fun updateAll(exceptions: List<TrackerAllowlistEntity>) {

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/trackingparameters/TrackingParametersRepository.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/trackingparameters/TrackingParametersRepository.kt
@@ -33,6 +33,7 @@ class RealTrackingParametersRepository(
     val database: PrivacyConfigDatabase,
     coroutineScope: CoroutineScope,
     dispatcherProvider: DispatcherProvider,
+    isMainProcess: Boolean,
 ) : TrackingParametersRepository {
 
     private val trackingParametersDao: TrackingParametersDao = database.trackingParametersDao()
@@ -42,7 +43,9 @@ class RealTrackingParametersRepository(
 
     init {
         coroutineScope.launch(dispatcherProvider.io()) {
-            loadToMemory()
+            if (isMainProcess) {
+                loadToMemory()
+            }
         }
     }
 

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/unprotectedtemporary/UnprotectedTemporaryRepository.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/unprotectedtemporary/UnprotectedTemporaryRepository.kt
@@ -34,6 +34,7 @@ class RealUnprotectedTemporaryRepository(
     val database: PrivacyConfigDatabase,
     coroutineScope: CoroutineScope,
     dispatcherProvider: DispatcherProvider,
+    isMainProcess: Boolean,
 ) : UnprotectedTemporaryRepository {
 
     private val unprotectedTemporaryDao: UnprotectedTemporaryDao =
@@ -41,7 +42,11 @@ class RealUnprotectedTemporaryRepository(
     override val exceptions = CopyOnWriteArrayList<FeatureException>()
 
     init {
-        coroutineScope.launch(dispatcherProvider.io()) { loadToMemory() }
+        coroutineScope.launch(dispatcherProvider.io()) {
+            if (isMainProcess) {
+                loadToMemory()
+            }
+        }
     }
 
     override fun updateAll(exceptions: List<UnprotectedTemporaryEntity>) {

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/useragent/UserAgentRepository.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/useragent/UserAgentRepository.kt
@@ -51,6 +51,7 @@ class RealUserAgentRepository(
     val database: PrivacyConfigDatabase,
     coroutineScope: CoroutineScope,
     dispatcherProvider: DispatcherProvider,
+    isMainProcess: Boolean,
 ) : UserAgentRepository {
 
     private val userAgentDao: UserAgentDao = database.userAgentDao()
@@ -69,7 +70,11 @@ class RealUserAgentRepository(
     override var ddgFixedUserAgentVersions = CopyOnWriteArrayList<String>()
 
     init {
-        coroutineScope.launch(dispatcherProvider.io()) { loadToMemory() }
+        coroutineScope.launch(dispatcherProvider.io()) {
+            if (isMainProcess) {
+                loadToMemory()
+            }
+        }
     }
 
     override fun updateAll(

--- a/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/amplinks/RealAmpLinksRepositoryTest.kt
+++ b/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/amplinks/RealAmpLinksRepositoryTest.kt
@@ -47,6 +47,7 @@ class RealAmpLinksRepositoryTest {
             mockDatabase,
             TestScope(),
             coroutineRule.testDispatcherProvider,
+            true,
         )
     }
 
@@ -58,6 +59,7 @@ class RealAmpLinksRepositoryTest {
             mockDatabase,
             TestScope(),
             coroutineRule.testDispatcherProvider,
+            true,
         )
 
         assertEquals(ampLinkExceptionEntity.toFeatureException(), testee.exceptions.first())
@@ -71,6 +73,7 @@ class RealAmpLinksRepositoryTest {
             mockDatabase,
             TestScope(),
             coroutineRule.testDispatcherProvider,
+            true,
         )
 
         testee.updateAll(listOf(), listOf(), listOf())
@@ -86,6 +89,7 @@ class RealAmpLinksRepositoryTest {
             mockDatabase,
             TestScope(),
             coroutineRule.testDispatcherProvider,
+            true,
         )
         assertEquals(1, testee.exceptions.size)
         assertEquals(1, testee.ampLinkFormats.size)

--- a/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/contentblocking/RealContentBlockingRepositoryTest.kt
+++ b/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/contentblocking/RealContentBlockingRepositoryTest.kt
@@ -55,6 +55,7 @@ class RealContentBlockingRepositoryTest {
                 mockDatabase,
                 TestScope(),
                 coroutineRule.testDispatcherProvider,
+                true,
             )
 
         assertEquals(
@@ -71,6 +72,7 @@ class RealContentBlockingRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    true,
                 )
 
             testee.updateAll(listOf())
@@ -87,6 +89,7 @@ class RealContentBlockingRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    true,
                 )
             assertEquals(1, testee.exceptions.size)
             reset(mockContentBlockingDao)

--- a/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/drm/RealDrmRepositoryTest.kt
+++ b/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/drm/RealDrmRepositoryTest.kt
@@ -50,14 +50,14 @@ class RealDrmRepositoryTest {
     fun whenRepositoryIsCreatedThenExceptionsLoadedIntoMemory() = runTest {
         givenDrmDaoContainsExceptions()
 
-        testee = RealDrmRepository(mockDatabase, this, coroutineRule.testDispatcherProvider)
+        testee = RealDrmRepository(mockDatabase, this, coroutineRule.testDispatcherProvider, true)
 
         assertEquals(drmException.toFeatureException(), testee.exceptions.first())
     }
 
     @Test
     fun whenUpdateAllThenUpdateAllCalled() = runTest {
-        testee = RealDrmRepository(mockDatabase, this, coroutineRule.testDispatcherProvider)
+        testee = RealDrmRepository(mockDatabase, this, coroutineRule.testDispatcherProvider, true)
 
         testee.updateAll(listOf())
 
@@ -67,7 +67,7 @@ class RealDrmRepositoryTest {
     @Test
     fun whenUpdateAllThenPreviousExceptionsAreCleared() = runTest {
         givenDrmDaoContainsExceptions()
-        testee = RealDrmRepository(mockDatabase, this, coroutineRule.testDispatcherProvider)
+        testee = RealDrmRepository(mockDatabase, this, coroutineRule.testDispatcherProvider, true)
         assertEquals(1, testee.exceptions.size)
         reset(mockDrmDao)
 

--- a/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/gpc/RealGpcRepositoryTest.kt
+++ b/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/gpc/RealGpcRepositoryTest.kt
@@ -56,6 +56,7 @@ class RealGpcRepositoryTest {
                 mockDatabase,
                 TestScope(),
                 coroutineRule.testDispatcherProvider,
+                true,
             )
     }
 
@@ -69,6 +70,7 @@ class RealGpcRepositoryTest {
                 mockDatabase,
                 TestScope(),
                 coroutineRule.testDispatcherProvider,
+                isMainProcess = true,
             )
 
         assertEquals(gpcException.toGpcException(), testee.exceptions.first())
@@ -83,6 +85,7 @@ class RealGpcRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    isMainProcess = true,
                 )
 
             testee.updateAll(listOf(), listOf(), configEntity)
@@ -102,6 +105,7 @@ class RealGpcRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    isMainProcess = true,
                 )
             assertEquals(1, testee.exceptions.size)
             reset(mockGpcExceptionsDao)
@@ -121,6 +125,7 @@ class RealGpcRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    isMainProcess = true,
                 )
             assertEquals(1, testee.headerEnabledSites.size)
             reset(mockGpcHeadersDao)
@@ -140,6 +145,7 @@ class RealGpcRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    isMainProcess = true,
                 )
             assertEquals(configEntity.config, testee.gpcContentScopeConfig)
             givenGpcDaoContainsConfig(configEntity2)

--- a/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/https/RealHttpsRepositoryTest.kt
+++ b/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/https/RealHttpsRepositoryTest.kt
@@ -49,6 +49,7 @@ class RealHttpsRepositoryTest {
                 mockDatabase,
                 TestScope(),
                 coroutineRule.testDispatcherProvider,
+                true,
             )
     }
 
@@ -61,6 +62,7 @@ class RealHttpsRepositoryTest {
                 mockDatabase,
                 TestScope(),
                 coroutineRule.testDispatcherProvider,
+                true,
             )
 
         assertEquals(httpException.toFeatureException(), testee.exceptions.first())
@@ -74,6 +76,7 @@ class RealHttpsRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    true,
                 )
 
             testee.updateAll(listOf())
@@ -90,6 +93,7 @@ class RealHttpsRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    true,
                 )
             assertEquals(1, testee.exceptions.size)
             reset(mockHttpsDao)

--- a/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/trackerallowlist/RealTrackerAllowlistRepositoryTest.kt
+++ b/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/trackerallowlist/RealTrackerAllowlistRepositoryTest.kt
@@ -49,6 +49,7 @@ class RealTrackerAllowlistRepositoryTest {
                 mockDatabase,
                 TestScope(),
                 coroutineRule.testDispatcherProvider,
+                isMainProcess = true,
             )
     }
 
@@ -61,6 +62,7 @@ class RealTrackerAllowlistRepositoryTest {
                 mockDatabase,
                 TestScope(),
                 coroutineRule.testDispatcherProvider,
+                isMainProcess = true,
             )
 
         assertEquals(trackerAllowlistEntity, testee.exceptions.first())
@@ -74,6 +76,7 @@ class RealTrackerAllowlistRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    isMainProcess = true,
                 )
 
             testee.updateAll(listOf())
@@ -90,6 +93,7 @@ class RealTrackerAllowlistRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    isMainProcess = true,
                 )
             assertEquals(1, testee.exceptions.size)
             reset(mockTrackerAllowlistDao)

--- a/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/trackingparameters/RealTrackingParametersRepositoryTest.kt
+++ b/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/trackingparameters/RealTrackingParametersRepositoryTest.kt
@@ -47,6 +47,7 @@ class RealTrackingParametersRepositoryTest {
             mockDatabase,
             TestScope(),
             coroutineRule.testDispatcherProvider,
+            isMainProcess = true,
         )
     }
 
@@ -58,6 +59,7 @@ class RealTrackingParametersRepositoryTest {
             mockDatabase,
             TestScope(),
             coroutineRule.testDispatcherProvider,
+            isMainProcess = true,
         )
 
         assertEquals(trackingParameterExceptionEntity.toFeatureException(), testee.exceptions.first())
@@ -70,6 +72,7 @@ class RealTrackingParametersRepositoryTest {
             mockDatabase,
             TestScope(),
             coroutineRule.testDispatcherProvider,
+            isMainProcess = true,
         )
 
         testee.updateAll(listOf(), listOf())
@@ -85,6 +88,7 @@ class RealTrackingParametersRepositoryTest {
             mockDatabase,
             TestScope(),
             coroutineRule.testDispatcherProvider,
+            isMainProcess = true,
         )
         assertEquals(1, testee.exceptions.size)
         assertEquals(1, testee.parameters.size)

--- a/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/unprotectedtemporary/RealUnprotectedTemporaryRepositoryTest.kt
+++ b/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/unprotectedtemporary/RealUnprotectedTemporaryRepositoryTest.kt
@@ -49,6 +49,7 @@ class RealUnprotectedTemporaryRepositoryTest {
                 mockDatabase,
                 TestScope(),
                 coroutineRule.testDispatcherProvider,
+                isMainProcess = true,
             )
     }
 
@@ -61,6 +62,7 @@ class RealUnprotectedTemporaryRepositoryTest {
                 mockDatabase,
                 TestScope(),
                 coroutineRule.testDispatcherProvider,
+                isMainProcess = true,
             )
 
         assertEquals(unprotectedTemporaryException.toFeatureException(), testee.exceptions.first())
@@ -74,6 +76,7 @@ class RealUnprotectedTemporaryRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    isMainProcess = true,
                 )
 
             testee.updateAll(listOf())
@@ -90,6 +93,7 @@ class RealUnprotectedTemporaryRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    isMainProcess = true,
                 )
             assertEquals(1, testee.exceptions.size)
             reset(mockUnprotectedTemporaryDao)

--- a/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/useragent/RealUserAgentRepositoryTest.kt
+++ b/privacy-config/privacy-config-store/src/test/java/com/duckduckgo/privacy/config/store/features/useragent/RealUserAgentRepositoryTest.kt
@@ -59,6 +59,7 @@ class RealUserAgentRepositoryTest {
                 mockDatabase,
                 TestScope(),
                 coroutineRule.testDispatcherProvider,
+                isMainProcess = true,
             )
     }
 
@@ -71,6 +72,7 @@ class RealUserAgentRepositoryTest {
                 mockDatabase,
                 TestScope(),
                 coroutineRule.testDispatcherProvider,
+                isMainProcess = true,
             )
 
         assertEquals(testee.omitApplicationExceptions.first(), actual)
@@ -86,6 +88,7 @@ class RealUserAgentRepositoryTest {
                 mockDatabase,
                 TestScope(),
                 coroutineRule.testDispatcherProvider,
+                isMainProcess = true,
             )
 
         assertEquals(testee.closestUserAgentState, true)
@@ -104,6 +107,7 @@ class RealUserAgentRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    isMainProcess = true,
                 )
 
             testee.updateAll(listOf(), listOf(), anyOrNull(), listOf())
@@ -120,6 +124,7 @@ class RealUserAgentRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    isMainProcess = true,
                 )
             assertEquals(1, testee.defaultExceptions.size)
             assertEquals(1, testee.omitApplicationExceptions.size)
@@ -142,6 +147,7 @@ class RealUserAgentRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    isMainProcess = true,
                 )
             assertEquals(true, testee.closestUserAgentState)
             assertEquals(true, testee.ddgFixedUserAgentState)

--- a/request-filterer/request-filterer-impl/src/main/java/com/duckduckgo/request/filterer/impl/di/RequestFiltererModule.kt
+++ b/request-filterer/request-filterer-impl/src/main/java/com/duckduckgo/request/filterer/impl/di/RequestFiltererModule.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.request.filterer.impl.di
 import android.content.Context
 import androidx.room.Room
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.di.IsMainProcess
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.request.filterer.store.ALL_MIGRATIONS
@@ -54,8 +55,9 @@ object RequestFiltererModule {
         database: RequestFiltererDatabase,
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
         dispatcherProvider: DispatcherProvider,
+        @IsMainProcess isMainProcess: Boolean,
     ): RequestFiltererRepository {
-        return RealRequestFiltererRepository(database, appCoroutineScope, dispatcherProvider)
+        return RealRequestFiltererRepository(database, appCoroutineScope, dispatcherProvider, isMainProcess)
     }
 
     @SingleInstanceIn(AppScope::class)

--- a/request-filterer/request-filterer-store/src/main/java/com/duckduckgo/request/filterer/store/RequestFiltererRepository.kt
+++ b/request-filterer/request-filterer-store/src/main/java/com/duckduckgo/request/filterer/store/RequestFiltererRepository.kt
@@ -32,6 +32,7 @@ class RealRequestFiltererRepository(
     val database: RequestFiltererDatabase,
     coroutineScope: CoroutineScope,
     dispatcherProvider: DispatcherProvider,
+    isMainProcess: Boolean,
 ) : RequestFiltererRepository {
 
     private val requestFiltererDao: RequestFiltererDao = database.requestFiltererDao()
@@ -41,7 +42,9 @@ class RealRequestFiltererRepository(
 
     init {
         coroutineScope.launch(dispatcherProvider.io()) {
-            loadToMemory()
+            if (isMainProcess) {
+                loadToMemory()
+            }
         }
     }
 

--- a/request-filterer/request-filterer-store/src/test/java/com/duckduckgo/request/filterer/store/RealRequestFiltererRepositoryTest.kt
+++ b/request-filterer/request-filterer-store/src/test/java/com/duckduckgo/request/filterer/store/RealRequestFiltererRepositoryTest.kt
@@ -51,6 +51,7 @@ class RealRequestFiltererRepositoryTest {
             mockDatabase,
             TestScope(),
             coroutineRule.testDispatcherProvider,
+            true,
         )
 
         assertEquals(requestFiltererExceptionEntity.toFeatureException(), testee.exceptions.first())
@@ -65,6 +66,7 @@ class RealRequestFiltererRepositoryTest {
             mockDatabase,
             TestScope(),
             coroutineRule.testDispatcherProvider,
+            true,
         )
 
         assertEquals(DEFAULT_WINDOW_IN_MS, testee.settings.windowInMs)
@@ -78,6 +80,7 @@ class RealRequestFiltererRepositoryTest {
             mockDatabase,
             TestScope(),
             coroutineRule.testDispatcherProvider,
+            true,
         )
 
         testee.updateAll(listOf(), policy)
@@ -93,6 +96,7 @@ class RealRequestFiltererRepositoryTest {
             mockDatabase,
             TestScope(),
             coroutineRule.testDispatcherProvider,
+            true,
         )
         assertEquals(1, testee.exceptions.size)
         assertEquals(WINDOW_IN_MS, testee.settings.windowInMs)

--- a/runtime-checks/runtime-checks-impl/src/main/java/com/duckduckgo/runtimechecks/impl/di/RuntimeChecksModule.kt
+++ b/runtime-checks/runtime-checks-impl/src/main/java/com/duckduckgo/runtimechecks/impl/di/RuntimeChecksModule.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.runtimechecks.impl.di
 import android.content.Context
 import androidx.room.Room
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.di.IsMainProcess
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.runtimechecks.store.ALL_MIGRATIONS
@@ -51,7 +52,8 @@ object RuntimeChecksModule {
         database: RuntimeChecksDatabase,
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
         dispatcherProvider: DispatcherProvider,
+        @IsMainProcess isMainProcess: Boolean,
     ): RuntimeChecksRepository {
-        return RealRuntimeChecksRepository(database, appCoroutineScope, dispatcherProvider)
+        return RealRuntimeChecksRepository(database, appCoroutineScope, dispatcherProvider, isMainProcess)
     }
 }

--- a/runtime-checks/runtime-checks-store/src/main/java/com/duckduckgo/runtimechecks/store/RuntimeChecksRepository.kt
+++ b/runtime-checks/runtime-checks-store/src/main/java/com/duckduckgo/runtimechecks/store/RuntimeChecksRepository.kt
@@ -28,9 +28,10 @@ interface RuntimeChecksRepository {
 }
 
 class RealRuntimeChecksRepository constructor(
-    private val database: RuntimeChecksDatabase,
+    database: RuntimeChecksDatabase,
     coroutineScope: CoroutineScope,
-    private val dispatcherProvider: DispatcherProvider,
+    dispatcherProvider: DispatcherProvider,
+    isMainProcess: Boolean,
 ) : RuntimeChecksRepository {
 
     private val runtimeChecksDao: RuntimeChecksDao = database.runtimeChecksDao()
@@ -38,7 +39,9 @@ class RealRuntimeChecksRepository constructor(
 
     init {
         coroutineScope.launch(dispatcherProvider.io()) {
-            loadToMemory()
+            if (isMainProcess) {
+                loadToMemory()
+            }
         }
     }
 

--- a/runtime-checks/runtime-checks-store/src/test/java/com/duckduckgo/runtimechecks/store/RuntimeChecksRepositoryTest.kt
+++ b/runtime-checks/runtime-checks-store/src/test/java/com/duckduckgo/runtimechecks/store/RuntimeChecksRepositoryTest.kt
@@ -49,6 +49,7 @@ class RuntimeChecksRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    isMainProcess = true,
                 )
 
             verify(mockRuntimeChecksDao).get()
@@ -64,6 +65,7 @@ class RuntimeChecksRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    isMainProcess = true,
                 )
 
             verify(mockRuntimeChecksDao).get()
@@ -78,6 +80,7 @@ class RuntimeChecksRepositoryTest {
                     mockDatabase,
                     TestScope(),
                     coroutineRule.testDispatcherProvider,
+                    isMainProcess = true,
                 )
 
             testee.updateAll(runtimeChecksEntity)

--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/drmblock/DrmBlockRepository.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/drmblock/DrmBlockRepository.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.site.permissions.impl.drmblock
 
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.di.IsMainProcess
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
@@ -41,13 +42,16 @@ class RealDrmBlockRepository @Inject constructor(
     val drmBlockDao: DrmBlockDao,
     @AppCoroutineScope appCoroutineScope: CoroutineScope,
     dispatcherProvider: DispatcherProvider,
+    @IsMainProcess isMainProcess: Boolean,
 ) : DrmBlockRepository {
 
     override val exceptions = CopyOnWriteArrayList<FeatureException>()
 
     init {
         appCoroutineScope.launch(dispatcherProvider.io()) {
-            loadToMemory()
+            if (isMainProcess) {
+                loadToMemory()
+            }
         }
     }
 

--- a/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/di/VoiceSearchModule.kt
+++ b/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/di/VoiceSearchModule.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.voice.impl.di
 import android.content.Context
 import androidx.room.Room
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.di.IsMainProcess
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.voice.api.VoiceSearchStatusListener
@@ -66,7 +67,8 @@ object VoiceSearchModule {
         database: VoiceSearchDatabase,
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
         dispatcherProvider: DispatcherProvider,
+        @IsMainProcess isMainProcess: Boolean,
     ): VoiceSearchFeatureRepository {
-        return RealVoiceSearchFeatureRepository(database, appCoroutineScope, dispatcherProvider)
+        return RealVoiceSearchFeatureRepository(database, appCoroutineScope, dispatcherProvider, isMainProcess)
     }
 }

--- a/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/remoteconfig/VoiceSearchFeatureRepository.kt
+++ b/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/remoteconfig/VoiceSearchFeatureRepository.kt
@@ -35,6 +35,7 @@ class RealVoiceSearchFeatureRepository constructor(
     database: VoiceSearchDatabase,
     coroutineScope: CoroutineScope,
     dispatcherProvider: DispatcherProvider,
+    isMainProcess: Boolean,
 ) : VoiceSearchFeatureRepository {
 
     private val voiceSearchDao: VoiceSearchDao = database.voiceSearchDao()
@@ -44,7 +45,11 @@ class RealVoiceSearchFeatureRepository constructor(
         get() = _minVersion
 
     init {
-        coroutineScope.launch(dispatcherProvider.io()) { loadToMemory() }
+        coroutineScope.launch(dispatcherProvider.io()) {
+            if (isMainProcess) {
+                loadToMemory()
+            }
+        }
     }
 
     override fun updateAllExceptions(exceptions: List<Manufacturer>, minVersion: Int) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1206608309382832/f

### Description
Many privacy plugins data is loaded into memory for both `:app` and `:vpn` processes.
Even when the plugins are only used from the app process, because privacy config is only downloaded from the `main` process, the loading mistakenly happens in the `vpn` process as well because
all plugins have a `loadToMemory` method that is executed in the `init` block (ie. when the instance is created) and the `PluginPoint<MainProcessLifecycleObserver>` is a dependency to the `Application` instance,
which is created for both `vpn` and `app` processes.

However loading into data for the `vpn` process should not be required/done as we don't use that data from the `vpn` process.

This task is a stop gap to avoid that in-memory data loading to happen. 

In sub-sequent PRs we'll want to have a better nad more standardize mechanism to perform in-memory Cache backed by disk storage.


### Steps to test this PR
Code review and smoke test the app
Make sure privacy config downloads and sets correctly.
