### PR TITLE
Always use default or first non-browser app link activity

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksLauncher.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksLauncher.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.app.browser.applinks
 
 import android.content.ActivityNotFoundException
-import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.widget.Toast
@@ -42,23 +41,8 @@ class DuckDuckGoAppLinksLauncher @Inject constructor() : AppLinksLauncher {
         appLink.appIntent?.let {
             it.flags = Intent.FLAG_ACTIVITY_NEW_TASK
             startActivityOrQuietlyFail(context, it)
-        } ?: run {
-            if (appLink.excludedComponents != null) {
-                val title = context.getString(R.string.appLinkIntentChooserTitle)
-                val chooserIntent = getChooserIntent(appLink.uriString, title, appLink.excludedComponents!!)
-                startActivityOrQuietlyFail(context, chooserIntent)
-            }
         }
         viewModel.clearPreviousUrl()
-    }
-
-    private fun getChooserIntent(url: String?, title: String, excludedComponents: List<ComponentName>): Intent {
-        val urlIntent = Intent.parseUri(url, Intent.URI_ANDROID_APP_SCHEME).apply {
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK
-        }
-        return Intent.createChooser(urlIntent, title).apply {
-            putExtra(Intent.EXTRA_EXCLUDE_COMPONENTS, excludedComponents.toTypedArray())
-        }
     }
 
     private fun startActivityOrQuietlyFail(context: Context, intent: Intent) {

--- a/app/src/test/java/com/duckduckgo/app/browser/SpecialUrlDetectorImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/SpecialUrlDetectorImplTest.kt
@@ -27,13 +27,11 @@ import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType.*
 import com.duckduckgo.app.browser.SpecialUrlDetectorImpl.Companion.EMAIL_MAX_LENGTH
 import com.duckduckgo.app.browser.SpecialUrlDetectorImpl.Companion.PHONE_MAX_LENGTH
 import com.duckduckgo.app.browser.SpecialUrlDetectorImpl.Companion.SMS_MAX_LENGTH
-import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.privacy.config.api.AmpLinkType
 import com.duckduckgo.privacy.config.api.AmpLinks
 import com.duckduckgo.privacy.config.api.TrackingParameters
 import com.duckduckgo.subscriptions.api.Subscriptions
 import java.net.URISyntaxException
-import junit.framework.TestCase.assertNull
 import junit.framework.TestCase.assertTrue
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -58,9 +56,6 @@ class SpecialUrlDetectorImplTest {
 
     @Mock
     lateinit var mockTrackingParameters: TrackingParameters
-
-    @Mock
-    lateinit var appBuildConfig: AppBuildConfig
 
     @Mock
     lateinit var subscriptions: Subscriptions
@@ -119,10 +114,11 @@ class SpecialUrlDetectorImplTest {
 
     @Test
     fun whenOneNonBrowserActivityFoundThenReturnAppLinkWithIntent() {
+        whenever(mockPackageManager.resolveActivity(any(), eq(PackageManager.MATCH_DEFAULT_ONLY))).thenReturn(buildAppResolveInfo())
         whenever(mockPackageManager.queryIntentActivities(any(), anyInt())).thenReturn(
             listOf(
-                buildAppResolveInfo(),
                 buildBrowserResolveInfo(),
+                buildAppResolveInfo(),
                 ResolveInfo(),
             ),
         )
@@ -136,31 +132,6 @@ class SpecialUrlDetectorImplTest {
         assertEquals("https://example.com", appLinkType.uriString)
         assertEquals(EXAMPLE_APP_PACKAGE, appLinkType.appIntent!!.component!!.packageName)
         assertEquals(EXAMPLE_APP_ACTIVITY_NAME, appLinkType.appIntent!!.component!!.className)
-        assertNull(appLinkType.excludedComponents)
-    }
-
-    @Test
-    fun whenMultipleNonBrowserActivitiesFoundThenReturnAppLinkWithExcludedComponents() {
-        whenever(mockPackageManager.queryIntentActivities(any(), anyInt())).thenReturn(
-            listOf(
-                buildAppResolveInfo(),
-                buildAppResolveInfo(),
-                buildBrowserResolveInfo(),
-                ResolveInfo(),
-            ),
-        )
-        val type = testee.determineType("https://example.com")
-        verify(mockPackageManager).queryIntentActivities(
-            argThat { hasCategory(Intent.CATEGORY_BROWSABLE) },
-            eq(PackageManager.GET_RESOLVED_FILTER),
-        )
-        assertTrue(type is AppLink)
-        val appLinkType = type as AppLink
-        assertEquals("https://example.com", appLinkType.uriString)
-        assertEquals(1, appLinkType.excludedComponents!!.size)
-        assertEquals(EXAMPLE_BROWSER_PACKAGE, appLinkType.excludedComponents!![0].packageName)
-        assertEquals(EXAMPLE_BROWSER_ACTIVITY_NAME, appLinkType.excludedComponents!![0].className)
-        assertNull(appLinkType.appIntent)
     }
 
     @Test

--- a/browser-api/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
@@ -16,7 +16,6 @@
 
 package com.duckduckgo.app.browser
 
-import android.content.ComponentName
 import android.content.Intent
 import android.net.Uri
 
@@ -32,7 +31,6 @@ interface SpecialUrlDetector {
         class Sms(val telephoneNumber: String) : UrlType()
         class AppLink(
             val appIntent: Intent? = null,
-            val excludedComponents: List<ComponentName>? = null,
             val uriString: String,
         ) : UrlType()
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207056767580178/f

### Description
This PR will open an app link if it is:
- The default or first activity
- Is a non-browser acitivity

This fixes: https://app.asana.com/0/1202552961248957/1206992174651170/f

### Steps to test this PR

_Install Ticketmaster US (Link in task)_
- [x] Check out develop
- [x] Search for “dogs"
- [x] Click the first link
- [x] Verify that the snackbar “You can open this link in Ticketmaster” is shown
- [x] Check out this branch
- [x] Search for “dogs”
- [x] Click the first link
- [x] Verify that the snackbar is not shown

_Maps_
- [x] Go to maps.google.com
- [x] Verify that the snackbar “You can open this link in Maps” is shown

_Ticketmaster_
- [x] Go to ticketmaster.com
- [x] Verify that the snackbar “You can open this link in Ticketmaster” is shown
