### PR TITLE
CH - set per site basis

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewRequestInterceptorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewRequestInterceptorTest.kt
@@ -83,7 +83,6 @@ class WebViewRequestInterceptorTest {
         fakeToggle,
         fakeUserAllowListRepository,
         FakeStatisticsDataStore(),
-        mock(),
     )
 
     private var webView: WebView = mock()

--- a/app/src/androidTest/java/com/duckduckgo/app/global/api/ApiRequestInterceptorTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/api/ApiRequestInterceptorTest.kt
@@ -61,7 +61,6 @@ class ApiRequestInterceptorTest {
             fakeToggle,
             fakeUserAllowListRepository,
             mock(),
-            mock(),
         )
 
         testee = ApiRequestInterceptor(

--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/DomainsReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/DomainsReferenceTest.kt
@@ -115,7 +115,6 @@ class DomainsReferenceTest(private val testCase: TestCase) {
         fakeToggle,
         fakeUserAllowListRepository,
         mock(),
-        mock(),
     )
     private val mockGpc: Gpc = mock()
     private val mockAdClickManager: AdClickManager = mock()

--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/SurrogatesReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/SurrogatesReferenceTest.kt
@@ -110,7 +110,6 @@ class SurrogatesReferenceTest(private val testCase: TestCase) {
         fakeToggle,
         fakeUserAllowListRepository,
         mock(),
-        mock(),
     )
     private val mockGpc: Gpc = mock()
     private val mockAdClickManager: AdClickManager = mock()

--- a/user-agent/user-agent-api/src/main/java/com/duckduckgo/user/agent/api/ClientBrandHintProvider.kt
+++ b/user-agent/user-agent-api/src/main/java/com/duckduckgo/user/agent/api/ClientBrandHintProvider.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.user.agent.api
+
+import android.webkit.WebSettings
+
+interface ClientBrandHintProvider {
+
+    /**
+     * Sets the client hint header SEC-CH-UA based on a specific URL and the fact that it can be an exception
+     * @param settings [WebSettings] where the agent metadata will be set
+     * @param url where the client hint will be set
+     */
+    fun setOn(settings: WebSettings?, documentUrl: String)
+
+    /**
+     * Sets the default client hint header SEC-CH-UA
+     * @param settings [WebSettings] where the agent metadata will be set
+     */
+    fun setDefault(settings: WebSettings)
+
+    /**
+     * Checks if the url passed as parameter will force a change of branding
+     * @param url where the client hint will be set
+     * @return true if the branding should change
+     */
+    fun shouldChangeBranding(documentUrl: String): Boolean
+}

--- a/user-agent/user-agent-api/src/main/java/com/duckduckgo/user/agent/api/UserAgentProvider.kt
+++ b/user-agent/user-agent-api/src/main/java/com/duckduckgo/user/agent/api/UserAgentProvider.kt
@@ -16,8 +16,6 @@
 
 package com.duckduckgo.user.agent.api
 
-import android.webkit.WebSettings
-
 interface UserAgentProvider {
     /**
      * Provides the user agent based on a specific URL and if the website should be displayed in desktop mode or not
@@ -26,11 +24,6 @@ interface UserAgentProvider {
      * @return a string with the user agent
      */
     fun userAgent(url: String? = null, isDesktop: Boolean = false): String
-
-    /**
-     * Sets the correct Sec-CH-UA hint header for our browser
-     */
-    fun setHintHeader(settings: WebSettings)
 }
 
 /**

--- a/user-agent/user-agent-impl/build.gradle
+++ b/user-agent/user-agent-impl/build.gradle
@@ -18,6 +18,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'com.squareup.anvil'
+    id 'com.google.devtools.ksp' version "$ksp_version"
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"
@@ -29,10 +30,10 @@ dependencies {
     implementation project(':di')
     implementation project(':common-utils')
     implementation project(':browser-api')
-    implementation project(':user-agent-api')
     implementation project(':feature-toggles-api')
     implementation project(':privacy-config-api')
     implementation project(':app-build-config-api')
+    implementation project(':user-agent-api')
     implementation project(':statistics')
 
     implementation AndroidX.appCompat
@@ -45,6 +46,12 @@ dependencies {
     implementation Square.retrofit2.converter.moshi
     implementation "com.squareup.moshi:moshi-kotlin:_"
 
+    // Room
+    implementation AndroidX.room.runtime
+    implementation AndroidX.room.ktx
+    testImplementation AndroidX.room.testing
+    ksp AndroidX.room.compiler
+
     // Testing dependencies
     testImplementation project(':feature-toggles-test')
     testImplementation project(':common-test')
@@ -55,6 +62,8 @@ dependencies {
     testImplementation AndroidX.test.ext.junit
     testImplementation Square.retrofit2.converter.moshi
     testImplementation Testing.junit4
+    testImplementation AndroidX.archCore.testing
+    androidTestImplementation AndroidX.archCore.testing
 }
 
 anvil {
@@ -63,5 +72,8 @@ anvil {
 
 
 android {
-  namespace 'com.duckduckgo.user.agent.impl'
+    namespace 'com.duckduckgo.user.agent.impl'
+    compileOptions {
+        coreLibraryDesugaringEnabled = true
+    }
 }

--- a/user-agent/user-agent-impl/src/main/java/com/duckduckgo/user/agent/impl/ClientBrandHintProvider.kt
+++ b/user-agent/user-agent-impl/src/main/java/com/duckduckgo/user/agent/impl/ClientBrandHintProvider.kt
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.user.agent.impl
+
+import android.annotation.SuppressLint
+import android.net.Uri
+import android.webkit.WebSettings
+import androidx.webkit.UserAgentMetadata
+import androidx.webkit.UserAgentMetadata.BrandVersion
+import androidx.webkit.WebSettingsCompat
+import androidx.webkit.WebViewFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.user.agent.api.ClientBrandHintProvider
+import com.duckduckgo.user.agent.impl.remoteconfig.BrandingChange
+import com.duckduckgo.user.agent.impl.remoteconfig.BrandingChange.Change
+import com.duckduckgo.user.agent.impl.remoteconfig.BrandingChange.None
+import com.duckduckgo.user.agent.impl.remoteconfig.ClientBrandHintFeature
+import com.duckduckgo.user.agent.impl.remoteconfig.ClientBrandHintFeatureSettingsRepository
+import com.duckduckgo.user.agent.impl.remoteconfig.ClientBrandsHints
+import com.duckduckgo.user.agent.impl.remoteconfig.ClientBrandsHints.CHROME
+import com.duckduckgo.user.agent.impl.remoteconfig.ClientBrandsHints.DDG
+import com.duckduckgo.user.agent.impl.remoteconfig.ClientBrandsHints.WEBVIEW
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+import timber.log.Timber
+
+@ContributesBinding(AppScope::class)
+class RealClientBrandHintProvider @Inject constructor(
+    private val clientBrandHintFeature: ClientBrandHintFeature,
+    private val repository: ClientBrandHintFeatureSettingsRepository,
+) : ClientBrandHintProvider {
+
+    private var currentDomain: String? = null
+    private var currentBranding: ClientBrandsHints = DDG
+
+    override fun setDefault(settings: WebSettings) {
+        if (WebViewFeature.isFeatureSupported(WebViewFeature.USER_AGENT_METADATA)) {
+            if (clientBrandHintFeature.self().isEnabled()) {
+                Timber.v("ClientBrandHintProvider: branding enabled, initialising metadata with DuckDuckGo branding")
+                setUserAgentMetadata(settings, DEFAULT_ENABLED_BRANDING)
+            } else {
+                Timber.v("ClientBrandHintProvider: branding disabled, initialising metadata with Google Chrome branding")
+                setUserAgentMetadata(settings, DEFAULT_DISABLED_BRANDING)
+            }
+        }
+    }
+
+    override fun shouldChangeBranding(
+        documentUrl: String,
+    ): Boolean {
+        Timber.v("ClientBrandHintProvider: should branding change for $documentUrl?")
+        val brandingChange = calculateBrandingChange(documentUrl) is Change
+        return brandingChange
+    }
+
+    private fun calculateBrandingChange(documentUrl: String): BrandingChange {
+        if (WebViewFeature.isFeatureSupported(WebViewFeature.USER_AGENT_METADATA)) {
+            val documentDomain = Uri.parse(documentUrl).host
+
+            if (!clientBrandHintFeature.self().isEnabled()) {
+                return if (currentBranding != DEFAULT_DISABLED_BRANDING) {
+                    Timber.v("ClientBrandHintProvider: branding is disabled but current branding is not default")
+                    Change(DEFAULT_DISABLED_BRANDING)
+                } else {
+                    Timber.v("ClientBrandHintProvider: branding for is disabled, default branding already applied")
+                    None
+                }
+            }
+
+            Timber.v("ClientBrandHintProvider: check brand for request url $documentUrl with domain $documentDomain")
+            Timber.v("ClientBrandHintProvider: currentDomain is $currentDomain currentBranding is $currentBranding")
+
+            if (currentDomain == documentDomain) {
+                Timber.d("ClientBrandHintProvider: Branding already applied for $currentDomain, skipping")
+                return None
+            }
+
+            val customBranding = repository.clientBrandHints.filter { it.domain == documentDomain }
+            if (customBranding.isEmpty()) {
+                Timber.i("ClientBrandHintProvider: $documentDomain doesn't have custom branding")
+                return if (currentBranding == DEFAULT_ENABLED_BRANDING) {
+                    Timber.i("ClientBrandHintProvider: branding already active, skipping")
+                    None
+                } else {
+                    Timber.i("ClientBrandHintProvider: $documentUrl is not an exception, change to default braning")
+                    Change(DEFAULT_ENABLED_BRANDING)
+                }
+            } else {
+                val branding = customBranding.first().brand
+                return if (branding == currentBranding) {
+                    Timber.i("ClientBrandHintProvider: branding already active, skipping")
+                    None
+                } else {
+                    Timber.i("ClientBrandHintProvider: $documentUrl has custom branding, change branding to $branding")
+                    Change(branding)
+                }
+            }
+        } else {
+            return None
+        }
+    }
+
+    override fun setOn(
+        settings: WebSettings?,
+        documentUrl: String,
+    ) {
+        if (settings == null) {
+            return
+        }
+
+        val brandingChange = calculateBrandingChange(documentUrl)
+        currentDomain = Uri.parse(documentUrl).host
+        if (brandingChange is Change) {
+            setUserAgentMetadata(settings, brandingChange.branding)
+        }
+    }
+
+    @SuppressLint("RequiresFeature")
+    private fun setUserAgentMetadata(
+        settings: WebSettings,
+        branding: ClientBrandsHints,
+    ) {
+        currentBranding = branding
+        val metadata = WebSettingsCompat.getUserAgentMetadata(settings)
+        val finalBrandList = metadata.brandVersionList.map {
+            when (currentBranding) {
+                CHROME -> {
+                    if (it.brand.contains(DDG.getBrand()) || it.brand.contains(WEBVIEW.getBrand())) {
+                        BrandVersion.Builder()
+                            .setBrand(currentBranding.getBrand())
+                            .setFullVersion(it.fullVersion)
+                            .setMajorVersion(it.majorVersion)
+                            .build()
+                    } else {
+                        it
+                    }
+                }
+
+                DDG -> {
+                    if (it.brand.contains(CHROME.getBrand()) || it.brand.contains(WEBVIEW.getBrand())) {
+                        BrandVersion.Builder()
+                            .setBrand(currentBranding.getBrand())
+                            .setFullVersion(it.fullVersion)
+                            .setMajorVersion(it.majorVersion)
+                            .build()
+                    } else {
+                        it
+                    }
+                }
+
+                WEBVIEW -> {
+                    if (it.brand.contains(CHROME.getBrand()) || it.brand.contains(DDG.getBrand())) {
+                        BrandVersion.Builder()
+                            .setBrand(currentBranding.getBrand())
+                            .setFullVersion(it.fullVersion)
+                            .setMajorVersion(it.majorVersion)
+                            .build()
+                    } else {
+                        it
+                    }
+                }
+            }
+        }
+        Timber.i("ClientBrandHintProvider: original Brand List ${metadata.brandVersionList}")
+        Timber.i("ClientBrandHintProvider: updated Brand List $finalBrandList")
+
+        val ua = UserAgentMetadata.Builder()
+            .setPlatform(metadata.platform)
+            .setPlatformVersion(metadata.platformVersion)
+            .setFullVersion(metadata.fullVersion)
+            .setModel(metadata.model)
+            .setBitness(metadata.bitness)
+            .setArchitecture(metadata.architecture)
+            .setWow64(metadata.isWow64)
+            .setMobile(metadata.isMobile)
+            .setBrandVersionList(finalBrandList)
+            .build()
+        WebSettingsCompat.setUserAgentMetadata(settings, ua)
+    }
+
+    companion object {
+        private val DEFAULT_ENABLED_BRANDING: ClientBrandsHints = DDG
+        private val DEFAULT_DISABLED_BRANDING: ClientBrandsHints = CHROME
+    }
+}

--- a/user-agent/user-agent-impl/src/main/java/com/duckduckgo/user/agent/impl/UserAgentProvider.kt
+++ b/user-agent/user-agent-impl/src/main/java/com/duckduckgo/user/agent/impl/UserAgentProvider.kt
@@ -20,10 +20,6 @@ import android.content.Context
 import android.os.Build
 import android.webkit.WebSettings
 import androidx.core.net.toUri
-import androidx.webkit.UserAgentMetadata
-import androidx.webkit.UserAgentMetadata.BrandVersion
-import androidx.webkit.WebSettingsCompat
-import androidx.webkit.WebViewFeature
 import com.duckduckgo.app.browser.UriString
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
@@ -64,7 +60,6 @@ class RealUserAgentProvider @Inject constructor(
     private val toggle: FeatureToggle,
     private val userAllowListRepository: UserAllowListRepository,
     private val statisticsDataStore: StatisticsDataStore,
-    private val clientBrandHintFeature: ClientBrandHintFeature,
 ) : UserAgentProvider {
 
     private val baseAgent: String by lazy { concatWithSpaces(mobilePrefix, getWebKitVersionOnwards(false)) }
@@ -73,39 +68,6 @@ class RealUserAgentProvider @Inject constructor(
     private val ddgFixedBaseDesktopAgent: String by lazy { concatWithSpaces(ddgFixedDesktopPrefix, getWebKitVersionOnwards(true)) }
     private val safariComponent: String? by lazy { getSafariComponentFromUserAgent() }
     private val applicationComponent = "DuckDuckGo/${device.majorAppVersion}"
-
-    override fun setHintHeader(settings: WebSettings) {
-        if (WebViewFeature.isFeatureSupported(WebViewFeature.USER_AGENT_METADATA)) {
-            val metadata = WebSettingsCompat.getUserAgentMetadata(settings)
-            val finalBrandList = metadata.brandVersionList.map {
-                if (clientBrandHintFeature.self().isEnabled()) {
-                    if (it.brand.contains("Android")) {
-                        BrandVersion.Builder().setBrand("DuckDuckGo").setFullVersion(it.fullVersion).setMajorVersion(it.majorVersion).build()
-                    } else {
-                        it
-                    }
-                } else {
-                    if (it.brand.contains("DuckDuckGo")) {
-                        BrandVersion.Builder().setBrand("Android WebView").setFullVersion(it.fullVersion).setMajorVersion(it.majorVersion).build()
-                    } else {
-                        it
-                    }
-                }
-            }
-            val ua = UserAgentMetadata.Builder()
-                .setPlatform(metadata.platform)
-                .setPlatformVersion(metadata.platformVersion)
-                .setFullVersion(metadata.fullVersion)
-                .setModel(metadata.model)
-                .setBitness(metadata.bitness)
-                .setArchitecture(metadata.architecture)
-                .setWow64(metadata.isWow64)
-                .setMobile(metadata.isMobile)
-                .setBrandVersionList(finalBrandList)
-                .build()
-            WebSettingsCompat.setUserAgentMetadata(settings, ua)
-        }
-    }
 
     /**
      * Returns, our custom UA, including our application component before Safari

--- a/user-agent/user-agent-impl/src/main/java/com/duckduckgo/user/agent/impl/di/ClientBrandHintModule.kt
+++ b/user-agent/user-agent-impl/src/main/java/com/duckduckgo/user/agent/impl/di/ClientBrandHintModule.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.user.agent.impl.di
+
+import android.content.Context
+import androidx.room.Room
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.user.agent.impl.store.ALL_MIGRATIONS
+import com.duckduckgo.user.agent.impl.store.ClientBrandHintDatabase
+import com.squareup.anvil.annotations.ContributesTo
+import dagger.Module
+import dagger.Provides
+import dagger.SingleInstanceIn
+
+@Module
+@ContributesTo(AppScope::class)
+class ClientBrandHintModule {
+
+    @Provides
+    @SingleInstanceIn(AppScope::class)
+    fun provideClientHintDatabase(context: Context): ClientBrandHintDatabase {
+        return Room.databaseBuilder(context, ClientBrandHintDatabase::class.java, "clientbrandhints.db")
+            .fallbackToDestructiveMigration()
+            .addMigrations(*ALL_MIGRATIONS)
+            .build()
+    }
+}

--- a/user-agent/user-agent-impl/src/main/java/com/duckduckgo/user/agent/impl/remoteconfig/ClientBrandHintFeature.kt
+++ b/user-agent/user-agent-impl/src/main/java/com/duckduckgo/user/agent/impl/remoteconfig/ClientBrandHintFeature.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.user.agent.impl.remoteconfig
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "clientBrandHint",
+    settingsStore = ClientBrandHintFeatureSettingsStore::class,
+)
+
+interface ClientBrandHintFeature {
+    @Toggle.DefaultValue(true)
+    fun self(): Toggle
+}

--- a/user-agent/user-agent-impl/src/main/java/com/duckduckgo/user/agent/impl/remoteconfig/ClientBrandHintFeatureModels.kt
+++ b/user-agent/user-agent-impl/src/main/java/com/duckduckgo/user/agent/impl/remoteconfig/ClientBrandHintFeatureModels.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.user.agent.impl.remoteconfig
+
+data class ClientBrandHintDomain(
+    val domain: String,
+    val brand: ClientBrandsHints,
+)
+
+data class ClientBrandHintSettings(
+    val domains: List<ClientBrandHintDomain>,
+)
+
+/** Public enum class for the client hint brand list */
+enum class ClientBrandsHints {
+    DDG, CHROME, WEBVIEW;
+
+    fun getBrand(): String {
+        return when (this) {
+            DDG -> "DuckDuckGo"
+            CHROME -> "Google Chrome"
+            WEBVIEW -> "Android WebView"
+        }
+    }
+
+    companion object {
+        fun from(name: String): ClientBrandsHints {
+            return when (name) {
+                DDG.name -> DDG
+                CHROME.name -> CHROME
+                WEBVIEW.name -> WEBVIEW
+                else -> DDG
+            }
+        }
+    }
+}
+
+sealed class BrandingChange {
+    data object None : BrandingChange()
+    data class Change(val branding: ClientBrandsHints) : BrandingChange()
+}

--- a/user-agent/user-agent-impl/src/main/java/com/duckduckgo/user/agent/impl/remoteconfig/ClientBrandHintFeatureSettingsRepository.kt
+++ b/user-agent/user-agent-impl/src/main/java/com/duckduckgo/user/agent/impl/remoteconfig/ClientBrandHintFeatureSettingsRepository.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.user.agent.impl.remoteconfig
+
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.di.IsMainProcess
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.user.agent.impl.store.ClientBrandHintDatabase
+import com.duckduckgo.user.agent.impl.store.ClientHintBrandDomainEntity
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import java.util.concurrent.CopyOnWriteArrayList
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+interface ClientBrandHintFeatureSettingsRepository {
+    fun updateAllSettings(settings: ClientBrandHintSettings)
+    val clientBrandHints: CopyOnWriteArrayList<ClientBrandHintDomain>
+}
+
+@ContributesBinding(AppScope::class)
+@SingleInstanceIn(AppScope::class)
+class RealClientBrandHintFeatureSettingsRepository @Inject constructor(
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    dispatcherProvider: DispatcherProvider,
+    database: ClientBrandHintDatabase,
+    @IsMainProcess isMainProcess: Boolean,
+) : ClientBrandHintFeatureSettingsRepository {
+
+    private val dao = database.clientBrandHintDao()
+
+    init {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            if (isMainProcess) {
+                loadToMemory()
+            }
+        }
+    }
+
+    override fun updateAllSettings(settings: ClientBrandHintSettings) {
+        Timber.i("ClientBrandHintProvider: update domains to ${settings.domains}")
+        dao.updateAllDomains(settings.domains.map { ClientHintBrandDomainEntity(it.domain, it.brand.name) })
+        loadToMemory()
+    }
+
+    override val clientBrandHints = CopyOnWriteArrayList<ClientBrandHintDomain>()
+
+    private fun loadToMemory() {
+        clientBrandHints.clear()
+        val clientBrandHintsDomainList = dao.getAllDomains()
+        Timber.i("ClientBrandHintProvider: loading domains to memory $clientBrandHintsDomainList")
+        clientBrandHints.addAll(clientBrandHintsDomainList.map { ClientBrandHintDomain(it.url, ClientBrandsHints.from(it.brand)) })
+    }
+}

