### PR TITLE
Update app link handling

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksHandler.kt
@@ -57,10 +57,12 @@ class DuckDuckGoAppLinksHandler @Inject constructor() : AppLinksHandler {
 
         previousUrl?.let {
             if (isSameOrSubdomain(it, urlString)) {
-                if (isAUserQuery || !hasTriggeredForDomain || alwaysTriggerList.contains(urlString.extractDomain())) {
+                val shouldTrigger = alwaysTriggerList.contains(urlString.extractDomain())
+                if (isAUserQuery || !hasTriggeredForDomain || shouldTrigger) {
                     previousUrl = urlString
                     launchAppLink()
                     hasTriggeredForDomain = true
+                    if (shouldTrigger) return true
                 }
                 return false
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksLauncher.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksLauncher.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.browser.applinks
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
+import android.provider.Browser.EXTRA_APPLICATION_ID
 import android.widget.Toast
 import androidx.annotation.StringRes
 import com.duckduckgo.app.browser.BrowserTabViewModel
@@ -39,10 +40,25 @@ class DuckDuckGoAppLinksLauncher @Inject constructor() : AppLinksLauncher {
     override fun openAppLink(context: Context?, appLink: AppLink, viewModel: BrowserTabViewModel) {
         if (context == null) return
         appLink.appIntent?.let {
-            it.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            configureIntent(it, context)
             startActivityOrQuietlyFail(context, it)
         }
         viewModel.clearPreviousUrl()
+    }
+
+    private fun configureIntent(
+        intent: Intent,
+        context: Context
+    ) {
+        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+
+        intent.addCategory(Intent.CATEGORY_BROWSABLE)
+        intent.selector?.addCategory(Intent.CATEGORY_BROWSABLE)
+
+        intent.component = null
+        intent.selector?.component = null
+
+        intent.putExtra(EXTRA_APPLICATION_ID, context.packageName)
     }
 
     private fun startActivityOrQuietlyFail(context: Context, intent: Intent) {

--- a/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksLauncher.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/applinks/AppLinksLauncher.kt
@@ -48,7 +48,7 @@ class DuckDuckGoAppLinksLauncher @Inject constructor() : AppLinksLauncher {
 
     private fun configureIntent(
         intent: Intent,
-        context: Context
+        context: Context,
     ) {
         intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
 

--- a/app/src/test/java/com/duckduckgo/app/browser/applinks/DuckDuckGoAppLinksHandlerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/applinks/DuckDuckGoAppLinksHandlerTest.kt
@@ -230,7 +230,7 @@ class DuckDuckGoAppLinksHandlerTest {
         testee.isAUserQuery = false
         testee.hasTriggeredForDomain = true
         testee.previousUrl = "digid.nl/something"
-        assertFalse(
+        assertTrue(
             testee.handleAppLink(
                 isForMainFrame = true,
                 urlString = "app.digid.nl/something",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207158394406477/f

### Description
- For better compatibility, adds additional configuration to the intent we use to open app links.
- Halts navigation for links that are in the “always trigger” list.
- Fixes: https://app.asana.com/0/414730916066338/1207137747934827/f

### Steps to test this PR
_Sanity check_
- [x] Go to maps.google.com
- [x] Verify that the “Open in app” snackbar is shown
- [x] Tap “Open in app”
- [x] Verify that Maps is opened
