### PR TITLE
Add temporary pixels for DMA choice screens

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -275,4 +275,7 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     SSL_CERTIFICATE_WARNING_EXPIRED_SHOWN("m_certificate_warning_displayed_expired"),
     SSL_CERTIFICATE_WARNING_UNTRUSTED_SHOWN("m_certificate_warning_displayed_untrusted"),
     SSL_CERTIFICATE_WARNING_GENERIC_SHOWN("m_certificate_warning_displayed_generic"),
+
+    DMA_CHOICE_SCREEN_SEARCH_CHOICE_LEGACY_INSTALL("m_dma_search_choice_legacy_install"),
+    DMA_CHOICE_SCREEN_DEFAULT_BROWSER_LEGACY_INSTALL("m_dma_default_browser_legacy_install"),
 }

--- a/app/src/play/java/com/duckduckgo/referral/PlayStoreAppReferrerStateListener.kt
+++ b/app/src/play/java/com/duckduckgo/referral/PlayStoreAppReferrerStateListener.kt
@@ -25,6 +25,8 @@ import android.os.Build
 import com.android.installreferrer.api.InstallReferrerClient
 import com.android.installreferrer.api.InstallReferrerClient.InstallReferrerResponse.*
 import com.android.installreferrer.api.InstallReferrerStateListener
+import com.duckduckgo.app.pixels.AppPixelName.DMA_CHOICE_SCREEN_DEFAULT_BROWSER_LEGACY_INSTALL
+import com.duckduckgo.app.pixels.AppPixelName.DMA_CHOICE_SCREEN_SEARCH_CHOICE_LEGACY_INSTALL
 import com.duckduckgo.app.playstore.PlayStoreAndroidUtils.Companion.PLAY_STORE_PACKAGE
 import com.duckduckgo.app.playstore.PlayStoreAndroidUtils.Companion.PLAY_STORE_REFERRAL_SERVICE
 import com.duckduckgo.app.referral.*
@@ -32,6 +34,8 @@ import com.duckduckgo.app.referral.AppInstallationReferrerStateListener.Companio
 import com.duckduckgo.app.referral.ParseFailureReason.*
 import com.duckduckgo.app.referral.ParsedReferrerResult.*
 import com.duckduckgo.app.statistics.AtbInitializerListener
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.experiments.api.VariantManager
 import com.duckduckgo.experiments.impl.VariantManagerImpl.Companion.RESERVED_EU_BROWSER_CHOICE_AUCTION_VARIANT
@@ -48,6 +52,8 @@ class PlayStoreAppReferrerStateListener @Inject constructor(
     private val appInstallationReferrerParser: AppInstallationReferrerParser,
     private val appReferrerDataStore: AppReferrerDataStore,
     private val variantManager: VariantManager,
+    private val appBuildConfig: AppBuildConfig,
+    private val pixel: Pixel,
 ) : InstallReferrerStateListener, AppInstallationReferrerStateListener, AtbInitializerListener {
 
     private val referralClient = InstallReferrerClient.newBuilder(context).build()
@@ -177,10 +183,18 @@ class PlayStoreAppReferrerStateListener @Inject constructor(
             is EuAuctionSearchChoiceReferrerFound -> {
                 variantManager.updateAppReferrerVariant(RESERVED_EU_SEARCH_CHOICE_AUCTION_VARIANT)
                 appReferrerDataStore.installedFromEuAuction = true
+                // to be removed June 10th 2024 -> https://app.asana.com/0/1205278999335242/1207268538033883/f
+                if (appBuildConfig.sdkInt < Build.VERSION_CODES.TIRAMISU) {
+                    pixel.fire(DMA_CHOICE_SCREEN_SEARCH_CHOICE_LEGACY_INSTALL)
+                }
             }
             is EuAuctionBrowserChoiceReferrerFound -> {
                 variantManager.updateAppReferrerVariant(RESERVED_EU_BROWSER_CHOICE_AUCTION_VARIANT)
                 appReferrerDataStore.installedFromEuAuction = true
+                // to be removed June 10th 2024 -> https://app.asana.com/0/1205278999335242/1207268538033883/f
+                if (appBuildConfig.sdkInt < Build.VERSION_CODES.TIRAMISU) {
+                    pixel.fire(DMA_CHOICE_SCREEN_DEFAULT_BROWSER_LEGACY_INSTALL)
+                }
             }
             else -> {}
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207300933614494

### Description
Add two temporary pixels that allow us to measure installs in legacy Android devices.
