### PR TITLE
Add dev settings to clear previously seen surveys so they can be tested again

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/survey/AutofillSurveyStore.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/survey/AutofillSurveyStore.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.withContext
 interface AutofillSurveyStore {
     suspend fun hasSurveyBeenTaken(id: String): Boolean
     suspend fun recordSurveyWasShown(id: String)
+    suspend fun resetPreviousSurveys()
 }
 
 @ContributesBinding(AppScope::class)
@@ -56,6 +57,14 @@ class AutofillSurveyStoreImpl @Inject constructor(
             newValue.add(id)
             prefs.edit {
                 putStringSet(SURVEY_IDS, newValue)
+            }
+        }
+    }
+
+    override suspend fun resetPreviousSurveys() {
+        withContext(dispatchers.io()) {
+            prefs.edit {
+                remove(SURVEY_IDS)
             }
         }
     }

--- a/autofill/autofill-internal/src/main/java/com/duckduckgo/autofill/internal/AutofillInternalSettingsActivity.kt
+++ b/autofill/autofill-internal/src/main/java/com/duckduckgo/autofill/internal/AutofillInternalSettingsActivity.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.autofill.impl.configuration.AutofillJavascriptEnvironmentC
 import com.duckduckgo.autofill.impl.email.incontext.store.EmailProtectionInContextDataStore
 import com.duckduckgo.autofill.impl.store.InternalAutofillStore
 import com.duckduckgo.autofill.impl.store.NeverSavedSiteRepository
+import com.duckduckgo.autofill.impl.ui.credential.management.survey.AutofillSurveyStore
 import com.duckduckgo.autofill.internal.databinding.ActivityAutofillInternalSettingsBinding
 import com.duckduckgo.browser.api.UserBrowserProperties
 import com.duckduckgo.common.ui.DuckDuckGoActivity
@@ -83,6 +84,9 @@ class AutofillInternalSettingsActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var autofillJavascriptEnvironmentConfiguration: AutofillJavascriptEnvironmentConfiguration
 
+    @Inject
+    lateinit var autofillSurveyStore: AutofillSurveyStore
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
@@ -132,6 +136,16 @@ class AutofillInternalSettingsActivity : DuckDuckGoActivity() {
         configureLoginsUiEventHandlers()
         configureNeverSavedSitesEventHandlers()
         configureAutofillJsConfigEventHandlers()
+        configureSurveyEventHandlers()
+    }
+
+    private fun configureSurveyEventHandlers() {
+        binding.autofillSurveyResetButton.setOnClickListener {
+            lifecycleScope.launch(dispatchers.io()) {
+                autofillSurveyStore.resetPreviousSurveys()
+            }
+            Toast.makeText(this, getString(R.string.autofillDevSettingsSurveySectionResetted), Toast.LENGTH_SHORT).show()
+        }
     }
 
     private fun configureNeverSavedSitesEventHandlers() = with(binding) {

--- a/autofill/autofill-internal/src/main/res/layout/activity_autofill_internal_settings.xml
+++ b/autofill/autofill-internal/src/main/res/layout/activity_autofill_internal_settings.xml
@@ -209,5 +209,24 @@
             app:primaryText="@string/autofillDevSettingsConfigDebugTitle"
             app:secondaryText="@string/autofillDevSettingsConfigDebugSubtitle" />
 
+        <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+            android:id="@+id/autofillSurveySectionTitle"
+            android:layout_width="match_parent"
+            android:layout_marginTop="20dp"
+            android:layout_height="wrap_content"
+            app:primaryText="@string/autofillDevSettingsSurveySectionTitle" />
+
+        <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+            android:id="@+id/autofillSurveyResetButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:primaryText="@string/autofillDevSettingsSurveySectionResetPreviousSurveysTitle"
+            app:secondaryText="@string/autofillDevSettingsSurveySectionInstruction" />
+
+
     </LinearLayout>
 </androidx.core.widget.NestedScrollView>

--- a/autofill/autofill-internal/src/main/res/values/donottranslate.xml
+++ b/autofill/autofill-internal/src/main/res/values/donottranslate.xml
@@ -69,4 +69,9 @@
     <string name="autofillDevSettingsAddSampleLoginsSameSubdomainSubtitle">Adds multiple logins for https://fill.dev with same username and password</string>
     <string name="autofillDevSettingsAddSampleLoginsMultipleSubdomains">Add duplicate logins (across different subdomains)</string>
     <string name="autofillDevSettingsAddSampleLoginsMultipleSubdomainsSubtitle">Adds multiple logins for https://fill.dev with same username and password but across different subdomains</string>
+
+    <string name="autofillDevSettingsSurveySectionTitle">Autofill Survey</string>
+    <string name="autofillDevSettingsSurveySectionResetPreviousSurveysTitle">Previously Seen Surveys</string>
+    <string name="autofillDevSettingsSurveySectionInstruction">Tap to reset available surveys</string>
+    <string name="autofillDevSettingsSurveySectionResetted">Previously seen surveys available again</string>
 </resources>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1207179707350730/f 

### Description
Adds a dev setting to reset previous surveys so you can test taking the survey again.

### Steps to test this PR
QA-optional since it's just dev settings. but steps to test are below:

- [x] Dismiss or view the autofill survey in autofill settings; verify the prompt to take the survey is gone
- [x] Visit the internal autofill dev settings (`Settings`->`Autofill Dev Settings`)
- [x] Scroll all the way to the bottom and tap on `Previously Seen Surveys`)
- [x] Return to autofill settings and verify the survey reappears
