### PR TITLE
Sync: Add field validation

### DIFF
--- a/app/src/test/java/com/duckduckgo/app/bookmarks/BookmarkTestUtils.kt
+++ b/app/src/test/java/com/duckduckgo/app/bookmarks/BookmarkTestUtils.kt
@@ -84,6 +84,16 @@ object BookmarkTestUtils {
         return relations
     }
 
+    fun createInvalidBookmark(): Bookmark {
+        val veryLongTitle = String(CharArray(3000) { 'a' + (it % 26) })
+        return aBookmark(id = "invalid", title = veryLongTitle, url = "invalid")
+    }
+
+    fun createInvalidFolder(): BookmarkFolder {
+        val veryLongName = String(CharArray(3000) { 'a' + (it % 26) })
+        return aBookmarkFolder(id = "invalidFolder", name = veryLongName, parentId = SavedSitesNames.BOOKMARKS_ROOT)
+    }
+
     fun aBookmarkFolder(
         id: String,
         name: String,

--- a/app/src/test/java/com/duckduckgo/app/bookmarks/model/SavedSitesParserTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/bookmarks/model/SavedSitesParserTest.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
 import com.duckduckgo.savedsites.api.models.SavedSite.Favorite
 import com.duckduckgo.savedsites.api.models.SavedSitesNames
 import com.duckduckgo.savedsites.api.models.TreeNode
+import com.duckduckgo.savedsites.impl.MissingEntitiesRelationReconciler
 import com.duckduckgo.savedsites.impl.RealFavoritesDelegate
 import com.duckduckgo.savedsites.impl.RealSavedSitesRepository
 import com.duckduckgo.savedsites.impl.service.RealSavedSitesParser
@@ -86,12 +87,14 @@ class SavedSitesParserTest {
             savedSitesEntitiesDao,
             savedSitesRelationsDao,
             savedSitesSettingsRepository,
+            MissingEntitiesRelationReconciler(savedSitesEntitiesDao),
             coroutinesTestRule.testDispatcherProvider,
         )
         repository = RealSavedSitesRepository(
             savedSitesEntitiesDao,
             savedSitesRelationsDao,
             favoritesDelegate,
+            MissingEntitiesRelationReconciler(savedSitesEntitiesDao),
             coroutinesTestRule.testDispatcherProvider,
         )
         parser = RealSavedSitesParser()

--- a/app/src/test/java/com/duckduckgo/app/bookmarks/model/SavedSitesRepositoryTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/bookmarks/model/SavedSitesRepositoryTest.kt
@@ -34,6 +34,7 @@ import com.duckduckgo.savedsites.api.models.FolderBranch
 import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
 import com.duckduckgo.savedsites.api.models.SavedSite.Favorite
 import com.duckduckgo.savedsites.api.models.SavedSitesNames
+import com.duckduckgo.savedsites.impl.MissingEntitiesRelationReconciler
 import com.duckduckgo.savedsites.impl.RealFavoritesDelegate
 import com.duckduckgo.savedsites.impl.RealSavedSitesRepository
 import com.duckduckgo.savedsites.store.Entity
@@ -80,9 +81,17 @@ class SavedSitesRepositoryTest {
             savedSitesEntitiesDao,
             savedSitesRelationsDao,
             favoritesDisplayModeSettings,
+            MissingEntitiesRelationReconciler(savedSitesEntitiesDao),
             coroutineRule.testDispatcherProvider,
         )
-        repository = RealSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, favoritesDelegate, coroutineRule.testDispatcherProvider)
+        val relationsReconciler = MissingEntitiesRelationReconciler(savedSitesEntitiesDao)
+        repository = RealSavedSitesRepository(
+            savedSitesEntitiesDao,
+            savedSitesRelationsDao,
+            favoritesDelegate,
+            relationsReconciler,
+            coroutineRule.testDispatcherProvider,
+        )
     }
 
     @After

--- a/app/src/test/java/com/duckduckgo/app/bookmarks/service/SavedSitesExporterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/bookmarks/service/SavedSitesExporterTest.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
 import com.duckduckgo.savedsites.api.models.SavedSitesNames
 import com.duckduckgo.savedsites.api.models.TreeNode
 import com.duckduckgo.savedsites.api.service.ExportSavedSitesResult
+import com.duckduckgo.savedsites.impl.MissingEntitiesRelationReconciler
 import com.duckduckgo.savedsites.impl.RealFavoritesDelegate
 import com.duckduckgo.savedsites.impl.RealSavedSitesRepository
 import com.duckduckgo.savedsites.impl.service.RealSavedSitesExporter
@@ -76,6 +77,7 @@ class SavedSitesExporterTest {
             savedSitesEntitiesDao,
             savedSitesRelationsDao,
             savedSitesSettingsRepository,
+            MissingEntitiesRelationReconciler(savedSitesEntitiesDao),
             coroutinesTestRule.testDispatcherProvider,
         )
 
@@ -83,6 +85,7 @@ class SavedSitesExporterTest {
             savedSitesEntitiesDao,
             savedSitesRelationsDao,
             favoritesDelegate,
+            MissingEntitiesRelationReconciler(savedSitesEntitiesDao),
             coroutinesTestRule.testDispatcherProvider,
         )
 

--- a/app/src/test/java/com/duckduckgo/app/sync/SavedSitesSyncDataProviderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/sync/SavedSitesSyncDataProviderTest.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.savedsites.api.models.SavedSite
 import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
 import com.duckduckgo.savedsites.api.models.SavedSite.Favorite
 import com.duckduckgo.savedsites.api.models.SavedSitesNames
+import com.duckduckgo.savedsites.impl.MissingEntitiesRelationReconciler
 import com.duckduckgo.savedsites.impl.RealFavoritesDelegate
 import com.duckduckgo.savedsites.impl.RealSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.RealSavedSitesFormFactorSyncMigration
@@ -118,6 +119,7 @@ class SavedSitesSyncDataProviderTest {
             savedSitesEntitiesDao,
             savedSitesRelationsDao,
             savedSitesSettingsRepository,
+            MissingEntitiesRelationReconciler(savedSitesEntitiesDao),
             coroutinesTestRule.testDispatcherProvider,
         )
 
