### PR TITLE
Wrap web message listener onPostMessage calls in a runCatching

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/configuration/integration/modern/listener/WebMessageListenerGetAutofillConfig.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/configuration/integration/modern/listener/WebMessageListenerGetAutofillConfig.kt
@@ -30,6 +30,7 @@ import dagger.SingleInstanceIn
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 @SuppressLint("RequiresFeature")
 @SingleInstanceIn(FragmentScope::class)
@@ -50,9 +51,13 @@ class WebMessageListenerGetAutofillConfig @Inject constructor(
         isMainFrame: Boolean,
         reply: JavaScriptReplyProxy,
     ) {
-        job += appCoroutineScope.launch(dispatchers.io()) {
-            val config = autofillRuntimeConfigProvider.getRuntimeConfiguration(sourceOrigin.toString())
-            reply.postMessage(config)
+        kotlin.runCatching {
+            job += appCoroutineScope.launch(dispatchers.io()) {
+                val config = autofillRuntimeConfigProvider.getRuntimeConfiguration(sourceOrigin.toString())
+                reply.postMessage(config)
+            }
+        }.onFailure {
+            Timber.e(it, "Error while processing autofill web message for %s", key)
         }
     }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/configuration/integration/modern/listener/WebMessageListenerGetAutofillData.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/configuration/integration/modern/listener/WebMessageListenerGetAutofillData.kt
@@ -71,19 +71,23 @@ class WebMessageListenerGetAutofillData @Inject constructor(
         isMainFrame: Boolean,
         reply: JavaScriptReplyProxy,
     ) {
-        val originalUrl: String? = webView.url
+        runCatching {
+            val originalUrl: String? = webView.url
 
-        job += appCoroutineScope.launch(dispatchers.io()) {
-            val requestId = storeReply(reply)
+            job += appCoroutineScope.launch(dispatchers.io()) {
+                val requestId = storeReply(reply)
 
-            getAutofillData(
-                message.data.toString(),
-                AutofillWebMessageRequest(
-                    requestOrigin = sourceOrigin.toString(),
-                    originalPageUrl = originalUrl,
-                    requestId = requestId,
-                ),
-            )
+                getAutofillData(
+                    message.data.toString(),
+                    AutofillWebMessageRequest(
+                        requestOrigin = sourceOrigin.toString(),
+                        originalPageUrl = originalUrl,
+                        requestId = requestId,
+                    ),
+                )
+            }
+        }.onFailure {
+            Timber.e(it, "Error while processing autofill web message for %s", key)
         }
     }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/configuration/integration/modern/listener/email/WebMessageListenerEmailGetCapabilities.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/configuration/integration/modern/listener/email/WebMessageListenerEmailGetCapabilities.kt
@@ -31,6 +31,7 @@ import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.invoke
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 @SingleInstanceIn(FragmentScope::class)
 @ContributesMultibinding(FragmentScope::class)
@@ -53,10 +54,14 @@ class WebMessageListenerEmailGetCapabilities @Inject constructor(
         isMainFrame: Boolean,
         reply: JavaScriptReplyProxy,
     ) {
-        if (!EmailProtectionUrl.isEmailProtectionUrl(webView.url)) return
+        kotlin.runCatching {
+            if (!EmailProtectionUrl.isEmailProtectionUrl(webView.url)) return
 
-        job += appCoroutineScope.launch(dispatchers.io()) {
-            reply.postMessage(generateResponse())
+            job += appCoroutineScope.launch(dispatchers.io()) {
+                reply.postMessage(generateResponse())
+            }
+        }.onFailure {
+            Timber.e(it, "Error while processing autofill web message for %s", key)
         }
     }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/configuration/integration/modern/listener/email/WebMessageListenerEmailGetUserData.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/configuration/integration/modern/listener/email/WebMessageListenerEmailGetUserData.kt
@@ -31,6 +31,7 @@ import dagger.SingleInstanceIn
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 @SingleInstanceIn(FragmentScope::class)
 @ContributesMultibinding(FragmentScope::class)
@@ -54,10 +55,14 @@ class WebMessageListenerEmailGetUserData @Inject constructor(
         isMainFrame: Boolean,
         reply: JavaScriptReplyProxy,
     ) {
-        if (!EmailProtectionUrl.isEmailProtectionUrl(webView.url)) return
+        kotlin.runCatching {
+            if (!EmailProtectionUrl.isEmailProtectionUrl(webView.url)) return
 
-        job += appCoroutineScope.launch(dispatchers.io()) {
-            reply.postMessage(generateResponse())
+            job += appCoroutineScope.launch(dispatchers.io()) {
+                reply.postMessage(generateResponse())
+            }
+        }.onFailure {
+            Timber.e(it, "Error while processing autofill web message for %s", key)
         }
     }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/configuration/integration/modern/listener/email/WebMessageListenerEmailRemoveCredentials.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/configuration/integration/modern/listener/email/WebMessageListenerEmailRemoveCredentials.kt
@@ -31,6 +31,7 @@ import dagger.SingleInstanceIn
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 @SingleInstanceIn(FragmentScope::class)
 @ContributesMultibinding(FragmentScope::class)
@@ -54,10 +55,14 @@ class WebMessageListenerEmailRemoveCredentials @Inject constructor(
         isMainFrame: Boolean,
         reply: JavaScriptReplyProxy,
     ) {
-        if (!EmailProtectionUrl.isEmailProtectionUrl(webView.url)) return
+        kotlin.runCatching {
+            if (!EmailProtectionUrl.isEmailProtectionUrl(webView.url)) return
 
-        appCoroutineScope.launch(dispatchers.io()) {
-            emailManager.signOut()
+            appCoroutineScope.launch(dispatchers.io()) {
+                emailManager.signOut()
+            }
+        }.onFailure {
+            Timber.e(it, "Error while processing autofill web message for %s", key)
         }
     }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/configuration/integration/modern/listener/email/WebMessageListenerEmailStoreCredentials.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/configuration/integration/modern/listener/email/WebMessageListenerEmailStoreCredentials.kt
@@ -60,13 +60,17 @@ class WebMessageListenerEmailStoreCredentials @Inject constructor(
         isMainFrame: Boolean,
         reply: JavaScriptReplyProxy,
     ) {
-        if (!EmailProtectionUrl.isEmailProtectionUrl(webView.url)) return
+        kotlin.runCatching {
+            if (!EmailProtectionUrl.isEmailProtectionUrl(webView.url)) return
 
-        appCoroutineScope.launch(dispatchers.io()) {
-            parseIncomingMessage(message.data.toString())?.let {
-                emailManager.storeCredentials(it.token, it.userName, it.cohort)
-                Timber.i("Saved email protection credentials for user %s", it.userName)
+            appCoroutineScope.launch(dispatchers.io()) {
+                parseIncomingMessage(message.data.toString())?.let {
+                    emailManager.storeCredentials(it.token, it.userName, it.cohort)
+                    Timber.i("Saved email protection credentials for user %s", it.userName)
+                }
             }
+        }.onFailure {
+            Timber.e(it, "Error while processing autofill web message for %s", key)
         }
     }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/configuration/integration/modern/listener/email/incontext/WebMessageListenerGetIncontextSignupDismissedAt.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/configuration/integration/modern/listener/email/incontext/WebMessageListenerGetIncontextSignupDismissedAt.kt
@@ -33,6 +33,7 @@ import dagger.SingleInstanceIn
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 @SingleInstanceIn(FragmentScope::class)
 @ContributesMultibinding(FragmentScope::class)
@@ -55,8 +56,12 @@ class WebMessageListenerGetIncontextSignupDismissedAt @Inject constructor(
         isMainFrame: Boolean,
         reply: JavaScriptReplyProxy,
     ) {
-        job += appCoroutineScope.launch(dispatchers.io()) {
-            reply.postMessage(generateResponse())
+        kotlin.runCatching {
+            job += appCoroutineScope.launch(dispatchers.io()) {
+                reply.postMessage(generateResponse())
+            }
+        }.onFailure {
+            Timber.e(it, "Error while processing autofill web message for %s", key)
         }
     }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/configuration/integration/modern/listener/email/incontext/WebMessageListenerShowInContextEmailProtectionSignupPrompt.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/configuration/integration/modern/listener/email/incontext/WebMessageListenerShowInContextEmailProtectionSignupPrompt.kt
@@ -33,6 +33,7 @@ import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import timber.log.Timber
 
 @SingleInstanceIn(FragmentScope::class)
 @ContributesMultibinding(FragmentScope::class)
@@ -53,18 +54,22 @@ class WebMessageListenerShowInContextEmailProtectionSignupPrompt @Inject constru
         isMainFrame: Boolean,
         reply: JavaScriptReplyProxy,
     ) {
-        val originalUrl: String? = webView.url
+        kotlin.runCatching {
+            val originalUrl: String? = webView.url
 
-        job += appCoroutineScope.launch(dispatchers.io()) {
-            val requestOrigin = sourceOrigin.toString()
-            val requestId = storeReply(reply)
+            job += appCoroutineScope.launch(dispatchers.io()) {
+                val requestOrigin = sourceOrigin.toString()
+                val requestId = storeReply(reply)
 
-            val autofillWebMessageRequest = AutofillWebMessageRequest(
-                requestOrigin = requestOrigin,
-                originalPageUrl = originalUrl,
-                requestId = requestId,
-            )
-            showInContextEmailProtectionSignupPrompt(autofillWebMessageRequest)
+                val autofillWebMessageRequest = AutofillWebMessageRequest(
+                    requestOrigin = requestOrigin,
+                    originalPageUrl = originalUrl,
+                    requestId = requestId,
+                )
+                showInContextEmailProtectionSignupPrompt(autofillWebMessageRequest)
+            }
+        }.onFailure {
+            Timber.e(it, "Error while processing autofill web message for %s", key)
         }
     }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/configuration/integration/modern/listener/password/WebMessageListenerStoreFormData.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/configuration/integration/modern/listener/password/WebMessageListenerStoreFormData.kt
@@ -73,18 +73,22 @@ class WebMessageListenerStoreFormData @Inject constructor(
         isMainFrame: Boolean,
         reply: JavaScriptReplyProxy,
     ) {
-        // important to call suppressor as soon as possible
-        systemAutofillServiceSuppressor.suppressAutofill(webView)
+        kotlin.runCatching {
+            // important to call suppressor as soon as possible
+            systemAutofillServiceSuppressor.suppressAutofill(webView)
 
-        val originalUrl: String? = webView.url
+            val originalUrl: String? = webView.url
 
-        appCoroutineScope.launch(dispatchers.io()) {
-            val requestOrigin = sourceOrigin.toString()
-            val requestId = storeReply(reply)
-            storeFormData(
-                message.data.toString(),
-                AutofillWebMessageRequest(requestOrigin = requestOrigin, originalPageUrl = originalUrl, requestId = requestId),
-            )
+            appCoroutineScope.launch(dispatchers.io()) {
+                val requestOrigin = sourceOrigin.toString()
+                val requestId = storeReply(reply)
+                storeFormData(
+                    message.data.toString(),
+                    AutofillWebMessageRequest(requestOrigin = requestOrigin, originalPageUrl = originalUrl, requestId = requestId),
+                )
+            }
+        }.onFailure {
+            Timber.e(it, "Error while processing autofill web message for %s", key)
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207224424059893/f 

### Description
In investigating crashes, we think it's possible that an exception happening in the web message listener `onPostMessage` callbacks can result in webview crashing. In order to help pin down whether that's what is causing those crashes, will add `runCatching` guards inside the web message listeners.

### Steps to test this PR
QA-optional