### PR TITLE
Update anvil to 2.5 beta to fix every other build needing a clean

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/sync/FakeDeviceSyncState.kt
+++ b/app/src/main/java/com/duckduckgo/app/sync/FakeDeviceSyncState.kt
@@ -26,7 +26,7 @@ import javax.inject.*
  */
 @ContributesBinding(
     scope = AppScope::class,
-    priority = ContributesBinding.Priority.NORMAL,
+    rank = ContributesBinding.RANK_NORMAL,
 )
 class FakeDeviceSyncState @Inject constructor() : DeviceSyncState {
     override fun isFeatureEnabled(): Boolean = false

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext {
         kotlin_version = '1.9.20'
         spotless = '6.1.2'
-        anvil_version = '2.4.9'
+        anvil_version = '2.5.0-beta07'
         ksp_version = '1.9.20-1.0.14'
         gradle_plugin = '8.1.2'
         min_sdk = 26

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt
@@ -27,17 +27,20 @@ import com.duckduckgo.feature.toggles.api.FakeToggleStore
 import com.duckduckgo.feature.toggles.api.FeatureExceptions
 import com.duckduckgo.feature.toggles.api.FeatureSettings
 import com.duckduckgo.feature.toggles.api.FeatureToggles
+import com.duckduckgo.feature.toggles.api.RemoteFeatureStoreNamed
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.Lazy
+import dagger.SingleInstanceIn
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
@@ -102,6 +105,27 @@ class ContributesRemoteFeatureCodeGeneratorTest {
     }
 
     @Test
+    fun `the generated class is singleInstance annotated in the right scope`() {
+        val generatedClass = Class
+            .forName("com.duckduckgo.feature.toggles.codegen.TestTriggerFeature_RemoteFeature")
+            .kotlin
+
+        val annotation = generatedClass.java.getAnnotation(SingleInstanceIn::class.java)!!
+        assertEquals(TriggerTestScope::class, annotation.scope)
+    }
+
+    @Test
+    fun `the generated class is RemoteFeatureStoreNamed annotated in the right scope`() {
+        val generatedClass = Class
+            .forName("com.duckduckgo.feature.toggles.codegen.TestTriggerFeature_RemoteFeature")
+            .kotlin
+
+        val annotation = generatedClass.java.getAnnotation(RemoteFeatureStoreNamed::class.java)!!
+        assertEquals(TestTriggerFeature::class, annotation.value)
+    }
+
+    @Test
+    @Ignore("ContributesBinding is only present in kotlin metadata now, we need to fix")
     fun `the generated class contributes the toggle store binding`() {
         val generatedClass = Class
             .forName("com.duckduckgo.feature.toggles.codegen.TestTriggerFeature_RemoteFeature")
@@ -113,6 +137,7 @@ class ContributesRemoteFeatureCodeGeneratorTest {
     }
 
     @Test
+    @Ignore("ContributesMultibinding is only present in kotlin metadata now, we need to fix")
     fun `the generated class contributes the privacy plugin multibinding`() {
         val generatedClass = Class
             .forName("com.duckduckgo.feature.toggles.codegen.TestTriggerFeature_RemoteFeature")

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/integration/NetpVpnNetworkStackProviderImpl.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/integration/NetpVpnNetworkStackProviderImpl.kt
@@ -27,7 +27,7 @@ import javax.inject.Inject
 
 @ContributesBinding(
     scope = VpnScope::class,
-    priority = ContributesBinding.Priority.HIGHEST, // we replace the provider in AppTP using DI without having to touch production code
+    rank = ContributesBinding.RANK_HIGHEST, // we replace the provider in AppTP using DI without having to touch production code
 )
 class NetpVpnNetworkStackProviderImpl @Inject constructor(
     private val vpnNetworkStacks: PluginPoint<VpnNetworkStack>,

--- a/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/network/NetPInternalDefaultConfigProvider.kt
+++ b/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/network/NetPInternalDefaultConfigProvider.kt
@@ -32,7 +32,7 @@ import logcat.logcat
 
 @ContributesBinding(
     scope = VpnScope::class,
-    priority = ContributesBinding.Priority.HIGHEST,
+    rank = ContributesBinding.RANK_HIGHEST,
 )
 class NetPInternalDefaultConfigProvider @Inject constructor(
     private val realNetPConfigProvider: RealNetPDefaultConfigProvider,

--- a/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/network/WgServerInternalProvider.kt
+++ b/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/network/WgServerInternalProvider.kt
@@ -22,12 +22,11 @@ import com.duckduckgo.networkprotection.impl.configuration.WgServerDebugProvider
 import com.duckduckgo.networkprotection.store.remote_config.NetPEgressServer
 import com.duckduckgo.networkprotection.store.remote_config.NetPServerRepository
 import com.squareup.anvil.annotations.ContributesBinding
-import com.squareup.anvil.annotations.ContributesBinding.Priority.HIGHEST
 import javax.inject.Inject
 
 @ContributesBinding(
     scope = AppScope::class,
-    priority = HIGHEST, // binding for internal build wins
+    rank = ContributesBinding.RANK_HIGHEST, // binding for internal build wins
 )
 class WgServerInternalProvider @Inject constructor(
     private val netPServerRepository: NetPServerRepository,

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/AppDeviceSyncState.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/AppDeviceSyncState.kt
@@ -24,7 +24,7 @@ import javax.inject.*
 @ContributesBinding(
     scope = AppScope::class,
     boundType = DeviceSyncState::class,
-    priority = ContributesBinding.Priority.HIGHEST,
+    rank = ContributesBinding.RANK_HIGHEST,
 )
 class AppDeviceSyncState @Inject constructor(
     private val syncFeatureToggle: SyncFeatureToggle,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207159274091706/f 

### Description
Updates anvil to `2.5.0-beta07`

#### Why jump to a beta?
The current version requires a clean build every other build, meaning even small code changes are taking ~2 mins to test. This problem is resolved on 2.5 branch, so even though there isn't a stable release it's worth it to avoid this tedious build issue and get the code deploying again within seconds.

**Typical build times i'm seeing**
| Before | Now
|--------|--------|
| 1m 40s | 25s | 

#### Why the other changes in the PR?

##### Deprecated priorities 
Anvil changed how you indicate which binding has priority if there are competing ones.

| Old Way | New Way |
|--------|--------|
|`priority = ContributesBinding.Priority.NORMAL` |`rank = ContributesBinding.RANK_NORMAL` |
|`priority = ContributesBinding.Priority.HIGHEST` | `rank = ContributesBinding.RANK_HIGHEST` |
|etc...|etc...

##### Can no longer access `ContributesBinding::class.java` 

One of the changes means that we can't access the java class like the above, which we only did in two unit tests for the code generator. It's still fine to reference `ContributesBinding::class` which is what's needed in the codegen itself, but our test was needing `ContributesBinding::class.java` which we can't do; have ignored these two tests for now.


### Steps to test this PR

- [x] Ensure all CI tests pass
- [x] Smoke test, since Anvil can affect everything app-wide