@@ -126,6 +128,7 @@ class SavedSitesSyncDataProviderTest {
             savedSitesEntitiesDao,
             savedSitesRelationsDao,
             favoritesDelegate,
+            MissingEntitiesRelationReconciler(savedSitesEntitiesDao),
             coroutinesTestRule.testDispatcherProvider,
         )
         store = RealSavedSitesSyncStore(

--- a/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesDeduplicationPersisterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesDeduplicationPersisterTest.kt
@@ -38,6 +38,7 @@ import com.duckduckgo.savedsites.impl.sync.SyncSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.algorithm.RealSavedSitesDuplicateFinder
 import com.duckduckgo.savedsites.impl.sync.algorithm.SavedSitesDeduplicationPersister
 import com.duckduckgo.savedsites.impl.sync.algorithm.SavedSitesDuplicateFinder
+import com.duckduckgo.savedsites.impl.sync.store.RealSavedSitesSyncEntitiesStore
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDao
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDatabase
 import com.duckduckgo.savedsites.store.SavedSitesEntitiesDao
@@ -67,8 +68,10 @@ class SavedSitesDeduplicationPersisterTest {
     private lateinit var savedSitesRelationsDao: SavedSitesRelationsDao
     private lateinit var savedSitesMetadataDao: SavedSitesSyncMetadataDao
     private lateinit var duplicateFinder: SavedSitesDuplicateFinder
-
     private lateinit var persister: SavedSitesDeduplicationPersister
+    private val store = RealSavedSitesSyncEntitiesStore(
+        InstrumentationRegistry.getInstrumentation().context,
+    )
 
     @Before
     fun setup() {
@@ -95,7 +98,7 @@ class SavedSitesDeduplicationPersisterTest {
             coroutinesTestRule.testDispatcherProvider,
         )
 
-        syncSavedSitesRepository = RealSyncSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, savedSitesMetadataDao)
+        syncSavedSitesRepository = RealSyncSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, savedSitesMetadataDao, store)
         repository = RealSavedSitesRepository(
             savedSitesEntitiesDao,
             savedSitesRelationsDao,

--- a/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesDeduplicationPersisterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesDeduplicationPersisterTest.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.savedsites.api.models.BookmarkFolder
 import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
 import com.duckduckgo.savedsites.api.models.SavedSitesNames
+import com.duckduckgo.savedsites.impl.MissingEntitiesRelationReconciler
 import com.duckduckgo.savedsites.impl.RealFavoritesDelegate
 import com.duckduckgo.savedsites.impl.RealSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.RealSyncSavedSitesRepository
@@ -90,6 +91,7 @@ class SavedSitesDeduplicationPersisterTest {
             savedSitesEntitiesDao,
             savedSitesRelationsDao,
             FakeDisplayModeSettingsRepository(),
+            MissingEntitiesRelationReconciler(savedSitesEntitiesDao),
             coroutinesTestRule.testDispatcherProvider,
         )
 
@@ -98,6 +100,7 @@ class SavedSitesDeduplicationPersisterTest {
             savedSitesEntitiesDao,
             savedSitesRelationsDao,
             favoritesDelegate,
+            MissingEntitiesRelationReconciler(savedSitesEntitiesDao),
             coroutinesTestRule.testDispatcherProvider,
         )
         duplicateFinder = RealSavedSitesDuplicateFinder(repository)

--- a/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesDuplicateFinderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesDuplicateFinderTest.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.savedsites.impl.sync.SyncSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.algorithm.RealSavedSitesDuplicateFinder
 import com.duckduckgo.savedsites.impl.sync.algorithm.SavedSitesDuplicateFinder
 import com.duckduckgo.savedsites.impl.sync.algorithm.SavedSitesDuplicateResult
+import com.duckduckgo.savedsites.impl.sync.store.RealSavedSitesSyncEntitiesStore
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDao
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDatabase
 import com.duckduckgo.savedsites.store.SavedSitesEntitiesDao
@@ -65,8 +66,10 @@ class SavedSitesDuplicateFinderTest {
     private lateinit var savedSitesEntitiesDao: SavedSitesEntitiesDao
     private lateinit var savedSitesRelationsDao: SavedSitesRelationsDao
     private lateinit var savedSitesMetadataDao: SavedSitesSyncMetadataDao
-
     private lateinit var duplicateFinder: SavedSitesDuplicateFinder
+    private val store = RealSavedSitesSyncEntitiesStore(
+        InstrumentationRegistry.getInstrumentation().context,
+    )
 
     @Before
     fun setup() {
@@ -93,7 +96,7 @@ class SavedSitesDuplicateFinderTest {
             coroutinesTestRule.testDispatcherProvider,
         )
 
-        syncRepository = RealSyncSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, savedSitesMetadataDao)
+        syncRepository = RealSyncSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, savedSitesMetadataDao, store)
         repository = RealSavedSitesRepository(
             savedSitesEntitiesDao,
             savedSitesRelationsDao,

--- a/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesDuplicateFinderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesDuplicateFinderTest.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.savedsites.api.models.BookmarkFolder
 import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
 import com.duckduckgo.savedsites.api.models.SavedSitesNames
+import com.duckduckgo.savedsites.impl.MissingEntitiesRelationReconciler
 import com.duckduckgo.savedsites.impl.RealFavoritesDelegate
 import com.duckduckgo.savedsites.impl.RealSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.RealSyncSavedSitesRepository
@@ -88,6 +89,7 @@ class SavedSitesDuplicateFinderTest {
             savedSitesEntitiesDao,
             savedSitesRelationsDao,
             FakeDisplayModeSettingsRepository(),
+            MissingEntitiesRelationReconciler(savedSitesEntitiesDao),
             coroutinesTestRule.testDispatcherProvider,
         )
 
@@ -96,6 +98,7 @@ class SavedSitesDuplicateFinderTest {
             savedSitesEntitiesDao,
             savedSitesRelationsDao,
             favoritesDelegate,
+            MissingEntitiesRelationReconciler(savedSitesEntitiesDao),
             coroutinesTestRule.testDispatcherProvider,
         )
 

--- a/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesLocalWinsPersisterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesLocalWinsPersisterTest.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.savedsites.api.models.BookmarkFolder
 import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
 import com.duckduckgo.savedsites.api.models.SavedSitesNames
+import com.duckduckgo.savedsites.impl.MissingEntitiesRelationReconciler
 import com.duckduckgo.savedsites.impl.RealFavoritesDelegate
 import com.duckduckgo.savedsites.impl.RealSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.RealSyncSavedSitesRepository
@@ -90,6 +91,7 @@ class SavedSitesLocalWinsPersisterTest {
             savedSitesEntitiesDao,
             savedSitesRelationsDao,
             FakeDisplayModeSettingsRepository(),
+            MissingEntitiesRelationReconciler(savedSitesEntitiesDao),
             coroutinesTestRule.testDispatcherProvider,
         )
         syncRepository = RealSyncSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, savedSitesMetadataDao)
@@ -97,6 +99,7 @@ class SavedSitesLocalWinsPersisterTest {
             savedSitesEntitiesDao,
             savedSitesRelationsDao,
             favoritesDelegate,
+            MissingEntitiesRelationReconciler(savedSitesEntitiesDao),
             coroutinesTestRule.testDispatcherProvider,
         )
         persister = SavedSitesLocalWinsPersister(repository, syncRepository)

--- a/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesLocalWinsPersisterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesLocalWinsPersisterTest.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.savedsites.impl.RealSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.RealSyncSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.SyncSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.algorithm.SavedSitesLocalWinsPersister
+import com.duckduckgo.savedsites.impl.sync.store.RealSavedSitesSyncEntitiesStore
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDao
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDatabase
 import com.duckduckgo.savedsites.store.SavedSitesEntitiesDao
@@ -64,8 +65,10 @@ class SavedSitesLocalWinsPersisterTest {
     private lateinit var savedSitesEntitiesDao: SavedSitesEntitiesDao
     private lateinit var savedSitesRelationsDao: SavedSitesRelationsDao
     private lateinit var savedSitesMetadataDao: SavedSitesSyncMetadataDao
-
     private lateinit var persister: SavedSitesLocalWinsPersister
+    private val store = RealSavedSitesSyncEntitiesStore(
+        InstrumentationRegistry.getInstrumentation().context,
+    )
 
     private val twoHoursAgo = DatabaseDateFormatter.iso8601(OffsetDateTime.now(ZoneOffset.UTC).minusHours(2))
 
@@ -94,7 +97,7 @@ class SavedSitesLocalWinsPersisterTest {
             MissingEntitiesRelationReconciler(savedSitesEntitiesDao),
             coroutinesTestRule.testDispatcherProvider,
         )
-        syncRepository = RealSyncSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, savedSitesMetadataDao)
+        syncRepository = RealSyncSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, savedSitesMetadataDao, store)
         repository = RealSavedSitesRepository(
             savedSitesEntitiesDao,
             savedSitesRelationsDao,

--- a/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesRemoteWinsPersisterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesRemoteWinsPersisterTest.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.savedsites.impl.RealSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.RealSyncSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.SyncSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.algorithm.SavedSitesRemoteWinsPersister
+import com.duckduckgo.savedsites.impl.sync.store.RealSavedSitesSyncEntitiesStore
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDao
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDatabase
 import com.duckduckgo.savedsites.store.SavedSitesEntitiesDao
@@ -64,8 +65,10 @@ class SavedSitesRemoteWinsPersisterTest {
     private lateinit var savedSitesEntitiesDao: SavedSitesEntitiesDao
     private lateinit var savedSitesRelationsDao: SavedSitesRelationsDao
     private lateinit var savedSitesMetadataDao: SavedSitesSyncMetadataDao
-
     private lateinit var persister: SavedSitesRemoteWinsPersister
+    private val store = RealSavedSitesSyncEntitiesStore(
+        InstrumentationRegistry.getInstrumentation().context,
+    )
 
     private val twoHoursAgo = DatabaseDateFormatter.iso8601(OffsetDateTime.now(ZoneOffset.UTC).minusHours(2))
 
@@ -92,7 +95,7 @@ class SavedSitesRemoteWinsPersisterTest {
             MissingEntitiesRelationReconciler(savedSitesEntitiesDao),
             coroutinesTestRule.testDispatcherProvider,
         )
-        syncRepository = RealSyncSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, savedSitesMetadataDao)
+        syncRepository = RealSyncSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, savedSitesMetadataDao, store)
         repository = RealSavedSitesRepository(
             savedSitesEntitiesDao,
             savedSitesRelationsDao,

--- a/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesRemoteWinsPersisterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesRemoteWinsPersisterTest.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.savedsites.api.models.BookmarkFolder
 import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
 import com.duckduckgo.savedsites.api.models.SavedSitesNames
+import com.duckduckgo.savedsites.impl.MissingEntitiesRelationReconciler
 import com.duckduckgo.savedsites.impl.RealFavoritesDelegate
 import com.duckduckgo.savedsites.impl.RealSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.RealSyncSavedSitesRepository
@@ -88,6 +89,7 @@ class SavedSitesRemoteWinsPersisterTest {
             savedSitesEntitiesDao,
             savedSitesRelationsDao,
             FakeDisplayModeSettingsRepository(),
+            MissingEntitiesRelationReconciler(savedSitesEntitiesDao),
             coroutinesTestRule.testDispatcherProvider,
         )
         syncRepository = RealSyncSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, savedSitesMetadataDao)
@@ -95,6 +97,7 @@ class SavedSitesRemoteWinsPersisterTest {
             savedSitesEntitiesDao,
             savedSitesRelationsDao,
             favoritesDelegate,
+            MissingEntitiesRelationReconciler(savedSitesEntitiesDao),
             coroutinesTestRule.testDispatcherProvider,
         )
 

--- a/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesTimestampPersisterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesTimestampPersisterTest.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.savedsites.api.models.BookmarkFolder
 import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
 import com.duckduckgo.savedsites.api.models.SavedSitesNames
+import com.duckduckgo.savedsites.impl.MissingEntitiesRelationReconciler
 import com.duckduckgo.savedsites.impl.RealFavoritesDelegate
 import com.duckduckgo.savedsites.impl.RealSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.RealSyncSavedSitesRepository
@@ -91,6 +92,7 @@ class SavedSitesTimestampPersisterTest {
             savedSitesEntitiesDao,
             savedSitesRelationsDao,
             FakeDisplayModeSettingsRepository(),
+            MissingEntitiesRelationReconciler(savedSitesEntitiesDao),
             coroutinesTestRule.testDispatcherProvider,
         )
         syncRepository = RealSyncSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, savedSitesMetadataDao)
@@ -98,6 +100,7 @@ class SavedSitesTimestampPersisterTest {
             savedSitesEntitiesDao,
             savedSitesRelationsDao,
             favoritesDelegate,
+            MissingEntitiesRelationReconciler(savedSitesEntitiesDao),
             coroutinesTestRule.testDispatcherProvider,
         )
 

--- a/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesTimestampPersisterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesTimestampPersisterTest.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.savedsites.impl.RealSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.RealSyncSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.SyncSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.algorithm.SavedSitesTimestampPersister
+import com.duckduckgo.savedsites.impl.sync.store.RealSavedSitesSyncEntitiesStore
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDao
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDatabase
 import com.duckduckgo.savedsites.store.SavedSitesEntitiesDao
