### PR TITLE
Expand bookmarks bottom sheet

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksBottomSheetDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksBottomSheetDialog.kt
@@ -21,13 +21,19 @@ import android.content.Context
 import android.text.SpannableString
 import android.view.LayoutInflater
 import android.view.WindowManager
+import android.widget.FrameLayout
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.core.content.ContextCompat
 import com.duckduckgo.app.browser.databinding.BottomSheetAddBookmarkBinding
 import com.duckduckgo.common.ui.view.show
+import com.duckduckgo.mobile.android.R as CommonR
+import com.google.android.material.R
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.google.android.material.shape.CornerFamily
+import com.google.android.material.shape.MaterialShapeDrawable
+import com.google.android.material.shape.ShapeAppearanceModel
 
 @SuppressLint("NoBottomSheetDialog")
 class BookmarksBottomSheetDialog(builder: Builder) : BottomSheetDialog(builder.context) {
@@ -164,9 +170,26 @@ class BookmarksBottomSheetDialog(builder: Builder) : BottomSheetDialog(builder.c
 
         /** Start the dialog and display it on screen */
         fun show() {
-            dialog = BookmarksBottomSheetDialog(this)
-            dialog?.behavior?.state = BottomSheetBehavior.STATE_EXPANDED
+            dialog = BookmarksBottomSheetDialog(this).apply {
+                this.behavior.state = BottomSheetBehavior.STATE_EXPANDED
+                this.behavior.isDraggable = false
+                roundCornersAlways(this)
+            }
             dialog?.show()
+        }
+
+        // TODO: Use a style when bookmarks is moved to its own module
+        private fun roundCornersAlways(dialog: BottomSheetDialog) {
+            dialog.setOnShowListener { dialogInterface ->
+                val bottomSheetDialog = dialogInterface as BottomSheetDialog
+                val bottomSheet = bottomSheetDialog.findViewById<FrameLayout>(R.id.design_bottom_sheet)
+                bottomSheet?.background = MaterialShapeDrawable(
+                    ShapeAppearanceModel.builder().apply {
+                        setTopLeftCorner(CornerFamily.ROUNDED, context.resources.getDimension(CommonR.dimen.dialogBorderRadius))
+                        setTopRightCorner(CornerFamily.ROUNDED, context.resources.getDimension(CommonR.dimen.dialogBorderRadius))
+                    }.build(),
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksBottomSheetDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/ui/BookmarksBottomSheetDialog.kt
@@ -26,6 +26,7 @@ import androidx.annotation.DrawableRes
 import androidx.core.content.ContextCompat
 import com.duckduckgo.app.browser.databinding.BottomSheetAddBookmarkBinding
 import com.duckduckgo.common.ui.view.show
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 
 @SuppressLint("NoBottomSheetDialog")
@@ -164,6 +165,7 @@ class BookmarksBottomSheetDialog(builder: Builder) : BottomSheetDialog(builder.c
         /** Start the dialog and display it on screen */
         fun show() {
             dialog = BookmarksBottomSheetDialog(this)
+            dialog?.behavior?.state = BottomSheetBehavior.STATE_EXPANDED
             dialog?.show()
         }
     }

--- a/app/src/main/res/drawable/rounded_top_corners_bottom_sheet_drawable.xml
+++ b/app/src/main/res/drawable/rounded_top_corners_bottom_sheet_drawable.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2022 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners
+        android:topLeftRadius="@dimen/dialogBorderRadius"
+        android:topRightRadius="@dimen/dialogBorderRadius" />
+    <solid android:color="?attr/daxColorContainer" />
+</shape>

--- a/app/src/main/res/drawable/rounded_top_corners_bottom_sheet_drawable.xml
+++ b/app/src/main/res/drawable/rounded_top_corners_bottom_sheet_drawable.xml
@@ -19,5 +19,5 @@
     <corners
         android:topLeftRadius="@dimen/dialogBorderRadius"
         android:topRightRadius="@dimen/dialogBorderRadius" />
-    <solid android:color="?attr/daxColorContainer" />
+    <solid android:color="?attr/daxColorSurface" />
 </shape>

--- a/app/src/main/res/layout/bottom_sheet_add_bookmark.xml
+++ b/app/src/main/res/layout/bottom_sheet_add_bookmark.xml
@@ -21,7 +21,8 @@
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:paddingTop="@dimen/actionBottomSheetVerticalPadding"
-    android:paddingBottom="@dimen/actionBottomSheetVerticalPadding">
+    android:paddingBottom="@dimen/actionBottomSheetVerticalPadding"
+    android:background="@drawable/rounded_top_corners_bottom_sheet_drawable">
 
     <com.duckduckgo.common.ui.view.text.DaxTextView
         android:id="@+id/bookmarksBottomSheetDialogTitle"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1206893161772617/f

### Description
Ensures that the bookmarks bottom sheet is always expanded.

### Steps to test this PR
- [x] Add a bookmark in landscape mode.
- [x] Verify that the bottom sheet is fully visible.

### UI changes
| Before  | After |
| ------ | ----- |
![bookmarks_bottom_sheet](https://github.com/duckduckgo/Android/assets/3471025/cb49eeaa-f26f-4fe7-877d-7b0ddea4040d)|![bookmarks_bottom_sheet_after](https://github.com/duckduckgo/Android/assets/3471025/828d6d6e-1a37-4124-b5c9-7ea66cf0421b)



