### PR TITLE
Return this instead of empty when stack trace redaction throws

### DIFF
--- a/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/ExceptionModels.kt
+++ b/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/ExceptionModels.kt
@@ -121,5 +121,5 @@ internal fun String.sanitizeStackTrace(): String {
         sanitizedStackTrace = sanitizedStackTrace.replace(ipv4Regex, "[REDACTED_IPV4]")
 
         return sanitizedStackTrace
-    }.getOrDefault("")
+    }.getOrDefault(this)
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207030958834222/f

### Description
Return original stack trace instead of empty string when redaction throws

### Steps to test this PR
QA optional
