### PR TITLE
Android: distinguish browser vs custom tabs Crash/ANRs

### DIFF
--- a/anrs/anrs-api/src/main/java/com/duckduckgo/anrs/api/AnrRepository.kt
+++ b/anrs/anrs-api/src/main/java/com/duckduckgo/anrs/api/AnrRepository.kt
@@ -32,4 +32,5 @@ data class Anr(
     val stackTrace: List<String>,
     val timestamp: String,
     val webView: String,
+    val customTab: Boolean,
 )

--- a/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/AnrOfflinePixelSender.kt
+++ b/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/AnrOfflinePixelSender.kt
@@ -44,6 +44,7 @@ class AnrOfflinePixelSender @Inject constructor(
                     mapOf(
                         ANR_STACKTRACE to ss,
                         ANR_WEBVIEW_VERSION to it.webView,
+                        ANR_CUSTOM_TAB to it.customTab.toString(),
                     ),
                     mapOf(),
                     COUNT,
@@ -58,6 +59,7 @@ class AnrOfflinePixelSender @Inject constructor(
     companion object {
         const val ANR_STACKTRACE = "stackTrace"
         const val ANR_WEBVIEW_VERSION = "webView"
+        const val ANR_CUSTOM_TAB = "customTab"
     }
 }
 

--- a/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/AnrSupervisor.kt
+++ b/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/AnrSupervisor.kt
@@ -20,6 +20,7 @@ import android.os.Debug
 import android.os.Handler
 import android.os.Looper
 import com.duckduckgo.app.anrs.store.AnrsDatabase
+import com.duckduckgo.app.browser.customtabs.CustomTabDetector
 import com.duckduckgo.browser.api.BrowserLifecycleObserver
 import com.duckduckgo.browser.api.WebViewVersionProvider
 import com.duckduckgo.di.scopes.AppScope
@@ -59,6 +60,7 @@ internal fun Any.notifyAll() = (this as Object).notifyAll()
 
 class AnrSupervisorRunnable @Inject constructor(
     private val webViewVersionProvider: WebViewVersionProvider,
+    private val customTabDetector: CustomTabDetector,
     anrsDatabase: AnrsDatabase,
 ) : Runnable {
 
@@ -89,9 +91,9 @@ class AnrSupervisorRunnable @Inject constructor(
                         logcat { "UI Thread responded within ${ANR_THRESHOLD_MILLIS}ms" }
                     } else {
                         val e = AnrException(handler.looper.thread)
-                        logcat { "ANR Detected: ${e.threadStateMap}" }
+                        logcat { "In custom tab: ${customTabDetector.isCustomTab()}. ANR Detected: ${e.threadStateMap}." }
 
-                        anrDao.insert(e.asAnrData(webViewVersionProvider.getFullVersion()).asAnrEntity())
+                        anrDao.insert(e.asAnrData(webViewVersionProvider.getFullVersion(), customTabDetector.isCustomTab()).asAnrEntity())
 
                         // wait until thread responds again
                         callback.wait()

--- a/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/CrashOfflinePixelSender.kt
+++ b/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/CrashOfflinePixelSender.kt
@@ -55,6 +55,7 @@ class CrashOfflinePixelSender @Inject constructor(
                         EXCEPTION_APP_VERSION to exception.version,
                         EXCEPTION_TIMESTAMP to exception.timestamp,
                         EXCEPTION_WEBVIEW_VERSION to webViewVersionProvider.getFullVersion(),
+                        EXCEPTION_CUSTOM_TAB to exception.customTab.toString(),
                     )
 
                 if (isVerifiedPlayStoreInstall()) {
@@ -88,5 +89,6 @@ class CrashOfflinePixelSender @Inject constructor(
         private const val EXCEPTION_APP_VERSION = "v"
         private const val EXCEPTION_TIMESTAMP = "t"
         private const val EXCEPTION_WEBVIEW_VERSION = "webView"
+        private const val EXCEPTION_CUSTOM_TAB = "customTab"
     }
 }

--- a/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/ExceptionModels.kt
+++ b/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/ExceptionModels.kt
@@ -38,6 +38,7 @@ internal data class AnrData(
     val stackTrace: ArrayList<String>,
     val timeStamp: String = FORMATTER_SECONDS.format(LocalDateTime.now()),
     val webView: String,
+    val customTab: Boolean,
 )
 
 internal fun AnrData.asAnrEntity(): AnrEntity {
@@ -50,10 +51,11 @@ internal fun AnrData.asAnrEntity(): AnrEntity {
         stackTrace = stackTrace,
         timestamp = timeStamp,
         webView = webView,
+        customTab = customTab,
     )
 }
 
-internal fun Throwable.asAnrData(webView: String): AnrData {
+internal fun Throwable.asAnrData(webView: String, customTab: Boolean): AnrData {
     return AnrData(
         name = this.toString().replace(": $message", "", true),
         message = message,
@@ -61,6 +63,7 @@ internal fun Throwable.asAnrData(webView: String): AnrData {
         file = stackTrace.getOrNull(0)?.fileName,
         lineNumber = stackTrace.getOrNull(0)?.lineNumber ?: Int.MIN_VALUE,
         webView = webView,
+        customTab = customTab,
     )
 }
 
@@ -68,6 +71,7 @@ internal fun CrashLogger.Crash.asCrashEntity(
     appVersion: String,
     processName: String,
     webView: String,
+    customTab: Boolean,
 ): ExceptionEntity {
     val timestamp = FORMATTER_SECONDS.format(LocalDateTime.now())
     val stacktrace = this.t.asLog().sanitizeStackTrace()
@@ -80,6 +84,7 @@ internal fun CrashLogger.Crash.asCrashEntity(
         version = appVersion,
         timestamp = timestamp,
         webView = webView,
+        customTab = customTab,
     )
 }
 

--- a/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/RealAnrRepository.kt
+++ b/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/RealAnrRepository.kt
@@ -51,6 +51,7 @@ private fun AnrEntity.asAnr(): Anr {
         stackTrace = stackTrace,
         timestamp = timestamp,
         webView = webView,
+        customTab = customTab,
     )
 }
 

--- a/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/RealCrashLogger.kt
+++ b/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/RealCrashLogger.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.anr
 
 import com.duckduckgo.anrs.api.CrashLogger
 import com.duckduckgo.app.anrs.store.UncaughtExceptionDao
+import com.duckduckgo.app.browser.customtabs.CustomTabDetector
 import com.duckduckgo.app.di.ProcessName
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.browser.api.WebViewVersionProvider
@@ -31,11 +32,19 @@ class RealCrashLogger @Inject constructor(
     private val appBuildConfig: AppBuildConfig,
     private val uncaughtExceptionDao: UncaughtExceptionDao,
     private val webViewVersionProvider: WebViewVersionProvider,
+    private val customTabDetector: CustomTabDetector,
     @ProcessName private val processName: String,
 ) : CrashLogger {
     override fun logCrash(crash: CrashLogger.Crash) {
         checkMainThread()
 
-        uncaughtExceptionDao.add(crash.asCrashEntity(appBuildConfig.versionName, processName, webViewVersionProvider.getFullVersion()))
+        uncaughtExceptionDao.add(
+            crash.asCrashEntity(
+                appBuildConfig.versionName,
+                processName,
+                webViewVersionProvider.getFullVersion(),
+                customTabDetector.isCustomTab(),
+            ),
+        )
     }
 }

--- a/anrs/anrs-store/src/main/java/com/duckduckgo/app/anrs/store/AnrEntity.kt
+++ b/anrs/anrs-store/src/main/java/com/duckduckgo/app/anrs/store/AnrEntity.kt
@@ -29,4 +29,5 @@ data class AnrEntity(
     val stackTrace: List<String>,
     val timestamp: String,
     val webView: String,
+    val customTab: Boolean,
 )

--- a/anrs/anrs-store/src/main/java/com/duckduckgo/app/anrs/store/AnrsDatabase.kt
+++ b/anrs/anrs-store/src/main/java/com/duckduckgo/app/anrs/store/AnrsDatabase.kt
@@ -28,7 +28,7 @@ import com.squareup.moshi.Types.newParameterizedType
 
 @Database(
     exportSchema = true,
-    version = 2,
+    version = 3,
     entities = [AnrEntity::class],
 )
 @TypeConverters(AnrTypeConverter::class)
@@ -38,14 +38,21 @@ abstract class AnrsDatabase : RoomDatabase() {
     companion object {
 
         private val MIGRATION_1_TO_2: Migration = object : Migration(1, 2) {
-            override fun migrate(database: SupportSQLiteDatabase) {
-                database.execSQL("ALTER TABLE `anr_entity` ADD COLUMN `webView` TEXT NOT NULL DEFAULT \"unknown\"")
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE `anr_entity` ADD COLUMN `webView` TEXT NOT NULL DEFAULT \"unknown\"")
+            }
+        }
+
+        private val MIGRATION_2_TO_3: Migration = object : Migration(1, 2) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE `anr_entity` ADD COLUMN `customTab` TEXT NOT NULL DEFAULT \"false\"")
             }
         }
 
         val ALL_MIGRATIONS: List<Migration>
             get() = listOf(
                 MIGRATION_1_TO_2,
+                MIGRATION_2_TO_3,
             )
     }
 }