@@ -65,8 +66,10 @@ class SavedSitesTimestampPersisterTest {
     private lateinit var savedSitesEntitiesDao: SavedSitesEntitiesDao
     private lateinit var savedSitesRelationsDao: SavedSitesRelationsDao
     private lateinit var savedSitesMetadataDao: SavedSitesSyncMetadataDao
-
     private lateinit var persister: SavedSitesTimestampPersister
+    private val store = RealSavedSitesSyncEntitiesStore(
+        InstrumentationRegistry.getInstrumentation().context,
+    )
 
     private val threeHoursAgo = DatabaseDateFormatter.iso8601(OffsetDateTime.now(ZoneOffset.UTC).minusHours(3))
     private val twoHoursAgo = DatabaseDateFormatter.iso8601(OffsetDateTime.now(ZoneOffset.UTC).minusHours(2))
@@ -95,7 +98,7 @@ class SavedSitesTimestampPersisterTest {
             MissingEntitiesRelationReconciler(savedSitesEntitiesDao),
             coroutinesTestRule.testDispatcherProvider,
         )
-        syncRepository = RealSyncSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, savedSitesMetadataDao)
+        syncRepository = RealSyncSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, savedSitesMetadataDao, store)
         repository = RealSavedSitesRepository(
             savedSitesEntitiesDao,
             savedSitesRelationsDao,

--- a/app/src/test/java/com/duckduckgo/savedsites/impl/MissingEntitiesRelationReconcilerTest.kt
+++ b/app/src/test/java/com/duckduckgo/savedsites/impl/MissingEntitiesRelationReconcilerTest.kt
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.savedsites.impl
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.app.global.db.AppDatabase
+import com.duckduckgo.savedsites.store.Entity
+import com.duckduckgo.savedsites.store.EntityType.BOOKMARK
+import junit.framework.TestCase
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MissingEntitiesRelationReconcilerTest {
+
+    private val db = Room.inMemoryDatabaseBuilder(InstrumentationRegistry.getInstrumentation().targetContext, AppDatabase::class.java)
+        .allowMainThreadQueries()
+        .build()
+    private val savedSitesEntitiesDao = db.syncEntitiesDao()
+    private val testee = MissingEntitiesRelationReconciler(savedSitesEntitiesDao)
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun whenInvalidEntitiesAreConsecutiveThenResultListKeepsCorrectPositions() = runTest {
+        val initialEntities = listOf("A", "Inv1", "Inv2", "B")
+
+        initialEntities.forEachIndexed { index, entityId ->
+            if (!entityId.startsWith("Inv")) {
+                savedSitesEntitiesDao.insert(Entity(entityId, "title", "www.example.com", type = BOOKMARK, lastModified = "timestamp"))
+            }
+        }
+
+        val list = testee.reconcileRelations(initialEntities, listOf("B", "A"))
+
+        TestCase.assertEquals(listOf("B", "A", "Inv1", "Inv2"), list)
+    }
+
+    @Test
+    fun whenInvalidEntitiesBetweenValidEntitiesThenResultListKeepsCorrectPositions() = runTest {
+        val initialEntities = listOf("A", "Inv1", "C", "Inv2", "D")
+
+        initialEntities.forEachIndexed { index, entityId ->
+            if (!entityId.startsWith("Inv")) {
+                savedSitesEntitiesDao.insert(Entity(entityId, "title", "www.example.com", type = BOOKMARK, lastModified = "timestamp"))
+            }
+        }
+
+        val list = testee.reconcileRelations(initialEntities, listOf("D", "C", "A"))
+
+        TestCase.assertEquals(listOf("D", "Inv1", "C", "Inv2", "A"), list)
+    }
+
+    @Test
+    fun whenInvalidEntitiesBetweenMultipleValidEntitiesThenResultListKeepsCorrectPositions() = runTest {
+        val initialEntities = listOf("A", "B", "Inv1", "C", "D", "Inv2", "E", "F")
+
+        initialEntities.forEachIndexed { index, entityId ->
+            if (!entityId.startsWith("Inv")) {
+                savedSitesEntitiesDao.insert(Entity(entityId, "title", "www.example.com", type = BOOKMARK, lastModified = "timestamp"))
+            }
+        }
+
+        val list = testee.reconcileRelations(initialEntities, listOf("A", "C", "E", "F", "B", "D"))
+
+        TestCase.assertEquals(listOf("A", "Inv1", "C", "Inv2", "E", "F", "B", "D"), list)
+    }
+
+    @Test
+    fun whenInvalidEntitiesAndValidItemRemovedThenResultListKeepsCorrectPositions() = runTest {
+        val initialEntities = listOf("A", "B", "Inv1", "C", "D", "Inv2", "E", "F")
+
+        initialEntities.forEachIndexed { index, entityId ->
+            if (!entityId.startsWith("Inv")) {
+                savedSitesEntitiesDao.insert(Entity(entityId, "title", "www.example.com", type = BOOKMARK, lastModified = "timestamp"))
+            }
+        }
+
+        val list = testee.reconcileRelations(initialEntities, listOf("A", "B", "C", "E", "F"))
+
+        TestCase.assertEquals(listOf("A", "B", "Inv1", "C", "Inv2", "E", "F"), list)
+    }
+
+    @Test
+    fun whenInvalidEntitiesAndValidItemAddedAtTheEndOfListThenResultListKeepsCorrectPositions() = runTest {
+        val initialEntities = listOf("A", "B", "Inv1", "C", "D", "Inv2", "E", "F")
+
+        initialEntities.forEachIndexed { index, entityId ->
+            if (!entityId.startsWith("Inv")) {
+                savedSitesEntitiesDao.insert(Entity(entityId, "title", "www.example.com", type = BOOKMARK, lastModified = "timestamp"))
+            }
+        }
+
+        val list = testee.reconcileRelations(initialEntities, listOf("A", "B", "C", "E", "F", "G"))
+
+        TestCase.assertEquals(listOf("A", "B", "Inv1", "C", "Inv2", "E", "F", "G"), list)
+    }
+
+    @Test
+    fun whenInvalidEntitiesAndValidItemAddedInTheMiddleOfListThenResultListKeepsCorrectPositions() = runTest {
+        val initialEntities = listOf("A", "B", "Inv1", "C", "D", "Inv2", "E", "F")
+
+        initialEntities.forEachIndexed { index, entityId ->
+            if (!entityId.startsWith("Inv")) {
+                savedSitesEntitiesDao.insert(Entity(entityId, "title", "www.example.com", type = BOOKMARK, lastModified = "timestamp"))
+            }
+        }
+
+        val list = testee.reconcileRelations(initialEntities, listOf("A", "B", "C", "G", "E", "F"))
+
+        TestCase.assertEquals(listOf("A", "B", "Inv1", "C", "G", "Inv2", "E", "F"), list)
+    }
+
+    @Test
+    fun whenInvalidEntitiesIsFirstItemThenResultListKeepsCorrectPositions() = runTest {
+        val initialEntities = listOf("Inv0", "A", "B", "Inv1", "C", "D", "Inv2", "E", "F")
+
+        initialEntities.forEachIndexed { index, entityId ->
+            if (!entityId.startsWith("Inv")) {
+                savedSitesEntitiesDao.insert(Entity(entityId, "title", "www.example.com", type = BOOKMARK, lastModified = "timestamp"))
+            }
+        }
+
+        val list = testee.reconcileRelations(initialEntities, listOf("A", "B", "C", "G", "E", "F"))
+
+        TestCase.assertEquals(listOf("Inv0", "A", "B", "Inv1", "C", "G", "Inv2", "E", "F"), list)
+    }
+
+    @Test
+    fun whenInvalidEntitiesIsFirstItemAndItemsReorderedThenResultListKeepsCorrectPositions() = runTest {
+        val initialEntities = listOf("Inv0", "A", "B", "Inv1", "C", "D", "Inv2", "E", "F")
+
+        initialEntities.forEachIndexed { index, entityId ->
+            if (!entityId.startsWith("Inv")) {
+                savedSitesEntitiesDao.insert(Entity(entityId, "title", "www.example.com", type = BOOKMARK, lastModified = "timestamp"))
+            }
+        }
+
+        val list = testee.reconcileRelations(initialEntities, listOf("F", "E", "A", "B", "C", "G"))
+
+        TestCase.assertEquals(listOf("Inv0", "F", "Inv1", "Inv2", "E", "A", "B", "C", "G"), list)
+    }
+
+    @Test
+    fun whenInvalidMultipleEntitiesStartListThenResultListKeepsCorrectPositions() = runTest {
+        val initialEntities = listOf("Inv0", "Inv1", "Inv2", "A", "B", "C", "D", "E", "F")
+
+        initialEntities.forEachIndexed { index, entityId ->
+            if (!entityId.startsWith("Inv")) {
+                savedSitesEntitiesDao.insert(Entity(entityId, "title", "www.example.com", type = BOOKMARK, lastModified = "timestamp"))
+            }
+        }
+
+        val list = testee.reconcileRelations(initialEntities, listOf("A", "B", "C", "D", "E", "F"))
+
+        TestCase.assertEquals(listOf("Inv0", "Inv1", "Inv2", "A", "B", "C", "D", "E", "F"), list)
+    }
+
+    @Test
+    fun whenNoInvalidEntitiesThenReturnSameList() = runTest {
+        val initialEntities = listOf("A", "B", "C", "D", "E", "F")
+
+        initialEntities.forEachIndexed { index, entityId ->
+            if (!entityId.startsWith("Inv")) {
+                savedSitesEntitiesDao.insert(Entity(entityId, "title", "www.example.com", type = BOOKMARK, lastModified = "timestamp"))
+            }
+        }
+
+        val list = testee.reconcileRelations(initialEntities, listOf("A", "B", "C", "G", "E", "F"))
+
+        TestCase.assertEquals(listOf("A", "B", "C", "G", "E", "F"), list)
+    }
+}

--- a/app/src/test/java/com/duckduckgo/savedsites/impl/RealFavoritesDelegateTest.kt
+++ b/app/src/test/java/com/duckduckgo/savedsites/impl/RealFavoritesDelegateTest.kt
@@ -413,6 +413,7 @@ class RealFavoritesDelegateTest {
             savedSitesEntitiesDao,
             savedSitesRelationsDao,
             displayModeSettingsRepository,
+            MissingEntitiesRelationReconciler(savedSitesEntitiesDao),
             coroutineRule.testDispatcherProvider,
         )
     }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsInvalidItemSyncMessagePlugin.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsInvalidItemSyncMessagePlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 DuckDuckGo
+ * Copyright (c) 2024 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,16 @@
 
 package com.duckduckgo.autofill.sync
 
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
+import android.content.Context
+import android.view.View
+import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.sync.api.SyncMessagePlugin
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
 
