### PR TITLE
Introduce backup rules to exclude backups

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,10 +37,12 @@
         android:label="@string/appName"
         android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="${appIconRound}"
+        android:dataExtractionRules="@xml/backup_rules_android_12_upwards"
+        android:fullBackupContent="@xml/backup_rules_android_11_and_older"
         android:supportsRtl="true"
         android:theme="@style/Theme.DuckDuckGo.Light"
         android:requestLegacyExternalStorage="true"
-        tools:ignore="GoogleAppIndexingWarning">
+        tools:ignore="GoogleAppIndexingWarning,UnusedAttribute">
         <meta-data
             android:name="android.webkit.WebView.MetricsOptOut"
             android:value="true" />

--- a/app/src/main/res/xml/backup_rules_android_11_and_older.xml
+++ b/app/src/main/res/xml/backup_rules_android_11_and_older.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2024 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<full-backup-content>
+    <exclude domain="file" path="."/>
+    <exclude domain="database" path="."/>
+    <exclude domain="sharedpref" path="."/>
+    <exclude domain="external" path="."/>
+    <exclude domain="root" path="."/>
+</full-backup-content>

--- a/app/src/main/res/xml/backup_rules_android_12_upwards.xml
+++ b/app/src/main/res/xml/backup_rules_android_12_upwards.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2024 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="file" path="."/>
+        <exclude domain="database" path="."/>
+        <exclude domain="sharedpref" path="."/>
+        <exclude domain="external" path="."/>
+        <exclude domain="root" path="."/>
+    </cloud-backup>
+
+    <device-transfer>
+        <exclude domain="file" path="."/>
+        <exclude domain="database" path="."/>
+        <exclude domain="sharedpref" path="."/>
+        <exclude domain="external" path="."/>
+        <exclude domain="root" path="."/>
+    </device-transfer>
+
+</data-extraction-rules>


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/0/1206667832334038/f 

### Description
Device backups are mostly disabled except for one instance where device-to-device backups are allowed. I've only noticed it happening for recent Samsung devices (specifically, the Samsung S24) but might be the same for others. For these devices:
- they ignore `appBackup="false"` (which might be reasonable, given it's deprecated)
- they do a device-to-device back (e.g., as part of the new device setup wizard where you can copy from your old phone)
- this leaves the app working except for the secure functions (Autofill, Email Protection, Sync) which indicate that the "device is not supported". The reason for this is that encrypted data has been migrated between the devices but the decryption key was not, leaving those secure functions broken.

This PR disables those device-to-device backups entirely so the app can't be left in a broken state. There are two different mechanisms depending on whether the app is running on an Android 13 or newer device vs Android 12 or older.

Separate to this PR, I will pick up the conversation on backups more generally (whether to embrace more, whether to leave disabled etc...).

### Steps to test this PR

Testing is a little fiddly, so happy to video chat our way through the review. ☎️

### Android 13 / Android 14
- [ ] Install our app on Android 13 / 14
- [ ] Go through onboarding to reach new tab page
- [ ] Run test script to trigger a device-to-device backup
- [ ] It should fail, meaning the app won't be removed from the device. re-launch the app and everything will be as it was.

### Android 12
- [ ] Same as before

### Optional testing steps (Transferring an individual app between two devices using Samsung Smart Switch)
- [ ] Install Samsung Smart Switch on both devices (doesn't need to be a Samsung)
- [ ] Install our app on device A, launch it and get through onboarding
- [ ] Use Smart Switch to transfer that app to device B
- [ ] Verify on device B that the app either starts as a fresh launch and shows onboarding, or that it doesnt' transfer