### PR TITLE
Add transparent video poster image

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserChromeClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserChromeClientTest.kt
@@ -20,6 +20,7 @@ package com.duckduckgo.app.browser
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.Color
 import android.net.Uri
 import android.os.Message
 import android.view.View
@@ -27,6 +28,7 @@ import android.webkit.PermissionRequest
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import android.webkit.WebView
+import androidx.core.graphics.get
 import androidx.core.net.toUri
 import androidx.test.annotation.UiThreadTest
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
@@ -34,6 +36,7 @@ import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.site.permissions.api.SitePermissionsManager
 import com.duckduckgo.site.permissions.api.SitePermissionsManager.SitePermissions
+import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
@@ -241,6 +244,15 @@ class BrowserChromeClientTest {
         testee.onPermissionRequest(mockRequest)
 
         verify(mockWebViewClientListener, never()).onSitePermissionRequested(mockRequest, permissions)
+    }
+
+    @Test
+    fun whenGetDefaultVideoPosterThenReturnTransparentPixel() = runTest {
+        val bitmap = testee.defaultVideoPoster
+
+        assertEquals(1, bitmap.width)
+        assertEquals(1, bitmap.height)
+        assertEquals(Color.TRANSPARENT, bitmap[0, 0])
     }
 
     private val mockMsg = Message().apply {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserChromeClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserChromeClient.kt
@@ -17,10 +17,18 @@
 package com.duckduckgo.app.browser
 
 import android.graphics.Bitmap
+import android.graphics.Bitmap.Config.ARGB_8888
+import android.graphics.Color
 import android.net.Uri
 import android.os.Message
 import android.view.View
-import android.webkit.*
+import android.webkit.GeolocationPermissions
+import android.webkit.JsPromptResult
+import android.webkit.JsResult
+import android.webkit.PermissionRequest
+import android.webkit.ValueCallback
+import android.webkit.WebChromeClient
+import android.webkit.WebView
 import com.duckduckgo.app.browser.navigation.safeCopyBackForwardList
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
@@ -205,5 +213,9 @@ class BrowserChromeClient @Inject constructor(
         callback: GeolocationPermissions.Callback,
     ) {
         webViewClientListener?.onSiteLocationPermissionRequested(origin, callback)
+    }
+
+    override fun getDefaultVideoPoster(): Bitmap {
+        return Bitmap.createBitmap(intArrayOf(Color.TRANSPARENT), 1, 1, ARGB_8888)
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1206703905023237/f

### Description
Removes `WebChromeClient`’s default video poster image

### Steps to test this PR
- [x] Go to a site that has videos with this issue (e.g. facebook.com)
- [x] Verify that the poster image is gone

### UI changes
| Before  | After |
| ------ | ----- |
![Screenshot_20240301_114505](https://github.com/duckduckgo/Android/assets/3471025/c9358580-897f-48e3-b6fb-ad87dee36fe4)|![Screenshot_20240301_115254](https://github.com/duckduckgo/Android/assets/3471025/82927cc0-9fa9-400e-9ca4-1645692862c0)