--- a/user-agent/user-agent-impl/src/main/java/com/duckduckgo/user/agent/impl/remoteconfig/ClientBrandHintFeatureSettingsStore.kt
+++ b/user-agent/user-agent-impl/src/main/java/com/duckduckgo/user/agent/impl/remoteconfig/ClientBrandHintFeatureSettingsStore.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.user.agent.impl.remoteconfig
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.FeatureSettings
+import com.duckduckgo.feature.toggles.api.RemoteFeatureStoreNamed
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import javax.inject.Inject
+import timber.log.Timber
+
+@ContributesBinding(AppScope::class)
+@RemoteFeatureStoreNamed(ClientBrandHintFeature::class)
+class ClientBrandHintFeatureSettingsStore @Inject constructor(
+    private val repository: ClientBrandHintFeatureSettingsRepository,
+) : FeatureSettings.Store {
+
+    private val jsonAdapter by lazy { buildJsonAdapter() }
+
+    override fun store(jsonString: String) {
+        Timber.v("ClientBrandHintProvider: store $jsonString")
+        jsonAdapter.fromJson(jsonString)?.let {
+            repository.updateAllSettings(it)
+        }
+    }
+
+    private fun buildJsonAdapter(): JsonAdapter<ClientBrandHintSettings> {
+        val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+        return moshi.adapter(ClientBrandHintSettings::class.java)
+    }
+}

