### PR TITLE
Update content scope scripts to version 5.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^10.5.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#11.0.1",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.12.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.13.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#3.5.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1708702034"
       },
@@ -60,16 +60,16 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "10.6.1",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-10.6.1.tgz",
-      "integrity": "sha512-ptgT0sp4zmQTZHAyGR9TN/WJT9W7kTb/yvaF20FwwSIcLKd2xLe2jCDwbGTaLVSqAixWDKqzZ1Dg3l7HE159Sw=="
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-10.6.2.tgz",
+      "integrity": "sha512-d1AZePYIiheZt+RI9OV3s4LW2woNl4XSrQNqY0TYHfSessK1Y/a0aFpTXYdvPIH2JWw48jVS0XGRk1P1tSK+4w=="
     },
     "node_modules/@duckduckgo/autofill": {
       "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#6053999d6af384a716ab0ce7205dbab5d70ed1b3",
       "hasInstallScript": true
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#1bb3bc5eb565735051f342a87b5405d4374876c7",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#673533082f9200ec4c6422dc929973c5b31d855d",
       "hasInstallScript": true,
       "workspaces": [
         "packages/special-pages",
@@ -90,8 +90,7 @@
       }
     },
     "node_modules/@duckduckgo/privacy-reference-tests": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#a603ff9af22ca3ff7ce2e7ffbfe18c447d9f23e8",
-      "license": "Apache-2.0"
+      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#a603ff9af22ca3ff7ce2e7ffbfe18c447d9f23e8"
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.5",
@@ -267,9 +266,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.11.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz",
-      "integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
+      "version": "20.12.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
+      "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -1076,9 +1075,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.30.0.tgz",
-      "integrity": "sha512-Y/SblUl5kEyEFzhMAQdsxVHh+utAxd4IuRNJzKywY/4uzSogh3G219jqbDDxYu4MXO9CzY3tSEqmZvW6AoEDJw==",
+      "version": "5.30.4",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.30.4.tgz",
+      "integrity": "sha512-xRdd0v64a8mFK9bnsKVdoNP9GQIKUAaJPTaqEQDL4w/J8WaW4sWXXoMZ+6SimPkfT5bElreXf8m9HnmPc3E1BQ==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^10.5.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#11.0.1",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.12.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.13.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#3.5.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1708702034"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207155651458025/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [x] All tests must pass