### PR TITLE
Android: Remove webView?.hitTestResult?.extra

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1300,11 +1300,7 @@ class BrowserTabFragment :
 
             is Command.OpenMessageInNewTab -> {
                 if (isActiveCustomTab()) {
-                    webView?.hitTestResult?.extra?.let { data ->
-                        webView?.loadUrl(Uri.parse(data).toString())
-                    } ?: run {
-                        (activity as CustomTabActivity).openMessageInNewFragmentInCustomTab(it.message, this, customTabToolbarColor)
-                    }
+                    (activity as CustomTabActivity).openMessageInNewFragmentInCustomTab(it.message, this, customTabToolbarColor)
                 } else {
                     browserActivity?.openMessageInNewTab(it.message, it.sourceTabId)
                 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207192888968116/f

### Description
Removed extra check when handling `OpenMessageInNewTab` command in Custom Tab.

### Steps to test this PR

Test link in DDG Custom Tab
- [x] Install from this branch and set DDG as default browser.
- [x] Open the Custom Tab Test app (see https://app.asana.com/0/1200905986587319/1207025963579423/f) and use this url: https://appsumo.com/products/tidycal/?content=Image%20of%20TidyCal&_kx=XrBlyqQ7F44JePDtpVpyhbB6nfFPdrfHleFi8Cp75iQ.Ktp4ZG
- [x] Notice a DDG Custom Tab is opened.
- [x] Scroll down and tap on `Meet TidyCal` link.
- [x] Notice the new page is opened in the same Custom Tab and the url is `tidycal.com`.

### NO UI changes
