### PR TITLE
Fix tab being blank for slow loading documents.

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1018,7 +1018,6 @@ class BrowserTabViewModel @Inject constructor(
         Timber.i("Blank: cancel job $deferredBlankSite")
         deferredBlankSite?.cancel()
         deferredBlankSite = viewModelScope.launch(dispatchers.io()) {
-            delay(timeMillis = NEW_CONTENT_MAX_DELAY_MS)
             withContext(dispatchers.main()) {
                 command.value = HideWebContent
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -123,7 +123,7 @@ class BrowserWebViewClient @Inject constructor(
         url: Uri,
         isForMainFrame: Boolean,
     ): Boolean {
-        Timber.v("shouldOverride $url")
+        Timber.v("shouldOverride webViewUrl: ${webView.url} URL: $url")
         try {
             if (isForMainFrame && dosDetector.isUrlGeneratingDos(url)) {
                 webView.loadUrl("about:blank")
@@ -264,6 +264,18 @@ class BrowserWebViewClient @Inject constructor(
         }
     }
 
+    override fun onPageCommitVisible (webView: WebView, url: String) {
+        // Show only when the commit matches the tab state
+        if (webView.url == url) {
+            Timber.v("onPageCommitVisible webViewUrl: ${webView.url} URL: $url")
+            val navigationList = webView.safeCopyBackForwardList() ?: return
+            webViewClientListener?.navigationStateChanged(WebViewNavigationState(navigationList))
+            if (url != null && url == lastPageStarted) {
+                webViewClientListener?.pageRefreshed(url)
+            }
+        }
+    }
+
     private fun loadUrl(
         listener: WebViewClientListener,
         webView: WebView,
@@ -298,11 +310,6 @@ class BrowserWebViewClient @Inject constructor(
             appCoroutineScope.launch(dispatcherProvider.io()) {
                 thirdPartyCookieManager.processUriForThirdPartyCookies(webView, url.toUri())
             }
-        }
-        val navigationList = webView.safeCopyBackForwardList() ?: return
-        webViewClientListener?.navigationStateChanged(WebViewNavigationState(navigationList))
-        if (url != null && url == lastPageStarted) {
-            webViewClientListener?.pageRefreshed(url)
         }
         lastPageStarted = url
         browserAutofillConfigurator.configureAutofillForCurrentPage(webView, url)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/715106103902962/1206610402862961/f

### Description

- The change moves the hiding of the document to immediate rather than a timeout.
- We also then change the address bar on `onPageCommitVisible` which also then shows the new document.

### Steps to test this PR

Some details in: https://app.asana.com/0/72649045549333/1190194123689893

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
