### PR TITLE
Update content scope scripts to version 5.6.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -745,7 +745,8 @@
         'harmfulApis',
         'webCompat',
         'windowsPermissionUsage',
-        'brokerProtection'
+        'brokerProtection',
+        'performanceMetrics'
     ]);
 
     /** @typedef {baseFeatures[number]|otherFeatures[number]} FeatureName */
@@ -757,7 +758,8 @@
         ],
         'apple-isolated': [
             'duckPlayer',
-            'brokerProtection'
+            'brokerProtection',
+            'performanceMetrics'
         ],
         android: [
             ...baseFeatures,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^10.3.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.1.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.5.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.6.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#3.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1708702034"
       },
@@ -59,9 +59,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-10.3.0.tgz",
-      "integrity": "sha512-dUf37qkaYDuXEytU9mNNLGw28S1t1M1dFnvMHZDV9BpINVJeAl1ye7CmlABuGlDs6URrp2ZLZ5IxcKQhQglYcw=="
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-10.3.1.tgz",
+      "integrity": "sha512-RuqAQ/588fgrPHMn8AIpFwjDaHaHKnMtGMjiZF5KTMynQtDAZzze2csl+E81yrFbwFT1IZmazX7lO28db7DM6w=="
     },
     "node_modules/@duckduckgo/autofill": {
       "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#03d3e3a959dd75afbe8c59b5a203ea676d37555d",
@@ -69,7 +69,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#a9a0aeb0d259930406a0337ccc719c9afa8b575f",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#edd96481d49b094c260f9a79e078abdbdd3a83fb",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -268,9 +268,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.11.27",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.27.tgz",
-      "integrity": "sha512-qyUZfMnCg1KEz57r7pzFtSGt49f6RPkPBis3Vo4PbS7roQEDn22hiHzl/Lo1q4i4hDEgBJmBF/NTNg2XR0HbFg==",
+      "version": "20.11.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.28.tgz",
+      "integrity": "sha512-M/GPWVS2wLkSkNHVeLkrF2fD5Lx5UC4PxA0uZcKc6QqbIQUJyW1jVjueJYi1z8n0I5PxYrtpnPnWglE+y9A0KA==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^10.3.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.1.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.5.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.6.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#3.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1708702034"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1206855832321443/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass