### PR TITLE
Move the ReinstallAtbListener inside experiments-impl module

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/install/AppInstallStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/install/AppInstallStore.kt
@@ -36,8 +36,6 @@ interface AppInstallStore : MainProcessLifecycleObserver {
 
     var newDefaultBrowserDialogCount: Int
 
-    var returningUserChecked: Boolean
-
     fun hasInstallTimestampRecorded(): Boolean
 }
 
@@ -62,10 +60,6 @@ class AppInstallSharedPreferences @Inject constructor(private val context: Conte
         get() = preferences.getInt(ROLE_MANAGER_BROWSER_DIALOG_KEY, 0)
         set(defaultBrowser) = preferences.edit { putInt(ROLE_MANAGER_BROWSER_DIALOG_KEY, defaultBrowser) }
 
-    override var returningUserChecked: Boolean
-        get() = preferences.getBoolean(KEY_RETURNING_USER, false)
-        set(checked) = preferences.edit { putBoolean(KEY_RETURNING_USER, checked) }
-
     override fun hasInstallTimestampRecorded(): Boolean = preferences.contains(KEY_TIMESTAMP_UTC)
 
     private val preferences: SharedPreferences by lazy { context.getSharedPreferences(FILENAME, Context.MODE_PRIVATE) }
@@ -84,7 +78,6 @@ class AppInstallSharedPreferences @Inject constructor(private val context: Conte
         const val KEY_TIMESTAMP_UTC = "INSTALL_TIMESTAMP_UTC"
         const val KEY_WIDGET_INSTALLED = "KEY_WIDGET_INSTALLED"
         const val KEY_DEFAULT_BROWSER = "KEY_DEFAULT_BROWSER"
-        const val KEY_RETURNING_USER = "KEY_RETURNING_USER"
         private const val ROLE_MANAGER_BROWSER_DIALOG_KEY = "ROLE_MANAGER_BROWSER_DIALOG_KEY"
     }
 }

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/ExperimentVariantRepository.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/ExperimentVariantRepository.kt
@@ -19,7 +19,7 @@ package com.duckduckgo.experiments.impl
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.experiments.impl.VariantManagerImpl.Companion.DEFAULT_VARIANT
-import com.duckduckgo.experiments.impl.VariantManagerImpl.Companion.REINSTALL_VARIANT
+import com.duckduckgo.experiments.impl.reinstalls.REINSTALL_VARIANT
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 import timber.log.Timber

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/VariantManagerImpl.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/VariantManagerImpl.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.experiments.api.VariantConfig
 import com.duckduckgo.experiments.api.VariantManager
+import com.duckduckgo.experiments.impl.reinstalls.REINSTALL_VARIANT
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 import timber.log.Timber
@@ -136,8 +137,6 @@ class VariantManagerImpl @Inject constructor(
 
         // this will be returned when there are no other active experiments
         val DEFAULT_VARIANT = Variant(key = "", filterBy = { noFilter() })
-
-        const val REINSTALL_VARIANT = "ru"
 
         private fun noFilter(): Boolean = true
     }

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/reinstalls/BackupServiceDataStore.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/reinstalls/BackupServiceDataStore.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.app.reinstalls
+package com.duckduckgo.experiments.impl.reinstalls
 
 import android.content.Context
 import android.content.SharedPreferences

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/reinstalls/DownloadsDirectoryManager.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/reinstalls/DownloadsDirectoryManager.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.app.reinstalls
+package com.duckduckgo.experiments.impl.reinstalls
 
 import android.os.Environment
 import com.duckduckgo.di.scopes.AppScope

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/reinstalls/ReinstallAtbListener.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/reinstalls/ReinstallAtbListener.kt
@@ -90,7 +90,7 @@ private annotation class ReinstallSharedPrefs
 
 @Module
 @ContributesTo(AppScope::class)