-class FakeCredentialsSyncStore : CredentialsSyncStore {
-    override var serverModifiedSince: String = "0"
-    override var startTimeStamp: String = "0"
-    override var clientModifiedSince: String = "0"
-    override var isSyncPaused: Boolean = false
-    override fun isSyncPausedFlow(): Flow<Boolean> = emptyFlow()
-    override var invalidEntitiesIds: List<String> = emptyList()
+@ContributesMultibinding(scope = ActivityScope::class)
+class CredentialsInvalidItemSyncMessagePlugin @Inject constructor() : SyncMessagePlugin {
+    override fun getView(context: Context): View {
+        return CredentialsInvalidItemsView(context)
+    }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsInvalidItemsView.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsInvalidItemsView.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.sync
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.text.SpannableStringBuilder
+import android.util.AttributeSet
+import android.widget.FrameLayout
+import androidx.core.view.isVisible
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewTreeLifecycleOwner
+import androidx.lifecycle.findViewTreeViewModelStoreOwner
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.autofill.api.AutofillScreens.AutofillSettingsScreenNoParams
+import com.duckduckgo.autofill.impl.R
+import com.duckduckgo.autofill.impl.databinding.ViewCredentialsInvalidItemsWarningBinding
+import com.duckduckgo.autofill.sync.CredentialsInvalidItemsViewModel.Command
+import com.duckduckgo.autofill.sync.CredentialsInvalidItemsViewModel.Command.NavigateToCredentials
+import com.duckduckgo.autofill.sync.CredentialsInvalidItemsViewModel.ViewState
+import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.ConflatedJob
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.ViewViewModelFactory
+import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.navigation.api.GlobalActivityStarter
+import dagger.android.support.AndroidSupportInjection
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+
+@InjectWith(ViewScope::class)
+class CredentialsInvalidItemsView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyle: Int = 0,
+) : FrameLayout(context, attrs, defStyle) {
+
+    @Inject
+    lateinit var globalActivityStarter: GlobalActivityStarter
+
+    @Inject
+    lateinit var viewModelFactory: ViewViewModelFactory
+
+    @Inject
+    lateinit var dispatcherProvider: DispatcherProvider
+
+    private var coroutineScope: CoroutineScope? = null
+
+    private var job: ConflatedJob = ConflatedJob()
+
+    private val binding: ViewCredentialsInvalidItemsWarningBinding by viewBinding()
+
+    private val viewModel: CredentialsInvalidItemsViewModel by lazy {
+        ViewModelProvider(findViewTreeViewModelStoreOwner()!!, viewModelFactory)[CredentialsInvalidItemsViewModel::class.java]
+    }
+
+    override fun onAttachedToWindow() {
+        AndroidSupportInjection.inject(this)
+        super.onAttachedToWindow()
+
+        ViewTreeLifecycleOwner.get(this)?.lifecycle?.addObserver(viewModel)
+
+        @SuppressLint("NoHardcodedCoroutineDispatcher")
+        coroutineScope = CoroutineScope(SupervisorJob() + dispatcherProvider.main())
+
+        viewModel.viewState()
+            .onEach { render(it) }
+            .launchIn(coroutineScope!!)
+
+        job += viewModel.commands()
+            .onEach { processCommands(it) }
+            .launchIn(coroutineScope!!)
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        ViewTreeLifecycleOwner.get(this)?.lifecycle?.removeObserver(viewModel)
+        coroutineScope?.cancel()
+        job.cancel()
+        coroutineScope = null
+    }
+
+    private fun processCommands(command: Command) {
+        when (command) {
+            NavigateToCredentials -> navigateToCredentials()
+        }
+    }
+
+    private fun render(viewState: ViewState) {
+        this.isVisible = viewState.warningVisible
+
+        val spannable = SpannableStringBuilder(
+            context.resources.getQuantityString(
+                R.plurals.syncCredentialInvalidItemsWarning,
+                viewState.invalidItemsSize,
+                viewState.hint,
+                viewState.invalidItemsSize - 1,
+            ),
+        ).append(context.getText(R.string.syncCredentialInvalidItemsWarningLink))
+
+        binding.credentialsInvalidItemsWarning.setClickableLink(
+            "manage_passwords",
+            spannable,
+            onClick = {
+                viewModel.onWarningActionClicked()
+            },
+        )
+    }
+
+    private fun navigateToCredentials() {
+        globalActivityStarter.start(this.context, AutofillSettingsScreenNoParams)
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsInvalidItemsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsInvalidItemsViewModel.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.sync
+
+import android.annotation.SuppressLint
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.autofill.api.domain.app.LoginCredentials
+import com.duckduckgo.autofill.sync.CredentialsInvalidItemsViewModel.Command.NavigateToCredentials
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.ViewScope
+import javax.inject.Inject
+import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+
+@SuppressLint("NoLifecycleObserver") // we don't observe app lifecycle
+@ContributesViewModel(ViewScope::class)
+class CredentialsInvalidItemsViewModel @Inject constructor(
+    private val dispatcherProvider: DispatcherProvider,
+    private val crendentialsSyncRepository: CredentialsSync,
+) : ViewModel(), DefaultLifecycleObserver {
+    data class ViewState(
+        val warningVisible: Boolean = false,
+        val invalidItemsSize: Int = 0,
+        val hint: String = "",
+    )
+
+    sealed class Command {
+        data object NavigateToCredentials : Command()
+    }
+
+    private val command = Channel<Command>(1, DROP_OLDEST)
+
+    private val _viewState = MutableStateFlow(ViewState())
+    fun viewState(): Flow<ViewState> = _viewState.onStart {
+        viewModelScope.launch(dispatcherProvider.io()) {
+            emitNewViewState()
+        }
+    }
+
+    override fun onResume(owner: LifecycleOwner) {
+        viewModelScope.launch(dispatcherProvider.io()) {
+            emitNewViewState()
+        }
+    }
+
+    fun commands(): Flow<Command> = command.receiveAsFlow()
+
+    private suspend fun emitNewViewState() {
+        val invalidItems = crendentialsSyncRepository.getInvalidCredentials()
+        _viewState.emit(
+            ViewState(
+                warningVisible = invalidItems.isNotEmpty(),
+                hint = invalidItems.firstOrNull().getHint(),
+                invalidItemsSize = invalidItems.size,
+            ),
+        )
+    }
+
+    fun onWarningActionClicked() {
+        viewModelScope.launch {
+            command.send(NavigateToCredentials)
+        }
+    }
+
+    private fun LoginCredentials?.getHint(): String {
+        val hint: String =
+            this?.domainTitle.takeUnless { it.isNullOrEmpty() }
+                ?: this?.domain.takeUnless { it.isNullOrEmpty() }
+                ?: this?.username.takeUnless { it.isNullOrEmpty() } ?: ""
+        this?.notes.takeUnless { it.isNullOrEmpty() } ?: ""
+
+        return hint.shortenString(HINT_MAX_HINT_LENGTH)
+    }
+
+    private fun String.shortenString(maxLength: Int): String {
+        return this.takeIf { it.length <= maxLength } ?: (this.take(maxLength - 3) + "...")
+    }
+
+    companion object {
+        const val HINT_MAX_HINT_LENGTH = 15
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsSyncStore.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsSyncStore.kt
@@ -37,6 +37,7 @@ interface CredentialsSyncStore {
     var clientModifiedSince: String
     var isSyncPaused: Boolean
     fun isSyncPausedFlow(): Flow<Boolean>
+    var invalidEntitiesIds: List<String>
 }
 
 @ContributesBinding(AppScope::class)
@@ -69,6 +70,13 @@ class RealCredentialsSyncStore @Inject constructor(
             preferences.edit(true) { putBoolean(KEY_CLIENT_LIMIT_EXCEEDED, value) }
             emitNewValue()
         }
+    override var invalidEntitiesIds: List<String>
+        get() = preferences.getStringSet(KEY_CLIENT_INVALID_IDS, mutableSetOf())?.toList() ?: mutableListOf()
+        set(value) {
+            preferences.edit(true) {
+                putStringSet(KEY_CLIENT_INVALID_IDS, value.toSet())
+            }
+        }
 
     override fun isSyncPausedFlow(): Flow<Boolean> = syncPausedSharedFlow
 
@@ -87,5 +95,6 @@ class RealCredentialsSyncStore @Inject constructor(
         private const val KEY_START_TIMESTAMP = "KEY_START_TIMESTAMP"
         private const val KEY_END_TIMESTAMP = "KEY_END_TIMESTAMP"
         private const val KEY_CLIENT_LIMIT_EXCEEDED = "KEY_CLIENT_LIMIT_EXCEEDED"
+        private const val KEY_CLIENT_INVALID_IDS = "KEY_CLIENT_INVALID_IDS"
     }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/provider/CredentialsSyncLocalValidationFeature.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/provider/CredentialsSyncLocalValidationFeature.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 DuckDuckGo
+ * Copyright (c) 2024 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,17 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.autofill.sync
+package com.duckduckgo.autofill.sync.provider
 
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
 
-class FakeCredentialsSyncStore : CredentialsSyncStore {
-    override var serverModifiedSince: String = "0"
-    override var startTimeStamp: String = "0"
-    override var clientModifiedSince: String = "0"
-    override var isSyncPaused: Boolean = false
-    override fun isSyncPausedFlow(): Flow<Boolean> = emptyFlow()
-    override var invalidEntitiesIds: List<String> = emptyList()
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "credentialsLocalFieldValidation",
+)
+interface CredentialsSyncLocalValidationFeature {
+    @Toggle.DefaultValue(false)
+    fun self(): Toggle
 }

--- a/autofill/autofill-impl/src/main/res/layout/view_credentials_invalid_items_warning.xml
+++ b/autofill/autofill-impl/src/main/res/layout/view_credentials_invalid_items_warning.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright (c) 2023 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<com.duckduckgo.common.ui.view.InfoPanel xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/credentialsInvalidItemsWarning"
+    style="@style/Widget.DuckDuckGo.InfoPanel"
+    android:layout_margin="@dimen/keyline_4"
+    app:panelBackground="@drawable/info_panel_alert_background"
+    app:panelDrawable="@drawable/ic_info_panel_alert" />

--- a/autofill/autofill-impl/src/main/res/values/donottranslate.xml
+++ b/autofill/autofill-impl/src/main/res/values/donottranslate.xml
@@ -15,5 +15,10 @@
   -->
 
 <resources>
-
+    <!-- Sync settings screen -->
+    <plurals name="syncCredentialInvalidItemsWarning" instruction="%1$ represents a site name or url, %2$d is the number of other invalid sites">
+        <item quantity="one">Your password for %1$s can’t sync because one of its fields exceeds the character limit.\n\n</item>
+        <item quantity="other">Your passwords for %1$s and %2$d other sites can’t sync because some of their fields exceed the character limit.\n\n</item>
+    </plurals>
+    <string name="syncCredentialInvalidItemsWarningLink"><annotation type="manage_passwords">Manage Passwords</annotation></string>
 </resources>

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/CredentialsFixtures.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/CredentialsFixtures.kt
@@ -48,6 +48,15 @@ object CredentialsFixtures {
         notes = "My Amazon account",
     )
 
+    val invalidCredentials = LoginCredentials(
+        id = 4L,
+        domain = "www.invalid.com",
+        username = "invalidUS",
+        password = "invalidPW",
+        domainTitle = String(CharArray(3000) { 'a' + (it % 26) }),
+        notes = "My Invalid account",
+    )
+
     fun LoginCredentials.toLoginCredentialEntryResponse(): CredentialsSyncEntryResponse =
         CredentialsSyncEntryResponse(
             id = id.toString(),

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/CredentialsInvalidItemsViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/CredentialsInvalidItemsViewModelTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.sync
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.cash.turbine.test
+import com.duckduckgo.autofill.sync.CredentialsFixtures.invalidCredentials
+import com.duckduckgo.autofill.sync.CredentialsFixtures.spotifyCredentials
+import com.duckduckgo.common.test.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CredentialsInvalidItemsViewModelTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val db = inMemoryAutofillDatabase()
+    private val secureStorage = FakeSecureStorage()
+    private val credentialsSyncStore = FakeCredentialsSyncStore()
+    private val credentialsSyncMetadata = CredentialsSyncMetadata(db.credentialsSyncDao())
+    private val credentialsSync = CredentialsSync(
+        secureStorage,
+        credentialsSyncStore,
+        credentialsSyncMetadata,
+        FakeCrypto(),
+        FakeCredentialsSyncLocalValidationFeature(),
+    )
+
+    private val viewModel = CredentialsInvalidItemsViewModel(
+        dispatcherProvider = coroutineRule.testDispatcherProvider,
+        crendentialsSyncRepository = credentialsSync,
+    )
+
+    @Test
+    fun whenNoInvalidCredentialsThenWarningNotVisible() = runTest {
+        viewModel.viewState().test {
+            val awaitItem = awaitItem()
+            assertFalse(awaitItem.warningVisible)
+            assertEquals(0, awaitItem.invalidItemsSize)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenInvalidCredentialsThenWarningVisible() = runTest {
+        credentialsSync.saveCredential(invalidCredentials, "remote1")
+        credentialsSync.saveCredential(spotifyCredentials, "remote2")
+        credentialsSync.getUpdatesSince("0") // trigger sync so invalid credentials are detected
+
+        viewModel.viewState().test {
+            val awaitItem = awaitItem()
+            assertTrue(awaitItem.warningVisible)
+            assertEquals(1, awaitItem.invalidItemsSize)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/CredentialsSyncTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/CredentialsSyncTest.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.impl.securestorage.WebsiteLoginDetails
 import com.duckduckgo.autofill.impl.securestorage.WebsiteLoginDetailsWithCredentials
 import com.duckduckgo.autofill.store.CredentialsSyncMetadataEntity
+import com.duckduckgo.autofill.sync.CredentialsFixtures.invalidCredentials
 import com.duckduckgo.autofill.sync.CredentialsFixtures.spotifyCredentials
 import com.duckduckgo.autofill.sync.CredentialsFixtures.toLoginCredentials
 import com.duckduckgo.autofill.sync.CredentialsFixtures.twitterCredentials
@@ -43,7 +44,13 @@ internal class CredentialsSyncTest {
     private val secureStorage = FakeSecureStorage()
     private val credentialsSyncStore = FakeCredentialsSyncStore()
     private val credentialsSyncMetadata = CredentialsSyncMetadata(db.credentialsSyncDao())
-    private val credentialsSync = CredentialsSync(secureStorage, credentialsSyncStore, credentialsSyncMetadata, FakeCrypto())
+    private val credentialsSync = CredentialsSync(
+        secureStorage,
+        credentialsSyncStore,
+        credentialsSyncMetadata,
+        FakeCrypto(),
+        FakeCredentialsSyncLocalValidationFeature(),
+    )
 
     @After fun after() = runBlocking {
         db.close()
@@ -143,6 +150,59 @@ internal class CredentialsSyncTest {
             ),
             updates,
         )
+    }
+
+    @Test
+    fun whenOnFirstWithInvalidCredentialsThenChangesDoesNotContainInvalidEntities() = runTest {
+        givenLocalCredentials(
+            invalidCredentials,
+        )
+
+        val syncChanges = credentialsSync.getUpdatesSince("0")
+
+        assertTrue(syncChanges.isEmpty())
+        assertTrue(credentialsSyncStore.invalidEntitiesIds.size == 1)
+    }
+
+    @Test
+    fun whenNewCredentialsIsInvalidThenChangesDoesNotContainInvalidEntity() = runTest {
+        givenLocalCredentials(
+            spotifyCredentials,
+            invalidCredentials.copy(lastUpdatedMillis = 1689592358516),
+        )
+
+        val syncChanges = credentialsSync.getUpdatesSince("2022-08-30T00:00:00Z")
+
+        assertTrue(syncChanges.isEmpty())
+        assertTrue(credentialsSyncStore.invalidEntitiesIds.size == 1)
+    }
+
+    @Test
+    fun whenInvalidCredentialsPresentThenAlwaysRetryItemsAndUpdateInvalidList() = runTest {
+        givenLocalCredentials(
+            invalidCredentials,
+            spotifyCredentials.copy(lastUpdatedMillis = 1689592358516),
+        )
+        credentialsSyncStore.invalidEntitiesIds = listOf(credentialsSyncMetadata.getSyncMetadata(invalidCredentials.id!!)!!.syncId)
+
+        val syncChanges = credentialsSync.getUpdatesSince("2022-08-30T00:00:00Z")
+
+        assertTrue(syncChanges.size == 1)
+        assertTrue(syncChanges.first().title == spotifyCredentials.domainTitle)
+        assertTrue(credentialsSyncStore.invalidEntitiesIds.size == 1)
+    }
+
+    @Test
+    fun whenInvalidCredentialsThenReturnInvalidCredentials() = runTest {
+        givenLocalCredentials(
+            invalidCredentials,
+        )
+        credentialsSyncStore.invalidEntitiesIds = listOf(credentialsSyncMetadata.getSyncMetadata(invalidCredentials.id!!)!!.syncId)
+
+        val invalidItems = credentialsSync.getInvalidCredentials()
+
+        assertTrue(invalidItems.isNotEmpty())
+        assertEquals(invalidCredentials, invalidItems.first())
     }
 
     @Test
@@ -294,6 +354,7 @@ internal class CredentialsSyncTest {
     private suspend fun givenLocalCredentials(vararg credentials: LoginCredentials) {
         credentials.forEach { credential ->
             val loginDetails = WebsiteLoginDetails(
+                id = credential.id,
                 domain = credential.domain,
                 username = credential.username,
                 domainTitle = credential.domainTitle,

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/FakeCredentialsSyncLocalValidationFeature.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/FakeCredentialsSyncLocalValidationFeature.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 DuckDuckGo
+ * Copyright (c) 2024 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,12 @@
 
 package com.duckduckgo.autofill.sync
 
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
+import com.duckduckgo.autofill.sync.provider.CredentialsSyncLocalValidationFeature
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.toggle.TestToggle
 
-class FakeCredentialsSyncStore : CredentialsSyncStore {
-    override var serverModifiedSince: String = "0"
-    override var startTimeStamp: String = "0"
-    override var clientModifiedSince: String = "0"
-    override var isSyncPaused: Boolean = false
-    override fun isSyncPausedFlow(): Flow<Boolean> = emptyFlow()
-    override var invalidEntitiesIds: List<String> = emptyList()
+class FakeCredentialsSyncLocalValidationFeature : CredentialsSyncLocalValidationFeature {
+    var enabled = true
+
+    override fun self(): Toggle = TestToggle(enabled)
 }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/persister/CredentialsLastModifiedWinsStrategyTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/persister/CredentialsLastModifiedWinsStrategyTest.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.autofill.sync.CredentialsFixtures.twitterCredentials
 import com.duckduckgo.autofill.sync.CredentialsSync
 import com.duckduckgo.autofill.sync.CredentialsSyncMapper
 import com.duckduckgo.autofill.sync.CredentialsSyncMetadata
+import com.duckduckgo.autofill.sync.FakeCredentialsSyncLocalValidationFeature
 import com.duckduckgo.autofill.sync.FakeCredentialsSyncStore
 import com.duckduckgo.autofill.sync.FakeCrypto
 import com.duckduckgo.autofill.sync.FakeSecureStorage
@@ -56,7 +57,13 @@ internal class CredentialsLastModifiedWinsStrategyTest {
     private val secureStorage = FakeSecureStorage()
     private val credentialsSyncStore = FakeCredentialsSyncStore()
     private val credentialsSyncMetadata = CredentialsSyncMetadata(db.credentialsSyncDao())
-    private val credentialsSync = CredentialsSync(secureStorage, credentialsSyncStore, credentialsSyncMetadata, FakeCrypto())
+    private val credentialsSync = CredentialsSync(
+        secureStorage,
+        credentialsSyncStore,
+        credentialsSyncMetadata,
+        FakeCrypto(),
+        FakeCredentialsSyncLocalValidationFeature(),
+    )
 
     @After fun after() = runBlocking {
         db.close()

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/persister/CredentialsLocalWinsStrategyTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/persister/CredentialsLocalWinsStrategyTest.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.autofill.sync.CredentialsFixtures.twitterCredentials
 import com.duckduckgo.autofill.sync.CredentialsSync
 import com.duckduckgo.autofill.sync.CredentialsSyncMapper
 import com.duckduckgo.autofill.sync.CredentialsSyncMetadata
+import com.duckduckgo.autofill.sync.FakeCredentialsSyncLocalValidationFeature
 import com.duckduckgo.autofill.sync.FakeCredentialsSyncStore
 import com.duckduckgo.autofill.sync.FakeCrypto
 import com.duckduckgo.autofill.sync.FakeSecureStorage
@@ -55,7 +56,13 @@ internal class CredentialsLocalWinsStrategyTest {
     private val secureStorage = FakeSecureStorage()
     private val credentialsSyncStore = FakeCredentialsSyncStore()
     private val credentialsSyncMetadata = CredentialsSyncMetadata(db.credentialsSyncDao())
-    private val credentialsSync = CredentialsSync(secureStorage, credentialsSyncStore, credentialsSyncMetadata, FakeCrypto())
+    private val credentialsSync = CredentialsSync(
+        secureStorage,
+        credentialsSyncStore,
+        credentialsSyncMetadata,
+        FakeCrypto(),
+        FakeCredentialsSyncLocalValidationFeature(),
+    )
 
     @After fun after() = runBlocking {
         db.close()

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/persister/CredentialsRemoteWinsStrategyTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/persister/CredentialsRemoteWinsStrategyTest.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.autofill.sync.CredentialsFixtures.twitterCredentials
 import com.duckduckgo.autofill.sync.CredentialsSync
 import com.duckduckgo.autofill.sync.CredentialsSyncMapper
 import com.duckduckgo.autofill.sync.CredentialsSyncMetadata
+import com.duckduckgo.autofill.sync.FakeCredentialsSyncLocalValidationFeature
 import com.duckduckgo.autofill.sync.FakeCredentialsSyncStore
 import com.duckduckgo.autofill.sync.FakeCrypto
 import com.duckduckgo.autofill.sync.FakeSecureStorage
@@ -55,7 +56,13 @@ internal class CredentialsRemoteWinsStrategyTest {
     private val secureStorage = FakeSecureStorage()
     private val credentialsSyncStore = FakeCredentialsSyncStore()
     private val credentialsSyncMetadata = CredentialsSyncMetadata(db.credentialsSyncDao())
-    private val credentialsSync = CredentialsSync(secureStorage, credentialsSyncStore, credentialsSyncMetadata, FakeCrypto())
+    private val credentialsSync = CredentialsSync(
+        secureStorage,
+        credentialsSyncStore,
+        credentialsSyncMetadata,
+        FakeCrypto(),
+        FakeCredentialsSyncLocalValidationFeature(),
+    )
 
     @After fun after() = runBlocking {
         db.close()

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/persister/CrendentialsDedupStrategyTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/persister/CrendentialsDedupStrategyTest.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.autofill.sync.CredentialsFixtures.twitterCredentials
 import com.duckduckgo.autofill.sync.CredentialsSync
 import com.duckduckgo.autofill.sync.CredentialsSyncMapper
 import com.duckduckgo.autofill.sync.CredentialsSyncMetadata
+import com.duckduckgo.autofill.sync.FakeCredentialsSyncLocalValidationFeature
 import com.duckduckgo.autofill.sync.FakeCredentialsSyncStore
 import com.duckduckgo.autofill.sync.FakeCrypto
 import com.duckduckgo.autofill.sync.FakeSecureStorage
@@ -55,7 +56,13 @@ internal class CredentialsDedupStrategyTest {
     private val secureStorage = FakeSecureStorage()
     private val credentialsSyncStore = FakeCredentialsSyncStore()
     private val credentialsSyncMetadata = CredentialsSyncMetadata(db.credentialsSyncDao())
-    private val credentialsSync = CredentialsSync(secureStorage, credentialsSyncStore, credentialsSyncMetadata, FakeCrypto())
+    private val credentialsSync = CredentialsSync(
+        secureStorage,
+        credentialsSyncStore,
+        credentialsSyncMetadata,
+        FakeCrypto(),
+        FakeCredentialsSyncLocalValidationFeature(),
+    )
 
     @After fun after() = runBlocking {
         db.close()

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/provider/CredentialsSyncDataProviderTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/provider/CredentialsSyncDataProviderTest.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.autofill.sync.CredentialsFixtures
 import com.duckduckgo.autofill.sync.CredentialsFixtures.toWebsiteLoginCredentials
 import com.duckduckgo.autofill.sync.CredentialsSync
 import com.duckduckgo.autofill.sync.CredentialsSyncMetadata
+import com.duckduckgo.autofill.sync.FakeCredentialsSyncLocalValidationFeature
 import com.duckduckgo.autofill.sync.FakeCredentialsSyncStore
 import com.duckduckgo.autofill.sync.FakeCrypto
 import com.duckduckgo.autofill.sync.FakeSecureStorage
@@ -53,7 +54,13 @@ internal class CredentialsSyncDataProviderTest {
     private val secureStorage = FakeSecureStorage()
     private val credentialsSyncMetadata = CredentialsSyncMetadata(db.credentialsSyncDao())
     private val credentialsSyncStore = FakeCredentialsSyncStore()
-    private val credentialsSync = CredentialsSync(secureStorage, credentialsSyncStore, credentialsSyncMetadata, FakeCrypto())
+    private val credentialsSync = CredentialsSync(
+        secureStorage,
+        credentialsSyncStore,
+        credentialsSyncMetadata,
+        FakeCrypto(),
+        FakeCredentialsSyncLocalValidationFeature(),
+    )
     private val appBuildConfig = mock<AppBuildConfig>().apply {
         whenever(this.flavor).thenReturn(BuildFlavor.PLAY)
     }

--- a/saved-sites/saved-sites-impl/build.gradle
+++ b/saved-sites/saved-sites-impl/build.gradle
@@ -24,6 +24,8 @@ plugins {
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"
 
 dependencies {
+    implementation project(path: ':feature-toggles-api')
+    implementation project(path: ':app-build-config-api')
     implementation project(path: ':di')
     implementation project(path: ':statistics')
     implementation project(path: ':common-utils')

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/RelationsReconciler.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/RelationsReconciler.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.savedsites.impl
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.savedsites.store.SavedSitesEntitiesDao
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface RelationsReconciler {
+    fun reconcileRelations(
+        originalRelations: List<String>,
+        newFolderRelations: List<String>,
+    ): List<String>
+}
+
+@ContributesBinding(AppScope::class)
+class MissingEntitiesRelationReconciler @Inject constructor(
+    val savedSitesEntitiesDao: SavedSitesEntitiesDao,
+) : RelationsReconciler {
+    override fun reconcileRelations(
+        originalRelations: List<String>,
+        newFolderRelations: List<String>,
+    ): List<String> {
+        val missingEntities = (originalRelations - newFolderRelations.toSet()).filter {
+            savedSitesEntitiesDao.entityById(it) == null
+        }.toMutableList()
+        if (missingEntities.isEmpty()) return newFolderRelations
+
+        val result = mutableListOf<String>()
+        val originalMap: Map<String, Int> = originalRelations.withIndex().associateBy({ it.value }, { it.index })
+        // if missing entities at the top of the list
+        // find the firstNotMissingItem, add anything before it
+        originalRelations
+            .find { !missingEntities.contains(it) }
+            ?.let { firstNotMissingItem -> originalMap[firstNotMissingItem] }
+            ?.let { firstNotMissingItemPosition ->
+                result.addAll(missingEntities.take(firstNotMissingItemPosition))
+                missingEntities.removeAll(result)
+            }
+
+        val missingEntitiesMap = missingEntities.associateBy({ originalRelations.indexOf(it) }, { it }).toMutableMap()
+        val missingEntitiesPositions = missingEntities.map { originalRelations.indexOf(it) }
+
+        var index = -1
+        for (entityId in newFolderRelations) {
+            val originalIndex = originalMap[entityId]
+            if (originalIndex != null) {
+                if (index == -1) { // first item we add it directly
+                    result.add(entityId)
+                } else {
+                    if (originalIndex > index) {
+                        result.addAll(findMissingEntitiesBetween(index, originalIndex, missingEntitiesMap, missingEntitiesPositions))
+                    } else if (originalIndex < index) {
+                        result.addAll(findMissingEntitiesBetween(index, originalRelations.size, missingEntitiesMap, missingEntitiesPositions))
+                        result.addAll(findMissingEntitiesBetween(0, originalIndex, missingEntitiesMap, missingEntitiesPositions))
+                    }
+                    result.add(entityId)
+                }
+                index = originalIndex
+            } else {
+                result.add(entityId) // add if not present in originalMap
+            }
+        }
+
+        if (missingEntitiesMap.isNotEmpty()) {
+            result.addAll(missingEntitiesMap.values.toList())
+        }
+        return result.distinct()
+    }
+
+    private fun findMissingEntitiesBetween(
+        from: Int,
+        to: Int,
+        missingEntitiesMap: MutableMap<Int, String>,
+        missingEntitiesPositions: List<Int>,
+    ): List<String> {
+        val result = mutableListOf<String>()
+        missingEntitiesPositions.forEach { position ->
+            if (position in from..to) {
+                missingEntitiesMap[position]?.let { id ->
+                    result.add(id)
+                }
+                missingEntitiesMap.remove(position)
+            }
+        }
+        return result
+    }
+}

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/SavedSitesRepository.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/SavedSitesRepository.kt
@@ -47,6 +47,7 @@ class RealSavedSitesRepository(
     private val savedSitesEntitiesDao: SavedSitesEntitiesDao,
     private val savedSitesRelationsDao: SavedSitesRelationsDao,
     private val favoritesDelegate: FavoritesDelegate,
+    private val relationsReconciler: RelationsReconciler,
     private val dispatcherProvider: DispatcherProvider = DefaultDispatcherProvider(),
 ) : SavedSitesRepository {
 
@@ -507,7 +508,11 @@ class RealSavedSitesRepository(
         folderId: String,
         entities: List<String>,
     ) {
-        savedSitesRelationsDao.replaceBookmarkFolder(folderId, entities)
+        val reconciledList = relationsReconciler.reconcileRelations(
+            originalRelations = savedSitesRelationsDao.relationsByFolderId(folderId).map { it.entityId },
+            newFolderRelations = entities,
+        )
+        savedSitesRelationsDao.replaceBookmarkFolder(folderId, reconciledList)
     }
 
     override fun getFolder(folderId: String): BookmarkFolder? {

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/di/SavedSitesModule.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/di/SavedSitesModule.kt
@@ -96,9 +96,10 @@ class SavedSitesModule {
         savedSitesEntitiesDao: SavedSitesEntitiesDao,
         savedSitesRelationsDao: SavedSitesRelationsDao,
         favoritesDelegate: FavoritesDelegate,
+        relationsReconciler: RelationsReconciler,
         coroutineDispatcher: DispatcherProvider = DefaultDispatcherProvider(),
     ): SavedSitesRepository {
-        return RealSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, favoritesDelegate, coroutineDispatcher)
+        return RealSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, favoritesDelegate, relationsReconciler, coroutineDispatcher)
     }
 
     @Provides

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/di/SavedSitesModule.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/di/SavedSitesModule.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.savedsites.impl.service.RealSavedSitesParser
 import com.duckduckgo.savedsites.impl.service.SavedSitesParser
 import com.duckduckgo.savedsites.impl.sync.*
 import com.duckduckgo.savedsites.impl.sync.store.ALL_MIGRATIONS
+import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncEntitiesStore
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDao
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDatabase
 import com.duckduckgo.savedsites.store.SavedSitesEntitiesDao
@@ -108,8 +109,9 @@ class SavedSitesModule {
         savedSitesEntitiesDao: SavedSitesEntitiesDao,
         savedSitesRelationsDao: SavedSitesRelationsDao,
         savedSitesSyncMetadataDao: SavedSitesSyncMetadataDao,
+        savedSitesSyncEntitiesStore: SavedSitesSyncEntitiesStore,
     ): SyncSavedSitesRepository {
-        return RealSyncSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, savedSitesSyncMetadataDao)
+        return RealSyncSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, savedSitesSyncMetadataDao, savedSitesSyncEntitiesStore)
     }
 
     @Provides

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/BookmarksSyncLocalValidationFeature.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/BookmarksSyncLocalValidationFeature.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 DuckDuckGo
+ * Copyright (c) 2024 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,17 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.autofill.sync
+package com.duckduckgo.savedsites.impl.sync
 
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
 
-class FakeCredentialsSyncStore : CredentialsSyncStore {
-    override var serverModifiedSince: String = "0"
-    override var startTimeStamp: String = "0"
-    override var clientModifiedSince: String = "0"
-    override var isSyncPaused: Boolean = false
-    override fun isSyncPausedFlow(): Flow<Boolean> = emptyFlow()
-    override var invalidEntitiesIds: List<String> = emptyList()
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "bookmarksLocalFieldValidation",
+)
+interface BookmarksSyncLocalValidationFeature {
+    @Toggle.DefaultValue(false)
+    fun self(): Toggle
 }

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/RealSyncSavedSitesRepository.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/RealSyncSavedSitesRepository.kt
@@ -270,9 +270,10 @@ class RealSyncSavedSitesRepository(
     }
 
     override fun getFolderDiff(folderId: String): SyncFolderChildren {
-        val entities = savedSitesEntitiesDao.allEntitiesInFolderSync(folderId)
-        val deletedChildren = entities.filter { it.deleted }.map { it.entityId }
-        val childrenLocal = entities.filterNot { it.deleted }.map { it.entityId }
+        val entitiesId = savedSitesRelationsDao.relationsByFolderId(folderId).map { it.entityId }
+        val existingEntities = savedSitesEntitiesDao.allEntitiesInFolderSync(folderId)
+        val deletedChildren = existingEntities.filter { it.deleted }.map { it.entityId }
+        val childrenLocal = entitiesId.filterNot { deletedChildren.contains(it) }
 
         val metadata = savedSitesSyncMetadataDao.get(folderId)
             // no response stored for this folder, add children in insert modifier too

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSiteInvalidItemsView.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSiteInvalidItemsView.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.savedsites.impl.sync
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.text.SpannableStringBuilder
+import android.util.AttributeSet
+import android.widget.FrameLayout
+import androidx.core.view.isVisible
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewTreeLifecycleOwner
+import androidx.lifecycle.findViewTreeViewModelStoreOwner
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.browser.api.ui.BrowserScreens.BookmarksScreenNoParams
+import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.ConflatedJob
+import com.duckduckgo.common.utils.ViewViewModelFactory
+import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.navigation.api.GlobalActivityStarter
+import com.duckduckgo.saved.sites.impl.R
+import com.duckduckgo.saved.sites.impl.databinding.ViewSaveSiteRateLimitWarningBinding
+import com.duckduckgo.savedsites.impl.sync.SavedSiteInvalidItemsViewModel.Command
+import com.duckduckgo.savedsites.impl.sync.SavedSiteInvalidItemsViewModel.Command.NavigateToBookmarks
+import com.duckduckgo.savedsites.impl.sync.SavedSiteInvalidItemsViewModel.ViewState
+import dagger.android.support.AndroidSupportInjection
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+
+@InjectWith(ViewScope::class)
+class SavedSiteInvalidItemsView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyle: Int = 0,
+) : FrameLayout(context, attrs, defStyle) {
+
+    @Inject
+    lateinit var globalActivityStarter: GlobalActivityStarter
+
+    @Inject
+    lateinit var viewModelFactory: ViewViewModelFactory
+
+    private var coroutineScope: CoroutineScope? = null
+
+    private var job: ConflatedJob = ConflatedJob()
+
+    private val binding: ViewSaveSiteRateLimitWarningBinding by viewBinding()
+
+    private val viewModel: SavedSiteInvalidItemsViewModel by lazy {
+        ViewModelProvider(findViewTreeViewModelStoreOwner()!!, viewModelFactory)[SavedSiteInvalidItemsViewModel::class.java]
+    }
+
+    override fun onAttachedToWindow() {
+        AndroidSupportInjection.inject(this)
+        super.onAttachedToWindow()
+
+        ViewTreeLifecycleOwner.get(this)?.lifecycle?.addObserver(viewModel)
+
+        @SuppressLint("NoHardcodedCoroutineDispatcher")
+        coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+
+        viewModel.viewState()
+            .onEach { render(it) }
+            .launchIn(coroutineScope!!)
+
+        job += viewModel.commands()
+            .onEach { processCommands(it) }
+            .launchIn(coroutineScope!!)
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        ViewTreeLifecycleOwner.get(this)?.lifecycle?.removeObserver(viewModel)
+        coroutineScope?.cancel()
+        job.cancel()
+        coroutineScope = null
+    }
+
+    private fun processCommands(command: Command) {
+        when (command) {
+            NavigateToBookmarks -> navigateToBookmarks()
+        }
+    }
+
+    private fun render(viewState: ViewState) {
+        this.isVisible = viewState.warningVisible
+
+        val spannable = SpannableStringBuilder(
+            context.resources.getQuantityString(
+                R.plurals.saved_site_invalid_items_warning,
+                viewState.invalidItemsSize,
+                viewState.hint,
+                viewState.invalidItemsSize - 1,
+            ),
+        ).append(context.getText(R.string.saved_site_invalid_items_warning_link))
+
+        binding.saveSiteRateLimitWarning.setClickableLink(
+            "manage_bookmarks",
+            spannable,
+            onClick = {
+                viewModel.onWarningActionClicked()
+            },
+        )
+    }
+
+    private fun navigateToBookmarks() {
+        globalActivityStarter.start(this.context, BookmarksScreenNoParams)
+    }
+}

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSiteInvalidItemsViewModel.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSiteInvalidItemsViewModel.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.savedsites.impl.sync
+
+import android.annotation.SuppressLint
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.savedsites.impl.sync.SavedSiteInvalidItemsViewModel.Command.NavigateToBookmarks
+import javax.inject.Inject
+import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+
+@SuppressLint("NoLifecycleObserver") // we don't observe app lifecycle
+@ContributesViewModel(ViewScope::class)
+class SavedSiteInvalidItemsViewModel @Inject constructor(
+    private val dispatcherProvider: DispatcherProvider,
+    private val syncSavedSitesRepository: SyncSavedSitesRepository,
+) : ViewModel(), DefaultLifecycleObserver {
+
+    data class ViewState(
+        val warningVisible: Boolean = false,
+        val invalidItemsSize: Int = 0,
+        val hint: String = "",
+    )
+
+    sealed class Command {
+        data object NavigateToBookmarks : Command()
+    }
+
+    private val command = Channel<Command>(1, DROP_OLDEST)
+
+    private val _viewState = MutableStateFlow(ViewState())
+    fun viewState(): Flow<ViewState> = _viewState.onStart {
+        viewModelScope.launch(dispatcherProvider.io()) {
+            emitNewViewState()
+        }
+    }
+
+    override fun onResume(owner: LifecycleOwner) {
+        viewModelScope.launch(dispatcherProvider.io()) {
+            emitNewViewState()
+        }
+    }
+
+    fun commands(): Flow<Command> = command.receiveAsFlow()
+
+    private suspend fun emitNewViewState() {
+        val invalidItems = syncSavedSitesRepository.getInvalidSavedSites()
+        _viewState.emit(
+            ViewState(
+                warningVisible = invalidItems.isNotEmpty(),
+                hint = invalidItems.firstOrNull()?.title?.shortenString(15) ?: "",
+                invalidItemsSize = invalidItems.size,
+            ),
+        )
+    }
+
+    fun onWarningActionClicked() {
+        viewModelScope.launch {
+            command.send(NavigateToBookmarks)
+        }
+    }
+
+    private fun String.shortenString(maxLength: Int): String {
+        return this.takeIf { it.length <= maxLength } ?: (this.take(maxLength - 3) + "...")
+    }
+}

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSitesInvalidItemSyncMessagePlugin.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSitesInvalidItemSyncMessagePlugin.kt
@@ -14,16 +14,18 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.autofill.sync
+package com.duckduckgo.savedsites.impl.sync
 
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
+import android.content.Context
+import android.view.View
+import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.sync.api.SyncMessagePlugin
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
 
-class FakeCredentialsSyncStore : CredentialsSyncStore {
-    override var serverModifiedSince: String = "0"
-    override var startTimeStamp: String = "0"
-    override var clientModifiedSince: String = "0"
-    override var isSyncPaused: Boolean = false
-    override fun isSyncPausedFlow(): Flow<Boolean> = emptyFlow()
-    override var invalidEntitiesIds: List<String> = emptyList()
+@ContributesMultibinding(scope = ActivityScope::class)
+class SavedSitesInvalidItemSyncMessagePlugin @Inject constructor() : SyncMessagePlugin {
+    override fun getView(context: Context): View {
+        return SavedSiteInvalidItemsView(context)
+    }
 }

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSitesSyncDataProvider.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSitesSyncDataProvider.kt
@@ -40,6 +40,7 @@ class SavedSitesSyncDataProvider @Inject constructor(
     private val savedSitesSyncStore: SavedSitesSyncStore,
     private val syncCrypto: SyncCrypto,
     private val savedSitesFormFactorSyncMigration: SavedSitesFormFactorSyncMigration,
+    private val bookmarksSyncLocalValidationFeature: BookmarksSyncLocalValidationFeature,
 ) : SyncableDataProvider {
     override fun getType(): SyncableType = BOOKMARKS
 
@@ -73,20 +74,33 @@ class SavedSitesSyncDataProvider @Inject constructor(
             if (folder.isDeleted()) {
                 updates.add(deletedEntry(folder.id))
             } else {
-                updates.add(encryptedFolder(folder))
+                updates.add(encryptedFolder(fixFolderIfNecessary(folder)))
             }
         }
+
+        // retry invalid items
+        val newInvalidItems = mutableListOf<String>()
+        val oldInvalidSavedSites = syncSavedSitesRepository.getInvalidSavedSites()
+        Timber.i("Sync-Bookmarks: invalid items to retry: $oldInvalidSavedSites")
 
         // then we add individual bookmarks that have been modified
         val bookmarks = syncSavedSitesRepository.getBookmarksModifiedSince(since)
-        bookmarks.forEach { bookmark ->
+        (oldInvalidSavedSites + bookmarks).forEach { bookmark ->
+            Timber.i("Sync-Bookmarks: processing bookmark ${bookmark.id}")
             if (bookmark.isDeleted()) {
                 updates.add(deletedEntry(bookmark.id))
             } else {
-                updates.add(encryptedSavedSite(bookmark))
+                encryptedSavedSite(bookmark).also {
+                    if (isValid(it)) {
+                        updates.add(it)
+                    } else {
+                        newInvalidItems.add(bookmark.id)
+                    }
+                }
             }
         }
 
+        syncSavedSitesRepository.markSavedSitesAsInvalid(newInvalidItems)
         return updates.distinct()
     }
 
@@ -120,6 +134,7 @@ class SavedSitesSyncDataProvider @Inject constructor(
         folderId: String,
         requestEntries: MutableList<SyncSavedSitesRequestEntry>,
     ): List<SyncSavedSitesRequestEntry> {
+        val invalidItems = mutableListOf<String>()
         syncSavedSitesRepository.getAllFolderContentSync(folderId).apply {
             val folder = repository.getFolder(folderId)
             if (folder != null) {
@@ -127,7 +142,14 @@ class SavedSitesSyncDataProvider @Inject constructor(
                     if (bookmark.deleted != null) {
                         requestEntries.add(deletedEntry(bookmark.id))
                     } else {
-                        requestEntries.add(encryptedSavedSite(bookmark))
+                        encryptedSavedSite(bookmark).also {
+                                encryptedSavedSite ->
+                            if (isValid(encryptedSavedSite)) {
+                                requestEntries.add(encryptedSavedSite)
+                            } else {
+                                invalidItems.add(bookmark.id)
+                            }
+                        }
                     }
                 }
                 for (eachFolder in this.second) {
@@ -137,9 +159,10 @@ class SavedSitesSyncDataProvider @Inject constructor(
                         getRequestEntriesFor(eachFolder.id, requestEntries)
                     }
                 }
-                requestEntries.add(encryptedFolder(folder))
+                requestEntries.add(encryptedFolder(fixFolderIfNecessary(folder)))
             }
         }
+        syncSavedSitesRepository.markSavedSitesAsInvalid(invalidItems)
         return requestEntries
     }
 
@@ -197,11 +220,33 @@ class SavedSitesSyncDataProvider @Inject constructor(
         }
     }
 
+    private fun isValid(syncSavedSite: SyncSavedSitesRequestEntry): Boolean {
+        if (bookmarksSyncLocalValidationFeature.self().isEnabled().not()) return true // no validation required
+
+        val titleLength = syncSavedSite.title?.length ?: 0
+        val urlLength = syncSavedSite.page?.url?.length ?: 0
+
+        return (titleLength >= MAX_ENCRYPTED_TITLE_LENGTH || urlLength >= MAX_ENCRYPTED_URL_LENGTH).not()
+    }
+
+    private fun fixFolderIfNecessary(folder: BookmarkFolder): BookmarkFolder {
+        if (bookmarksSyncLocalValidationFeature.self().isEnabled().not()) return folder
+
+        val fixedName = folder.name.take(MAX_FOLDER_TITLE_LENGTH)
+        return folder.copy(name = fixedName)
+    }
+
     private class Adapters {
         companion object {
             private val moshi = Moshi.Builder().build()
             val patchAdapter: JsonAdapter<SyncBookmarksRequest> =
                 moshi.adapter(SyncBookmarksRequest::class.java)
         }
+    }
+
+    companion object {
+        const val MAX_ENCRYPTED_TITLE_LENGTH = 3000
+        const val MAX_FOLDER_TITLE_LENGTH = 2000
+        const val MAX_ENCRYPTED_URL_LENGTH = 3000
     }
 }

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSitesSyncPersister.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSitesSyncPersister.kt
@@ -77,6 +77,7 @@ class SavedSitesSyncPersister @Inject constructor(
         savedSitesFormFactorSyncMigration.onFormFactorFavouritesDisabled()
         savedSitesSyncState.onSyncDisabled()
         savedSitesSyncRepository.removeMetadata()
+        savedSitesSyncRepository.markSavedSitesAsInvalid(emptyList())
     }
 
     fun process(

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SyncEntitiesExtension.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SyncEntitiesExtension.kt
@@ -23,6 +23,15 @@ import java.time.*
 fun Entity.mapToBookmark(relationId: String): SavedSite.Bookmark =
     SavedSite.Bookmark(this.entityId, this.title, this.url.orEmpty(), relationId, this.lastModified, deleted = this.deletedFlag())
 
+fun Entity.mapToSavedSite(): SavedSite =
+    SavedSite.Bookmark(
+        id = this.entityId,
+        title = this.title,
+        url = this.url.orEmpty(),
+        lastModified = this.lastModified,
+        deleted = this.deletedFlag(),
+    )
+
 fun Entity.mapToFavorite(index: Int = 0): SavedSite.Favorite =
     SavedSite.Favorite(
         id = this.entityId,

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SyncSavedSitesRepository.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SyncSavedSitesRepository.kt
@@ -185,4 +185,14 @@ interface SyncSavedSitesRepository {
      * they are available for the next sync operation
      */
     fun setLocalEntitiesForNextSync(startTimestamp: String)
+
+    /**
+     * Returns the list of [SavedSite] that are marked as Invalid
+     */
+    fun getInvalidSavedSites(): List<SavedSite>
+
+    /**
+     * Marks as Invalid a list of [SavedSite] with the given ids
+     */
+    fun markSavedSitesAsInvalid(ids: List<String>)
 }

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/store/SavedSitesSyncEntitiesStore.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/store/SavedSitesSyncEntitiesStore.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.savedsites.impl.sync.store
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+interface SavedSitesSyncEntitiesStore {
+    var invalidEntitiesIds: List<String>
+}
+
+@ContributesBinding(AppScope::class)
+@SingleInstanceIn(AppScope::class)
+class RealSavedSitesSyncEntitiesStore @Inject constructor(
+    private val context: Context,
+) : SavedSitesSyncEntitiesStore {
+
+    override var invalidEntitiesIds: List<String>
+        get() = preferences.getStringSet(KEY_CLIENT_INVALID_IDS, mutableSetOf())?.toList() ?: mutableListOf()
+        set(value) {
+            preferences.edit(true) {
+                putStringSet(KEY_CLIENT_INVALID_IDS, value.toSet())
+            }
+        }
+
+    private val preferences: SharedPreferences
+        get() = context.getSharedPreferences(FILENAME, Context.MODE_PRIVATE)
+
+    companion object {
+        const val FILENAME = "com.duckduckgo.savedsites.sync.entities.store"
+        private const val KEY_CLIENT_INVALID_IDS = "KEY_CLIENT_INVALID_IDS"
+    }
+}

--- a/saved-sites/saved-sites-impl/src/main/res/values/donottranslate.xml
+++ b/saved-sites/saved-sites-impl/src/main/res/values/donottranslate.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2024 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!-- smartling.entity_escaping = false -->
+<!-- smartling.instruction_attributes = instruction -->
+<resources>
+    <!-- Sync settings screen -->
+    <plurals name="saved_site_invalid_items_warning" instruction="%1$ represents a site name or url, %2$d is the number of other invalid sites">
+        <item quantity="one">Your bookmark for %1$s can’t sync because one of its fields exceeds the character limit.\n\n</item>
+        <item quantity="other">Your bookmarks for %1$s and %2$d other sites can’t sync because some of their fields exceed the character limit.\n\n</item>
+    </plurals>
+    <string name="saved_site_invalid_items_warning_link"><annotation type="manage_bookmarks">Manage Bookmarks</annotation></string>
+</resources>

--- a/saved-sites/saved-sites-store/src/main/java/com/duckduckgo/savedsites/store/SavedSitesEntitiesDao.kt
+++ b/saved-sites/saved-sites-store/src/main/java/com/duckduckgo/savedsites/store/SavedSitesEntitiesDao.kt
@@ -41,6 +41,9 @@ interface SavedSitesEntitiesDao {
     @Query("select * from entities where deleted=0")
     fun entities(): List<Entity>
 
+    @Query("select * from entities where entities.entityId IN (:ids)")
+    fun entities(ids: List<String>): List<Entity>
+
     @Query(
         "select * from entities inner join relations on entities.entityId = relations.entityId " +
             "and entities.type = :type and relations.folderId = :folderId and entities.deleted = 0",


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1206754257727806/f 

### Description
When calculating diff folder changes, for missing entities in the local db, we should stop adding them as deleted from folder. Instead just keep data as it is.

### Steps to test this PR

Best way to test this PR without hardcoding lines is by using `feature/cristian/sync/filter_invalid_items_patch` branch. That way you could test what happens when entities are missing in the payload.

_Feature 1_
- [ ] Checkout branch `feature/cristian/sync/filter_invalid_items_patch`
- [ ] fresh install in 2 devices
- [ ] go to Device A
- [ ] create a sync account
- [ ] go to device B
- [ ] join the sync account
- [ ] go back to Device A
- [ ] turn on airplane mode (we are going to create invalid bookmarks)
- [ ] create a bookmark (Bookmark1A), and edit title to have >3000 chars
- [ ] turn off airplane
- [ ] make something to trigger sync (e.g: access bookmarks screen)
- [ ] Take note of Bookmark1A Id (we will need it later)
- [ ] go back to Device B
- [ ] add this filter in your logcat for device B `package:mine message~:"Sync-Bookmarks-Metadata"`
(now we will perform some actions on DeviceB, ensure you **NEVER** see the Bookmark1A Id in the bookmarks_root Diff as Deleted)
- [ ] go to bookmarks screen, that should trigger sync
- [ ] add a bookmark (bookmark1B)
- [ ] remove the bookmark1B

_Ensure relations are not removed_
- [ ] Checkout this branch
- [ ] fresh install
- [ ] create some bookmarks and folders
- [ ] From the IDE, go to inspect Database -> saved sites  -> entity table
- [ ] choose a random bookmark and take note of the bookmark id
- [ ] change that bookmark id manually to something different from the inspect database view
- [ ] In the UI that bookmark will disappear, however relations to the old id should not disappear
- [ ] move/sort bookmarks
- [ ] ensure we never lose the relation to the old Id
- [ ] (optional) again in the db, update the bookmark id again with the right Id
- [ ] (optional) now that entity should be visible again in the UI

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
