### PR TITLE
Android: Mastify app login not working in Custom Tab

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/customtabs/IntentDispatcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/customtabs/IntentDispatcherViewModel.kt
@@ -51,7 +51,7 @@ class IntentDispatcherViewModel @Inject constructor(
         viewModelScope.launch(dispatcherProvider.io()) {
             runCatching {
                 val hasSession = intent?.hasExtra(CustomTabsIntent.EXTRA_SESSION) == true
-                val intentText = intent?.intentText
+                val intentText = intent?.intentText?.sanitize()
                 val toolbarColor = intent?.getIntExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR, defaultColor) ?: defaultColor
                 val isEmailProtectionLink = emailProtectionLinkVerifier.shouldDelegateToInContextView(intentText, true)
                 val customTabRequested = hasSession && !isEmailProtectionLink
@@ -70,5 +70,11 @@ class IntentDispatcherViewModel @Inject constructor(
                 Timber.w("Error handling custom tab intent %s", it.message)
             }
         }
+    }
+
+    private fun String.sanitize(): String {
+        // Some apps send URLs with spaces in the intent. This is happening mostly for authorization URLs.
+        // E.g https://mastodon.social/oauth/authorize?client_id=AcfPDZlcKUjwIatVtMt8B8cmdW-w1CSOR6_rYS_6Kxs&scope=read write push&redirect_uri=mastify://oauth&response_type=code
+        return this.replace(" ", "%20")
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/customtabs/IntentDispatcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/customtabs/IntentDispatcherViewModelTest.kt
@@ -97,6 +97,28 @@ class IntentDispatcherViewModelTest {
         }
     }
 
+    @Test
+    fun whenIntentReceivedWithSessionAndUrlContainingSpacesThenSpacesAreReplacedAndCustomTabIsRequested() = runTest {
+        val urlWithSpaces =
+            """
+                https://mastodon.social/oauth/authorize?client_id=AcfPDZlcKUjwIatVtMt8B8cmdW-w1CSOR6_rYS_6Kxs&scope=read write push&redirect_uri=mastify://oauth&response_type=code
+            """.trimIndent()
+        val expectedUrl =
+            """
+                https://mastodon.social/oauth/authorize?client_id=AcfPDZlcKUjwIatVtMt8B8cmdW-w1CSOR6_rYS_6Kxs&scope=read%20write%20push&redirect_uri=mastify://oauth&response_type=code
+            """.trimIndent()
+        whenever(mockIntent.intentText).thenReturn(urlWithSpaces)
+        configureHasSession(true)
+
+        testee.onIntentReceived(mockIntent, DEFAULT_COLOR)
+
+        testee.viewState.test {
+            val state = awaitItem()
+            assertTrue(state.customTabRequested)
+            assertEquals(expectedUrl, state.intentText)
+        }
+    }
+
     private fun configureHasSession(returnValue: Boolean) {
         whenever(mockIntent.hasExtra(CustomTabsIntent.EXTRA_SESSION)).thenReturn(returnValue)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207136535292676/f

### Description
Sanitized the url inside the intent for Custom Tab. 

### Steps to test this PR

- [x] Install DDG from this branch and set it as default browser.
- [x] Install Mastify app.
- [x] Open the Mastify app and log in to Mastodon. For more details see https://app.asana.com/0/0/1207092601847905/1207122564414424/f
- [x] Check you see the login page in the DDG Custom Tab. On that page you can successfully log in and afterwards you are prompted to open the Mastify app and you are logged in in there.


### NO UI changes
| Before - using oauth URL unchanged | After - fixed oauth URL |
| ------ | ----- |
|![mastify_before](https://github.com/duckduckgo/Android/assets/7963079/65232995-7b51-4a42-b52f-cdc0c5693684)|![mastify_after](https://github.com/duckduckgo/Android/assets/7963079/586d2574-6dcc-411d-b802-aaaae3aef9bc)|