--- a/user-agent/user-agent-impl/src/main/java/com/duckduckgo/user/agent/impl/store/ClientBrandHintDao.kt
+++ b/user-agent/user-agent-impl/src/main/java/com/duckduckgo/user/agent/impl/store/ClientBrandHintDao.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.user.agent.impl.store
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+
+@Dao
+abstract class ClientBrandHintDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract fun insertDomains(exceptions: List<ClientHintBrandDomainEntity>)
+
+    @Query("select * from user_agent_client_hint_brand_domains")
+    abstract fun getAllDomains(): List<ClientHintBrandDomainEntity>
+
+    @Transaction
+    open fun updateAllDomains(domains: List<ClientHintBrandDomainEntity>) {
+        deleteDomains()
+        insertDomains(domains)
+    }
+
+    @Query("delete from user_agent_client_hint_brand_domains")
+    abstract fun deleteDomains()
+}

--- a/user-agent/user-agent-impl/src/main/java/com/duckduckgo/user/agent/impl/store/ClientBrandHintDatabase.kt
+++ b/user-agent/user-agent-impl/src/main/java/com/duckduckgo/user/agent/impl/store/ClientBrandHintDatabase.kt
@@ -14,18 +14,22 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.user.agent.impl
+package com.duckduckgo.user.agent.impl.store
 
