### PR TITLE
Make encrypted shared preferences safe

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/prefs/SafeSharedPreferences.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/prefs/SafeSharedPreferences.kt
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.prefs
+
+import android.content.SharedPreferences
+import android.content.SharedPreferences.Editor
+import android.content.SharedPreferences.OnSharedPreferenceChangeListener
+
+/**
+ * This class is a wrapper around shared prefs.
+ *
+ * We should primarily use it to wrap encrypted shared prefs so that we don't end up with crashes when decrypting information.
+ * We know this crashes happen (eg. java.lang.SecurityException: Could not decrypt value.) when eg. user perform backups across devices
+ * and the keys are not carried over to the new device.
+ */
+internal class SafeSharedPreferences(
+    private val unsafePrefs: SharedPreferences,
+) : SharedPreferences {
+
+    override fun getAll(): MutableMap<String, *> {
+        return runCatching { unsafePrefs.all }.getOrDefault(mutableMapOf())
+    }
+
+    override fun getString(
+        key: String?,
+        defValue: String?,
+    ): String? {
+        return runCatching { unsafePrefs.getString(key, defValue) }.getOrDefault(defValue)
+    }
+
+    override fun getStringSet(
+        key: String?,
+        defValue: MutableSet<String>?,
+    ): MutableSet<String>? {
+        return runCatching { unsafePrefs.getStringSet(key, defValue) }.getOrDefault(defValue)
+    }
+
+    override fun getInt(
+        key: String?,
+        defValue: Int,
+    ): Int {
+        return runCatching { unsafePrefs.getInt(key, defValue) }.getOrDefault(defValue)
+    }
+
+    override fun getLong(
+        key: String?,
+        defValue: Long,
+    ): Long {
+        return runCatching { unsafePrefs.getLong(key, defValue) }.getOrDefault(defValue)
+    }
+
+    override fun getFloat(
+        key: String?,
+        defValue: Float,
+    ): Float {
+        return runCatching { unsafePrefs.getFloat(key, defValue) }.getOrDefault(defValue)
+    }
+
+    override fun getBoolean(
+        key: String?,
+        defValue: Boolean,
+    ): Boolean {
+        return runCatching { unsafePrefs.getBoolean(key, defValue) }.getOrDefault(defValue)
+    }
+
+    override fun contains(key: String?): Boolean {
+        return runCatching { unsafePrefs.contains(key) }.getOrDefault(false)
+    }
+
+    override fun edit(): Editor {
+        return SafeEditor(unsafePrefs.edit())
+    }
+
+    override fun registerOnSharedPreferenceChangeListener(listener: OnSharedPreferenceChangeListener?) {
+        unsafePrefs.registerOnSharedPreferenceChangeListener(listener)
+    }
+
+    override fun unregisterOnSharedPreferenceChangeListener(listener: OnSharedPreferenceChangeListener?) {
+        unsafePrefs.unregisterOnSharedPreferenceChangeListener(listener)
+    }
+
+    private class SafeEditor(
+        private val editor: Editor,
+    ) : Editor {
+        override fun putString(
+            key: String?,
+            defValue: String?,
+        ): Editor {
+            runCatching { editor.putString(key, defValue) }
+            return this
+        }
+
+        override fun putStringSet(
+            key: String?,
+            defValue: MutableSet<String>?,
+        ): Editor {
+            runCatching { editor.putStringSet(key, defValue) }
+            return this
+        }
+
+        override fun putInt(
+            key: String?,
+            defValue: Int,
+        ): Editor {
+            runCatching { editor.putInt(key, defValue) }
+            return this
+        }
+
+        override fun putLong(
+            key: String?,
+            defValue: Long,
+        ): Editor {
+            runCatching { editor.putLong(key, defValue) }
+            return this
+        }
+
+        override fun putFloat(
+            key: String?,
+            defValue: Float,
+        ): Editor {
+            runCatching { editor.putFloat(key, defValue) }
+            return this
+        }
+
+        override fun putBoolean(
+            key: String?,
+            defValue: Boolean,
+        ): Editor {
+            runCatching { editor.putBoolean(key, defValue) }
+            return this
+        }
+
+        override fun remove(key: String?): Editor {
+            runCatching { editor.remove(key) }
+            return this
+        }
+
+        override fun clear(): Editor {
+            runCatching { editor.clear() }
+            return this
+        }
+
+        override fun commit(): Boolean {
+            return runCatching { editor.commit() }.getOrDefault(true)
+        }
+
+        override fun apply() {
+            runCatching { editor.apply() }
+        }
+    }
+}

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/prefs/VpnSharedPreferencesProvider.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/prefs/VpnSharedPreferencesProvider.kt
@@ -62,7 +62,7 @@ class VpnSharedPreferencesProviderImpl @Inject constructor(
         name: String,
         multiprocess: Boolean,
     ): SharedPreferences {
-        return if (multiprocess) {
+        val prefs = if (multiprocess) {
             context.getEncryptedHarmonySharedPreferences(
                 name,
                 MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC),
@@ -78,6 +78,8 @@ class VpnSharedPreferencesProviderImpl @Inject constructor(
                 EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
             )
         }
+
+        return SafeSharedPreferences(prefs)
     }
 
     private fun migrateToHarmonyIfNecessary(name: String): SharedPreferences {

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/prefs/VpnSharedPreferencesProviderImplTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/prefs/VpnSharedPreferencesProviderImplTest.kt
@@ -77,4 +77,21 @@ class VpnSharedPreferencesProviderImplTest {
         assertNotEquals(1f, harmony.getFloat("float", 0f))
         assertNotEquals(1L, harmony.getLong("long", 0L))
     }
+
+    @Test
+    fun testSafeSharedPreferences() {
+        val prefs = SafeSharedPreferences(vpnPreferencesProvider.getSharedPreferences(NAME))
+
+        prefs.edit(commit = true) { putBoolean("bool", true) }
+        prefs.edit(commit = true) { putString("string", "true") }
+        prefs.edit(commit = true) { putInt("int", 1) }
+        prefs.edit(commit = true) { putFloat("float", 1f) }
+        prefs.edit(commit = true) { putLong("long", 1L) }
+
+        assertEquals(true, prefs.getBoolean("bool", false))
+        assertEquals("true", prefs.getString("string", "false"))
+        assertEquals(1, prefs.getInt("int", 0))
+        assertEquals(1f, prefs.getFloat("float", 0f))
+        assertEquals(1L, prefs.getLong("long", 0L))
+    }
 }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/store/SubscriptionsDataStore.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/store/SubscriptionsDataStore.kt
@@ -141,7 +141,10 @@ class SubscriptionsEncryptedDataStore @Inject constructor(
             }
         }
 
-    override fun canUseEncryption(): Boolean = encryptedPreferences != null
+    override fun canUseEncryption(): Boolean {
+        encryptedPreferences?.edit(commit = true) { putBoolean("test", true) }
+        return encryptedPreferences?.getBoolean("test", false) == true
+    }
 
     companion object {
         const val FILENAME = "com.duckduckgo.subscriptions.store"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207043620647316/f

### Description
Ensure encrypted shared prefs can't crash when decryption fails.
Decryption can fail eg. as a result of phone backups that do not copy the keys across.

### Steps to test this PR
Code review and smoke test PPro
