### PR TITLE
Add voice language check

### DIFF
--- a/voice-search/voice-search-impl/src/main/AndroidManifest.xml
+++ b/voice-search/voice-search-impl/src/main/AndroidManifest.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2024 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.duckduckgo.voice.impl">
+
+    <application>
+        <receiver android:name=".language.LocaleChangeReceiver" android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.LOCALE_CHANGED" />
+            </intent-filter>
+        </receiver>
+    </application>
+
+</manifest>

--- a/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/RealVoiceSearchAvailability.kt
+++ b/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/RealVoiceSearchAvailability.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.voice.impl
 
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.voice.api.VoiceSearchAvailability
+import com.duckduckgo.voice.impl.language.LanguageSupportChecker
 import com.duckduckgo.voice.impl.remoteconfig.VoiceSearchFeature
 import com.duckduckgo.voice.impl.remoteconfig.VoiceSearchFeatureRepository
 import com.duckduckgo.voice.store.VoiceSearchRepository
@@ -30,6 +31,7 @@ class RealVoiceSearchAvailability @Inject constructor(
     private val voiceSearchFeature: VoiceSearchFeature,
     private val voiceSearchFeatureRepository: VoiceSearchFeatureRepository,
     private val voiceSearchRepository: VoiceSearchRepository,
+    private val languageSupportChecker: LanguageSupportChecker,
 ) : VoiceSearchAvailability {
     companion object {
         private const val URL_DDG_SERP = "https://duckduckgo.com/?"
@@ -40,6 +42,7 @@ class RealVoiceSearchAvailability @Inject constructor(
             voiceSearchFeature.self().isEnabled() &&
                 hasValidVersion(sdkInt) &&
                 isOnDeviceSpeechRecognitionSupported &&
+                languageSupportChecker.isLanguageSupported() &&
                 hasValidLocale(languageTag) &&
                 voiceSearchFeatureRepository.manufacturerExceptions.none { it.name == deviceManufacturer }
         }

--- a/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/language/LanguageSupportChecker.kt
+++ b/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/language/LanguageSupportChecker.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.voice.impl.language
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.os.Build.VERSION_CODES
+import android.speech.RecognitionSupport
+import android.speech.RecognitionSupportCallback
+import androidx.annotation.RequiresApi
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.voice.impl.VoiceSearchAvailabilityConfigProvider
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+interface LanguageSupportChecker {
+    fun isLanguageSupported(): Boolean
+    fun checkLanguageSupport(languageTag: String)
+}
+
+@SuppressLint("NewApi")
+@ContributesBinding(AppScope::class)
+@SingleInstanceIn(AppScope::class)
+class RealLanguageSupportChecker @Inject constructor(
+    private val context: Context,
+    configProvider: VoiceSearchAvailabilityConfigProvider,
+    private val languageSupportCheckerDelegate: LanguageSupportCheckerDelegate,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    dispatcherProvider: DispatcherProvider,
+) : LanguageSupportChecker {
+    private var isLanguageSupported: Boolean? = null
+
+    init {
+        val config = configProvider.get()
+        if (config.sdkInt >= VERSION_CODES.TIRAMISU) {
+            appCoroutineScope.launch(dispatcherProvider.main()) {
+                checkLanguageSupport(config.languageTag)
+            }
+        }
+    }
+
+    @RequiresApi(VERSION_CODES.TIRAMISU)
+    override fun checkLanguageSupport(languageTag: String) {
+        languageSupportCheckerDelegate.checkRecognitionSupport(
+            context,
+            languageTag,
+            object : RecognitionSupportCallback {
+                override fun onSupportResult(recognitionSupport: RecognitionSupport) {
+                    isLanguageSupported = languageTag in recognitionSupport.installedOnDeviceLanguages
+                }
+
+                override fun onError(error: Int) {
+                    isLanguageSupported = false
+                }
+            },
+        )
+    }
+
+    override fun isLanguageSupported(): Boolean {
+        return isLanguageSupported ?: false
+    }
+}

--- a/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/language/LanguageSupportCheckerDelegate.kt
+++ b/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/language/LanguageSupportCheckerDelegate.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.voice.impl.language
+
+import android.content.Context
+import android.content.Intent
+import android.os.Build.VERSION_CODES
+import android.speech.RecognitionSupportCallback
+import android.speech.RecognizerIntent
+import android.speech.SpeechRecognizer.createOnDeviceSpeechRecognizer
+import androidx.annotation.RequiresApi
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import java.util.concurrent.Executors
+import javax.inject.Inject
+
+interface LanguageSupportCheckerDelegate {
+    fun checkRecognitionSupport(context: Context, languageTag: String, callback: RecognitionSupportCallback)
+}
+
+@ContributesBinding(AppScope::class)
+class RealLanguageSupportCheckerDelegate @Inject constructor() : LanguageSupportCheckerDelegate {
+    @RequiresApi(VERSION_CODES.TIRAMISU)
+    override fun checkRecognitionSupport(context: Context, languageTag: String, callback: RecognitionSupportCallback) {
+        createOnDeviceSpeechRecognizer(context).checkRecognitionSupport(
+            Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH),
+            Executors.newSingleThreadExecutor(),
+            callback,
+        )
+    }
+}

--- a/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/language/LocaleChangeReceiver.kt
+++ b/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/language/LocaleChangeReceiver.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.voice.impl.language
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.di.scopes.ReceiverScope
+import com.duckduckgo.voice.impl.VoiceSearchAvailabilityConfigProvider
+import dagger.android.AndroidInjection
+import javax.inject.Inject
+
+@InjectWith(ReceiverScope::class)
+class LocaleChangeReceiver : BroadcastReceiver() {
+
+    @Inject lateinit var languageSupportChecker: LanguageSupportChecker
+
+    @Inject lateinit var configProvider: VoiceSearchAvailabilityConfigProvider
+
+    override fun onReceive(context: Context, intent: Intent) {
+        AndroidInjection.inject(this, context)
+
+        if (intent.action == Intent.ACTION_LOCALE_CHANGED) {
+            languageSupportChecker.checkLanguageSupport(configProvider.get().languageTag)
+        }
+    }
+}

--- a/voice-search/voice-search-impl/src/test/java/com/duckduckgo/voice/impl/language/RealLanguageSupportCheckerTest.kt
+++ b/voice-search/voice-search-impl/src/test/java/com/duckduckgo/voice/impl/language/RealLanguageSupportCheckerTest.kt
@@ -1,0 +1,114 @@
+import android.content.Context
+import android.speech.RecognitionSupport
+import android.speech.RecognitionSupportCallback
+import android.speech.SpeechRecognizer
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.voice.impl.VoiceSearchAvailabilityConfig
+import com.duckduckgo.voice.impl.VoiceSearchAvailabilityConfigProvider
+import com.duckduckgo.voice.impl.language.LanguageSupportCheckerDelegate
+import com.duckduckgo.voice.impl.language.RealLanguageSupportChecker
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+
+@ExperimentalCoroutinesApi
+class RealLanguageSupportCheckerTest {
+
+    @get:Rule
+    var coroutineRule = CoroutineTestRule()
+
+    @Mock
+    private lateinit var context: Context
+
+    @Mock
+    private lateinit var configProvider: VoiceSearchAvailabilityConfigProvider
+
+    @Mock
+    private lateinit var languageSupportCheckerDelegate: LanguageSupportCheckerDelegate
+
+    private lateinit var languageSupportChecker: RealLanguageSupportChecker
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+
+        val config = VoiceSearchAvailabilityConfig("Samsung", 33, "en-US", true)
+        whenever(configProvider.get()).thenReturn(config)
+    }
+
+    private fun instantiate() {
+        languageSupportChecker = RealLanguageSupportChecker(
+            context,
+            configProvider,
+            languageSupportCheckerDelegate,
+            TestScope(),
+            coroutineRule.testDispatcherProvider,
+        )
+    }
+
+    @Test
+    fun whenLanguageInstalledThenLanguageIsSupported() {
+        instantiate()
+
+        val callbackCaptor = argumentCaptor<RecognitionSupportCallback>()
+        verify(languageSupportCheckerDelegate).checkRecognitionSupport(eq(context), eq("en-US"), callbackCaptor.capture())
+
+        callbackCaptor.firstValue.onSupportResult(
+            mock(RecognitionSupport::class.java).apply {
+                whenever(this.installedOnDeviceLanguages).thenReturn(listOf("en-US"))
+            },
+        )
+        assertTrue(languageSupportChecker.isLanguageSupported())
+    }
+
+    @Test
+    fun whenLanguageNotInstalledThenLanguageIsNotSupported() {
+        instantiate()
+
+        val callbackCaptor = argumentCaptor<RecognitionSupportCallback>()
+        verify(languageSupportCheckerDelegate).checkRecognitionSupport(eq(context), eq("en-US"), callbackCaptor.capture())
+
+        callbackCaptor.firstValue.onSupportResult(
+            mock(RecognitionSupport::class.java).apply {
+                whenever(this.installedOnDeviceLanguages).thenReturn(listOf("de-ZA"))
+            },
+        )
+        assertFalse(languageSupportChecker.isLanguageSupported())
+    }
+
+    @Test
+    fun whenSpeechRecognizerErrorThenLanguageIsNotSupported() {
+        instantiate()
+
+        val callbackCaptor = argumentCaptor<RecognitionSupportCallback>()
+        verify(languageSupportCheckerDelegate).checkRecognitionSupport(eq(context), eq("en-US"), callbackCaptor.capture())
+
+        callbackCaptor.firstValue.onError(SpeechRecognizer.ERROR_CANNOT_CHECK_SUPPORT)
+
+        assertFalse(languageSupportChecker.isLanguageSupported())
+    }
+
+    @Test
+    fun whenSdkLowerThanTiramisuThenLanguageIsNotSupported() {
+        val config = VoiceSearchAvailabilityConfig("Samsung", 32, "en-US", true)
+        whenever(configProvider.get()).thenReturn(config)
+
+        instantiate()
+
+        verifyNoInteractions(languageSupportCheckerDelegate)
+
+        assertFalse(languageSupportChecker.isLanguageSupported())
+    }
+}


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1206752616572876/f

### Description
Determines if the matching locale language packs are installed for voice search.
- Uses `SpeechRecognizer.checkRecognitionSupport()` to determine `isLanguageSupported()`.
- Uses `Intent.ACTION_LOCALE_CHANGED` to update the UI if the locale is changed.

### Steps to test this PR

_With matching locale and voice pack_
- [x] Set the locale to `en-US`.
- [x] Go to system Settings > Android System Intelligence.
- [ ] Verify that the English (US) voice pack is installed.
- [x] Install from this branch and go to Settings > Accessibility.
- [x] Verify that the voice search setting is available.
- [x] Enable voice search.
- [x] Verify that voice search works correctly.

_With non-matching locale and voice pack_
- [x] Set the locale to `de-US` (Or similar unsupported locale).
- [x] Open the app.
- [x] Verify that the voice search icon has been removed.
- [x] Go to Settings > Accessibility.
- [x] Verify that the setting is not available.

