### PR TITLE
Better caching of js to inject for autofill

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/configuration/AutofillJavascriptLoader.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/configuration/AutofillJavascriptLoader.kt
@@ -20,6 +20,7 @@ import com.duckduckgo.autofill.impl.configuration.AutofillJavascriptEnvironmentC
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
 import java.io.BufferedReader
 import javax.inject.Inject
 import kotlinx.coroutines.withContext
@@ -28,6 +29,7 @@ interface AutofillJavascriptLoader {
     suspend fun getAutofillJavascript(): String
 }
 
+@SingleInstanceIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 class DefaultAutofillJavascriptLoader @Inject constructor(
     private val filenameProvider: AutofillJavascriptEnvironmentConfiguration,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207229909321475/f 

### Description
In `DefaultAutofillJavascriptLoader`, we lazily load JS from disk which will be injected into the WebView. At the moment, each new tab creation will result in yet another disk read for the JS.

With this PR, we construct javascript loader as a singleton so that the JS is more quickly available to each subsequent tab that is created.

### Steps to test this PR
QA-optional
