### PR TITLE
Autofill engagement pixels

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/PasswordStoreEventListener.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/PasswordStoreEventListener.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl
+
+import com.duckduckgo.anvil.annotations.ContributesPluginPoint
+import com.duckduckgo.di.scopes.AppScope
+
+@ContributesPluginPoint(AppScope::class)
+interface PasswordStoreEventListener {
+    /**
+     * Called when a credential is added to the password store
+     * This includes one being automatically saved, the user manually saving one, or one being imported via sync.
+     *
+     * @param id the id of the credential that was added
+     */
+    fun onCredentialAdded(id: Long) {}
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/di/AutofillModule.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/di/AutofillModule.kt
@@ -36,6 +36,7 @@ import com.duckduckgo.autofill.store.LastUpdatedTimeProvider
 import com.duckduckgo.autofill.store.RealAutofillPrefsStore
 import com.duckduckgo.autofill.store.RealInternalTestUserStore
 import com.duckduckgo.autofill.store.RealLastUpdatedTimeProvider
+import com.duckduckgo.autofill.store.engagement.AutofillEngagementDatabase
 import com.duckduckgo.autofill.store.feature.AutofillDefaultStateDecider
 import com.duckduckgo.autofill.store.feature.AutofillFeatureRepository
 import com.duckduckgo.autofill.store.feature.RealAutofillDefaultStateDecider
@@ -135,6 +136,16 @@ class AutofillModule {
         database: AutofillDatabase,
     ): CredentialsSyncMetadataDao {
         return database.credentialsSyncDao()
+    }
+
+    @Provides
+    @SingleInstanceIn(AppScope::class)
+    fun providesAutofillEngagementDb(
+        context: Context,
+    ): AutofillEngagementDatabase {
+        return Room.databaseBuilder(context, AutofillEngagementDatabase::class.java, "autofill_engagement.db")
+            .addMigrations(*AutofillEngagementDatabase.ALL_MIGRATIONS)
+            .build()
     }
 }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/engagement/AutofillRefreshRetentionListener.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/engagement/AutofillRefreshRetentionListener.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.engagement
