### PR TITLE
Add remote messaging internal feature

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -232,6 +232,7 @@ dependencies {
     implementation project(':remote-messaging-api')
     implementation project(':remote-messaging-impl')
     implementation project(':remote-messaging-store')
+    internalImplementation project(":remote-messaging-internal")
 
     implementation project(':voice-search-api')
     implementation project(':voice-search-impl')

--- a/internal-features/internal-features-api/src/main/java/com/duckduckgo/internal/features/api/InternalFeaturePlugin.kt
+++ b/internal-features/internal-features-api/src/main/java/com/duckduckgo/internal/features/api/InternalFeaturePlugin.kt
@@ -40,6 +40,7 @@ interface InternalFeaturePlugin {
         const val VPN_SETTINGS_PRIO_KEY = 400
         const val SUBS_SETTINGS_PRIO_KEY = 500
         const val AUTOFILL_SETTINGS_PRIO_KEY = 600
+        const val RMF_SETTINGS_PRIO_KEY = 650
         const val AUDIT_SETTINGS_PRIO_KEY = 700
         const val ADS_SETTINGS_PRIO_KEY = 800
     }

--- a/remote-messaging/remote-messaging-internal/build.gradle
+++ b/remote-messaging/remote-messaging-internal/build.gradle
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+    id 'com.squareup.anvil'
+    id 'com.google.devtools.ksp' version "$ksp_version"
+}
+
+apply from: "$rootProject.projectDir/gradle/android-library.gradle"
+
+dependencies {
+	implementation project(":remote-messaging-api")
+	implementation project(":remote-messaging-impl")
+
+    anvil project(':anvil-compiler')
+    implementation project(':anvil-annotations')
+    implementation project(':di')
+    implementation project(':common-ui')
+    implementation project(':common-utils')
+    implementation project(':navigation-api')
+    implementation project(':internal-features-api')
+    implementation project(':feature-toggles-api')
+    implementation project(":app-build-config-api") // needed for feature toggles
+    implementation project(':browser-api')
+
+    ksp AndroidX.room.compiler
+
+    implementation KotlinX.coroutines.android
+    implementation AndroidX.core.ktx
+    implementation Google.dagger
+    implementation Google.android.material
+    implementation AndroidX.constraintLayout
+
+    implementation "com.squareup.logcat:logcat:_"
+
+    testImplementation Testing.junit4
+    testImplementation "org.mockito.kotlin:mockito-kotlin:_"
+    testImplementation project(':common-test')
+    testImplementation project(':feature-toggles-test')
+    testImplementation CashApp.turbine
+    testImplementation Testing.robolectric
+    testImplementation(KotlinX.coroutines.test) {
+        // https://github.com/Kotlin/kotlinx.coroutines/issues/2023
+        // conflicts with mockito due to direct inclusion of byte buddy
+        exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
+    }
+
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
+}
+
+android {
+    namespace "com.duckduckgo.remotemessaging.internal"
+    anvil {
+        generateDaggerFactories = true // default is false
+    }
+    lint {
+        baseline file("lint-baseline.xml")
+    }
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
+    compileOptions {
+        coreLibraryDesugaringEnabled = true
+    }
+}
+

--- a/remote-messaging/remote-messaging-internal/lint-baseline.xml
+++ b/remote-messaging/remote-messaging-internal/lint-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.1.2" type="baseline" client="gradle" dependencies="false" name="AGP (8.1.2)" variant="all" version="8.1.2">
+
+</issues>

--- a/remote-messaging/remote-messaging-internal/src/main/AndroidManifest.xml
+++ b/remote-messaging/remote-messaging-internal/src/main/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
+
+    <application>
+        <activity
+            android:name="com.duckduckgo.remote.messaging.internal.feature.RMFInternalSettingsActivity"
+            android:label="RMF Dev Settings"
+            android:exported="false" />
+    </application>
+
+</manifest>

