### PR TITLE
Re-enable Maestro's automatic test retries

### DIFF
--- a/.maestro/config.yaml
+++ b/.maestro/config.yaml
@@ -2,7 +2,7 @@ appStartup:
   enabled: false
 appSize:
   enabled: false
-disableRetries: true
+disableRetries: false
 
 flows:
  - "**"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207274917087185/f 

### Description
Re-enables the Maestro [retry behavior](https://cloud.mobile.dev/reference/retries). These were disabled in https://github.com/duckduckgo/Android/pull/4438 but we've seen global test flakiness since.

### Steps to test this PR

QA-optional