### PR TITLE
Add desugaring library dependency to modules that use related compile option

### DIFF
--- a/ad-click/ad-click-impl/build.gradle
+++ b/ad-click/ad-click-impl/build.gradle
@@ -92,4 +92,6 @@ dependencies {
     testImplementation Testing.robolectric
 
     testImplementation project(path: ':common-test')
+
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
 }

--- a/ad-click/ad-click-store/build.gradle
+++ b/ad-click/ad-click-store/build.gradle
@@ -61,4 +61,6 @@ dependencies {
     testImplementation 'app.cash.turbine:turbine:_'
     testImplementation Testing.robolectric
     testImplementation project(path: ':common-test')
+
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
 }

--- a/anrs/anrs-impl/build.gradle
+++ b/anrs/anrs-impl/build.gradle
@@ -48,6 +48,8 @@ dependencies {
     testImplementation AndroidX.test.ext.junit
     testImplementation "org.mockito.kotlin:mockito-kotlin:_"
     testImplementation Testing.robolectric
+
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
 }
 
 android {

--- a/app-store/build.gradle
+++ b/app-store/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     implementation AndroidX.room.runtime
 
     ksp AndroidX.room.compiler
+
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
 }
 android {
   namespace 'com.duckduckgo.app'

--- a/app-tracking-protection/vpn-impl/build.gradle
+++ b/app-tracking-protection/vpn-impl/build.gradle
@@ -136,4 +136,6 @@ dependencies {
     testImplementation project(':common-test')
     testImplementation project(':vpn-api-test')
     testImplementation project(':feature-toggles-test')
+
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
 }

--- a/app-tracking-protection/vpn-store/build.gradle
+++ b/app-tracking-protection/vpn-store/build.gradle
@@ -79,4 +79,6 @@ dependencies {
     testImplementation AndroidX.test.ext.junit
 
     androidTestUtil AndroidX.test.orchestrator
+
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
 }

--- a/autofill/autofill-impl/build.gradle
+++ b/autofill/autofill-impl/build.gradle
@@ -83,6 +83,7 @@ dependencies {
         exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
     }
 
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
 }
 
 android {

--- a/broken-site/broken-site-impl/build.gradle
+++ b/broken-site/broken-site-impl/build.gradle
@@ -82,4 +82,6 @@ dependencies {
     testImplementation AndroidX.core
     testImplementation CashApp.turbine
     testImplementation project(path: ':common-test')
+
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
 }

--- a/broken-site/broken-site-store/build.gradle
+++ b/broken-site/broken-site-store/build.gradle
@@ -36,6 +36,8 @@ dependencies {
     implementation project(':broken-site-api')
 
     testImplementation Testing.junit4
+
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
 }
 android {
     defaultConfig {

--- a/common/common-utils/build.gradle
+++ b/common/common-utils/build.gradle
@@ -73,4 +73,6 @@ dependencies {
     testImplementation "androidx.test:runner:_"
     testImplementation Testing.robolectric
     testImplementation project(path: ':common-test')
+
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
 }

--- a/downloads/downloads-impl/build.gradle
+++ b/downloads/downloads-impl/build.gradle
@@ -86,4 +86,6 @@ dependencies {
     testImplementation 'app.cash.turbine:turbine:_'
     testImplementation Testing.robolectric
     testImplementation project(path: ':common-test')
+
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
 }

--- a/downloads/downloads-store/build.gradle
+++ b/downloads/downloads-store/build.gradle
@@ -54,6 +54,8 @@ dependencies {
     testImplementation 'app.cash.turbine:turbine:_'
     testImplementation Testing.robolectric
     testImplementation project(path: ':common-test')
+
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
 }
 
 android {

--- a/example-feature/example-feature-api-android/build.gradle
+++ b/example-feature/example-feature-api-android/build.gradle
@@ -33,6 +33,8 @@ dependencies {
 
     implementation KotlinX.coroutines.core
     implementation AndroidX.appCompat
+
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
 }
 
 

--- a/example-feature/example-feature-impl/build.gradle
+++ b/example-feature/example-feature-impl/build.gradle
@@ -47,6 +47,8 @@ dependencies {
         // conflicts with mockito due to direct inclusion of byte buddy
         exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
     }
+
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
 }
 
 android {

--- a/fingerprint-protection/fingerprint-protection-impl/build.gradle
+++ b/fingerprint-protection/fingerprint-protection-impl/build.gradle
@@ -92,4 +92,6 @@ dependencies {
     testImplementation Testing.robolectric
 
     testImplementation project(path: ':common-test')
+
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
 }

--- a/fingerprint-protection/fingerprint-protection-store/build.gradle
+++ b/fingerprint-protection/fingerprint-protection-store/build.gradle
@@ -61,4 +61,6 @@ dependencies {
     testImplementation 'app.cash.turbine:turbine:_'
     testImplementation Testing.robolectric
     testImplementation project(path: ':common-test')
+
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
 }

--- a/network-protection/network-protection-impl/build.gradle
+++ b/network-protection/network-protection-impl/build.gradle
@@ -83,6 +83,8 @@ dependencies {
 
     // Shimmer
     implementation "com.facebook.shimmer:shimmer:_"
+
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
 }
 
 ext {

--- a/network-protection/network-protection-store/build.gradle
+++ b/network-protection/network-protection-store/build.gradle
@@ -37,6 +37,8 @@ dependencies {
     testImplementation project(path: ':common-test')
     testImplementation Testing.junit4
     testImplementation "org.mockito.kotlin:mockito-kotlin:_"
+
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
 }
 
 android {

--- a/privacy-config/privacy-config-impl/build.gradle
+++ b/privacy-config/privacy-config-impl/build.gradle
@@ -74,6 +74,8 @@ dependencies {
 
     androidTestImplementation project(path: ':common-test')
     testImplementation project(path: ':common-test')
+
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
 }
 
 android {

--- a/privacy-protections-popup/privacy-protections-popup-impl/build.gradle
+++ b/privacy-protections-popup/privacy-protections-popup-impl/build.gradle
@@ -64,6 +64,8 @@ dependencies {
 
     implementation AndroidX.work.runtimeKtx
     testImplementation AndroidX.work.testing
+
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
 }
 
 android {

--- a/remote-messaging/remote-messaging-impl/build.gradle
+++ b/remote-messaging/remote-messaging-impl/build.gradle
@@ -72,6 +72,8 @@ dependencies {
         // conflicts with mockito due to direct inclusion of byte buddy
         exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
     }
+
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
 }
 
 android {

--- a/remote-messaging/remote-messaging-store/build.gradle
+++ b/remote-messaging/remote-messaging-store/build.gradle
@@ -45,4 +45,6 @@ dependencies {
 
     testImplementation project(path: ':common-test')
     testImplementation Testing.junit4
+
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
 }

--- a/saved-sites/saved-sites-impl/build.gradle
+++ b/saved-sites/saved-sites-impl/build.gradle
@@ -75,6 +75,7 @@ dependencies {
         exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
     }
 
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
 }
 
 android {

--- a/saved-sites/saved-sites-store/build.gradle
+++ b/saved-sites/saved-sites-store/build.gradle
@@ -65,4 +65,6 @@ dependencies {
         // conflicts with mockito due to direct inclusion of byte buddy
         exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
     }
+
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
 }

--- a/site-permissions/site-permissions-store/build.gradle
+++ b/site-permissions/site-permissions-store/build.gradle
@@ -48,4 +48,6 @@ dependencies {
 
     testImplementation project(path: ':common-test')
     testImplementation Testing.junit4
+
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
 }

--- a/statistics/build.gradle
+++ b/statistics/build.gradle
@@ -79,6 +79,8 @@ dependencies {
 
     androidTestImplementation AndroidX.test.runner
     androidTestImplementation AndroidX.test.rules
+
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
 }
 
 android {

--- a/sync/sync-impl/build.gradle
+++ b/sync/sync-impl/build.gradle
@@ -91,6 +91,7 @@ dependencies {
         exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
     }
 
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
 }
 
 android {

--- a/sync/sync-settings-impl/build.gradle
+++ b/sync/sync-settings-impl/build.gradle
@@ -68,6 +68,8 @@ dependencies {
         // conflicts with mockito due to direct inclusion of byte buddy
         exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
     }
+
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
 }
 
 android {

--- a/sync/sync-store/build.gradle
+++ b/sync/sync-store/build.gradle
@@ -63,4 +63,6 @@ dependencies {
         // conflicts with mockito due to direct inclusion of byte buddy
         exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
     }
+
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
 }

--- a/user-agent/user-agent-impl/build.gradle
+++ b/user-agent/user-agent-impl/build.gradle
@@ -64,6 +64,8 @@ dependencies {
     testImplementation Testing.junit4
     testImplementation AndroidX.archCore.testing
     androidTestImplementation AndroidX.archCore.testing
+
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
 }
 
 anvil {

--- a/verified-installation/verified-installation-impl/build.gradle
+++ b/verified-installation/verified-installation-impl/build.gradle
@@ -49,6 +49,8 @@ dependencies {
         // conflicts with mockito due to direct inclusion of byte buddy
         exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
     }
+
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
 }
 
 android {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207009441394392/f

### Description

Missing declarations of desugaring library cause some gradle tasks to fail.

### Steps to test this PR

Run `./gradlew assembleDebugAndroidTest` and verify that build completed successfully.

### No UI changes