### PR TITLE
allow contributing from modules to matching attributes mappers

### DIFF
--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/RemoteMessagingConfigMatcher.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/RemoteMessagingConfigMatcher.kt
@@ -47,7 +47,7 @@ class RemoteMessagingConfigMatcher(
         return null
     }
 
-    private suspend fun Iterable<Int>.evaluateMatchingRules(rules: Map<Int, List<MatchingAttribute<*>>>): EvaluationResult {
+    private suspend fun Iterable<Int>.evaluateMatchingRules(rules: Map<Int, List<MatchingAttribute>>): EvaluationResult {
         var result: EvaluationResult = EvaluationResult.Match
 
         for (rule in this) {
@@ -68,7 +68,7 @@ class RemoteMessagingConfigMatcher(
         return result
     }
 
-    private suspend fun Iterable<Int>.evaluateExclusionRules(rules: Map<Int, List<MatchingAttribute<*>>>): EvaluationResult {
+    private suspend fun Iterable<Int>.evaluateExclusionRules(rules: Map<Int, List<MatchingAttribute>>): EvaluationResult {
         var result: EvaluationResult = EvaluationResult.Fail
 
         for (rule in this) {
@@ -89,7 +89,7 @@ class RemoteMessagingConfigMatcher(
         return result
     }
 
-    private suspend fun evaluateAttribute(matchingAttribute: MatchingAttribute<*>): EvaluationResult {
+    private suspend fun evaluateAttribute(matchingAttribute: MatchingAttribute): EvaluationResult {
         if (matchingAttribute is Unknown) {
             return matchingAttribute.fallback.toResult()
         } else {

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/di/RemoteMessagingModule.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/di/RemoteMessagingModule.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.DaggerSet
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.remote.messaging.api.AttributeMatcherPlugin
+import com.duckduckgo.remote.messaging.api.JsonToMatchingAttributeMapper
 import com.duckduckgo.remote.messaging.api.MessageActionMapperPlugin
 import com.duckduckgo.remote.messaging.api.RemoteMessagingRepository
 import com.duckduckgo.remote.messaging.impl.*
@@ -104,10 +105,11 @@ object DataSourceModule {
     @Provides
     @SingleInstanceIn(AppScope::class)
     fun providesRemoteMessagingConfigJsonMapper(
+        matchingAttributeMappers: DaggerSet<JsonToMatchingAttributeMapper>,
         actionMappers: DaggerSet<MessageActionMapperPlugin>,
         appBuildConfig: AppBuildConfig,
     ): RemoteMessagingConfigJsonMapper {
-        return RemoteMessagingConfigJsonMapper(appBuildConfig, actionMappers)
+        return RemoteMessagingConfigJsonMapper(appBuildConfig, matchingAttributeMappers, actionMappers)
     }
 
     @Provides

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/mappers/JsonRulesMapper.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/mappers/JsonRulesMapper.kt
@@ -16,6 +16,8 @@
 
 package com.duckduckgo.remote.messaging.impl.mappers
 
+import com.duckduckgo.remote.messaging.api.JsonMatchingAttribute
+import com.duckduckgo.remote.messaging.api.JsonToMatchingAttributeMapper
 import com.duckduckgo.remote.messaging.api.MatchingAttribute
 import com.duckduckgo.remote.messaging.impl.models.*
 import com.duckduckgo.remote.messaging.impl.models.toIntOrDefault
@@ -27,14 +29,14 @@ import timber.log.Timber
 private val dateFormatter = SimpleDateFormat("yyyy-mm-dd")
 
 @Suppress("UNCHECKED_CAST")
-private val localeMapper: (JsonMatchingAttribute) -> MatchingAttribute<String> = { jsonMatchingAttribute ->
+private val localeMapper: (JsonMatchingAttribute) -> MatchingAttribute = { jsonMatchingAttribute ->
     Locale(
         value = jsonMatchingAttribute.value.toStringList(),
         fallback = jsonMatchingAttribute.fallback,
     )
 }
 
-private val osApiMapper: (JsonMatchingAttribute) -> MatchingAttribute<Int> = { jsonMatchingAttribute ->
+private val osApiMapper: (JsonMatchingAttribute) -> MatchingAttribute = { jsonMatchingAttribute ->
     Api(
         value = jsonMatchingAttribute.value.toIntOrDefault(MATCHING_ATTR_INT_DEFAULT_VALUE),
         min = jsonMatchingAttribute.min.toIntOrDefault(MATCHING_ATTR_INT_DEFAULT_VALUE),
@@ -43,7 +45,7 @@ private val osApiMapper: (JsonMatchingAttribute) -> MatchingAttribute<Int> = { j
     )
 }
 
-private val webViewMapper: (JsonMatchingAttribute) -> MatchingAttribute<String> = { jsonMatchingAttribute ->
+private val webViewMapper: (JsonMatchingAttribute) -> MatchingAttribute = { jsonMatchingAttribute ->
     WebView(
         value = jsonMatchingAttribute.value.toStringOrDefault(MATCHING_ATTR_STRING_DEFAULT_VALUE),
         min = jsonMatchingAttribute.min.toStringOrDefault(MATCHING_ATTR_STRING_DEFAULT_VALUE),
@@ -53,21 +55,21 @@ private val webViewMapper: (JsonMatchingAttribute) -> MatchingAttribute<String> 
 }
 
 @Suppress("UNCHECKED_CAST")
-private val flavorMapper: (JsonMatchingAttribute) -> MatchingAttribute<String> = { jsonMatchingAttribute ->
+private val flavorMapper: (JsonMatchingAttribute) -> MatchingAttribute = { jsonMatchingAttribute ->
     Flavor(
         value = jsonMatchingAttribute.value.toStringList(),
         fallback = jsonMatchingAttribute.fallback,
     )
 }
 
-private val appIdMapper: (JsonMatchingAttribute) -> MatchingAttribute<String> = { jsonMatchingAttribute ->
+private val appIdMapper: (JsonMatchingAttribute) -> MatchingAttribute = { jsonMatchingAttribute ->
     AppId(
         value = jsonMatchingAttribute.value.toStringOrDefault(MATCHING_ATTR_STRING_DEFAULT_VALUE),
         fallback = jsonMatchingAttribute.fallback,
     )
 }
 
-private val appVersionMapper: (JsonMatchingAttribute) -> MatchingAttribute<String> = { jsonMatchingAttribute ->
+private val appVersionMapper: (JsonMatchingAttribute) -> MatchingAttribute = { jsonMatchingAttribute ->
     AppVersion(
         value = jsonMatchingAttribute.value.toStringOrDefault(MATCHING_ATTR_STRING_DEFAULT_VALUE),
         min = jsonMatchingAttribute.min.toStringOrDefault(MATCHING_ATTR_STRING_DEFAULT_VALUE),
@@ -76,77 +78,77 @@ private val appVersionMapper: (JsonMatchingAttribute) -> MatchingAttribute<Strin
     )
 }
 
-private val atbMapper: (JsonMatchingAttribute) -> MatchingAttribute<String> = { jsonMatchingAttribute ->
+private val atbMapper: (JsonMatchingAttribute) -> MatchingAttribute = { jsonMatchingAttribute ->
     Atb(
         value = jsonMatchingAttribute.value.toStringOrDefault(MATCHING_ATTR_STRING_DEFAULT_VALUE),
         fallback = jsonMatchingAttribute.fallback,
     )
 }
 
-private val appAtbMapper: (JsonMatchingAttribute) -> MatchingAttribute<String> = { jsonMatchingAttribute ->
+private val appAtbMapper: (JsonMatchingAttribute) -> MatchingAttribute = { jsonMatchingAttribute ->
     AppAtb(
         value = jsonMatchingAttribute.value.toStringOrDefault(MATCHING_ATTR_STRING_DEFAULT_VALUE),
         fallback = jsonMatchingAttribute.fallback,
     )
 }
 
-private val searchAtbMapper: (JsonMatchingAttribute) -> MatchingAttribute<String> = { jsonMatchingAttribute ->
+private val searchAtbMapper: (JsonMatchingAttribute) -> MatchingAttribute = { jsonMatchingAttribute ->
     SearchAtb(
         value = jsonMatchingAttribute.value.toStringOrDefault(MATCHING_ATTR_STRING_DEFAULT_VALUE),
         fallback = jsonMatchingAttribute.fallback,
     )
 }
 
-private val expVariantMapper: (JsonMatchingAttribute) -> MatchingAttribute<String> = { jsonMatchingAttribute ->
+private val expVariantMapper: (JsonMatchingAttribute) -> MatchingAttribute = { jsonMatchingAttribute ->
     ExpVariant(
         value = jsonMatchingAttribute.value.toStringOrDefault(MATCHING_ATTR_STRING_DEFAULT_VALUE),
         fallback = jsonMatchingAttribute.fallback,
     )
 }
 
-private val installedGPlayMapper: (JsonMatchingAttribute) -> MatchingAttribute<Boolean> = { jsonMatchingAttribute ->
+private val installedGPlayMapper: (JsonMatchingAttribute) -> MatchingAttribute = { jsonMatchingAttribute ->
     InstalledGPlay(
         value = jsonMatchingAttribute.value as Boolean,
         fallback = jsonMatchingAttribute.fallback,
     )
 }
 
-private val defaultBrowserMapper: (JsonMatchingAttribute) -> MatchingAttribute<Boolean> = { jsonMatchingAttribute ->
+private val defaultBrowserMapper: (JsonMatchingAttribute) -> MatchingAttribute = { jsonMatchingAttribute ->
     DefaultBrowser(
         value = jsonMatchingAttribute.value as Boolean,
         fallback = jsonMatchingAttribute.fallback,
     )
 }
 
-private val emailEnabledMapper: (JsonMatchingAttribute) -> MatchingAttribute<Boolean> = { jsonMatchingAttribute ->
+private val emailEnabledMapper: (JsonMatchingAttribute) -> MatchingAttribute = { jsonMatchingAttribute ->
     EmailEnabled(
         value = jsonMatchingAttribute.value as Boolean,
         fallback = jsonMatchingAttribute.fallback,
     )
 }
 
-private val appTrackingProtectionOnboarded: (JsonMatchingAttribute) -> MatchingAttribute<Boolean> = { jsonMatchingAttribute ->
+private val appTrackingProtectionOnboarded: (JsonMatchingAttribute) -> MatchingAttribute = { jsonMatchingAttribute ->
     AppTpOnboarded(
         value = jsonMatchingAttribute.value as Boolean,
         fallback = jsonMatchingAttribute.fallback,
     )
 }
 
-private val networkProtectionOnboarded: (JsonMatchingAttribute) -> MatchingAttribute<Boolean> = { jsonMatchingAttribute ->
+private val networkProtectionOnboarded: (JsonMatchingAttribute) -> MatchingAttribute = { jsonMatchingAttribute ->
     NetPOnboarded(
         value = jsonMatchingAttribute.value as Boolean,
         fallback = jsonMatchingAttribute.fallback,
     )
 }
 
-private val widgetAddedMapper: (JsonMatchingAttribute) -> MatchingAttribute<Boolean> = { jsonMatchingAttribute ->
+private val widgetAddedMapper: (JsonMatchingAttribute) -> MatchingAttribute = { jsonMatchingAttribute ->
     WidgetAdded(
         value = jsonMatchingAttribute.value as Boolean,
         fallback = jsonMatchingAttribute.fallback,
     )
 }
 
-private val searchCountMapper: (JsonMatchingAttribute) -> MatchingAttribute<Int> = { jsonMatchingAttribute ->
+private val searchCountMapper: (JsonMatchingAttribute) -> MatchingAttribute = { jsonMatchingAttribute ->
     SearchCount(
         value = jsonMatchingAttribute.value.toIntOrDefault(MATCHING_ATTR_INT_DEFAULT_VALUE),
         min = jsonMatchingAttribute.min.toIntOrDefault(MATCHING_ATTR_INT_DEFAULT_VALUE),
@@ -155,7 +157,7 @@ private val searchCountMapper: (JsonMatchingAttribute) -> MatchingAttribute<Int>
     )
 }
 
-private val bookmarksMapper: (JsonMatchingAttribute) -> MatchingAttribute<Int> = { jsonMatchingAttribute ->
+private val bookmarksMapper: (JsonMatchingAttribute) -> MatchingAttribute = { jsonMatchingAttribute ->
     Bookmarks(
         value = jsonMatchingAttribute.value.toIntOrDefault(MATCHING_ATTR_INT_DEFAULT_VALUE),
         min = jsonMatchingAttribute.min.toIntOrDefault(MATCHING_ATTR_INT_DEFAULT_VALUE),
@@ -164,7 +166,7 @@ private val bookmarksMapper: (JsonMatchingAttribute) -> MatchingAttribute<Int> =
     )
 }
 
-private val favoritesMapper: (JsonMatchingAttribute) -> MatchingAttribute<Int> = { jsonMatchingAttribute ->
+private val favoritesMapper: (JsonMatchingAttribute) -> MatchingAttribute = { jsonMatchingAttribute ->
     Favorites(
         value = jsonMatchingAttribute.value.toIntOrDefault(MATCHING_ATTR_INT_DEFAULT_VALUE),
         min = jsonMatchingAttribute.min.toIntOrDefault(MATCHING_ATTR_INT_DEFAULT_VALUE),
@@ -173,14 +175,14 @@ private val favoritesMapper: (JsonMatchingAttribute) -> MatchingAttribute<Int> =
     )
 }
 
-private val appThemeMapper: (JsonMatchingAttribute) -> MatchingAttribute<String> = { jsonMatchingAttribute ->
+private val appThemeMapper: (JsonMatchingAttribute) -> MatchingAttribute = { jsonMatchingAttribute ->
     AppTheme(
         value = jsonMatchingAttribute.value.toStringOrDefault(MATCHING_ATTR_STRING_DEFAULT_VALUE),
         fallback = jsonMatchingAttribute.fallback,
     )
 }
 
-private val daysSinceInstalledMapper: (JsonMatchingAttribute) -> MatchingAttribute<Int> = { jsonMatchingAttribute ->
+private val daysSinceInstalledMapper: (JsonMatchingAttribute) -> MatchingAttribute = { jsonMatchingAttribute ->
     DaysSinceInstalled(
         value = jsonMatchingAttribute.value.toIntOrDefault(MATCHING_ATTR_INT_DEFAULT_VALUE),
         min = jsonMatchingAttribute.min.toIntOrDefault(MATCHING_ATTR_INT_DEFAULT_VALUE),
@@ -189,7 +191,7 @@ private val daysSinceInstalledMapper: (JsonMatchingAttribute) -> MatchingAttribu
     )
 }
 
-private val daysUsedSinceMapper: (JsonMatchingAttribute) -> MatchingAttribute<Int> = { jsonMatchingAttribute ->
+private val daysUsedSinceMapper: (JsonMatchingAttribute) -> MatchingAttribute = { jsonMatchingAttribute ->
     DaysUsedSince(
         since = dateFormatter.parse(jsonMatchingAttribute.since as String)!!,
         value = jsonMatchingAttribute.value.toIntOrDefault(MATCHING_ATTR_INT_DEFAULT_VALUE),
@@ -223,12 +225,18 @@ private val attributesMappers = mapOf(
     Pair("netpOnboarded", networkProtectionOnboarded),
 )
 
-fun List<JsonMatchingRule>.mapToMatchingRules(): Map<Int, List<MatchingAttribute<*>>> = this.map {
-    Pair(it.id, it.attributes.map { attrs -> attrs.map() })
+fun List<JsonMatchingRule>.mapToMatchingRules(
+    matchingAttributeMappers: Set<JsonToMatchingAttributeMapper>,
+): Map<Int, List<MatchingAttribute>> = this.map {
+    Pair(it.id, it.attributes.map { attrs -> attrs.map(matchingAttributeMappers) })
 }.toMap()
 
-private fun Map.Entry<String, JsonMatchingAttribute>.map(): MatchingAttribute<*> {
+private fun Map.Entry<String, JsonMatchingAttribute>.map(matchingAttributeMappers: Set<JsonToMatchingAttributeMapper>): MatchingAttribute {
     return runCatching {
+        matchingAttributeMappers.forEach {
+            val matchingAttribute = it.map(this.key, this.value)
+            if (matchingAttribute != null) return@runCatching matchingAttribute
+        }
         attributesMappers[this.key]?.invoke(this.value) ?: Unknown(this.value.fallback)
     }.onFailure {
         Timber.i("RMF: error $it")

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/mappers/RemoteMessagingConfigJsonMapper.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/mappers/RemoteMessagingConfigJsonMapper.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.remote.messaging.impl.mappers
 
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.remote.messaging.api.JsonToMatchingAttributeMapper
 import com.duckduckgo.remote.messaging.api.MessageActionMapperPlugin
 import com.duckduckgo.remote.messaging.impl.models.JsonRemoteMessagingConfig
 import com.duckduckgo.remote.messaging.impl.models.RemoteConfig
@@ -24,12 +25,13 @@ import timber.log.Timber
 
 class RemoteMessagingConfigJsonMapper(
     private val appBuildConfig: AppBuildConfig,
+    private val matchingAttributeMappers: Set<JsonToMatchingAttributeMapper>,
     private val actionMappers: Set<MessageActionMapperPlugin>,
 ) {
     fun map(jsonRemoteMessagingConfig: JsonRemoteMessagingConfig): RemoteConfig {
         val messages = jsonRemoteMessagingConfig.messages.mapToRemoteMessage(appBuildConfig.deviceLocale, actionMappers)
         Timber.i("RMF: messages parsed $messages")
-        val rules = jsonRemoteMessagingConfig.rules.mapToMatchingRules()
+        val rules = jsonRemoteMessagingConfig.rules.mapToMatchingRules(matchingAttributeMappers)
         return RemoteConfig(
             messages = messages,
             rules = rules,

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/matchers/AndroidAppAttributeMatcher.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/matchers/AndroidAppAttributeMatcher.kt
@@ -26,7 +26,7 @@ class AndroidAppAttributeMatcher(
     private val appProperties: AppProperties,
     private val appBuildConfig: AppBuildConfig,
 ) : AttributeMatcherPlugin {
-    override suspend fun evaluate(matchingAttribute: MatchingAttribute<*>): Boolean? {
+    override suspend fun evaluate(matchingAttribute: MatchingAttribute): Boolean? {
         return when (matchingAttribute) {
             is Flavor -> {
                 matchingAttribute.matches(appBuildConfig.flavor.toString())

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/matchers/UserAttributeMatcher.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/matchers/UserAttributeMatcher.kt
@@ -24,7 +24,7 @@ import com.duckduckgo.remote.messaging.impl.models.*
 class UserAttributeMatcher(
     private val userBrowserProperties: UserBrowserProperties,
 ) : AttributeMatcherPlugin {
-    override suspend fun evaluate(matchingAttribute: MatchingAttribute<*>): Boolean? {
+    override suspend fun evaluate(matchingAttribute: MatchingAttribute): Boolean? {
         return when (matchingAttribute) {
             is AppTheme -> {
                 matchingAttribute.matches(userBrowserProperties.appTheme().toString())

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/models/JsonRemoteMessagingConfig.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/models/JsonRemoteMessagingConfig.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.remote.messaging.impl.models
 
+import com.duckduckgo.remote.messaging.api.JsonMatchingAttribute
 import com.duckduckgo.remote.messaging.api.JsonMessageAction
 
 data class JsonRemoteMessagingConfig(
@@ -57,14 +58,6 @@ data class JsonContentTranslations(
 data class JsonMatchingRule(
     val id: Int,
     val attributes: Map<String, JsonMatchingAttribute>,
-)
-
-data class JsonMatchingAttribute(
-    val value: Any? = null,
-    val min: Any? = null,
-    val max: Any? = null,
-    val since: Any? = null,
-    val fallback: Boolean? = null,
 )
 
 sealed class JsonMessageType(val jsonValue: String) {

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/models/MatchingAttributes.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/models/MatchingAttributes.kt
@@ -23,8 +23,8 @@ import timber.log.Timber
 data class Locale(
     override val value: List<String> = emptyList(),
     val fallback: Boolean? = null,
-) : MatchingAttribute<String>, StringArrayMatchingAttribute {
-    override fun matches(matchingValue: String): Boolean? {
+) : MatchingAttribute, StringArrayMatchingAttribute {
+    fun matches(matchingValue: String): Boolean? {
         if (this == Locale()) return false
         return (this as StringArrayMatchingAttribute).matches(matchingValue)
     }
@@ -35,8 +35,8 @@ data class Api(
     override val max: Int = MATCHING_ATTR_INT_DEFAULT_VALUE,
     override val value: Int = MATCHING_ATTR_INT_DEFAULT_VALUE,
     val fallback: Boolean? = null,
-) : MatchingAttribute<Int>, RangeIntMatchingAttribute, IntMatchingAttribute {
-    override fun matches(matchingValue: Int): Boolean? {
+) : MatchingAttribute, RangeIntMatchingAttribute, IntMatchingAttribute {
+    fun matches(matchingValue: Int): Boolean? {
         if (this == Api()) return false
 
         if (this.value != MATCHING_ATTR_INT_DEFAULT_VALUE) {
@@ -51,8 +51,8 @@ data class WebView(
     override val max: String = MATCHING_ATTR_STRING_DEFAULT_VALUE,
     override val value: String = MATCHING_ATTR_STRING_DEFAULT_VALUE,
     val fallback: Boolean? = null,
-) : MatchingAttribute<String>, RangeStringMatchingAttribute, StringMatchingAttribute {
-    override fun matches(matchingValue: String): Boolean? {
+) : MatchingAttribute, RangeStringMatchingAttribute, StringMatchingAttribute {
+    fun matches(matchingValue: String): Boolean? {
         if (this == WebView()) return false
         if (value != MATCHING_ATTR_STRING_DEFAULT_VALUE) {
             return (this as StringMatchingAttribute).matches(matchingValue)
@@ -64,8 +64,8 @@ data class WebView(
 data class Flavor(
     override val value: List<String> = emptyList(),
     val fallback: Boolean? = null,
-) : MatchingAttribute<String>, StringArrayMatchingAttribute {
-    override fun matches(matchingValue: String): Boolean? {
+) : MatchingAttribute, StringArrayMatchingAttribute {
+    fun matches(matchingValue: String): Boolean? {
         if (this == Flavor()) return false
         return (this as StringArrayMatchingAttribute).matches(matchingValue)
     }
@@ -74,8 +74,8 @@ data class Flavor(
 data class AppId(
     override val value: String = MATCHING_ATTR_STRING_DEFAULT_VALUE,
     val fallback: Boolean? = null,
-) : MatchingAttribute<String>, StringMatchingAttribute {
-    override fun matches(matchingValue: String): Boolean? {
+) : MatchingAttribute, StringMatchingAttribute {
+    fun matches(matchingValue: String): Boolean? {
         return (this as StringMatchingAttribute).matches(matchingValue)
     }
 }
@@ -85,8 +85,8 @@ data class AppVersion(
     override val max: String = MATCHING_ATTR_STRING_DEFAULT_VALUE,
     override val value: String = MATCHING_ATTR_STRING_DEFAULT_VALUE,
     val fallback: Boolean? = null,
-) : MatchingAttribute<String>, RangeStringMatchingAttribute, StringMatchingAttribute {
-    override fun matches(matchingValue: String): Boolean? {
+) : MatchingAttribute, RangeStringMatchingAttribute, StringMatchingAttribute {
+    fun matches(matchingValue: String): Boolean? {
         if (this == AppVersion()) return false
         if (value != MATCHING_ATTR_STRING_DEFAULT_VALUE) {
             return (this as StringMatchingAttribute).matches(matchingValue)
@@ -98,8 +98,8 @@ data class AppVersion(
 data class Atb(
     override val value: String = MATCHING_ATTR_STRING_DEFAULT_VALUE,
     val fallback: Boolean? = null,
-) : MatchingAttribute<String>, StringMatchingAttribute {
-    override fun matches(matchingValue: String): Boolean? {
+) : MatchingAttribute, StringMatchingAttribute {
+    fun matches(matchingValue: String): Boolean? {
         return (this as StringMatchingAttribute).matches(matchingValue)
     }
 }
@@ -107,8 +107,8 @@ data class Atb(
 data class AppAtb(
     override val value: String = MATCHING_ATTR_STRING_DEFAULT_VALUE,
     val fallback: Boolean? = null,
-) : MatchingAttribute<String>, StringMatchingAttribute {
-    override fun matches(matchingValue: String): Boolean? {
+) : MatchingAttribute, StringMatchingAttribute {
+    fun matches(matchingValue: String): Boolean? {
         return (this as StringMatchingAttribute).matches(matchingValue)
     }
 }
@@ -116,8 +116,8 @@ data class AppAtb(
 data class SearchAtb(
     override val value: String = MATCHING_ATTR_STRING_DEFAULT_VALUE,
     val fallback: Boolean? = null,
-) : MatchingAttribute<String>, StringMatchingAttribute {
-    override fun matches(matchingValue: String): Boolean? {
+) : MatchingAttribute, StringMatchingAttribute {
+    fun matches(matchingValue: String): Boolean? {
         return (this as StringMatchingAttribute).matches(matchingValue)
     }
 }
@@ -125,8 +125,8 @@ data class SearchAtb(
 data class ExpVariant(
     override val value: String = MATCHING_ATTR_STRING_DEFAULT_VALUE,
     val fallback: Boolean? = null,
-) : MatchingAttribute<String>, StringMatchingAttribute {
-    override fun matches(matchingValue: String): Boolean? {
+) : MatchingAttribute, StringMatchingAttribute {
+    fun matches(matchingValue: String): Boolean? {
         return (this as StringMatchingAttribute).matches(matchingValue)
     }
 }
@@ -134,8 +134,8 @@ data class ExpVariant(
 data class InstalledGPlay(
     override val value: Boolean,
     val fallback: Boolean? = null,
-) : MatchingAttribute<Boolean>, BooleanMatchingAttribute {
-    override fun matches(matchingValue: Boolean): Boolean? {
+) : MatchingAttribute, BooleanMatchingAttribute {
+    fun matches(matchingValue: Boolean): Boolean? {
         return (this as BooleanMatchingAttribute).matches(matchingValue)
     }
 }
@@ -143,8 +143,8 @@ data class InstalledGPlay(
 data class DefaultBrowser(
     override val value: Boolean,
     val fallback: Boolean? = null,
-) : MatchingAttribute<Boolean>, BooleanMatchingAttribute {
-    override fun matches(matchingValue: Boolean): Boolean? {
+) : MatchingAttribute, BooleanMatchingAttribute {
+    fun matches(matchingValue: Boolean): Boolean? {
         return (this as BooleanMatchingAttribute).matches(matchingValue)
     }
 }
@@ -152,8 +152,8 @@ data class DefaultBrowser(
 data class EmailEnabled(
     override val value: Boolean,
     val fallback: Boolean? = null,
-) : MatchingAttribute<Boolean>, BooleanMatchingAttribute {
-    override fun matches(matchingValue: Boolean): Boolean? {
+) : MatchingAttribute, BooleanMatchingAttribute {
+    fun matches(matchingValue: Boolean): Boolean? {
         return (this as BooleanMatchingAttribute).matches(matchingValue)
     }
 }
@@ -161,8 +161,8 @@ data class EmailEnabled(
 data class AppTpOnboarded(
     override val value: Boolean,
     val fallback: Boolean? = null,
-) : MatchingAttribute<Boolean>, BooleanMatchingAttribute {
-    override fun matches(matchingValue: Boolean): Boolean? {
+) : MatchingAttribute, BooleanMatchingAttribute {
+    fun matches(matchingValue: Boolean): Boolean? {
         return (this as BooleanMatchingAttribute).matches(matchingValue)
     }
 }
@@ -170,8 +170,8 @@ data class AppTpOnboarded(
 data class NetPOnboarded(
     override val value: Boolean,
     val fallback: Boolean? = null,
-) : MatchingAttribute<Boolean>, BooleanMatchingAttribute {
-    override fun matches(matchingValue: Boolean): Boolean? {
+) : MatchingAttribute, BooleanMatchingAttribute {
+    fun matches(matchingValue: Boolean): Boolean? {
         return (this as BooleanMatchingAttribute).matches(matchingValue)
     }
 }
@@ -179,8 +179,8 @@ data class NetPOnboarded(
 data class WidgetAdded(
     override val value: Boolean,
     val fallback: Boolean? = null,
-) : MatchingAttribute<Boolean>, BooleanMatchingAttribute {
-    override fun matches(matchingValue: Boolean): Boolean? {
+) : MatchingAttribute, BooleanMatchingAttribute {
+    fun matches(matchingValue: Boolean): Boolean? {
         return (this as BooleanMatchingAttribute).matches(matchingValue)
     }
 }
@@ -190,8 +190,8 @@ data class SearchCount(
     override val max: Int = MATCHING_ATTR_INT_DEFAULT_VALUE,
     override val value: Int = MATCHING_ATTR_INT_DEFAULT_VALUE,
     val fallback: Boolean? = null,
-) : MatchingAttribute<Int>, RangeIntMatchingAttribute, IntMatchingAttribute {
-    override fun matches(matchingValue: Int): Boolean? {
+) : MatchingAttribute, RangeIntMatchingAttribute, IntMatchingAttribute {
+    fun matches(matchingValue: Int): Boolean? {
         if (this == SearchCount()) return false
         if (value != MATCHING_ATTR_INT_DEFAULT_VALUE) {
             return (this as IntMatchingAttribute).matches(matchingValue)
@@ -205,8 +205,8 @@ data class Bookmarks(
     override val max: Int = MATCHING_ATTR_INT_DEFAULT_VALUE,
     override val value: Int = MATCHING_ATTR_INT_DEFAULT_VALUE,
     val fallback: Boolean? = null,
-) : MatchingAttribute<Int>, RangeIntMatchingAttribute, IntMatchingAttribute {
-    override fun matches(matchingValue: Int): Boolean? {
+) : MatchingAttribute, RangeIntMatchingAttribute, IntMatchingAttribute {
+    fun matches(matchingValue: Int): Boolean? {
         if (this == Bookmarks()) return false
         if (value != MATCHING_ATTR_INT_DEFAULT_VALUE) {
             return (this as IntMatchingAttribute).matches(matchingValue)
@@ -220,8 +220,8 @@ data class Favorites(
     override val max: Int = MATCHING_ATTR_INT_DEFAULT_VALUE,
     override val value: Int = MATCHING_ATTR_INT_DEFAULT_VALUE,
     val fallback: Boolean? = null,
-) : MatchingAttribute<Int>, RangeIntMatchingAttribute, IntMatchingAttribute {
-    override fun matches(matchingValue: Int): Boolean? {
+) : MatchingAttribute, RangeIntMatchingAttribute, IntMatchingAttribute {
+    fun matches(matchingValue: Int): Boolean? {
         if (this == Favorites()) return false
         if (value != MATCHING_ATTR_INT_DEFAULT_VALUE) {
             return (this as IntMatchingAttribute).matches(matchingValue)
@@ -233,8 +233,8 @@ data class Favorites(
 data class AppTheme(
     override val value: String = MATCHING_ATTR_STRING_DEFAULT_VALUE,
     val fallback: Boolean? = null,
-) : MatchingAttribute<String>, StringMatchingAttribute {
-    override fun matches(matchingValue: String): Boolean? {
+) : MatchingAttribute, StringMatchingAttribute {
+    fun matches(matchingValue: String): Boolean? {
         return (this as StringMatchingAttribute).matches(matchingValue)
     }
 }
@@ -244,8 +244,8 @@ data class DaysSinceInstalled(
     override val max: Int = MATCHING_ATTR_INT_DEFAULT_VALUE,
     override val value: Int = MATCHING_ATTR_INT_DEFAULT_VALUE,
     val fallback: Boolean? = null,
-) : MatchingAttribute<Int>, RangeIntMatchingAttribute, IntMatchingAttribute {
-    override fun matches(matchingValue: Int): Boolean? {
+) : MatchingAttribute, RangeIntMatchingAttribute, IntMatchingAttribute {
+    fun matches(matchingValue: Int): Boolean? {
         if (this == DaysSinceInstalled()) return false
 
         if (value != MATCHING_ATTR_INT_DEFAULT_VALUE) {
@@ -259,14 +259,14 @@ data class DaysUsedSince(
     override val since: Date,
     override val value: Int,
     val fallback: Boolean? = null,
-) : MatchingAttribute<Int>, DateMatchingAttribute {
-    override fun matches(matchingValue: Int): Boolean? {
+) : MatchingAttribute, DateMatchingAttribute {
+    fun matches(matchingValue: Int): Boolean? {
         return (this as DateMatchingAttribute).matches(matchingValue)
     }
 }
 
-data class Unknown(val fallback: Boolean?) : MatchingAttribute<Unit> {
-    override fun matches(matchingValue: Unit): Boolean? {
+data class Unknown(val fallback: Boolean?) : MatchingAttribute {
+    fun matches(matchingValue: Unit): Boolean? {
         return fallback
     }
 }

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/models/RemoteConfig.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/models/RemoteConfig.kt
@@ -21,5 +21,5 @@ import com.duckduckgo.remote.messaging.api.RemoteMessage
 
 data class RemoteConfig(
     val messages: List<RemoteMessage>,
-    val rules: Map<Int, List<MatchingAttribute<*>>>,
+    val rules: Map<Int, List<MatchingAttribute>>,
 )

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/fixtures/FakeJsonMatchingAttributeMapper.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/fixtures/FakeJsonMatchingAttributeMapper.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.remote.messaging.fixtures
+
+import com.duckduckgo.remote.messaging.api.JsonMatchingAttribute
+import com.duckduckgo.remote.messaging.api.JsonToMatchingAttributeMapper
+import com.duckduckgo.remote.messaging.api.MatchingAttribute
+
+class FakeJsonMatchingAttributeMapper : JsonToMatchingAttributeMapper {
+    override fun map(
+        key: String,
+        jsonMatchingAttribute: JsonMatchingAttribute,
+    ): MatchingAttribute? {
+        if (key == "Fake") {
+            return FakeMatchingAttribute(jsonMatchingAttribute.value as Boolean)
+        }
+
+        return null
+    }
+}
+
+data class FakeMatchingAttribute(val value: Boolean) : MatchingAttribute

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/fixtures/FakeJsonMatchingAttributeMapperPlugins.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/fixtures/FakeJsonMatchingAttributeMapperPlugins.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 DuckDuckGo
+ * Copyright (c) 2024 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,22 +14,8 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.remote.messaging.api
+package com.duckduckgo.remote.messaging.fixtures
 
-interface AttributeMatcherPlugin {
-    suspend fun evaluate(matchingAttribute: MatchingAttribute): Boolean?
-}
-
-interface MatchingAttribute
-
-interface JsonToMatchingAttributeMapper {
-    fun map(key: String, jsonMatchingAttribute: JsonMatchingAttribute): MatchingAttribute?
-}
-
-data class JsonMatchingAttribute(
-    val value: Any? = null,
-    val min: Any? = null,
-    val max: Any? = null,
-    val since: Any? = null,
-    val fallback: Boolean? = null,
-)
+val jsonMatchingAttributeMappers = listOf(
+    FakeJsonMatchingAttributeMapper(),
+).toSet()

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/JsonRulesMapperTest.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/JsonRulesMapperTest.kt
@@ -16,10 +16,12 @@
 
 package com.duckduckgo.remote.messaging.impl
 
+import com.duckduckgo.remote.messaging.api.JsonMatchingAttribute
 import com.duckduckgo.remote.messaging.api.MatchingAttribute
+import com.duckduckgo.remote.messaging.fixtures.FakeMatchingAttribute
+import com.duckduckgo.remote.messaging.fixtures.jsonMatchingAttributeMappers
 import com.duckduckgo.remote.messaging.impl.mappers.mapToMatchingRules
 import com.duckduckgo.remote.messaging.impl.models.*
-import com.duckduckgo.remote.messaging.impl.models.JsonMatchingAttribute
 import com.duckduckgo.remote.messaging.impl.models.JsonMatchingRule
 import java.text.SimpleDateFormat
 import org.junit.Assert.assertEquals
@@ -32,7 +34,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
 
     @Test
     fun whenJsonMatchingAttributeThenReturnMatchingAttribute() {
-        val matchingRule = listOf(testCase.jsonMatchingRule).mapToMatchingRules()
+        val matchingRule = listOf(testCase.jsonMatchingRule).mapToMatchingRules(jsonMatchingAttributeMappers)
 
         assertEquals(testCase.matchingRules, matchingRule)
     }
@@ -41,6 +43,16 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
         @JvmStatic
         @Parameterized.Parameters()
         fun parameters() = arrayOf(
+            TestCase(
+                givenJsonRule(
+                    Pair("Fake", JsonMatchingAttribute(value = false)),
+                    Pair("flavor", JsonMatchingAttribute(value = emptyList<String>())),
+                ),
+                matchingRule(
+                    FakeMatchingAttribute(value = false),
+                    Flavor(value = emptyList(), fallback = null),
+                ),
+            ),
             TestCase(
                 givenJsonRule(
                     Pair("locale", JsonMatchingAttribute(value = listOf("ES"))),
@@ -624,10 +636,10 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
             )
         }
 
-        private fun matchingRule(vararg matchingAttribute: MatchingAttribute<*>): Map<Int, List<MatchingAttribute<*>>> {
+        private fun matchingRule(vararg matchingAttribute: MatchingAttribute): Map<Int, List<MatchingAttribute>> {
             return mapOf(Pair(5, matchingAttribute.toList()))
         }
     }
 
-    data class TestCase(val jsonMatchingRule: JsonMatchingRule, val matchingRules: Map<Int, List<MatchingAttribute<*>>>)
+    data class TestCase(val jsonMatchingRule: JsonMatchingRule, val matchingRules: Map<Int, List<MatchingAttribute>>)
 }

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/RealRemoteMessagingConfigProcessorTest.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/RealRemoteMessagingConfigProcessorTest.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.remote.messaging.api.RemoteMessagingRepository
 import com.duckduckgo.remote.messaging.fixtures.JsonRemoteMessageOM.aJsonRemoteMessagingConfig
 import com.duckduckgo.remote.messaging.fixtures.RemoteMessagingConfigOM.aRemoteMessagingConfig
+import com.duckduckgo.remote.messaging.fixtures.jsonMatchingAttributeMappers
 import com.duckduckgo.remote.messaging.fixtures.messageActionPlugins
 import com.duckduckgo.remote.messaging.impl.mappers.RemoteMessagingConfigJsonMapper
 import com.duckduckgo.remote.messaging.store.RemoteMessagingConfigRepository
@@ -42,7 +43,11 @@ class RealRemoteMessagingConfigProcessorTest {
     @get:Rule var coroutineRule = CoroutineTestRule()
 
     private val appBuildConfig: AppBuildConfig = mock()
-    private val remoteMessagingConfigJsonMapper = RemoteMessagingConfigJsonMapper(appBuildConfig, messageActionPlugins)
+    private val remoteMessagingConfigJsonMapper = RemoteMessagingConfigJsonMapper(
+        appBuildConfig,
+        jsonMatchingAttributeMappers,
+        messageActionPlugins,
+    )
     private val remoteMessagingConfigRepository = mock<RemoteMessagingConfigRepository>()
     private val remoteMessagingRepository = mock<RemoteMessagingRepository>()
     private val remoteMessagingConfigMatcher = RemoteMessagingConfigMatcher(setOf(mock(), mock(), mock()), mock())

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/RemoteMessagingConfigJsonMapperTest.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/RemoteMessagingConfigJsonMapperTest.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.remote.messaging.api.Content.Placeholder.ANNOUNCE
 import com.duckduckgo.remote.messaging.api.Content.Placeholder.APP_UPDATE
 import com.duckduckgo.remote.messaging.api.Content.Placeholder.CRITICAL_UPDATE
 import com.duckduckgo.remote.messaging.api.RemoteMessage
+import com.duckduckgo.remote.messaging.fixtures.jsonMatchingAttributeMappers
 import com.duckduckgo.remote.messaging.fixtures.messageActionPlugins
 import com.duckduckgo.remote.messaging.impl.mappers.RemoteMessagingConfigJsonMapper
 import com.duckduckgo.remote.messaging.impl.models.*
@@ -52,7 +53,7 @@ class RemoteMessagingConfigJsonMapperTest {
     fun whenValidJsonParsedThenMessagesMappedIntoRemoteConfig() = runTest {
         val result = getConfigFromJson("json/remote_messaging_config.json")
 
-        val testee = RemoteMessagingConfigJsonMapper(appBuildConfig, messageActionPlugins)
+        val testee = RemoteMessagingConfigJsonMapper(appBuildConfig, jsonMatchingAttributeMappers, messageActionPlugins)
 
         val config = testee.map(result)
 
@@ -119,7 +120,7 @@ class RemoteMessagingConfigJsonMapperTest {
     fun whenValidJsonParsedThenRulesMappedIntoRemoteConfig() = runTest {
         val result = getConfigFromJson("json/remote_messaging_config.json")
 
-        val testee = RemoteMessagingConfigJsonMapper(appBuildConfig, messageActionPlugins)
+        val testee = RemoteMessagingConfigJsonMapper(appBuildConfig, jsonMatchingAttributeMappers, messageActionPlugins)
 
         val config = testee.map(result)
 
@@ -143,7 +144,7 @@ class RemoteMessagingConfigJsonMapperTest {
     fun whenJsonMessagesHaveUnknownTypesThenMessagesNotMappedIntoConfig() = runTest {
         val result = getConfigFromJson("json/remote_messaging_config_unsupported_items.json")
 
-        val testee = RemoteMessagingConfigJsonMapper(appBuildConfig, messageActionPlugins)
+        val testee = RemoteMessagingConfigJsonMapper(appBuildConfig, jsonMatchingAttributeMappers, messageActionPlugins)
 
         val config = testee.map(result)
 
@@ -154,7 +155,7 @@ class RemoteMessagingConfigJsonMapperTest {
     fun whenJsonMessagesHaveUnknownTypesThenRulesMappedIntoConfig() = runTest {
         val result = getConfigFromJson("json/remote_messaging_config_unsupported_items.json")
 
-        val testee = RemoteMessagingConfigJsonMapper(appBuildConfig, messageActionPlugins)
+        val testee = RemoteMessagingConfigJsonMapper(appBuildConfig, jsonMatchingAttributeMappers, messageActionPlugins)
 
         val config = testee.map(result)
 
@@ -171,7 +172,7 @@ class RemoteMessagingConfigJsonMapperTest {
     fun whenJsonMessagesMalformedOrMissingInformationThenMessagesNotParsedIntoConfig() = runTest {
         val result = getConfigFromJson("json/remote_messaging_config_malformed.json")
 
-        val testee = RemoteMessagingConfigJsonMapper(appBuildConfig, messageActionPlugins)
+        val testee = RemoteMessagingConfigJsonMapper(appBuildConfig, jsonMatchingAttributeMappers, messageActionPlugins)
 
         val config = testee.map(result)
 
@@ -192,7 +193,7 @@ class RemoteMessagingConfigJsonMapperTest {
     fun whenJsonMatchingAttributesMalformedThenParsedAsUnknownIntoConfig() = runTest {
         val result = getConfigFromJson("json/remote_messaging_config_malformed.json")
 
-        val testee = RemoteMessagingConfigJsonMapper(appBuildConfig, messageActionPlugins)
+        val testee = RemoteMessagingConfigJsonMapper(appBuildConfig, jsonMatchingAttributeMappers, messageActionPlugins)
 
         val config = testee.map(result)
 
@@ -207,7 +208,7 @@ class RemoteMessagingConfigJsonMapperTest {
     fun whenUnknownMatchingAttributeDoesNotProvideFallbackThenFallbackIsNull() = runTest {
         val result = getConfigFromJson("json/remote_messaging_config_malformed.json")
 
-        val testee = RemoteMessagingConfigJsonMapper(appBuildConfig, messageActionPlugins)
+        val testee = RemoteMessagingConfigJsonMapper(appBuildConfig, jsonMatchingAttributeMappers, messageActionPlugins)
 
         val config = testee.map(result)
 

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/RemoteMessagingConfigMatcherTest.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/RemoteMessagingConfigMatcherTest.kt
@@ -353,7 +353,7 @@ class RemoteMessagingConfigMatcherTest {
     }
 
     private suspend fun givenDeviceMatches(
-        vararg matchingAttributes: MatchingAttribute<*>,
+        vararg matchingAttributes: MatchingAttribute,
     ) {
         whenever(deviceAttributeMatcher.evaluate(any())).thenReturn(false)
         whenever(androidAppAttributeMatcher.evaluate(any())).thenReturn(false)
@@ -372,7 +372,7 @@ class RemoteMessagingConfigMatcherTest {
 
     private fun rule(
         id: Int,
-        vararg matchingAttributes: MatchingAttribute<*>,
+        vararg matchingAttributes: MatchingAttribute,
     ) = Pair(id, matchingAttributes.asList())
 
     private fun rules(vararg ids: Int) = ids.asList()

--- a/sync/sync-impl/build.gradle
+++ b/sync/sync-impl/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     implementation project(path: ':saved-sites-api')
     implementation project(':feature-toggles-api')
     implementation project(':navigation-api')
+    implementation project(':remote-messaging-api')
 
     implementation project(path: ':app-build-config-api')
     implementation project(path: ':privacy-config-api')

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/rmf/SyncJsonMatchingAttributeMapper.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/rmf/SyncJsonMatchingAttributeMapper.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.rmf
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.remote.messaging.api.JsonMatchingAttribute
+import com.duckduckgo.remote.messaging.api.JsonToMatchingAttributeMapper
+import com.duckduckgo.remote.messaging.api.MatchingAttribute
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+class SyncJsonMatchingAttributeMapper @Inject constructor() : JsonToMatchingAttributeMapper {
+    override fun map(key: String, jsonMatchingAttribute: JsonMatchingAttribute): MatchingAttribute? {
+        return when (key) {
+            "syncEnabled" -> {
+                SyncEnabledMatchingAttribute(
+                    jsonMatchingAttribute.value as Boolean,
+                )
+            }
+            else -> null
+        }
+    }
+}
+
+data class SyncEnabledMatchingAttribute(
+    val remoteValue: Boolean,
+) : MatchingAttribute

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/rmf/SyncMatchingAttributes.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/rmf/SyncMatchingAttributes.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 DuckDuckGo
+ * Copyright (c) 2024 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,29 +14,25 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.remote.messaging.impl.matchers
+package com.duckduckgo.sync.impl.rmf
 
-import com.duckduckgo.appbuildconfig.api.AppBuildConfig
-import com.duckduckgo.browser.api.AppProperties
+import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.remote.messaging.api.AttributeMatcherPlugin
 import com.duckduckgo.remote.messaging.api.MatchingAttribute
-import com.duckduckgo.remote.messaging.impl.models.*
+import com.duckduckgo.sync.store.SyncStore
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
 
-class DeviceAttributeMatcher(
-    private val appBuildConfig: AppBuildConfig,
-    private val appProperties: AppProperties,
+@ContributesMultibinding(AppScope::class)
+class SyncAttributeMatcherPlugin @Inject constructor(
+    private val syncStore: SyncStore,
 ) : AttributeMatcherPlugin {
     override suspend fun evaluate(matchingAttribute: MatchingAttribute): Boolean? {
         return when (matchingAttribute) {
-            is Api -> {
-                matchingAttribute.matches(appBuildConfig.sdkInt)
+            is SyncEnabledMatchingAttribute -> {
+                matchingAttribute.remoteValue == syncStore.isSignedIn()
             }
-            is Locale -> {
-                matchingAttribute.matches(appBuildConfig.deviceLocale.asJsonFormat())
-            }
-            is WebView -> {
-                matchingAttribute.matches(appProperties.webView())
-            }
+
             else -> return null
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202552961248957/1207001823978864/f 
Api proposal change: https://app.asana.com/0/1202552961248957/1207001823978859/f

### Description
The PR allows modules to contribute with matching attribute mappers to the remote messaging processor.

As part of the new api we are introducing a new matching attribute that makes use of new api.

### Steps to test this PR

_Feature 1_
- [x] checkout branch
- [x] go to RemoteMessagingService and change the url with `https://jsonblob.com/api/jsonBlob/1225382942368194560`
- [x] fresh install
- [x] skip onboarding
- [x] you shouldn't see any RMF in the new tab
- [x] now create a sync account
- [x] Go to https://www.jsonblob.com/1225382942368194560 and bump version +1 and click save
- [x] restart app (using fire button or killing it)
- [x] you should now see a remote message in the new tab

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
