### PR TITLE
Ensure nullTun is null on error/timeout

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
@@ -103,6 +103,8 @@ enum class DeviceShieldPixelNames(override val pixelName: String, val enqueue: B
 
     ATP_ESTABLISH_TUN_INTERFACE_ERROR_DAILY("m_atp_ev_establish_tun_error_d"),
     ATP_ESTABLISH_TUN_INTERFACE_ERROR("m_atp_ev_establish_tun_error_c"),
+    ATP_ESTABLISH_NULL_TUN_INTERFACE_ERROR_DAILY("m_atp_ev_establish_null_tun_error_d"),
+    ATP_ESTABLISH_NULL_TUN_INTERFACE_ERROR("m_atp_ev_establish_null_tun_error_c"),
 
     ATP_PROCESS_EXPENDABLE_LOW_DAILY("m_atp_ev_expen_memory_low_d"),
     ATP_PROCESS_EXPENDABLE_MODERATE_DAILY("m_atp_ev_expen_memory_moderate_d"),

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
@@ -199,7 +199,15 @@ interface DeviceShieldPixels {
      */
     fun privacyReportOnboardingFAQDisplayed()
 
+    /**
+     * Will fire when the there's an error establishing the TUN interface
+     */
     fun vpnEstablishTunInterfaceError()
+
+    /**
+     * Will fire when the there's an error establishing the null TUN interface
+     */
+    fun vpnEstablishNullTunInterfaceError()
 
     /** Will fire when the process has gone to the expendable list */
     fun vpnProcessExpendableLow(payload: Map<String, String>)
@@ -538,6 +546,11 @@ class RealDeviceShieldPixels @Inject constructor(
     override fun vpnEstablishTunInterfaceError() {
         tryToFireDailyPixel(DeviceShieldPixelNames.ATP_ESTABLISH_TUN_INTERFACE_ERROR_DAILY)
         firePixel(DeviceShieldPixelNames.ATP_ESTABLISH_TUN_INTERFACE_ERROR)
+    }
+
+    override fun vpnEstablishNullTunInterfaceError() {
+        tryToFireDailyPixel(DeviceShieldPixelNames.ATP_ESTABLISH_NULL_TUN_INTERFACE_ERROR_DAILY)
+        firePixel(DeviceShieldPixelNames.ATP_ESTABLISH_NULL_TUN_INTERFACE_ERROR)
     }
 
     override fun vpnProcessExpendableLow(payload: Map<String, String>) {

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
@@ -319,12 +319,14 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope(), V
         val nullTun = createNullRouteTempTunnel()?.let {
             if (!it.waitForTunnelUpOrTimeout()) {
                 logcat(WARN) { "VPN log: timeout waiting for null tunnel to go up" }
+                null
+            } else {
+                it
             }
-            it
         }
         if (nullTun == null) {
-            logcat(ERROR) { "VPN log: Failed to establish the TUN interface" }
-            deviceShieldPixels.vpnEstablishTunInterfaceError()
+            logcat(ERROR) { "VPN log: Failed to establish the null TUN interface" }
+            deviceShieldPixels.vpnEstablishNullTunInterfaceError()
             stopVpn(VpnStopReason.ERROR, false)
             return@withContext
         }
@@ -529,7 +531,6 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope(), V
 
         if (tunInterface == null) {
             logcat(ERROR) { "VPN log: Failed to establish VPN tunnel" }
-            stopVpn(VpnStopReason.ERROR, false)
         } else {
             logcat { "VPN log: Final TUN interface created ${tunInterface.fd}" }
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1206718079780252/f

### Description
Ensure the `nullTun` is set to `null` upon failure so that we stop the VPN rather than risking progressing in unstable state

### Steps to test this PR
Smoke tests AppTP/VPN