--- a/anrs/anrs-store/src/main/java/com/duckduckgo/app/anrs/store/CrashDatabase.kt
+++ b/anrs/anrs-store/src/main/java/com/duckduckgo/app/anrs/store/CrashDatabase.kt
@@ -23,7 +23,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     exportSchema = true,
-    version = 2,
+    version = 3,
     entities = [ExceptionEntity::class],
 )
 abstract class CrashDatabase : RoomDatabase() {
@@ -32,14 +32,21 @@ abstract class CrashDatabase : RoomDatabase() {
     companion object {
 
         private val MIGRATION_1_TO_2: Migration = object : Migration(1, 2) {
-            override fun migrate(database: SupportSQLiteDatabase) {
-                database.execSQL("ALTER TABLE `uncaught_exception_entity` ADD COLUMN `webView` TEXT NOT NULL DEFAULT \"unknown\"")
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE `uncaught_exception_entity` ADD COLUMN `webView` TEXT NOT NULL DEFAULT \"unknown\"")
+            }
+        }
+
+        private val MIGRATION_2_TO_3: Migration = object : Migration(1, 2) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE `uncaught_exception_entity` ADD COLUMN `customTab` TEXT NOT NULL DEFAULT \"false\"")
             }
         }
 
         val ALL_MIGRATIONS: List<Migration>
             get() = listOf(
                 MIGRATION_1_TO_2,
+                MIGRATION_2_TO_3,
             )
     }
 }

