### PR TITLE
Re-establish hardware check reporting for autofill capabilities

### DIFF
--- a/app/src/test/java/com/duckduckgo/autofill/pixel/AutofillUniquePixelSenderTest.kt
+++ b/app/src/test/java/com/duckduckgo/autofill/pixel/AutofillUniquePixelSenderTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.pixel
+
+import android.content.Context
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_DEVICE_CAPABILITY_CAPABLE
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_DEVICE_CAPABILITY_DEVICE_AUTH_DISABLED
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_DEVICE_CAPABILITY_SECURE_STORAGE_UNAVAILABLE
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_DEVICE_CAPABILITY_SECURE_STORAGE_UNAVAILABLE_AND_DEVICE_AUTH_DISABLED
+import com.duckduckgo.autofill.impl.pixel.AutofillUniquePixelSender
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.test.api.InMemorySharedPreferences
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class AutofillUniquePixelSenderTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+
+    private val mockPixel: Pixel = mock()
+    private val context: Context = mock()
+    private val fakePreferences = InMemorySharedPreferences()
+
+    private val testee = AutofillUniquePixelSender(
+        pixel = mockPixel,
+        context = context,
+        appCoroutineScope = TestScope(),
+        dispatchers = coroutineTestRule.testDispatcherProvider,
+    )
+
+    @Before
+    fun before() {
+        whenever(context.getSharedPreferences(SHARED_PREFS_FILE, Context.MODE_PRIVATE)).thenReturn(fakePreferences)
+    }
+
+    @Test
+    fun whenSharedPreferencesHasNoValueThenReturnsFalse() = runTest {
+        configureSharePreferencesMissingKey()
+        assertFalse(testee.hasDeterminedCapabilities())
+    }
+
+    @Test
+    fun whenPixelSentThenSharedPreferencesRecordsPixelWasSentBefore() = runTest {
+        testee.sendCapabilitiesPixel(secureStorageAvailable = true, deviceAuthAvailable = true)
+        assertTrue(testee.hasDeterminedCapabilities())
+    }
+
+    @Test
+    fun whenSecureStorageIsAvailableAndDeviceAuthEnabledThenSendCorrectPixel() {
+        testee.sendCapabilitiesPixel(secureStorageAvailable = true, deviceAuthAvailable = true)
+        verify(mockPixel).fire(AUTOFILL_DEVICE_CAPABILITY_CAPABLE)
+    }
+
+    @Test
+    fun whenSecureStorageIsAvailableButDeviceAuthDisabledThenSendCorrectPixel() {
+        testee.sendCapabilitiesPixel(secureStorageAvailable = true, deviceAuthAvailable = false)
+        verify(mockPixel).fire(AUTOFILL_DEVICE_CAPABILITY_DEVICE_AUTH_DISABLED)
+    }
+
+    @Test
+    fun whenDeviceAuthEnabledButSecureStorageIsNotAvailableThenSendCorrectPixel() {
+        testee.sendCapabilitiesPixel(secureStorageAvailable = false, deviceAuthAvailable = true)
+        verify(mockPixel).fire(AUTOFILL_DEVICE_CAPABILITY_SECURE_STORAGE_UNAVAILABLE)
+    }
+
+    @Test
+    fun whenDeviceAuthDisabledAndSecureStorageIsNotAvailableThenSendCorrectPixel() {
+        testee.sendCapabilitiesPixel(secureStorageAvailable = false, deviceAuthAvailable = false)
+        verify(mockPixel).fire(AUTOFILL_DEVICE_CAPABILITY_SECURE_STORAGE_UNAVAILABLE_AND_DEVICE_AUTH_DISABLED)
+    }
+
+    private fun configureSharePreferencesMissingKey() {
+        fakePreferences.remove(KEY_CAPABILITIES_DETERMINED)
+    }
+
+    companion object {
+        private const val SHARED_PREFS_FILE = "com.duckduckgo.autofill.pixel.AutofillPixelSender"
+        private const val KEY_CAPABILITIES_DETERMINED = "KEY_CAPABILITIES_DETERMINED"
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillDeviceCapabilityReporter.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillDeviceCapabilityReporter.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.pixel
+
+import androidx.annotation.UiThread
+import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator
+import com.duckduckgo.autofill.impl.securestorage.SecureStorage
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = MainProcessLifecycleObserver::class,
+)
+class AutofillDeviceCapabilityReporter @Inject constructor(
+    private val pixel: AutofillPixelSender,
+    private val secureStorage: SecureStorage,
+    private val dispatchers: DispatcherProvider,
+    private val deviceAuthenticator: DeviceAuthenticator,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+) : MainProcessLifecycleObserver {
+
+    @UiThread
+    override fun onCreate(owner: LifecycleOwner) {
+        Timber.v("Autofill device capability reporter created")
+
+        appCoroutineScope.launch(dispatchers.io()) {
+            if (pixel.hasDeterminedCapabilities()) {
+                Timber.v("Already determined device autofill capabilities previously")
+                return@launch
+            }
+
+            try {
+                val secureStorageAvailable = secureStorage.canAccessSecureStorage()
+                val deviceAuthAvailable = deviceAuthenticator.hasValidDeviceAuthentication()
+
+                Timber.d(
+                    "Autofill device capabilities:" +
+                        "\nSecure storage available: $secureStorageAvailable" +
+                        "\nDevice auth available: $deviceAuthAvailable",
+                )
+
+                pixel.sendCapabilitiesPixel(secureStorageAvailable, deviceAuthAvailable)
+            } catch (e: Error) {
+                Timber.w(e, "Failed to determine device autofill capabilities")
+                pixel.sendCapabilitiesUndeterminablePixel()
+            }
+        }
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
@@ -87,6 +87,14 @@ enum class AutofillPixelNames(override val pixelName: String) : Pixel.PixelName 
     AUTOFILL_NEVER_SAVE_FOR_THIS_SITE_CONFIRMATION_PROMPT_DISMISSED("m_autofill_settings_reset_excluded_dismissed"),
 
     AUTOFILL_OVERLAPPING_DIALOG("m_autofill_overlapping_dialog"),
+
+    AUTOFILL_DEVICE_CAPABILITY_CAPABLE("m_autofill_device_capability_capable"),
+    AUTOFILL_DEVICE_CAPABILITY_SECURE_STORAGE_UNAVAILABLE("m_autofill_device_capability_secure_storage_unavailable"),
+    AUTOFILL_DEVICE_CAPABILITY_DEVICE_AUTH_DISABLED("m_autofill_device_capability_device_auth_disabled"),
+    AUTOFILL_DEVICE_CAPABILITY_SECURE_STORAGE_UNAVAILABLE_AND_DEVICE_AUTH_DISABLED(
+        "m_autofill_device_capability_secure_storage_unavailable_and_device_auth_disabled",
+    ),
+    AUTOFILL_DEVICE_CAPABILITY_UNKNOWN_ERROR("m_autofill_device_capability_unknown"),
 }
 
 @ContributesMultibinding(

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelSender.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelSender.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.pixel
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_DEVICE_CAPABILITY_CAPABLE
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_DEVICE_CAPABILITY_DEVICE_AUTH_DISABLED
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_DEVICE_CAPABILITY_SECURE_STORAGE_UNAVAILABLE
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_DEVICE_CAPABILITY_SECURE_STORAGE_UNAVAILABLE_AND_DEVICE_AUTH_DISABLED
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_DEVICE_CAPABILITY_UNKNOWN_ERROR
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+interface AutofillPixelSender {
+    suspend fun hasDeterminedCapabilities(): Boolean
+    fun sendCapabilitiesPixel(
+        secureStorageAvailable: Boolean,
+        deviceAuthAvailable: Boolean,
+    )
+
+    fun sendCapabilitiesUndeterminablePixel()
+}
+
+@ContributesBinding(AppScope::class)
+@SingleInstanceIn(AppScope::class)
+class AutofillUniquePixelSender @Inject constructor(
+    private val pixel: Pixel,
+    private val context: Context,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val dispatchers: DispatcherProvider,
+) : AutofillPixelSender {
+
+    val preferences: SharedPreferences
+        get() = context.getSharedPreferences(SHARED_PREFS_FILE, Context.MODE_PRIVATE)
+
+    override suspend fun hasDeterminedCapabilities(): Boolean {
+        return preferences.getBoolean(KEY_CAPABILITIES_DETERMINED, false)
+    }
+
+    override fun sendCapabilitiesPixel(
+        secureStorageAvailable: Boolean,
+        deviceAuthAvailable: Boolean,
+    ) {
+        appCoroutineScope.launch(dispatchers.io()) {
+            sendPixel(secureStorageAvailable, deviceAuthAvailable).let {
+                Timber.v("Autofill capability pixel fired: %s", it)
+            }
+            preferences.edit { putBoolean(KEY_CAPABILITIES_DETERMINED, true) }
+        }
+    }
+
+    override fun sendCapabilitiesUndeterminablePixel() {
+        appCoroutineScope.launch(dispatchers.io()) {
+            pixel.fire(AUTOFILL_DEVICE_CAPABILITY_UNKNOWN_ERROR)
+            preferences.edit { putBoolean(KEY_CAPABILITIES_DETERMINED, true) }
+        }
+    }
+
+    private fun sendPixel(
+        secureStorageAvailable: Boolean,
+        deviceAuthAvailable: Boolean,
+    ): AutofillPixelNames {
+        val pixelName = if (secureStorageAvailable && deviceAuthAvailable) {
+            AUTOFILL_DEVICE_CAPABILITY_CAPABLE
+        } else if (!secureStorageAvailable && !deviceAuthAvailable) {
+            AUTOFILL_DEVICE_CAPABILITY_SECURE_STORAGE_UNAVAILABLE_AND_DEVICE_AUTH_DISABLED
+        } else if (!deviceAuthAvailable) {
+            AUTOFILL_DEVICE_CAPABILITY_DEVICE_AUTH_DISABLED
+        } else {
+            AUTOFILL_DEVICE_CAPABILITY_SECURE_STORAGE_UNAVAILABLE
+        }
+        pixel.fire(pixelName)
+        return pixelName
+    }
+
+    companion object {
+        private const val SHARED_PREFS_FILE = "com.duckduckgo.autofill.pixel.AutofillPixelSender"
+        private const val KEY_CAPABILITIES_DETERMINED = "KEY_CAPABILITIES_DETERMINED"
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1206638124888251/f 

### Description
Re-establishes the hardware check for Autofill device capabilities (including the encrypted storage check). This was removed previously as it was assumed the values were unlikely to change over time, but recently seen an increase in feedback suggesting a newer device (Samsung S24) is hitting this scenario indicating it is something that can and will change over time. 

### Steps to test this PR

Logcat Filter: `package:mine message~:"capabilit"`

- [ ] Fresh install and launch the app
- [ ] Verify that you see `Autofill capability pixel fired`
- [ ] Background / restore to foreground; verify no new logs about the capability detector
- [ ] Kill the app and re-launch it; verify capability detector reports `Already determined device autofill capabilities previously` and does nothing else