### PR TITLE
Disable no notifications prompt experiment

### DIFF
--- a/privacy-config/privacy-config-impl/src/main/res/raw/privacy_config.json
+++ b/privacy-config/privacy-config-impl/src/main/res/raw/privacy_config.json
@@ -947,50 +947,7 @@
                     "reason": "Site breakage"
                 }
             ]
-        },
-        "notificationPermissions": {
-            "state": "enabled",
-            "features": {
-                "noPermissionsPrompt": {
-                    "state": "enabled",
-                    "targets": [
-                        {
-                            "variantKey": "mg"
-                        }
-                    ]
-                }
-            }
         }
     },
-    "unprotectedTemporary": [],
-    "experimentalVariants": {
-        "variants": [
-            {
-                "desc": "this is SERP don't remove",
-                "variantKey": "sc",
-                "weight": 0.0
-            },
-            {
-                "desc": "this is SERP don't remove",
-                "variantKey": "se",
-                "weight": 0.0
-            },
-            {
-                "desc": "Control group for notification permissions experiment",
-                "variantKey": "mf",
-                "weight": 1.0,
-                "filters": {
-                    "androidVersion": ["34", "33"]
-                }
-            },
-            {
-                "desc": "No notifications permissions prompt experimental group",
-                "variantKey": "mg",
-                "weight": 1.0,
-                "filters": {
-                    "androidVersion": ["34", "33"]
-                }
-            }
-        ]
-    }
+    "unprotectedTemporary": []
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1206465832156620/f

### Description
Disable experiment from local privacy_config.json

### Steps to test this PR
_Android >= 13_
- [x] Fresh install from branch
- [x] Check notifications permissions prompt appears
- [x] Check onboarding works as expected

_Android < 13_
- [x] Fresh install from branch
- [x] Check onboarding works as expected

_Existing sample users_
- [x] Remove DuckDuckGo folder from Downloads directory
- [x] Fresh install from develop
- [x] Make sure you are already part of the experiment (variants `mg` or `mf` already assigned)
- [x] Install from branch
- [x] Check you still have variant assigned

### No UI changes
