### PR TITLE
Add custom tab navigation

### DIFF
--- a/.github/workflows/custom-tabs-nightly.yml
+++ b/.github/workflows/custom-tabs-nightly.yml
@@ -1,0 +1,76 @@
+name: Custom Tabs nightly tests
+
+on:
+  schedule:
+    - cron: '0 5 * * *' # run at 5 AM UTC
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  instrumentation_tests:
+    runs-on: ubuntu-latest
+    name: Custom Tabs nightly tests
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+
+      - name: Create folder
+        if: always()
+        run: mkdir apk
+
+      - name: Decode keys
+        uses: davidSchuppa/base64Secret-toFile-action@v2
+        with:
+          secret: ${{ secrets.FAKE_RELEASE_PROPERTIES }}
+          fileName: ddg_android_build.properties
+          destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
+
+      - name: Decode key file
+        uses: davidSchuppa/base64Secret-toFile-action@v2
+        with:
+          secret: ${{ secrets.FAKE_RELEASE_KEY }}
+          fileName: android
+          destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
+
+      - name: Assemble internal release APK
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: assembleInternalRelease -Pforce-default-variant -x lint
+
+      - name: Move APK to new folder
+        if: always()
+        run: find . -name "*.apk"  -exec mv '{}' apk/release.apk \;
+
+      - name: Custom Tabs Flows
+        uses: mobile-dev-inc/action-maestro-cloud@v1.8.1
+        with:
+          api-key: ${{ secrets.MOBILE_DEV_API_KEY }}
+          name: ${{ github.sha }}
+          app-file: apk/release.apk
+          android-api-level: 30
+          workspace: .maestro
+          include-tags: customTabsTest
+
+      - name: Create Asana task when workflow failed
+        if: ${{ failure() }}
+        id: create-failure-task
+        uses: duckduckgo/native-github-asana-sync@v1.1
+        with:
+          asana-pat: ${{ secrets.GH_ASANA_SECRET }}
+          asana-project: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
+          asana-section: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
+          asana-task-name: GH Workflow Failure - Custom Tabs Flows
+          asana-task-description: The Custom Tabs nightly workflow has failed. See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}
+          action: 'create-asana-task'

--- a/.maestro/custom_tabs/custom_tabs_navigation.yaml
+++ b/.maestro/custom_tabs/custom_tabs_navigation.yaml
@@ -1,0 +1,64 @@
+appId: com.duckduckgo.mobile.android
+name: "Custom Tabs navigation"
+tags:
+  - customTabsTest
+---
+- launchApp:
+    clearState: true
+    stopApp: true
+
+- assertVisible:
+    text: ".*Not to worry! Searching and browsing privately.*"
+- tapOn: "let's do it!"
+- runFlow:
+    when:
+      visible: "set as default"
+    commands:
+      - tapOn: "duckduckgo"
+      - tapOn: "set as default"
+      - assertVisible:
+          text: ".*I'll also upgrade the security of your connection if possible.*"
+
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+- tapOn:
+    text: "settings"
+- scrollUntilVisible:
+    element:
+      text: "developer settings"
+    direction: DOWN
+- tapOn:
+    text: "developer settings"
+- scrollUntilVisible:
+    element:
+      text: "custom tabs"
+    direction: DOWN
+- tapOn:
+    text: "custom tabs"
+- tapOn:
+    text: "add your url here"
+- inputText: "https://www.search-company.site"
+- tapOn:
+    text: "load custom tab"
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+- assertVisible:
+    text: "running in duckduckgo"
+- action: back
+- tapOn:
+    text: "[Ad 1] SERP Ad (heuristic)"
+- action: back
+- tapOn:
+    text: "[Ad 1] SERP Ad (heuristic)"
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/backMenuItem"
+- assertVisible:
+    text: "Search engine"
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/forwardMenuItem"
+- assertVisible:
+    text: "Publisher site"