-import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
-import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.feature.toggles.api.Toggle
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
 
-@ContributesRemoteFeature(
-    scope = AppScope::class,
-    featureName = "clientBrandHint",
+@Database(
+    exportSchema = true,
+    version = 1,
+    entities = [
+        ClientHintBrandDomainEntity::class,
+    ],
 )
+abstract class ClientBrandHintDatabase : RoomDatabase() {
 
-interface ClientBrandHintFeature {
-    @Toggle.DefaultValue(false)
-    fun self(): Toggle
+    abstract fun clientBrandHintDao(): ClientBrandHintDao
 }
+
+val ALL_MIGRATIONS = emptyArray<Migration>()

--- a/user-agent/user-agent-impl/src/main/java/com/duckduckgo/user/agent/impl/store/ClientBrandHintDatabaseModels.kt
+++ b/user-agent/user-agent-impl/src/main/java/com/duckduckgo/user/agent/impl/store/ClientBrandHintDatabaseModels.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.user.agent.impl.store
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "user_agent_client_hint_brand_domains")
+data class ClientHintBrandDomainEntity(
+    @PrimaryKey
+    val url: String,
+    val brand: String,
+)

--- a/user-agent/user-agent-impl/src/test/java/com/duckduckgo/user/agent/impl/UserAgentProviderTest.kt
+++ b/user-agent/user-agent-impl/src/test/java/com/duckduckgo/user/agent/impl/UserAgentProviderTest.kt
@@ -17,11 +17,7 @@
 package com.duckduckgo.user.agent.impl
 
 import android.net.Uri
-import android.webkit.WebView
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.webkit.WebSettingsCompat
-import androidx.webkit.WebViewFeature
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.statistics.model.Atb
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
@@ -37,11 +33,11 @@ import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.api.UserAgent
 import com.duckduckgo.user.agent.api.UserAgentInterceptor
 import com.duckduckgo.user.agent.api.UserAgentProvider
+import com.duckduckgo.user.agent.impl.remoteconfig.ClientBrandHintFeature
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -59,7 +55,7 @@ class UserAgentProviderTest {
     var coroutinesTestRule = CoroutineTestRule()
 
     private lateinit var testee: UserAgentProvider
-    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+
     private var deviceInfo: DeviceInfo = mock()
     private var userAgent: UserAgent = mock()
     private var toggle: FeatureToggle = mock()
@@ -453,37 +449,6 @@ class UserAgentProviderTest {
         assertTrue("$actual does not match expected regex", ValidationRegex.closestDesktopArch.matches(actual))
     }
 
-    @Test
-    fun whenHintFeatureDisabledThenMetadataContainsAndroid() {
-        if (WebViewFeature.isFeatureSupported(WebViewFeature.USER_AGENT_METADATA)) {
-            val settings = WebView(context).settings
-            testee = getUserAgentProvider(Agent.DEFAULT, deviceInfo)
-            testee.setHintHeader(settings)
-
-            val metadata = WebSettingsCompat.getUserAgentMetadata(settings)
-            val result = metadata.brandVersionList.firstOrNull {
-                it.brand.contains("Android")
-            }
-            assertNotNull(result)
-        }
-    }
-
-    @Test
-    fun whenHintFeatureEnabledThenMetadataContainsDuckDuckGo() {
-        if (WebViewFeature.isFeatureSupported(WebViewFeature.USER_AGENT_METADATA)) {
-            whenever(clientBrandHintFeature.self().isEnabled()).thenReturn(true)
-            val settings = WebView(context).settings
-            testee = getUserAgentProvider(Agent.DEFAULT, deviceInfo)
-            testee.setHintHeader(settings)
-
-            val metadata = WebSettingsCompat.getUserAgentMetadata(settings)
-            val result = metadata.brandVersionList.firstOrNull {
-                it.brand.contains("DuckDuckGo")
-            }
-            assertNotNull(result)
-        }
-    }
-
     private fun getUserAgentProvider(
         defaultUserAgent: String,
         device: DeviceInfo,
@@ -497,7 +462,6 @@ class UserAgentProviderTest {
             toggle,
             FakeUserAllowListRepo(),
             statisticsDataStore,
-            clientBrandHintFeature,
         )
     }
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/1174433894299346/1206613427401112

### Description

### Steps to test this PR

For Branding enabled replace PrivacyConfigService URL with https://jsonblob.com/api/jsonBlob/1215300292118962176
For Branding disabled replace PrivacyConfigService URL with https://jsonblob.com/api/jsonBlob/1215411576298659840

Filter log with ClientBrandHintProvider
Use chrome dev tools to inspect header

_Default when branding enabled_
- [x] Open app and browser
- [x] Verify SEC-CH-UA header contains DuckDuckGo

_Default when branding disabled_
- [ ] Open app and browser
- [ ] Verify SEC-CH-UA header contains Google Chrome

_Branding enabled in exception “as.com” (Chrome branding)_
- [x] Open app and make a search in SERP (not an exception site)
- [x] Verify SEC-CH-UA header contains DuckDuckGo
- [x] Navigate to as.com
- [x] Verify SEC-CH-UA header changes to Google Chrome
- [x] Navigate back to previous page (serp)
- [x] Verify SEC-CH-UA header contains DuckDuckGo
- [x] Navigate to as.com
- [ ] Verify SEC-CH-UA header changes to Google Chrome

_Branding enabled in exception “example.com” (Android WebView branding)_
- [x] Open app and make a search in SERP (not an exception site)
- [x] Verify SEC-CH-UA header contains DuckDuckGo
- [x] Navigate to example.com”
- [x] Verify SEC-CH-UA header changes to Android WebView
- [x] Navigate back to previous page (serp)
- [x] Verify SEC-CH-UA header contains DuckDuckGo
- [x] Navigate to example.com”
- [x] Verify SEC-CH-UA header changes to Android WebView

_Branding enabled navigate through links_
- [x] Open app and make a search in SERP for “as periodico"
- [x] Verify SEC-CH-UA header contains DuckDuckGo
- [x] Tap on the link that opens as.com
- [x] Verify SEC-CH-UA header changes to Google Chrome
- [x] Navigate back to previous page (serp)
- [x] Verify SEC-CH-UA header contains DuckDuckGo
- [x] Navigate forward
- [x] Verify SEC-CH-UA header changes to Google Chrome

_Branding disabled in exception “as.com"_
- [x] Open app and make a search in SERP (not an exception site)
- [x] Verify SEC-CH-UA header contains Google Chrome
- [x] Navigate to as.com
- [x] Verify SEC-CH-UA header doesn’t change
- [x] Navigate back to previous page (serp)
- [x] Verify SEC-CH-UA header doesn’t change

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206765381189699