### PR TITLE
Automatically logout invalid sync devices

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
@@ -307,7 +307,9 @@ class AppSyncAccountRepository @Inject constructor(
                             )
                         } catch (throwable: Throwable) {
                             throwable.asErrorResult().alsoFireAccountErrorPixel()
-                            logout(device.deviceId)
+                            if (syncStore.deviceId != device.deviceId) {
+                                logout(device.deviceId)
+                            }
                             null
                         }
                     }.sortedWith { a, b ->

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
@@ -292,18 +292,22 @@ class AppSyncAccountRepository @Inject constructor(
 
             is Result.Success -> {
                 return Result.Success(
-                    result.data.mapNotNull {
-                        return@mapNotNull kotlin.runCatching {
+                    result.data.mapNotNull { device ->
+                        try {
+                            val decryptedDeviceName = nativeLib.decryptData(device.deviceName, primaryKey).decryptedData
+                            val decryptedDeviceType = device.deviceType.takeUnless { it.isNullOrEmpty() }?.let { encryptedDeviceType ->
+                                DeviceType(nativeLib.decryptData(encryptedDeviceType, primaryKey).decryptedData)
+                            } ?: DeviceType()
+
                             ConnectedDevice(
-                                thisDevice = syncStore.deviceId == it.deviceId,
-                                deviceName = nativeLib.decryptData(it.deviceName, primaryKey).decryptedData,
-                                deviceId = it.deviceId,
-                                deviceType = it.deviceType.takeUnless { it.isNullOrEmpty() }?.let { encryptedDeviceType ->
-                                    DeviceType(nativeLib.decryptData(encryptedDeviceType, primaryKey).decryptedData)
-                                } ?: DeviceType(),
+                                thisDevice = syncStore.deviceId == device.deviceId,
+                                deviceName = decryptedDeviceName,
+                                deviceId = device.deviceId,
+                                deviceType = decryptedDeviceType,
                             )
-                        }.getOrElse { throwable ->
+                        } catch (throwable: Throwable) {
                             throwable.asErrorResult().alsoFireAccountErrorPixel()
+                            logout(device.deviceId)
                             null
                         }
                     }.sortedWith { a, b ->

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
@@ -312,6 +312,24 @@ class AppSyncAccountRepositoryTest {
     }
 
     @Test
+    fun getConnectedDevicesDecryptionFailsThenLogoutDevice() {
+        givenAuthenticatedDevice()
+        prepareForEncryption()
+        val thisDevice = Device(deviceId = deviceId, deviceName = deviceName, jwIat = "", deviceType = deviceFactor)
+        val anotherDevice = Device(deviceId = "anotherDeviceId", deviceName = deviceName, jwIat = "", deviceType = deviceFactor)
+        whenever(syncStore.token).thenReturn(token)
+        whenever(syncStore.deviceId).thenReturn(deviceId)
+        whenever(syncStore.primaryKey).thenReturn(primaryKey)
+        whenever(nativeLib.decryptData(anyString(), anyString())).thenThrow(NegativeArraySizeException())
+        whenever(syncApi.getDevices(anyString())).thenReturn(Result.Success(listOf(thisDevice)))
+        whenever(syncApi.logout("token", "deviceId")).thenReturn(Result.Success(Logout("deviceId")))
+
+        val result = syncRepo.getConnectedDevices() as Success
+        verify(syncApi).logout("token", "deviceId")
+        assertTrue(result.data.isEmpty())
+    }
+
+    @Test
     fun whenGenerateRecoveryCodeAsStringThenReturnExpectedJson() {
         whenever(syncStore.primaryKey).thenReturn(primaryKey)
         whenever(syncStore.userId).thenReturn(userId)

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
@@ -316,15 +316,16 @@ class AppSyncAccountRepositoryTest {
         givenAuthenticatedDevice()
         prepareForEncryption()
         val thisDevice = Device(deviceId = deviceId, deviceName = deviceName, jwIat = "", deviceType = deviceFactor)
+        val otherDevice = Device(deviceId = "otherDeviceId", deviceName = "otherDeviceName", jwIat = "", deviceType = "otherDeviceType")
         whenever(syncStore.token).thenReturn(token)
         whenever(syncStore.deviceId).thenReturn(deviceId)
         whenever(syncStore.primaryKey).thenReturn(primaryKey)
         whenever(nativeLib.decryptData(anyString(), anyString())).thenThrow(NegativeArraySizeException())
-        whenever(syncApi.getDevices(anyString())).thenReturn(Result.Success(listOf(thisDevice)))
-        whenever(syncApi.logout("token", "deviceId")).thenReturn(Result.Success(Logout("deviceId")))
+        whenever(syncApi.getDevices(anyString())).thenReturn(Result.Success(listOf(thisDevice, otherDevice)))
+        whenever(syncApi.logout("token", "otherDeviceId")).thenReturn(Result.Success(Logout("otherDeviceId")))
 
         val result = syncRepo.getConnectedDevices() as Success
-        verify(syncApi).logout("token", "deviceId")
+        verify(syncApi).logout("token", "otherDeviceId")
         assertTrue(result.data.isEmpty())
     }
 

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
@@ -316,7 +316,6 @@ class AppSyncAccountRepositoryTest {
         givenAuthenticatedDevice()
         prepareForEncryption()
         val thisDevice = Device(deviceId = deviceId, deviceName = deviceName, jwIat = "", deviceType = deviceFactor)
-        val anotherDevice = Device(deviceId = "anotherDeviceId", deviceName = deviceName, jwIat = "", deviceType = deviceFactor)
         whenever(syncStore.token).thenReturn(token)
         whenever(syncStore.deviceId).thenReturn(deviceId)
         whenever(syncStore.primaryKey).thenReturn(primaryKey)


### PR DESCRIPTION
To prevent phantom devices being allowed to sync a user's data, we automatically logout devices that cannot be decrypted, instead of just ignoring them.

<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL:  https://app.asana.com/0/0/1206693867033120/f

### Description
It is possible for someone to sync a device to another user's account such that the device data cannot be decrypted. This results in an invalid "phantom" device that can sync data from a user's account without their knowledge (and they are unable to view or remove said device from the UI).

As a result, we introduce a fix that automatically logs out invalid devices to prevent this issue from occurring. In the very rare case that a device accidentally contains invalid encrypted data, the rightful owner of that device should be able to just re-sync it.

### Steps to test this PR
Note: requires two devices and some form of request interception (i.e. BurpSuite). There is an integration test that covers this test case too.
1. Setup sync on device A
2. Sync device B to device A
3. Turn on request interception in BurpSuite
4. Rename device B on device B to any arbitrary string
5. In Burp Interceptor, replace the encrypted device name with `G9rm2IHsRj9cNg==` (random data)
6. Forward the request to the backend
7. On device A, go to settings>sync & backup
8. Ensure only one device is shown
9. On device B, go to settings>sync & backup
10. Check that the device has been logged out

_Feature 1_
- [ ] Automatically logout invalid devices
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