--- a/.maestro/custom_tabs/custom_tabs_navigation_new_tab.yaml
+++ b/.maestro/custom_tabs/custom_tabs_navigation_new_tab.yaml
@@ -1,0 +1,70 @@
+appId: com.duckduckgo.mobile.android
+name: "Custom Tabs navigation in new tab"
+tags:
+  - customTabsTest
+---
+- launchApp:
+    clearState: true
+    stopApp: true
+
+- assertVisible:
+    text: ".*Not to worry! Searching and browsing privately.*"
+- tapOn: "let's do it!"
+- runFlow:
+    when:
+      visible: "set as default"
+    commands:
+      - tapOn: "duckduckgo"
+      - tapOn: "set as default"
+      - assertVisible:
+          text: ".*I'll also upgrade the security of your connection if possible.*"
+
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+- tapOn:
+    text: "settings"
+- scrollUntilVisible:
+    element:
+      text: "developer settings"
+    direction: DOWN
+- tapOn:
+    text: "developer settings"
+- scrollUntilVisible:
+    element:
+      text: "custom tabs"
+    direction: DOWN
+- tapOn:
+    text: "custom tabs"
+- tapOn:
+    text: "add your url here"
+- inputText: "https://www.search-company.site"
+- tapOn:
+    text: "load custom tab"
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+- assertVisible:
+    text: "running in duckduckgo"
+- action: back
+- tapOn:
+    text: "[Ad 2] Shopping Tab Ad (heuristic)"
+- assertVisible:
+    text: "Publisher site"
+- action: back
+- tapOn:
+    text: "[Ad 2] Shopping Tab Ad (heuristic)"
+- tapOn:
+    text: "Red shoes"
+- assertVisible:
+    text: "Checkout"
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/backMenuItem"
+- assertVisible:
+    text: "Red shoes"
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+- tapOn:
+    id: "com.duckduckgo.mobile.android:id/forwardMenuItem"
+- assertVisible:
+    text: "Checkout"

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -1549,6 +1549,21 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenIsCustomTabAndCannotGoBackThenReturnFalse() {
+        setupNavigation(isBrowsing = true, canGoBack = false)
+        assertFalse(testee.onUserPressedBack(isCustomTab = true))
+    }
+
+    @Test
+    fun whenIsCustomTabAndCannotGoBackThenNavigateBackAndReturnTrue() {
+        setupNavigation(isBrowsing = true, canGoBack = true)
+        assertTrue(testee.onUserPressedBack(isCustomTab = true))
+
+        val backCommand = captureCommands().lastValue as NavigationCommand.NavigateBack
+        assertNotNull(backCommand)
+    }
+
+    @Test
     fun whenHomeShowingByPressingBackOnInvalidatedBrowserThenForwardButtonInactive() {
         setupNavigation(isBrowsing = true)
         givenInvalidatedGlobalLayout()

--- a/app/src/internal/AndroidManifest.xml
+++ b/app/src/internal/AndroidManifest.xml
@@ -11,6 +11,10 @@
             android:name="com.duckduckgo.app.audit.AuditSettingsActivity"
             android:label="@string/auditSettingsTitle"
             android:parentActivityName="com.duckduckgo.app.settings.SettingsActivity" />
+        <activity
+            android:name="com.duckduckgo.app.dev.settings.customtabs.CustomTabsInternalSettingsActivity"
+            android:label="@string/customTabsTitle"
+            android:parentActivityName="com.duckduckgo.app.settings.SettingsActivity" />
     </application>
 
 </manifest>

--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/DevSettingsActivity.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/DevSettingsActivity.kt
@@ -34,6 +34,7 @@ import com.duckduckgo.app.browser.R.layout
 import com.duckduckgo.app.browser.databinding.ActivityDevSettingsBinding
 import com.duckduckgo.app.browser.webview.WebContentDebuggingFeature
 import com.duckduckgo.app.dev.settings.DevSettingsViewModel.Command
+import com.duckduckgo.app.dev.settings.customtabs.CustomTabsInternalSettingsActivity
 import com.duckduckgo.app.dev.settings.db.UAOverride
 import com.duckduckgo.app.dev.settings.privacy.TrackerDataDevReceiver.Companion.DOWNLOAD_TDS_INTENT_ACTION
 import com.duckduckgo.common.ui.DuckDuckGoActivity
@@ -100,6 +101,7 @@ class DevSettingsActivity : DuckDuckGoActivity() {
         }
         binding.overrideUserAgentSelector.setOnClickListener { viewModel.onUserAgentSelectorClicked() }
         binding.overridePrivacyRemoteConfigUrl.setOnClickListener { viewModel.onRemotePrivacyUrlClicked() }
+        binding.customTabs.setOnClickListener { viewModel.customTabsClicked() }
     }
 
     private fun observeViewModel() {
@@ -128,6 +130,7 @@ class DevSettingsActivity : DuckDuckGoActivity() {
             is Command.OpenUASelector -> showUASelector()
             is Command.ShowSavedSitesClearedConfirmation -> showSavedSitesClearedConfirmation()
             is Command.ChangePrivacyConfigUrl -> showChangePrivacyUrl()
+            is Command.CustomTabs -> showCustomTabs()
             else -> TODO()
         }
     }
