### PR TITLE
 Android: Fix RTE caused by liveTabs()

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -440,7 +440,6 @@ class BrowserTabViewModelTest {
 
         whenever(mockDismissedCtaDao.dismissedCtas()).thenReturn(dismissedCtaDaoChannel.consumeAsFlow())
         whenever(mockTabRepository.flowTabs).thenReturn(flowOf(emptyList()))
-        whenever(mockTabRepository.liveTabs).thenReturn(tabsLiveData)
         whenever(mockEmailManager.signedInFlow()).thenReturn(emailStateFlow.asStateFlow())
         whenever(mockSavedSitesRepository.getFavorites()).thenReturn(favoriteListFlow.consumeAsFlow())
         whenever(mockSavedSitesRepository.getBookmarks()).thenReturn(bookmarksListFlow.consumeAsFlow())

--- a/app/src/androidTest/java/com/duckduckgo/app/tabs/model/TabDataRepositoryTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/tabs/model/TabDataRepositoryTest.kt
@@ -19,9 +19,9 @@
 package com.duckduckgo.app.tabs.model
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import androidx.lifecycle.MutableLiveData
 import androidx.room.Room
 import androidx.test.platform.app.InstrumentationRegistry
+import app.cash.turbine.test
 import com.duckduckgo.app.blockingObserve
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.browser.tabpreview.WebViewPreviewPersister
@@ -216,7 +216,9 @@ class TabDataRepositoryTest {
 
         testee.addDefaultTab()
 
-        assertTrue(testee.liveTabs.blockingObserve()?.size == 1)
+        testee.flowTabs.test {
+            assertTrue(awaitItem().size == 1)
+        }
     }
 
     @Test
@@ -227,7 +229,9 @@ class TabDataRepositoryTest {
 
         testee.addDefaultTab()
 
-        assertTrue(testee.liveTabs.blockingObserve()?.size == 1)
+        testee.flowTabs.test {
+            assertTrue(awaitItem().size == 1)
+        }
     }
 
     @Test
@@ -433,8 +437,6 @@ class TabDataRepositoryTest {
     private fun mockDatabase(): TabsDao {
         whenever(mockDao.flowDeletableTabs())
             .thenReturn(daoDeletableTabs.consumeAsFlow())
-        whenever(mockDao.liveTabs())
-            .thenReturn(MutableLiveData())
 
         return mockDao
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1034,14 +1034,11 @@ class BrowserTabFragment :
     }
 
     private fun addTabsObserver() {
-        viewModel.tabs.observe(
-            viewLifecycleOwner,
-            Observer {
-                it?.let {
-                    decorator.renderTabIcon(it)
-                }
-            },
-        )
+        viewModel.tabs.flowWithLifecycle(viewLifecycleOwner.lifecycle)
+            .onEach {
+                decorator.renderTabIcon(it)
+            }
+            .launchIn(viewLifecycleOwner.lifecycleScope)
 
         viewModel.liveSelectedTab.distinctUntilChanged().observe(
             viewLifecycleOwner,
@@ -1622,7 +1619,6 @@ class BrowserTabFragment :
 
     private fun openInNewBackgroundTab() {
         omnibar.appBarLayout.setExpanded(true, true)
-        viewModel.tabs.removeObservers(this)
         decorator.incrementTabs()
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -374,7 +374,7 @@ class BrowserTabViewModel @Inject constructor(
 
     var skipHome = false
     var hasCtaBeenShownForCurrentPage: AtomicBoolean = AtomicBoolean(false)
-    val tabs: LiveData<List<TabEntity>> = tabRepository.liveTabs
+    val tabs: Flow<List<TabEntity>> = tabRepository.flowTabs
     val liveSelectedTab: LiveData<TabEntity> = tabRepository.liveSelectedTab
     val survey: LiveData<Survey> = ctaViewModel.surveyLiveData
     val command: SingleLiveEvent<Command> = SingleLiveEvent()
@@ -1221,9 +1221,11 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     private fun setAdClickActiveTabData(url: String?) {
-        val sourceTabId = tabRepository.liveSelectedTab.value?.sourceTabId
-        val sourceTabUrl = tabRepository.liveTabs.value?.firstOrNull { it.tabId == sourceTabId }?.url
-        adClickManager.setActiveTabId(tabId, url, sourceTabId, sourceTabUrl)
+        viewModelScope.launch {
+            val sourceTabId = tabRepository.liveSelectedTab.value?.sourceTabId
+            val sourceTabUrl = tabRepository.flowTabs.firstOrNull()?.firstOrNull { it.tabId == sourceTabId }?.url
+            adClickManager.setActiveTabId(tabId, url, sourceTabId, sourceTabUrl)
+        }
     }
 
     private fun cacheAppLink(url: String?) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -52,6 +52,7 @@ import com.duckduckgo.di.scopes.ActivityScope
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -92,7 +93,7 @@ class BrowserViewModel @Inject constructor(
     private val currentViewState: ViewState
         get() = viewState.value!!
 
-    var tabs: LiveData<List<TabEntity>> = tabRepository.liveTabs
+    var tabs: Flow<List<TabEntity>> = tabRepository.flowTabs
     var selectedTab: LiveData<TabEntity> = tabRepository.liveSelectedTab
     val command: SingleLiveEvent<Command> = SingleLiveEvent()
 

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -316,7 +316,7 @@ class CtaViewModel @Inject constructor(
         }
     }
 
-    private fun forceStopFireButtonPulseAnimationFlow() = tabRepository.flowTabs.distinctUntilChanged()
+    private fun forceStopFireButtonPulseAnimationFlow() = tabRepository.flowTabs
         .map { tabs ->
             if (tabs.size >= MAX_TABS_OPEN_FIRE_EDUCATION) return@map true
             return@map false

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
@@ -19,7 +19,6 @@ package com.duckduckgo.app.tabs.model
 import android.net.Uri
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.distinctUntilChanged
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.browser.tabpreview.WebViewPreviewPersister
 import com.duckduckgo.app.di.AppCoroutineScope
@@ -54,9 +53,7 @@ class TabDataRepository @Inject constructor(
     private val dispatchers: DispatcherProvider,
 ) : TabRepository {
 
-    override val liveTabs: LiveData<List<TabEntity>> = tabsDao.liveTabs().distinctUntilChanged()
-
-    override val flowTabs: Flow<List<TabEntity>> = tabsDao.flowTabs()
+    override val flowTabs: Flow<List<TabEntity>> = tabsDao.flowTabs().distinctUntilChanged()
 
     private val childTabClosedSharedFlow = MutableSharedFlow<String>()
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -29,6 +29,8 @@ import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 
 @ContributesViewModel(ActivityScope::class)
@@ -39,7 +41,7 @@ class TabSwitcherViewModel @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
 ) : ViewModel() {
 
-    var tabs: LiveData<List<TabEntity>> = tabRepository.liveTabs
+    var tabs: Flow<List<TabEntity>> = tabRepository.flowTabs
     var deletableTabs: LiveData<List<TabEntity>> = tabRepository.flowDeletableTabs.asLiveData(
         context = viewModelScope.coroutineContext,
     )
@@ -85,7 +87,7 @@ class TabSwitcherViewModel @Inject constructor(
 
     fun onCloseAllTabsConfirmed() {
         viewModelScope.launch(dispatcherProvider.io()) {
-            tabs.value?.forEach {
+            tabs.firstOrNull()?.forEach {
                 onTabDeleted(it)
             }
         }

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -19,7 +19,6 @@
 package com.duckduckgo.app.tabs.ui
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import com.duckduckgo.adclick.api.AdClickManager
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
@@ -28,6 +27,7 @@ import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command
 import com.duckduckgo.common.test.CoroutineTestRule
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
@@ -69,7 +69,7 @@ class TabSwitcherViewModelTest {
     private lateinit var testee: TabSwitcherViewModel
 
     private val repoDeletableTabs = Channel<List<TabEntity>>()
-    private val tabs = MutableLiveData<List<TabEntity>>()
+    private val tabs = MutableStateFlow<List<TabEntity>>(emptyList())
 
     @Before
     fun before() {
@@ -77,7 +77,7 @@ class TabSwitcherViewModelTest {
         runBlocking {
             whenever(mockTabRepository.flowDeletableTabs)
                 .thenReturn(repoDeletableTabs.consumeAsFlow())
-            whenever(mockTabRepository.liveTabs)
+            whenever(mockTabRepository.flowTabs)
                 .thenReturn(tabs)
             whenever(mockTabRepository.add()).thenReturn("TAB_ID")
             testee = TabSwitcherViewModel(
@@ -180,16 +180,12 @@ class TabSwitcherViewModelTest {
     @Test
     fun whenOnCloseAllTabsConfirmedThenTabDeletedAndTabIdClearedAndSessionDeleted() = runTest {
         val tab = TabEntity("ID", position = 0)
-        tabs.postValue(listOf(tab))
+        tabs.emit(listOf(tab))
 
         testee.onCloseAllTabsConfirmed()
 
-        testee.tabs.observeForever {
-            runBlocking {
-                verify(mockTabRepository).delete(tab)
-            }
-            verify(mockAdClickManager).clearTabId(tab.tabId)
-            verify(mockWebViewSessionStorage).deleteSession(tab.tabId)
-        }
+        verify(mockTabRepository).delete(tab)
+        verify(mockAdClickManager).clearTabId(tab.tabId)
+        verify(mockWebViewSessionStorage).deleteSession(tab.tabId)
     }
 }

--- a/browser-api/src/main/java/com/duckduckgo/app/tabs/model/TabRepository.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/tabs/model/TabRepository.kt
@@ -27,8 +27,6 @@ interface TabRepository {
     /**
      * @return the tabs that are NOT marked as deletable in the DB
      */
-    val liveTabs: LiveData<List<TabEntity>>
-
     val flowTabs: Flow<List<TabEntity>>
 
     val childClosedTabs: SharedFlow<String>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1206101789026134/f

### Description
Remove livetabs() usages and replace it with flowtabs()

### Steps to test this PR

- [x] Install build
- [x] Open a few tabs
- [x] Verify that each one is opened correctly
- [x] Verify that unopened tabs have blue dot
- [x] Verify that opened tabs have correct icons and titles
- [x] Click context menu 
- [x] Verify that Close all tabs is available
- [x] Click close all tabs
- [x] Verify that all tabs are closed
- [x] Click on context menu again
- [x] Verify that Close all tabs is no available
- [x] Smoke test tab switcher activity

