### PR TITLE
Fix landscape menu width

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/menu/BrowserPopupMenu.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/menu/BrowserPopupMenu.kt
@@ -17,9 +17,7 @@
 package com.duckduckgo.app.browser.menu
 
 import android.content.Context
-import android.content.res.Configuration
 import android.view.LayoutInflater
-import android.view.ViewGroup.LayoutParams
 import androidx.core.view.isVisible
 import com.duckduckgo.app.browser.BrowserTabViewModel.BrowserViewState
 import com.duckduckgo.app.browser.R
@@ -34,7 +32,7 @@ class BrowserPopupMenu(
 ) : PopupMenu(
     layoutInflater,
     resourceId = R.layout.popup_window_browser_menu,
-    width = getPopupMenuWidth(context),
+    width = context.resources.getDimensionPixelSize(dimen.popupMenuWidth),
 ) {
     private val binding = PopupWindowBrowserMenuBinding.inflate(layoutInflater)
 
@@ -113,14 +111,5 @@ class BrowserPopupMenu(
             binding.printPageMenuItem.isVisible = viewState.canPrintPage
             binding.autofillMenuItem.isVisible = viewState.showAutofill
         }
-    }
-}
-
-private fun getPopupMenuWidth(context: Context): Int {
-    val orientation = context.resources.configuration.orientation
-    return if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
-        LayoutParams.WRAP_CONTENT
-    } else {
-        context.resources.getDimensionPixelSize(dimen.popupMenuWidth)
     }
 }


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1206738710607101/f

### Description
Makes the browser menu the same width in portrait and landscape.

### Steps to test this PR
- [ ] Verify that the menu is the correct width on a Pixel Fold in landscape.

### UI changes
| Before  | After |
| ------ | ----- |
![pixel fold before](https://github.com/duckduckgo/Android/assets/3471025/60ab2889-de8f-4d34-a4be-dd8a213ed3e0)|![pixel fold after](https://github.com/duckduckgo/Android/assets/3471025/3afb97f1-652a-44df-a5b8-ca7dc1b3143b)


