### PR TITLE
Github Issue: [Bug] Download confirmation dialog is cut off in vertical/tablet mode

### DIFF
--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DownloadConfirmationFragment.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DownloadConfirmationFragment.kt
@@ -84,7 +84,9 @@ class DownloadConfirmationFragment : BottomSheetDialogFragment() {
     }
 
     private fun setupViews(binding: DownloadConfirmationBinding) {
-        (dialog as BottomSheetDialog).behavior.state = BottomSheetBehavior.STATE_EXPANDED
+        if (resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+            (dialog as BottomSheetDialog).behavior.state = BottomSheetBehavior.STATE_EXPANDED
+        }
         val fileName = file?.name ?: ""
         binding.downloadMessage.text = fileName
         binding.continueDownload.setOnClickListener {

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DownloadConfirmationFragment.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DownloadConfirmationFragment.kt
@@ -27,6 +27,8 @@ import com.duckduckgo.downloads.api.DownloadConfirmationDialogListener
 import com.duckduckgo.downloads.api.FileDownloader.PendingFileDownload
 import com.duckduckgo.downloads.impl.RealDownloadConfirmation.Companion.PENDING_DOWNLOAD_BUNDLE_KEY
 import com.duckduckgo.downloads.impl.databinding.DownloadConfirmationBinding
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.android.support.AndroidSupportInjection
 import java.io.File
@@ -82,6 +84,7 @@ class DownloadConfirmationFragment : BottomSheetDialogFragment() {
     }
 
     private fun setupViews(binding: DownloadConfirmationBinding) {
+        (dialog as BottomSheetDialog).behavior.state = BottomSheetBehavior.STATE_EXPANDED
         val fileName = file?.name ?: ""
         binding.downloadMessage.text = fileName
         binding.continueDownload.setOnClickListener {

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DownloadConfirmationFragment.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DownloadConfirmationFragment.kt
@@ -38,6 +38,8 @@ import logcat.logcat
 @InjectWith(FragmentScope::class)
 class DownloadConfirmationFragment : BottomSheetDialogFragment() {
 
+    override fun getTheme(): Int = R.style.DownloadsBottomSheetDialogTheme
+
     val listener: DownloadConfirmationDialogListener
         get() {
             return if (parentFragment != null) {
@@ -84,9 +86,7 @@ class DownloadConfirmationFragment : BottomSheetDialogFragment() {
     }
 
     private fun setupViews(binding: DownloadConfirmationBinding) {
-        if (resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
-            (dialog as BottomSheetDialog).behavior.state = BottomSheetBehavior.STATE_EXPANDED
-        }
+        (dialog as BottomSheetDialog).behavior.state = BottomSheetBehavior.STATE_EXPANDED
         val fileName = file?.name ?: ""
         binding.downloadMessage.text = fileName
         binding.continueDownload.setOnClickListener {

--- a/downloads/downloads-impl/src/main/res/drawable/rounded_top_corners_bottom_sheet_background.xml
+++ b/downloads/downloads-impl/src/main/res/drawable/rounded_top_corners_bottom_sheet_background.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2024 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners
+        android:topLeftRadius="@dimen/dialogBorderRadius"
+        android:topRightRadius="@dimen/dialogBorderRadius" />
+    <solid android:color="?attr/daxColorSurface" />
+</shape>

--- a/downloads/downloads-impl/src/main/res/layout/download_confirmation.xml
+++ b/downloads/downloads-impl/src/main/res/layout/download_confirmation.xml
@@ -20,6 +20,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
+    android:background="@drawable/rounded_top_corners_bottom_sheet_background"
     android:paddingTop="@dimen/actionBottomSheetVerticalPadding"
     android:paddingBottom="@dimen/actionBottomSheetVerticalPadding">
 

--- a/downloads/downloads-impl/src/main/res/values/styles.xml
+++ b/downloads/downloads-impl/src/main/res/values/styles.xml
@@ -1,0 +1,29 @@
+<!--
+  ~ Copyright (c) 2024 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources>
+
+    <style name="DownloadsBottomSheetDialogTheme" parent="@style/ThemeOverlay.MaterialComponents.BottomSheetDialog">
+        <item name="bottomSheetStyle">@style/DownloadsBottomSheetStyle</item>
+    </style>
+
+    <style name="DownloadsBottomSheetStyle" parent="Widget.MaterialComponents.BottomSheet.Modal">
+        <item name="backgroundTint">@android:color/transparent</item>
+        <item name="behavior_skipCollapsed">true</item>
+        <item name="behavior_draggable">false</item>
+    </style>
+
+</resources>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/715106103902962/1206905297723362/f

### Description
Expanded the download bottom sheet.

### Steps to test this PR

- [x] Install from this branch.
- [x] Go to a site from where you can download files. E.g https://www.thinkbroadband.com/download
- [x] With the device in landscape download a file.
- [x] Notice the bottomsheet is shown in full height.

### UI changes (landscape). No changes in portrait.
| Before (landscape) | After (landscape) |
| ------ | ----- |
|![Download_land_before](https://github.com/duckduckgo/Android/assets/7963079/1c6ded92-a8b9-4027-b145-27fdad959e6b)|![Download_land_after_v2](https://github.com/duckduckgo/Android/assets/7963079/ec77759c-9148-4e24-a4a0-1e0b63a645bb)|

| Before (portrait) | After (portrait) |
| ------ | ----- |
|![Download_portrait_before](https://github.com/duckduckgo/Android/assets/7963079/1c0acfa4-4a9a-4c43-a94a-152f6027fb3b)|![Download_portrait_after](https://github.com/duckduckgo/Android/assets/7963079/3122a3b9-aa31-41ce-8f43-b824b95830c9)|
