### PR TITLE
Register in VPN process as well

### DIFF
--- a/anrs/anrs-impl/build.gradle
+++ b/anrs/anrs-impl/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation project(':verified-installation-api')
     implementation project(':library-loader-api')
     implementation project(':feature-toggles-api')
+    implementation project(':data-store-api')
 
     implementation AndroidX.core.ktx
     implementation KotlinX.coroutines.core
@@ -48,6 +49,7 @@ dependencies {
     implementation AndroidX.room.rxJava2
 
     testImplementation project(':common-test')
+    implementation project(':data-store-test')
     testImplementation Testing.junit4
     testImplementation AndroidX.archCore.testing
     testImplementation AndroidX.test.ext.junit

--- a/anrs/anrs-impl/src/main/cpp/jni.cpp
+++ b/anrs/anrs-impl/src/main/cpp/jni.cpp
@@ -65,7 +65,7 @@ Java_com_duckduckgo_app_anr_ndk_NativeCrashInit_jni_1register_1sighandler(
 
     send_crash_handle_init_pixel();
 
-    log_print(ANDROID_LOG_ERROR, "Native crash handler successfully initialized.");
+    log_print(ANDROID_LOG_ERROR, "Native crash handler successfully initialized on %s.", pname);
 }
 
 extern "C" JNIEXPORT void JNICALL

--- a/anrs/anrs-impl/src/main/cpp/pixel.cpp
+++ b/anrs/anrs-impl/src/main/cpp/pixel.cpp
@@ -58,7 +58,7 @@ void send_crash_pixel() {
     char path[2048];
     sprintf(path, "/t/m_app_native_crash_android?appVersion=%s&pn=%s&customTab=%s", appVersion, pname, isCustomTab ? "true" : "false");
     send_request(host, path);
-    log_print(ANDROID_LOG_ERROR, "Native crash pixel sent");
+    log_print(ANDROID_LOG_ERROR, "Native crash pixel sent on %s", pname);
 }
 
 void send_crash_handle_init_pixel() {
@@ -66,5 +66,5 @@ void send_crash_handle_init_pixel() {
     char path[2048];
     sprintf(path, "/t/m_app_register_native_crash_handler_android?appVersion=%s&pn=%s&customTab=%s", appVersion, pname, isCustomTab ? "true" : "false");
     send_request(host, path);
-    log_print(ANDROID_LOG_ERROR, "Native crash handler init pixel sent");
+    log_print(ANDROID_LOG_ERROR, "Native crash handler init pixel sent on %s", pname);
 }

--- a/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/AnrOfflinePixelSender.kt
+++ b/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/AnrOfflinePixelSender.kt
@@ -57,9 +57,9 @@ class AnrOfflinePixelSender @Inject constructor(
     }
 
     companion object {
-        const val ANR_STACKTRACE = "stackTrace"
-        const val ANR_WEBVIEW_VERSION = "webView"
-        const val ANR_CUSTOM_TAB = "customTab"
+        private const val ANR_STACKTRACE = "stackTrace"
+        private const val ANR_WEBVIEW_VERSION = "webView"
+        private const val ANR_CUSTOM_TAB = "customTab"
     }
 }
 

--- a/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/ndk/NativeCrashFeature.kt
+++ b/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/ndk/NativeCrashFeature.kt
@@ -16,13 +16,29 @@
 
 package com.duckduckgo.app.anr.ndk
 
+import android.content.SharedPreferences
+import androidx.core.content.edit
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.RemoteFeatureStoreNamed
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
     featureName = "androidNativeCrash",
+    toggleStore = NativeCrashFeatureMultiProcessStore::class,
 )
 interface NativeCrashFeature {
     @Toggle.DefaultValue(true)
@@ -31,4 +47,42 @@ interface NativeCrashFeature {
 
     @Toggle.DefaultValue(true)
     fun nativeCrashHandling(): Toggle
+
+    @Toggle.DefaultValue(true)
+    fun nativeCrashHandlingSecondaryProcess(): Toggle
+}
+
+@ContributesBinding(AppScope::class)
+@SingleInstanceIn(AppScope::class)
+@RemoteFeatureStoreNamed(NativeCrashFeature::class)
+class NativeCrashFeatureMultiProcessStore @Inject constructor(
+    @AppCoroutineScope private val coroutineScope: CoroutineScope,
+    private val dispatcherProvider: DispatcherProvider,
+    private val sharedPreferencesProvider: SharedPreferencesProvider,
+    moshi: Moshi,
+) : Toggle.Store {
+
+    private val preferences: SharedPreferences by lazy {
+        sharedPreferencesProvider.getSharedPreferences(PREFS_FILENAME, multiprocess = true, migrate = false)
+    }
+
+    private val stateAdapter: JsonAdapter<State> by lazy {
+        moshi.newBuilder().add(KotlinJsonAdapterFactory()).build().adapter(State::class.java)
+    }
+
+    override fun set(key: String, state: State) {
+        coroutineScope.launch(dispatcherProvider.io()) {
+            preferences.edit(commit = true) { putString(key, stateAdapter.toJson(state)) }
+        }
+    }
+
+    override fun get(key: String): State? {
+        return preferences.getString(key, null)?.let {
+            stateAdapter.fromJson(it)
+        }
+    }
+
+    companion object {
+        private const val PREFS_FILENAME = "com.duckduckgo.app.androidNativeCrash.feature.v1"
+    }
 }

--- a/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/ndk/NativeCrashInit.kt
+++ b/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/ndk/NativeCrashInit.kt
@@ -43,6 +43,10 @@ import logcat.logcat
     scope = AppScope::class,
     boundType = MainProcessLifecycleObserver::class,
 )
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = VpnProcessLifecycleObserver::class,
+)
 @SingleInstanceIn(AppScope::class)
 class NativeCrashInit @Inject constructor(
     context: Context,
@@ -89,7 +93,8 @@ class NativeCrashInit @Inject constructor(
 
     private suspend fun jniRegisterNativeSignalHandler() = withContext(dispatcherProvider.io()) {
         runCatching {
-            if (!nativeCrashFeature.nativeCrashHandling().isEnabled()) return@withContext
+            if (isMainProcess && !nativeCrashFeature.nativeCrashHandling().isEnabled()) return@withContext
+            if (!isMainProcess && !nativeCrashFeature.nativeCrashHandlingSecondaryProcess().isEnabled()) return@withContext
 
             val logLevel = if (appBuildConfig.isDebug || appBuildConfig.isInternalBuild()) {
                 Log.VERBOSE

--- a/anrs/anrs-impl/src/test/java/com/duckduckgo/app/anr/ndk/NativeCrashFeatureMultiProcessStoreTest.kt
+++ b/anrs/anrs-impl/src/test/java/com/duckduckgo/app/anr/ndk/NativeCrashFeatureMultiProcessStoreTest.kt
@@ -1,0 +1,43 @@
+package com.duckduckgo.app.anr.ndk
+
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.data.store.api.FakeSharedPreferencesProvider
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.squareup.moshi.Moshi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+
+class NativeCrashFeatureMultiProcessStoreTest {
+
+    @get:Rule var coroutineRule = CoroutineTestRule()
+
+    private val store = NativeCrashFeatureMultiProcessStore(
+        coroutineRule.testScope,
+        coroutineRule.testDispatcherProvider,
+        FakeSharedPreferencesProvider(),
+        Moshi.Builder().build(),
+    )
+
+    @Test
+    fun `test set value`() = runTest {
+        val expected = Toggle.State(enable = true)
+        store.set("key", expected)
+
+        Assert.assertEquals(expected, store.get("key"))
+    }
+
+    @Test
+    fun `test get missing value`() = runTest {
+        Assert.assertNull(store.get("key"))
+    }
+
+    @Test
+    fun `test get when value is not present`() {
+        val expected = Toggle.State(enable = true)
+        store.set("key", expected)
+
+        Assert.assertNull(store.get("wrong key"))
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207294405155930

### Description
Add native crash handling for VPN process now that we also have it for the main process

### Steps to test this PR
_Test native crash handing_
- [x] apply the patch from [this Asana task](https://app.asana.com/0/0/1207294405155932/f) to this PR
- [x] build and fresh install and launch app
- [x] Enable AppTP
- [x] verify `Native crash handler init pixel sent on vpn` appears in logcat
- [x] verify `Native crash handler successfully initialized on vpn.` apperas in logcat
- [x] verify VPN crashes and `Native crash pixel sent on vpn` appears in logcat
- [ ] In kibana, verify pixels appear when applying this filter `pixel:m.app*.native.crash.*`
_(pixels should have `pn=vpn` and the right version, may be difficult to find them as now we send for `pn=main` in production. Logcats above should be enough)_
- [ ] pixels have the right params, `vpn` process name, right `appVersion` and right `customTab` true/false value

_Test disabling crash handling_
- [x] use jsonblob or something else to set custom privacy config
- [x] add the following feature and set `nativeCrashHandlingSecondaryProcess` to `disabled`
```json
    "androidNativeCrash": {
      "exceptions": [],
      "state": "enabled",
      "hash": "38",
      "features": {
        "nativeCrashHandlingSecondaryProcess": {
          "state": "enabled"
        }
      }
    }
```
- [x] kill the processes and re-launch the app and verify none of the `vpn` related logcats in previous test appear
