### PR TITLE
Avoid double WebView initialisation on new tab screen

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -3809,8 +3809,17 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenSubmittedQueryAndNavigationStateIsNullThenResetHistoryCommandSent() {
+    fun whenSubmittedQueryAndNavigationStateIsNullAndNeverPreviouslyLoadedSiteThenResetHistoryCommandNotSent() {
         whenever(mockOmnibarConverter.convertQueryToUrl("nytimes.com", null)).thenReturn("nytimes.com")
+        testee.onUserSubmittedQuery("nytimes.com")
+        assertCommandNotIssued<Command.ResetHistory>()
+    }
+
+    @Test
+    fun whenSubmittedQueryAndNavigationStateIsNullAndPreviouslyLoadedSiteThenResetHistoryCommandSent() {
+        whenever(mockOmnibarConverter.convertQueryToUrl("nytimes.com", null)).thenReturn("nytimes.com")
+        setupNavigation(isBrowsing = true)
+        testee.onUserPressedBack()
         testee.onUserSubmittedQuery("nytimes.com")
         assertCommandIssued<Command.ResetHistory>()
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -290,6 +290,8 @@ class BrowserTabViewModel @Inject constructor(
     var siteLiveData: MutableLiveData<Site> = MutableLiveData()
     val privacyShieldViewState: MutableLiveData<PrivacyShieldViewState> = MutableLiveData()
 
+    // if navigating from home, want to know if a site was loaded previously to decide whether to reset WebView
+    private var returnedHomeAfterSiteLoaded = false
     var skipHome = false
     var hasCtaBeenShownForCurrentPage: AtomicBoolean = AtomicBoolean(false)
     val tabs: LiveData<List<TabEntity>> = tabRepository.liveTabs
@@ -774,6 +776,7 @@ class BrowserTabViewModel @Inject constructor(
                 }
 
                 if (shouldClearHistoryOnNewQuery()) {
+                    returnedHomeAfterSiteLoaded = false
                     command.value = ResetHistory
                 }
 
@@ -841,7 +844,7 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     private fun shouldClearHistoryOnNewQuery(): Boolean {
-        val navigation = webNavigationState ?: return true
+        val navigation = webNavigationState ?: return returnedHomeAfterSiteLoaded
         return !currentBrowserViewState().browserShowing && navigation.hasNavigationHistory
     }
 
@@ -1004,6 +1007,7 @@ class BrowserTabViewModel @Inject constructor(
         site = null
         onSiteChanged()
         webNavigationState = null
+        returnedHomeAfterSiteLoaded = true
 
         val browserState = browserStateModifier.copyForHomeShowing(currentBrowserViewState()).copy(
             canGoForward = currentGlobalLayoutState() !is Invalidated,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1207230436936681/f 

### Description
Avoids the cost of initialising the `WebView` twice on a new tab screen.
- We initialise a `WebView` when creating the new tab
- We destroy it and rebuild a new one when loading the first site

### Steps to test this PR

For testing, essentially want to ensure that the behavior is exactly the same as production right now (except under the hood, `WebView` not created twice). 

#### [optional] Verify `WebView` created twice currently
- [x] checkout `develop`
- [x] add a log statement to `BrowserTabFragment.configureWebView()`, launch a new tab and count number of inits

#### Ensuring previous fix still applied
In particular, want to ensure the previous fix is still good meaning the following steps are true:

- [x] Install from this branch and get to new tab page
- [x] Visit any site or perform a search (`Site A`)
- [x] Press back; verify you go back to home tab
- [x] Visit a new site or performs a search (`Site B`)
- [x] Verify you don't see `Site A` before `Site B` starts loading
- [x] Press back; verify you go back to home tab

#### Any other smoke testing welcome

e.g.,:
- [x] Custom tabs navigation works same as prod
- [x] Back/forward navigation works same as prod