### PR TITLE
Make vpn internal receivers exported

### DIFF
--- a/app-tracking-protection/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/InternalFeatureReceiver.kt
+++ b/app-tracking-protection/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/InternalFeatureReceiver.kt
@@ -20,7 +20,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import com.duckduckgo.common.utils.extensions.registerNotExportedReceiver
+import com.duckduckgo.common.utils.extensions.registerExportedReceiver
 
 /**
  * Abstract class to create generic receivers for internal features accessible through
@@ -45,7 +45,8 @@ abstract class InternalFeatureReceiver(
 
     fun register() {
         unregister()
-        context.registerNotExportedReceiver(this, IntentFilter(intentAction()))
+        // needs exported because it's registered    on the :vpn process but can be intent-trigger from the :app process
+        context.registerExportedReceiver(this, IntentFilter(intentAction()))
     }
 
     fun unregister() {

--- a/app-tracking-protection/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/rules/ExceptionRulesDebugReceiver.kt
+++ b/app-tracking-protection/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/rules/ExceptionRulesDebugReceiver.kt
@@ -21,7 +21,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import com.duckduckgo.common.utils.DispatcherProvider
-import com.duckduckgo.common.utils.extensions.registerNotExportedReceiver
+import com.duckduckgo.common.utils.extensions.registerExportedReceiver
 import com.duckduckgo.di.scopes.VpnScope
 import com.duckduckgo.mobile.android.vpn.service.VpnServiceCallbacks
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnStopReason
@@ -49,7 +49,8 @@ class ExceptionRulesDebugReceiver(
 
     init {
         kotlin.runCatching { context.unregisterReceiver(this) }
-        context.registerNotExportedReceiver(this, IntentFilter(intentAction))
+        // needs to be exported because it's register on the :vpn process but can be intent-trigger from the :app process
+        context.registerExportedReceiver(this, IntentFilter(intentAction))
     }
 
     override fun onReceive(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1206752051778589/f

### Description
Make the internal receivers exported so they work across processess

### Steps to test this PR
- [ ] enable AppTP
- [ ]