--- a/remote-messaging/remote-messaging-internal/src/main/java/com/duckduckgo/remote/messaging/internal/feature/InternalViews.kt
+++ b/remote-messaging/remote-messaging-internal/src/main/java/com/duckduckgo/remote/messaging/internal/feature/InternalViews.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.remote.messaging.internal.feature
+
+import android.content.Context
+import com.duckduckgo.anvil.annotations.PriorityKey
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.internal.features.api.InternalFeaturePlugin
+import com.duckduckgo.internal.features.api.InternalFeaturePlugin.Companion.RMF_SETTINGS_PRIO_KEY
+import com.duckduckgo.navigation.api.GlobalActivityStarter
+import com.duckduckgo.remote.messaging.internal.feature.RMFInternalScreens.InternalSettings
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+@PriorityKey(RMF_SETTINGS_PRIO_KEY)
+class InternalSettingsActivity @Inject constructor(
+    private val globalActivityStarter: GlobalActivityStarter,
+) : InternalFeaturePlugin {
+    override fun internalFeatureTitle(): String {
+        return "Remote messaging Settings"
+    }
+
+    override fun internalFeatureSubtitle(): String {
+        return "Remote messaging dev settings for internal users"
+    }
+
+    override fun onInternalFeatureClicked(activityContext: Context) {
+        globalActivityStarter.start(activityContext, InternalSettings)
+    }
+}

--- a/remote-messaging/remote-messaging-internal/src/main/java/com/duckduckgo/remote/messaging/internal/feature/RMFInternalSettingsActivity.kt
+++ b/remote-messaging/remote-messaging-internal/src/main/java/com/duckduckgo/remote/messaging/internal/feature/RMFInternalSettingsActivity.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.remote.messaging.internal.feature
+
+import android.os.Bundle
+import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.common.ui.DuckDuckGoActivity
+import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.plugins.PluginPoint
+import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.navigation.api.GlobalActivityStarter
+import com.duckduckgo.remote.messaging.internal.feature.RMFInternalScreens.InternalSettings
+import com.duckduckgo.remotemessaging.internal.databinding.ActivityRmfInternalSettingsBinding
+import javax.inject.Inject
+
+@InjectWith(ActivityScope::class)
+@ContributeToActivityStarter(InternalSettings::class)
+class RMFInternalSettingsActivity : DuckDuckGoActivity() {
+
+    @Inject
+    lateinit var settings: PluginPoint<RmfSettingPlugin>
+
+    private val binding: ActivityRmfInternalSettingsBinding by viewBinding()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(binding.root)
+        setupToolbar(binding.toolbar)
+
+        setupUiElementState()
+    }
+
+    private fun setupUiElementState() {
+        settings.getPlugins()
+            .mapNotNull { it.getView(this) }
+            .forEach { remoteViewPlugin ->
+                binding.rmfSettingsContent.addView(remoteViewPlugin)
+            }
+    }
+}
+
+sealed class RMFInternalScreens : GlobalActivityStarter.ActivityParams {
+    data object InternalSettings : RMFInternalScreens() {
+        private fun readResolve(): Any = InternalSettings
+    }
+}

--- a/remote-messaging/remote-messaging-internal/src/main/java/com/duckduckgo/remote/messaging/internal/feature/RmfSettingPlugin.kt
+++ b/remote-messaging/remote-messaging-internal/src/main/java/com/duckduckgo/remote/messaging/internal/feature/RmfSettingPlugin.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.remote.messaging.internal.feature
+
+import android.content.*
+import android.view.*
+import com.duckduckgo.anvil.annotations.ContributesPluginPoint
+import com.duckduckgo.di.scopes.ActivityScope
+
+/**
+ * Use this interface to create a new plugin that will be used to display a specific settings section
+ */
+@ContributesPluginPoint(ActivityScope::class)
+interface RmfSettingPlugin {
+    /**
+     * This method returns a [View] that will be used as a setting item
+     * @return [View]
+     */
+    fun getView(context: Context): View?
+}

--- a/remote-messaging/remote-messaging-internal/src/main/java/com/duckduckgo/remote/messaging/internal/feature/RmfStagingEnvInterceptor.kt
+++ b/remote-messaging/remote-messaging-internal/src/main/java/com/duckduckgo/remote/messaging/internal/feature/RmfStagingEnvInterceptor.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.remote.messaging.internal.feature
+
+import com.duckduckgo.app.global.api.ApiInterceptorPlugin
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.remote.messaging.internal.setting.RmfInternalSettings
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+import logcat.logcat
+import okhttp3.HttpUrl
+import okhttp3.Interceptor
+import okhttp3.Interceptor.Chain
+import okhttp3.Response
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = ApiInterceptorPlugin::class,
+)
+class RmfStagingEnvInterceptor @Inject constructor(
+    private val rmfInternalSettings: RmfInternalSettings,
+) : ApiInterceptorPlugin, Interceptor {
+    override fun getInterceptor(): Interceptor = this
+    override fun intercept(chain: Chain): Response {
+        val lastSegment = chain.request().url.encodedPathSegments.last()
+
+        if (rmfInternalSettings.useStatingEndpoint().isEnabled() && chain.request().url.isProductionEnvironment()) {
+            val newRequest = chain.request().newBuilder()
+
+            val changedUrl = RMF_STAGING_ENV + lastSegment
+            logcat { "RMF environment changed to $changedUrl" }
+            newRequest.url(changedUrl)
+            return chain.proceed(newRequest.build())
+        }
+
+        return chain.proceed(chain.request())
+    }
+
+    private fun HttpUrl.isProductionEnvironment(): Boolean {
+        return this.toString().let {
+            it.contains(RMF_REQUEST) && !it.contains(RMF_STAGING_ENV)
+        }
+    }
+
+    companion object {
+        private const val RMF_REQUEST = "https://staticcdn.duckduckgo.com/remotemessaging/"
+        private const val RMF_STAGING_ENV = "https://staticcdn.duckduckgo.com/remotemessaging/config/staging/"
+    }
+}

