### PR TITLE
Enforce declaredMethods order when evaluating FFs

### DIFF
--- a/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesRemoteFeatureCodeGenerator.kt
+++ b/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesRemoteFeatureCodeGenerator.kt
@@ -418,6 +418,7 @@ class ContributesRemoteFeatureCodeGenerator : CodeGenerator {
                             val concatMethodNames = this.feature.get().javaClass
                                 .declaredMethods
                                 .map { it.name }
+                                .sorted()
                                 .joinToString(separator = "")
                             val hash = %T().writeUtf8(concatMethodNames).md5().hex()
                             return hash


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1206628523510268/f

### Description
See [task](https://app.asana.com/0/488551667048375/1206628523510268/f) for full context explanation

### Steps to test this PR

_Test_
- [x] install from this branch and launch the app
- [x] go to app settings -> developer settings -> override privacy remote config URL
- [x] toggle "use custom URL" on and enter `https://jsonblob.com/api/jsonBlob/1126094951384629248`
- [x] tap on force reloading
- [x] Use AS (or Flipper) to see the contents of the share prefs `com.duckduckgo.feature.toggle.androidBrowserConfig`
- [x] take note of the `hash`
-- repeat 3 times --
- [x] force close the app and re-launch
- [x] Use AS (or Flipper) to see the contents of the share prefs `com.duckduckgo.feature.toggle.androidBrowserConfig`
- [x] verify the `hash` is the same
-- END repeat 3 times --
- [x] take note of the sate (enabled/disabled) of the `androidBrowserConfig` sub-features
- [x] Go to https://www.jsonblob.com/1126094951384629248 and modify the `hash` of `androidBrowserConfig`
- [x] force close the app and re-launch
- [x] verify the `hash` is the same
- [x] Go to https://www.jsonblob.com/1126094951384629248 and increase the version
- [x] force close the app and re-launch
- [x] verify the `hash` is different this time, and take note of it
- [x] verify the state of the sub-features has not change
- [x] Apply the following patch and rebuild / re-install / re-launch the app
```kotlin
Index: app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt	(revision 5fe8bd5216708fbbe945832377600bc90233eb24)
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt	(date 1707729280159)
@@ -59,4 +59,7 @@
      */
     @Toggle.DefaultValue(false)
     fun optimizeTrackerEvaluation(): Toggle
+
+    @Toggle.DefaultValue(false)
+    fun testFlag(): Toggle
 }
```
- [x] verify the `androidBrowserConfig_testFlag` is now present in the `com.duckduckgo.feature.toggle.androidBrowserConfig` and its `enable` value is most likely `true` (`rolloutThreshold` < `98`)
- [x] verify the `hash` has changed
