### PR TITLE
Fix Download confirmation dialog is cut off in vertical/tablet mode bug

### DIFF
--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DownloadConfirmationFragment.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DownloadConfirmationFragment.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.downloads.impl
 
+import android.app.Dialog
 import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -27,6 +28,7 @@ import com.duckduckgo.downloads.api.DownloadConfirmationDialogListener
 import com.duckduckgo.downloads.api.FileDownloader.PendingFileDownload
 import com.duckduckgo.downloads.impl.RealDownloadConfirmation.Companion.PENDING_DOWNLOAD_BUNDLE_KEY
 import com.duckduckgo.downloads.impl.databinding.DownloadConfirmationBinding
+import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.android.support.AndroidSupportInjection
 import java.io.File
@@ -68,6 +70,15 @@ class DownloadConfirmationFragment : BottomSheetDialogFragment() {
         setupDownload()
         setupViews(binding)
         return binding.root
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val dialog = super.onCreateDialog(savedInstanceState) as BottomSheetDialog
+        dialog.behavior.apply {
+            isFitToContents = true
+            peekHeight = resources.displayMetrics.heightPixels / 2
+        }
+        return dialog
     }
 
     private fun setupDownload() {


### PR DESCRIPTION
Task/Issue URL: https://github.com/duckduckgo/Android/issues/4342

### Fix Download confirmation dialog is cut off in vertical/tablet mode

### Steps to test this PR

_Feature 1_

- [ ] Hold your android device in vertical position.
- [ ] Select a file to download
- [ ] Select a file to download
- [ ] Observe the dialog hiding beyond bottom screen border

### UI changes
| Before  |

![315940047-6c7ce7e1-431e-4a53-8ee5-ba71b43e9a38](https://github.com/duckduckgo/Android/assets/16717834/9f6335e6-5719-4d27-aab5-b6c423692503)


| After |
![Screenshot_2024-03-30-21-37-35-504_com duckduckgo mobile android debug](https://github.com/duckduckgo/Android/assets/16717834/ba454336-3100-4802-9a5e-14acb5bdced1)

!(Upload before screenshot)|(Upload after screenshot)|