--- a/remote-messaging/remote-messaging-internal/src/main/java/com/duckduckgo/remote/messaging/internal/setting/RmfInternalSettings.kt
+++ b/remote-messaging/remote-messaging-internal/src/main/java/com/duckduckgo/remote/messaging/internal/setting/RmfInternalSettings.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.remote.messaging.internal.setting
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "internalRmfSettings", // will never appear in production
+)
+interface RmfInternalSettings {
+    @Toggle.DefaultValue(false)
+    fun self(): Toggle
+
+    @Toggle.DefaultValue(false)
+    fun useStatingEndpoint(): Toggle
+}

--- a/remote-messaging/remote-messaging-internal/src/main/java/com/duckduckgo/remote/messaging/internal/setting/RmfStagingEndpointSettingView.kt
+++ b/remote-messaging/remote-messaging-internal/src/main/java/com/duckduckgo/remote/messaging/internal/setting/RmfStagingEndpointSettingView.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.remote.messaging.internal.setting
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import android.widget.CompoundButton
+import android.widget.FrameLayout
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.navigation.api.GlobalActivityStarter
+import com.duckduckgo.remote.messaging.internal.feature.RmfSettingPlugin
+import com.duckduckgo.remotemessaging.internal.databinding.RmfSimpleViewBinding
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.android.support.AndroidSupportInjection
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+@InjectWith(ViewScope::class)
+class RmfStagingEndpointSettingView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyle: Int = 0,
+) : FrameLayout(context, attrs, defStyle) {
+
+    @Inject
+    lateinit var globalActivityStarter: GlobalActivityStarter
+
+    @Inject
+    lateinit var rmfInternalSettings: RmfInternalSettings
+
+    @Inject
+    lateinit var dispatcherProvider: DispatcherProvider
+
+    @Inject
+    @AppCoroutineScope
+    lateinit var appCoroutineScope: CoroutineScope
+
+    private val toggleListener = CompoundButton.OnCheckedChangeListener { _, value ->
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            rmfInternalSettings.useStatingEndpoint().setEnabled(State(enable = value))
+        }
+    }
+
+    private val binding: RmfSimpleViewBinding by viewBinding()
+
+    override fun onAttachedToWindow() {
+        AndroidSupportInjection.inject(this)
+        super.onAttachedToWindow()
+
+        binding.root.showSwitch()
+        binding.root.setPrimaryText("Use RMF staging endpoint")
+        binding.root.setSecondaryText("Enable to use RMF staging endpoint")
+
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            binding.root.quietlySetIsChecked(rmfInternalSettings.useStatingEndpoint().isEnabled(), toggleListener)
+        }
+    }
+}
+
+@ContributesMultibinding(ActivityScope::class)
+class RecoverSubscriptionViewPlugin @Inject constructor() : RmfSettingPlugin {
+    override fun getView(context: Context): View {
+        return RmfStagingEndpointSettingView(context)
+    }
+}

--- a/remote-messaging/remote-messaging-internal/src/main/res/layout/activity_rmf_internal_settings.xml
+++ b/remote-messaging/remote-messaging-internal/src/main/res/layout/activity_rmf_internal_settings.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2024 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context="com.duckduckgo.remote.messaging.internal.feature.RMFInternalSettingsActivity">
+
+    <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/appBar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:theme="@style/Widget.DuckDuckGo.ToolbarTheme"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+    >
+
+        <androidx.appcompat.widget.Toolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                android:background="?attr/daxColorSurface"
+                android:theme="@style/Widget.DuckDuckGo.ToolbarTheme"
+                app:popupTheme="@style/Widget.DuckDuckGo.PopUpOverflowMenu"/>
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginTop="64dp"
+            tools:ignore="Overdraw">
+
+        <LinearLayout
+                android:id="@+id/rmfSettingsContent"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"/>
+
+    </ScrollView>
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/remote-messaging/remote-messaging-internal/src/main/res/layout/rmf_simple_view.xml
+++ b/remote-messaging/remote-messaging-internal/src/main/res/layout/rmf_simple_view.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2024 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:id="@+id/subs_copy_data"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:showSwitch="false"
+/>

