### PR TITLE
Update dependencies to match Anvil 2.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,10 @@
 buildscript {
 
     ext {
-        kotlin_version = '1.9.20'
+        kotlin_version = '1.9.22'
         spotless = '6.1.2'
         anvil_version = '2.5.0-beta07'
-        ksp_version = '1.9.20-1.0.14'
+        ksp_version = '1.9.22-1.0.17'
         gradle_plugin = '8.1.2'
         min_sdk = 26
         target_sdk = 34

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version "1.9.20"
+    id 'org.jetbrains.kotlin.jvm' version "1.9.22"
 }
 
 repositories {

--- a/versions.properties
+++ b/versions.properties
@@ -81,13 +81,13 @@ version.com.nhaarman.mockitokotlin2..mockito-kotlin=2.2.0
 
 version.google.android.material=1.7.0
 
-version.google.dagger=2.48.1
+version.google.dagger=2.51.1
 
 version.jakewharton.rxrelay2=2.0.0
 
 version.jakewharton.timber=5.0.1
 
-version.kotlin=1.9.20
+version.kotlin=1.9.22
 
 version.kotlinx.coroutines=1.7.3
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207208354433631/f

### Description
Since we moved to Anvil 2.5 (https://github.com/duckduckgo/Android/pull/4462), this PR updates these matching dependencies:

`kotlin_version = ‘1.9.20'` → `‘1.9.22'`
`version.google.dagger=2.48.1` → `2.51.1`

### Testing

- Nightly run: https://github.com/duckduckgo/Android/actions/runs/8908351852 ✅
- Tested with IntelliJ 2024.1.1 ✅

### Steps to test this PR

- [ ] Smoke test
