### PR TITLE
cancel previous notifs ID before showing new one

### DIFF
--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/notification/NotificationUtils.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/notification/NotificationUtils.kt
@@ -29,6 +29,7 @@ fun NotificationManagerCompat.checkPermissionAndNotify(
     notification: Notification,
 ) {
     if (ActivityCompat.checkSelfPermission(context, POST_NOTIFICATIONS) == PERMISSION_GRANTED) {
+        cancel(id) // ensure previous notifications with same ID are dismissed
         notify(id, notification)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207068928136802/f

### Description
Ensure previous notifs are cancel before showing new ones. This seems to trip in some OEMs

### Steps to test this PR
smoke test VPN/AppTP notifs
