### PR TITLE
Truncate export PCAP file on overwrite

### DIFF
--- a/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/feature/NetPInternalSettingsActivity.kt
+++ b/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/feature/NetPInternalSettingsActivity.kt
@@ -97,7 +97,8 @@ class NetPInternalSettingsActivity : DuckDuckGoActivity() {
     private val exportPcapFile = registerForActivityResult(ExportPcapContract()) { data ->
         data?.let { uri ->
             lifecycleScope.launch(dispatcherProvider.io()) {
-                contentResolver.openOutputStream(uri)?.let { out ->
+                // "w" mode does not truncate on Android 10/11, use "rwt" mode workaround
+                contentResolver.openOutputStream(uri, "rwt")?.let { out ->
                     if (netpGetPcapFile().length() > 0) {
                         val input = FileInputStream(netpGetPcapFile())
 


### PR DESCRIPTION
Task/Issue URL: Related to https://github.com/duckduckgo/Android/pull/4371

### Description
In Android 10/11, the "w" write mode no longer truncates the file during an overwrite. More details about this workaround can be found at https://issuetracker.google.com/issues/180526528

During the fix for https://github.com/duckduckgo/Android/issues/3069 all other instances of `ContentResolver.open...` were reviewed to see if they also used the "w" mode. The only other one was for exporting PCAP files as it used `contentResolver.openOutputStream(uri)` which is a convenience function that calls `contentResolver.openOutputStream(uri, "w")`.

### Steps to test this PR

1. Export a PCAP file and overwrite any existing file of substantial size, the exported PCAP file should now be truncated and there should no longer be trailing bytes of the overwritten file. 

