### PR TITLE
Update app scheme test to assert on spreadprivacy instead of duckduckgo

### DIFF
--- a/.maestro/security_tests/3_-_AddressBarSpoof,_appschemes.yaml
+++ b/.maestro/security_tests/3_-_AddressBarSpoof,_appschemes.yaml
@@ -13,12 +13,11 @@ tags:
 - tapOn: "Got It"
 - tapOn: "Start"
 - tapOn: "Phew!"
-# This test should reject trying to load
-# This test is expected to load duckduckgo.com, not remain on the current page with spoofed content.
-- assertVisible: "Privacy, simplified." # DuckDuckGo home page
+# This test is expected to load spreadprivacy.com, not remain on the current page with spoofed content.
+- assertVisible: "Spread Privacy" # DuckDuckGo blog homepage
 - copyTextFrom:
     id: "omnibarTextInput"
-- assertTrue: ${maestro.copiedText == "https://duckduckgo.com/"} # DuckDuckGo home page
+- assertTrue: ${maestro.copiedText == "https://spreadprivacy.com/"} # DuckDuckGo blog home page
 - tapOn:
     id: "omnibarTextInput"
 # Test 2

--- a/.maestro/security_tests/3_-_AddressBarSpoof,_appschemes.yaml
+++ b/.maestro/security_tests/3_-_AddressBarSpoof,_appschemes.yaml
@@ -1,4 +1,4 @@
-appId: com.duckduckgo.mobile.android
+appId: com.duckduckgo.mobile.android.debug
 tags:
     - securityTest
 ---
@@ -12,7 +12,6 @@ tags:
 - pressKey: Enter
 - tapOn: "Got It"
 - tapOn: "Start"
-- tapOn: "Phew!"
 # This test is expected to load spreadprivacy.com, not remain on the current page with spoofed content.
 - assertVisible: "Spread Privacy" # DuckDuckGo blog homepage
 - copyTextFrom:

--- a/.maestro/security_tests/3_-_AddressBarSpoof,_appschemes.yaml
+++ b/.maestro/security_tests/3_-_AddressBarSpoof,_appschemes.yaml
@@ -1,4 +1,4 @@
-appId: com.duckduckgo.mobile.android.debug
+appId: com.duckduckgo.mobile.android
 tags:
     - securityTest
 ---


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207057471208066/f

### Description
Two issues:
- assertVisible: "Privacy, simplified." is not true anymore for all cases.
- duckduckgo.com has too frequent updates/experiments that affect our test assertions.

Therefore, I changed the exploit target to spreadprivacy.com for this specific test (as other tests do not rely on specific content being visible on duckduckgo.com). Now we can assert on a more reliable string ("Spread Privacy").

### Steps to test this PR
- `maestro test .maestro/security_tests/3_-_AddressBarSpoof,_appschemes.yaml`
