### PR TITLE
Fix: FF with defaultValue set to true should evaluate threshold

### DIFF
--- a/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureToggles.kt
+++ b/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureToggles.kt
@@ -266,10 +266,7 @@ internal class ToggleImpl constructor(
             return
         }
 
-        // local state is false (and remote state is enabled) try incremental rollout
-        if (!state.enable) {
-            state = calculateRolloutState(state)
-        }
+        state = evaluateRolloutThreshold(state)
 
         // remote state is null, means app update. Propagate the local state to remote state
         if (state.remoteEnableState == null) {
@@ -284,7 +281,7 @@ internal class ToggleImpl constructor(
         return store.get(key)
     }
 
-    private fun calculateRolloutState(
+    private fun evaluateRolloutThreshold(
         inputState: State,
     ): State {
         fun checkAndSetRolloutThreshold(state: State): State {

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt
@@ -213,7 +213,7 @@ class FeatureTogglesTest {
         assertTrue(feature.self().isEnabled())
 
         feature.self().setEnabled(state.copy(rollout = listOf(1.0, 2.0)))
-        assertTrue(feature.self().isEnabled())
+        assertEquals(feature.self().rolloutThreshold() < 2.0, feature.self().isEnabled())
 
         feature.self().setEnabled(state.copy(rollout = listOf(0.5, 2.0), rolloutThreshold = 0.0))
         assertTrue(feature.self().isEnabled())
@@ -229,9 +229,9 @@ class FeatureTogglesTest {
             rollout = listOf(100.0),
             rolloutThreshold = null,
         )
-        val expected = state.copy(remoteEnableState = state.enable)
         feature.self().setEnabled(state)
         assertTrue(feature.self().isEnabled())
+        val expected = state.copy(remoteEnableState = state.enable, rolloutThreshold = feature.self().getRawStoredState()?.rolloutThreshold)
         assertEquals(expected, toggleStore.get("test"))
     }
 
@@ -369,7 +369,8 @@ class FeatureTogglesTest {
         )
         feature.self().setEnabled(state)
         assertTrue(feature.self().isEnabled())
-        assertEquals(state, toggleStore.get("test"))
+        val expected = state.copy(rolloutThreshold = feature.self().getRawStoredState()?.rolloutThreshold)
+        assertEquals(expected, toggleStore.get("test"))
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207205379865938/f

### Description
FF that had the default value set to true and use it would no longer evaluate the rollout threshold.

### Steps to test this PR
See integration tests added
