### PR TITLE
Filtering invalid items from Bookmarks patch

### DIFF
--- a/app/src/test/java/com/duckduckgo/app/bookmarks/BookmarkTestUtils.kt
+++ b/app/src/test/java/com/duckduckgo/app/bookmarks/BookmarkTestUtils.kt
@@ -84,6 +84,16 @@ object BookmarkTestUtils {
         return relations
     }
 
+    fun createInvalidBookmark(): Bookmark {
+        val veryLongTitle = String(CharArray(3000) { 'a' + (it % 26) })
+        return aBookmark(id = "invalid", title = veryLongTitle, url = "invalid")
+    }
+
+    fun createInvalidFolder(): BookmarkFolder {
+        val veryLongName = String(CharArray(3000) { 'a' + (it % 26) })
+        return aBookmarkFolder(id = "invalidFolder", name = veryLongName, parentId = SavedSitesNames.BOOKMARKS_ROOT)
+    }
+
     fun aBookmarkFolder(
         id: String,
         name: String,

--- a/app/src/test/java/com/duckduckgo/app/bookmarks/model/SyncSavedSitesRepositoryTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/bookmarks/model/SyncSavedSitesRepositoryTest.kt
@@ -40,9 +40,9 @@ import com.duckduckgo.savedsites.api.models.SavedSitesNames
 import com.duckduckgo.savedsites.impl.MissingEntitiesRelationReconciler
 import com.duckduckgo.savedsites.impl.RealFavoritesDelegate
 import com.duckduckgo.savedsites.impl.RealSavedSitesRepository
-import com.duckduckgo.savedsites.impl.sync.RealSavedSitesSyncStore
 import com.duckduckgo.savedsites.impl.sync.RealSyncSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.SyncSavedSitesRepository
+import com.duckduckgo.savedsites.impl.sync.store.RealSavedSitesSyncEntitiesStore
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDao
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDatabase
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataEntity
@@ -87,10 +87,8 @@ class SyncSavedSitesRepositoryTest {
     private lateinit var savedSitesDatabase: SavedSitesSyncMetadataDatabase
     private lateinit var repository: SyncSavedSitesRepository
     private lateinit var savedSitesRepository: SavedSitesRepository
-    private val store = RealSavedSitesSyncStore(
+    private val store = RealSavedSitesSyncEntitiesStore(
         InstrumentationRegistry.getInstrumentation().context,
-        coroutinesTestRule.testScope,
-        coroutinesTestRule.testDispatcherProvider,
     )
 
     val stringListType = Types.newParameterizedType(List::class.java, String::class.java)

--- a/app/src/test/java/com/duckduckgo/app/sync/SavedSitesSyncDataProviderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/sync/SavedSitesSyncDataProviderTest.kt
@@ -46,6 +46,7 @@ import com.duckduckgo.savedsites.impl.sync.SyncFolderChildren
 import com.duckduckgo.savedsites.impl.sync.SyncSavedSiteRequestFolder
 import com.duckduckgo.savedsites.impl.sync.SyncSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.SyncSavedSitesRequestEntry
+import com.duckduckgo.savedsites.impl.sync.store.RealSavedSitesSyncEntitiesStore
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDao
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDatabase
 import com.duckduckgo.savedsites.store.SavedSitesEntitiesDao
@@ -82,7 +83,10 @@ class SavedSitesSyncDataProviderTest {
     private lateinit var savedSitesRelationsDao: SavedSitesRelationsDao
     private lateinit var savedSitesMetadataDao: SavedSitesSyncMetadataDao
     private lateinit var savedSitesFormFactorSyncMigration: SavedSitesFormFactorSyncMigration
-    private val store = RealSavedSitesSyncStore(
+    private val syncEntitiesStore = RealSavedSitesSyncEntitiesStore(
+        InstrumentationRegistry.getInstrumentation().context,
+    )
+    private val syncFeatureStore = RealSavedSitesSyncStore(
         InstrumentationRegistry.getInstrumentation().context,
         coroutinesTestRule.testScope,
         coroutinesTestRule.testDispatcherProvider,
@@ -131,7 +135,7 @@ class SavedSitesSyncDataProviderTest {
             coroutinesTestRule.testDispatcherProvider,
         )
 
-        syncRepository = RealSyncSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, savedSitesMetadataDao, store)
+        syncRepository = RealSyncSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, savedSitesMetadataDao, syncEntitiesStore)
         repository = RealSavedSitesRepository(
             savedSitesEntitiesDao,
             savedSitesRelationsDao,
@@ -145,7 +149,7 @@ class SavedSitesSyncDataProviderTest {
             savedSitesRelationsDao,
             savedSitesSettingsRepository,
         )
-        parser = SavedSitesSyncDataProvider(repository, syncRepository, store, FakeCrypto(), savedSitesFormFactorSyncMigration)
+        parser = SavedSitesSyncDataProvider(repository, syncRepository, syncFeatureStore, FakeCrypto(), savedSitesFormFactorSyncMigration)
 
         favoritesFolder = repository.insert(favoritesFolder)
         bookmarksRootFolder = repository.insert(bookmarksRootFolder)
@@ -490,8 +494,8 @@ class SavedSitesSyncDataProviderTest {
         lastServerSyncTimestamp: String,
         lastClientSyncTimestmp: String = lastServerSyncTimestamp,
     ) {
-        store.serverModifiedSince = lastServerSyncTimestamp
-        store.clientModifiedSince = lastClientSyncTimestmp
+        syncFeatureStore.serverModifiedSince = lastServerSyncTimestamp
+        syncFeatureStore.clientModifiedSince = lastClientSyncTimestmp
     }
 
     private fun fromSavedSite(savedSite: SavedSite): SyncSavedSitesRequestEntry {

--- a/app/src/test/java/com/duckduckgo/app/sync/SavedSitesSyncDataProviderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/sync/SavedSitesSyncDataProviderTest.kt
@@ -20,13 +20,15 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.app.bookmarks.BookmarkTestUtils.aBookmark
+import com.duckduckgo.app.bookmarks.BookmarkTestUtils.createInvalidBookmark
+import com.duckduckgo.app.bookmarks.BookmarkTestUtils.createInvalidFolder
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.formatters.time.DatabaseDateFormatter
 import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.savedsites.api.models.BookmarkFolder
 import com.duckduckgo.savedsites.api.models.SavedSite
-import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
 import com.duckduckgo.savedsites.api.models.SavedSite.Favorite
 import com.duckduckgo.savedsites.api.models.SavedSitesNames
 import com.duckduckgo.savedsites.impl.MissingEntitiesRelationReconciler
@@ -37,7 +39,7 @@ import com.duckduckgo.savedsites.impl.sync.RealSavedSitesSyncStore
 import com.duckduckgo.savedsites.impl.sync.RealSyncSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.SavedSitesFormFactorSyncMigration
 import com.duckduckgo.savedsites.impl.sync.SavedSitesSyncDataProvider
-import com.duckduckgo.savedsites.impl.sync.SavedSitesSyncStore
+import com.duckduckgo.savedsites.impl.sync.SavedSitesSyncDataProvider.Companion.MAX_FOLDER_TITLE_LENGTH
 import com.duckduckgo.savedsites.impl.sync.SyncBookmarkPage
 import com.duckduckgo.savedsites.impl.sync.SyncBookmarksRequest
 import com.duckduckgo.savedsites.impl.sync.SyncFolderChildren
@@ -80,7 +82,11 @@ class SavedSitesSyncDataProviderTest {
     private lateinit var savedSitesRelationsDao: SavedSitesRelationsDao
     private lateinit var savedSitesMetadataDao: SavedSitesSyncMetadataDao
     private lateinit var savedSitesFormFactorSyncMigration: SavedSitesFormFactorSyncMigration
-    private lateinit var store: SavedSitesSyncStore
+    private val store = RealSavedSitesSyncStore(
+        InstrumentationRegistry.getInstrumentation().context,
+        coroutinesTestRule.testScope,
+        coroutinesTestRule.testDispatcherProvider,
+    )
 
     private lateinit var parser: SavedSitesSyncDataProvider
 
@@ -92,6 +98,8 @@ class SavedSitesSyncDataProviderTest {
     private val bookmark2 = aBookmark("bookmark2", "Bookmark 2", "https://bookmark2.com")
     private val bookmark3 = aBookmark("bookmark3", "Bookmark 3", "https://bookmark3.com")
     private val bookmark4 = aBookmark("bookmark4", "Bookmark 4", "https://bookmark4.com")
+    private val invalidBookmark = createInvalidBookmark()
+    private val invalidFolder = createInvalidFolder()
 
     private val threeHoursAgo = OffsetDateTime.now(ZoneOffset.UTC).minusHours(3)
     private val twoHoursAgo = OffsetDateTime.now(ZoneOffset.UTC).minusHours(2)
@@ -123,17 +131,12 @@ class SavedSitesSyncDataProviderTest {
             coroutinesTestRule.testDispatcherProvider,
         )
 
-        syncRepository = RealSyncSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, savedSitesMetadataDao)
+        syncRepository = RealSyncSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, savedSitesMetadataDao, store)
         repository = RealSavedSitesRepository(
             savedSitesEntitiesDao,
             savedSitesRelationsDao,
             favoritesDelegate,
             MissingEntitiesRelationReconciler(savedSitesEntitiesDao),
-            coroutinesTestRule.testDispatcherProvider,
-        )
-        store = RealSavedSitesSyncStore(
-            InstrumentationRegistry.getInstrumentation().context,
-            coroutinesTestRule.testScope,
             coroutinesTestRule.testDispatcherProvider,
         )
 
@@ -210,6 +213,77 @@ class SavedSitesSyncDataProviderTest {
         assertTrue(changes.bookmarks.updates[0].id == "bookmark3")
         assertTrue(changes.bookmarks.updates[1].id == "bookmark4")
         assertTrue(changes.bookmarks.updates[2].id == "bookmarks_root")
+    }
+
+    @Test
+    fun whenOnFirstSyncBookmarkIsInvalidThenChangesDoesNotContainInvalidEntity() {
+        repository.insert(invalidBookmark)
+
+        val syncChanges = parser.getChanges()
+
+        val changes = Adapters.adapter.fromJson(syncChanges.jsonString)!!
+        assertTrue(changes.bookmarks.updates.size == 1)
+        assertTrue(changes.bookmarks.updates[0].id == "bookmarks_root")
+        assertTrue(changes.bookmarks.updates[0].folder?.children?.current?.contains(invalidBookmark.id) ?: false)
+    }
+
+    @Test
+    fun whenOnFirstSyncFolderIsInvalidThenChangesContainDataFixed() {
+        repository.insert(invalidBookmark)
+        repository.insert(invalidFolder)
+
+        val syncChanges = parser.getChanges()
+
+        val changes = Adapters.adapter.fromJson(syncChanges.jsonString)!!
+        assertTrue(changes.bookmarks.updates.size == 2)
+        assertTrue(changes.bookmarks.updates[0].id == invalidFolder.id)
+        assertTrue(changes.bookmarks.updates[0].title?.length == MAX_FOLDER_TITLE_LENGTH)
+        assertTrue(changes.bookmarks.updates[1].id == "bookmarks_root")
+        assertTrue(changes.bookmarks.updates[1].folder?.children?.current?.contains(invalidFolder.id) ?: false)
+    }
+
+    @Test
+    fun whenNewBookmarkIsInvalidThenChangesDoesNotContainInvalidEntity() {
+        setLastSyncTime(DatabaseDateFormatter.iso8601(twoHoursAgo))
+        repository.insert(invalidBookmark.copy(lastModified = DatabaseDateFormatter.iso8601(oneHourAgo)))
+
+        val syncChanges = parser.getChanges()
+
+        val changes = Adapters.adapter.fromJson(syncChanges.jsonString)!!
+        assertTrue(changes.bookmarks.updates.size == 1)
+        assertTrue(changes.bookmarks.updates[0].id == "bookmarks_root")
+        assertTrue(changes.bookmarks.updates[0].folder?.children?.current?.contains(invalidBookmark.id) ?: false)
+    }
+
+    @Test
+    fun whenNewFolderIsInvalidThenChangesContainDataFixed() {
+        setLastSyncTime(DatabaseDateFormatter.iso8601(twoHoursAgo))
+        repository.insert(invalidBookmark.copy(lastModified = DatabaseDateFormatter.iso8601(oneHourAgo)))
+        repository.insert(invalidFolder.copy(lastModified = DatabaseDateFormatter.iso8601(oneHourAgo)))
+
+        val syncChanges = parser.getChanges()
+
+        val changes = Adapters.adapter.fromJson(syncChanges.jsonString)!!
+        assertTrue(changes.bookmarks.updates.size == 2)
+        assertTrue(changes.bookmarks.updates.find { it.id == invalidFolder.id }!!.title?.length == MAX_FOLDER_TITLE_LENGTH)
+        assertTrue(changes.bookmarks.updates.find { it.id == "bookmarks_root" }!!.folder?.children?.current?.contains(invalidFolder.id) ?: false)
+    }
+
+    @Test
+    fun whenInvalidBookmarkPresentAndValidBookmarkAddedThenOnlyValidBookmarkIncluded() {
+        repository.insert(invalidBookmark)
+        syncRepository.markSavedSitesAsInvalid(listOf(invalidBookmark.id))
+        setLastSyncTime(DatabaseDateFormatter.iso8601(twoHoursAgo))
+        repository.insert(bookmark1.copy(lastModified = DatabaseDateFormatter.iso8601(oneHourAgo)))
+
+        val syncChanges = parser.getChanges()
+
+        val changes = Adapters.adapter.fromJson(syncChanges.jsonString)!!
+        assertTrue(changes.bookmarks.updates.size == 2)
+        assertTrue(changes.bookmarks.updates.find { it.id == "bookmarks_root" }!!.folder?.children?.current?.contains(invalidBookmark.id) ?: false)
+        assertTrue(changes.bookmarks.updates.find { it.id == "bookmarks_root" }!!.folder?.children?.current?.contains(bookmark1.id) ?: false)
+        assertTrue(changes.bookmarks.updates.find { it.id == bookmark1.id } != null)
+        assertTrue(syncRepository.getInvalidSavedSites().size == 1)
     }
 
     @Test
@@ -462,15 +536,6 @@ class SavedSitesSyncDataProviderTest {
         timestamp: String = "2023-05-10T16:10:32.338Z",
     ): Favorite {
         return Favorite(id, title, url, lastModified = timestamp, position)
-    }
-
-    private fun aBookmark(
-        id: String,
-        title: String,
-        url: String,
-        timestamp: String = "2023-05-10T16:10:32.338Z",
-    ): Bookmark {
-        return Bookmark(id, title, url, lastModified = timestamp)
     }
 
     private class Adapters {

--- a/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesDeduplicationPersisterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesDeduplicationPersisterTest.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.savedsites.api.models.SavedSitesNames
 import com.duckduckgo.savedsites.impl.MissingEntitiesRelationReconciler
 import com.duckduckgo.savedsites.impl.RealFavoritesDelegate
 import com.duckduckgo.savedsites.impl.RealSavedSitesRepository
+import com.duckduckgo.savedsites.impl.sync.RealSavedSitesSyncStore
 import com.duckduckgo.savedsites.impl.sync.RealSyncSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.SyncSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.algorithm.RealSavedSitesDuplicateFinder
@@ -67,8 +68,12 @@ class SavedSitesDeduplicationPersisterTest {
     private lateinit var savedSitesRelationsDao: SavedSitesRelationsDao
     private lateinit var savedSitesMetadataDao: SavedSitesSyncMetadataDao
     private lateinit var duplicateFinder: SavedSitesDuplicateFinder
-
     private lateinit var persister: SavedSitesDeduplicationPersister
+    private val store = RealSavedSitesSyncStore(
+        InstrumentationRegistry.getInstrumentation().context,
+        coroutinesTestRule.testScope,
+        coroutinesTestRule.testDispatcherProvider,
+    )
 
     @Before
     fun setup() {
@@ -95,7 +100,7 @@ class SavedSitesDeduplicationPersisterTest {
             coroutinesTestRule.testDispatcherProvider,
         )
 
-        syncSavedSitesRepository = RealSyncSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, savedSitesMetadataDao)
+        syncSavedSitesRepository = RealSyncSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, savedSitesMetadataDao, store)
         repository = RealSavedSitesRepository(
             savedSitesEntitiesDao,
             savedSitesRelationsDao,

--- a/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesDeduplicationPersisterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesDeduplicationPersisterTest.kt
@@ -33,12 +33,12 @@ import com.duckduckgo.savedsites.api.models.SavedSitesNames
 import com.duckduckgo.savedsites.impl.MissingEntitiesRelationReconciler
 import com.duckduckgo.savedsites.impl.RealFavoritesDelegate
 import com.duckduckgo.savedsites.impl.RealSavedSitesRepository
-import com.duckduckgo.savedsites.impl.sync.RealSavedSitesSyncStore
 import com.duckduckgo.savedsites.impl.sync.RealSyncSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.SyncSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.algorithm.RealSavedSitesDuplicateFinder
 import com.duckduckgo.savedsites.impl.sync.algorithm.SavedSitesDeduplicationPersister
 import com.duckduckgo.savedsites.impl.sync.algorithm.SavedSitesDuplicateFinder
+import com.duckduckgo.savedsites.impl.sync.store.RealSavedSitesSyncEntitiesStore
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDao
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDatabase
 import com.duckduckgo.savedsites.store.SavedSitesEntitiesDao
@@ -69,10 +69,8 @@ class SavedSitesDeduplicationPersisterTest {
     private lateinit var savedSitesMetadataDao: SavedSitesSyncMetadataDao
     private lateinit var duplicateFinder: SavedSitesDuplicateFinder
     private lateinit var persister: SavedSitesDeduplicationPersister
-    private val store = RealSavedSitesSyncStore(
+    private val store = RealSavedSitesSyncEntitiesStore(
         InstrumentationRegistry.getInstrumentation().context,
-        coroutinesTestRule.testScope,
-        coroutinesTestRule.testDispatcherProvider,
     )
 
     @Before

--- a/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesDuplicateFinderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesDuplicateFinderTest.kt
@@ -30,12 +30,12 @@ import com.duckduckgo.savedsites.api.models.SavedSitesNames
 import com.duckduckgo.savedsites.impl.MissingEntitiesRelationReconciler
 import com.duckduckgo.savedsites.impl.RealFavoritesDelegate
 import com.duckduckgo.savedsites.impl.RealSavedSitesRepository
-import com.duckduckgo.savedsites.impl.sync.RealSavedSitesSyncStore
 import com.duckduckgo.savedsites.impl.sync.RealSyncSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.SyncSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.algorithm.RealSavedSitesDuplicateFinder
 import com.duckduckgo.savedsites.impl.sync.algorithm.SavedSitesDuplicateFinder
 import com.duckduckgo.savedsites.impl.sync.algorithm.SavedSitesDuplicateResult
+import com.duckduckgo.savedsites.impl.sync.store.RealSavedSitesSyncEntitiesStore
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDao
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDatabase
 import com.duckduckgo.savedsites.store.SavedSitesEntitiesDao
@@ -67,10 +67,8 @@ class SavedSitesDuplicateFinderTest {
     private lateinit var savedSitesRelationsDao: SavedSitesRelationsDao
     private lateinit var savedSitesMetadataDao: SavedSitesSyncMetadataDao
     private lateinit var duplicateFinder: SavedSitesDuplicateFinder
-    private val store = RealSavedSitesSyncStore(
+    private val store = RealSavedSitesSyncEntitiesStore(
         InstrumentationRegistry.getInstrumentation().context,
-        coroutinesTestRule.testScope,
-        coroutinesTestRule.testDispatcherProvider,
     )
 
     @Before

--- a/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesDuplicateFinderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesDuplicateFinderTest.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.savedsites.api.models.SavedSitesNames
 import com.duckduckgo.savedsites.impl.MissingEntitiesRelationReconciler
 import com.duckduckgo.savedsites.impl.RealFavoritesDelegate
 import com.duckduckgo.savedsites.impl.RealSavedSitesRepository
+import com.duckduckgo.savedsites.impl.sync.RealSavedSitesSyncStore
 import com.duckduckgo.savedsites.impl.sync.RealSyncSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.SyncSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.algorithm.RealSavedSitesDuplicateFinder
@@ -65,8 +66,12 @@ class SavedSitesDuplicateFinderTest {
     private lateinit var savedSitesEntitiesDao: SavedSitesEntitiesDao
     private lateinit var savedSitesRelationsDao: SavedSitesRelationsDao
     private lateinit var savedSitesMetadataDao: SavedSitesSyncMetadataDao
-
     private lateinit var duplicateFinder: SavedSitesDuplicateFinder
+    private val store = RealSavedSitesSyncStore(
+        InstrumentationRegistry.getInstrumentation().context,
+        coroutinesTestRule.testScope,
+        coroutinesTestRule.testDispatcherProvider,
+    )
 
     @Before
     fun setup() {
@@ -93,7 +98,7 @@ class SavedSitesDuplicateFinderTest {
             coroutinesTestRule.testDispatcherProvider,
         )
 
-        syncRepository = RealSyncSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, savedSitesMetadataDao)
+        syncRepository = RealSyncSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, savedSitesMetadataDao, store)
         repository = RealSavedSitesRepository(
             savedSitesEntitiesDao,
             savedSitesRelationsDao,

--- a/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesLocalWinsPersisterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesLocalWinsPersisterTest.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.savedsites.api.models.SavedSitesNames
 import com.duckduckgo.savedsites.impl.MissingEntitiesRelationReconciler
 import com.duckduckgo.savedsites.impl.RealFavoritesDelegate
 import com.duckduckgo.savedsites.impl.RealSavedSitesRepository
+import com.duckduckgo.savedsites.impl.sync.RealSavedSitesSyncStore
 import com.duckduckgo.savedsites.impl.sync.RealSyncSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.SyncSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.algorithm.SavedSitesLocalWinsPersister
@@ -64,8 +65,12 @@ class SavedSitesLocalWinsPersisterTest {
     private lateinit var savedSitesEntitiesDao: SavedSitesEntitiesDao
     private lateinit var savedSitesRelationsDao: SavedSitesRelationsDao
     private lateinit var savedSitesMetadataDao: SavedSitesSyncMetadataDao
-
     private lateinit var persister: SavedSitesLocalWinsPersister
+    private val store = RealSavedSitesSyncStore(
+        InstrumentationRegistry.getInstrumentation().context,
+        coroutinesTestRule.testScope,
+        coroutinesTestRule.testDispatcherProvider,
+    )
 
     private val twoHoursAgo = DatabaseDateFormatter.iso8601(OffsetDateTime.now(ZoneOffset.UTC).minusHours(2))
 
@@ -94,7 +99,7 @@ class SavedSitesLocalWinsPersisterTest {
             MissingEntitiesRelationReconciler(savedSitesEntitiesDao),
             coroutinesTestRule.testDispatcherProvider,
         )
-        syncRepository = RealSyncSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, savedSitesMetadataDao)
+        syncRepository = RealSyncSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, savedSitesMetadataDao, store)
         repository = RealSavedSitesRepository(
             savedSitesEntitiesDao,
             savedSitesRelationsDao,

--- a/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesLocalWinsPersisterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesLocalWinsPersisterTest.kt
@@ -32,10 +32,10 @@ import com.duckduckgo.savedsites.api.models.SavedSitesNames
 import com.duckduckgo.savedsites.impl.MissingEntitiesRelationReconciler
 import com.duckduckgo.savedsites.impl.RealFavoritesDelegate
 import com.duckduckgo.savedsites.impl.RealSavedSitesRepository
-import com.duckduckgo.savedsites.impl.sync.RealSavedSitesSyncStore
 import com.duckduckgo.savedsites.impl.sync.RealSyncSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.SyncSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.algorithm.SavedSitesLocalWinsPersister
+import com.duckduckgo.savedsites.impl.sync.store.RealSavedSitesSyncEntitiesStore
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDao
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDatabase
 import com.duckduckgo.savedsites.store.SavedSitesEntitiesDao
@@ -66,10 +66,8 @@ class SavedSitesLocalWinsPersisterTest {
     private lateinit var savedSitesRelationsDao: SavedSitesRelationsDao
     private lateinit var savedSitesMetadataDao: SavedSitesSyncMetadataDao
     private lateinit var persister: SavedSitesLocalWinsPersister
-    private val store = RealSavedSitesSyncStore(
+    private val store = RealSavedSitesSyncEntitiesStore(
         InstrumentationRegistry.getInstrumentation().context,
-        coroutinesTestRule.testScope,
-        coroutinesTestRule.testDispatcherProvider,
     )
 
     private val twoHoursAgo = DatabaseDateFormatter.iso8601(OffsetDateTime.now(ZoneOffset.UTC).minusHours(2))

--- a/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesRemoteWinsPersisterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesRemoteWinsPersisterTest.kt
@@ -32,10 +32,10 @@ import com.duckduckgo.savedsites.api.models.SavedSitesNames
 import com.duckduckgo.savedsites.impl.MissingEntitiesRelationReconciler
 import com.duckduckgo.savedsites.impl.RealFavoritesDelegate
 import com.duckduckgo.savedsites.impl.RealSavedSitesRepository
-import com.duckduckgo.savedsites.impl.sync.RealSavedSitesSyncStore
 import com.duckduckgo.savedsites.impl.sync.RealSyncSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.SyncSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.algorithm.SavedSitesRemoteWinsPersister
+import com.duckduckgo.savedsites.impl.sync.store.RealSavedSitesSyncEntitiesStore
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDao
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDatabase
 import com.duckduckgo.savedsites.store.SavedSitesEntitiesDao
@@ -66,10 +66,8 @@ class SavedSitesRemoteWinsPersisterTest {
     private lateinit var savedSitesRelationsDao: SavedSitesRelationsDao
     private lateinit var savedSitesMetadataDao: SavedSitesSyncMetadataDao
     private lateinit var persister: SavedSitesRemoteWinsPersister
-    private val store = RealSavedSitesSyncStore(
+    private val store = RealSavedSitesSyncEntitiesStore(
         InstrumentationRegistry.getInstrumentation().context,
-        coroutinesTestRule.testScope,
-        coroutinesTestRule.testDispatcherProvider,
     )
 
     private val twoHoursAgo = DatabaseDateFormatter.iso8601(OffsetDateTime.now(ZoneOffset.UTC).minusHours(2))

--- a/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesRemoteWinsPersisterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesRemoteWinsPersisterTest.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.savedsites.api.models.SavedSitesNames
 import com.duckduckgo.savedsites.impl.MissingEntitiesRelationReconciler
 import com.duckduckgo.savedsites.impl.RealFavoritesDelegate
 import com.duckduckgo.savedsites.impl.RealSavedSitesRepository
+import com.duckduckgo.savedsites.impl.sync.RealSavedSitesSyncStore
 import com.duckduckgo.savedsites.impl.sync.RealSyncSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.SyncSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.algorithm.SavedSitesRemoteWinsPersister
@@ -64,8 +65,12 @@ class SavedSitesRemoteWinsPersisterTest {
     private lateinit var savedSitesEntitiesDao: SavedSitesEntitiesDao
     private lateinit var savedSitesRelationsDao: SavedSitesRelationsDao
     private lateinit var savedSitesMetadataDao: SavedSitesSyncMetadataDao
-
     private lateinit var persister: SavedSitesRemoteWinsPersister
+    private val store = RealSavedSitesSyncStore(
+        InstrumentationRegistry.getInstrumentation().context,
+        coroutinesTestRule.testScope,
+        coroutinesTestRule.testDispatcherProvider,
+    )
 
     private val twoHoursAgo = DatabaseDateFormatter.iso8601(OffsetDateTime.now(ZoneOffset.UTC).minusHours(2))
 
@@ -92,7 +97,7 @@ class SavedSitesRemoteWinsPersisterTest {
             MissingEntitiesRelationReconciler(savedSitesEntitiesDao),
             coroutinesTestRule.testDispatcherProvider,
         )
-        syncRepository = RealSyncSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, savedSitesMetadataDao)
+        syncRepository = RealSyncSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, savedSitesMetadataDao, store)
         repository = RealSavedSitesRepository(
             savedSitesEntitiesDao,
             savedSitesRelationsDao,

--- a/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesTimestampPersisterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesTimestampPersisterTest.kt
@@ -32,10 +32,10 @@ import com.duckduckgo.savedsites.api.models.SavedSitesNames
 import com.duckduckgo.savedsites.impl.MissingEntitiesRelationReconciler
 import com.duckduckgo.savedsites.impl.RealFavoritesDelegate
 import com.duckduckgo.savedsites.impl.RealSavedSitesRepository
-import com.duckduckgo.savedsites.impl.sync.RealSavedSitesSyncStore
 import com.duckduckgo.savedsites.impl.sync.RealSyncSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.SyncSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.algorithm.SavedSitesTimestampPersister
+import com.duckduckgo.savedsites.impl.sync.store.RealSavedSitesSyncEntitiesStore
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDao
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDatabase
 import com.duckduckgo.savedsites.store.SavedSitesEntitiesDao
@@ -67,10 +67,8 @@ class SavedSitesTimestampPersisterTest {
     private lateinit var savedSitesRelationsDao: SavedSitesRelationsDao
     private lateinit var savedSitesMetadataDao: SavedSitesSyncMetadataDao
     private lateinit var persister: SavedSitesTimestampPersister
-    private val store = RealSavedSitesSyncStore(
+    private val store = RealSavedSitesSyncEntitiesStore(
         InstrumentationRegistry.getInstrumentation().context,
-        coroutinesTestRule.testScope,
-        coroutinesTestRule.testDispatcherProvider,
     )
 
     private val threeHoursAgo = DatabaseDateFormatter.iso8601(OffsetDateTime.now(ZoneOffset.UTC).minusHours(3))

--- a/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesTimestampPersisterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/sync/algorithm/SavedSitesTimestampPersisterTest.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.savedsites.api.models.SavedSitesNames
 import com.duckduckgo.savedsites.impl.MissingEntitiesRelationReconciler
 import com.duckduckgo.savedsites.impl.RealFavoritesDelegate
 import com.duckduckgo.savedsites.impl.RealSavedSitesRepository
+import com.duckduckgo.savedsites.impl.sync.RealSavedSitesSyncStore
 import com.duckduckgo.savedsites.impl.sync.RealSyncSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.SyncSavedSitesRepository
 import com.duckduckgo.savedsites.impl.sync.algorithm.SavedSitesTimestampPersister
@@ -65,8 +66,12 @@ class SavedSitesTimestampPersisterTest {
     private lateinit var savedSitesEntitiesDao: SavedSitesEntitiesDao
     private lateinit var savedSitesRelationsDao: SavedSitesRelationsDao
     private lateinit var savedSitesMetadataDao: SavedSitesSyncMetadataDao
-
     private lateinit var persister: SavedSitesTimestampPersister
+    private val store = RealSavedSitesSyncStore(
+        InstrumentationRegistry.getInstrumentation().context,
+        coroutinesTestRule.testScope,
+        coroutinesTestRule.testDispatcherProvider,
+    )
 
     private val threeHoursAgo = DatabaseDateFormatter.iso8601(OffsetDateTime.now(ZoneOffset.UTC).minusHours(3))
     private val twoHoursAgo = DatabaseDateFormatter.iso8601(OffsetDateTime.now(ZoneOffset.UTC).minusHours(2))
@@ -95,7 +100,7 @@ class SavedSitesTimestampPersisterTest {
             MissingEntitiesRelationReconciler(savedSitesEntitiesDao),
             coroutinesTestRule.testDispatcherProvider,
         )
-        syncRepository = RealSyncSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, savedSitesMetadataDao)
+        syncRepository = RealSyncSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, savedSitesMetadataDao, store)
         repository = RealSavedSitesRepository(
             savedSitesEntitiesDao,
             savedSitesRelationsDao,

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsInvalidItemSyncMessagePlugin.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsInvalidItemSyncMessagePlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 DuckDuckGo
+ * Copyright (c) 2024 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,16 @@
 
 package com.duckduckgo.autofill.sync
 
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
+import android.content.Context
+import android.view.View
+import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.sync.api.SyncMessagePlugin
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
 
-class FakeCredentialsSyncStore : CredentialsSyncStore {
-    override var serverModifiedSince: String = "0"
-    override var startTimeStamp: String = "0"
-    override var clientModifiedSince: String = "0"
-    override var isSyncPaused: Boolean = false
-    override fun isSyncPausedFlow(): Flow<Boolean> = emptyFlow()
-    override var invalidEntitiesIds: List<String> = emptyList()
+@ContributesMultibinding(scope = ActivityScope::class)
+class CredentialsInvalidItemSyncMessagePlugin @Inject constructor() : SyncMessagePlugin {
+    override fun getView(context: Context): View {
+        return CredentialsInvalidItemsView(context)
+    }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsInvalidItemsView.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsInvalidItemsView.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.sync
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.text.SpannableStringBuilder
+import android.util.AttributeSet
+import android.widget.FrameLayout
+import androidx.core.view.isVisible
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewTreeLifecycleOwner
+import androidx.lifecycle.findViewTreeViewModelStoreOwner
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.autofill.api.AutofillScreens.AutofillSettingsScreenNoParams
+import com.duckduckgo.autofill.impl.R
+import com.duckduckgo.autofill.impl.databinding.ViewCredentialsInvalidItemsWarningBinding
+import com.duckduckgo.autofill.sync.CredentialsInvalidItemsViewModel.Command
+import com.duckduckgo.autofill.sync.CredentialsInvalidItemsViewModel.Command.NavigateToCredentials
+import com.duckduckgo.autofill.sync.CredentialsInvalidItemsViewModel.ViewState
+import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.ConflatedJob
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.ViewViewModelFactory
+import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.navigation.api.GlobalActivityStarter
+import dagger.android.support.AndroidSupportInjection
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+
+@InjectWith(ViewScope::class)
+class CredentialsInvalidItemsView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyle: Int = 0,
+) : FrameLayout(context, attrs, defStyle) {
+
+    @Inject
+    lateinit var globalActivityStarter: GlobalActivityStarter
+
+    @Inject
+    lateinit var viewModelFactory: ViewViewModelFactory
+
+    @Inject
+    lateinit var dispatcherProvider: DispatcherProvider
+
+    private var coroutineScope: CoroutineScope? = null
+
+    private var job: ConflatedJob = ConflatedJob()
+
+    private val binding: ViewCredentialsInvalidItemsWarningBinding by viewBinding()
+
+    private val viewModel: CredentialsInvalidItemsViewModel by lazy {
+        ViewModelProvider(findViewTreeViewModelStoreOwner()!!, viewModelFactory)[CredentialsInvalidItemsViewModel::class.java]
+    }
+
+    override fun onAttachedToWindow() {
+        AndroidSupportInjection.inject(this)
+        super.onAttachedToWindow()
+
+        ViewTreeLifecycleOwner.get(this)?.lifecycle?.addObserver(viewModel)
+
+        @SuppressLint("NoHardcodedCoroutineDispatcher")
+        coroutineScope = CoroutineScope(SupervisorJob() + dispatcherProvider.main())
+
+        viewModel.viewState()
+            .onEach { render(it) }
+            .launchIn(coroutineScope!!)
+
+        job += viewModel.commands()
+            .onEach { processCommands(it) }
+            .launchIn(coroutineScope!!)
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        ViewTreeLifecycleOwner.get(this)?.lifecycle?.removeObserver(viewModel)
+        coroutineScope?.cancel()
+        job.cancel()
+        coroutineScope = null
+    }
+
+    private fun processCommands(command: Command) {
+        when (command) {
+            NavigateToCredentials -> navigateToCredentials()
+        }
+    }
+
+    private fun render(viewState: ViewState) {
+        this.isVisible = viewState.warningVisible
+
+        val spannable = SpannableStringBuilder(
+            context.resources.getQuantityString(
+                R.plurals.syncCredentialInvalidItemsWarning,
+                viewState.invalidItemsSize,
+                viewState.hint,
+                viewState.invalidItemsSize - 1,
+            ),
+        ).append(context.getText(R.string.syncCredentialInvalidItemsWarningLink))
+
+        binding.credentialsInvalidItemsWarning.setClickableLink(
+            "manage_passwords",
+            spannable,
+            onClick = {
+                viewModel.onWarningActionClicked()
+            },
+        )
+    }
+
+    private fun navigateToCredentials() {
+        globalActivityStarter.start(this.context, AutofillSettingsScreenNoParams)
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsInvalidItemsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsInvalidItemsViewModel.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.sync
+
+import android.annotation.SuppressLint
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.autofill.api.domain.app.LoginCredentials
+import com.duckduckgo.autofill.sync.CredentialsInvalidItemsViewModel.Command.NavigateToCredentials
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.ViewScope
+import javax.inject.Inject
+import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+
+@SuppressLint("NoLifecycleObserver") // we don't observe app lifecycle
+@ContributesViewModel(ViewScope::class)
+class CredentialsInvalidItemsViewModel @Inject constructor(
+    private val dispatcherProvider: DispatcherProvider,
+    private val crendentialsSyncRepository: CredentialsSync,
+) : ViewModel(), DefaultLifecycleObserver {
+    data class ViewState(
+        val warningVisible: Boolean = false,
+        val invalidItemsSize: Int = 0,
+        val hint: String = "",
+    )
+
+    sealed class Command {
+        data object NavigateToCredentials : Command()
+    }
+
+    private val command = Channel<Command>(1, DROP_OLDEST)
+
+    private val _viewState = MutableStateFlow(ViewState())
+    fun viewState(): Flow<ViewState> = _viewState.onStart {
+        viewModelScope.launch(dispatcherProvider.io()) {
+            emitNewViewState()
+        }
+    }
+
+    override fun onResume(owner: LifecycleOwner) {
+        viewModelScope.launch(dispatcherProvider.io()) {
+            emitNewViewState()
+        }
+    }
+
+    fun commands(): Flow<Command> = command.receiveAsFlow()
+
+    private suspend fun emitNewViewState() {
+        val invalidItems = crendentialsSyncRepository.getInvalidCredentials()
+        _viewState.emit(
+            ViewState(
+                warningVisible = invalidItems.isNotEmpty(),
+                hint = invalidItems.firstOrNull().getHint(),
+                invalidItemsSize = invalidItems.size,
+            ),
+        )
+    }
+
+    fun onWarningActionClicked() {
+        viewModelScope.launch {
+            command.send(NavigateToCredentials)
+        }
+    }
+
+    private fun LoginCredentials?.getHint(): String {
+        val hint: String =
+            this?.domainTitle.takeUnless { it.isNullOrEmpty() }
+                ?: this?.domain.takeUnless { it.isNullOrEmpty() }
+                ?: this?.username.takeUnless { it.isNullOrEmpty() } ?: ""
+        this?.notes.takeUnless { it.isNullOrEmpty() } ?: ""
+
+        return hint.shortenString(HINT_MAX_HINT_LENGTH)
+    }
+
+    private fun String.shortenString(maxLength: Int): String {
+        return this.takeIf { it.length <= maxLength } ?: (this.take(maxLength - 3) + "...")
+    }
+
+    companion object {
+        const val HINT_MAX_HINT_LENGTH = 15
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsSyncStore.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsSyncStore.kt
@@ -37,6 +37,7 @@ interface CredentialsSyncStore {
     var clientModifiedSince: String
     var isSyncPaused: Boolean
     fun isSyncPausedFlow(): Flow<Boolean>
+    var invalidEntitiesIds: List<String>
 }
 
 @ContributesBinding(AppScope::class)
@@ -69,6 +70,13 @@ class RealCredentialsSyncStore @Inject constructor(
             preferences.edit(true) { putBoolean(KEY_CLIENT_LIMIT_EXCEEDED, value) }
             emitNewValue()
         }
+    override var invalidEntitiesIds: List<String>
+        get() = preferences.getStringSet(KEY_CLIENT_INVALID_IDS, mutableSetOf())?.toList() ?: mutableListOf()
+        set(value) {
+            preferences.edit(true) {
+                putStringSet(KEY_CLIENT_INVALID_IDS, value.toSet())
+            }
+        }
 
     override fun isSyncPausedFlow(): Flow<Boolean> = syncPausedSharedFlow
 
@@ -87,5 +95,6 @@ class RealCredentialsSyncStore @Inject constructor(
         private const val KEY_START_TIMESTAMP = "KEY_START_TIMESTAMP"
         private const val KEY_END_TIMESTAMP = "KEY_END_TIMESTAMP"
         private const val KEY_CLIENT_LIMIT_EXCEEDED = "KEY_CLIENT_LIMIT_EXCEEDED"
+        private const val KEY_CLIENT_INVALID_IDS = "KEY_CLIENT_INVALID_IDS"
     }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/provider/CredentialsSyncLocalValidationFeature.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/provider/CredentialsSyncLocalValidationFeature.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 DuckDuckGo
+ * Copyright (c) 2024 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,17 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.autofill.sync
+package com.duckduckgo.autofill.sync.provider
 
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
 
-class FakeCredentialsSyncStore : CredentialsSyncStore {
-    override var serverModifiedSince: String = "0"
-    override var startTimeStamp: String = "0"
-    override var clientModifiedSince: String = "0"
-    override var isSyncPaused: Boolean = false
-    override fun isSyncPausedFlow(): Flow<Boolean> = emptyFlow()
-    override var invalidEntitiesIds: List<String> = emptyList()
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "credentialsLocalFieldValidation",
+)
+interface CredentialsSyncLocalValidationFeature {
+    @Toggle.DefaultValue(false)
+    fun self(): Toggle
 }

--- a/autofill/autofill-impl/src/main/res/layout/view_credentials_invalid_items_warning.xml
+++ b/autofill/autofill-impl/src/main/res/layout/view_credentials_invalid_items_warning.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright (c) 2023 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<com.duckduckgo.common.ui.view.InfoPanel xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/credentialsInvalidItemsWarning"
+    style="@style/Widget.DuckDuckGo.InfoPanel"
+    android:layout_margin="@dimen/keyline_4"
+    app:panelBackground="@drawable/info_panel_alert_background"
+    app:panelDrawable="@drawable/ic_info_panel_alert" />

--- a/autofill/autofill-impl/src/main/res/values/donottranslate.xml
+++ b/autofill/autofill-impl/src/main/res/values/donottranslate.xml
@@ -15,5 +15,10 @@
   -->
 
 <resources>
-
+    <!-- Sync settings screen -->
+    <plurals name="syncCredentialInvalidItemsWarning" instruction="%1$ represents a site name or url, %2$d is the number of other invalid sites">
+        <item quantity="one">Your password for %1$s can’t sync because one of its fields exceeds the character limit.\n\n</item>
+        <item quantity="other">Your passwords for %1$s and %2$d other sites can’t sync because some of their fields exceed the character limit.\n\n</item>
+    </plurals>
+    <string name="syncCredentialInvalidItemsWarningLink"><annotation type="manage_passwords">Manage Passwords</annotation></string>
 </resources>

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/CredentialsFixtures.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/CredentialsFixtures.kt
@@ -48,6 +48,15 @@ object CredentialsFixtures {
         notes = "My Amazon account",
     )
 
+    val invalidCredentials = LoginCredentials(
+        id = 4L,
+        domain = "www.invalid.com",
+        username = "invalidUS",
+        password = "invalidPW",
+        domainTitle = String(CharArray(3000) { 'a' + (it % 26) }),
+        notes = "My Invalid account",
+    )
+
     fun LoginCredentials.toLoginCredentialEntryResponse(): CredentialsSyncEntryResponse =
         CredentialsSyncEntryResponse(
             id = id.toString(),

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/CredentialsInvalidItemsViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/CredentialsInvalidItemsViewModelTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.sync
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.cash.turbine.test
+import com.duckduckgo.autofill.sync.CredentialsFixtures.invalidCredentials
+import com.duckduckgo.autofill.sync.CredentialsFixtures.spotifyCredentials
+import com.duckduckgo.common.test.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CredentialsInvalidItemsViewModelTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val db = inMemoryAutofillDatabase()
+    private val secureStorage = FakeSecureStorage()
+    private val credentialsSyncStore = FakeCredentialsSyncStore()
+    private val credentialsSyncMetadata = CredentialsSyncMetadata(db.credentialsSyncDao())
+    private val credentialsSync = CredentialsSync(
+        secureStorage,
+        credentialsSyncStore,
+        credentialsSyncMetadata,
+        FakeCrypto(),
+        FakeCredentialsSyncLocalValidationFeature(),
+    )
+
+    private val viewModel = CredentialsInvalidItemsViewModel(
+        dispatcherProvider = coroutineRule.testDispatcherProvider,
+        crendentialsSyncRepository = credentialsSync,
+    )
+
+    @Test
+    fun whenNoInvalidCredentialsThenWarningNotVisible() = runTest {
+        viewModel.viewState().test {
+            val awaitItem = awaitItem()
+            assertFalse(awaitItem.warningVisible)
+            assertEquals(0, awaitItem.invalidItemsSize)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenInvalidCredentialsThenWarningVisible() = runTest {
+        credentialsSync.saveCredential(invalidCredentials, "remote1")
+        credentialsSync.saveCredential(spotifyCredentials, "remote2")
+        credentialsSync.getUpdatesSince("0") // trigger sync so invalid credentials are detected
+
+        viewModel.viewState().test {
+            val awaitItem = awaitItem()
+            assertTrue(awaitItem.warningVisible)
+            assertEquals(1, awaitItem.invalidItemsSize)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/CredentialsSyncTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/CredentialsSyncTest.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.impl.securestorage.WebsiteLoginDetails
 import com.duckduckgo.autofill.impl.securestorage.WebsiteLoginDetailsWithCredentials
 import com.duckduckgo.autofill.store.CredentialsSyncMetadataEntity
+import com.duckduckgo.autofill.sync.CredentialsFixtures.invalidCredentials
 import com.duckduckgo.autofill.sync.CredentialsFixtures.spotifyCredentials
 import com.duckduckgo.autofill.sync.CredentialsFixtures.toLoginCredentials
 import com.duckduckgo.autofill.sync.CredentialsFixtures.twitterCredentials
@@ -43,7 +44,13 @@ internal class CredentialsSyncTest {
     private val secureStorage = FakeSecureStorage()
     private val credentialsSyncStore = FakeCredentialsSyncStore()
     private val credentialsSyncMetadata = CredentialsSyncMetadata(db.credentialsSyncDao())
-    private val credentialsSync = CredentialsSync(secureStorage, credentialsSyncStore, credentialsSyncMetadata, FakeCrypto())
+    private val credentialsSync = CredentialsSync(
+        secureStorage,
+        credentialsSyncStore,
+        credentialsSyncMetadata,
+        FakeCrypto(),
+        FakeCredentialsSyncLocalValidationFeature(),
+    )
 
     @After fun after() = runBlocking {
         db.close()
@@ -143,6 +150,59 @@ internal class CredentialsSyncTest {
             ),
             updates,
         )
+    }
+
+    @Test
+    fun whenOnFirstWithInvalidCredentialsThenChangesDoesNotContainInvalidEntities() = runTest {
+        givenLocalCredentials(
+            invalidCredentials,
+        )
+
+        val syncChanges = credentialsSync.getUpdatesSince("0")
+
+        assertTrue(syncChanges.isEmpty())
+        assertTrue(credentialsSyncStore.invalidEntitiesIds.size == 1)
+    }
+
+    @Test
+    fun whenNewCredentialsIsInvalidThenChangesDoesNotContainInvalidEntity() = runTest {
+        givenLocalCredentials(
+            spotifyCredentials,
+            invalidCredentials.copy(lastUpdatedMillis = 1689592358516),
+        )
+
+        val syncChanges = credentialsSync.getUpdatesSince("2022-08-30T00:00:00Z")
+
+        assertTrue(syncChanges.isEmpty())
+        assertTrue(credentialsSyncStore.invalidEntitiesIds.size == 1)
+    }
+
+    @Test
+    fun whenInvalidCredentialsPresentThenAlwaysRetryItemsAndUpdateInvalidList() = runTest {
+        givenLocalCredentials(
+            invalidCredentials,
+            spotifyCredentials.copy(lastUpdatedMillis = 1689592358516),
+        )
+        credentialsSyncStore.invalidEntitiesIds = listOf(credentialsSyncMetadata.getSyncMetadata(invalidCredentials.id!!)!!.syncId)
+
+        val syncChanges = credentialsSync.getUpdatesSince("2022-08-30T00:00:00Z")
+
+        assertTrue(syncChanges.size == 1)
+        assertTrue(syncChanges.first().title == spotifyCredentials.domainTitle)
+        assertTrue(credentialsSyncStore.invalidEntitiesIds.size == 1)
+    }
+
+    @Test
+    fun whenInvalidCredentialsThenReturnInvalidCredentials() = runTest {
+        givenLocalCredentials(
+            invalidCredentials,
+        )
+        credentialsSyncStore.invalidEntitiesIds = listOf(credentialsSyncMetadata.getSyncMetadata(invalidCredentials.id!!)!!.syncId)
+
+        val invalidItems = credentialsSync.getInvalidCredentials()
+
+        assertTrue(invalidItems.isNotEmpty())
+        assertEquals(invalidCredentials, invalidItems.first())
     }
 
     @Test
@@ -294,6 +354,7 @@ internal class CredentialsSyncTest {
     private suspend fun givenLocalCredentials(vararg credentials: LoginCredentials) {
         credentials.forEach { credential ->
             val loginDetails = WebsiteLoginDetails(
+                id = credential.id,
                 domain = credential.domain,
                 username = credential.username,
                 domainTitle = credential.domainTitle,

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/FakeCredentialsSyncLocalValidationFeature.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/FakeCredentialsSyncLocalValidationFeature.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 DuckDuckGo
+ * Copyright (c) 2024 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,12 @@
 
 package com.duckduckgo.autofill.sync
 
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
+import com.duckduckgo.autofill.sync.provider.CredentialsSyncLocalValidationFeature
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.toggle.TestToggle
 
-class FakeCredentialsSyncStore : CredentialsSyncStore {
-    override var serverModifiedSince: String = "0"
-    override var startTimeStamp: String = "0"
-    override var clientModifiedSince: String = "0"
-    override var isSyncPaused: Boolean = false
-    override fun isSyncPausedFlow(): Flow<Boolean> = emptyFlow()
-    override var invalidEntitiesIds: List<String> = emptyList()
+class FakeCredentialsSyncLocalValidationFeature : CredentialsSyncLocalValidationFeature {
+    var enabled = true
+
+    override fun self(): Toggle = TestToggle(enabled)
 }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/persister/CredentialsLastModifiedWinsStrategyTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/persister/CredentialsLastModifiedWinsStrategyTest.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.autofill.sync.CredentialsFixtures.twitterCredentials
 import com.duckduckgo.autofill.sync.CredentialsSync
 import com.duckduckgo.autofill.sync.CredentialsSyncMapper
 import com.duckduckgo.autofill.sync.CredentialsSyncMetadata
+import com.duckduckgo.autofill.sync.FakeCredentialsSyncLocalValidationFeature
 import com.duckduckgo.autofill.sync.FakeCredentialsSyncStore
 import com.duckduckgo.autofill.sync.FakeCrypto
 import com.duckduckgo.autofill.sync.FakeSecureStorage
@@ -56,7 +57,13 @@ internal class CredentialsLastModifiedWinsStrategyTest {
     private val secureStorage = FakeSecureStorage()
     private val credentialsSyncStore = FakeCredentialsSyncStore()
     private val credentialsSyncMetadata = CredentialsSyncMetadata(db.credentialsSyncDao())
-    private val credentialsSync = CredentialsSync(secureStorage, credentialsSyncStore, credentialsSyncMetadata, FakeCrypto())
+    private val credentialsSync = CredentialsSync(
+        secureStorage,
+        credentialsSyncStore,
+        credentialsSyncMetadata,
+        FakeCrypto(),
+        FakeCredentialsSyncLocalValidationFeature(),
+    )
 
     @After fun after() = runBlocking {
         db.close()

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/persister/CredentialsLocalWinsStrategyTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/persister/CredentialsLocalWinsStrategyTest.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.autofill.sync.CredentialsFixtures.twitterCredentials
 import com.duckduckgo.autofill.sync.CredentialsSync
 import com.duckduckgo.autofill.sync.CredentialsSyncMapper
 import com.duckduckgo.autofill.sync.CredentialsSyncMetadata
+import com.duckduckgo.autofill.sync.FakeCredentialsSyncLocalValidationFeature
 import com.duckduckgo.autofill.sync.FakeCredentialsSyncStore
 import com.duckduckgo.autofill.sync.FakeCrypto
 import com.duckduckgo.autofill.sync.FakeSecureStorage
@@ -55,7 +56,13 @@ internal class CredentialsLocalWinsStrategyTest {
     private val secureStorage = FakeSecureStorage()
     private val credentialsSyncStore = FakeCredentialsSyncStore()
     private val credentialsSyncMetadata = CredentialsSyncMetadata(db.credentialsSyncDao())
-    private val credentialsSync = CredentialsSync(secureStorage, credentialsSyncStore, credentialsSyncMetadata, FakeCrypto())
+    private val credentialsSync = CredentialsSync(
+        secureStorage,
+        credentialsSyncStore,
+        credentialsSyncMetadata,
+        FakeCrypto(),
+        FakeCredentialsSyncLocalValidationFeature(),
+    )
 
     @After fun after() = runBlocking {
         db.close()

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/persister/CredentialsRemoteWinsStrategyTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/persister/CredentialsRemoteWinsStrategyTest.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.autofill.sync.CredentialsFixtures.twitterCredentials
 import com.duckduckgo.autofill.sync.CredentialsSync
 import com.duckduckgo.autofill.sync.CredentialsSyncMapper
 import com.duckduckgo.autofill.sync.CredentialsSyncMetadata
+import com.duckduckgo.autofill.sync.FakeCredentialsSyncLocalValidationFeature
 import com.duckduckgo.autofill.sync.FakeCredentialsSyncStore
 import com.duckduckgo.autofill.sync.FakeCrypto
 import com.duckduckgo.autofill.sync.FakeSecureStorage
@@ -55,7 +56,13 @@ internal class CredentialsRemoteWinsStrategyTest {
     private val secureStorage = FakeSecureStorage()
     private val credentialsSyncStore = FakeCredentialsSyncStore()
     private val credentialsSyncMetadata = CredentialsSyncMetadata(db.credentialsSyncDao())
-    private val credentialsSync = CredentialsSync(secureStorage, credentialsSyncStore, credentialsSyncMetadata, FakeCrypto())
+    private val credentialsSync = CredentialsSync(
+        secureStorage,
+        credentialsSyncStore,
+        credentialsSyncMetadata,
+        FakeCrypto(),
+        FakeCredentialsSyncLocalValidationFeature(),
+    )
 
     @After fun after() = runBlocking {
         db.close()

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/persister/CrendentialsDedupStrategyTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/persister/CrendentialsDedupStrategyTest.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.autofill.sync.CredentialsFixtures.twitterCredentials
 import com.duckduckgo.autofill.sync.CredentialsSync
 import com.duckduckgo.autofill.sync.CredentialsSyncMapper
 import com.duckduckgo.autofill.sync.CredentialsSyncMetadata
+import com.duckduckgo.autofill.sync.FakeCredentialsSyncLocalValidationFeature
 import com.duckduckgo.autofill.sync.FakeCredentialsSyncStore
 import com.duckduckgo.autofill.sync.FakeCrypto
 import com.duckduckgo.autofill.sync.FakeSecureStorage
@@ -55,7 +56,13 @@ internal class CredentialsDedupStrategyTest {
     private val secureStorage = FakeSecureStorage()
     private val credentialsSyncStore = FakeCredentialsSyncStore()
     private val credentialsSyncMetadata = CredentialsSyncMetadata(db.credentialsSyncDao())
-    private val credentialsSync = CredentialsSync(secureStorage, credentialsSyncStore, credentialsSyncMetadata, FakeCrypto())
+    private val credentialsSync = CredentialsSync(
+        secureStorage,
+        credentialsSyncStore,
+        credentialsSyncMetadata,
+        FakeCrypto(),
+        FakeCredentialsSyncLocalValidationFeature(),
+    )
 
     @After fun after() = runBlocking {
         db.close()

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/provider/CredentialsSyncDataProviderTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/provider/CredentialsSyncDataProviderTest.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.autofill.sync.CredentialsFixtures
 import com.duckduckgo.autofill.sync.CredentialsFixtures.toWebsiteLoginCredentials
 import com.duckduckgo.autofill.sync.CredentialsSync
 import com.duckduckgo.autofill.sync.CredentialsSyncMetadata
+import com.duckduckgo.autofill.sync.FakeCredentialsSyncLocalValidationFeature
 import com.duckduckgo.autofill.sync.FakeCredentialsSyncStore
 import com.duckduckgo.autofill.sync.FakeCrypto
 import com.duckduckgo.autofill.sync.FakeSecureStorage
@@ -53,7 +54,13 @@ internal class CredentialsSyncDataProviderTest {
     private val secureStorage = FakeSecureStorage()
     private val credentialsSyncMetadata = CredentialsSyncMetadata(db.credentialsSyncDao())
     private val credentialsSyncStore = FakeCredentialsSyncStore()
-    private val credentialsSync = CredentialsSync(secureStorage, credentialsSyncStore, credentialsSyncMetadata, FakeCrypto())
+    private val credentialsSync = CredentialsSync(
+        secureStorage,
+        credentialsSyncStore,
+        credentialsSyncMetadata,
+        FakeCrypto(),
+        FakeCredentialsSyncLocalValidationFeature(),
+    )
     private val appBuildConfig = mock<AppBuildConfig>().apply {
         whenever(this.flavor).thenReturn(BuildFlavor.PLAY)
     }

--- a/saved-sites/saved-sites-impl/build.gradle
+++ b/saved-sites/saved-sites-impl/build.gradle
@@ -24,6 +24,8 @@ plugins {
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"
 
 dependencies {
+    implementation project(path: ':feature-toggles-api')
+    implementation project(path: ':app-build-config-api')
     implementation project(path: ':di')
     implementation project(path: ':statistics')
     implementation project(path: ':common-utils')

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/di/SavedSitesModule.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/di/SavedSitesModule.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.savedsites.impl.service.RealSavedSitesParser
 import com.duckduckgo.savedsites.impl.service.SavedSitesParser
 import com.duckduckgo.savedsites.impl.sync.*
 import com.duckduckgo.savedsites.impl.sync.store.ALL_MIGRATIONS
+import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncEntitiesStore
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDao
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDatabase
 import com.duckduckgo.savedsites.store.SavedSitesEntitiesDao
@@ -108,9 +109,9 @@ class SavedSitesModule {
         savedSitesEntitiesDao: SavedSitesEntitiesDao,
         savedSitesRelationsDao: SavedSitesRelationsDao,
         savedSitesSyncMetadataDao: SavedSitesSyncMetadataDao,
-        savedSitesSyncStore: SavedSitesSyncStore,
+        savedSitesSyncEntitiesStore: SavedSitesSyncEntitiesStore,
     ): SyncSavedSitesRepository {
-        return RealSyncSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, savedSitesSyncMetadataDao, savedSitesSyncStore)
+        return RealSyncSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, savedSitesSyncMetadataDao, savedSitesSyncEntitiesStore)
     }
 
     @Provides

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/di/SavedSitesModule.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/di/SavedSitesModule.kt
@@ -108,8 +108,9 @@ class SavedSitesModule {
         savedSitesEntitiesDao: SavedSitesEntitiesDao,
         savedSitesRelationsDao: SavedSitesRelationsDao,
         savedSitesSyncMetadataDao: SavedSitesSyncMetadataDao,
+        savedSitesSyncStore: SavedSitesSyncStore,
     ): SyncSavedSitesRepository {
-        return RealSyncSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, savedSitesSyncMetadataDao)
+        return RealSyncSavedSitesRepository(savedSitesEntitiesDao, savedSitesRelationsDao, savedSitesSyncMetadataDao, savedSitesSyncStore)
     }
 
     @Provides

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/BookmarksSyncLocalValidationFeature.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/BookmarksSyncLocalValidationFeature.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 DuckDuckGo
+ * Copyright (c) 2024 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,17 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.autofill.sync
+package com.duckduckgo.savedsites.impl.sync
 
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
 
-class FakeCredentialsSyncStore : CredentialsSyncStore {
-    override var serverModifiedSince: String = "0"
-    override var startTimeStamp: String = "0"
-    override var clientModifiedSince: String = "0"
-    override var isSyncPaused: Boolean = false
-    override fun isSyncPausedFlow(): Flow<Boolean> = emptyFlow()
-    override var invalidEntitiesIds: List<String> = emptyList()
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "bookmarksLocalFieldValidation",
+)
+interface BookmarksSyncLocalValidationFeature {
+    @Toggle.DefaultValue(false)
+    fun self(): Toggle
 }

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/RealSavedSitesSyncStore.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/RealSavedSitesSyncStore.kt
@@ -37,6 +37,7 @@ interface SavedSitesSyncStore {
     var clientModifiedSince: String
     var isSyncPaused: Boolean
     fun isSyncPausedFlow(): Flow<Boolean>
+    var invalidEntitiesIds: List<String>
 }
 
 @ContributesBinding(AppScope::class)
@@ -69,6 +70,14 @@ class RealSavedSitesSyncStore @Inject constructor(
             emitNewValue()
         }
 
+    override var invalidEntitiesIds: List<String>
+        get() = preferences.getStringSet(KEY_CLIENT_INVALID_IDS, mutableSetOf())?.toList() ?: mutableListOf()
+        set(value) {
+            preferences.edit(true) {
+                putStringSet(KEY_CLIENT_INVALID_IDS, value.toSet())
+            }
+        }
+
     override fun isSyncPausedFlow(): Flow<Boolean> = syncPausedSharedFlow
 
     private fun emitNewValue() {
@@ -86,5 +95,6 @@ class RealSavedSitesSyncStore @Inject constructor(
         private const val KEY_START_TIMESTAMP = "KEY_START_TIMESTAMP"
         private const val KEY_CLIENT_MODIFIED_SINCE = "KEY_CLIENT_MODIFIED_SINCE"
         private const val KEY_CLIENT_LIMIT_EXCEEDED = "KEY_CLIENT_LIMIT_EXCEEDED"
+        private const val KEY_CLIENT_INVALID_IDS = "KEY_CLIENT_INVALID_IDS"
     }
 }

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/RealSavedSitesSyncStore.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/RealSavedSitesSyncStore.kt
@@ -37,7 +37,6 @@ interface SavedSitesSyncStore {
     var clientModifiedSince: String
     var isSyncPaused: Boolean
     fun isSyncPausedFlow(): Flow<Boolean>
-    var invalidEntitiesIds: List<String>
 }
 
 @ContributesBinding(AppScope::class)
@@ -70,14 +69,6 @@ class RealSavedSitesSyncStore @Inject constructor(
             emitNewValue()
         }
 
-    override var invalidEntitiesIds: List<String>
-        get() = preferences.getStringSet(KEY_CLIENT_INVALID_IDS, mutableSetOf())?.toList() ?: mutableListOf()
-        set(value) {
-            preferences.edit(true) {
-                putStringSet(KEY_CLIENT_INVALID_IDS, value.toSet())
-            }
-        }
-
     override fun isSyncPausedFlow(): Flow<Boolean> = syncPausedSharedFlow
 
     private fun emitNewValue() {
@@ -95,6 +86,5 @@ class RealSavedSitesSyncStore @Inject constructor(
         private const val KEY_START_TIMESTAMP = "KEY_START_TIMESTAMP"
         private const val KEY_CLIENT_MODIFIED_SINCE = "KEY_CLIENT_MODIFIED_SINCE"
         private const val KEY_CLIENT_LIMIT_EXCEEDED = "KEY_CLIENT_LIMIT_EXCEEDED"
-        private const val KEY_CLIENT_INVALID_IDS = "KEY_CLIENT_INVALID_IDS"
     }
 }

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/RealSyncSavedSitesRepository.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/RealSyncSavedSitesRepository.kt
@@ -20,6 +20,7 @@ import com.duckduckgo.common.utils.formatters.time.DatabaseDateFormatter
 import com.duckduckgo.savedsites.api.models.*
 import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
 import com.duckduckgo.savedsites.api.models.SavedSite.Favorite
+import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncEntitiesStore
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataDao
 import com.duckduckgo.savedsites.impl.sync.store.SavedSitesSyncMetadataEntity
 import com.duckduckgo.savedsites.store.*
@@ -36,7 +37,7 @@ class RealSyncSavedSitesRepository(
     private val savedSitesEntitiesDao: SavedSitesEntitiesDao,
     private val savedSitesRelationsDao: SavedSitesRelationsDao,
     private val savedSitesSyncMetadataDao: SavedSitesSyncMetadataDao,
-    private val savedSitesSyncStore: SavedSitesSyncStore,
+    private val savedSitesEntitiesStore: SavedSitesSyncEntitiesStore,
 ) : SyncSavedSitesRepository {
 
     private val stringListType = Types.newParameterizedType(List::class.java, String::class.java)
@@ -393,14 +394,14 @@ class RealSyncSavedSitesRepository(
     }
 
     override fun getInvalidSavedSites(): List<SavedSite> {
-        return savedSitesSyncStore.invalidEntitiesIds.takeIf { it.isNotEmpty() }?.let { ids ->
+        return savedSitesEntitiesStore.invalidEntitiesIds.takeIf { it.isNotEmpty() }?.let { ids ->
             getSavedSites(ids)
         } ?: emptyList()
     }
 
     override fun markSavedSitesAsInvalid(ids: List<String>) {
         Timber.i("Sync-Bookmarks: Storing invalid items: $ids")
-        savedSitesSyncStore.invalidEntitiesIds = ids
+        savedSitesEntitiesStore.invalidEntitiesIds = ids
     }
 
     private fun getSavedSites(ids: List<String>): List<SavedSite> {

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSiteInvalidItemsView.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSiteInvalidItemsView.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.savedsites.impl.sync
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.text.SpannableStringBuilder
+import android.util.AttributeSet
+import android.widget.FrameLayout
+import androidx.core.view.isVisible
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewTreeLifecycleOwner
+import androidx.lifecycle.findViewTreeViewModelStoreOwner
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.browser.api.ui.BrowserScreens.BookmarksScreenNoParams
+import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.ConflatedJob
+import com.duckduckgo.common.utils.ViewViewModelFactory
+import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.navigation.api.GlobalActivityStarter
+import com.duckduckgo.saved.sites.impl.R
+import com.duckduckgo.saved.sites.impl.databinding.ViewSaveSiteRateLimitWarningBinding
+import com.duckduckgo.savedsites.impl.sync.SavedSiteInvalidItemsViewModel.Command
+import com.duckduckgo.savedsites.impl.sync.SavedSiteInvalidItemsViewModel.Command.NavigateToBookmarks
+import com.duckduckgo.savedsites.impl.sync.SavedSiteInvalidItemsViewModel.ViewState
+import dagger.android.support.AndroidSupportInjection
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+
+@InjectWith(ViewScope::class)
+class SavedSiteInvalidItemsView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyle: Int = 0,
+) : FrameLayout(context, attrs, defStyle) {
+
+    @Inject
+    lateinit var globalActivityStarter: GlobalActivityStarter
+
+    @Inject
+    lateinit var viewModelFactory: ViewViewModelFactory
+
+    private var coroutineScope: CoroutineScope? = null
+
+    private var job: ConflatedJob = ConflatedJob()
+
+    private val binding: ViewSaveSiteRateLimitWarningBinding by viewBinding()
+
+    private val viewModel: SavedSiteInvalidItemsViewModel by lazy {
+        ViewModelProvider(findViewTreeViewModelStoreOwner()!!, viewModelFactory)[SavedSiteInvalidItemsViewModel::class.java]
+    }
+
+    override fun onAttachedToWindow() {
+        AndroidSupportInjection.inject(this)
+        super.onAttachedToWindow()
+
+        ViewTreeLifecycleOwner.get(this)?.lifecycle?.addObserver(viewModel)
+
+        @SuppressLint("NoHardcodedCoroutineDispatcher")
+        coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+
+        viewModel.viewState()
+            .onEach { render(it) }
+            .launchIn(coroutineScope!!)
+
+        job += viewModel.commands()
+            .onEach { processCommands(it) }
+            .launchIn(coroutineScope!!)
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        ViewTreeLifecycleOwner.get(this)?.lifecycle?.removeObserver(viewModel)
+        coroutineScope?.cancel()
+        job.cancel()
+        coroutineScope = null
+    }
+
+    private fun processCommands(command: Command) {
+        when (command) {
+            NavigateToBookmarks -> navigateToBookmarks()
+        }
+    }
+
+    private fun render(viewState: ViewState) {
+        this.isVisible = viewState.warningVisible
+
+        val spannable = SpannableStringBuilder(
+            context.resources.getQuantityString(
+                R.plurals.saved_site_invalid_items_warning,
+                viewState.invalidItemsSize,
+                viewState.hint,
+                viewState.invalidItemsSize - 1,
+            ),
+        ).append(context.getText(R.string.saved_site_invalid_items_warning_link))
+
+        binding.saveSiteRateLimitWarning.setClickableLink(
+            "manage_bookmarks",
+            spannable,
+            onClick = {
+                viewModel.onWarningActionClicked()
+            },
+        )
+    }
+
+    private fun navigateToBookmarks() {
+        globalActivityStarter.start(this.context, BookmarksScreenNoParams)
+    }
+}

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSiteInvalidItemsViewModel.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSiteInvalidItemsViewModel.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.savedsites.impl.sync
+
+import android.annotation.SuppressLint
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.savedsites.impl.sync.SavedSiteInvalidItemsViewModel.Command.NavigateToBookmarks
+import javax.inject.Inject
+import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+
+@SuppressLint("NoLifecycleObserver") // we don't observe app lifecycle
+@ContributesViewModel(ViewScope::class)
+class SavedSiteInvalidItemsViewModel @Inject constructor(
+    private val dispatcherProvider: DispatcherProvider,
+    private val syncSavedSitesRepository: SyncSavedSitesRepository,
+) : ViewModel(), DefaultLifecycleObserver {
+
+    data class ViewState(
+        val warningVisible: Boolean = false,
+        val invalidItemsSize: Int = 0,
+        val hint: String = "",
+    )
+
+    sealed class Command {
+        data object NavigateToBookmarks : Command()
+    }
+
+    private val command = Channel<Command>(1, DROP_OLDEST)
+
+    private val _viewState = MutableStateFlow(ViewState())
+    fun viewState(): Flow<ViewState> = _viewState.onStart {
+        viewModelScope.launch(dispatcherProvider.io()) {
+            emitNewViewState()
+        }
+    }
+
+    override fun onResume(owner: LifecycleOwner) {
+        viewModelScope.launch(dispatcherProvider.io()) {
+            emitNewViewState()
+        }
+    }
+
+    fun commands(): Flow<Command> = command.receiveAsFlow()
+
+    private suspend fun emitNewViewState() {
+        val invalidItems = syncSavedSitesRepository.getInvalidSavedSites()
+        _viewState.emit(
+            ViewState(
+                warningVisible = invalidItems.isNotEmpty(),
+                hint = invalidItems.firstOrNull()?.title?.shortenString(15) ?: "",
+                invalidItemsSize = invalidItems.size,
+            ),
+        )
+    }
+
+    fun onWarningActionClicked() {
+        viewModelScope.launch {
+            command.send(NavigateToBookmarks)
+        }
+    }
+
+    private fun String.shortenString(maxLength: Int): String {
+        return this.takeIf { it.length <= maxLength } ?: (this.take(maxLength - 3) + "...")
+    }
+}

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSitesInvalidItemSyncMessagePlugin.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSitesInvalidItemSyncMessagePlugin.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.savedsites.impl.sync
+
+import android.content.Context
+import android.view.View
+import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.sync.api.SyncMessagePlugin
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+@ContributesMultibinding(scope = ActivityScope::class)
+class SavedSitesInvalidItemSyncMessagePlugin @Inject constructor() : SyncMessagePlugin {
+    override fun getView(context: Context): View {
+        return SavedSiteInvalidItemsView(context)
+    }
+}

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSitesSyncDataProvider.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSitesSyncDataProvider.kt
@@ -40,6 +40,7 @@ class SavedSitesSyncDataProvider @Inject constructor(
     private val savedSitesSyncStore: SavedSitesSyncStore,
     private val syncCrypto: SyncCrypto,
     private val savedSitesFormFactorSyncMigration: SavedSitesFormFactorSyncMigration,
+    private val bookmarksSyncLocalValidationFeature: BookmarksSyncLocalValidationFeature,
 ) : SyncableDataProvider {
     override fun getType(): SyncableType = BOOKMARKS
 
@@ -220,6 +221,8 @@ class SavedSitesSyncDataProvider @Inject constructor(
     }
 
     private fun isValid(syncSavedSite: SyncSavedSitesRequestEntry): Boolean {
+        if (bookmarksSyncLocalValidationFeature.self().isEnabled().not()) return true // no validation required
+
         val titleLength = syncSavedSite.title?.length ?: 0
         val urlLength = syncSavedSite.page?.url?.length ?: 0
 
@@ -227,6 +230,8 @@ class SavedSitesSyncDataProvider @Inject constructor(
     }
 
     private fun fixFolderIfNecessary(folder: BookmarkFolder): BookmarkFolder {
+        if (bookmarksSyncLocalValidationFeature.self().isEnabled().not()) return folder
+
         val fixedName = folder.name.take(MAX_FOLDER_TITLE_LENGTH)
         return folder.copy(name = fixedName)
     }

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSitesSyncPersister.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSitesSyncPersister.kt
@@ -77,6 +77,7 @@ class SavedSitesSyncPersister @Inject constructor(
         savedSitesFormFactorSyncMigration.onFormFactorFavouritesDisabled()
         savedSitesSyncState.onSyncDisabled()
         savedSitesSyncRepository.removeMetadata()
+        savedSitesSyncRepository.markSavedSitesAsInvalid(emptyList())
     }
 
     fun process(

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SyncEntitiesExtension.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SyncEntitiesExtension.kt
@@ -23,6 +23,15 @@ import java.time.*
 fun Entity.mapToBookmark(relationId: String): SavedSite.Bookmark =
     SavedSite.Bookmark(this.entityId, this.title, this.url.orEmpty(), relationId, this.lastModified, deleted = this.deletedFlag())
 
+fun Entity.mapToSavedSite(): SavedSite =
+    SavedSite.Bookmark(
+        id = this.entityId,
+        title = this.title,
+        url = this.url.orEmpty(),
+        lastModified = this.lastModified,
+        deleted = this.deletedFlag(),
+    )
+
 fun Entity.mapToFavorite(index: Int = 0): SavedSite.Favorite =
     SavedSite.Favorite(
         id = this.entityId,

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SyncSavedSitesRepository.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SyncSavedSitesRepository.kt
@@ -185,4 +185,14 @@ interface SyncSavedSitesRepository {
      * they are available for the next sync operation
      */
     fun setLocalEntitiesForNextSync(startTimestamp: String)
+
+    /**
+     * Returns the list of [SavedSite] that are marked as Invalid
+     */
+    fun getInvalidSavedSites(): List<SavedSite>
+
+    /**
+     * Marks as Invalid a list of [SavedSite] with the given ids
+     */
+    fun markSavedSitesAsInvalid(ids: List<String>)
 }

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/store/SavedSitesSyncEntitiesStore.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/store/SavedSitesSyncEntitiesStore.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.savedsites.impl.sync.store
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+interface SavedSitesSyncEntitiesStore {
+    var invalidEntitiesIds: List<String>
+}
+
+@ContributesBinding(AppScope::class)
+@SingleInstanceIn(AppScope::class)
+class RealSavedSitesSyncEntitiesStore @Inject constructor(
+    private val context: Context,
+) : SavedSitesSyncEntitiesStore {
+
+    override var invalidEntitiesIds: List<String>
+        get() = preferences.getStringSet(KEY_CLIENT_INVALID_IDS, mutableSetOf())?.toList() ?: mutableListOf()
+        set(value) {
+            preferences.edit(true) {
+                putStringSet(KEY_CLIENT_INVALID_IDS, value.toSet())
+            }
+        }
+
+    private val preferences: SharedPreferences
+        get() = context.getSharedPreferences(FILENAME, Context.MODE_PRIVATE)
+
+    companion object {
+        const val FILENAME = "com.duckduckgo.savedsites.sync.entities.store"
+        private const val KEY_CLIENT_INVALID_IDS = "KEY_CLIENT_INVALID_IDS"
+    }
+}

--- a/saved-sites/saved-sites-impl/src/main/res/values/donottranslate.xml
+++ b/saved-sites/saved-sites-impl/src/main/res/values/donottranslate.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2024 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!-- smartling.entity_escaping = false -->
+<!-- smartling.instruction_attributes = instruction -->
+<resources>
+    <!-- Sync settings screen -->
+    <plurals name="saved_site_invalid_items_warning" instruction="%1$ represents a site name or url, %2$d is the number of other invalid sites">
+        <item quantity="one">Your bookmark for %1$s can’t sync because one of its fields exceeds the character limit.\n\n</item>
+        <item quantity="other">Your bookmarks for %1$s and %2$d other sites can’t sync because some of their fields exceed the character limit.\n\n</item>
+    </plurals>
+    <string name="saved_site_invalid_items_warning_link"><annotation type="manage_bookmarks">Manage Bookmarks</annotation></string>
+</resources>

--- a/saved-sites/saved-sites-store/src/main/java/com/duckduckgo/savedsites/store/SavedSitesEntitiesDao.kt
+++ b/saved-sites/saved-sites-store/src/main/java/com/duckduckgo/savedsites/store/SavedSitesEntitiesDao.kt
@@ -41,6 +41,9 @@ interface SavedSitesEntitiesDao {
     @Query("select * from entities where deleted=0")
     fun entities(): List<Entity>
 
+    @Query("select * from entities where entities.entityId IN (:ids)")
+    fun entities(ids: List<String>): List<Entity>
+
     @Query(
         "select * from entities inner join relations on entities.entityId = relations.entityId " +
             "and entities.type = :type and relations.folderId = :folderId and entities.deleted = 0",


### PR DESCRIPTION
<!--
Note: This checklist is a reminder of our shared engineering expectations. 
The items in Bold are required
If your PR involves UI changes:
    1. Upload screenshots or screencasts that illustrate the changes before / after
    2. Add them under the UI changes section (feel free to add more columns if needed)
If your PR does not involve UI changes, you can remove the **UI changes** section

At a minimum, make sure your changes are tested in API 23 and one of the more recent API levels available.
-->

Task/Issue URL: https://app.asana.com/0/488551667048375/1206852460574030/f

### Description
Some users have bookmarks that fail in the sync BE validation because some of their fields exceed length.

PR includes changes to :
- Filtering invalid bookmarks/favorites
- Fixing invalid bookmark folder names
- Display a message to notify users some bookmarks are not syncing

### Steps to test this PR
(as usual, you will need 2 devices for testing)
_Feature 1_
- [ ] fresh install on device A
- [ ] create an invalid bookmark (>3000 chars in title)
- [ ] create an invalid folder (>3000 chars in title)
- [ ] create another invalid bookmark (>3000chars) and save it inside Invalid Folder
- [ ] mark both invalid bookmarks as favorites
- [ ] fresh install on device B
- [ ] create a sync account
- [ ] create a valid bookmark on device B
- [ ] Join device A into device B sync account
- [ ] ensure in device A appears device B bookmark
- [ ] Go to device B
- [ ] ensure no invalid boomarks from device A
- [ ] ensure invalid folder from device A appears
- [ ] Go back again to device A
- [ ] Go to sync settings
- [ ] ensure info message is shown
- [ ] Go to bookmarks list and fix all invalid bookmarks
- [ ] Go to device B
- [ ] ensure both devices are synced (same bookmarks and favorites)

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
