### PR TITLE
Fix OOM crash on Timber.d

### DIFF
--- a/downloads/downloads-impl/build.gradle
+++ b/downloads/downloads-impl/build.gradle
@@ -67,7 +67,7 @@ dependencies {
         exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
     }
 
-    implementation JakeWharton.timber
+    implementation "com.squareup.logcat:logcat:_"
 
     // Room
     implementation AndroidX.room.runtime

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DownloadConfirmationFragment.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DownloadConfirmationFragment.kt
@@ -31,7 +31,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.android.support.AndroidSupportInjection
 import java.io.File
 import javax.inject.Inject
-import timber.log.Timber
+import logcat.logcat
 
 @InjectWith(FragmentScope::class)
 class DownloadConfirmationFragment : BottomSheetDialogFragment() {
@@ -89,7 +89,7 @@ class DownloadConfirmationFragment : BottomSheetDialogFragment() {
             dismiss()
         }
         binding.cancel.setOnClickListener {
-            Timber.i("Cancelled download for url ${pendingDownload.url}")
+            logcat { "Cancelled download for url ${pendingDownload.url}" }
             listener.cancelDownload()
             dismiss()
         }

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DownloaderUtil.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DownloaderUtil.kt
@@ -24,7 +24,7 @@ import java.util.Locale
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 import kotlin.jvm.Throws
-import timber.log.Timber
+import logcat.logcat
 
 object DownloaderUtil {
 
@@ -132,7 +132,7 @@ object DownloaderUtil {
         val mimeTypeFromFileExtension = MimeTypeMap.getSingleton().getMimeTypeFromExtension(fileExtension)
 
         if (mimeTypeFromFileExtension != null) {
-            Timber.d("File extension $fileExtension matched mime type $mimeTypeFromFileExtension.")
+            logcat { "File extension $fileExtension matched mime type $mimeTypeFromFileExtension." }
             return ".$fileExtension"
         }
 

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/FileDownloadCallback.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/FileDownloadCallback.kt
@@ -21,9 +21,15 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.downloads.api.*
+import com.duckduckgo.downloads.api.DownloadCommand.ShowDownloadStartedMessage
+import com.duckduckgo.downloads.api.DownloadCommand.ShowDownloadSuccessMessage
 import com.duckduckgo.downloads.api.DownloadFailReason.*
 import com.duckduckgo.downloads.api.model.DownloadItem
+import com.duckduckgo.downloads.impl.R.string
 import com.duckduckgo.downloads.impl.pixels.DownloadsPixelName
+import com.duckduckgo.downloads.impl.pixels.DownloadsPixelName.DOWNLOAD_REQUEST_FAILED
+import com.duckduckgo.downloads.impl.pixels.DownloadsPixelName.DOWNLOAD_REQUEST_STARTED
+import com.duckduckgo.downloads.impl.pixels.DownloadsPixelName.DOWNLOAD_REQUEST_SUCCEEDED
 import com.duckduckgo.downloads.store.DownloadStatus.FINISHED
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
@@ -35,7 +41,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
-import timber.log.Timber
+import logcat.logcat
 
 interface DownloadCallback {
     /**
@@ -94,10 +100,10 @@ class FileDownloadCallback @Inject constructor(
     private val command = Channel<DownloadCommand>(1, BufferOverflow.DROP_OLDEST)
 
     override fun onStart(downloadItem: DownloadItem) {
-        Timber.d("Download started for file ${downloadItem.fileName}")
-        pixel.fire(DownloadsPixelName.DOWNLOAD_REQUEST_STARTED)
-        val downloadStartedMessage = DownloadCommand.ShowDownloadStartedMessage(
-            messageId = R.string.downloadsDownloadStartedMessage,
+        logcat { "Download started for file ${downloadItem.fileName}" }
+        pixel.fire(DOWNLOAD_REQUEST_STARTED)
+        val downloadStartedMessage = ShowDownloadStartedMessage(
+            messageId = string.downloadsDownloadStartedMessage,
             fileName = downloadItem.fileName,
         )
         fileDownloadNotificationManager.showDownloadInProgressNotification(downloadItem.downloadId, downloadItem.fileName)
@@ -112,8 +118,8 @@ class FileDownloadCallback @Inject constructor(
     }
 
     override fun onSuccess(downloadId: Long, contentLength: Long, file: File, mimeType: String?) {
-        Timber.d("Download succeeded for file ${file.name} / $mimeType / $contentLength")
-        pixel.fire(DownloadsPixelName.DOWNLOAD_REQUEST_SUCCEEDED)
+        logcat { "Download succeeded for file ${file.name} / $mimeType / $contentLength" }
+        pixel.fire(DOWNLOAD_REQUEST_SUCCEEDED)
         fileDownloadNotificationManager.showDownloadFinishedNotification(
             downloadId = downloadId,
             file = file,
@@ -124,8 +130,8 @@ class FileDownloadCallback @Inject constructor(
             mediaScanner.scan(file)
             downloadsRepository.getDownloadItem(downloadId)?.let {
                 command.send(
-                    DownloadCommand.ShowDownloadSuccessMessage(
-                        messageId = R.string.downloadsDownloadFinishedMessage,
+                    ShowDownloadSuccessMessage(
+                        messageId = string.downloadsDownloadFinishedMessage,
                         fileName = it.fileName,
                         filePath = it.filePath,
                     ),
@@ -135,8 +141,8 @@ class FileDownloadCallback @Inject constructor(
     }
 
     override fun onSuccess(file: File, mimeType: String?) {
-        Timber.d("Download succeeded for file with name ${file.name} / $mimeType")
-        pixel.fire(DownloadsPixelName.DOWNLOAD_REQUEST_SUCCEEDED)
+        logcat { "Download succeeded for file with name ${file.name} / $mimeType" }
+        pixel.fire(DOWNLOAD_REQUEST_SUCCEEDED)
         fileDownloadNotificationManager.showDownloadFinishedNotification(
             downloadId = 0,
             file = file,
@@ -146,8 +152,8 @@ class FileDownloadCallback @Inject constructor(
             downloadsRepository.update(fileName = file.name, downloadStatus = FINISHED, contentLength = file.length())
             mediaScanner.scan(file)
             command.send(
-                DownloadCommand.ShowDownloadSuccessMessage(
-                    messageId = R.string.downloadsDownloadFinishedMessage,
+                ShowDownloadSuccessMessage(
+                    messageId = string.downloadsDownloadFinishedMessage,
                     fileName = file.name,
                     filePath = file.absolutePath,
                     mimeType = mimeType,
@@ -157,8 +163,8 @@ class FileDownloadCallback @Inject constructor(
     }
 
     override fun onError(url: String?, downloadId: Long?, reason: DownloadFailReason) {
-        Timber.d("Failed to download file with url $url (id = $downloadId) and reason $reason.")
-        pixel.fire(DownloadsPixelName.DOWNLOAD_REQUEST_FAILED)
+        logcat { "Failed to download file with url $url (id = $downloadId) and reason $reason." }
+        pixel.fire(DOWNLOAD_REQUEST_FAILED)
         handleFailedDownload(downloadId = downloadId ?: 0, url = url, reason = reason)
         downloadId?.let {
             appCoroutineScope.launch(dispatchers.io()) {
@@ -175,9 +181,9 @@ class FileDownloadCallback @Inject constructor(
         appCoroutineScope.launch(dispatchers.io()) {
             val item = downloadsRepository.getDownloadItem(downloadId)
             if (item == null) {
-                Timber.d("Cancelled download file with downloadId $downloadId from the app.")
+                logcat { "Cancelled download file with downloadId $downloadId from the app." }
             } else {
-                Timber.d("Cancelled to download file with downloadId $downloadId from the notification.")
+                logcat { "Cancelled to download file with downloadId $downloadId from the notification." }
                 downloadsRepository.delete(listOf(downloadId))
             }
             pixel.fire(DownloadsPixelName.DOWNLOAD_REQUEST_CANCELLED)

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/FilenameExtractor.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/FilenameExtractor.kt
@@ -23,7 +23,7 @@ import com.duckduckgo.downloads.impl.FilenameExtractor.GuessQuality.NotGoodEnoug
 import com.duckduckgo.downloads.impl.FilenameExtractor.GuessQuality.TriedAllOptions
 import java.io.File
 import javax.inject.Inject
-import timber.log.Timber
+import logcat.logcat
 
 class FilenameExtractor @Inject constructor(
     private val pixel: Pixel,
@@ -77,7 +77,7 @@ class FilenameExtractor @Inject constructor(
             guessedFilename = guessedFilename.removeSuffix(DEFAULT_FILE_TYPE)
         }
 
-        Timber.v("From URL [$url], guessed [$guessedFilename]")
+        logcat { "From URL [$url], guessed [$guessedFilename]" }
         return guessedFilename
     }
 

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/UrlFileDownloadCallManager.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/UrlFileDownloadCallManager.kt
@@ -21,9 +21,9 @@ import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
+import logcat.logcat
 import okhttp3.ResponseBody
 import retrofit2.Call
-import timber.log.Timber
 
 interface UrlFileDownloadCallManager {
     fun add(downloadId: Long, call: Call<ResponseBody>)
@@ -44,7 +44,7 @@ class RealUrlFileDownloadCallManager @Inject constructor() : UrlFileDownloadCall
      * It is safe to call this method multiple times with the same [downloadId].
      */
     override fun remove(downloadId: Long) {
-        Timber.d("Removing download $downloadId")
+        logcat { "Removing download $downloadId" }
         callsMap[downloadId]?.cancel()
         callsMap.remove(downloadId)
     }
@@ -54,7 +54,7 @@ class RealUrlFileDownloadCallManager @Inject constructor() : UrlFileDownloadCall
      * The ongoing download is identified by its [downloadId] and the network [call].
      */
     override fun add(downloadId: Long, call: Call<ResponseBody>) {
-        Timber.d("Adding download $downloadId")
+        logcat { "Adding download $downloadId" }
         callsMap[downloadId] = call
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1206718079780225/f

### Description
Fix a OOM crash that happens in production when using Timber.d() and parameters are larged. In this case a url that embeds a file to download

The fix is replacing Timber by logcat, which is something we wanted to do anyways little by little.

### Steps to test this PR
NA, just code review
