### PR TITLE
Constrain RMF dialog

### DIFF
--- a/app/src/main/res/layout/include_new_browser_tab.xml
+++ b/app/src/main/res/layout/include_new_browser_tab.xml
@@ -48,7 +48,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
 
-            <FrameLayout
+            <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
 
@@ -56,20 +56,26 @@
                     android:id="@+id/ddgLogo"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_gravity="top|center"
                     android:layout_marginTop="@dimen/homeTabDdgLogoTopMargin"
                     android:alpha="0"
                     android:contentDescription="@string/duckDuckGoLogoDescription"
                     android:maxWidth="180dp"
                     android:maxHeight="180dp"
                     app:srcCompat="@drawable/logo_full"
-                    android:visibility="gone" />
+                    android:visibility="gone"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent" />
 
                 <com.duckduckgo.common.ui.view.MessageCta
                     android:id="@+id/messageCta"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content" />
-            </FrameLayout>
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    app:layout_constraintWidth_max="600dp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/ddgLogo" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
             <include layout="@layout/include_quick_access_items" />
 

--- a/app/src/main/res/layout/include_new_browser_tab.xml
+++ b/app/src/main/res/layout/include_new_browser_tab.xml
@@ -74,7 +74,7 @@
                     app:layout_constraintWidth_max="600dp"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/ddgLogo" />
+                    app:layout_constraintTop_toTopOf="parent" />
             </androidx.constraintlayout.widget.ConstraintLayout>
 
             <include layout="@layout/include_quick_access_items" />


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207024411305243/f

### Description
Constrains the width of the RMF dialog to 600dp.

### Steps to test this PR

_Point at the JSON blob linked in the task_
- [ ] Complete onboarding.
- [ ] Rotate to landscape.
- [ ] Verify that the RMF dialog is constrained.

### UI changes
| Before  | After |
| ------ | ----- |
![before_constraint](https://github.com/duckduckgo/Android/assets/3471025/11447f63-9ca1-451c-bbc0-3c533158503f)|![after_constraint](https://github.com/duckduckgo/Android/assets/3471025/811c98be-3c4f-4460-9fb1-58e1058934c1)


