### PR TITLE
split sync data e2e to avoid timeout

### DIFF
--- a/.github/workflows/sync-critical-path.yml
+++ b/.github/workflows/sync-critical-path.yml
@@ -60,7 +60,7 @@ jobs:
         if: always()
         run: find . -name "*.apk"  -exec mv '{}' apk/release.apk \;
 
-      - name: Sync Flows
+      - name: Run Sync flows
         uses: mobile-dev-inc/action-maestro-cloud@v1.8.1
         with:
           api-key: ${{ secrets.MOBILE_DEV_API_KEY }}
@@ -71,6 +71,13 @@ jobs:
           include-tags: syncCriticalPathTest
           env: |
             CODE=${{ steps.sync-recovery-code.outputs.recovery-code }}
+
+      - name: Maestro Output
+        run: |
+          echo "Console URL: ${{ steps.maestro.outputs.MAESTRO_CLOUD_CONSOLE_URL }}"
+          echo "Flow Results: ${{ steps.maestro.outputs.MAESTRO_CLOUD_FLOW_RESULTS }}"
+          echo "Upload Status: ${{ steps.maestro.outputs.MAESTRO_CLOUD_UPLOAD_STATUS }}"
+          echo "App Binary ID:: ${{ steps.maestro.outputs.MAESTRO_CLOUD_APP_BINARY_ID }}"
 
       - name: Create Asana task when workflow failed
         if: ${{ failure() }}

--- a/.maestro/config.yaml
+++ b/.maestro/config.yaml
@@ -3,6 +3,10 @@ appStartup:
 appSize:
   enabled: false
 disableRetries: true
-
+executionOrder:
+  continueOnFailure: false # default is true
+  flowsOrder:
+    - "Sync Critical Path test: Data can be synced p1"
+    - "Sync Critical Path test: Data can be synced p2"
 flows:
  - "**"

--- a/.maestro/sync_flows/sync_data_p1.yaml
+++ b/.maestro/sync_flows/sync_data_p1.yaml
@@ -1,0 +1,12 @@
+# Test Definition: https://app.asana.com/0/1205017362573508/1205044961533557
+appId: com.duckduckgo.mobile.android
+name: "Sync Critical Path test: Data can be synced p1"
+tags:
+  - syncCriticalPathTest
+---
+- runFlow: ../sync_flows/steps/action_add_new_device.yaml
+- runFlow: ../sync_flows/steps/action_add_bookmarks_and_folders.yaml
+# Enable Unified Favourites
+- runFlow: ../sync_flows/steps/action_enable_unified_favourites.yaml
+# Disable account
+- runFlow: ../sync_flows/steps/action_disable_sync.yaml

--- a/.maestro/sync_flows/sync_data_p2.yaml
+++ b/.maestro/sync_flows/sync_data_p2.yaml
@@ -1,15 +1,9 @@
 # Test Definition: https://app.asana.com/0/1205017362573508/1205044961533557
 appId: com.duckduckgo.mobile.android
-name: "Sync Critical Path test: Data can be synced"
+name: "Sync Critical Path test: Data can be synced p2"
 tags:
   - syncCriticalPathTest
 ---
-- runFlow: ../sync_flows/steps/action_add_new_device.yaml
-- runFlow: ../sync_flows/steps/action_add_bookmarks_and_folders.yaml
-# Enable Unified Favourites
-- runFlow: ../sync_flows/steps/action_enable_unified_favourites.yaml
-# Disable account
-- runFlow: ../sync_flows/steps/action_disable_sync.yaml
 # Recover account
 - runFlow: ../sync_flows/steps/action_add_new_device.yaml
 # Verify newly created bookmarks and folders have been added


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207158873962452/f 

### Description
Splits long maestro E2E test into 2 test so we can run them sequentially

### Steps to test this PR

_Feature 1_
- [ ] CI should pass
https://github.com/duckduckgo/Android/actions/runs/8815711077/job/24198207620

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