@@ -162,6 +165,11 @@ class DevSettingsActivity : DuckDuckGoActivity() {
     private fun showChangePrivacyUrl() {
         val options = ActivityOptions.makeSceneTransitionAnimation(this).toBundle()
         startActivity(PrivacyConfigInternalSettingsActivity.intent(this), options)
+    }
+
+    private fun showCustomTabs() {
+        val options = ActivityOptions.makeSceneTransitionAnimation(this).toBundle()
+        startActivity(CustomTabsInternalSettingsActivity.intent(this), options)
     }
 
     companion object {

--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/DevSettingsViewModel.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/DevSettingsViewModel.kt
@@ -60,6 +60,7 @@ class DevSettingsViewModel @Inject constructor(
         object OpenUASelector : Command()
         object ShowSavedSitesClearedConfirmation : Command()
         object ChangePrivacyConfigUrl : Command()
+        object CustomTabs : Command()
     }
 
     private val viewState = MutableStateFlow(ViewState())
@@ -128,6 +129,10 @@ class DevSettingsViewModel @Inject constructor(
 
     fun onRemotePrivacyUrlClicked() {
         viewModelScope.launch { command.send(Command.ChangePrivacyConfigUrl) }
+    }
+
+    fun customTabsClicked() {
+        viewModelScope.launch { command.send(Command.CustomTabs) }
     }
 
     fun onUserAgentSelected(userAgent: UAOverride) {

--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/customtabs/CustomTabsInternalSettingsActivity.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/customtabs/CustomTabsInternalSettingsActivity.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.dev.settings.customtabs
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.widget.Toast
+import androidx.browser.customtabs.CustomTabsIntent
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.databinding.ActivityCustomTabsInternalSettingsBinding
+import com.duckduckgo.common.ui.DuckDuckGoActivity
+import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.di.scopes.ActivityScope
+
+@InjectWith(ActivityScope::class)
+class CustomTabsInternalSettingsActivity : DuckDuckGoActivity() {
+
+    private val binding: ActivityCustomTabsInternalSettingsBinding by viewBinding()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(binding.root)
+        setupToolbar(binding.toolbar)
+
+        binding.load.setOnClickListener {
+            val url = binding.urlInput.text
+            if (url.isNotBlank()) {
+                if (!url.startsWith("http://") && !url.startsWith("https://")) {
+                    openCustomTab("http://$url")
+                } else {
+                    openCustomTab(url)
+                }
+            }
+        }
+    }
+
+    private fun openCustomTab(url: String) {
+        val customTabsIntent = CustomTabsIntent.Builder().build()
+        kotlin.runCatching {
+            customTabsIntent.launchUrl(this, Uri.parse(url))
+        }.onFailure {
+            Toast.makeText(this, getString(R.string.customTabsInvalidUrl), Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    companion object {
+        fun intent(context: Context): Intent {
+            return Intent(context, CustomTabsInternalSettingsActivity::class.java)
+        }
+    }
+}

--- a/app/src/internal/res/layout/activity_custom_tabs_internal_settings.xml
+++ b/app/src/internal/res/layout/activity_custom_tabs_internal_settings.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2024 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".CustomTabsInternalSettingsActivity">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/Widget.DuckDuckGo.ToolbarTheme"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="?attr/daxColorSurface"
+            android:theme="@style/Widget.DuckDuckGo.ToolbarTheme"
+            app:popupTheme="@style/Widget.DuckDuckGo.PopUpOverflowMenu" />
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <com.duckduckgo.common.ui.view.text.DaxTextInput
+        android:id="@+id/urlInput"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/keyline_3"
+        android:layout_marginStart="@dimen/keyline_3"
+        android:hint="@string/customTabsUrlHint"
+        app:editable="true"
+        android:layout_marginTop="@dimen/keyline_4"
+        app:layout_constraintTop_toBottomOf="@id/appBar"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+        android:id="@+id/load"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/customTabsLoad"
+        android:layout_marginEnd="@dimen/keyline_3"
+        android:layout_marginStart="@dimen/keyline_3"
+        android:layout_marginTop="@dimen/keyline_2"
+        app:layout_constraintTop_toBottomOf="@id/urlInput"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/internal/res/layout/activity_dev_settings.xml
+++ b/app/src/internal/res/layout/activity_dev_settings.xml
@@ -80,6 +80,14 @@
                 app:primaryText="@string/devSettingsClearSavedSites"
                 app:secondaryText="@string/devSettingsClearSavedSitesSubtitle" />
 
+            <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+                android:id="@+id/customTabs"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="@string/devSettingsScreenCustomTabs"
+                app:secondaryText="@string/devSettingsScreenCustomTabsSubtitle"
+                />
+
             <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
                 android:id="@+id/privacyTitle"
                 android:layout_width="wrap_content"

--- a/app/src/internal/res/values/donottranslate.xml
+++ b/app/src/internal/res/values/donottranslate.xml
@@ -37,7 +37,9 @@
     <string name="devSettingsScreenUserAgentSection">User Agent</string>
     <string name="devSettingsScreenUserAgentOverride">Override UserAgent</string>
     <string name="devSettingsScreenPrivacyRemoteConfigUrlOverride">Override Privacy Remote Config URL</string>
+    <string name="devSettingsScreenCustomTabs">Custom Tabs</string>
     <string name="devSettingsScreenPrivacyRemoteConfigUrlOverrideSubtitle">Click here to customize the Privacy Remote Config URL</string>
+    <string name="devSettingsScreenCustomTabsSubtitle">Load a Custom Tab for a specified URL</string>
     <string name="devSettingsScreenUserAgentSelectorTitle">UserAgent</string>
     <string name="devSettingsScreenUserAgentFirefox">Firefox</string>
     <string name="devSettingsScreenUserAgentDefault">Default</string>
@@ -76,4 +78,11 @@
     <string name="surrogatesSubtitle">Main frame and iFrame should be green.</string>
     <string name="surrogatesDisabledTitle">Surrogates Disabled</string>
     <string name="surrogatesDisabledSubtitle">Main frame and iFrame should be red.</string>
+
+    <!-- Custom tabs -->
+    <string name="customTabsTitle">Custom Tabs</string>
+    <string name="customTabsLoad">Load Custom Tab</string>
+    <string name="customTabsUrlHint">Add your URL here</string>
+    <string name="customTabsInvalidUrl">Invalid URL</string>
+
 </resources>

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2786,9 +2786,9 @@ class BrowserTabFragment :
         viewModel.onConfigurationChanged()
     }
 
-    fun onBackPressed(): Boolean {
+    fun onBackPressed(isCustomTab: Boolean = false): Boolean {
         if (!isAdded) return false
-        return viewModel.onUserPressedBack()
+        return viewModel.onUserPressedBack(isCustomTab)
     }
 
     private fun resetWebView() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -965,7 +965,7 @@ class BrowserTabViewModel @Inject constructor(
      *
      * @return true if navigation handled, otherwise false
      */
-    fun onUserPressedBack(): Boolean {
+    fun onUserPressedBack(isCustomTab: Boolean = false): Boolean {
         navigationAwareLoginDetector.onEvent(NavigationEvent.UserAction.NavigateBack)
         val navigation = webNavigationState ?: return false
         val hasSourceTab = tabRepository.liveSelectedTab.value?.sourceTabId != null
@@ -987,19 +987,21 @@ class BrowserTabViewModel @Inject constructor(
         if (navigation.canGoBack) {
             command.value = NavigationCommand.NavigateBack(navigation.stepsToPreviousPage)
             return true
-        } else if (hasSourceTab) {
+        } else if (hasSourceTab && !isCustomTab) {
             viewModelScope.launch {
                 removeCurrentTabFromRepository()
             }
             return true
-        } else if (!skipHome) {
+        } else if (!skipHome && !isCustomTab) {
             navigateHome()
             command.value = ShowKeyboard
             return true
         }
 
-        Timber.d("User pressed back and tab is set to skip home; need to generate WebView preview now")
-        command.value = GenerateWebViewPreviewImage
+        if (!isCustomTab) {
+            Timber.d("User pressed back and tab is set to skip home; need to generate WebView preview now")
+            command.value = GenerateWebViewPreviewImage
+        }
         return false
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/customtabs/CustomTabActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/customtabs/CustomTabActivity.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.os.Message
+import androidx.activity.OnBackPressedCallback
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
@@ -59,6 +60,8 @@ class CustomTabActivity : DuckDuckGoActivity() {
         }.launchIn(lifecycleScope)
 
         viewModel.onCustomTabCreated(url, toolbarColor)
+
+        configureOnBackPressedListener()
     }
 
     fun openMessageInNewFragmentInCustomTab(
@@ -105,5 +108,20 @@ class CustomTabActivity : DuckDuckGoActivity() {
                 putExtra(Intent.EXTRA_TEXT, text)
             }
         }
+    }
+
+    private fun configureOnBackPressedListener() {
+        onBackPressedDispatcher.addCallback(
+            this,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    val currentFragment = supportFragmentManager.findFragmentById(R.id.fragmentTabContainer) as? BrowserTabFragment
+                    if (currentFragment?.onBackPressed(isCustomTab = true) != true) {
+                        isEnabled = false
+                        finish()
+                    }
+                }
+            },
+        )
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/customtabs/CustomTabActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/customtabs/CustomTabActivity.kt
@@ -74,6 +74,7 @@ class CustomTabActivity : DuckDuckGoActivity() {
         val transaction = supportFragmentManager.beginTransaction()
         transaction.hide(currentFragment)
         transaction.add(R.id.fragmentTabContainer, newFragment, tabId)
+        transaction.addToBackStack(tabId)
         transaction.commit()
         newFragment.messageFromPreviousTab = message
     }
@@ -116,7 +117,9 @@ class CustomTabActivity : DuckDuckGoActivity() {
             object : OnBackPressedCallback(true) {
                 override fun handleOnBackPressed() {
                     val currentFragment = supportFragmentManager.findFragmentById(R.id.fragmentTabContainer) as? BrowserTabFragment
-                    if (currentFragment?.onBackPressed(isCustomTab = true) != true) {
+                    if (supportFragmentManager.backStackEntryCount > 0) {
+                        supportFragmentManager.popBackStack()
+                    } else if (currentFragment?.onBackPressed(isCustomTab = true) == false) {
                         isEnabled = false
                         finish()
                     }

--- a/app/src/main/java/com/duckduckgo/app/browser/customtabs/CustomTabActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/customtabs/CustomTabActivity.kt
@@ -117,9 +117,12 @@ class CustomTabActivity : DuckDuckGoActivity() {
             object : OnBackPressedCallback(true) {
                 override fun handleOnBackPressed() {
                     val currentFragment = supportFragmentManager.findFragmentById(R.id.fragmentTabContainer) as? BrowserTabFragment
+                    if (currentFragment != null && currentFragment.onBackPressed(isCustomTab = true)) {
+                        return
+                    }
                     if (supportFragmentManager.backStackEntryCount > 0) {
                         supportFragmentManager.popBackStack()
-                    } else if (currentFragment?.onBackPressed(isCustomTab = true) == false) {
+                    } else {
                         isEnabled = false
                         finish()
                     }

--- a/app/src/main/java/com/duckduckgo/app/browser/customtabs/CustomTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/customtabs/CustomTabViewModel.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import timber.log.Timber
+
 @ContributesViewModel(ActivityScope::class)
 class CustomTabViewModel @Inject constructor(
     private val customTabDetector: CustomTabDetector,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207186871481910/f

### Description
Adds navigation in custom tabs via gestures or the UI.

### Steps to test this PR

- [ ] Make the DuckDuckGo debug app the default browser
- [ ] Open Gmail
- [ ] Click on a link in one of the emails
- [ ] Verify that navigation inside the custom tab works as expected

(You can check that it has opened in a custom tab by clicking the 3 dots and in the menu it will say "Running in DuckDuckGo")

### UI changes
Forward nav is now enabled:
![combined](https://github.com/duckduckgo/Android/assets/3471025/e930dacb-5335-436a-bc1f-50b51ca8e9a2)

