### PR TITLE
Add warning to password management screen for incompatible WebViews

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModel.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.api.email.EmailManager
+import com.duckduckgo.autofill.impl.InternalAutofillCapabilityChecker
 import com.duckduckgo.autofill.impl.R
 import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator
 import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator.AuthConfiguration
@@ -107,6 +108,7 @@ class AutofillSettingsViewModel @Inject constructor(
     private val duckAddressIdentifier: DuckAddressIdentifier,
     private val syncEngine: SyncEngine,
     private val neverSavedSiteRepository: NeverSavedSiteRepository,
+    private val capabilityChecker: InternalAutofillCapabilityChecker,
 ) : ViewModel() {
 
     private val _viewState = MutableStateFlow(ViewState())
@@ -360,7 +362,11 @@ class AutofillSettingsViewModel @Inject constructor(
     fun onViewCreated() {
         if (combineJob != null) return
         combineJob = viewModelScope.launch(dispatchers.io()) {
-            _viewState.value = _viewState.value.copy(autofillEnabled = autofillStore.autofillEnabled)
+            _viewState.value = _viewState.value.copy(
+                autofillEnabled = autofillStore.autofillEnabled,
+                webViewCompatible = capabilityChecker.webViewSupportsAutofill(),
+            )
+
             val allCredentials = autofillStore.getAllCredentials().distinctUntilChanged()
             val combined = allCredentials.combine(searchQueryFilter) { credentials, filter ->
                 credentialListFilter.filter(credentials, filter)
@@ -640,6 +646,7 @@ class AutofillSettingsViewModel @Inject constructor(
         val logins: List<LoginCredentials>? = null,
         val credentialMode: CredentialMode? = null,
         val credentialSearchQuery: String = "",
+        val webViewCompatible: Boolean = true,
     )
 
     /**

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementListMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementListMode.kt
@@ -220,6 +220,12 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
                         binding.credentialToggleGroup.gone()
                         binding.logins.updateTopMargin(resources.getDimensionPixelSize(CommonR.dimen.keyline_4))
                     }
+
+                    if (state.webViewCompatible) {
+                        binding.webViewUnsupportedWarningPanel.gone()
+                    } else {
+                        binding.webViewUnsupportedWarningPanel.show()
+                    }
                 }
             }
         }

--- a/autofill/autofill-impl/src/main/res/layout/fragment_autofill_management_list_mode.xml
+++ b/autofill/autofill-impl/src/main/res/layout/fragment_autofill_management_list_mode.xml
@@ -26,6 +26,18 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
+        <com.duckduckgo.common.ui.view.InfoPanel
+            android:id="@+id/webViewUnsupportedWarningPanel"
+            style="@style/Widget.DuckDuckGo.InfoPanel"
+            android:visibility="gone"
+            android:layout_margin="@dimen/keyline_4"
+            app:panelText="@string/credentialManagementWebViewIncompatibleErrorMessage"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:panelBackground="@drawable/info_panel_alert_background"
+            app:panelDrawable="@drawable/ic_info_panel_alert" />
+
         <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
             android:id="@+id/enabledToggle"
             android:layout_width="0dp"
@@ -36,7 +48,7 @@
             app:showSwitch="true"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toBottomOf="@id/webViewUnsupportedWarningPanel"/>
 
         <com.duckduckgo.common.ui.view.divider.HorizontalDivider
             android:id="@+id/topDivider"

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModelTest.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel.PixelName
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.api.email.EmailManager
+import com.duckduckgo.autofill.impl.InternalAutofillCapabilityChecker
 import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENABLE_AUTOFILL_TOGGLE_MANUALLY_DISABLED
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENABLE_AUTOFILL_TOGGLE_MANUALLY_ENABLED
@@ -91,6 +92,7 @@ class AutofillSettingsViewModelTest {
     private val webUrlIdentifier: WebUrlIdentifier = mock()
     private val duckAddressIdentifier: DuckAddressIdentifier = RealDuckAddressIdentifier()
     private val neverSavedSiteRepository: NeverSavedSiteRepository = mock()
+    private val capabilityChecker: InternalAutofillCapabilityChecker = mock()
     private val testee = AutofillSettingsViewModel(
         autofillStore = mockStore,
         clipboardInteractor = clipboardInteractor,
@@ -105,6 +107,7 @@ class AutofillSettingsViewModelTest {
         duckAddressIdentifier = duckAddressIdentifier,
         syncEngine = mock(),
         neverSavedSiteRepository = neverSavedSiteRepository,
+        capabilityChecker = capabilityChecker,
     )
 
     @Before
@@ -564,6 +567,26 @@ class AutofillSettingsViewModelTest {
             val commands = awaitItem()
             assertTrue(commands.contains(ShowDisabledMode))
             assertFalse(commands.contains(LaunchDeviceAuth))
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenInListModeAndWebViewCompatibleThenPassedInViewState() = runTest {
+        whenever(capabilityChecker.webViewSupportsAutofill()).thenReturn(true)
+        testee.onViewCreated()
+        testee.viewState.test {
+            assertTrue(awaitItem().webViewCompatible)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenInListModeAndWebViewIncompatibleThenPassedInViewState() = runTest {
+        whenever(capabilityChecker.webViewSupportsAutofill()).thenReturn(false)
+        testee.onViewCreated()
+        testee.viewState.test {
+            assertFalse(awaitItem().webViewCompatible)
             cancelAndIgnoreRemainingEvents()
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206831477446960/f

### Description
Adds a warning panel to the top of password management screen if the system WebView is incompatible with autofilling. We still let the user manage their saved passwords manually.

### Steps to test this PR

The UI change will only show if the system WebView's feature capabilities reveal it cannot support autofilling. Easiest way to see the UI warning therefore is to manually edit `AutofillCapabilityCheckerImpl.webViewSupportsAutofill()` to return `false`.

- [ ] Test that you **do not** see the warning panel on a normal, modern WebView
- [ ] Test that you **do see it** when you've hacked `webViewSupportsAutofill()` to return false

### UI changes
<img width=70% src=https://github.com/duckduckgo/Android/assets/1336281/dcf8ce64-fb7a-44dd-8c17-83af8f99f824 />
