### PR TITLE
Refactor closing Privacy Dashboard on allowlist change

### DIFF
--- a/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModel.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModel.kt
@@ -212,9 +212,9 @@ class PrivacyDashboardHybridViewModel @Inject constructor(
                     .distinctUntilChanged()
                     .drop(1) // Emit only when domain was added to or removed from the allowlist
             }
-            .onEach { allowlistChanged ->
+            .onEach {
                 // Setting userChangedValues to true will trigger closing the screen
-                viewState.update { it?.copy(userChangedValues = allowlistChanged) }
+                viewState.update { it?.copy(userChangedValues = true) }
             }
             .launchIn(viewModelScope)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1206003719166625/f

### Description

The following line is fundamentally broken, because `site.userAllowList` also takes content blocking exceptions into account, so we're comparing apples to oranges: 

`site.userAllowList != site.domain in allowlistedDomains`

As a quick workaround, `.drop(1)` was added, and this PR fixes it properly by not depending on `site.userAllowList` at all, just observing the user allowlist state.

### Steps to test this PR

No behavior changes are expected as a result of this PR.

#### Privacy Dashboard is closed automatically after toggling protections
- [x] Navigate to the Privacy Dashboard
- [x] Toggle protections
- [x] Verify that the screen closed itself after a slight delay (300ms) and the page reloaded automatically

#### Privacy Dashboard is closed automatically after toggling protections on Broken Site screen
- [x] Navigate to the Privacy Dashboard
- [x] Tap "Website not working?" to go to the Broken Site screen 
- [x] Toggle protections
- [x] Press back or submit report
- [x] Verify that after exiting Broken Site screen you landed on the page which reloads automatically

#### Screen stays open for allowlisted domains
- [x] Go to strava.com
- [x] Navigate to the Privacy Dashboard
- [x] Verify that protections are disabled and the screen doesn't close automatically

### No UI changes