### PR TITLE
Fix crash in VPN internal sysapps dev setting

### DIFF
--- a/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/feature/system_apps/NetPSystemAppsExclusionListActivity.kt
+++ b/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/feature/system_apps/NetPSystemAppsExclusionListActivity.kt
@@ -29,20 +29,14 @@ import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
-import com.duckduckgo.di.scopes.VpnScope
 import com.duckduckgo.networkprotection.api.NetworkProtectionState
 import com.duckduckgo.networkprotection.internal.databinding.ActivityNetpInternalSystemAppsExclusionBinding
 import com.duckduckgo.networkprotection.internal.network.NetPInternalExclusionListProvider
-import dagger.WrongScope
 import javax.inject.Inject
 import kotlinx.coroutines.flow.*
 import logcat.logcat
 
-@WrongScope(
-    comment = "VpnScope to access dependencies in there",
-    correctScope = ActivityScope::class,
-)
-@InjectWith(VpnScope::class)
+@InjectWith(ActivityScope::class)
 class NetPSystemAppsExclusionListActivity : DuckDuckGoActivity(), SystemAppView.SystemAppListener {
 
     @Inject


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1206363377509730/f

### Description
Fix crash in manage system apps VPN internal setting.

The activity was in the wrong scope and now that we moved to monolithic activity component it was crashing

### Steps to test this PR
- [x] install from this branch
- [x] enable VPN
- [x] go to app settings -> netp dev settings -> manage system apps
- [x] verify app does not crash (develop should crash)
- [x] verify you can disable/re-enable system apps
