### PR TITLE
Some links aren't working in custom tabs

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1266,7 +1266,13 @@ class BrowserTabFragment :
             }
 
             is Command.OpenMessageInNewTab -> {
-                browserActivity?.openMessageInNewTab(it.message, it.sourceTabId)
+                if (isActiveCustomTab()) {
+                    webView?.hitTestResult?.extra?.let { data ->
+                        webView?.loadUrl(Uri.parse(data).toString())
+                    }
+                } else {
+                    browserActivity?.openMessageInNewTab(it.message, it.sourceTabId)
+                }
             }
 
             is Command.OpenInNewBackgroundTab -> {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414730916066338/1207014985604648/f

### Description
Handled target=_blank links in Custom Tabs.

### Steps to test this PR

Test link in DDG app
- [x] Install from this branch.
- [x] Open the app and navigate on https://appsumo.com/products/tidycal/?content=Image%20of%20TidyCal&_kx=XrBlyqQ7F44JePDtpVpyhbB6nfFPdrfHleFi8Cp75iQ.Ktp4ZG
- [x] Scroll down and tap on `Meet TidyCal` link.
- [x] Notice a new tab is opened with the url `tidycal.com`.

Test link in DDG Custom Tab
- [x] Install from this branch and set DDG as default browser.
- [x] Open the Custom Tab Test app (see https://app.asana.com/0/1200905986587319/1207025963579423/f) and use this url: https://appsumo.com/products/tidycal/?content=Image%20of%20TidyCal&_kx=XrBlyqQ7F44JePDtpVpyhbB6nfFPdrfHleFi8Cp75iQ.Ktp4ZG
- [x] Notice a DDG Custom Tab is opened.
- [x] Scroll down and tap on `Meet TidyCal` link.
- [x] Notice the new page is opened in the same Custom Tab and the url is `tidycal.com`.

### NO UI changes
