### PR TITLE
adds error pixel when compress fails

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/engine/SyncGzipInterceptor.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/engine/SyncGzipInterceptor.kt
@@ -41,7 +41,7 @@ import okio.buffer
     scope = AppScope::class,
     boundType = ApiInterceptorPlugin::class,
 )
-class SyngGzipInterceptor @Inject constructor(
+class SyncGzipInterceptor @Inject constructor(
     private val syncFeature: SyncFeature,
     private val pixel: Pixel,
 ) : ApiInterceptorPlugin, Interceptor {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/engine/SyngGzipInterceptor.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/engine/SyngGzipInterceptor.kt
@@ -16,10 +16,14 @@
 
 package com.duckduckgo.sync.impl.engine
 
+import android.util.Base64
 import com.duckduckgo.app.global.api.ApiInterceptorPlugin
+import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.SyncService
+import com.duckduckgo.sync.impl.pixels.SyncPixelName
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters
 import com.squareup.anvil.annotations.ContributesMultibinding
 import java.io.IOException
 import javax.inject.Inject
@@ -39,6 +43,7 @@ import okio.buffer
 )
 class SyngGzipInterceptor @Inject constructor(
     private val syncFeature: SyncFeature,
+    private val pixel: Pixel,
 ) : ApiInterceptorPlugin, Interceptor {
 
     override fun intercept(chain: Chain): Response {
@@ -51,13 +56,25 @@ class SyngGzipInterceptor @Inject constructor(
 
         // check if it's http operation is PATCH
         if (chain.request().method == "PATCH" && syncFeature.gzipPatchRequests().isEnabled()) {
-            val originalRequest = chain.request()
-            val body = originalRequest.body ?: return chain.proceed(originalRequest)
-            val compressedRequest = originalRequest.newBuilder()
-                .header("Content-Encoding", "gzip")
-                .method(originalRequest.method, forceContentLength(body.gzip()))
-                .build()
-            return chain.proceed(compressedRequest)
+            kotlin.runCatching {
+                val originalRequest = chain.request()
+                val body = originalRequest.body ?: return chain.proceed(originalRequest)
+                val compressedRequest = originalRequest.newBuilder()
+                    .header("Content-Encoding", "gzip")
+                    .method(originalRequest.method, forceContentLength(body.gzip()))
+                    .build()
+                return chain.proceed(compressedRequest)
+            }.onFailure {
+                val params = mapOf(
+                    SyncPixelParameters.ERROR to Base64.encodeToString(
+                        it.stackTraceToString().toByteArray(),
+                        Base64.NO_WRAP or Base64.NO_PADDING or Base64.URL_SAFE,
+                    ),
+                )
+                pixel.fire(SyncPixelName.SYNC_PATCH_COMPRESS_FAILED, params)
+                // if there is an exception, proceed with the original request
+                return chain.proceed(chain.request())
+            }
         }
 
         return chain.proceed(chain.request())

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixelParamRemovalPlugin.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixelParamRemovalPlugin.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.pixels
+
+import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin
+import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin.PixelParameter
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+class SyncPixelParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin {
+    override fun names(): List<Pair<String, Set<PixelParameter>>> {
+        return listOf(SyncPixelName.SYNC_PATCH_COMPRESS_FAILED.pixelName to PixelParameter.removeAtb())
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
@@ -235,6 +235,7 @@ enum class SyncPixelName(override val pixelName: String) : Pixel.PixelName {
     SYNC_DELETE_ACCOUNT_FAILURE("m_delete_account_error"),
     SYNC_USER_SIGNED_IN_FAILURE("m_login_existing_account_error"),
     SYNC_CREATE_PDF_FAILURE("m_sync_create_recovery_pdf_error"),
+    SYNC_PATCH_COMPRESS_FAILED("m_sync_patch_compression_failed"),
 }
 
 object SyncPixelParameters {
@@ -252,4 +253,5 @@ object SyncPixelParameters {
     const val ORPHANS_PRESENT = "%s_orphans_present"
     const val ERROR_CODE = "code"
     const val ERROR_REASON = "reason"
+    const val ERROR = "error"
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207259077953491/f 

### Description
Debug pixel in case of failure when trying to compress patch

### Steps to test this PR

_Feature 1_
- [ ] Hardcode an error in Gzip interceptor
- [ ] Run the app
- [ ] Ensure pixel is sent
- [ ] Ensure patch continues without compression

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