--- a/remote-messaging/remote-messaging-internal/src/test/java/com/duckduckgo/remote/messaging/internal/feature/RmfStagingEnvInterceptorTest.kt
+++ b/remote-messaging/remote-messaging-internal/src/test/java/com/duckduckgo/remote/messaging/internal/feature/RmfStagingEnvInterceptorTest.kt
@@ -1,0 +1,69 @@
+package com.duckduckgo.remote.messaging.internal.feature
+
+import com.duckduckgo.common.test.api.FakeChain
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.remote.messaging.internal.setting.RmfInternalSettings
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RmfStagingEnvInterceptorTest {
+
+    private val rmfInternalSettings = FakeFeatureToggleFactory.create(RmfInternalSettings::class.java)
+    private val interceptor = RmfStagingEnvInterceptor(rmfInternalSettings)
+
+    @Test
+    fun interceptEndpointWhenEnabled() {
+        rmfInternalSettings.useStatingEndpoint().setEnabled(State(enable = true))
+
+        val chain = FakeChain(RMF_URL_V1)
+        val response = interceptor.intercept(chain)
+
+        assertEquals(RMF_STAGING_URL, response.request.url.toString())
+
+        val chain2 = FakeChain(RMF_URL_V2)
+        val response2 = interceptor.intercept(chain2)
+
+        assertEquals(RMF_STAGING_URL, response2.request.url.toString())
+    }
+
+    @Test
+    fun interceptNoopWhenDisabled() {
+        rmfInternalSettings.useStatingEndpoint().setEnabled(State(enable = false))
+
+        val chain = FakeChain(RMF_URL_V1)
+        val response = interceptor.intercept(chain)
+
+        assertEquals(RMF_URL_V1, response.request.url.toString())
+
+        val chain2 = FakeChain(RMF_URL_V2)
+        val response2 = interceptor.intercept(chain2)
+
+        assertEquals(RMF_URL_V2, response2.request.url.toString())
+    }
+
+    @Test
+    fun interceptIgnoreUnknownEndpointWhenEnabled() {
+        rmfInternalSettings.useStatingEndpoint().setEnabled(State(enable = true))
+
+        val chain = FakeChain(UNKNOWN_URL)
+        val response = interceptor.intercept(chain)
+
+        assertEquals(UNKNOWN_URL, response.request.url.toString())
+    }
+
+    @Test
+    fun interceptIgnoreUnknownEndpointWhenDisabled() {
+        rmfInternalSettings.useStatingEndpoint().setEnabled(State(enable = false))
+
+        val chain = FakeChain(UNKNOWN_URL)
+        val response = interceptor.intercept(chain)
+
+        assertEquals(UNKNOWN_URL, response.request.url.toString())
+    }
+}
+
+private const val RMF_URL_V1 = "https://staticcdn.duckduckgo.com/remotemessaging/config/v1/android-config.json"
+private const val RMF_URL_V2 = "https://staticcdn.duckduckgo.com/remotemessaging/config/v2/android-config.json"
+private const val RMF_STAGING_URL = "https://staticcdn.duckduckgo.com/remotemessaging/config/staging/android-config.json"
+private const val UNKNOWN_URL = "https://unknown.com/remotemessaging/config/staging/android-config.json"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1206858506810306/f

### Description
Add dev setting to change to /remotemessaging staging

### Steps to test this PR

_Test_
- [ ] fresh install from this branch
- [ ] pass all the onboarding in the app (hide all tips)
- [ ] go to settings -> RMF dev settings and toggle "use RMF staging endpoint"
- [ ] fire button
- [ ] verify there is not RMF in new tab page
- [ ] enable AppTP
- [ ] override `invalidate` column in `remote_messaging` db table inside `remote_messaging.db`
- [ ] fire button
- [ ] verify there is not RMF in new tab page
- [ ] enable VPN
- [ ] override `invalidate` column in `remote_messaging` db table inside `remote_messaging.db`
- [ ] fire button
- [ ] verify RMF is displayed in NTP