+
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.statistics.api.RefreshRetentionAtbPlugin
+import com.duckduckgo.autofill.impl.engagement.store.AutofillEngagementRepository
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+@ContributesMultibinding(AppScope::class)
+class AutofillRefreshRetentionListener @Inject constructor(
+    private val engagementRepository: AutofillEngagementRepository,
+    @AppCoroutineScope private val coroutineScope: CoroutineScope,
+    private val dispatchers: DispatcherProvider,
+) : RefreshRetentionAtbPlugin {
+
+    override fun onSearchRetentionAtbRefreshed() {
+        coroutineScope.launch(dispatchers.io()) {
+            engagementRepository.recordSearchedToday()
+        }
+    }
+
+    override fun onAppRetentionAtbRefreshed() {
+        // no-op
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/engagement/DataAutofilledListener.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/engagement/DataAutofilledListener.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.engagement
+
+import com.duckduckgo.anvil.annotations.ContributesPluginPoint
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.autofill.impl.engagement.store.AutofillEngagementRepository
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+@ContributesPluginPoint(AppScope::class)
+interface DataAutofilledListener {
+    fun onAutofilledSavedPassword()
+    fun onAutofilledDuckAddress()
+    fun onUsedGeneratedPassword()
+}
+
+@ContributesMultibinding(AppScope::class)
+class DefaultDataAutofilledListener @Inject constructor(
+    private val engagementRepository: AutofillEngagementRepository,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val dispatchers: DispatcherProvider,
+) : DataAutofilledListener {
+
+    override fun onAutofilledSavedPassword() {
+        Timber.v("onAutofilledSavedPassword, recording autofilled today")
+        recordAutofilledToday()
+    }
+
+    override fun onAutofilledDuckAddress() {
+        Timber.v("onAutofilledDuckAddress, recording autofilled today")
+        recordAutofilledToday()
+    }
+
+    override fun onUsedGeneratedPassword() {
+        Timber.v("onUsedGeneratedPassword, recording autofilled today")
+        recordAutofilledToday()
+    }
+
+    private fun recordAutofilledToday() {
+        appCoroutineScope.launch(dispatchers.io()) {
+            engagementRepository.recordAutofilledToday()
+        }
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/engagement/EngagementPasswordAddedListener.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/engagement/EngagementPasswordAddedListener.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.engagement
+
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.UNIQUE
+import com.duckduckgo.autofill.impl.PasswordStoreEventListener
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames
+import com.duckduckgo.browser.api.UserBrowserProperties
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+@ContributesMultibinding(AppScope::class)
+class EngagementPasswordAddedListener @Inject constructor(
+    private val userBrowserProperties: UserBrowserProperties,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val dispatchers: DispatcherProvider,
+    private val pixel: Pixel,
+) : PasswordStoreEventListener {
+
+    override fun onCredentialAdded(id: Long) {
+        appCoroutineScope.launch(dispatchers.io()) {
+            val daysInstalled = userBrowserProperties.daysSinceInstalled()
+            Timber.v("onCredentialAdded. daysInstalled: $daysInstalled")
+            if (daysInstalled < 7) {
+                pixel.fire(AutofillPixelNames.AUTOFILL_ENGAGEMENT_ONBOARDED_USER, type = UNIQUE)
+            }
+        }
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/engagement/store/AutofillEngagementBucketing.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/engagement/store/AutofillEngagementBucketing.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.engagement.store
+
+import com.duckduckgo.autofill.impl.engagement.store.AutofillEngagementBucketing.Companion.FEW
+import com.duckduckgo.autofill.impl.engagement.store.AutofillEngagementBucketing.Companion.LOTS
+import com.duckduckgo.autofill.impl.engagement.store.AutofillEngagementBucketing.Companion.MANY
+import com.duckduckgo.autofill.impl.engagement.store.AutofillEngagementBucketing.Companion.NONE
+import com.duckduckgo.autofill.impl.engagement.store.AutofillEngagementBucketing.Companion.SOME
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface AutofillEngagementBucketing {
+    fun bucketNumberOfSavedPasswords(savedPasswords: Int): String
+
+    companion object {
+        const val NONE = "none"
+        const val FEW = "few"
+        const val SOME = "some"
+        const val MANY = "many"
+        const val LOTS = "lots"
+    }
+}
+
+@ContributesBinding(AppScope::class)
+class DefaultAutofillEngagementBucketing @Inject constructor() : AutofillEngagementBucketing {
+
+    override fun bucketNumberOfSavedPasswords(savedPasswords: Int): String {
+        return when {
+            savedPasswords == 0 -> NONE
+            savedPasswords < 4 -> FEW
+            savedPasswords < 11 -> SOME
+            savedPasswords < 50 -> MANY
+            else -> LOTS
+        }
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/engagement/store/AutofillEngagementRepository.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/engagement/store/AutofillEngagementRepository.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.engagement.store
+
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.DAILY
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENGAGEMENT_ACTIVE_USER
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENGAGEMENT_ENABLED_USER
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENGAGEMENT_STACKED_LOGINS
+import com.duckduckgo.autofill.impl.store.InternalAutofillStore
+import com.duckduckgo.autofill.store.engagement.AutofillEngagementDao
+import com.duckduckgo.autofill.store.engagement.AutofillEngagementDatabase
+import com.duckduckgo.autofill.store.engagement.AutofillEngagementEntity
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import javax.inject.Inject
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+
+interface AutofillEngagementRepository {
+
+    /**
+     * Record that the user has autofilled today
+     */
+    suspend fun recordAutofilledToday()
+
+    /**
+     * Record that the user has searched today
+     */
+    suspend fun recordSearchedToday()
+
+    /**
+     * Clear all data in the database, optionally preserving today's data
+     */
+    suspend fun clearData(preserveToday: Boolean = true)
+}
+
+@ContributesBinding(AppScope::class)
+@SingleInstanceIn(AppScope::class)
+class DefaultAutofillEngagementRepository @Inject constructor(
+    engagementDb: AutofillEngagementDatabase,
+    private val pixel: Pixel,
+    private val autofillStore: InternalAutofillStore,
+    private val engagementBucketing: AutofillEngagementBucketing,
+    private val dispatchers: DispatcherProvider,
+) : AutofillEngagementRepository {
+
+    private val autofillEngagementDao: AutofillEngagementDao = engagementDb.autofillEngagementDao()
+
+    override suspend fun recordAutofilledToday() {
+        withContext(dispatchers.io()) {
+            val engagement = todaysEngagement().copy(autofilled = true)
+            Timber.v("upserting %s because user autofilled", engagement)
+            processEvent(engagement)
+        }
+    }
+
+    override suspend fun recordSearchedToday() {
+        withContext(dispatchers.io()) {
+            val engagement = todaysEngagement().copy(searched = true)
+            Timber.v("upserting %s because user searched", engagement)
+            processEvent(engagement)
+        }
+    }
+
+    private suspend fun DefaultAutofillEngagementRepository.processEvent(engagement: AutofillEngagementEntity) {
+        autofillEngagementDao.upsert(engagement)
+        engagement.sendPixelsIfCriteriaMet()
+        clearData()
+    }
+
+    private suspend fun AutofillEngagementEntity.sendPixelsIfCriteriaMet() {
+        val numberStoredPasswords = getNumberStoredPasswords()
+
+        if (autofilled && searched) {
+            pixel.fire(AUTOFILL_ENGAGEMENT_ACTIVE_USER, type = DAILY)
+
+            val bucket = engagementBucketing.bucketNumberOfSavedPasswords(numberStoredPasswords)
+            pixel.fire(AUTOFILL_ENGAGEMENT_STACKED_LOGINS, mapOf("count_bucket" to bucket), type = DAILY)
+        }
+
+        if (searched && numberStoredPasswords >= 10) {
+            pixel.fire(AUTOFILL_ENGAGEMENT_ENABLED_USER, type = DAILY)
+        }
+    }
+
+    private suspend fun getNumberStoredPasswords(): Int {
+        return autofillStore.getCredentialCount().firstOrNull() ?: 0
+    }
+
+    override suspend fun clearData(preserveToday: Boolean) {
+        if (preserveToday) {
+            autofillEngagementDao.deleteOlderThan(todayString())
+        } else {
+            autofillEngagementDao.deleteAll()
+        }
+    }
+
+    private suspend fun todaysEngagement(): AutofillEngagementEntity {
+        val key = todayString()
+        return autofillEngagementDao.getEngagement(key) ?: entityForToday()
+    }
+
+    private fun entityForToday(): AutofillEngagementEntity {
+        return AutofillEngagementEntity(date = todayString(), autofilled = false, searched = false)
+    }
+
+    private fun todayString(): String {
+        return DATE_FORMATTER.format(LocalDate.now())
+    }
+
+    companion object {
+        private val DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
@@ -17,6 +17,10 @@
 package com.duckduckgo.autofill.impl.pixel
 
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENGAGEMENT_ACTIVE_USER
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENGAGEMENT_ENABLED_USER
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENGAGEMENT_ONBOARDED_USER
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENGAGEMENT_STACKED_LOGINS
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.EMAIL_TOOLTIP_DISMISSED
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.EMAIL_USE_ADDRESS
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.EMAIL_USE_ALIAS
@@ -95,6 +99,11 @@ enum class AutofillPixelNames(override val pixelName: String) : Pixel.PixelName 
     AUTOFILL_DEVICE_CAPABILITY_UNKNOWN_ERROR("m_autofill_device_capability_unknown"),
 
     AUTOFILL_SURVEY_AVAILABLE_PROMPT_DISPLAYED("m_autofill_management_screen_visit_survey_available"),
+
+    AUTOFILL_ENGAGEMENT_ACTIVE_USER("m_autofill_activeuser"),
+    AUTOFILL_ENGAGEMENT_ENABLED_USER("m_autofill_enableduser"),
+    AUTOFILL_ENGAGEMENT_ONBOARDED_USER("m_autofill_onboardeduser"),
+    AUTOFILL_ENGAGEMENT_STACKED_LOGINS("m_autofill_logins_stacked"),
 }
 
 @ContributesMultibinding(
@@ -107,6 +116,11 @@ object AutofillPixelsRequiringDataCleaning : PixelParamRemovalPlugin {
             EMAIL_USE_ALIAS.pixelName to PixelParameter.removeAll(),
             EMAIL_USE_ADDRESS.pixelName to PixelParameter.removeAll(),
             EMAIL_TOOLTIP_DISMISSED.pixelName to PixelParameter.removeAll(),
+
+            AUTOFILL_ENGAGEMENT_ACTIVE_USER.pixelName to PixelParameter.removeAtb(),
+            AUTOFILL_ENGAGEMENT_ENABLED_USER.pixelName to PixelParameter.removeAtb(),
+            AUTOFILL_ENGAGEMENT_ONBOARDED_USER.pixelName to PixelParameter.removeAtb(),
+            AUTOFILL_ENGAGEMENT_STACKED_LOGINS.pixelName to PixelParameter.removeAtb(),
         )
     }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/passwordgeneration/ResultHandlerUseGeneratedPassword.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/passwordgeneration/ResultHandlerUseGeneratedPassword.kt
@@ -27,8 +27,10 @@ import com.duckduckgo.autofill.api.ExistingCredentialMatchDetector.ContainsCrede
 import com.duckduckgo.autofill.api.UseGeneratedPasswordDialog
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.api.passwordgeneration.AutomaticSavedLoginsMonitor
+import com.duckduckgo.autofill.impl.engagement.DataAutofilledListener
 import com.duckduckgo.autofill.impl.store.InternalAutofillStore
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesMultibinding
 import javax.inject.Inject
@@ -44,6 +46,7 @@ class ResultHandlerUseGeneratedPassword @Inject constructor(
     private val autoSavedLoginsMonitor: AutomaticSavedLoginsMonitor,
     private val existingCredentialMatchDetector: ExistingCredentialMatchDetector,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val autofilledListeners: PluginPoint<DataAutofilledListener>,
 ) : AutofillFragmentResultsPlugin {
 
     override fun processResult(
@@ -96,6 +99,10 @@ class ResultHandlerUseGeneratedPassword @Inject constructor(
         }
         withContext(dispatchers.main()) {
             callback.onAcceptGeneratedPassword(originalUrl)
+        }
+
+        autofilledListeners.getPlugins().forEach {
+            it.onUsedGeneratedPassword()
         }
     }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsSync.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsSync.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.autofill.sync
 
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
+import com.duckduckgo.autofill.impl.PasswordStoreEventListener
 import com.duckduckgo.autofill.impl.securestorage.SecureStorage
 import com.duckduckgo.autofill.impl.securestorage.WebsiteLoginDetails
 import com.duckduckgo.autofill.impl.securestorage.WebsiteLoginDetailsWithCredentials
@@ -24,6 +25,7 @@ import com.duckduckgo.autofill.store.CredentialsSyncMetadataEntity
 import com.duckduckgo.autofill.sync.provider.CredentialsSyncLocalValidationFeature
 import com.duckduckgo.autofill.sync.provider.LoginCredentialEntry
 import com.duckduckgo.common.utils.formatters.time.DatabaseDateFormatter
+import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.api.SyncCrypto
 import dagger.SingleInstanceIn
@@ -40,6 +42,7 @@ class CredentialsSync @Inject constructor(
     private val credentialsSyncMetadata: CredentialsSyncMetadata,
     private val syncCrypto: SyncCrypto,
     private val credentialsSyncLocalValidationFeature: CredentialsSyncLocalValidationFeature,
+    private val passwordStoreEventPlugins: PluginPoint<PasswordStoreEventListener>,
 ) {
 
     suspend fun initMetadata() {
@@ -112,6 +115,7 @@ class CredentialsSync @Inject constructor(
             credentialsSyncMetadata.addOrUpdate(
                 CredentialsSyncMetadataEntity(syncId = remoteId, localId = autofillId, deleted_at = null, modified_at = null),
             )
+            passwordStoreEventPlugins.getPlugins().forEach { it.onCredentialAdded(autofillId) }
         }
     }
 

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/FakePasswordStoreEventPlugin.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/FakePasswordStoreEventPlugin.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl
+
+import com.duckduckgo.common.utils.plugins.PluginPoint
+
+class FakePasswordStoreEventPlugin(
+    private val plugins: List<PasswordStoreEventListener> = emptyList(),
+) : PluginPoint<PasswordStoreEventListener> {
+
+    override fun getPlugins() = plugins
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/SecureStoreBackedAutofillStoreTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/SecureStoreBackedAutofillStoreTest.kt
@@ -501,6 +501,7 @@ class SecureStoreBackedAutofillStoreTest {
             autofillPrefsStore = autofillPrefsStore,
             dispatcherProvider = coroutineTestRule.testDispatcherProvider,
             autofillUrlMatcher = autofillUrlMatcher,
+            passwordStoreEventListenersPlugins = FakePasswordStoreEventPlugin(),
             syncCredentialsListener = SyncCredentialsListener(
                 CredentialsSyncMetadata(inMemoryAutofillDatabase().credentialsSyncDao()),
                 coroutineTestRule.testDispatcherProvider,

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/email/ResultHandlerEmailProtectionChooseEmailTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/email/ResultHandlerEmailProtectionChooseEmailTest.kt
@@ -30,10 +30,12 @@ import com.duckduckgo.autofill.api.EmailProtectionChooseEmailDialog.UseEmailResu
 import com.duckduckgo.autofill.api.EmailProtectionChooseEmailDialog.UseEmailResultType.UsePersonalEmailAddress
 import com.duckduckgo.autofill.api.EmailProtectionChooseEmailDialog.UseEmailResultType.UsePrivateAliasAddress
 import com.duckduckgo.autofill.api.email.EmailManager
+import com.duckduckgo.autofill.impl.engagement.DataAutofilledListener
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.EMAIL_TOOLTIP_DISMISSED
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.EMAIL_USE_ADDRESS
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.EMAIL_USE_ALIAS
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.plugins.PluginPoint
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
@@ -59,6 +61,7 @@ class ResultHandlerEmailProtectionChooseEmailTest {
         dispatchers = coroutineTestRule.testDispatcherProvider,
         appCoroutineScope = coroutineTestRule.testScope,
         pixel = pixel,
+        autofilledListeners = FakePluginPoint(),
     )
 
     @Before
@@ -145,6 +148,12 @@ class ResultHandlerEmailProtectionChooseEmailTest {
         return Bundle().also {
             it.putString(EmailProtectionChooseEmailDialog.KEY_URL, url)
             it.putParcelable(EmailProtectionChooseEmailDialog.KEY_RESULT, result)
+        }
+    }
+
+    private class FakePluginPoint : PluginPoint<DataAutofilledListener> {
+        override fun getPlugins(): Collection<DataAutofilledListener> {
+            return emptyList()
         }
     }
 }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/engagement/EngagementPasswordAddedListenerTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/engagement/EngagementPasswordAddedListenerTest.kt
@@ -1,0 +1,58 @@
+package com.duckduckgo.autofill.impl.engagement
+
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.UNIQUE
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENGAGEMENT_ONBOARDED_USER
+import com.duckduckgo.browser.api.UserBrowserProperties
+import com.duckduckgo.common.test.CoroutineTestRule
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class EngagementPasswordAddedListenerTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+
+    private val userBrowserProperties: UserBrowserProperties = mock()
+    private val pixel: Pixel = mock()
+
+    private val testee = EngagementPasswordAddedListener(
+        userBrowserProperties = userBrowserProperties,
+        appCoroutineScope = coroutineTestRule.testScope,
+        dispatchers = coroutineTestRule.testDispatcherProvider,
+        pixel = pixel,
+    )
+
+    @Test
+    fun whenDaysInstalledLessThan7ThenPixelSent() {
+        whenever(userBrowserProperties.daysSinceInstalled()).thenReturn(0)
+        testee.onCredentialAdded(0)
+        verifyPixelSent()
+    }
+
+    @Test
+    fun whenDaysInstalledExactly7ThenPixelNotSent() {
+        whenever(userBrowserProperties.daysSinceInstalled()).thenReturn(7)
+        testee.onCredentialAdded(0)
+        verifyPixelNotSent()
+    }
+
+    @Test
+    fun whenDaysInstalledAbove7ThenPixelNotSent() {
+        whenever(userBrowserProperties.daysSinceInstalled()).thenReturn(10)
+        testee.onCredentialAdded(0)
+        verifyPixelNotSent()
+    }
+
+    private fun verifyPixelSent() {
+        verify(pixel).fire(AUTOFILL_ENGAGEMENT_ONBOARDED_USER, type = UNIQUE)
+    }
+
+    private fun verifyPixelNotSent() {
+        verify(pixel, never()).fire(AUTOFILL_ENGAGEMENT_ONBOARDED_USER, type = UNIQUE)
+    }
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/engagement/store/DefaultAutofillEngagementBucketingTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/engagement/store/DefaultAutofillEngagementBucketingTest.kt
@@ -1,0 +1,43 @@
+package com.duckduckgo.autofill.impl.engagement.store
+
+import com.duckduckgo.autofill.impl.engagement.store.AutofillEngagementBucketing.Companion.FEW
+import com.duckduckgo.autofill.impl.engagement.store.AutofillEngagementBucketing.Companion.LOTS
+import com.duckduckgo.autofill.impl.engagement.store.AutofillEngagementBucketing.Companion.MANY
+import com.duckduckgo.autofill.impl.engagement.store.AutofillEngagementBucketing.Companion.NONE
+import com.duckduckgo.autofill.impl.engagement.store.AutofillEngagementBucketing.Companion.SOME
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DefaultAutofillEngagementBucketingTest {
+    private val testee = DefaultAutofillEngagementBucketing()
+
+    @Test
+    fun whenZeroSavedPasswordsThenBucketIsNone() {
+        assertEquals(NONE, testee.bucketNumberOfSavedPasswords(0))
+    }
+
+    @Test
+    fun whenBetweenOneAndThreeSavedPasswordThenBucketIsFew() {
+        assertEquals(FEW, testee.bucketNumberOfSavedPasswords(1))
+        assertEquals(FEW, testee.bucketNumberOfSavedPasswords(2))
+        assertEquals(FEW, testee.bucketNumberOfSavedPasswords(3))
+    }
+
+    @Test
+    fun whenBetweenFourAndTenSavedPasswordThenBucketIsSome() {
+        assertEquals(SOME, testee.bucketNumberOfSavedPasswords(4))
+        assertEquals(SOME, testee.bucketNumberOfSavedPasswords(10))
+    }
+
+    @Test
+    fun whenBetweenElevenAndFortyNineSavedPasswordThenBucketIsMany() {
+        assertEquals(MANY, testee.bucketNumberOfSavedPasswords(11))
+        assertEquals(MANY, testee.bucketNumberOfSavedPasswords(49))
+    }
+
+    @Test
+    fun whenFiftyOrOverThenBucketIsMany() {
+        assertEquals(LOTS, testee.bucketNumberOfSavedPasswords(50))
+        assertEquals(LOTS, testee.bucketNumberOfSavedPasswords(Int.MAX_VALUE))
+    }
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/engagement/store/DefaultAutofillEngagementRepositoryTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/engagement/store/DefaultAutofillEngagementRepositoryTest.kt
@@ -1,0 +1,120 @@
+package com.duckduckgo.autofill.impl.engagement.store
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelName
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENGAGEMENT_ACTIVE_USER
+import com.duckduckgo.autofill.impl.store.InternalAutofillStore
+import com.duckduckgo.autofill.store.engagement.AutofillEngagementDatabase
+import com.duckduckgo.common.test.CoroutineTestRule
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class DefaultAutofillEngagementRepositoryTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    val db = Room.inMemoryDatabaseBuilder(context, AutofillEngagementDatabase::class.java)
+        .allowMainThreadQueries()
+        .build()
+
+    private val pixel = FakePixel()
+    private val autofillStore: InternalAutofillStore = mock()
+
+    @Before
+    fun setup() {
+        coroutineTestRule.testScope.runTest {
+            whenever(autofillStore.getCredentialCount()).thenReturn(flowOf(0))
+        }
+    }
+
+    private val testee = DefaultAutofillEngagementRepository(
+        engagementDb = db,
+        pixel = pixel,
+        autofillStore = autofillStore,
+        engagementBucketing = DefaultAutofillEngagementBucketing(),
+        dispatchers = coroutineTestRule.testDispatcherProvider,
+    )
+
+    @Test
+    fun whenAutofilledButNotSearchedThenActiveUserPixelNotSent() = runTest {
+        testee.recordAutofilledToday()
+        AUTOFILL_ENGAGEMENT_ACTIVE_USER.verifyNotSent()
+    }
+
+    @Test
+    fun whenSearchedButNotNotAutofilledThenActiveUserPixelNotSent() = runTest {
+        testee.recordSearchedToday()
+        AUTOFILL_ENGAGEMENT_ACTIVE_USER.verifyNotSent()
+    }
+
+    @Test
+    fun whenSearchedAndAutofilledThenActiveUserPixelSent() = runTest {
+        testee.recordSearchedToday()
+        testee.recordAutofilledToday()
+        AUTOFILL_ENGAGEMENT_ACTIVE_USER.verifySent()
+    }
+
+    private fun AutofillPixelNames.verifySent() {
+        assertTrue(pixel.firedPixels.contains(pixelName))
+    }
+
+    private fun AutofillPixelNames.verifyNotSent() {
+        assertFalse(pixel.firedPixels.contains(pixelName))
+    }
+
+    private class FakePixel : Pixel {
+
+        val firedPixels = mutableListOf<String>()
+
+        override fun fire(
+            pixel: PixelName,
+            parameters: Map<String, String>,
+            encodedParameters: Map<String, String>,
+            type: PixelType,
+        ) {
+            firedPixels.add(pixel.pixelName)
+        }
+
+        override fun fire(
+            pixelName: String,
+            parameters: Map<String, String>,
+            encodedParameters: Map<String, String>,
+            type: PixelType,
+        ) {
+            firedPixels.add(pixelName)
+        }
+
+        override fun enqueueFire(
+            pixel: PixelName,
+            parameters: Map<String, String>,
+            encodedParameters: Map<String, String>,
+        ) {
+            firedPixels.add(pixel.pixelName)
+        }
+
+        override fun enqueueFire(
+            pixelName: String,
+            parameters: Map<String, String>,
+            encodedParameters: Map<String, String>,
+        ) {
+            firedPixels.add(pixelName)
+        }
+    }
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/passwordgeneration/ResultHandlerUseGeneratedPasswordTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/passwordgeneration/ResultHandlerUseGeneratedPasswordTest.kt
@@ -29,8 +29,10 @@ import com.duckduckgo.autofill.api.UseGeneratedPasswordDialog.Companion.KEY_URL
 import com.duckduckgo.autofill.api.UseGeneratedPasswordDialog.Companion.KEY_USERNAME
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.api.passwordgeneration.AutomaticSavedLoginsMonitor
+import com.duckduckgo.autofill.impl.engagement.DataAutofilledListener
 import com.duckduckgo.autofill.impl.store.InternalAutofillStore
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.plugins.PluginPoint
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
@@ -56,6 +58,7 @@ class ResultHandlerUseGeneratedPasswordTest {
         appCoroutineScope = coroutineTestRule.testScope,
         autoSavedLoginsMonitor = autoSavedLoginsMonitor,
         existingCredentialMatchDetector = existingCredentialMatchDetector,
+        autofilledListeners = FakePluginPoint(),
     )
 
     @Before
@@ -193,5 +196,9 @@ class ResultHandlerUseGeneratedPasswordTest {
 
     private fun aLogin(id: Long = 0): LoginCredentials {
         return LoginCredentials(id = id, domain = "example.com", username = "user", password = "pw")
+    }
+
+    private class FakePluginPoint : PluginPoint<DataAutofilledListener> {
+        override fun getPlugins(): Collection<DataAutofilledListener> = emptyList()
     }
 }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/selecting/ResultHandlerCredentialSelectionTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/selecting/ResultHandlerCredentialSelectionTest.kt
@@ -28,8 +28,10 @@ import com.duckduckgo.autofill.api.ExistingCredentialMatchDetector
 import com.duckduckgo.autofill.api.ExistingCredentialMatchDetector.ContainsCredentialsResult.NoMatch
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.impl.deviceauth.FakeAuthenticator
+import com.duckduckgo.autofill.impl.engagement.DataAutofilledListener
 import com.duckduckgo.autofill.impl.store.InternalAutofillStore
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.plugins.PluginPoint
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
@@ -159,6 +161,13 @@ class ResultHandlerCredentialSelectionTest {
             deviceAuthenticator = deviceAuthenticator,
             appBuildConfig = appBuildConfig,
             autofillStore = autofillStore,
+            autofilledListeners = FakePluginPoint(),
         )
+    }
+
+    private class FakePluginPoint : PluginPoint<DataAutofilledListener> {
+        override fun getPlugins(): Collection<DataAutofilledListener> {
+            return emptyList()
+        }
     }
 }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/CredentialsInvalidItemsViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/CredentialsInvalidItemsViewModelTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.autofill.sync
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
+import com.duckduckgo.autofill.impl.FakePasswordStoreEventPlugin
 import com.duckduckgo.autofill.sync.CredentialsFixtures.invalidCredentials
 import com.duckduckgo.autofill.sync.CredentialsFixtures.spotifyCredentials
 import com.duckduckgo.common.test.CoroutineTestRule
@@ -45,6 +46,7 @@ class CredentialsInvalidItemsViewModelTest {
         credentialsSyncMetadata,
         FakeCrypto(),
         FakeCredentialsSyncLocalValidationFeature(),
+        FakePasswordStoreEventPlugin(),
     )
 
     private val viewModel = CredentialsInvalidItemsViewModel(

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/CredentialsSyncTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/CredentialsSyncTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.autofill.sync
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
+import com.duckduckgo.autofill.impl.FakePasswordStoreEventPlugin
 import com.duckduckgo.autofill.impl.securestorage.WebsiteLoginDetails
 import com.duckduckgo.autofill.impl.securestorage.WebsiteLoginDetailsWithCredentials
 import com.duckduckgo.autofill.store.CredentialsSyncMetadataEntity
@@ -50,6 +51,7 @@ internal class CredentialsSyncTest {
         credentialsSyncMetadata,
         FakeCrypto(),
         FakeCredentialsSyncLocalValidationFeature(),
+        FakePasswordStoreEventPlugin(),
     )
 
     @After fun after() = runBlocking {

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/persister/CredentialsLastModifiedWinsStrategyTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/persister/CredentialsLastModifiedWinsStrategyTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.autofill.sync.persister
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
+import com.duckduckgo.autofill.impl.FakePasswordStoreEventPlugin
 import com.duckduckgo.autofill.store.CredentialsSyncMetadataEntity
 import com.duckduckgo.autofill.sync.CredentialsFixtures.amazonCredentials
 import com.duckduckgo.autofill.sync.CredentialsFixtures.spotifyCredentials
@@ -63,6 +64,7 @@ internal class CredentialsLastModifiedWinsStrategyTest {
         credentialsSyncMetadata,
         FakeCrypto(),
         FakeCredentialsSyncLocalValidationFeature(),
+        FakePasswordStoreEventPlugin(),
     )
 
     @After fun after() = runBlocking {

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/persister/CredentialsLocalWinsStrategyTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/persister/CredentialsLocalWinsStrategyTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.autofill.sync.persister
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
+import com.duckduckgo.autofill.impl.FakePasswordStoreEventPlugin
 import com.duckduckgo.autofill.store.CredentialsSyncMetadataEntity
 import com.duckduckgo.autofill.sync.CredentialsFixtures.amazonCredentials
 import com.duckduckgo.autofill.sync.CredentialsFixtures.spotifyCredentials
@@ -62,6 +63,7 @@ internal class CredentialsLocalWinsStrategyTest {
         credentialsSyncMetadata,
         FakeCrypto(),
         FakeCredentialsSyncLocalValidationFeature(),
+        FakePasswordStoreEventPlugin(),
     )
 
     @After fun after() = runBlocking {

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/persister/CredentialsRemoteWinsStrategyTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/persister/CredentialsRemoteWinsStrategyTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.autofill.sync.persister
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
+import com.duckduckgo.autofill.impl.FakePasswordStoreEventPlugin
 import com.duckduckgo.autofill.store.CredentialsSyncMetadataEntity
 import com.duckduckgo.autofill.sync.CredentialsFixtures.amazonCredentials
 import com.duckduckgo.autofill.sync.CredentialsFixtures.spotifyCredentials
@@ -62,6 +63,7 @@ internal class CredentialsRemoteWinsStrategyTest {
         credentialsSyncMetadata,
         FakeCrypto(),
         FakeCredentialsSyncLocalValidationFeature(),
+        FakePasswordStoreEventPlugin(),
     )
 
     @After fun after() = runBlocking {

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/persister/CrendentialsDedupStrategyTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/persister/CrendentialsDedupStrategyTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.autofill.sync.persister
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
+import com.duckduckgo.autofill.impl.FakePasswordStoreEventPlugin
 import com.duckduckgo.autofill.store.CredentialsSyncMetadataEntity
 import com.duckduckgo.autofill.sync.CredentialsFixtures.amazonCredentials
 import com.duckduckgo.autofill.sync.CredentialsFixtures.spotifyCredentials
@@ -62,6 +63,7 @@ internal class CredentialsDedupStrategyTest {
         credentialsSyncMetadata,
         FakeCrypto(),
         FakeCredentialsSyncLocalValidationFeature(),
+        FakePasswordStoreEventPlugin(),
     )
 
     @After fun after() = runBlocking {

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/provider/CredentialsSyncDataProviderTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/sync/provider/CredentialsSyncDataProviderTest.kt
@@ -20,6 +20,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.appbuildconfig.api.BuildFlavor
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
+import com.duckduckgo.autofill.impl.FakePasswordStoreEventPlugin
 import com.duckduckgo.autofill.store.CredentialsSyncMetadataEntity
 import com.duckduckgo.autofill.sync.CredentialsFixtures
 import com.duckduckgo.autofill.sync.CredentialsFixtures.toWebsiteLoginCredentials
@@ -60,6 +61,7 @@ internal class CredentialsSyncDataProviderTest {
         credentialsSyncMetadata,
         FakeCrypto(),
         FakeCredentialsSyncLocalValidationFeature(),
+        FakePasswordStoreEventPlugin(),
     )
     private val appBuildConfig = mock<AppBuildConfig>().apply {
         whenever(this.flavor).thenReturn(BuildFlavor.PLAY)

--- a/autofill/autofill-internal/src/main/java/com/duckduckgo/autofill/internal/AutofillInternalSettingsActivity.kt
+++ b/autofill/autofill-internal/src/main/java/com/duckduckgo/autofill/internal/AutofillInternalSettingsActivity.kt
@@ -31,6 +31,7 @@ import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.api.email.EmailManager
 import com.duckduckgo.autofill.impl.configuration.AutofillJavascriptEnvironmentConfiguration
 import com.duckduckgo.autofill.impl.email.incontext.store.EmailProtectionInContextDataStore
+import com.duckduckgo.autofill.impl.engagement.store.AutofillEngagementRepository
 import com.duckduckgo.autofill.impl.store.InternalAutofillStore
 import com.duckduckgo.autofill.impl.store.NeverSavedSiteRepository
 import com.duckduckgo.autofill.impl.ui.credential.management.survey.AutofillSurveyStore
@@ -87,6 +88,9 @@ class AutofillInternalSettingsActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var autofillSurveyStore: AutofillSurveyStore
 
+    @Inject
+    lateinit var engagementRepository: AutofillEngagementRepository
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
@@ -137,6 +141,19 @@ class AutofillInternalSettingsActivity : DuckDuckGoActivity() {
         configureNeverSavedSitesEventHandlers()
         configureAutofillJsConfigEventHandlers()
         configureSurveyEventHandlers()
+        configureEngagementEventHandlers()
+    }
+
+    private fun configureEngagementEventHandlers() {
+        binding.engagementClearEngagementHistoryButton.setOnClickListener {
+            lifecycleScope.launch(dispatchers.io()) {
+                engagementRepository.clearData(preserveToday = false)
+                withContext(dispatchers.main()) {
+                    val message = getString(R.string.autofillDevSettingsEngagementHistoryCleared)
+                    Toast.makeText(this@AutofillInternalSettingsActivity, message, Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
     }
 
     private fun configureSurveyEventHandlers() {

--- a/autofill/autofill-internal/src/main/res/layout/activity_autofill_internal_settings.xml
+++ b/autofill/autofill-internal/src/main/res/layout/activity_autofill_internal_settings.xml
@@ -90,6 +90,23 @@
             android:layout_height="wrap_content" />
 
         <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+            android:id="@+id/engagementSectionTitle"
+            android:layout_width="match_parent"
+            android:layout_marginTop="20dp"
+            android:layout_height="wrap_content"
+            app:primaryText="@string/autofillDevSettingsEngagementTitle" />
+
+        <com.duckduckgo.common.ui.view.listitem.OneLineListItem
+            android:id="@+id/engagementClearEngagementHistoryButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:primaryText="@string/autofillDevSettingsEngagementClearHistory" />
+
+        <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
             android:id="@+id/emailProtectionInContextSectionTitle"
             android:layout_width="match_parent"
             android:layout_marginTop="20dp"

--- a/autofill/autofill-internal/src/main/res/values/donottranslate.xml
+++ b/autofill/autofill-internal/src/main/res/values/donottranslate.xml
@@ -21,6 +21,9 @@
     <string name="autofillDevSettingsSubtitle">Autofill and Email Protection dev options</string>
     <string name="autofillDevSettingsClearNeverAskAgainSettingButton">Clear \'never ask again\' setting</string>
     <string name="autofillDevSettingsEmailProtectionSignOutButton">Sign out</string>
+    <string name="autofillDevSettingsEngagementTitle">Engagement KPIs</string>
+    <string name="autofillDevSettingsEngagementClearHistory">Clear Engagement History</string>
+    <string name="autofillDevSettingsEngagementHistoryCleared">Cleared All Engagement History</string>
     <string name="autofillDevSettingsEmailProtectionTitle">Email Protection Settings</string>
     <string name="autofillDevSettingsEmailProtectionNeverAskAgainChoiceCleared">Never ask again choice cleared</string>
     <string name="autofillDevSettingsEmailProtectionSignedOut">Signed out</string>

--- a/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/engagement/AutofillEngagementDao.kt
+++ b/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/engagement/AutofillEngagementDao.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.store.engagement
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+
+@Dao
+abstract class AutofillEngagementDao {
+
+    @Upsert
+    abstract suspend fun upsert(engagement: AutofillEngagementEntity)
+
+    @Query("DELETE FROM autofill_engagement WHERE date < :date")
+    abstract suspend fun deleteOlderThan(date: String)
+
+    @Query("DELETE FROM autofill_engagement")
+    abstract suspend fun deleteAll()
+
+    @Query("SELECT * FROM autofill_engagement where date = :date")
+    abstract suspend fun getEngagement(date: String): AutofillEngagementEntity?
+}

--- a/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/engagement/AutofillEngagementDatabase.kt
+++ b/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/engagement/AutofillEngagementDatabase.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.store.engagement
+
+import androidx.room.Database
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import java.time.LocalDate
+
+@Database(
+    exportSchema = true,
+    version = 1,
+    entities = [
+        AutofillEngagementEntity::class,
+    ],
+)
+abstract class AutofillEngagementDatabase : RoomDatabase() {
+    abstract fun autofillEngagementDao(): AutofillEngagementDao
+
+    companion object {
+        val ALL_MIGRATIONS = emptyArray<Migration>()
+    }
+}
+
+@Entity(tableName = "autofill_engagement")
+data class AutofillEngagementEntity(
+    @PrimaryKey val date: String,
+    val autofilled: Boolean,
+    val searched: Boolean,
+) {
+    fun isToday(): Boolean {
+        return date == LocalDate.now().toString()
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1206508535741137/f 

# Description
Introduces some pixels around autofill engagement. 

# Steps to test this PR

ℹ️  Suggested logcat filter:
```
message~:"AutofillEngagementEntity" | message~:"Pixel.*m_autofill_logins_stacked" | message~:"pixel.*: m_autofill_onboardeduser" | message~:"pixel.*: m_autofill_activeuser" |  message~:"pixel.*: m_autofill_enableduser" | message~:"onCredentialAdded" | message~:"recording autofilled today" 
```

ℹ️  There is a dev setting in `Autofill Dev Settings` (internal builds) to `Clear Engagement History`; this wipes clean whether has searched or autofilled that day and can help test this PR quicker than having to keep removing all the app data each time.

ℹ️  To quickly launch `Autofill Dev Settings` (internal builds) run this: 
```
adb shell am start --activity-clear-top -n "com.duckduckgo.mobile.android.debug/com.duckduckgo.autofill.internal.AutofillInternalSettingsActivity"
```

## Active Users (autofilling types)
These tests verify that each of the following events are considered a valid autofill event for engagement purposes:

- autofilling using a saved password
- accepting an autogenerated password
- autofilling your duck address

Steps:
- [x] Add a login for fill.dev (manually or by saving when prompted)
- [x] Visit https://fill.dev/form/login-simple and choose to autofill saved password
- [x] Verify you see `onAutofilledSavedPassword` in the logs
- [x] Visit https://fill.dev/form/registration-username and choose to use a generated password
- [x] Verify you see `onUsedGeneratedPassword` in the logs
- [x] Login into Email Protection
- [x] Visit https://fill.dev/form/registration-email and choose to fill your Duck Address (your public one)
- [x] Verify you see `onAutofilledDuckAddress` in the logs
- [x] Visit https://fill.dev/form/registration-email and choose to use your private Duck Address (a private alias)
- [x] Verify you see `onAutofilledDuckAddress` in the logs

## Active Users (performing a search when you haven't autofilled today)
 - [x] Fresh install (or `Clear Engagement History` from dev settings)
 - [x] Perform a search (verify you do **not** see `m_autofill_activeuser` in logs)

## Active Users (perform both a search and an autofill event in the same day)

Carrying on from above, where you have already performed a search, now perform an autofill event. e.g., 
- [x] Visit https://fill.dev/form/registration-username and choose to use a generated password
- [x] Verify you see `m_autofill_activeuser` pixel in the logs
- [x] Repeat another search, and verify `m_autofill_activeuser` is not sent again (max once per day)

## Active Users (autofilled but have not searched today)
- [x] Fresh install  (or `Clear Engagement History` from dev settings)
- [x] Visit https://fill.dev/form/registration-username and choose to use a generated password
- [x] Verify you do **not** see `m_autofill_activeuser` in logs)

## Enabled Users (a user who has performed a search AND has >= 10 saved passwords)

- [x] Fresh install
- [x] Perform a search
- [x] Verify you do **not** see `m_autofill_enableduser` pixel
- [x] Fresh install (or `Clear Engagement History` from dev settings)
- [x] Add 10 or more saved passwords. 💡tip: if using `internal` build type you can use the Autofill dev settings to quickly add passwords
- [x] Perform a search
- [x] Verify you **do** see `m_autofill_enableduser`
- [x] Search again, and verify you do **not** see pixel again (max once per day)

## Onboarded Users (someone who has saved a password within their first week in the app)
- [x] Fresh install
- [x] Add a password (manually, or by saving when prompted, or imported via sync)
- [x] Verify you **do** see `m_autofill_onboardeduser` pixel
- [x] Add another password, and verify you do **not** see pixel again (max one time send, ever)

## Onboarded Users (out of timeframe: someone saved a password after a week in the app)
- [x] Fresh install and open the app
- [x] Set date on the device forward by >= 10 days
- [x] Add a password (manually, or by saving when prompted, or imported via sync)
- [x] Verify you do **not** see `m_autofill_onboardeduser`

## Stacked data
This is fired when user perform a search and performs an autofill in the same day, includes a bucketed count of saved passwords. Sent max once per day.

For the bucketing rules, which are included as the `count_bucket` param:

```
savedPasswords == 0 -> `none`
savedPasswords < 4 -> `few`
savedPasswords < 11 -> `some`
savedPasswords < 50 -> `many`
else -> `lots`
```

### none bucket
- [x] Fresh install (or `Clear Engagement History` from dev settings)
- [x] Perform an autofill event and a search
- [x] Verify you see pixel `m_autofill_logins_stacked` with `count_bucket=none` param

### few bucket
- [x] Fresh install (or `Clear Engagement History` from dev settings)
- [x] Have between 1 and 3 passwords saved
- [x] Perform an autofill event and a search
- [x] Verify you see pixel `m_autofill_logins_stacked` with `count_bucket=few` param

### some bucket
- [x] Fresh install (or set device date to next day)
- [x] Have between 4 and 10 passwords saved
- [x] Perform an autofill event
- [x] Verify you see pixel `m_autofill_logins_stacked` with `count_bucket=some` param

### many bucket
- [x] Fresh install (or set device date to next day)
- [x] Have between 11 and 49 passwords saved
- [x] Perform an autofill event
- [x] Verify you see pixel `m_autofill_logins_stacked` with `count_bucket=many` param

### lots bucket
- [x] Fresh install (or set device date to next day)
- [x] Have over 50 passwords saved
- [x] Perform an autofill event
- [x] Verify you see pixel `m_autofill_logins_stacked` with `count_bucket=lots` param