### PR TITLE
Update copy when deleting passwords to consider whether sync enabled or not

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
@@ -104,6 +104,9 @@ class AutofillManagementCredentialsMode : DuckDuckGoFragment(R.layout.fragment_a
     @Inject
     lateinit var browserNav: BrowserNav
 
+    @Inject
+    lateinit var stringBuilder: AutofillManagementStringBuilder
+
     // we need to revert the toolbar title when this fragment is destroyed, so will track its initial value
     private var initialActionBarTitle: String? = null
 
@@ -176,21 +179,28 @@ class AutofillManagementCredentialsMode : DuckDuckGoFragment(R.layout.fragment_a
 
     private fun launchDeleteLoginConfirmationDialog() {
         this.context?.let {
-            TextAlertDialogBuilder(it)
-                .setTitle(R.string.autofillDeleteLoginDialogTitle)
-                .setMessage(R.string.credentialManagementDeletePasswordConfirmationMessage)
-                .setDestructiveButtons(true)
-                .setPositiveButton(R.string.autofillDeleteLoginDialogDelete)
-                .setNegativeButton(R.string.autofillDeleteLoginDialogCancel)
-                .addEventListener(
-                    object : TextAlertDialogBuilder.EventListener() {
-                        override fun onPositiveButtonClicked() {
-                            viewModel.onDeleteCurrentCredentials()
-                            viewModel.onExitCredentialMode()
-                        }
-                    },
-                )
-                .show()
+            lifecycleScope.launch(dispatchers.io()) {
+                val dialogTitle = stringBuilder.stringForDeletePasswordDialogConfirmationTitle(numberToDelete = 1)
+                val dialogMessage = stringBuilder.stringForDeletePasswordDialogConfirmationMessage(numberToDelete = 1)
+
+                withContext(dispatchers.main()) {
+                    TextAlertDialogBuilder(it)
+                        .setTitle(dialogTitle)
+                        .setMessage(dialogMessage)
+                        .setDestructiveButtons(true)
+                        .setPositiveButton(R.string.autofillDeleteLoginDialogDelete)
+                        .setNegativeButton(R.string.autofillDeleteLoginDialogCancel)
+                        .addEventListener(
+                            object : TextAlertDialogBuilder.EventListener() {
+                                override fun onPositiveButtonClicked() {
+                                    viewModel.onDeleteCurrentCredentials()
+                                    viewModel.onExitCredentialMode()
+                                }
+                            },
+                        )
+                        .show()
+                }
+            }
         }
     }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementStringBuilder.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementStringBuilder.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.ui.credential.management.viewing
+
+import android.content.Context
+import android.content.res.Resources
+import com.duckduckgo.autofill.impl.R
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.sync.api.DeviceSyncState
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+import kotlinx.coroutines.withContext
+
+interface AutofillManagementStringBuilder {
+    fun stringForDeletePasswordDialogConfirmationTitle(numberToDelete: Int): String
+    suspend fun stringForDeletePasswordDialogConfirmationMessage(numberToDelete: Int): String
+}
+
+@ContributesBinding(FragmentScope::class)
+class AutofillManagementStringBuilderImpl @Inject constructor(
+    private val context: Context,
+    private val deviceSyncState: DeviceSyncState,
+    private val dispatchers: DispatcherProvider,
+) : AutofillManagementStringBuilder {
+
+    override fun stringForDeletePasswordDialogConfirmationTitle(numberToDelete: Int): String {
+        if (numberToDelete == 1) {
+            return context.getString(R.string.credentialManagementDeleteAllPasswordsDialogConfirmationTitleSingular)
+        }
+
+        return context.resources.getQuantityString(
+            R.plurals.credentialManagementDeleteAllPasswordsDialogConfirmationTitlePlural,
+            numberToDelete,
+            numberToDelete,
+        )
+    }
+
+    override suspend fun stringForDeletePasswordDialogConfirmationMessage(numberToDelete: Int): String {
+        val firstMessage = context.resources.deleteAllPasswordsWarning(numberToDelete)
+        val secondMessage = if (numberToDelete == 1) {
+            context.resources.getString(R.string.credentialManagementDeleteAllSecondInstructionSingular)
+        } else {
+            context.resources.getQuantityString(R.plurals.credentialManagementDeleteAllSecondInstructionPlural, numberToDelete)
+        }
+        return "$firstMessage $secondMessage"
+    }
+
+    private suspend fun Resources.deleteAllPasswordsWarning(numberToDelete: Int): String {
+        return withContext(dispatchers.io()) {
+            return@withContext if (deviceSyncState.isUserSignedInOnDevice()) {
+                if (numberToDelete == 1) {
+                    getString(R.string.credentialManagementDeleteAllPasswordsFirstInstructionSyncedSingular)
+                } else {
+                    getQuantityString(R.plurals.credentialManagementDeleteAllPasswordsFirstInstructionSyncedPlural, numberToDelete)
+                }
+            } else {
+                if (numberToDelete == 1) {
+                    getString(R.string.credentialManagementDeleteAllPasswordsDialogFirstInstructionNotSyncedSingular)
+                } else {
+                    getQuantityString(R.plurals.credentialManagementDeleteAllPasswordsDialogFirstInstructionNotSyncedPlural, numberToDelete)
+                }
+            }
+        }
+    }
+}

--- a/autofill/autofill-impl/src/main/res/values-bg/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-bg/strings-autofill-impl.xml
@@ -126,7 +126,6 @@
     <string name="saveLoginDialogSubtitle">Паролите се съхраняват сигурно на Вашето устройство.</string>
     <string name="autofillManagementAddLogin">Добавяне на парола</string>
     <string name="credentialManagementEditLoginTitleHint">Заглавие</string>
-    <string name="autofillDeleteLoginDialogTitle">Сигурни ли сте, че искате да изтриете тази парола?</string>
     <string name="autofillManagementDeletedConfirmation">Паролата е изтрита</string>
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Последна актуализация %1$s</string>
     <string name="autofillDisableAutofillPromptTitle">Искате ли да продължите да запазвате пароли?</string>
@@ -152,13 +151,6 @@
     <string name="credentialManagementClearNeverForThisSiteDialogNegativeButton">Отмени</string>
 
     <string name="credentialManagementDeleteAllPasswordsMenu">Изтриване на всички пароли</string>
-    <plurals name="credentialManagementDeleteAllPasswordsConfirmationTitle" instruction="Placeholder is a number representing how many passwords will be deleted">
-        <item quantity="one">Сигурни ли сте, че искате да изтриете %1$d парола?</item>
-        <item quantity="other">Сигурни ли сте, че искате да изтриете %1$d пароли?</item>
-    </plurals>
-
-    <string name="credentialManagementDeletePasswordConfirmationMessage">Вашата парола ще бъде изтрита от всички синхронизирани устройства. Уверете се, че все още имате друг начин за достъп до акаунта си.</string>
-    <string name="credentialManagementDeleteAllPasswordsConfirmationMessage">Вашите пароли ще бъдат изтрити от всички синхронизирани устройства. Уверете се, че все още имате друг начин за достъп до Вашите акаунти.</string>
 
     <plurals name="credentialManagementDeleteAllPasswordsSnackbarConfirmation" instruction="Placeholder is a number representing how many passwords were deleted">
         <item quantity="one">%1$d изтрита парола</item>

--- a/autofill/autofill-impl/src/main/res/values-cs/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-cs/strings-autofill-impl.xml
@@ -126,7 +126,6 @@
     <string name="saveLoginDialogSubtitle">Hesla se bezpečně ukládají do tvého zařízení.</string>
     <string name="autofillManagementAddLogin">Přidat heslo</string>
     <string name="credentialManagementEditLoginTitleHint">Název</string>
-    <string name="autofillDeleteLoginDialogTitle">Opravdu chceš smazat tohle heslo?</string>
     <string name="autofillManagementDeletedConfirmation">Heslo smazáno</string>
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Poslední aktualizace %1$s</string>
     <string name="autofillDisableAutofillPromptTitle">Chceš dál ukládat hesla?</string>
@@ -152,15 +151,6 @@
     <string name="credentialManagementClearNeverForThisSiteDialogNegativeButton">Zrušit</string>
 
     <string name="credentialManagementDeleteAllPasswordsMenu">Smazat všechna hesla</string>
-    <plurals name="credentialManagementDeleteAllPasswordsConfirmationTitle" instruction="Placeholder is a number representing how many passwords will be deleted">
-        <item quantity="one">Opravdu chceš smazat %1$d heslo?</item>
-        <item quantity="few">Opravdu chceš smazat %1$d hesla?</item>
-        <item quantity="many">Opravdu chceš smazat %1$d hesla?</item>
-        <item quantity="other">Opravdu chceš smazat %1$d hesel?</item>
-    </plurals>
-
-    <string name="credentialManagementDeletePasswordConfirmationMessage">Tvoje heslo se smaže ze všech synchronizovaných zařízení. Zkontroluj si předtím, že se i tak dostaneš ke svému účtu.</string>
-    <string name="credentialManagementDeleteAllPasswordsConfirmationMessage">Tvoje hesla se smažou ze všech synchronizovaných zařízení. Zkontroluj si předtím, že se k účtům i tak dostaneš.</string>
 
     <plurals name="credentialManagementDeleteAllPasswordsSnackbarConfirmation" instruction="Placeholder is a number representing how many passwords were deleted">
         <item quantity="one">%1$d smazané heslo</item>

--- a/autofill/autofill-impl/src/main/res/values-da/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-da/strings-autofill-impl.xml
@@ -126,7 +126,6 @@
     <string name="saveLoginDialogSubtitle">Adgangskoder gemmes sikkert på din enhed.</string>
     <string name="autofillManagementAddLogin">Tilføj adgangskode</string>
     <string name="credentialManagementEditLoginTitleHint">Titel</string>
-    <string name="autofillDeleteLoginDialogTitle">Er du sikker på, at du vil slette denne adgangskode?</string>
     <string name="autofillManagementDeletedConfirmation">Adgangskode slettet</string>
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Sidst opdateret %1$s</string>
     <string name="autofillDisableAutofillPromptTitle">Vil du fortsætte med at gemme adgangskoder?</string>
@@ -152,13 +151,6 @@
     <string name="credentialManagementClearNeverForThisSiteDialogNegativeButton">Annuller</string>
 
     <string name="credentialManagementDeleteAllPasswordsMenu">Slet alle adgangskoder</string>
-    <plurals name="credentialManagementDeleteAllPasswordsConfirmationTitle" instruction="Placeholder is a number representing how many passwords will be deleted">
-        <item quantity="one">Er du sikker på, at du vil slette %1$d adgangskode?</item>
-        <item quantity="other">Er du sikker på, at du vil slette %1$d adgangskoder?</item>
-    </plurals>
-
-    <string name="credentialManagementDeletePasswordConfirmationMessage">Din adgangskode slettes fra alle synkroniserede enheder. Husk at sikre, at du stadig har adgang til din konto.</string>
-    <string name="credentialManagementDeleteAllPasswordsConfirmationMessage">Dine adgangskoder slettes fra alle synkroniserede enheder. Husk at sikre, at du stadig har adgang til dine konti.</string>
 
     <plurals name="credentialManagementDeleteAllPasswordsSnackbarConfirmation" instruction="Placeholder is a number representing how many passwords were deleted">
         <item quantity="one">%1$d adgangskode slettet</item>

--- a/autofill/autofill-impl/src/main/res/values-de/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-de/strings-autofill-impl.xml
@@ -126,7 +126,6 @@
     <string name="saveLoginDialogSubtitle">Passwörter werden sicher auf deinem Gerät gespeichert.</string>
     <string name="autofillManagementAddLogin">Passwort hinzufügen</string>
     <string name="credentialManagementEditLoginTitleHint">Titel</string>
-    <string name="autofillDeleteLoginDialogTitle">Möchtest du dieses Passwort wirklich löschen?</string>
     <string name="autofillManagementDeletedConfirmation">Passwort gelöscht</string>
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Zuletzt aktualisiert %1$s</string>
     <string name="autofillDisableAutofillPromptTitle">Möchtest du weiterhin Passwörter speichern?</string>
@@ -152,13 +151,6 @@
     <string name="credentialManagementClearNeverForThisSiteDialogNegativeButton">Abbrechen</string>
 
     <string name="credentialManagementDeleteAllPasswordsMenu">Alle Passwörter löschen</string>
-    <plurals name="credentialManagementDeleteAllPasswordsConfirmationTitle" instruction="Placeholder is a number representing how many passwords will be deleted">
-        <item quantity="one">Möchtest du dieses %1$d Passwort wirklich löschen?</item>
-        <item quantity="other">Möchtest du diese %1$d Passwörter wirklich löschen?</item>
-    </plurals>
-
-    <string name="credentialManagementDeletePasswordConfirmationMessage">Dein Passwort wird von allen synchronisierten Geräten gelöscht. Vergewissere dich, dass du weiterhin eine Möglichkeit hast, auf dein Konto zuzugreifen.</string>
-    <string name="credentialManagementDeleteAllPasswordsConfirmationMessage">Deine Passwörter werden von allen synchronisierten Geräten gelöscht. Vergewissere dich, dass du weiterhin eine Möglichkeit hast, auf deine Konten zuzugreifen.</string>
 
     <plurals name="credentialManagementDeleteAllPasswordsSnackbarConfirmation" instruction="Placeholder is a number representing how many passwords were deleted">
         <item quantity="one">%1$d Passwort gelöscht</item>

--- a/autofill/autofill-impl/src/main/res/values-el/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-el/strings-autofill-impl.xml
@@ -126,7 +126,6 @@
     <string name="saveLoginDialogSubtitle">Οι κωδικοί πρόσβασης αποθηκεύονται με ασφάλεια στη συσκευή σας.</string>
     <string name="autofillManagementAddLogin">Προσθήκη κωδικού πρόσβασης</string>
     <string name="credentialManagementEditLoginTitleHint">Τίτλος</string>
-    <string name="autofillDeleteLoginDialogTitle">Θέλετε σίγουρα να διαγράψετε αυτόν τον κωδικό πρόσβασης;</string>
     <string name="autofillManagementDeletedConfirmation">Διαγραφή κωδικού πρόσβασης</string>
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Τελευταία ενημέρωση %1$s</string>
     <string name="autofillDisableAutofillPromptTitle">Θέλετε να συνεχίσετε να αποθηκεύετε κωδικούς πρόσβασης;</string>
@@ -152,13 +151,6 @@
     <string name="credentialManagementClearNeverForThisSiteDialogNegativeButton">Ακύρωση</string>
 
     <string name="credentialManagementDeleteAllPasswordsMenu">Διαγραφή όλων των κωδικών πρόσβασης</string>
-    <plurals name="credentialManagementDeleteAllPasswordsConfirmationTitle" instruction="Placeholder is a number representing how many passwords will be deleted">
-        <item quantity="one">Θέλετε σίγουρα να διαγράψετε %1$d κωδικούς πρόσβασης;</item>
-        <item quantity="other">Θέλετε σίγουρα να διαγράψετε %1$d κωδικούς πρόσβασης;</item>
-    </plurals>
-
-    <string name="credentialManagementDeletePasswordConfirmationMessage">Ο κωδικός πρόσβασής σας θα διαγραφεί από όλες τις συγχρονισμένες συσκευές. Βεβαιωθείτε ότι έχετε ακόμα τρόπο πρόσβασης στον λογαριασμό σας.</string>
-    <string name="credentialManagementDeleteAllPasswordsConfirmationMessage">Οι κωδικοί πρόσβασής σας θα διαγραφούν από όλες τις συγχρονισμένες συσκευές. Βεβαιωθείτε ότι έχετε ακόμα τρόπο πρόσβασης στους λογαριασμούς σας.</string>
 
     <plurals name="credentialManagementDeleteAllPasswordsSnackbarConfirmation" instruction="Placeholder is a number representing how many passwords were deleted">
         <item quantity="one">%1$d κωδικός πρόσβασης διαγράφηκε</item>

--- a/autofill/autofill-impl/src/main/res/values-es/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-es/strings-autofill-impl.xml
@@ -126,7 +126,6 @@
     <string name="saveLoginDialogSubtitle">Las contraseñas se almacenan de forma segura en tu dispositivo.</string>
     <string name="autofillManagementAddLogin">Añadir contraseña</string>
     <string name="credentialManagementEditLoginTitleHint">Título</string>
-    <string name="autofillDeleteLoginDialogTitle">¿Seguro de que quieres borrar esta contraseña?</string>
     <string name="autofillManagementDeletedConfirmation">Contraseña borrada</string>
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Última actualización %1$s</string>
     <string name="autofillDisableAutofillPromptTitle">¿Quieres seguir guardando contraseñas?</string>
@@ -152,13 +151,6 @@
     <string name="credentialManagementClearNeverForThisSiteDialogNegativeButton">Cancelar</string>
 
     <string name="credentialManagementDeleteAllPasswordsMenu">Borrar todas las contraseñas</string>
-    <plurals name="credentialManagementDeleteAllPasswordsConfirmationTitle" instruction="Placeholder is a number representing how many passwords will be deleted">
-        <item quantity="one">¿Seguro de que quieres borrar %1$d contraseña?</item>
-        <item quantity="other">¿Seguro de que quieres borrar %1$d contraseñas?</item>
-    </plurals>
-
-    <string name="credentialManagementDeletePasswordConfirmationMessage">Tu contraseña se borrará en todos los dispositivos sincronizados. Asegúrate de seguir teniendo una forma de acceder a tu cuenta.</string>
-    <string name="credentialManagementDeleteAllPasswordsConfirmationMessage">Tus contraseñas se borrarán en todos los dispositivos sincronizados. Asegúrate de seguir teniendo una forma de acceder a tus cuentas.</string>
 
     <plurals name="credentialManagementDeleteAllPasswordsSnackbarConfirmation" instruction="Placeholder is a number representing how many passwords were deleted">
         <item quantity="one">%1$d contraseña borrada</item>

--- a/autofill/autofill-impl/src/main/res/values-et/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-et/strings-autofill-impl.xml
@@ -126,7 +126,6 @@
     <string name="saveLoginDialogSubtitle">Paroolid salvestatakse turvaliselt sinu seadmesse.</string>
     <string name="autofillManagementAddLogin">Parooli lisamine</string>
     <string name="credentialManagementEditLoginTitleHint">Pealkiri</string>
-    <string name="autofillDeleteLoginDialogTitle">Kas oled kindel, et soovid selle parooli kustutada?</string>
     <string name="autofillManagementDeletedConfirmation">Parool on kustutatud</string>
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Viimati uuendatud %1$s</string>
     <string name="autofillDisableAutofillPromptTitle">Kas soovid jätkata paroolide salvestamist?</string>
@@ -152,13 +151,6 @@
     <string name="credentialManagementClearNeverForThisSiteDialogNegativeButton">Loobu</string>
 
     <string name="credentialManagementDeleteAllPasswordsMenu">Kustuta kõik paroolid</string>
-    <plurals name="credentialManagementDeleteAllPasswordsConfirmationTitle" instruction="Placeholder is a number representing how many passwords will be deleted">
-        <item quantity="one">Kas soovid kindlasti %1$d parooli kustutada?</item>
-        <item quantity="other">Kas soovid kindlasti %1$d parooli kustutada?</item>
-    </plurals>
-
-    <string name="credentialManagementDeletePasswordConfirmationMessage">Sinu parool kustutatakse kõigist sünkroonitud seadmetest. Veendu, et sulle jääks endiselt mõni viis oma kontole pääsemiseks.</string>
-    <string name="credentialManagementDeleteAllPasswordsConfirmationMessage">Sinu paroolid kustutatakse kõikidest sünkroonitud seadmetest. Veendu, et sulle jääks endiselt mõni viis oma kontodele pääsemiseks.</string>
 
     <plurals name="credentialManagementDeleteAllPasswordsSnackbarConfirmation" instruction="Placeholder is a number representing how many passwords were deleted">
         <item quantity="one">%1$d parool kustutatud</item>

--- a/autofill/autofill-impl/src/main/res/values-fi/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-fi/strings-autofill-impl.xml
@@ -126,7 +126,6 @@
     <string name="saveLoginDialogSubtitle">Salasanat tallennetaan laitteellesi turvallisesti.</string>
     <string name="autofillManagementAddLogin">Lisää salasana</string>
     <string name="credentialManagementEditLoginTitleHint">Otsikko</string>
-    <string name="autofillDeleteLoginDialogTitle">Haluatko varmasti poistaa tämän salasanan?</string>
     <string name="autofillManagementDeletedConfirmation">Salasana poistettu</string>
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Viimeksi päivitetty %1$s</string>
     <string name="autofillDisableAutofillPromptTitle">Haluatko jatkaa salasanojen tallentamista?</string>
@@ -152,13 +151,6 @@
     <string name="credentialManagementClearNeverForThisSiteDialogNegativeButton">Peruuta</string>
 
     <string name="credentialManagementDeleteAllPasswordsMenu">Poista kaikki salasanat</string>
-    <plurals name="credentialManagementDeleteAllPasswordsConfirmationTitle" instruction="Placeholder is a number representing how many passwords will be deleted">
-        <item quantity="one">Haluatko varmasti poistaa %1$d salasanan?</item>
-        <item quantity="other">Haluatko varmasti poistaa %1$d salasanaa?</item>
-    </plurals>
-
-    <string name="credentialManagementDeletePasswordConfirmationMessage">Salasanasi poistetaan kaikista synkronoiduista laitteista. Varmista, että pääset yhä käyttämään tiliäsi.</string>
-    <string name="credentialManagementDeleteAllPasswordsConfirmationMessage">Salasanasi poistetaan kaikista synkronoiduista laitteista. Varmista, että pääset yhä käyttämään tilejäsi.</string>
 
     <plurals name="credentialManagementDeleteAllPasswordsSnackbarConfirmation" instruction="Placeholder is a number representing how many passwords were deleted">
         <item quantity="one">%1$d salasana poistettu</item>

--- a/autofill/autofill-impl/src/main/res/values-fr/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-fr/strings-autofill-impl.xml
@@ -126,7 +126,6 @@
     <string name="saveLoginDialogSubtitle">Les mots de passe sont stockés en toute sécurité sur votre appareil.</string>
     <string name="autofillManagementAddLogin">Ajouter un mot de passe</string>
     <string name="credentialManagementEditLoginTitleHint">Titre</string>
-    <string name="autofillDeleteLoginDialogTitle">Voulez-vous vraiment supprimer ce mot de passe ?</string>
     <string name="autofillManagementDeletedConfirmation">Le mot de passe a été supprimé</string>
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Dernière modification : %1$s</string>
     <string name="autofillDisableAutofillPromptTitle">Voulez-vous continuer à enregistrer vos mots de passe ?</string>
@@ -152,13 +151,6 @@
     <string name="credentialManagementClearNeverForThisSiteDialogNegativeButton">Annuler</string>
 
     <string name="credentialManagementDeleteAllPasswordsMenu">Supprimer tous les mots de passe</string>
-    <plurals name="credentialManagementDeleteAllPasswordsConfirmationTitle" instruction="Placeholder is a number representing how many passwords will be deleted">
-        <item quantity="one">Voulez-vous vraiment supprimer %1$d mot de passe ?</item>
-        <item quantity="other">Voulez-vous vraiment supprimer %1$d mots de passe ?</item>
-    </plurals>
-
-    <string name="credentialManagementDeletePasswordConfirmationMessage">Votre mot de passe sera supprimé de tous les appareils synchronisés. Assurez-vous d\'avoir toujours un moyen d\'accéder à votre compte.</string>
-    <string name="credentialManagementDeleteAllPasswordsConfirmationMessage">Vos mots de passe seront supprimés de tous les appareils synchronisés. Assurez-vous d\'avoir toujours un moyen d\'accéder à vos comptes.</string>
 
     <plurals name="credentialManagementDeleteAllPasswordsSnackbarConfirmation" instruction="Placeholder is a number representing how many passwords were deleted">
         <item quantity="one">%1$d mot de passe supprimé</item>

--- a/autofill/autofill-impl/src/main/res/values-hr/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-hr/strings-autofill-impl.xml
@@ -126,7 +126,6 @@
     <string name="saveLoginDialogSubtitle">Lozinke su sigurno pohranjene na tvom uređaju.</string>
     <string name="autofillManagementAddLogin">Dodaj lozinku</string>
     <string name="credentialManagementEditLoginTitleHint">Naslov</string>
-    <string name="autofillDeleteLoginDialogTitle">Sigurno želiš izbrisati ovu lozinku?</string>
     <string name="autofillManagementDeletedConfirmation">Lozinka je izbrisana</string>
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Posljednje ažuriranje: %1$s</string>
     <string name="autofillDisableAutofillPromptTitle">Želiš li nastaviti spremati lozinke?</string>
@@ -152,15 +151,6 @@
     <string name="credentialManagementClearNeverForThisSiteDialogNegativeButton">Odustani</string>
 
     <string name="credentialManagementDeleteAllPasswordsMenu">Izbriši sve lozinke</string>
-    <plurals name="credentialManagementDeleteAllPasswordsConfirmationTitle" instruction="Placeholder is a number representing how many passwords will be deleted">
-        <item quantity="one">Sigurno želiš izbrisati %1$d lozinku?</item>
-        <item quantity="few">Sigurno želiš izbrisati %1$d lozinke?</item>
-        <item quantity="many">Sigurno želiš izbrisati %1$d lozinki?</item>
-        <item quantity="other">Sigurno želiš izbrisati %1$d lozinki?</item>
-    </plurals>
-
-    <string name="credentialManagementDeletePasswordConfirmationMessage">Tvoja lozinka bit će izbrisana sa svih sinkroniziranih uređaja. Uvjeri se da i dalje imaš način pristupa svom računu.</string>
-    <string name="credentialManagementDeleteAllPasswordsConfirmationMessage">Tvoje lozinke bit će izbrisane sa svih sinkroniziranih uređaja. Uvjeri se da i dalje imaš način pristupa svojim računima.</string>
 
     <plurals name="credentialManagementDeleteAllPasswordsSnackbarConfirmation" instruction="Placeholder is a number representing how many passwords were deleted">
         <item quantity="one">Izbrisana je %1$d lozinka</item>

--- a/autofill/autofill-impl/src/main/res/values-hu/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-hu/strings-autofill-impl.xml
@@ -126,7 +126,6 @@
     <string name="saveLoginDialogSubtitle">A jelszavakat az eszközöd biztonságosan tárolja.</string>
     <string name="autofillManagementAddLogin">Jelszó hozzáadása</string>
     <string name="credentialManagementEditLoginTitleHint">Cím</string>
-    <string name="autofillDeleteLoginDialogTitle">Biztosan törlöd ezt a jelszót?</string>
     <string name="autofillManagementDeletedConfirmation">Jelszó törölve</string>
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Utolsó frissítés: %1$s</string>
     <string name="autofillDisableAutofillPromptTitle">Továbbra is szeretnéd menteni a jelszavakat?</string>
@@ -152,13 +151,6 @@
     <string name="credentialManagementClearNeverForThisSiteDialogNegativeButton">Mégsem</string>
 
     <string name="credentialManagementDeleteAllPasswordsMenu">Minden jelszó törlése</string>
-    <plurals name="credentialManagementDeleteAllPasswordsConfirmationTitle" instruction="Placeholder is a number representing how many passwords will be deleted">
-        <item quantity="one">Biztosan törölni szeretnél %1$d jelszót?</item>
-        <item quantity="other">Biztosan törölni szeretnél %1$d jelszót?</item>
-    </plurals>
-
-    <string name="credentialManagementDeletePasswordConfirmationMessage">A jelszó az összes szinkronizált eszközről törölve lesz. Győződj meg róla, hogy továbbra is hozzáférsz a fiókodhoz.</string>
-    <string name="credentialManagementDeleteAllPasswordsConfirmationMessage">A jelszavak az összes szinkronizált eszközről törölve lesznek. Győződj meg róla, hogy továbbra is hozzáférsz a fiókjaidhoz.</string>
 
     <plurals name="credentialManagementDeleteAllPasswordsSnackbarConfirmation" instruction="Placeholder is a number representing how many passwords were deleted">
         <item quantity="one">%1$d jelszó törölve</item>

--- a/autofill/autofill-impl/src/main/res/values-it/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-it/strings-autofill-impl.xml
@@ -126,7 +126,6 @@
     <string name="saveLoginDialogSubtitle">Le password sono archiviate in modo sicuro sul tuo dispositivo.</string>
     <string name="autofillManagementAddLogin">Aggiungi password</string>
     <string name="credentialManagementEditLoginTitleHint">Titolo</string>
-    <string name="autofillDeleteLoginDialogTitle">Eliminare questa password?</string>
     <string name="autofillManagementDeletedConfirmation">Password eliminata</string>
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Ultimo aggiornamento %1$s</string>
     <string name="autofillDisableAutofillPromptTitle">Continuare a salvare le password?</string>
@@ -152,13 +151,6 @@
     <string name="credentialManagementClearNeverForThisSiteDialogNegativeButton">Annulla</string>
 
     <string name="credentialManagementDeleteAllPasswordsMenu">Elimina tutte le password</string>
-    <plurals name="credentialManagementDeleteAllPasswordsConfirmationTitle" instruction="Placeholder is a number representing how many passwords will be deleted">
-        <item quantity="one">Eliminare %1$d password?</item>
-        <item quantity="other">Eliminare %1$d password?</item>
-    </plurals>
-
-    <string name="credentialManagementDeletePasswordConfirmationMessage">La password verrà eliminata da tutti i dispositivi sincronizzati. Assicurati di avere ancora la possibilità di accedere al tuo account.</string>
-    <string name="credentialManagementDeleteAllPasswordsConfirmationMessage">Le password verranno eliminate da tutti i dispositivi sincronizzati. Assicurati di avere ancora la possibilità di accedere ai tuoi account.</string>
 
     <plurals name="credentialManagementDeleteAllPasswordsSnackbarConfirmation" instruction="Placeholder is a number representing how many passwords were deleted">
         <item quantity="one">%1$d password eliminata</item>

--- a/autofill/autofill-impl/src/main/res/values-lt/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-lt/strings-autofill-impl.xml
@@ -126,7 +126,6 @@
     <string name="saveLoginDialogSubtitle">Slaptažodžiai saugiai saugomi jūsų įrenginyje.</string>
     <string name="autofillManagementAddLogin">Pridėti slaptažodį</string>
     <string name="credentialManagementEditLoginTitleHint">Pavadinimas</string>
-    <string name="autofillDeleteLoginDialogTitle">Ar tikrai norite ištrinti šį slaptažodį?</string>
     <string name="autofillManagementDeletedConfirmation">Slaptažodis ištrintas</string>
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Paskutinį kartą atnaujinta %1$s</string>
     <string name="autofillDisableAutofillPromptTitle">Ar norite toliau saugoti slaptažodžius?</string>
@@ -152,15 +151,6 @@
     <string name="credentialManagementClearNeverForThisSiteDialogNegativeButton">Atšaukti</string>
 
     <string name="credentialManagementDeleteAllPasswordsMenu">Ištrinti visus slaptažodžius</string>
-    <plurals name="credentialManagementDeleteAllPasswordsConfirmationTitle" instruction="Placeholder is a number representing how many passwords will be deleted">
-        <item quantity="one">Ar tikrai norite ištrinti %1$d slaptažodį?</item>
-        <item quantity="few">Ar tikrai norite ištrinti %1$d slaptažodžius?</item>
-        <item quantity="many">Ar tikrai norite ištrinti %1$d slaptažodžio?</item>
-        <item quantity="other">Ar tikrai norite ištrinti %1$d slaptažodžių?</item>
-    </plurals>
-
-    <string name="credentialManagementDeletePasswordConfirmationMessage">Jūsų slaptažodis bus ištrintas iš visų sinchronizuojamų įrenginių. Įsitikinkite, kad vis dar turite būdą, kaip pasiekti paskyrą.</string>
-    <string name="credentialManagementDeleteAllPasswordsConfirmationMessage">Jūsų slaptažodžiai bus ištrinti iš visų sinchronizuojamų įrenginių. Įsitikinkite, kad vis dar turite būdą, kaip pasiekti paskyras.</string>
 
     <plurals name="credentialManagementDeleteAllPasswordsSnackbarConfirmation" instruction="Placeholder is a number representing how many passwords were deleted">
         <item quantity="one">%1$d slaptažodis ištrintas</item>

--- a/autofill/autofill-impl/src/main/res/values-lv/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-lv/strings-autofill-impl.xml
@@ -126,7 +126,6 @@
     <string name="saveLoginDialogSubtitle">Paroles tiek droši glabātas tavā ierīcē.</string>
     <string name="autofillManagementAddLogin">Pievienot paroli</string>
     <string name="credentialManagementEditLoginTitleHint">Nosaukums</string>
-    <string name="autofillDeleteLoginDialogTitle">Vai tiešām vēlies dzēst šo paroli?</string>
     <string name="autofillManagementDeletedConfirmation">Parole dzēsta</string>
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Pēdējoreiz atjaunināts %1$s</string>
     <string name="autofillDisableAutofillPromptTitle">Vai vēlaties turpināt saglabāt paroles?</string>
@@ -152,14 +151,6 @@
     <string name="credentialManagementClearNeverForThisSiteDialogNegativeButton">Atcelt</string>
 
     <string name="credentialManagementDeleteAllPasswordsMenu">Dzēst visas paroles</string>
-    <plurals name="credentialManagementDeleteAllPasswordsConfirmationTitle" instruction="Placeholder is a number representing how many passwords will be deleted">
-        <item quantity="zero">Vai tiešām vēlies dzēst %1$d paroles?</item>
-        <item quantity="one">Vai tiešām vēlies dzēst %1$d paroli?</item>
-        <item quantity="other">Vai tiešām vēlies dzēst %1$d paroles?</item>
-    </plurals>
-
-    <string name="credentialManagementDeletePasswordConfirmationMessage">Parole tiks dzēsta no visām sinhronizētajām ierīcēm. Pārliecinies, vai joprojām varēsi piekļūt savam kontam.</string>
-    <string name="credentialManagementDeleteAllPasswordsConfirmationMessage">Paroles tiks dzēstas no visām sinhronizētajām ierīcēm. Pārliecinies, vai joprojām varēsi piekļūt savam kontam.</string>
 
     <plurals name="credentialManagementDeleteAllPasswordsSnackbarConfirmation" instruction="Placeholder is a number representing how many passwords were deleted">
         <item quantity="zero">%1$d paroles izdzēstas</item>

--- a/autofill/autofill-impl/src/main/res/values-nb/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-nb/strings-autofill-impl.xml
@@ -126,7 +126,6 @@
     <string name="saveLoginDialogSubtitle">Passord lagres på enheten din på en sikker måte.</string>
     <string name="autofillManagementAddLogin">Legg til passord</string>
     <string name="credentialManagementEditLoginTitleHint">Tittel</string>
-    <string name="autofillDeleteLoginDialogTitle">Er du sikker på at du vil slette dette passordet?</string>
     <string name="autofillManagementDeletedConfirmation">Passordet er slettet</string>
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Sist oppdatert %1$s</string>
     <string name="autofillDisableAutofillPromptTitle">Vil du fortsette å lagre passord?</string>
@@ -152,13 +151,6 @@
     <string name="credentialManagementClearNeverForThisSiteDialogNegativeButton">Avbryt</string>
 
     <string name="credentialManagementDeleteAllPasswordsMenu">Slett alle passord</string>
-    <plurals name="credentialManagementDeleteAllPasswordsConfirmationTitle" instruction="Placeholder is a number representing how many passwords will be deleted">
-        <item quantity="one">Er du sikker på at du vil slette %1$d passord?</item>
-        <item quantity="other">Er du sikker på at du vil slette %1$d passord?</item>
-    </plurals>
-
-    <string name="credentialManagementDeletePasswordConfirmationMessage">Passordet ditt blir slettet fra alle synkroniserte enheter. Sørg for at du fortsatt har tilgang til kontoen din.</string>
-    <string name="credentialManagementDeleteAllPasswordsConfirmationMessage">Passordene dine slettes fra alle synkroniserte enheter. Sørg for at du fortsatt har tilgang til kontoene dine.</string>
 
     <plurals name="credentialManagementDeleteAllPasswordsSnackbarConfirmation" instruction="Placeholder is a number representing how many passwords were deleted">
         <item quantity="one">%1$d passord er slettet</item>

--- a/autofill/autofill-impl/src/main/res/values-nl/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-nl/strings-autofill-impl.xml
@@ -126,7 +126,6 @@
     <string name="saveLoginDialogSubtitle">Wachtwoorden worden veilig opgeslagen op je apparaat.</string>
     <string name="autofillManagementAddLogin">Wachtwoord toevoegen</string>
     <string name="credentialManagementEditLoginTitleHint">Titel</string>
-    <string name="autofillDeleteLoginDialogTitle">Weet je zeker dat je dit wachtwoord wilt verwijderen?</string>
     <string name="autofillManagementDeletedConfirmation">Wachtwoord verwijderd</string>
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Laatst bijgewerkt op %1$s</string>
     <string name="autofillDisableAutofillPromptTitle">Wil je wachtwoorden blijven opslaan?</string>
@@ -152,13 +151,6 @@
     <string name="credentialManagementClearNeverForThisSiteDialogNegativeButton">Annuleren</string>
 
     <string name="credentialManagementDeleteAllPasswordsMenu">Alle wachtwoorden verwijderen</string>
-    <plurals name="credentialManagementDeleteAllPasswordsConfirmationTitle" instruction="Placeholder is a number representing how many passwords will be deleted">
-        <item quantity="one">Weet je zeker dat je %1$d wachtwoord wilt verwijderen?</item>
-        <item quantity="other">Weet je zeker dat je %1$d wachtwoorden wilt verwijderen?</item>
-    </plurals>
-
-    <string name="credentialManagementDeletePasswordConfirmationMessage">Je wachtwoord wordt verwijderd van alle gesynchroniseerde apparaten. Zorg ervoor dat je nog steeds toegang hebt tot je account.</string>
-    <string name="credentialManagementDeleteAllPasswordsConfirmationMessage">Je wachtwoorden worden verwijderd van alle gesynchroniseerde apparaten. Zorg ervoor dat je nog steeds toegang hebt tot je accounts.</string>
 
     <plurals name="credentialManagementDeleteAllPasswordsSnackbarConfirmation" instruction="Placeholder is a number representing how many passwords were deleted">
         <item quantity="one">%1$d wachtwoord verwijderd</item>

--- a/autofill/autofill-impl/src/main/res/values-pl/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-pl/strings-autofill-impl.xml
@@ -126,7 +126,6 @@
     <string name="saveLoginDialogSubtitle">Hasła są bezpiecznie przechowywane na Twoim urządzeniu.</string>
     <string name="autofillManagementAddLogin">Dodaj hasło</string>
     <string name="credentialManagementEditLoginTitleHint">Tytuł</string>
-    <string name="autofillDeleteLoginDialogTitle">Czy na pewno chcesz usunąć to hasło?</string>
     <string name="autofillManagementDeletedConfirmation">Hasło usunięte</string>
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Ostatnia aktualizacja %1$s</string>
     <string name="autofillDisableAutofillPromptTitle">Czy chcesz nadal zapisywać hasła?</string>
@@ -152,15 +151,6 @@
     <string name="credentialManagementClearNeverForThisSiteDialogNegativeButton">Anuluj</string>
 
     <string name="credentialManagementDeleteAllPasswordsMenu">Usuń wszystkie hasła</string>
-    <plurals name="credentialManagementDeleteAllPasswordsConfirmationTitle" instruction="Placeholder is a number representing how many passwords will be deleted">
-        <item quantity="one">Czy na pewno chcesz usunąć %1$d hasło?</item>
-        <item quantity="few">Czy na pewno chcesz usunąć %1$d hasła?</item>
-        <item quantity="many">Czy na pewno chcesz usunąć %1$d haseł?</item>
-        <item quantity="other">Czy na pewno chcesz usunąć %1$d hasła?</item>
-    </plurals>
-
-    <string name="credentialManagementDeletePasswordConfirmationMessage">Twoje hasło zostanie usunięte ze wszystkich zsynchronizowanych urządzeń. Upewnij się, że nadal masz możliwość dostępu do swojego konta.</string>
-    <string name="credentialManagementDeleteAllPasswordsConfirmationMessage">Twoje hasła zostaną usunięte ze wszystkich zsynchronizowanych urządzeń. Upewnij się, że nadal masz możliwość dostępu do swoich kont.</string>
 
     <plurals name="credentialManagementDeleteAllPasswordsSnackbarConfirmation" instruction="Placeholder is a number representing how many passwords were deleted">
         <item quantity="one">Usunięto %1$d hasło</item>

--- a/autofill/autofill-impl/src/main/res/values-pt/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-pt/strings-autofill-impl.xml
@@ -126,7 +126,6 @@
     <string name="saveLoginDialogSubtitle">As palavras-passe são armazenadas com segurança no teu dispositivo.</string>
     <string name="autofillManagementAddLogin">Adicionar palavra-passe</string>
     <string name="credentialManagementEditLoginTitleHint">Título</string>
-    <string name="autofillDeleteLoginDialogTitle">Tens a certeza de que pretendes eliminar esta palavra-passe?</string>
     <string name="autofillManagementDeletedConfirmation">Palavra-passe eliminada</string>
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Última atualização a %1$s</string>
     <string name="autofillDisableAutofillPromptTitle">Pretendes continuar a guardar palavras-passe?</string>
@@ -152,13 +151,6 @@
     <string name="credentialManagementClearNeverForThisSiteDialogNegativeButton">Cancelar</string>
 
     <string name="credentialManagementDeleteAllPasswordsMenu">Eliminar todas as palavras-passe</string>
-    <plurals name="credentialManagementDeleteAllPasswordsConfirmationTitle" instruction="Placeholder is a number representing how many passwords will be deleted">
-        <item quantity="one">Tens a certeza de que pretendes eliminar %1$d palavra-passe?</item>
-        <item quantity="other">Tens a certeza de que pretendes eliminar %1$d palavras-passe?</item>
-    </plurals>
-
-    <string name="credentialManagementDeletePasswordConfirmationMessage">A tua palavra-passe será eliminada de todos os dispositivos sincronizados. Confirma que ainda tens uma forma de aceder à conta.</string>
-    <string name="credentialManagementDeleteAllPasswordsConfirmationMessage">As tuas palavras-passe serão eliminadas de todos os dispositivos sincronizados. Confirma que ainda tens uma forma de aceder às contas.</string>
 
     <plurals name="credentialManagementDeleteAllPasswordsSnackbarConfirmation" instruction="Placeholder is a number representing how many passwords were deleted">
         <item quantity="one">%1$d palavra-passe eliminada</item>

--- a/autofill/autofill-impl/src/main/res/values-ro/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-ro/strings-autofill-impl.xml
@@ -126,7 +126,6 @@
     <string name="saveLoginDialogSubtitle">Parolele sunt stocate în siguranță pe dispozitivul tău.</string>
     <string name="autofillManagementAddLogin">Adaugă parola</string>
     <string name="credentialManagementEditLoginTitleHint">Titlu</string>
-    <string name="autofillDeleteLoginDialogTitle">Sigur dorești să ștergi această parolă?</string>
     <string name="autofillManagementDeletedConfirmation">Parolă ștearsă</string>
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Ultima actualizare %1$s</string>
     <string name="autofillDisableAutofillPromptTitle">Dorești să continui să salvezi parolele?</string>
@@ -152,14 +151,6 @@
     <string name="credentialManagementClearNeverForThisSiteDialogNegativeButton">Anulare</string>
 
     <string name="credentialManagementDeleteAllPasswordsMenu">Șterge toate parolele</string>
-    <plurals name="credentialManagementDeleteAllPasswordsConfirmationTitle" instruction="Placeholder is a number representing how many passwords will be deleted">
-        <item quantity="one">Sigur dorești să ștergi %1$d parolă?</item>
-        <item quantity="few">Sigur dorești să ștergi %1$d parole?</item>
-        <item quantity="other">Sigur dorești să ștergi această %1$d de parole?</item>
-    </plurals>
-
-    <string name="credentialManagementDeletePasswordConfirmationMessage">Parola ta va fi ștearsă de pe toate dispozitivele sincronizate. Asigură-te că ai în continuare posibilitatea de a-ți accesa contul.</string>
-    <string name="credentialManagementDeleteAllPasswordsConfirmationMessage">Parolele tale vor fi șterse de pe toate dispozitivele sincronizate. Asigură-te că ai în continuare posibilitatea de a-ți accesa conturile.</string>
 
     <plurals name="credentialManagementDeleteAllPasswordsSnackbarConfirmation" instruction="Placeholder is a number representing how many passwords were deleted">
         <item quantity="one">%1$d parolă ștearsă</item>

--- a/autofill/autofill-impl/src/main/res/values-ru/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-ru/strings-autofill-impl.xml
@@ -126,7 +126,6 @@
     <string name="saveLoginDialogSubtitle">Пароли надежно защищены и хранятся на вашем устройстве.</string>
     <string name="autofillManagementAddLogin">Добавление пароля</string>
     <string name="credentialManagementEditLoginTitleHint">Название</string>
-    <string name="autofillDeleteLoginDialogTitle">Вы точно хотите удалить этот пароль?</string>
     <string name="autofillManagementDeletedConfirmation">Пароль удален</string>
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Последнее обновление: %1$s</string>
     <string name="autofillDisableAutofillPromptTitle">Продолжить сохранять пароли?</string>
@@ -152,15 +151,6 @@
     <string name="credentialManagementClearNeverForThisSiteDialogNegativeButton">Отменить</string>
 
     <string name="credentialManagementDeleteAllPasswordsMenu">Удалить все пароли</string>
-    <plurals name="credentialManagementDeleteAllPasswordsConfirmationTitle" instruction="Placeholder is a number representing how many passwords will be deleted">
-        <item quantity="one">Вы точно хотите удалить %1$d пароль?</item>
-        <item quantity="few">Вы точно хотите удалить %1$d пароля?</item>
-        <item quantity="many">Вы точно хотите удалить %1$d паролей?</item>
-        <item quantity="other">Вы точно хотите удалить пароли (%1$d)?</item>
-    </plurals>
-
-    <string name="credentialManagementDeletePasswordConfirmationMessage">Пароль будет удален со всех синхронизированных устройств. Обязательно убедитесь, что вы можете войти в свою учетную запись другим способом.</string>
-    <string name="credentialManagementDeleteAllPasswordsConfirmationMessage">Пароли будут удалены со всех синхронизированных устройств. Убедитесь, что вы по-прежнему можете войти в свои учетные записи.</string>
 
     <plurals name="credentialManagementDeleteAllPasswordsSnackbarConfirmation" instruction="Placeholder is a number representing how many passwords were deleted">
         <item quantity="one">Удален %1$d пароль</item>

--- a/autofill/autofill-impl/src/main/res/values-sk/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-sk/strings-autofill-impl.xml
@@ -126,7 +126,6 @@
     <string name="saveLoginDialogSubtitle">Heslá sú zabezpečeným spôsobom uložené vo vašom zariadení.</string>
     <string name="autofillManagementAddLogin">Pridať heslo</string>
     <string name="credentialManagementEditLoginTitleHint">Názov</string>
-    <string name="autofillDeleteLoginDialogTitle">Naozaj chcete odstrániť toto heslo?</string>
     <string name="autofillManagementDeletedConfirmation">Heslo bolo odstránené</string>
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Naposledy aktualizované %1$s</string>
     <string name="autofillDisableAutofillPromptTitle">Chcete pokračovať v ukladaní hesiel?</string>
@@ -152,15 +151,6 @@
     <string name="credentialManagementClearNeverForThisSiteDialogNegativeButton">Zrušiť</string>
 
     <string name="credentialManagementDeleteAllPasswordsMenu">Odstránenie všetkých hesiel</string>
-    <plurals name="credentialManagementDeleteAllPasswordsConfirmationTitle" instruction="Placeholder is a number representing how many passwords will be deleted">
-        <item quantity="one">Naozaj chcete odstrániť %1$d heslo?</item>
-        <item quantity="few">Naozaj chcete odstrániť %1$d heslá?</item>
-        <item quantity="many">Naozaj chcete odstrániť %1$d hesla?</item>
-        <item quantity="other">Naozaj chcete odstrániť %1$d hesiel?</item>
-    </plurals>
-
-    <string name="credentialManagementDeletePasswordConfirmationMessage">Vaše heslo sa odstráni zo všetkých synchronizovaných zariadení. Zabezpečte si prístup k svojmu účtu.</string>
-    <string name="credentialManagementDeleteAllPasswordsConfirmationMessage">Vaše heslá sa odstránia zo všetkých synchronizovaných zariadení. Zabezpečte si prístup k svojim účtom.</string>
 
     <plurals name="credentialManagementDeleteAllPasswordsSnackbarConfirmation" instruction="Placeholder is a number representing how many passwords were deleted">
         <item quantity="one">Bolo odstránené %1$d heslo</item>

--- a/autofill/autofill-impl/src/main/res/values-sl/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-sl/strings-autofill-impl.xml
@@ -126,7 +126,6 @@
     <string name="saveLoginDialogSubtitle">Gesla so varno shranjena v vaši napravi.</string>
     <string name="autofillManagementAddLogin">Dodajte geslo</string>
     <string name="credentialManagementEditLoginTitleHint">Naslov</string>
-    <string name="autofillDeleteLoginDialogTitle">Ali ste prepričani, da želite izbrisati to geslo?</string>
     <string name="autofillManagementDeletedConfirmation">Geslo je izbrisano</string>
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Nazadnje posodobljeno dne %1$s</string>
     <string name="autofillDisableAutofillPromptTitle">Ali želite še naprej shranjevati gesla?</string>
@@ -152,15 +151,6 @@
     <string name="credentialManagementClearNeverForThisSiteDialogNegativeButton">Prekliči</string>
 
     <string name="credentialManagementDeleteAllPasswordsMenu">Brisanje vseh gesel</string>
-    <plurals name="credentialManagementDeleteAllPasswordsConfirmationTitle" instruction="Placeholder is a number representing how many passwords will be deleted">
-        <item quantity="one">Ali ste prepričani, da želite izbrisati %1$d geslo?</item>
-        <item quantity="two">Ali ste prepričani, da želite izbrisati %1$d gesli?</item>
-        <item quantity="few">Ali ste prepričani, da želite izbrisati %1$d gesla?</item>
-        <item quantity="other">Ali ste prepričani, da želite izbrisati %1$d gesel?</item>
-    </plurals>
-
-    <string name="credentialManagementDeletePasswordConfirmationMessage">Vaše geslo bo izbrisano iz vseh sinhroniziranih naprav. Prepričajte se, da imate še vedno možnost dostopa do svojega računa.</string>
-    <string name="credentialManagementDeleteAllPasswordsConfirmationMessage">Vaša gesla bodo izbrisana iz vseh sinhroniziranih naprav. Prepričajte se, da imate še vedno možnost dostopa do svojih računov.</string>
 
     <plurals name="credentialManagementDeleteAllPasswordsSnackbarConfirmation" instruction="Placeholder is a number representing how many passwords were deleted">
         <item quantity="one">%1$d geslo je bilo izbrisano</item>

--- a/autofill/autofill-impl/src/main/res/values-sv/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-sv/strings-autofill-impl.xml
@@ -126,7 +126,6 @@
     <string name="saveLoginDialogSubtitle">Lösenord lagras säkert på din enhet.</string>
     <string name="autofillManagementAddLogin">Lägg till lösenord</string>
     <string name="credentialManagementEditLoginTitleHint">Rubrik</string>
-    <string name="autofillDeleteLoginDialogTitle">Är du säker på att du vill radera detta lösenord?</string>
     <string name="autofillManagementDeletedConfirmation">Lösenordet har raderats</string>
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Uppdaterades senast %1$s</string>
     <string name="autofillDisableAutofillPromptTitle">Vill du fortsätta spara lösenord?</string>
@@ -152,13 +151,6 @@
     <string name="credentialManagementClearNeverForThisSiteDialogNegativeButton">Avbryt</string>
 
     <string name="credentialManagementDeleteAllPasswordsMenu">Radera alla lösenord</string>
-    <plurals name="credentialManagementDeleteAllPasswordsConfirmationTitle" instruction="Placeholder is a number representing how many passwords will be deleted">
-        <item quantity="one">Är du säker på att du vill radera %1$d lösenord?</item>
-        <item quantity="other">Är du säker på att du vill radera %1$d lösenord?</item>
-    </plurals>
-
-    <string name="credentialManagementDeletePasswordConfirmationMessage">Ditt lösenord kommer att raderas från alla synkroniserade enheter. Se till att du har kvar ett sätt att komma åt ditt konto.</string>
-    <string name="credentialManagementDeleteAllPasswordsConfirmationMessage">Dina lösenord raderas från alla synkroniserade enheter. Se till att du har kvar ett sätt att komma åt dina konton.</string>
 
     <plurals name="credentialManagementDeleteAllPasswordsSnackbarConfirmation" instruction="Placeholder is a number representing how many passwords were deleted">
         <item quantity="one">%1$d lösenord raderat</item>

--- a/autofill/autofill-impl/src/main/res/values-tr/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-tr/strings-autofill-impl.xml
@@ -126,7 +126,6 @@
     <string name="saveLoginDialogSubtitle">Şifreler cihazınızda güvenli bir şekilde saklanır.</string>
     <string name="autofillManagementAddLogin">Şifre Ekle</string>
     <string name="credentialManagementEditLoginTitleHint">Title</string>
-    <string name="autofillDeleteLoginDialogTitle">Bu şifreyi silmek istediğinizden emin misiniz?</string>
     <string name="autofillManagementDeletedConfirmation">Şifre silindi</string>
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Son güncelleme %1$s</string>
     <string name="autofillDisableAutofillPromptTitle">Şifreleri kaydetmeye devam etmek istiyor musunuz?</string>
@@ -152,13 +151,6 @@
     <string name="credentialManagementClearNeverForThisSiteDialogNegativeButton">Vazgeç</string>
 
     <string name="credentialManagementDeleteAllPasswordsMenu">Tüm Şifreleri Sil</string>
-    <plurals name="credentialManagementDeleteAllPasswordsConfirmationTitle" instruction="Placeholder is a number representing how many passwords will be deleted">
-        <item quantity="one">Bu %1$d şifreyi silmek istediğinizden emin misiniz?</item>
-        <item quantity="other">Bu %1$d şifreyi silmek istediğinizden emin misiniz?</item>
-    </plurals>
-
-    <string name="credentialManagementDeletePasswordConfirmationMessage">Şifreniz senkronize edilen tüm cihazlardan silinecek. Hesabınıza başka bir şekilde erişebilecek olduğunuzdan emin olun.</string>
-    <string name="credentialManagementDeleteAllPasswordsConfirmationMessage">Şifreleriniz senkronize edilen tüm cihazlardan silinecektir. Hesaplarınıza başka bir şekilde erişebilecek olduğunuzdan emin olun.</string>
 
     <plurals name="credentialManagementDeleteAllPasswordsSnackbarConfirmation" instruction="Placeholder is a number representing how many passwords were deleted">
         <item quantity="one">%1$d şifre silindi</item>

--- a/autofill/autofill-impl/src/main/res/values/donottranslate.xml
+++ b/autofill/autofill-impl/src/main/res/values/donottranslate.xml
@@ -15,4 +15,24 @@
   -->
 
 <resources>
+
+    <string name="credentialManagementDeleteAllPasswordsDialogFirstInstructionNotSyncedSingular">Your password will be deleted from this device.</string>
+    <plurals name="credentialManagementDeleteAllPasswordsDialogFirstInstructionNotSyncedPlural">
+        <item quantity="other">Your passwords will be deleted from this device.</item>
+    </plurals>
+
+    <string name="credentialManagementDeleteAllPasswordsFirstInstructionSyncedSingular">Your password will be deleted from all synced devices.</string>
+    <plurals name="credentialManagementDeleteAllPasswordsFirstInstructionSyncedPlural">
+        <item quantity="other">Your passwords will be deleted from all synced devices.</item>
+    </plurals>
+
+    <string name="credentialManagementDeleteAllPasswordsDialogConfirmationTitleSingular">Are you sure you want to delete this password?</string>
+    <plurals name="credentialManagementDeleteAllPasswordsDialogConfirmationTitlePlural" instruction="Placeholder is a number representing how many passwords will be deleted">
+        <item quantity="other">Are you sure you want to delete %1$d passwords?</item>
+    </plurals>
+
+    <string name="credentialManagementDeleteAllSecondInstructionSingular">Make sure you still have a way to access your account.</string>
+    <plurals name="credentialManagementDeleteAllSecondInstructionPlural">
+        <item quantity="other">Make sure you still have a way to access your accounts.</item>
+    </plurals>
 </resources>

--- a/autofill/autofill-impl/src/main/res/values/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values/strings-autofill-impl.xml
@@ -126,7 +126,6 @@
     <string name="saveLoginDialogSubtitle">Passwords are stored securely on your device.</string>
     <string name="autofillManagementAddLogin">Add Password</string>
     <string name="credentialManagementEditLoginTitleHint">Title</string>
-    <string name="autofillDeleteLoginDialogTitle">Are you sure you want to delete this password?</string>
     <string name="autofillManagementDeletedConfirmation">Password deleted</string>
     <string name="credentialManagementEditLastUpdated" instruction="Placeholder is a date">Last updated %1$s</string>
     <string name="autofillDisableAutofillPromptTitle">Do you want to keep saving passwords?</string>
@@ -152,12 +151,6 @@
     <string name="credentialManagementClearNeverForThisSiteDialogNegativeButton">Cancel</string>
 
     <string name="credentialManagementDeleteAllPasswordsMenu">Delete All Passwords</string>
-    <plurals name="credentialManagementDeleteAllPasswordsConfirmationTitle" instruction="Placeholder is a number representing how many passwords will be deleted">
-        <item quantity="other">Are you sure you want to delete %1$d passwords?</item>
-    </plurals>
-
-    <string name="credentialManagementDeletePasswordConfirmationMessage">Your password will be deleted from all synced devices. Make sure you still have a way to access your account.</string>
-    <string name="credentialManagementDeleteAllPasswordsConfirmationMessage">Your passwords will be deleted from all synced devices. Make sure you still have a way to access your accounts.</string>
 
     <plurals name="credentialManagementDeleteAllPasswordsSnackbarConfirmation" instruction="Placeholder is a number representing how many passwords were deleted">
         <item quantity="one">%1$d password deleted</item>

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementStringBuilderImplTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementStringBuilderImplTest.kt
@@ -1,0 +1,87 @@
+package com.duckduckgo.autofill.impl.ui.credential.management.viewing
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.sync.api.DeviceSyncState
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class AutofillManagementStringBuilderImplTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+    private val deviceSyncState: DeviceSyncState = mock()
+
+    private val testee = AutofillManagementStringBuilderImpl(
+        context = context,
+        deviceSyncState = deviceSyncState,
+        dispatchers = coroutineTestRule.testDispatcherProvider,
+    )
+
+    @Test
+    fun whenDeletingOneLoginThenBuildsCorrectTitle() {
+        val str = testee.stringForDeletePasswordDialogConfirmationTitle(numberToDelete = 1)
+        assertEquals(DELETE_DIALOG_TITLE_1_PASSWORD, str)
+    }
+
+    @Test
+    fun whenDeletingMultipleLoginsThenBuildsCorrectTitle() {
+        val str = testee.stringForDeletePasswordDialogConfirmationTitle(numberToDelete = 2)
+        assertEquals(DELETE_DIALOG_TITLE_2_PASSWORDS, str)
+    }
+
+    @Test
+    fun whenDeletingOneLoginWithSyncEnabledThenBuildsCorrectMessage() = runTest {
+        configureSyncState(enabled = true)
+        val str = testee.stringForDeletePasswordDialogConfirmationMessage(numberToDelete = 1)
+        assertEquals("$DELETE_DIALOG_MESSAGE_1_SYNC_ENABLED_SINGULAR $DELETE_DIALOG_MESSAGE_2_SINGULAR", str)
+    }
+
+    @Test
+    fun whenDeletingOneLoginWithSyncDisabledThenBuildsCorrectMessage() = runTest {
+        configureSyncState(enabled = false)
+        val str = testee.stringForDeletePasswordDialogConfirmationMessage(numberToDelete = 1)
+        assertEquals("$DELETE_DIALOG_MESSAGE_1_SYNC_DISABLED_SINGULAR $DELETE_DIALOG_MESSAGE_2_SINGULAR", str)
+    }
+
+    @Test
+    fun whenDeletingTwoLoginsWithSyncEnabledThenBuildsCorrectMessage() = runTest {
+        configureSyncState(enabled = true)
+        val str = testee.stringForDeletePasswordDialogConfirmationMessage(numberToDelete = 2)
+        assertEquals("$DELETE_DIALOG_MESSAGE_1_SYNC_ENABLED_PLURAL $DELETE_DIALOG_MESSAGE_2_PLURAL", str)
+    }
+
+    @Test
+    fun whenDeletingTwoLoginsWithSyncDisabledThenBuildsCorrectMessage() = runTest {
+        configureSyncState(enabled = false)
+        val str = testee.stringForDeletePasswordDialogConfirmationMessage(numberToDelete = 2)
+        assertEquals("$DELETE_DIALOG_MESSAGE_1_SYNC_DISABLED_PLURAL $DELETE_DIALOG_MESSAGE_2_PLURAL", str)
+    }
+
+    private fun configureSyncState(enabled: Boolean) {
+        whenever(deviceSyncState.isUserSignedInOnDevice()).thenReturn(enabled)
+    }
+
+    private companion object {
+        private const val DELETE_DIALOG_TITLE_1_PASSWORD = "Are you sure you want to delete this password?"
+        private const val DELETE_DIALOG_TITLE_2_PASSWORDS = "Are you sure you want to delete 2 passwords?"
+
+        private const val DELETE_DIALOG_MESSAGE_1_SYNC_ENABLED_SINGULAR = "Your password will be deleted from all synced devices."
+        private const val DELETE_DIALOG_MESSAGE_1_SYNC_ENABLED_PLURAL = "Your passwords will be deleted from all synced devices."
+
+        private const val DELETE_DIALOG_MESSAGE_1_SYNC_DISABLED_SINGULAR = "Your password will be deleted from this device."
+        private const val DELETE_DIALOG_MESSAGE_1_SYNC_DISABLED_PLURAL = "Your passwords will be deleted from this device."
+
+        private const val DELETE_DIALOG_MESSAGE_2_SINGULAR = "Make sure you still have a way to access your account."
+        private const val DELETE_DIALOG_MESSAGE_2_PLURAL = "Make sure you still have a way to access your accounts."
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1206638124888258/f 

### Description
Copy changes around deleting passwords (now showing a different message when sync is enabled vs disabled). 

Translations will come in https://github.com/duckduckgo/Android/pull/4446

# Steps to test this PR

## Sync Disabled

### single saved password
- [ ] Disable sync (or leave it disabled if off already)
- [ ] Visit password management screen (overflow -> passwords)
- [ ] Add a single saved password (so you only have 1 total). 
- [ ] Return to password management screen
- [ ] Then choose overflow -> Delete All Passwords
- [ ] Verify the dialog title is **Are you sure you want to delete this password?**
- [ ] Verify the dialog message says "password" (singular) and "account" (singular)
- [ ] Verify the dialog message says it'll be "deleted from this device"
- [ ] Cancel the prompt. Click on the overflow of the saved password, and choose **Delete**. Ensure the last two checks you just did are still valid for this scenario.


### multiple saved passwords
- [ ] Add a second saved password (so you now have 2 total), and return to password management screen
- [ ] Then choose overflow -> Delete All Passwords
- [ ] Verify the dialog title is **Are you sure you want to delete 2 passwords**
- [ ] Verify the dialog message says "password**s**" and "account**s**"
- [ ] Verify the dialog message says it'll be "deleted from this device"


## Sync Enabled

### multiple saved passwords
- [ ] Enable sync
- [ ] Visit password management screen (overflow -> passwords). Ensure you have > 1 saved password.
- [ ] Then choose overflow -> Delete All Passwords
- [ ] Verify the dialog title is **Are you sure you want to delete 2 passwords**
- [ ] Verify the dialog message says "password**s**" and "account**s**"
- [ ] Verify the dialog message says it'll be "deleted from all synced devices"

### single saved password
- [ ] Enable sync
- [ ] Visit password management screen (overflow -> passwords). Ensure you have exactly 1 saved password.
- [ ] Then choose overflow -> Delete All Passwords
- [ ] Verify the dialog title is **Are you sure you want to delete this password?**
- [ ] Verify the dialog message says "password" (singular) and "account" (singular)
- [ ] Verify the dialog message says it'll be "deleted from all synced devices"