--- a/anrs/anrs-store/src/main/java/com/duckduckgo/app/anrs/store/ExceptionEntity.kt
+++ b/anrs/anrs-store/src/main/java/com/duckduckgo/app/anrs/store/ExceptionEntity.kt
@@ -29,4 +29,5 @@ data class ExceptionEntity(
     val version: String,
     val timestamp: String,
     val webView: String,
+    val customTab: Boolean,
 )

--- a/app/src/main/java/com/duckduckgo/app/browser/customtabs/RealCustomTabDetector.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/customtabs/RealCustomTabDetector.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.customtabs
+
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+@ContributesBinding(scope = AppScope::class)
+@SingleInstanceIn(AppScope::class)
+class RealCustomTabDetector @Inject constructor() : CustomTabDetector {
+
+    private var customTab: Boolean = false
+
+    override fun isCustomTab(): Boolean {
+        return customTab
+    }
+
+    override fun setCustomTab(value: Boolean) {
+        this.customTab = value
+    }
+}

--- a/browser-api/src/main/java/com/duckduckgo/app/browser/customtabs/CustomTabDetector.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/browser/customtabs/CustomTabDetector.kt
@@ -16,28 +16,8 @@
 
 package com.duckduckgo.app.browser.customtabs
 
-import com.duckduckgo.di.scopes.AppScope
-import com.squareup.anvil.annotations.ContributesBinding
-import dagger.SingleInstanceIn
-import javax.inject.Inject
-
 interface CustomTabDetector {
     fun isCustomTab(): Boolean
 
     fun setCustomTab(value: Boolean)
-}
-
-@ContributesBinding(scope = AppScope::class)
-@SingleInstanceIn(AppScope::class)
-class RealCustomTabDetector @Inject constructor() : CustomTabDetector {
-
-    private var customTab: Boolean = false
-
-    override fun isCustomTab(): Boolean {
-        return customTab
-    }
-
-    override fun setCustomTab(value: Boolean) {
-        this.customTab = value
-    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207164955333549/f

### Description
Added the `customTab` flag to the crashes and anrs to identify the custom tab scenario.

### Steps to test this PR

_Test ANR pixel with customTab=false (Browser)_
- [x] Checkout this branch and change the policy to `ExistingPeriodicWorkPolicy.REPLACE` in https://github.com/duckduckgo/Android/blob/feature/ana/android_distinguish_browser_vs_custom_tabs_crash_anrs/statistics/src/main/java/com/duckduckgo/app/statistics/api/OfflinePixelScheduler.kt#L55.
- [x] Add the below code to produce an ANR when tapping on "Find in page" from the overflow menu at https://github.com/duckduckgo/Android/blob/feature/ana/android_distinguish_browser_vs_custom_tabs_crash_anrs/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt#L3277
```
                    Handler(Looper.getMainLooper()).post {
                        Thread.sleep(10000)
                    }
```
- [x] Build and install.
- [x] Open the app.
- [x] Tap on "Find in Page" from the overflow menu.
- [x] Notice the ANR.
- [x] Restart the app.
- [x] Verify the `m_anr_exception` pixel is sent with `customTab=false` param.


_Test ANR pixel with customTab=true (Custom Tab)_
- [x] Checkout this branch and change the policy to `ExistingPeriodicWorkPolicy.REPLACE` in https://github.com/duckduckgo/Android/blob/feature/ana/android_distinguish_browser_vs_custom_tabs_crash_anrs/statistics/src/main/java/com/duckduckgo/app/statistics/api/OfflinePixelScheduler.kt#L55.
- [x] Add the below code to produce an ANR when tapping on "Find in page" from the overflow menu at https://github.com/duckduckgo/Android/blob/feature/ana/android_distinguish_browser_vs_custom_tabs_crash_anrs/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt#L3277
```
                    Handler(Looper.getMainLooper()).post {
                        Thread.sleep(10000)
                    }
```
- [x] Build and install.
- [x] Open Gmail or another app that uses Custom Tabs and navigate on a link from there.
- [x] Notice the DDG Custom Tab is open. 
- [x] Tap on "Find in Page" from the overflow menu.
- [x] Notice the ANR.
- [x] Restart the browser app.
- [x] Verify the `m_anr_exception` pixel is sent with `customTab=true` param.


_Test Crash pixel with customTab=false (Browser)_
- [x] Checkout this branch and change the policy to `ExistingPeriodicWorkPolicy.REPLACE` in https://github.com/duckduckgo/Android/blob/feature/ana/android_distinguish_browser_vs_custom_tabs_crash_anrs/statistics/src/main/java/com/duckduckgo/app/statistics/api/OfflinePixelScheduler.kt#L55.
- [x] Add the below code to produce a crash when tapping on "Find in page" from the overflow menu at https://github.com/duckduckgo/Android/blob/feature/ana/android_distinguish_browser_vs_custom_tabs_crash_anrs/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt#L3277
```
                    throw IllegalStateException("test")
```
- [x] Build and install.
- [x] Open the app.
- [x] Tap on "Find in Page" from the overflow menu.
- [x] Notice the crash.
- [x] Restart the app.
- [x] Verify the `m_d_ac_g` pixel is sent with `customTab=false` param.


_Test Crash pixel with customTab=true (Custom Tab)_
- [x] Checkout this branch and change the policy to `ExistingPeriodicWorkPolicy.REPLACE` in https://github.com/duckduckgo/Android/blob/feature/ana/android_distinguish_browser_vs_custom_tabs_crash_anrs/statistics/src/main/java/com/duckduckgo/app/statistics/api/OfflinePixelScheduler.kt#L55.
- [x] Add the below code to produce a crash when tapping on "Find in page" from the overflow menu at https://github.com/duckduckgo/Android/blob/feature/ana/android_distinguish_browser_vs_custom_tabs_crash_anrs/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt#L3277
```
                     throw IllegalStateException("test")
```
- [x] Build and install.
- [x] Open Gmail or another app that uses Custom Tabs and navigate on a link from there.
- [x] Notice the DDG Custom Tab is open. 
- [x] Tap on "Find in Page" from the overflow menu.
- [x] Notice the crash.
- [x] Restart the browser app.
- [x] Verify the `m_d_ac_g` pixel is sent with `customTab=true` param.


_Test the DB migration_
- [x] Install from develop.
- [x] Checkout this branch.
- [x] Add the below code to produce an ANR when tapping on "Find in page" from the overflow menu at https://github.com/duckduckgo/Android/blob/feature/ana/android_distinguish_browser_vs_custom_tabs_crash_anrs/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt#L3277
```
                    Handler(Looper.getMainLooper()).post {
                        Thread.sleep(10000)
                    }
```
- [x] Add the below code to produce a crash when tapping on "Share" from the overflow menu at https://github.com/duckduckgo/Android/blob/feature/ana/android_distinguish_browser_vs_custom_tabs_crash_anrs/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt#L3297
```
                     throw IllegalStateException("test")
```
- [x] Update the app using the code on this branch. It's important to be an update, not a fresh install.
- [x] Open the app.
- [x] Tap on "Find in Page" from the overflow menu.
- [x] Notice the ANR.
- [x] Notice the ANR DB is created and contains the custom tab column in the ANR table.
- [x] Open the app.
- [x] Tap on "Share" from the overflow menu.
- [x] Notice the crash.
- [x] Notice the Crash DB is created and contains the custom tab column in the Crash table.

### NO UI changes

