### PR TITLE
try-catch sitePermissionRequest.grant call

### DIFF
--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
@@ -282,7 +282,12 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
 
     private fun grantPermissions() {
         val permissions = permissionsHandledAutomatically.toTypedArray() + permissionsHandledByUser
-        sitePermissionRequest.grant(permissions)
+        try {
+            sitePermissionRequest.grant(permissions)
+        } catch (e: IllegalStateException) {
+            // IllegalStateException is thrown when grant() or deny() have been called already.
+            Timber.w("IllegalStateException when calling grant() site permissions")
+        }
     }
 
     private fun systemPermissionGranted() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207191338636817/f

### Description
try-catch calls to site permissions grant to ensure `Either grant() or deny() has been already called.` exception doesn't crash the app

### Steps to test this PR
QA optional
