### PR TITLE
Ensure addDocumentStartJavaScript is called on main thread

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/InlineBrowserAutofill.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/InlineBrowserAutofill.kt
@@ -81,11 +81,13 @@ class InlineBrowserAutofill @Inject constructor(
     ) {
         Timber.d("Autofill: Configuring modern integration with %d message listeners", webMessageListeners.getPlugins().size)
 
-        webMessageListeners.getPlugins().forEach {
-            webView.addWebMessageListener(it, autofillCallback, tabId)
-        }
+        withContext(dispatchers.main()) {
+            webMessageListeners.getPlugins().forEach {
+                webView.addWebMessageListener(it, autofillCallback, tabId)
+            }
 
-        autofillJavascriptInjector.addDocumentStartJavascript(webView)
+            autofillJavascriptInjector.addDocumentStartJavascript(webView)
+        }
     }
 
     override fun cancelPendingAutofillRequestToChooseCredentials() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207161413236108/f 

### Description
Ensures `WebViewCompat.addDocumentStartJavaScript` is invoked on main thread, as well as ensuring web message listeners are registered from main thread.

From testing, it didn't seem like it mattered from where `WebViewCompat.addDocumentStartJavaScript` was invoked, but we observed a crash indicating there was a potential deadlock and flagging it was called from the wrong thread.

```
java.lang.RuntimeException: Probable deadlock detected due to WebView API being called on incorrect thread while the UI thread is blocked.
```

### Steps to test this PR
- [ ] QA-optional