### PR TITLE
Revert "cancel previous notifs ID before showing new one (#4447)"

### DIFF
--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/notification/NotificationUtils.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/notification/NotificationUtils.kt
@@ -29,7 +29,6 @@ fun NotificationManagerCompat.checkPermissionAndNotify(
     notification: Notification,
 ) {
     if (ActivityCompat.checkSelfPermission(context, POST_NOTIFICATIONS) == PERMISSION_GRANTED) {
-        cancel(id) // ensure previous notifications with same ID are dismissed
         notify(id, notification)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207173112197170/f

### Description
Revert cancel notifs before notify as it's causing pulsing notif icon in the status bar in some OEMs

### Steps to test this PR
NA