-class IgnoringBatteryOptimizationsModule {
+class ReinstallAtbListenerModule {
     @Provides
     @ReinstallSharedPrefs
     fun provideReinstallSharedPrefs(context: Context): SharedPreferences {

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/reinstalls/ReinstallAtbListener.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/reinstalls/ReinstallAtbListener.kt
@@ -14,17 +14,26 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.app.reinstalls
+package com.duckduckgo.experiments.impl.reinstalls
 
+import android.content.Context
+import android.content.SharedPreferences
 import android.os.Build
-import com.duckduckgo.app.global.install.AppInstallStore
+import androidx.core.content.edit
 import com.duckduckgo.app.statistics.AtbInitializerListener
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesMultibinding
+import com.squareup.anvil.annotations.ContributesTo
+import dagger.Lazy
+import dagger.Module
+import dagger.Provides
 import dagger.SingleInstanceIn
 import javax.inject.Inject
+import javax.inject.Qualifier
+import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 @SingleInstanceIn(AppScope::class)
@@ -32,15 +41,16 @@ import timber.log.Timber
 class ReinstallAtbListener @Inject constructor(
     private val backupDataStore: BackupServiceDataStore,
     private val statisticsDataStore: StatisticsDataStore,
-    private val appInstallStore: AppInstallStore,
     private val appBuildConfig: AppBuildConfig,
     private val downloadsDirectoryManager: DownloadsDirectoryManager,
+    @ReinstallSharedPrefs private val reinstallSharedPrefs: Lazy<SharedPreferences>,
+    private val dispatcherProvider: DispatcherProvider,
 ) : AtbInitializerListener {
 
-    override suspend fun beforeAtbInit() {
+    override suspend fun beforeAtbInit() = withContext(dispatcherProvider.io()) {
         backupDataStore.clearBackupPreferences()
 
-        if (appBuildConfig.sdkInt >= Build.VERSION_CODES.R && !appInstallStore.returningUserChecked) {
+        if (appBuildConfig.sdkInt >= Build.VERSION_CODES.R && !reinstallSharedPrefs.get().isReturningUserChecked()) {
             val downloadDirectory = downloadsDirectoryManager.getDownloadsDirectory()
 
             val downloadFiles = downloadDirectory.list()?.asList() ?: emptyList()
@@ -51,16 +61,40 @@ class ReinstallAtbListener @Inject constructor(
             } else {
                 downloadsDirectoryManager.createNewDirectory(DDG_DOWNLOADS_DIRECTORY)
             }
-            appInstallStore.returningUserChecked = true
+            reinstallSharedPrefs.get().setReturningUserChecked()
         }
     }
 
     override fun beforeAtbInitTimeoutMillis(): Long = MAX_REINSTALL_WAIT_TIME_MS
 
+    private fun SharedPreferences.isReturningUserChecked(): Boolean {
+        return getBoolean(RETURNING_USER_CHECKED_TAG, false)
+    }
+
+    private fun SharedPreferences.setReturningUserChecked() {
+        this.edit(commit = true) { putBoolean(RETURNING_USER_CHECKED_TAG, true) }
+    }
+
     companion object {
         private const val MAX_REINSTALL_WAIT_TIME_MS = 1_500L
-
-        const val REINSTALL_VARIANT = "ru"
         private const val DDG_DOWNLOADS_DIRECTORY = "DuckDuckGo"
+        private const val RETURNING_USER_CHECKED_TAG = "RETURNING_USER_CHECKED_TAG"
+    }
+}
+
+internal const val REINSTALL_VARIANT = "ru"
+
+@Retention(AnnotationRetention.BINARY)
+@Qualifier
+private annotation class ReinstallSharedPrefs
+
+@Module
+@ContributesTo(AppScope::class)
+class IgnoringBatteryOptimizationsModule {
+    @Provides
+    @ReinstallSharedPrefs
+    fun provideReinstallSharedPrefs(context: Context): SharedPreferences {
+        val filename = "com.duckduckgo.experiments.impl.reinstalls.store.v1"
+        return context.getSharedPreferences(filename, Context.MODE_PRIVATE)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1206965708683424/f

### Description
Move the `ReinstallAtbListener` into the `experiments-impl` module

### Steps to test this PR

_User with Android version < 11_
- [x] Check you don't have `DuckDuckGo` directory in _Downloads_ folder
- Install from this branch
- Download an image giving storage permissions
- Close and open the app again
- [x] Check new `DuckDuckGo` directory has **NOT** been created in _Downloads_

**_Android version >= 11_**
_Existing user_
- Make sure you have a previous install
- [x] Check you don't have `DuckDuckGo` directory in _Downloads_ folder
- Install from this branch
- [x] Check new `DuckDuckGo` directory has been created

_New user install_
- [x] Check you don't have `DuckDuckGo` directory in _Downloads_ folder
- Fresh install from branch
- [x] Check new `DuckDuckGo` directory has been created
- [x] Check 'ru' variant has not been assigned

_Returning user install_
- Fresh install from branch
- [x] Check you have `DuckDuckGo` directory in _Downloads_ folder
- Uninstall and install the app again from branch
- [x] Check `DuckDuckGo` directory is still in _Downloads_
- [x] Check 'ru' variant has been assigned

_Manual directory removal_
- Fresh install from branch
- [x] Check you have `DuckDuckGo` directory in _Downloads_ folder
- Remove `DuckDuckGo' directory manually from your device Downloads folder
- Open the app again
- Check new `DuckDuckGo` directory has **NOT** been created again in _Downloads_

### No UI changes
