### PR TITLE
Add VPN state to broken sites report

### DIFF
--- a/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesMultipleReportReferenceTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesMultipleReportReferenceTest.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.test.FileUtilities
 import com.duckduckgo.experiments.api.VariantManager
 import com.duckduckgo.feature.toggles.api.FeatureToggle
+import com.duckduckgo.networkprotection.api.NetworkProtectionState
 import com.duckduckgo.privacy.config.api.Gpc
 import com.duckduckgo.privacy.config.api.PrivacyConfig
 import com.duckduckgo.privacy.config.api.PrivacyConfigData
@@ -84,6 +85,8 @@ class BrokenSitesMultipleReportReferenceTest(private val testCase: MultipleRepor
 
     private val mockBrokenSiteLastSentReport: BrokenSiteLastSentReport = mock()
 
+    private val networkProtectionState: NetworkProtectionState = mock()
+
     private val privacyProtectionsPopupExperimentExternalPixels: PrivacyProtectionsPopupExperimentExternalPixels = mock {
         runBlocking { whenever(mock.getPixelParams()).thenReturn(emptyMap()) }
     }
@@ -113,6 +116,8 @@ class BrokenSitesMultipleReportReferenceTest(private val testCase: MultipleRepor
     @Before
     fun before() {
         MockitoAnnotations.openMocks(this)
+        runBlocking { whenever(networkProtectionState.isRunning()) }.thenReturn(false)
+
         testee = BrokenSiteSubmitter(
             mockStatisticsDataStore,
             mockVariantManager,
@@ -129,6 +134,7 @@ class BrokenSitesMultipleReportReferenceTest(private val testCase: MultipleRepor
             mock(),
             mockBrokenSiteLastSentReport,
             privacyProtectionsPopupExperimentExternalPixels,
+            networkProtectionState,
         )
     }
 

--- a/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesReferenceTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesReferenceTest.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.test.FileUtilities
 import com.duckduckgo.experiments.api.VariantManager
 import com.duckduckgo.feature.toggles.api.FeatureToggle
+import com.duckduckgo.networkprotection.api.NetworkProtectionState
 import com.duckduckgo.privacy.config.api.Gpc
 import com.duckduckgo.privacy.config.api.PrivacyConfig
 import com.duckduckgo.privacy.config.api.PrivacyConfigData
@@ -82,6 +83,8 @@ class BrokenSitesReferenceTest(private val testCase: TestCase) {
 
     private val mockUserAllowListRepository: UserAllowListRepository = mock()
 
+    private val networkProtectionState: NetworkProtectionState = mock()
+
     private val privacyProtectionsPopupExperimentExternalPixels: PrivacyProtectionsPopupExperimentExternalPixels = mock {
         runBlocking { whenever(mock.getPixelParams()).thenReturn(emptyMap()) }
     }
@@ -110,6 +113,8 @@ class BrokenSitesReferenceTest(private val testCase: TestCase) {
     fun before() {
         MockitoAnnotations.openMocks(this)
         whenever(mockAppBuildConfig.deviceLocale).thenReturn(Locale.ENGLISH)
+        runBlocking { whenever(networkProtectionState.isRunning()) }.thenReturn(false)
+
         testee = BrokenSiteSubmitter(
             mockStatisticsDataStore,
             mockVariantManager,
@@ -126,6 +131,7 @@ class BrokenSitesReferenceTest(private val testCase: TestCase) {
             mock(),
             mock(),
             privacyProtectionsPopupExperimentExternalPixels,
+            networkProtectionState,
         )
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207135101272466/f

### Description
Send `vpnOn` parameter to broken site reports

### Steps to test this PR
- [x] install this build and launch app
- [x] enable VPN
- [x] load a page and send broken site report (logcat filter by `vpnOn`
- [x] verify that `epbf` pixel is seng and contains `vpnOn` param to `true`
- [ ] disable VPN and send broken site report
- [ ] verify that `epbf` pixel is seng and contains `vpnOn` param to `false`
