### PR TITLE
Truncate export bookmarks file on overwrite

### DIFF
--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/service/SavedSitesExporter.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/service/SavedSitesExporter.kt
@@ -58,7 +58,8 @@ class RealSavedSitesExporter(
             if (content.isEmpty()) {
                 return ExportSavedSitesResult.NoSavedSitesExported
             }
-            val file = contentResolver.openFileDescriptor(uri, "w")
+            // "w" mode does not truncate on Android 10/11, use "rwt" mode workaround - https://issuetracker.google.com/issues/180526528
+            val file = contentResolver.openFileDescriptor(uri, "rwt")
             if (file != null) {
                 val fileOutputStream = FileOutputStream(file.fileDescriptor)
                 fileOutputStream.write(content.toByteArray())


### PR DESCRIPTION

Task/Issue URL: https://github.com/duckduckgo/Android/issues/3069

### Description
In Android 10/11, the "w" write mode no longer truncates the file during an overwrite. More details about this workaround can be found at https://issuetracker.google.com/issues/180526528

### Steps to test this PR

1. Add some bookmarks to DDG and export them.
2. Delete half of the bookmarks and export them again to the same file, confirming overwriting.
3. Observe the size and contents of the file.

<details>
<summary>Example non-truncated output pre-fix</summary>

```
<!DOCTYPE NETSCAPE-Bookmark-file-1>
<!--This is an automatically generated file.
It will be read and overwritten.
Do Not Edit! -->
<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
<Title>Bookmarks</Title>
<H1>Bookmarks</H1>
<DL><p>
    <DT><H3 ADD_DATE="1618844074" LAST_MODIFIED="1618844074" PERSONAL_TOOLBAR_FOLDER="true">DuckDuckGo Bookmarks</H3>
    <DL><p>
        <DT><A HREF="https://en.m.wikipedia.org/wiki/DuckDuckGo" ADD_DATE="1618844074" LAST_MODIFIED="1618844074">DuckDuckGo - Wikipedia</A>
    </DL><p>
</DL><p>
/en.m.wikipedia.org/wiki/DuckDuckGo" ADD_DATE="1618844074" LAST_MODIFIED="1618844074">DuckDuckGo - Wikipedia</A>
        <DT><A HREF="https://duckduckgo.com/about" ADD_DATE="1618844074" LAST_MODIFIED="1618844074">About DuckDuckGo</A>
    </DL><p>
</DL><p>

```

</details>

<details>
<summary>Example truncated output post-fix</summary>

```
<!DOCTYPE NETSCAPE-Bookmark-file-1>
<!--This is an automatically generated file.
It will be read and overwritten.
Do Not Edit! -->
<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
<Title>Bookmarks</Title>
<H1>Bookmarks</H1>
<DL><p>
    <DT><H3 ADD_DATE="1618844074" LAST_MODIFIED="1618844074" PERSONAL_TOOLBAR_FOLDER="true">DuckDuckGo Bookmarks</H3>
    <DL><p>
        <DT><A HREF="https://en.m.wikipedia.org/wiki/DuckDuckGo" ADD_DATE="1618844074" LAST_MODIFIED="1618844074">DuckDuckGo - Wikipedia</A>
    </DL><p>
</DL><p>
```

</details>
