### PR TITLE
Add no-op WebMessageListener

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2358,9 +2358,13 @@ class BrowserTabFragment :
 
     // See https://app.asana.com/0/1200204095367872/1207300292572452/f (WebMessageListener debugging)
     private fun addNoOpWebMessageListener(webView: DuckDuckGoWebView) {
-        lifecycleScope.launch(dispatchers.io()) {
+        lifecycleScope.launch(dispatchers.main()) {
+            val isFeatureEnabled = withContext(dispatchers.io()) {
+                dummyWebMessageListenerFeature.self().isEnabled()
+            }
+
             if (WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER) &&
-                dummyWebMessageListenerFeature.self().isEnabled() &&
+                isFeatureEnabled &&
                 !webView.isDestroyed
             ) {
                 Timber.d("Adding no-op WebMessageListener")

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2357,8 +2357,11 @@ class BrowserTabFragment :
     }
 
     // See https://app.asana.com/0/1200204095367872/1207300292572452/f (WebMessageListener debugging)
-    private fun addNoOpWebMessageListener(webView: WebView) {
-        if (webMessageListenerFeature.self().isEnabled() && WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)) {
+    private fun addNoOpWebMessageListener(webView: DuckDuckGoWebView) {
+        if (WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER) &&
+            webMessageListenerFeature.self().isEnabled() &&
+            !webView.isDestroyed
+        ) {
             Timber.d("Adding no-op WebMessageListener")
             WebViewCompat.addWebMessageListener(
                 webView,

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -163,8 +163,8 @@ import com.duckduckgo.app.browser.viewstate.OmnibarViewState
 import com.duckduckgo.app.browser.viewstate.PrivacyShieldViewState
 import com.duckduckgo.app.browser.viewstate.SavedSiteChangedViewState
 import com.duckduckgo.app.browser.webshare.WebShareChooser
+import com.duckduckgo.app.browser.webview.DummyWebMessageListenerFeature
 import com.duckduckgo.app.browser.webview.WebContentDebugging
-import com.duckduckgo.app.browser.webview.WebMessageListenerFeature
 import com.duckduckgo.app.cta.ui.*
 import com.duckduckgo.app.cta.ui.DaxDialogCta.*
 import com.duckduckgo.app.di.AppCoroutineScope
@@ -486,7 +486,7 @@ class BrowserTabFragment :
     lateinit var subscriptions: Subscriptions
 
     @Inject
-    lateinit var webMessageListenerFeature: WebMessageListenerFeature
+    lateinit var dummyWebMessageListenerFeature: DummyWebMessageListenerFeature
 
     /**
      * We use this to monitor whether the user was seeing the in-context Email Protection signup prompt
@@ -2358,17 +2358,19 @@ class BrowserTabFragment :
 
     // See https://app.asana.com/0/1200204095367872/1207300292572452/f (WebMessageListener debugging)
     private fun addNoOpWebMessageListener(webView: DuckDuckGoWebView) {
-        if (WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER) &&
-            webMessageListenerFeature.self().isEnabled() &&
-            !webView.isDestroyed
-        ) {
-            Timber.d("Adding no-op WebMessageListener")
-            WebViewCompat.addWebMessageListener(
-                webView,
-                "testObj",
-                setOf("*"),
-            ) { _, _, _, _, _ ->
-                // no-op
+        lifecycleScope.launch(dispatchers.io()) {
+            if (WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER) &&
+                dummyWebMessageListenerFeature.self().isEnabled() &&
+                !webView.isDestroyed
+            ) {
+                Timber.d("Adding no-op WebMessageListener")
+                WebViewCompat.addWebMessageListener(
+                    webView,
+                    "testObj",
+                    setOf("*"),
+                ) { _, _, _, _, _ ->
+                    // no-op
+                }
             }
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoWebView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoWebView.kt
@@ -49,6 +49,8 @@ class DuckDuckGoWebView : WebView, NestedScrollingChild3 {
     private var nestedScrollHelper: NestedScrollingChildHelper = NestedScrollingChildHelper(this)
     private val helper = CoordinatorLayoutHelper()
 
+    var isDestroyed: Boolean = false
+
     constructor(context: Context) : this(context, null)
     constructor(
         context: Context,
@@ -60,6 +62,11 @@ class DuckDuckGoWebView : WebView, NestedScrollingChild3 {
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
         helper.onViewAttached(this)
+    }
+
+    override fun destroy() {
+        isDestroyed = true
+        super.destroy()
     }
 
     fun setBottomMatchingBehaviourEnabled(value: Boolean) {

--- a/app/src/main/java/com/duckduckgo/app/browser/webview/DummyWebMessageListenerFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/webview/DummyWebMessageListenerFeature.kt
@@ -22,10 +22,10 @@ import com.duckduckgo.feature.toggles.api.Toggle
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
-    featureName = "webMessageListener",
+    featureName = "dummyWebMessageListener",
 )
 
-interface WebMessageListenerFeature {
+interface DummyWebMessageListenerFeature {
 
     @Toggle.DefaultValue(false)
     fun self(): Toggle

--- a/app/src/main/java/com/duckduckgo/app/browser/webview/WebMessageListenerFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/webview/WebMessageListenerFeature.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.webview
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "webMessageListener",
+)
+
+interface WebMessageListenerFeature {
+
+    @Toggle.DefaultValue(false)
+    fun self(): Toggle
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1200204095367872/1207300292572452/f

### Description
Adds a no-op WebMessageListener in order to debug https://issuetracker.google.com/issues/338340758

### Steps to test this PR

- [ ] Check out this branch
- [ ] Run the app
- [ ] Verify that "Adding no-op WebMessageListener" is **not** visible in logcat
- [ ] Point the privacy config at the JSON blob linked in the task
- [ ] Relaunch the app
- [ ] Verify that "Adding no-op WebMessageListener" **is** visible in logcat
- [ ] Disable the `webMessageListener` feature in the JSON blob
- [ ] Relaunch the app
- [ ] Verify that "Adding no-op WebMessageListener" is **not** visible in logcat
