### PR TITLE
Detect encryption error state that could be recoverable

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -257,6 +257,7 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     EMAIL_DID_PRESS_WAITLIST_DIALOG_NOTIFY_ME("email_did_press_waitlist_dialog_notify_me"),
     EMAIL_DID_PRESS_WAITLIST_DIALOG_NO_THANKS("email_did_press_waitlist_dialog_dismiss"),
 
+    ENCRYPTION_UNABLE_TO_DECRYPT_SECURE_EMAIL_DATA("m_unable_to_decrypt_secure_email_data"),
     ENCRYPTED_IO_EXCEPTION("m_e_io_e"),
     ENCRYPTED_GENERAL_EXCEPTION("m_e_g_e"),
 

--- a/versions.properties
+++ b/versions.properties
@@ -51,7 +51,7 @@ version.androidx.webkit=1.9.0
 
 version.androidx.work=2.7.1
 
-version.androidx.security-crypto=1.1.0-alpha03
+version.androidx.security-crypto=1.1.0-alpha06
 
 version.app.cash.turbine=0.12.1
 


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1206692157281177/f 

### Description
Attempts to detect when user is in a state whereby the encrypted data is not accessible and tests whether they could access encrypted data on a new test file.
- if they can access encrypted data on a new test file, this is indicative that their local encrypted shared preferences is permanently undecryptable, and we should consider if we need a (possibly user-facing) mitigation to let them wipe it and re-initialise
- if they can't access encrytped data on a new test file, it's probable their device just can't support it

Also brings in the latest version of the AndroidX security library, as there are some related changes to the exception that is thrown in this scenario (including changing the thrown exception type and internally fixing a related race condition that could throw the exception)

### Steps to test this PR

- [ ] Install from `develop` first and add some passwords
- [ ] Install this branch. verify passwords are still accessible
- [ ] Ideally if you can, trigger the scenario whereby the device is backed up and restored, and its encrypted shared preferences become inaccessible. Alternatively, I think the next best thing here would be to manually edit the `com.duckduckgo.app.email.settings.xml` shared preferences file so that it was undecryptable. (perhaps useful to pair on this testing step)
- [ ] Launch the app and verify you see `m_unable_to_decrypt_secure_email_data` pixel