### PR TITLE
Filte sync invalid logins from request and notify user

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsInvalidItemSyncMessagePlugin.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsInvalidItemSyncMessagePlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 DuckDuckGo
+ * Copyright (c) 2024 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,16 @@
 
 package com.duckduckgo.autofill.sync
 
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
+import android.content.Context
+import android.view.View
+import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.sync.api.SyncMessagePlugin
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
 
-class FakeCredentialsSyncStore : CredentialsSyncStore {
-    override var serverModifiedSince: String = "0"
-    override var startTimeStamp: String = "0"
-    override var clientModifiedSince: String = "0"
-    override var isSyncPaused: Boolean = false
-    override fun isSyncPausedFlow(): Flow<Boolean> = emptyFlow()
-    override var invalidEntitiesIds: List<String> = emptyList()
+@ContributesMultibinding(scope = ActivityScope::class)
+class CredentialsInvalidItemSyncMessagePlugin @Inject constructor() : SyncMessagePlugin {
+    override fun getView(context: Context): View {
+        return CredentialsInvalidItemsView(context)
+    }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsInvalidItemsView.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsInvalidItemsView.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.sync
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.text.SpannableStringBuilder
+import android.util.AttributeSet
+import android.widget.FrameLayout
+import androidx.core.view.isVisible
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewTreeLifecycleOwner
+import androidx.lifecycle.findViewTreeViewModelStoreOwner
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.autofill.api.AutofillScreens.AutofillSettingsScreenNoParams
+import com.duckduckgo.autofill.impl.R
+import com.duckduckgo.autofill.impl.databinding.ViewCredentialsInvalidItemsWarningBinding
+import com.duckduckgo.autofill.sync.CredentialsInvalidItemsViewModel.Command
+import com.duckduckgo.autofill.sync.CredentialsInvalidItemsViewModel.Command.NavigateToCredentials
+import com.duckduckgo.autofill.sync.CredentialsInvalidItemsViewModel.ViewState
+import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.ConflatedJob
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.ViewViewModelFactory
+import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.navigation.api.GlobalActivityStarter
+import dagger.android.support.AndroidSupportInjection
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+
+@InjectWith(ViewScope::class)
+class CredentialsInvalidItemsView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyle: Int = 0,
+) : FrameLayout(context, attrs, defStyle) {
+
+    @Inject
+    lateinit var globalActivityStarter: GlobalActivityStarter
+
+    @Inject
+    lateinit var viewModelFactory: ViewViewModelFactory
+
+    @Inject
+    lateinit var dispatcherProvider: DispatcherProvider
+
+    private var coroutineScope: CoroutineScope? = null
+
+    private var job: ConflatedJob = ConflatedJob()
+
+    private val binding: ViewCredentialsInvalidItemsWarningBinding by viewBinding()
+
+    private val viewModel: CredentialsInvalidItemsViewModel by lazy {
+        ViewModelProvider(findViewTreeViewModelStoreOwner()!!, viewModelFactory)[CredentialsInvalidItemsViewModel::class.java]
+    }
+
+    override fun onAttachedToWindow() {
+        AndroidSupportInjection.inject(this)
+        super.onAttachedToWindow()
+
+        ViewTreeLifecycleOwner.get(this)?.lifecycle?.addObserver(viewModel)
+
+        @SuppressLint("NoHardcodedCoroutineDispatcher")
+        coroutineScope = CoroutineScope(SupervisorJob() + dispatcherProvider.main())
+
+        viewModel.viewState()
+            .onEach { render(it) }
+            .launchIn(coroutineScope!!)
+
+        job += viewModel.commands()
+            .onEach { processCommands(it) }
+            .launchIn(coroutineScope!!)
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        ViewTreeLifecycleOwner.get(this)?.lifecycle?.removeObserver(viewModel)
+        coroutineScope?.cancel()
+        job.cancel()
+        coroutineScope = null
+    }
+
+    private fun processCommands(command: Command) {
+        when (command) {
+            NavigateToCredentials -> navigateToCredentials()
+        }
+    }
+
+    private fun render(viewState: ViewState) {
+        this.isVisible = viewState.warningVisible
+
+        val spannable = SpannableStringBuilder(
+            context.resources.getQuantityString(
+                R.plurals.syncCredentialInvalidItemsWarning,
+                viewState.invalidItemsSize,
+                viewState.hint,
+                viewState.invalidItemsSize - 1,
+            ),
+        ).append(context.getText(R.string.syncCredentialInvalidItemsWarningLink))
+
+        binding.credentialsInvalidItemsWarning.setClickableLink(
+            "manage_passwords",
+            spannable,
+            onClick = {
+                viewModel.onWarningActionClicked()
+            },
+        )
+    }
+
+    private fun navigateToCredentials() {
+        globalActivityStarter.start(this.context, AutofillSettingsScreenNoParams)
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsInvalidItemsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsInvalidItemsViewModel.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.sync
+
+import android.annotation.SuppressLint
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.autofill.api.domain.app.LoginCredentials
+import com.duckduckgo.autofill.sync.CredentialsInvalidItemsViewModel.Command.NavigateToCredentials
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.ViewScope
+import javax.inject.Inject
+import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+
+@SuppressLint("NoLifecycleObserver") // we don't observe app lifecycle
+@ContributesViewModel(ViewScope::class)
+class CredentialsInvalidItemsViewModel @Inject constructor(
+    private val dispatcherProvider: DispatcherProvider,
+    private val crendentialsSyncRepository: CredentialsSync,
+) : ViewModel(), DefaultLifecycleObserver {
+    data class ViewState(
+        val warningVisible: Boolean = false,
+        val invalidItemsSize: Int = 0,
+        val hint: String = "",
+    )
+
+    sealed class Command {
+        data object NavigateToCredentials : Command()
+    }
+
+    private val command = Channel<Command>(1, DROP_OLDEST)
+
+    private val _viewState = MutableStateFlow(ViewState())
+    fun viewState(): Flow<ViewState> = _viewState.onStart {
+        viewModelScope.launch(dispatcherProvider.io()) {
+            emitNewViewState()
+        }
+    }
+
+    override fun onResume(owner: LifecycleOwner) {
+        viewModelScope.launch(dispatcherProvider.io()) {
+            emitNewViewState()
+        }
+    }
+
+    fun commands(): Flow<Command> = command.receiveAsFlow()
+
+    private suspend fun emitNewViewState() {
+        val invalidItems = crendentialsSyncRepository.getInvalidCredentials()
+        _viewState.emit(
+            ViewState(
+                warningVisible = invalidItems.isNotEmpty(),
+                hint = invalidItems.firstOrNull().getHint(),
+                invalidItemsSize = invalidItems.size,
+            ),
+        )
+    }
+
+    fun onWarningActionClicked() {
+        viewModelScope.launch {
+            command.send(NavigateToCredentials)
+        }
+    }
+
+    private fun LoginCredentials?.getHint(): String {
+        val hint: String =
+            this?.domainTitle.takeUnless { it.isNullOrEmpty() }
+                ?: this?.domain.takeUnless { it.isNullOrEmpty() }
+                ?: this?.username.takeUnless { it.isNullOrEmpty() } ?: ""
+        this?.notes.takeUnless { it.isNullOrEmpty() } ?: ""
+
+        return hint.shortenString(HINT_MAX_HINT_LENGTH)
+    }
+
+    private fun String.shortenString(maxLength: Int): String {
+        return this.takeIf { it.length <= maxLength } ?: (this.take(maxLength - 3) + "...")
+    }
+
+    companion object {
+        const val HINT_MAX_HINT_LENGTH = 15
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsSync.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsSync.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.autofill.impl.securestorage.SecureStorage
 import com.duckduckgo.autofill.impl.securestorage.WebsiteLoginDetails
 import com.duckduckgo.autofill.impl.securestorage.WebsiteLoginDetailsWithCredentials
 import com.duckduckgo.autofill.store.CredentialsSyncMetadataEntity
+import com.duckduckgo.autofill.sync.provider.CredentialsSyncLocalValidationFeature
 import com.duckduckgo.autofill.sync.provider.LoginCredentialEntry
 import com.duckduckgo.common.utils.formatters.time.DatabaseDateFormatter
 import com.duckduckgo.di.scopes.AppScope
@@ -38,6 +39,7 @@ class CredentialsSync @Inject constructor(
     private val credentialsSyncStore: CredentialsSyncStore,
     private val credentialsSyncMetadata: CredentialsSyncMetadata,
     private val syncCrypto: SyncCrypto,
+    private val credentialsSyncLocalValidationFeature: CredentialsSyncLocalValidationFeature,
 ) {
 
     suspend fun initMetadata() {
@@ -216,6 +218,8 @@ class CredentialsSync @Inject constructor(
     }
 
     private fun List<LoginCredentialEntry>.validItems(): List<LoginCredentialEntry> {
+        if (credentialsSyncLocalValidationFeature.self().isEnabled().not()) return this // Skip validation if feature is disabled
+
         return this.filter {
             (it.title?.length ?: 0) < MAX_ENCRYPTED_TITLE_LENGTH &&
                 (it.domain?.length ?: 0) < MAX_ENCRYPTED_DOMAIN_LENGTH &&

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsSync.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsSync.kt
@@ -55,11 +55,21 @@ class CredentialsSync @Inject constructor(
 
     suspend fun getUpdatesSince(since: Iso8601String): List<LoginCredentialEntry> {
         credentialsSyncStore.startTimeStamp = SyncDateProvider.now()
-        return if (since == "0") {
+        val changes = if (since == "0") {
             allContentAsUpdates()
         } else {
             changesSince(since)
         }
+        val toRetryItems = getInvalidCredentialsLocalId()
+            .mapNotNull { localId -> secureStorage.getWebsiteLoginDetailsWithCredentials(localId) }
+            .mapToLoginCredentialEntry()
+
+        val allChanges = changes + toRetryItems
+
+        val filteredChanges = allChanges.validItems()
+        markSavedSitesAsInvalid((allChanges - filteredChanges.toSet()).map { it.id })
+
+        return filteredChanges
     }
 
     suspend fun getCredentialWithSyncId(syncId: String): LoginCredentials? {
@@ -131,6 +141,15 @@ class CredentialsSync @Inject constructor(
         credentialsSyncMetadata.removeEntityWith(localId)
     }
 
+    suspend fun getInvalidCredentials(): List<LoginCredentials> {
+        return getInvalidCredentialsLocalId().mapNotNull { localId -> getCredentialWithId(localId) }
+    }
+
+    private fun markSavedSitesAsInvalid(ids: List<String>) {
+        Timber.i("CredentialsSync: Storing invalid items: $ids")
+        credentialsSyncStore.invalidEntitiesIds = ids
+    }
+
     private suspend fun allContentAsUpdates() = secureStorage.websiteLoginDetailsWithCredentials().firstOrNull().mapToLoginCredentialEntry()
 
     private suspend fun changesSince(since: Iso8601String): List<LoginCredentialEntry> {
@@ -150,7 +169,15 @@ class CredentialsSync @Inject constructor(
         Timber.d("CredentialsSync: modifiedSince changes: $changes")
         Timber.d("CredentialsSync: modifiedSince removed: $removedItems")
 
-        return changes.mapToLoginCredentialEntry() + removedItems
+        val changesEntries = changes.mapToLoginCredentialEntry()
+
+        return changesEntries + removedItems
+    }
+
+    private fun getInvalidCredentialsLocalId(): List<Long> {
+        return credentialsSyncStore.invalidEntitiesIds.takeIf { it.isNotEmpty() }?.mapNotNull { id ->
+            credentialsSyncMetadata.getLocalId(id)
+        } ?: emptyList()
     }
 
     private fun String?.encrypt(): String? {
@@ -186,5 +213,23 @@ class CredentialsSync @Inject constructor(
             notes = notes,
             lastUpdatedMillis = details.lastUpdatedMillis,
         )
+    }
+
+    private fun List<LoginCredentialEntry>.validItems(): List<LoginCredentialEntry> {
+        return this.filter {
+            (it.title?.length ?: 0) < MAX_ENCRYPTED_TITLE_LENGTH &&
+                (it.domain?.length ?: 0) < MAX_ENCRYPTED_DOMAIN_LENGTH &&
+                (it.notes?.length ?: 0) < MAX_ENCRYPTED_NOTES_LENGTH &&
+                (it.username?.length ?: 0) < MAX_ENCRYPTED_USERNAME_LENGTH &&
+                (it.password?.length ?: 0) < MAX_ENCRYPTED_PASSWORD_LENGTH
+        }
+    }
+
+    companion object {
+        const val MAX_ENCRYPTED_TITLE_LENGTH = 3_000
+        const val MAX_ENCRYPTED_DOMAIN_LENGTH = 1_000
+        const val MAX_ENCRYPTED_USERNAME_LENGTH = 1_000
+        const val MAX_ENCRYPTED_PASSWORD_LENGTH = 1_000
+        const val MAX_ENCRYPTED_NOTES_LENGTH = 10_000
     }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsSyncStore.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsSyncStore.kt
@@ -37,6 +37,7 @@ interface CredentialsSyncStore {
     var clientModifiedSince: String
     var isSyncPaused: Boolean
     fun isSyncPausedFlow(): Flow<Boolean>
+    var invalidEntitiesIds: List<String>
 }
 
 @ContributesBinding(AppScope::class)
@@ -69,6 +70,13 @@ class RealCredentialsSyncStore @Inject constructor(
             preferences.edit(true) { putBoolean(KEY_CLIENT_LIMIT_EXCEEDED, value) }
             emitNewValue()
         }
+    override var invalidEntitiesIds: List<String>
+        get() = preferences.getStringSet(KEY_CLIENT_INVALID_IDS, mutableSetOf())?.toList() ?: mutableListOf()
+        set(value) {
+            preferences.edit(true) {
+                putStringSet(KEY_CLIENT_INVALID_IDS, value.toSet())
+            }
+        }
 
     override fun isSyncPausedFlow(): Flow<Boolean> = syncPausedSharedFlow
 
@@ -87,5 +95,6 @@ class RealCredentialsSyncStore @Inject constructor(
         private const val KEY_START_TIMESTAMP = "KEY_START_TIMESTAMP"
         private const val KEY_END_TIMESTAMP = "KEY_END_TIMESTAMP"
         private const val KEY_CLIENT_LIMIT_EXCEEDED = "KEY_CLIENT_LIMIT_EXCEEDED"
+        private const val KEY_CLIENT_INVALID_IDS = "KEY_CLIENT_INVALID_IDS"
     }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/provider/CredentialsSyncLocalValidationFeature.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/provider/CredentialsSyncLocalValidationFeature.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.sync.provider
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "credentialsLocalFieldValidation",
+)
+interface CredentialsSyncLocalValidationFeature {
+    @Toggle.DefaultValue(false)
+    fun self(): Toggle
+}

--- a/autofill/autofill-impl/src/main/res/layout/view_credentials_invalid_items_warning.xml
+++ b/autofill/autofill-impl/src/main/res/layout/view_credentials_invalid_items_warning.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright (c) 2023 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<com.duckduckgo.common.ui.view.InfoPanel xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/credentialsInvalidItemsWarning"
+    style="@style/Widget.DuckDuckGo.InfoPanel"
+    android:layout_margin="@dimen/keyline_4"
+    app:panelBackground="@drawable/info_panel_alert_background"
+    app:panelDrawable="@drawable/ic_info_panel_alert" />

--- a/autofill/autofill-impl/src/main/res/values/donottranslate.xml
+++ b/autofill/autofill-impl/src/main/res/values/donottranslate.xml
@@ -15,5 +15,10 @@
   -->
 
 <resources>
-
+    <!-- Sync settings screen -->
+    <plurals name="syncCredentialInvalidItemsWarning" instruction="%1$ represents a site name or url, %2$d is the number of other invalid sites">
+        <item quantity="one">Your password for %1$s can’t sync because one of its fields exceeds the character limit.\n\n</item>
+        <item quantity="other">Your passwords for %1$s and %2$d other sites can’t sync because some of their fields exceed the character limit.\n\n</item>
+    </plurals>
+    <string name="syncCredentialInvalidItemsWarningLink"><annotation type="manage_passwords">Manage Passwords</annotation></string>
 </resources>

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/CredentialsFixtures.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/CredentialsFixtures.kt
@@ -48,6 +48,15 @@ object CredentialsFixtures {
         notes = "My Amazon account",
     )
 
+    val invalidCredentials = LoginCredentials(
+        id = 4L,
+        domain = "www.invalid.com",
+        username = "invalidUS",
+        password = "invalidPW",
+        domainTitle = String(CharArray(3000) { 'a' + (it % 26) }),
+        notes = "My Invalid account",
+    )
+
     fun LoginCredentials.toLoginCredentialEntryResponse(): CredentialsSyncEntryResponse =
         CredentialsSyncEntryResponse(
             id = id.toString(),

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/CredentialsInvalidItemsViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/CredentialsInvalidItemsViewModelTest.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.sync
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.cash.turbine.test
+import com.duckduckgo.autofill.sync.CredentialsFixtures.invalidCredentials
+import com.duckduckgo.autofill.sync.CredentialsFixtures.spotifyCredentials
+import com.duckduckgo.common.test.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CredentialsInvalidItemsViewModelTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val db = inMemoryAutofillDatabase()
+    private val secureStorage = FakeSecureStorage()
+    private val credentialsSyncStore = FakeCredentialsSyncStore()
+    private val credentialsSyncMetadata = CredentialsSyncMetadata(db.credentialsSyncDao())
+    private val credentialsSync = CredentialsSync(secureStorage, credentialsSyncStore, credentialsSyncMetadata, FakeCrypto())
+
+    private val viewModel = CredentialsInvalidItemsViewModel(
+        dispatcherProvider = coroutineRule.testDispatcherProvider,
+        crendentialsSyncRepository = credentialsSync,
+    )
+
+    @Test
+    fun whenNoInvalidCredentialsThenWarningNotVisible() = runTest {
+        viewModel.viewState().test {
+            val awaitItem = awaitItem()
+            assertFalse(awaitItem.warningVisible)
+            assertEquals(0, awaitItem.invalidItemsSize)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenInvalidCredentialsThenWarningVisible() = runTest {
+        credentialsSync.saveCredential(invalidCredentials, "remote1")
+        credentialsSync.saveCredential(spotifyCredentials, "remote2")
+        credentialsSync.getUpdatesSince("0") // trigger sync so invalid credentials are detected
+
+        viewModel.viewState().test {
+            val awaitItem = awaitItem()
+            assertTrue(awaitItem.warningVisible)
+            assertEquals(1, awaitItem.invalidItemsSize)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/CredentialsInvalidItemsViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/CredentialsInvalidItemsViewModelTest.kt
@@ -39,7 +39,13 @@ class CredentialsInvalidItemsViewModelTest {
     private val secureStorage = FakeSecureStorage()
     private val credentialsSyncStore = FakeCredentialsSyncStore()
     private val credentialsSyncMetadata = CredentialsSyncMetadata(db.credentialsSyncDao())
-    private val credentialsSync = CredentialsSync(secureStorage, credentialsSyncStore, credentialsSyncMetadata, FakeCrypto())
+    private val credentialsSync = CredentialsSync(
+        secureStorage,
+        credentialsSyncStore,
+        credentialsSyncMetadata,
+        FakeCrypto(),
+        FakeCredentialsSyncLocalValidationFeature(),
+    )
 
     private val viewModel = CredentialsInvalidItemsViewModel(
         dispatcherProvider = coroutineRule.testDispatcherProvider,

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/CredentialsSyncTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/CredentialsSyncTest.kt
@@ -44,7 +44,13 @@ internal class CredentialsSyncTest {
     private val secureStorage = FakeSecureStorage()
     private val credentialsSyncStore = FakeCredentialsSyncStore()
     private val credentialsSyncMetadata = CredentialsSyncMetadata(db.credentialsSyncDao())
-    private val credentialsSync = CredentialsSync(secureStorage, credentialsSyncStore, credentialsSyncMetadata, FakeCrypto())
+    private val credentialsSync = CredentialsSync(
+        secureStorage,
+        credentialsSyncStore,
+        credentialsSyncMetadata,
+        FakeCrypto(),
+        FakeCredentialsSyncLocalValidationFeature(),
+    )
 
     @After fun after() = runBlocking {
         db.close()

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/CredentialsSyncTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/CredentialsSyncTest.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.impl.securestorage.WebsiteLoginDetails
 import com.duckduckgo.autofill.impl.securestorage.WebsiteLoginDetailsWithCredentials
 import com.duckduckgo.autofill.store.CredentialsSyncMetadataEntity
+import com.duckduckgo.autofill.sync.CredentialsFixtures.invalidCredentials
 import com.duckduckgo.autofill.sync.CredentialsFixtures.spotifyCredentials
 import com.duckduckgo.autofill.sync.CredentialsFixtures.toLoginCredentials
 import com.duckduckgo.autofill.sync.CredentialsFixtures.twitterCredentials
@@ -143,6 +144,59 @@ internal class CredentialsSyncTest {
             ),
             updates,
         )
+    }
+
+    @Test
+    fun whenOnFirstWithInvalidCredentialsThenChangesDoesNotContainInvalidEntities() = runTest {
+        givenLocalCredentials(
+            invalidCredentials,
+        )
+
+        val syncChanges = credentialsSync.getUpdatesSince("0")
+
+        assertTrue(syncChanges.isEmpty())
+        assertTrue(credentialsSyncStore.invalidEntitiesIds.size == 1)
+    }
+
+    @Test
+    fun whenNewCredentialsIsInvalidThenChangesDoesNotContainInvalidEntity() = runTest {
+        givenLocalCredentials(
+            spotifyCredentials,
+            invalidCredentials.copy(lastUpdatedMillis = 1689592358516),
+        )
+
+        val syncChanges = credentialsSync.getUpdatesSince("2022-08-30T00:00:00Z")
+
+        assertTrue(syncChanges.isEmpty())
+        assertTrue(credentialsSyncStore.invalidEntitiesIds.size == 1)
+    }
+
+    @Test
+    fun whenInvalidCredentialsPresentThenAlwaysRetryItemsAndUpdateInvalidList() = runTest {
+        givenLocalCredentials(
+            invalidCredentials,
+            spotifyCredentials.copy(lastUpdatedMillis = 1689592358516),
+        )
+        credentialsSyncStore.invalidEntitiesIds = listOf(credentialsSyncMetadata.getSyncMetadata(invalidCredentials.id!!)!!.syncId)
+
+        val syncChanges = credentialsSync.getUpdatesSince("2022-08-30T00:00:00Z")
+
+        assertTrue(syncChanges.size == 1)
+        assertTrue(syncChanges.first().title == spotifyCredentials.domainTitle)
+        assertTrue(credentialsSyncStore.invalidEntitiesIds.size == 1)
+    }
+
+    @Test
+    fun whenInvalidCredentialsThenReturnInvalidCredentials() = runTest {
+        givenLocalCredentials(
+            invalidCredentials,
+        )
+        credentialsSyncStore.invalidEntitiesIds = listOf(credentialsSyncMetadata.getSyncMetadata(invalidCredentials.id!!)!!.syncId)
+
+        val invalidItems = credentialsSync.getInvalidCredentials()
+
+        assertTrue(invalidItems.isNotEmpty())
+        assertEquals(invalidCredentials, invalidItems.first())
     }
 
     @Test
@@ -294,6 +348,7 @@ internal class CredentialsSyncTest {
     private suspend fun givenLocalCredentials(vararg credentials: LoginCredentials) {
         credentials.forEach { credential ->
             val loginDetails = WebsiteLoginDetails(
+                id = credential.id,
                 domain = credential.domain,
                 username = credential.username,
                 domainTitle = credential.domainTitle,

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/FakeCredentialsSyncLocalValidationFeature.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/FakeCredentialsSyncLocalValidationFeature.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.sync
+
+import com.duckduckgo.autofill.sync.provider.CredentialsSyncLocalValidationFeature
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.toggle.TestToggle
+
+class FakeCredentialsSyncLocalValidationFeature : CredentialsSyncLocalValidationFeature {
+    var enabled = true
+
+    override fun self(): Toggle = TestToggle(enabled)
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/persister/CredentialsLastModifiedWinsStrategyTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/persister/CredentialsLastModifiedWinsStrategyTest.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.autofill.sync.CredentialsFixtures.twitterCredentials
 import com.duckduckgo.autofill.sync.CredentialsSync
 import com.duckduckgo.autofill.sync.CredentialsSyncMapper
 import com.duckduckgo.autofill.sync.CredentialsSyncMetadata
+import com.duckduckgo.autofill.sync.FakeCredentialsSyncLocalValidationFeature
 import com.duckduckgo.autofill.sync.FakeCredentialsSyncStore
 import com.duckduckgo.autofill.sync.FakeCrypto
 import com.duckduckgo.autofill.sync.FakeSecureStorage
@@ -56,7 +57,13 @@ internal class CredentialsLastModifiedWinsStrategyTest {
     private val secureStorage = FakeSecureStorage()
     private val credentialsSyncStore = FakeCredentialsSyncStore()
     private val credentialsSyncMetadata = CredentialsSyncMetadata(db.credentialsSyncDao())
-    private val credentialsSync = CredentialsSync(secureStorage, credentialsSyncStore, credentialsSyncMetadata, FakeCrypto())
+    private val credentialsSync = CredentialsSync(
+        secureStorage,
+        credentialsSyncStore,
+        credentialsSyncMetadata,
+        FakeCrypto(),
+        FakeCredentialsSyncLocalValidationFeature(),
+    )
 
     @After fun after() = runBlocking {
         db.close()

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/persister/CredentialsLocalWinsStrategyTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/persister/CredentialsLocalWinsStrategyTest.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.autofill.sync.CredentialsFixtures.twitterCredentials
 import com.duckduckgo.autofill.sync.CredentialsSync
 import com.duckduckgo.autofill.sync.CredentialsSyncMapper
 import com.duckduckgo.autofill.sync.CredentialsSyncMetadata
+import com.duckduckgo.autofill.sync.FakeCredentialsSyncLocalValidationFeature
 import com.duckduckgo.autofill.sync.FakeCredentialsSyncStore
 import com.duckduckgo.autofill.sync.FakeCrypto
 import com.duckduckgo.autofill.sync.FakeSecureStorage
@@ -55,7 +56,13 @@ internal class CredentialsLocalWinsStrategyTest {
     private val secureStorage = FakeSecureStorage()
     private val credentialsSyncStore = FakeCredentialsSyncStore()
     private val credentialsSyncMetadata = CredentialsSyncMetadata(db.credentialsSyncDao())
-    private val credentialsSync = CredentialsSync(secureStorage, credentialsSyncStore, credentialsSyncMetadata, FakeCrypto())
+    private val credentialsSync = CredentialsSync(
+        secureStorage,
+        credentialsSyncStore,
+        credentialsSyncMetadata,
+        FakeCrypto(),
+        FakeCredentialsSyncLocalValidationFeature(),
+    )
 
     @After fun after() = runBlocking {
         db.close()

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/persister/CredentialsRemoteWinsStrategyTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/persister/CredentialsRemoteWinsStrategyTest.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.autofill.sync.CredentialsFixtures.twitterCredentials
 import com.duckduckgo.autofill.sync.CredentialsSync
 import com.duckduckgo.autofill.sync.CredentialsSyncMapper
 import com.duckduckgo.autofill.sync.CredentialsSyncMetadata
+import com.duckduckgo.autofill.sync.FakeCredentialsSyncLocalValidationFeature
 import com.duckduckgo.autofill.sync.FakeCredentialsSyncStore
 import com.duckduckgo.autofill.sync.FakeCrypto
 import com.duckduckgo.autofill.sync.FakeSecureStorage
@@ -55,7 +56,13 @@ internal class CredentialsRemoteWinsStrategyTest {
     private val secureStorage = FakeSecureStorage()
     private val credentialsSyncStore = FakeCredentialsSyncStore()
     private val credentialsSyncMetadata = CredentialsSyncMetadata(db.credentialsSyncDao())
-    private val credentialsSync = CredentialsSync(secureStorage, credentialsSyncStore, credentialsSyncMetadata, FakeCrypto())
+    private val credentialsSync = CredentialsSync(
+        secureStorage,
+        credentialsSyncStore,
+        credentialsSyncMetadata,
+        FakeCrypto(),
+        FakeCredentialsSyncLocalValidationFeature(),
+    )
 
     @After fun after() = runBlocking {
         db.close()

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/persister/CrendentialsDedupStrategyTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/persister/CrendentialsDedupStrategyTest.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.autofill.sync.CredentialsFixtures.twitterCredentials
 import com.duckduckgo.autofill.sync.CredentialsSync
 import com.duckduckgo.autofill.sync.CredentialsSyncMapper
 import com.duckduckgo.autofill.sync.CredentialsSyncMetadata
+import com.duckduckgo.autofill.sync.FakeCredentialsSyncLocalValidationFeature
 import com.duckduckgo.autofill.sync.FakeCredentialsSyncStore
 import com.duckduckgo.autofill.sync.FakeCrypto
 import com.duckduckgo.autofill.sync.FakeSecureStorage
@@ -55,7 +56,13 @@ internal class CredentialsDedupStrategyTest {
     private val secureStorage = FakeSecureStorage()
     private val credentialsSyncStore = FakeCredentialsSyncStore()
     private val credentialsSyncMetadata = CredentialsSyncMetadata(db.credentialsSyncDao())
-    private val credentialsSync = CredentialsSync(secureStorage, credentialsSyncStore, credentialsSyncMetadata, FakeCrypto())
+    private val credentialsSync = CredentialsSync(
+        secureStorage,
+        credentialsSyncStore,
+        credentialsSyncMetadata,
+        FakeCrypto(),
+        FakeCredentialsSyncLocalValidationFeature(),
+    )
 
     @After fun after() = runBlocking {
         db.close()

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/provider/CredentialsSyncDataProviderTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/provider/CredentialsSyncDataProviderTest.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.autofill.sync.CredentialsFixtures
 import com.duckduckgo.autofill.sync.CredentialsFixtures.toWebsiteLoginCredentials
 import com.duckduckgo.autofill.sync.CredentialsSync
 import com.duckduckgo.autofill.sync.CredentialsSyncMetadata
+import com.duckduckgo.autofill.sync.FakeCredentialsSyncLocalValidationFeature
 import com.duckduckgo.autofill.sync.FakeCredentialsSyncStore
 import com.duckduckgo.autofill.sync.FakeCrypto
 import com.duckduckgo.autofill.sync.FakeSecureStorage
@@ -53,7 +54,13 @@ internal class CredentialsSyncDataProviderTest {
     private val secureStorage = FakeSecureStorage()
     private val credentialsSyncMetadata = CredentialsSyncMetadata(db.credentialsSyncDao())
     private val credentialsSyncStore = FakeCredentialsSyncStore()
-    private val credentialsSync = CredentialsSync(secureStorage, credentialsSyncStore, credentialsSyncMetadata, FakeCrypto())
+    private val credentialsSync = CredentialsSync(
+        secureStorage,
+        credentialsSyncStore,
+        credentialsSyncMetadata,
+        FakeCrypto(),
+        FakeCredentialsSyncLocalValidationFeature(),
+    )
     private val appBuildConfig = mock<AppBuildConfig>().apply {
         whenever(this.flavor).thenReturn(BuildFlavor.PLAY)
     }

--- a/saved-sites/saved-sites-impl/build.gradle
+++ b/saved-sites/saved-sites-impl/build.gradle
@@ -24,6 +24,8 @@ plugins {
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"
 
 dependencies {
+    implementation project(path: ':feature-toggles-api')
+    implementation project(path: ':app-build-config-api')
     implementation project(path: ':di')
     implementation project(path: ':statistics')
     implementation project(path: ':common-utils')

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/BookmarksSyncLocalValidationFeature.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/BookmarksSyncLocalValidationFeature.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.savedsites.impl.sync
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "bookmarksLocalFieldValidation",
+)
+interface BookmarksSyncLocalValidationFeature {
+    @Toggle.DefaultValue(false)
+    fun self(): Toggle
+}

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSitesSyncDataProvider.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSitesSyncDataProvider.kt
@@ -40,6 +40,7 @@ class SavedSitesSyncDataProvider @Inject constructor(
     private val savedSitesSyncStore: SavedSitesSyncStore,
     private val syncCrypto: SyncCrypto,
     private val savedSitesFormFactorSyncMigration: SavedSitesFormFactorSyncMigration,
+    private val bookmarksSyncLocalValidationFeature: BookmarksSyncLocalValidationFeature,
 ) : SyncableDataProvider {
     override fun getType(): SyncableType = BOOKMARKS
 
@@ -220,6 +221,8 @@ class SavedSitesSyncDataProvider @Inject constructor(
     }
 
     private fun isValid(syncSavedSite: SyncSavedSitesRequestEntry): Boolean {
+        if (bookmarksSyncLocalValidationFeature.self().isEnabled().not()) return true // no validation required
+
         val titleLength = syncSavedSite.title?.length ?: 0
         val urlLength = syncSavedSite.page?.url?.length ?: 0
 
@@ -227,6 +230,8 @@ class SavedSitesSyncDataProvider @Inject constructor(
     }
 
     private fun fixFolderIfNecessary(folder: BookmarkFolder): BookmarkFolder {
+        if (bookmarksSyncLocalValidationFeature.self().isEnabled().not()) return folder
+
         val fixedName = folder.name.take(MAX_FOLDER_TITLE_LENGTH)
         return folder.copy(name = fixedName)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1206852460574032/f 

### Description
Some users have Logins that fail in the sync BE validation because some of their fields exceed length.

PR includes changes to :
- Filtering invalid logins
- Display a message to notify users some logins are not syncing

### Steps to test this PR

_Feature 1_
- [ ] fresh install on device A
- [ ] create a login with a title (>3k chars), or domain/username/password(>1k chars), or notes (>10k chars)
- [ ] create a sync account
- [ ] ensure in sync settings you see a warning saying some items are invalid
- [ ] create a second sync invalid login
- [ ] ensure in sync settings you see warning indicating there are more than 1 invalid logins
- [ ] Clicking on manage logins should take you to the login screen
- [ ] update the invalid fields
- [ ] Go back to sync settings
- [ ] ensure warning message is gone

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
