### PR TITLE
Android: Link sharing from another app to DDG is broken

### DIFF
--- a/app/src/test/java/com/duckduckgo/app/browser/customtabs/IntentDispatcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/customtabs/IntentDispatcherViewModelTest.kt
@@ -119,6 +119,43 @@ class IntentDispatcherViewModelTest {
         }
     }
 
+    @Test
+    fun whenIntentReceivedWithNoSessionAndIntentTextContainingSpacesAndNotStartingWithHttpSchemaThenNoChangesAreMadeToTheIntent() = runTest {
+        val intentTextWithSpaces =
+            """
+                Voyager 1 is still bringing us surprises from the very edge of our solar system https://www.independent.co.uk/space/voyager-1-nasa-latest-solar-system-b2535462.html
+            """.trimIndent()
+        whenever(mockIntent.intentText).thenReturn(intentTextWithSpaces)
+        configureHasSession(false)
+        configureIsEmailProtectionLink(false)
+
+        testee.onIntentReceived(mockIntent, DEFAULT_COLOR)
+
+        testee.viewState.test {
+            val state = awaitItem()
+            assertFalse(state.customTabRequested)
+            assertEquals(intentTextWithSpaces, state.intentText)
+        }
+    }
+
+    @Test
+    fun whenIntentReceivedWithSessionAndIntentTextContainingSpacesAndNotStartingWithHttpSchemaThenNoChangesAreMadeToTheIntent() = runTest {
+        val intentTextWithSpaces =
+            """
+                Voyager 1 is still bringing us surprises from the very edge of our solar system https://www.independent.co.uk/space/voyager-1-nasa-latest-solar-system-b2535462.html
+            """.trimIndent()
+        whenever(mockIntent.intentText).thenReturn(intentTextWithSpaces)
+        configureHasSession(true)
+
+        testee.onIntentReceived(mockIntent, DEFAULT_COLOR)
+
+        testee.viewState.test {
+            val state = awaitItem()
+            assertTrue(state.customTabRequested)
+            assertEquals(intentTextWithSpaces, state.intentText)
+        }
+    }
+
     private fun configureHasSession(returnValue: Boolean) {
         whenever(mockIntent.hasExtra(CustomTabsIntent.EXTRA_SESSION)).thenReturn(returnValue)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207192888968125/f

### Description
Fixed link sharing from another app to DDG.

### Steps to test this PR

See the issue in develop
- [x] Install from develop.
- [x] Open Google News and tap on share and choose DuckDuckGo.
- [x] Notice the DDG app is open and shows a text with encoded spaces. 

Test the fix
- [x] Install from this branch.
- [x] Open Google News and tap on share and choose DuckDuckGo.
- [x] Notice the DDG app is open and shows a text without encoded spaces. This is the same behavior as in old DDG versions, like `5.194.0`.

### NO UI changes
| Issue  | Fix |
| ------ | ----- |
|![issue](https://github.com/duckduckgo/Android/assets/7963079/99b86ddc-eac9-49ce-8e33-ebbcfba60200)|![fix](https://github.com/duckduckgo/Android/assets/7963079/90355fb8-e045-4ad4-a39d-eebcf233785f)|
