### PR TITLE
Move VpnSharedPreferencesProvider to data-store module

### DIFF
--- a/app-tracking-protection/vpn-impl/build.gradle
+++ b/app-tracking-protection/vpn-impl/build.gradle
@@ -64,6 +64,7 @@ dependencies {
     implementation project(':statistics')
     implementation project(':library-loader-api')
     implementation project(':network-protection-api')
+    implementation project(':data-store-api')
 
     implementation AndroidX.core.ktx
 
@@ -80,10 +81,6 @@ dependencies {
 
     // multi-process shared preferences
     implementation "com.frybits.harmony:harmony:_"
-    implementation 'com.frybits.harmony:harmony-crypto:_'
-
-    // Security crypto
-    implementation AndroidX.security.crypto
 
     // Lottie
     implementation "com.airbnb.android:lottie:_"

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/VpnFeaturesRegistryImpl.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/VpnFeaturesRegistryImpl.kt
@@ -20,7 +20,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
 import com.duckduckgo.common.utils.DispatcherProvider
-import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.mobile.android.vpn.service.TrackerBlockingVpnService
 import java.util.UUID
 import kotlinx.coroutines.sync.Mutex
@@ -32,7 +32,7 @@ private const val IS_INITIALIZED = "IS_INITIALIZED"
 
 internal class VpnFeaturesRegistryImpl(
     private val vpnServiceWrapper: VpnServiceWrapper,
-    private val sharedPreferencesProvider: VpnSharedPreferencesProvider,
+    private val sharedPreferencesProvider: SharedPreferencesProvider,
     private val dispatcherProvider: DispatcherProvider,
 ) : VpnFeaturesRegistry {
 

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/bugreport/NetworkTypeCollector.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/bugreport/NetworkTypeCollector.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.mobile.android.vpn.bugreport
 
 import android.content.Context
 import android.content.SharedPreferences
-import android.net.*
 import android.os.SystemClock
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/cohort/CohortStore.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/cohort/CohortStore.kt
@@ -23,11 +23,11 @@ import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.appbuildconfig.api.isInternalBuild
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.checkMainThread
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.di.scopes.VpnScope
 import com.duckduckgo.mobile.android.vpn.AppTpVpnFeature
 import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
-import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
 import com.duckduckgo.mobile.android.vpn.service.VpnServiceCallbacks
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnStopReason
 import com.squareup.anvil.annotations.ContributesBinding
@@ -61,7 +61,7 @@ interface CohortStore {
     boundType = VpnServiceCallbacks::class,
 )
 class RealCohortStore @Inject constructor(
-    private val sharedPreferencesProvider: VpnSharedPreferencesProvider,
+    private val sharedPreferencesProvider: SharedPreferencesProvider,
     private val vpnFeaturesRegistry: VpnFeaturesRegistry,
     private val dispatcherProvider: DispatcherProvider,
     private val appBuildConfig: AppBuildConfig,

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/di/VpnAppModule.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/di/VpnAppModule.kt
@@ -21,12 +21,12 @@ import android.content.res.Resources
 import android.net.ConnectivityManager
 import androidx.room.Room
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.mobile.android.vpn.Vpn
 import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
 import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistryImpl
 import com.duckduckgo.mobile.android.vpn.VpnServiceWrapper
-import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
 import com.duckduckgo.mobile.android.vpn.stats.AppTrackerBlockingStatsRepository
 import com.duckduckgo.mobile.android.vpn.stats.RealAppTrackerBlockingStatsRepository
 import com.duckduckgo.mobile.android.vpn.store.*
@@ -92,7 +92,7 @@ object VpnAppModule {
     @SingleInstanceIn(AppScope::class)
     fun provideVpnFeaturesRegistry(
         context: Context,
-        sharedPreferencesProvider: VpnSharedPreferencesProvider,
+        sharedPreferencesProvider: SharedPreferencesProvider,
         dispatcherProvider: DispatcherProvider,
     ): VpnFeaturesRegistry {
         return VpnFeaturesRegistryImpl(VpnServiceWrapper(context, dispatcherProvider), sharedPreferencesProvider, dispatcherProvider)

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/feature/AppTpRemoteFeatures.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/feature/AppTpRemoteFeatures.kt
@@ -22,13 +22,13 @@ import androidx.core.content.edit
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.RemoteFeatureStoreNamed
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.feature.toggles.api.Toggle.DefaultValue
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.mobile.android.vpn.feature.settings.ExceptionListsSettingStore
-import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
@@ -63,14 +63,14 @@ interface AppTpRemoteFeatures {
 class AppTpRemoteFeaturesStore @Inject constructor(
     @AppCoroutineScope private val coroutineScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
-    private val vpnSharedPreferencesProvider: VpnSharedPreferencesProvider,
+    private val sharedPreferencesProvider: SharedPreferencesProvider,
     moshi: Moshi,
 ) : Toggle.Store {
 
     private val togglesCache = ConcurrentHashMap<String, State>()
 
     private val preferences: SharedPreferences by lazy {
-        vpnSharedPreferencesProvider.getSharedPreferences(PREFS_FILENAME, multiprocess = true, migrate = false)
+        sharedPreferencesProvider.getSharedPreferences(PREFS_FILENAME, multiprocess = true, migrate = false)
     }
     private val stateAdapter: JsonAdapter<State> by lazy {
         moshi.newBuilder().add(KotlinJsonAdapterFactory()).build().adapter(State::class.java)

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
@@ -19,8 +19,8 @@ package com.duckduckgo.mobile.android.vpn.pixels
 import android.content.SharedPreferences
 import androidx.core.content.edit
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
 import java.time.Instant
@@ -367,11 +367,11 @@ interface DeviceShieldPixels {
 @SingleInstanceIn(AppScope::class)
 class RealDeviceShieldPixels @Inject constructor(
     private val pixel: Pixel,
-    private val vpnSharedPreferencesProvider: VpnSharedPreferencesProvider,
+    private val sharedPreferencesProvider: SharedPreferencesProvider,
 ) : DeviceShieldPixels {
 
     private val preferences: SharedPreferences by lazy {
-        vpnSharedPreferencesProvider.getSharedPreferences(
+        sharedPreferencesProvider.getSharedPreferences(
             DS_PIXELS_PREF_FILE,
             multiprocess = true,
             migrate = true,

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/notification/VpnNotificationStore.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/notification/VpnNotificationStore.kt
@@ -18,8 +18,8 @@ package com.duckduckgo.mobile.android.vpn.service.notification
 
 import android.content.SharedPreferences
 import androidx.core.content.edit
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 
@@ -29,10 +29,10 @@ interface VpnNotificationStore {
 
 @ContributesBinding(AppScope::class)
 class RealVpnNotificationStore @Inject constructor(
-    private val vpnSharedPreferencesProvider: VpnSharedPreferencesProvider,
+    private val sharedPreferencesProvider: SharedPreferencesProvider,
 ) : VpnNotificationStore {
     private val prefs: SharedPreferences by lazy {
-        vpnSharedPreferencesProvider.getSharedPreferences(FILENAME, multiprocess = true, migrate = false)
+        sharedPreferencesProvider.getSharedPreferences(FILENAME, multiprocess = true, migrate = false)
     }
 
     override var persistentNotifDimissedTimestamp: Long

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/onboarding/VpnStore.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/onboarding/VpnStore.kt
@@ -18,8 +18,8 @@ package com.duckduckgo.mobile.android.vpn.ui.onboarding
 
 import android.content.SharedPreferences
 import androidx.core.content.edit
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
 import java.time.Instant
@@ -42,7 +42,7 @@ interface VpnStore {
 @ContributesBinding(AppScope::class)
 @SingleInstanceIn(AppScope::class)
 class SharedPreferencesVpnStore @Inject constructor(
-    private val sharedPreferencesProvider: VpnSharedPreferencesProvider,
+    private val sharedPreferencesProvider: SharedPreferencesProvider,
 ) : VpnStore {
 
     private val preferences: SharedPreferences by lazy {

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/VpnFeaturesRegistryImplTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/VpnFeaturesRegistryImplTest.kt
@@ -21,7 +21,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.test.api.InMemorySharedPreferences
 import com.duckduckgo.common.utils.DispatcherProvider
-import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
 import org.junit.Before
@@ -36,7 +36,7 @@ class VpnFeaturesRegistryImplTest {
     @get:Rule
     val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
 
-    private val sharedPreferencesProvider: VpnSharedPreferencesProvider = mock()
+    private val sharedPreferencesProvider: SharedPreferencesProvider = mock()
     private lateinit var vpnServiceWrapper: TestVpnServiceWrapper
 
     private lateinit var vpnFeaturesRegistry: VpnFeaturesRegistry

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/cohort/CohortPixelInterceptorTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/cohort/CohortPixelInterceptorTest.kt
@@ -21,8 +21,8 @@ import com.duckduckgo.appbuildconfig.api.BuildFlavor
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.test.api.FakeChain
 import com.duckduckgo.common.test.api.InMemorySharedPreferences
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
-import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
 import java.time.LocalDate
 import org.junit.Assert
 import org.junit.Before
@@ -49,7 +49,7 @@ class CohortPixelInterceptorTest {
     private lateinit var cohortStore: CohortStore
     private lateinit var cohortCalculator: CohortCalculator
 
-    private val sharedPreferencesProvider = mock<VpnSharedPreferencesProvider>()
+    private val sharedPreferencesProvider = mock<SharedPreferencesProvider>()
 
     @Before
     fun setup() {

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/cohort/RealCohortStoreTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/cohort/RealCohortStoreTest.kt
@@ -20,10 +20,10 @@ import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.appbuildconfig.api.BuildFlavor
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.test.api.InMemorySharedPreferences
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.mobile.android.vpn.AppTpVpnFeature
 import com.duckduckgo.mobile.android.vpn.FakeVpnFeaturesRegistry
 import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
-import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
 import java.time.LocalDate
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
@@ -47,7 +47,7 @@ class RealCohortStoreTest {
     @Mock
     private lateinit var appBuildConfig: AppBuildConfig
 
-    private val sharedPreferencesProvider = mock<VpnSharedPreferencesProvider>()
+    private val sharedPreferencesProvider = mock<SharedPreferencesProvider>()
 
     private lateinit var cohortStore: CohortStore
 

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/feature/AppTpRemoteFeaturesStoreTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/feature/AppTpRemoteFeaturesStoreTest.kt
@@ -4,9 +4,9 @@ import android.content.SharedPreferences
 import androidx.core.content.edit
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.test.api.InMemorySharedPreferences
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.feature.toggles.api.Toggle.State
-import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import kotlinx.coroutines.test.runTest
@@ -30,7 +30,7 @@ class AppTpRemoteFeaturesStoreTest {
         appTpRemoteFeaturesStore = AppTpRemoteFeaturesStore(
             coroutineRule.testScope,
             coroutineRule.testDispatcherProvider,
-            object : VpnSharedPreferencesProvider {
+            object : SharedPreferencesProvider {
                 override fun getSharedPreferences(
                     name: String,
                     multiprocess: Boolean,
@@ -81,7 +81,7 @@ class AppTpRemoteFeaturesStoreTest {
         val store = AppTpRemoteFeaturesStore(
             coroutineRule.testScope,
             coroutineRule.testDispatcherProvider,
-            object : VpnSharedPreferencesProvider {
+            object : SharedPreferencesProvider {
                 override fun getSharedPreferences(
                     name: String,
                     multiprocess: Boolean,

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/pixels/RealDeviceShieldPixelsTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/pixels/RealDeviceShieldPixelsTest.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.mobile.android.vpn.pixels
 
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.test.api.InMemorySharedPreferences
-import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import java.util.*
 import org.junit.Before
 import org.junit.Test
@@ -27,7 +27,7 @@ import org.mockito.kotlin.*
 class RealDeviceShieldPixelsTest {
 
     private val pixel = mock<Pixel>()
-    private val sharedPreferencesProvider = mock<VpnSharedPreferencesProvider>()
+    private val sharedPreferencesProvider = mock<SharedPreferencesProvider>()
 
     lateinit var deviceShieldPixels: DeviceShieldPixels
 

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/onboarding/SharedPreferencesVpnStoreTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/onboarding/SharedPreferencesVpnStoreTest.kt
@@ -19,7 +19,7 @@ package com.duckduckgo.mobile.android.vpn.ui.onboarding
 import android.content.SharedPreferences
 import androidx.core.content.edit
 import com.duckduckgo.common.test.api.InMemorySharedPreferences
-import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 import org.junit.Assert.*
@@ -31,7 +31,7 @@ import org.mockito.kotlin.whenever
 
 class SharedPreferencesVpnStoreTest {
 
-    private val sharedPreferencesProvider = mock<VpnSharedPreferencesProvider>()
+    private val sharedPreferencesProvider = mock<SharedPreferencesProvider>()
 
     private lateinit var sharedPreferencesVpnStore: SharedPreferencesVpnStore
     private lateinit var preferences: SharedPreferences

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -166,6 +166,8 @@ fladle {
 }
 
 dependencies {
+	implementation project(":data-store-impl")
+	implementation project(":data-store-api")
 	implementation project(":verified-installation-impl")
 	implementation project(":verified-installation-api")
 

--- a/data-store/data-store-api/build.gradle
+++ b/data-store/data-store-api/build.gradle
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+}
+
+apply from: "$rootProject.projectDir/gradle/android-library.gradle"
+
+android {
+    namespace "com.duckduckgo.datastore.api"
+    compileOptions {
+        coreLibraryDesugaringEnabled = true
+    }
+}
+
+dependencies {
+    implementation project(':navigation-api')
+
+    implementation KotlinX.coroutines.core
+    implementation AndroidX.appCompat
+}
+
+

--- a/data-store/data-store-api/src/main/java/com/duckduckgo/data/store/api/SharedPreferencesProvider.kt
+++ b/data-store/data-store-api/src/main/java/com/duckduckgo/data/store/api/SharedPreferencesProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 DuckDuckGo
+ * Copyright (c) 2024 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.mobile.android.vpn.prefs
+package com.duckduckgo.data.store.api
 
 import android.content.SharedPreferences
 
-interface VpnSharedPreferencesProvider {
+interface SharedPreferencesProvider {
     /**
      * Returns an instance of Shared preferences
      * @param name Name of the shared preferences
      * @param multiprocess `true` if the shared preferences will be accessed from several processes else `false`
-     * @param migrate `true` if the shared preferences existed prior to use the [VpnSharedPreferencesProvider], else `false`
+     * @param migrate `true` if the shared preferences existed prior to use the [SharedPreferencesProvider], else `false`
      */
     fun getSharedPreferences(name: String, multiprocess: Boolean = false, migrate: Boolean = false): SharedPreferences
 

--- a/data-store/data-store-impl/build.gradle
+++ b/data-store/data-store-impl/build.gradle
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+    id 'com.squareup.anvil'
+    id 'com.google.devtools.ksp' version "$ksp_version"
+}
+
+apply from: "$rootProject.projectDir/gradle/android-library.gradle"
+
+dependencies {
+	implementation project(":data-store-api")
+
+    anvil project(':anvil-compiler')
+    implementation project(':anvil-annotations')
+    implementation project(':di')
+    ksp AndroidX.room.compiler
+
+    implementation KotlinX.coroutines.android
+    implementation AndroidX.core.ktx
+    implementation Google.dagger
+
+    implementation "com.squareup.logcat:logcat:_"
+
+    // multi-process shared preferences
+    implementation "com.frybits.harmony:harmony:_"
+    implementation 'com.frybits.harmony:harmony-crypto:_'
+
+    // Security crypto
+    implementation AndroidX.security.crypto
+
+    testImplementation "org.mockito.kotlin:mockito-kotlin:_"
+    testImplementation project(':common-test')
+    testImplementation Testing.junit4
+    testImplementation AndroidX.test.ext.junit
+    testImplementation CashApp.turbine
+    testImplementation Testing.robolectric
+    testImplementation(KotlinX.coroutines.test) {
+        // https://github.com/Kotlin/kotlinx.coroutines/issues/2023
+        // conflicts with mockito due to direct inclusion of byte buddy
+        exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
+    }
+
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
+}
+
+android {
+    namespace "com.duckduckgo.datastore.impl"
+    anvil {
+        generateDaggerFactories = true // default is false
+    }
+    lint {
+        baseline file("lint-baseline.xml")
+    }
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
+    compileOptions {
+        coreLibraryDesugaringEnabled = true
+    }
+}
+

--- a/data-store/data-store-impl/lint-baseline.xml
+++ b/data-store/data-store-impl/lint-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.1.2" type="baseline" client="gradle" dependencies="false" name="AGP (8.1.2)" variant="all" version="8.1.2">
+
+</issues>

--- a/data-store/data-store-impl/src/main/java/com/duckduckgo/data/store/impl/SafeSharedPreferences.kt
+++ b/data-store/data-store-impl/src/main/java/com/duckduckgo/data/store/impl/SafeSharedPreferences.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.mobile.android.vpn.prefs
+package com.duckduckgo.data.store.impl
 
 import android.content.SharedPreferences
 import android.content.SharedPreferences.Editor

--- a/data-store/data-store-impl/src/main/java/com/duckduckgo/data/store/impl/SharedPreferencesProviderImpl.kt
+++ b/data-store/data-store-impl/src/main/java/com/duckduckgo/data/store/impl/SharedPreferencesProviderImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 DuckDuckGo
+ * Copyright (c) 2024 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.mobile.android.vpn.prefs
+package com.duckduckgo.data.store.impl
 
 import android.content.Context
 import android.content.Context.MODE_PRIVATE
@@ -23,6 +23,7 @@ import androidx.core.content.edit
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import androidx.security.crypto.MasterKeys
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.frybits.harmony.getHarmonySharedPreferences
 import com.frybits.harmony.secure.getEncryptedHarmonySharedPreferences
@@ -34,9 +35,9 @@ import logcat.logcat
 private const val MIGRATED_TO_HARMONY = "migrated_to_harmony"
 
 @ContributesBinding(AppScope::class)
-class VpnSharedPreferencesProviderImpl @Inject constructor(
+class SharedPreferencesProviderImpl @Inject constructor(
     private val context: Context,
-) : VpnSharedPreferencesProvider {
+) : SharedPreferencesProvider {
     override fun getSharedPreferences(name: String, multiprocess: Boolean, migrate: Boolean): SharedPreferences {
         return if (multiprocess) {
             if (migrate) {

--- a/data-store/data-store-impl/src/test/java/com/duckduckgo/data/store/impl/SharedPreferencesProviderImplTest.kt
+++ b/data-store/data-store-impl/src/test/java/com/duckduckgo/data/store/impl/SharedPreferencesProviderImplTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 DuckDuckGo
+ * Copyright (c) 2024 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.mobile.android.vpn.prefs
+package com.duckduckgo.data.store.impl
 
 import android.content.Context
 import android.content.Context.MODE_PRIVATE
@@ -22,6 +22,7 @@ import android.content.SharedPreferences
 import androidx.core.content.edit
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import java.util.UUID
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
@@ -30,18 +31,18 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class VpnSharedPreferencesProviderImplTest {
+class SharedPreferencesProviderImplTest {
 
     private val context: Context = InstrumentationRegistry.getInstrumentation().context.applicationContext
     private lateinit var prefs: SharedPreferences
-    private lateinit var vpnPreferencesProvider: VpnSharedPreferencesProvider
+    private lateinit var vpnPreferencesProvider: SharedPreferencesProvider
     private lateinit var NAME: String
 
     @Before
     fun setup() {
         NAME = UUID.randomUUID().toString()
         prefs = context.getSharedPreferences(NAME, MODE_PRIVATE)
-        vpnPreferencesProvider = VpnSharedPreferencesProviderImpl(context)
+        vpnPreferencesProvider = SharedPreferencesProviderImpl(context)
     }
 
     @Test
@@ -80,7 +81,7 @@ class VpnSharedPreferencesProviderImplTest {
 
     @Test
     fun testSafeSharedPreferences() {
-        val prefs = SafeSharedPreferences(vpnPreferencesProvider.getSharedPreferences(NAME))
+        val prefs = com.duckduckgo.data.store.impl.SafeSharedPreferences(vpnPreferencesProvider.getSharedPreferences(NAME))
 
         prefs.edit(commit = true) { putBoolean("bool", true) }
         prefs.edit(commit = true) { putString("string", "true") }

--- a/data-store/data-store-test/build.gradle
+++ b/data-store/data-store-test/build.gradle
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+}
+
+apply from: "$rootProject.projectDir/gradle/android-library.gradle"
+
+dependencies {
+    implementation project(':data-store-api')
+    implementation project(':common-test')
+    implementation KotlinX.coroutines.core
+}
+android {
+  namespace 'com.duckduckgo.data.store.api.test'
+}

--- a/data-store/data-store-test/src/main/java/com/duckduckgo/data/store/api/FakeSharedPreferencesProvider.kt
+++ b/data-store/data-store-test/src/main/java/com/duckduckgo/data/store/api/FakeSharedPreferencesProvider.kt
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.mobile.android.vpn.prefs
+package com.duckduckgo.data.store.api
 
 import android.content.SharedPreferences
 import com.duckduckgo.common.test.api.InMemorySharedPreferences
 
-class FakeVpnSharedPreferencesProvider : VpnSharedPreferencesProvider {
+class FakeSharedPreferencesProvider : SharedPreferencesProvider {
     override fun getSharedPreferences(name: String, multiprocess: Boolean, migrate: Boolean): SharedPreferences {
         return InMemorySharedPreferences()
     }

--- a/data-store/readme.md
+++ b/data-store/readme.md
@@ -1,0 +1,9 @@
+# Feature Name
+
+This module contains public API and implementation for data-store related classes.
+
+## Who can help you better understand this feature?
+- Aitor Viana
+
+## More information
+- [Asana: feature documentation](❓)

--- a/network-protection/network-protection-impl/build.gradle
+++ b/network-protection/network-protection-impl/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     implementation project(':subscriptions-api')
     implementation project(':settings-api')
     implementation project(':remote-messaging-api')
+    implementation project(':data-store-api')
 
     implementation AndroidX.appCompat
     implementation AndroidX.constraintLayout
@@ -63,6 +64,7 @@ dependencies {
 
     testImplementation project(':common-test')
     testImplementation project(':vpn-api-test')
+    testImplementation project(':data-store-test')
     testImplementation CashApp.turbine
     testImplementation Testing.junit4
     testImplementation AndroidX.archCore.testing

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/cohort/NetpCohortStore.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/cohort/NetpCohortStore.kt
@@ -18,8 +18,8 @@ package com.duckduckgo.networkprotection.impl.cohort
 
 import android.content.SharedPreferences
 import androidx.core.content.edit
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
 import com.duckduckgo.networkprotection.impl.state.NetPFeatureRemover
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -40,7 +40,7 @@ interface NetpCohortStore {
     boundType = NetPFeatureRemover.NetPStoreRemovalPlugin::class,
 )
 class RealNetpCohortStore @Inject constructor(
-    private val sharedPreferencesProvider: VpnSharedPreferencesProvider,
+    private val sharedPreferencesProvider: SharedPreferencesProvider,
 ) : NetpCohortStore, NetPFeatureRemover.NetPStoreRemovalPlugin {
     private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
 

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/configuration/WgTunnel.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/configuration/WgTunnel.kt
@@ -18,9 +18,9 @@ package com.duckduckgo.networkprotection.impl.configuration
 
 import android.content.SharedPreferences
 import androidx.core.content.edit
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.di.scopes.VpnScope
-import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
 import com.duckduckgo.networkprotection.impl.config.NetPDefaultConfigProvider
 import com.duckduckgo.networkprotection.impl.configuration.WgServerApi.Mode.FailureRecovery
 import com.squareup.anvil.annotations.ContributesBinding
@@ -246,10 +246,10 @@ class RealWgTunnel @Inject constructor(
 private annotation class InternalApi
 
 class WgTunnelStore constructor(
-    private val vpnSharedPreferencesProvider: VpnSharedPreferencesProvider,
+    private val sharedPreferencesProvider: SharedPreferencesProvider,
 ) {
     private val prefs: SharedPreferences by lazy {
-        vpnSharedPreferencesProvider.getSharedPreferences(FILENAME, multiprocess = true, migrate = false)
+        sharedPreferencesProvider.getSharedPreferences(FILENAME, multiprocess = true, migrate = false)
     }
 
     var wireguardConfig: Config?
@@ -292,7 +292,7 @@ class WgTunnelStore constructor(
 object WgTunnelStoreModule {
     @Provides
     @InternalApi
-    fun provideWgTunnelStore(preferencesProvider: VpnSharedPreferencesProvider): WgTunnelStore {
+    fun provideWgTunnelStore(preferencesProvider: SharedPreferencesProvider): WgTunnelStore {
         return WgTunnelStore(preferencesProvider)
     }
 }

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/connectionclass/ConnectionQualityStore.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/connectionclass/ConnectionQualityStore.kt
@@ -19,12 +19,12 @@ package com.duckduckgo.networkprotection.impl.connectionclass
 import android.content.SharedPreferences
 import androidx.core.content.edit
 import com.duckduckgo.common.utils.DispatcherProvider
-import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import javax.inject.Inject
 import kotlinx.coroutines.withContext
 
 class ConnectionQualityStore @Inject constructor(
-    private val sharedPreferencesProvider: VpnSharedPreferencesProvider,
+    private val sharedPreferencesProvider: SharedPreferencesProvider,
     private val dispatcherProvider: DispatcherProvider,
 ) {
 

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/di/NetworkProtectionModule.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/di/NetworkProtectionModule.kt
@@ -19,8 +19,8 @@ package com.duckduckgo.networkprotection.impl.di
 import android.content.Context
 import androidx.room.Room
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
 import com.duckduckgo.mobile.android.vpn.ui.AppBreakageCategory
 import com.duckduckgo.networkprotection.impl.R
 import com.duckduckgo.networkprotection.store.NetPExclusionListRepository
@@ -44,8 +44,8 @@ object DataModule {
     @Provides
     @SingleInstanceIn(AppScope::class)
     fun provideNetworkProtectionRepository(
-        vpnSharedPreferencesProvider: VpnSharedPreferencesProvider,
-    ): NetworkProtectionPrefs = RealNetworkProtectionPrefs(vpnSharedPreferencesProvider)
+        sharedPreferencesProvider: SharedPreferencesProvider,
+    ): NetworkProtectionPrefs = RealNetworkProtectionPrefs(sharedPreferencesProvider)
 
     @SingleInstanceIn(AppScope::class)
     @Provides
@@ -109,6 +109,6 @@ object NetPBreakageCategoriesModule {
 object NetPDataStoreModule {
     @Provides
     fun provideNetPDataStore(
-        vpnSharedPreferencesProvider: VpnSharedPreferencesProvider,
-    ): NetpDataStore = NetpDataStoreSharedPreferences(vpnSharedPreferencesProvider)
+        sharedPreferencesProvider: SharedPreferencesProvider,
+    ): NetpDataStore = NetpDataStoreSharedPreferences(sharedPreferencesProvider)
 }

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/exclusion/systemapps/SystemAppsExclusionRepository.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/exclusion/systemapps/SystemAppsExclusionRepository.kt
@@ -21,10 +21,10 @@ import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import androidx.core.content.edit
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.mobile.android.vpn.exclusion.SystemAppOverridesProvider
-import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
 import com.duckduckgo.networkprotection.impl.exclusion.isSystemApp
 import com.duckduckgo.networkprotection.impl.exclusion.systemapps.SystemAppsExclusionRepository.SystemAppCategory
 import com.duckduckgo.networkprotection.impl.exclusion.systemapps.SystemAppsExclusionRepository.SystemAppCategory.Communication
@@ -62,13 +62,13 @@ interface SystemAppsExclusionRepository {
 @SingleInstanceIn(AppScope::class)
 class RealSystemAppsExclusionRepository @Inject constructor(
     private val netPSettingsLocalConfig: NetPSettingsLocalConfig,
-    private val vpnSharedPreferencesProvider: VpnSharedPreferencesProvider,
+    private val sharedPreferencesProvider: SharedPreferencesProvider,
     private val packageManager: PackageManager,
     private val systemAppOverridesProvider: SystemAppOverridesProvider,
     private val dispatcherProvider: DispatcherProvider,
 ) : SystemAppsExclusionRepository {
     private val preferences: SharedPreferences by lazy {
-        vpnSharedPreferencesProvider.getSharedPreferences(
+        sharedPreferencesProvider.getSharedPreferences(
             FILENAME,
             multiprocess = false,
             migrate = false,

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/pixels/NetworkProtectionPixels.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/pixels/NetworkProtectionPixels.kt
@@ -19,8 +19,8 @@ package com.duckduckgo.networkprotection.impl.pixels
 import android.content.SharedPreferences
 import androidx.core.content.edit
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
 import com.duckduckgo.networkprotection.impl.cohort.NetpCohortStore
 import com.duckduckgo.networkprotection.impl.pixels.NetworkProtectionPixelNames.*
 import com.squareup.anvil.annotations.ContributesBinding
@@ -288,13 +288,13 @@ interface NetworkProtectionPixels {
 @SingleInstanceIn(AppScope::class)
 class RealNetworkProtectionPixel @Inject constructor(
     private val pixel: Pixel,
-    private val vpnSharedPreferencesProvider: VpnSharedPreferencesProvider,
+    private val sharedPreferencesProvider: SharedPreferencesProvider,
     private val cohortStore: NetpCohortStore,
     private val etTimestamp: ETTimestamp,
 ) : NetworkProtectionPixels {
 
     private val preferences: SharedPreferences by lazy {
-        vpnSharedPreferencesProvider.getSharedPreferences(
+        sharedPreferencesProvider.getSharedPreferences(
             NETP_PIXELS_PREF_FILE,
             multiprocess = true,
             migrate = false,

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/revoked/AccessRevokedDialog.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/revoked/AccessRevokedDialog.kt
@@ -23,8 +23,8 @@ import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder.EventListener
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.networkprotection.impl.R
 import com.duckduckgo.networkprotection.impl.pixels.NetworkProtectionPixels
@@ -59,11 +59,11 @@ class RealAccessRevokedDialog @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
     private val globalActivityStarter: GlobalActivityStarter,
     private val networkProtectionPixels: NetworkProtectionPixels,
-    private val vpnSharedPreferencesProvider: VpnSharedPreferencesProvider,
+    private val sharedPreferencesProvider: SharedPreferencesProvider,
 ) : AccessRevokedDialog {
 
     private val preferences: SharedPreferences by lazy {
-        vpnSharedPreferencesProvider.getSharedPreferences(
+        sharedPreferencesProvider.getSharedPreferences(
             FILENAME,
             multiprocess = true,
             migrate = false,

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/subscription/NetPWaitlistEndedChecker.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/subscription/NetPWaitlistEndedChecker.kt
@@ -19,8 +19,8 @@ package com.duckduckgo.networkprotection.impl.subscription
 import android.content.SharedPreferences
 import androidx.core.content.edit
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.di.scopes.VpnScope
-import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
 import com.duckduckgo.mobile.android.vpn.service.VpnServiceCallbacks
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnStopReason
 import com.duckduckgo.networkprotection.api.NetworkProtectionState
@@ -39,12 +39,12 @@ class NetPWaitlistEndedChecker @Inject constructor(
     private val netpSubscriptionManager: NetpSubscriptionManager,
     private val dispatcherProvider: DispatcherProvider,
     private val networkProtectionState: NetworkProtectionState,
-    private val vpnSharedPreferencesProvider: VpnSharedPreferencesProvider,
+    private val sharedPreferencesProvider: SharedPreferencesProvider,
     private val networkProtectionPixels: NetworkProtectionPixels,
 ) : VpnServiceCallbacks {
 
     private val preferences: SharedPreferences by lazy {
-        vpnSharedPreferencesProvider.getSharedPreferences("com.duckduckgo.networkprotection.subscription.vpnWaitlistChecker")
+        sharedPreferencesProvider.getSharedPreferences("com.duckduckgo.networkprotection.subscription.vpnWaitlistChecker")
     }
 
     override fun onVpnStarted(coroutineScope: CoroutineScope) {

--- a/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/WgVpnNetworkStackTest.kt
+++ b/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/WgVpnNetworkStackTest.kt
@@ -16,9 +16,9 @@
 
 package com.duckduckgo.networkprotection.impl
 
+import com.duckduckgo.data.store.api.FakeSharedPreferencesProvider
 import com.duckduckgo.mobile.android.vpn.network.FakeDnsProvider
 import com.duckduckgo.mobile.android.vpn.network.VpnNetworkStack.VpnTunnelConfig
-import com.duckduckgo.mobile.android.vpn.prefs.FakeVpnSharedPreferencesProvider
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnStopReason.RESTART
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnStopReason.SELF_STOP
 import com.duckduckgo.networkprotection.impl.config.NetPDefaultConfigProvider
@@ -104,7 +104,7 @@ class WgVpnNetworkStackTest {
 
         privateDnsProvider = FakeDnsProvider()
         networkProtectionRepository = RealNetworkProtectionRepository(
-            RealNetworkProtectionPrefs(FakeVpnSharedPreferencesProvider()),
+            RealNetworkProtectionPrefs(FakeSharedPreferencesProvider()),
         )
 
         wgConfig = Config.parse(BufferedReader(StringReader(wgQuickConfig)))

--- a/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/configuration/WgTunnelTest.kt
+++ b/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/configuration/WgTunnelTest.kt
@@ -2,7 +2,7 @@ package com.duckduckgo.networkprotection.impl.configuration
 
 import android.os.Build.VERSION
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.duckduckgo.mobile.android.vpn.prefs.FakeVpnSharedPreferencesProvider
+import com.duckduckgo.data.store.api.FakeSharedPreferencesProvider
 import com.duckduckgo.networkprotection.impl.config.NetPDefaultConfigProvider
 import com.duckduckgo.networkprotection.impl.configuration.WgServerApi.Mode.FailureRecovery
 import com.wireguard.config.Config
@@ -60,7 +60,7 @@ class WgTunnelTest {
             whenever(wgServerApi.registerPublicKey(eq(keys.publicKey.toBase64()), isNull()))
                 .thenReturn(serverData.copy(publicKey = keys.publicKey.toBase64()))
         }
-        wgTunnelStore = WgTunnelStore(FakeVpnSharedPreferencesProvider())
+        wgTunnelStore = WgTunnelStore(FakeSharedPreferencesProvider())
         wgTunnel = RealWgTunnel(wgServerApi, netPDefaultConfigProvider, wgTunnelStore)
     }
 

--- a/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/connectionclass/ConnectionClassManagerTest.kt
+++ b/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/connectionclass/ConnectionClassManagerTest.kt
@@ -1,7 +1,7 @@
 package com.duckduckgo.networkprotection.impl.connectionclass
 
 import com.duckduckgo.common.test.CoroutineTestRule
-import com.duckduckgo.mobile.android.vpn.prefs.FakeVpnSharedPreferencesProvider
+import com.duckduckgo.data.store.api.FakeSharedPreferencesProvider
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -21,7 +21,7 @@ class ConnectionClassManagerTest {
             ExponentialGeometricAverage(),
             coroutineRule.testScope,
             ConnectionQualityStore(
-                FakeVpnSharedPreferencesProvider(),
+                FakeSharedPreferencesProvider(),
                 coroutineRule.testDispatcherProvider,
             ),
         )

--- a/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/connectionclass/ConnectionQualityStoreTest.kt
+++ b/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/connectionclass/ConnectionQualityStoreTest.kt
@@ -1,7 +1,7 @@
 package com.duckduckgo.networkprotection.impl.connectionclass
 
 import com.duckduckgo.common.test.CoroutineTestRule
-import com.duckduckgo.mobile.android.vpn.prefs.FakeVpnSharedPreferencesProvider
+import com.duckduckgo.data.store.api.FakeSharedPreferencesProvider
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -16,7 +16,7 @@ class ConnectionQualityStoreTest {
 
     @Before
     fun setup() {
-        connectionQualityStore = ConnectionQualityStore(FakeVpnSharedPreferencesProvider(), coroutineRule.testDispatcherProvider)
+        connectionQualityStore = ConnectionQualityStore(FakeSharedPreferencesProvider(), coroutineRule.testDispatcherProvider)
     }
 
     @Test

--- a/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/pixels/RealNetworkProtectionPixelTest.kt
+++ b/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/pixels/RealNetworkProtectionPixelTest.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.networkprotection.impl.pixels
 
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.test.api.InMemorySharedPreferences
-import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.networkprotection.impl.cohort.NetpCohortStore
 import com.duckduckgo.networkprotection.impl.pixels.NetworkProtectionPixelNames.NETP_ENABLE_UNIQUE
 import java.time.LocalDate
@@ -37,7 +37,7 @@ class RealNetworkProtectionPixelTest {
     private lateinit var pixel: Pixel
 
     @Mock
-    private lateinit var vpnSharedPreferencesProvider: VpnSharedPreferencesProvider
+    private lateinit var sharedPreferencesProvider: SharedPreferencesProvider
 
     private lateinit var fakeNetpCohortStore: FakeNetpCohortStore
 
@@ -51,11 +51,11 @@ class RealNetworkProtectionPixelTest {
         }
         val prefs = InMemorySharedPreferences()
         whenever(
-            vpnSharedPreferencesProvider.getSharedPreferences(eq("com.duckduckgo.networkprotection.pixels.v1"), eq(true), eq(false)),
+            sharedPreferencesProvider.getSharedPreferences(eq("com.duckduckgo.networkprotection.pixels.v1"), eq(true), eq(false)),
         ).thenReturn(prefs)
         testee = RealNetworkProtectionPixel(
             pixel,
-            vpnSharedPreferencesProvider,
+            sharedPreferencesProvider,
             fakeNetpCohortStore,
             object : ETTimestamp() {
                 override fun formattedTimestamp(): String {

--- a/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/store/RealNetworkProtectionRepositoryTest.kt
+++ b/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/store/RealNetworkProtectionRepositoryTest.kt
@@ -16,7 +16,7 @@
 
 package com.duckduckgo.networkprotection.impl.store
 
-import com.duckduckgo.mobile.android.vpn.prefs.FakeVpnSharedPreferencesProvider
+import com.duckduckgo.data.store.api.FakeSharedPreferencesProvider
 import com.duckduckgo.networkprotection.store.NetworkProtectionPrefs
 import com.duckduckgo.networkprotection.store.RealNetworkProtectionPrefs
 import com.wireguard.config.Config
@@ -53,7 +53,7 @@ class RealNetworkProtectionRepositoryTest {
     @Before
     fun setUp() {
         MockitoAnnotations.openMocks(this)
-        networkProtectionPrefs = RealNetworkProtectionPrefs(FakeVpnSharedPreferencesProvider())
+        networkProtectionPrefs = RealNetworkProtectionPrefs(FakeSharedPreferencesProvider())
         testee = RealNetworkProtectionRepository(networkProtectionPrefs)
     }
 

--- a/network-protection/network-protection-internal/build.gradle
+++ b/network-protection/network-protection-internal/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     implementation project(':vpn-api')
     implementation project(':internal-features-api')
     implementation project(':navigation-api')
+    implementation project(':data-store-api')
 
     implementation Square.moshi
     implementation Square.okHttp3.okHttp

--- a/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/feature/unsafe_wifi/UnsafeWifiMonitor.kt
+++ b/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/feature/unsafe_wifi/UnsafeWifiMonitor.kt
@@ -33,8 +33,8 @@ import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.notification.checkPermissionAndNotify
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
 import com.duckduckgo.networkprotection.api.NetworkProtectionState
 import com.duckduckgo.networkprotection.impl.notification.NetPDisabledNotificationBuilder
 import com.duckduckgo.networkprotection.impl.notification.NetPDisabledNotificationScheduler
@@ -55,7 +55,7 @@ class UnsafeWifiMonitor @Inject constructor(
     private val netPDisabledNotificationBuilder: NetPDisabledNotificationBuilder,
     private val notificationManager: NotificationManagerCompat,
     private val dispatcherProvider: DispatcherProvider,
-    private val sharedPreferencesProvider: VpnSharedPreferencesProvider,
+    private val sharedPreferencesProvider: SharedPreferencesProvider,
     private val appBuildConfig: AppBuildConfig,
 ) : MainProcessLifecycleObserver {
 

--- a/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/network/NetPInternalEnvDataStore.kt
+++ b/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/network/NetPInternalEnvDataStore.kt
@@ -18,13 +18,13 @@ package com.duckduckgo.networkprotection.internal.network
 
 import android.content.SharedPreferences
 import androidx.core.content.edit
-import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import javax.inject.Inject
 
-class NetPInternalEnvDataStore @Inject constructor(vpnSharedPreferencesProvider: VpnSharedPreferencesProvider) {
+class NetPInternalEnvDataStore @Inject constructor(sharedPreferencesProvider: SharedPreferencesProvider) {
 
     private val preferences: SharedPreferences by lazy {
-        vpnSharedPreferencesProvider.getSharedPreferences(FILENAME, multiprocess = true, migrate = false)
+        sharedPreferencesProvider.getSharedPreferences(FILENAME, multiprocess = true, migrate = false)
     }
 
     var customDns: String?

--- a/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/network/NetPInternalExclusionListProvider.kt
+++ b/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/network/NetPInternalExclusionListProvider.kt
@@ -20,17 +20,17 @@ import android.content.SharedPreferences
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import androidx.core.content.edit
-import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.networkprotection.internal.feature.NetPInternalFeatureToggles
 import javax.inject.Inject
 
 class NetPInternalExclusionListProvider @Inject constructor(
     private val packageManager: PackageManager,
     private val netPInternalFeatureToggles: NetPInternalFeatureToggles,
-    private val vpnSharedPreferencesProvider: VpnSharedPreferencesProvider,
+    private val sharedPreferencesProvider: SharedPreferencesProvider,
 ) {
     private val preferences: SharedPreferences by lazy {
-        vpnSharedPreferencesProvider.getSharedPreferences(
+        sharedPreferencesProvider.getSharedPreferences(
             FILENAME,
             multiprocess = true,
             migrate = false,

--- a/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/network/NetPInternalMtuProvider.kt
+++ b/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/network/NetPInternalMtuProvider.kt
@@ -17,14 +17,14 @@
 package com.duckduckgo.networkprotection.internal.network
 
 import android.content.SharedPreferences
-import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import javax.inject.Inject
 
 class NetPInternalMtuProvider @Inject constructor(
-    private val vpnSharedPreferencesProvider: VpnSharedPreferencesProvider,
+    private val sharedPreferencesProvider: SharedPreferencesProvider,
 ) {
     private val preferences: SharedPreferences by lazy {
-        vpnSharedPreferencesProvider.getSharedPreferences(
+        sharedPreferencesProvider.getSharedPreferences(
             FILENAME,
             multiprocess = true,
             migrate = false,

--- a/network-protection/network-protection-store/build.gradle
+++ b/network-protection/network-protection-store/build.gradle
@@ -24,7 +24,8 @@ apply from: "$rootProject.projectDir/gradle/android-library.gradle"
 
 dependencies {
     implementation project(':vpn-api')
-    implementation project(path: ':common-utils')
+    implementation project(':common-utils')
+    implementation project(':data-store-api')
 
     implementation AndroidX.core.ktx
 

--- a/network-protection/network-protection-store/src/main/java/com/duckduckgo/networkprotection/store/NetpDataStore.kt
+++ b/network-protection/network-protection-store/src/main/java/com/duckduckgo/networkprotection/store/NetpDataStore.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.networkprotection.store
 
 import android.content.SharedPreferences
 import androidx.core.content.edit
-import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 
 interface NetpDataStore {
     var authToken: String?
@@ -28,11 +28,11 @@ interface NetpDataStore {
 }
 
 class NetpDataStoreSharedPreferences constructor(
-    private val vpnSharedPreferencesProvider: VpnSharedPreferencesProvider,
+    private val sharedPreferencesProvider: SharedPreferencesProvider,
 ) : NetpDataStore {
 
     private val preferences: SharedPreferences by lazy {
-        vpnSharedPreferencesProvider.getSharedPreferences(
+        sharedPreferencesProvider.getSharedPreferences(
             FILENAME,
             multiprocess = true,
             migrate = false,

--- a/network-protection/network-protection-store/src/main/java/com/duckduckgo/networkprotection/store/NetworkProtectionPrefs.kt
+++ b/network-protection/network-protection-store/src/main/java/com/duckduckgo/networkprotection/store/NetworkProtectionPrefs.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.networkprotection.store
 
 import android.content.SharedPreferences
 import androidx.core.content.edit
-import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 
 interface NetworkProtectionPrefs {
     fun putBoolean(
@@ -78,10 +78,10 @@ interface NetworkProtectionPrefs {
 }
 
 class RealNetworkProtectionPrefs constructor(
-    private val vpnSharedPreferencesProvider: VpnSharedPreferencesProvider,
+    private val sharedPreferencesProvider: SharedPreferencesProvider,
 ) : NetworkProtectionPrefs {
     private val prefs: SharedPreferences by lazy {
-        vpnSharedPreferencesProvider.getSharedPreferences(FILENAME, multiprocess = true, migrate = false)
+        sharedPreferencesProvider.getSharedPreferences(FILENAME, multiprocess = true, migrate = false)
     }
 
     override fun putString(

--- a/subscriptions/subscriptions-impl/build.gradle
+++ b/subscriptions/subscriptions-impl/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     implementation project(path: ':downloads-api')
     implementation project(path: ':statistics')
     implementation project(':privacy-config-api') // remote feature flag
-    implementation project(':vpn-api') // remote feature flag
+    implementation project(':data-store-api')
     implementation project(':remote-messaging-api') // remote feature flag
 
     implementation AndroidX.appCompat

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -28,11 +28,11 @@ import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.browser.api.ui.BrowserScreens.SettingsScreenNoParams
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.extensions.toTldPlusOne
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.RemoteFeatureStoreNamed
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.feature.toggles.api.Toggle.State
-import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.subscriptions.api.Product
 import com.duckduckgo.subscriptions.api.SubscriptionStatus
@@ -148,13 +148,13 @@ interface PrivacyProFeature {
 class PrivacyProFeatureStore @Inject constructor(
     @AppCoroutineScope private val coroutineScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
-    private val vpnSharedPreferencesProvider: VpnSharedPreferencesProvider,
+    private val sharedPreferencesProvider: SharedPreferencesProvider,
     moshi: Moshi,
 ) : Toggle.Store {
 
     private val preferences: SharedPreferences by lazy {
         // migrate old values to new multiprocess shared prefs
-        vpnSharedPreferencesProvider.getSharedPreferences(FILENAME, multiprocess = true, migrate = true)
+        sharedPreferencesProvider.getSharedPreferences(FILENAME, multiprocess = true, migrate = true)
     }
     private val stateAdapter: JsonAdapter<State> by lazy {
         moshi.newBuilder().add(KotlinJsonAdapterFactory()).build().adapter(State::class.java)

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/store/SubscriptionsDataStore.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/store/SubscriptionsDataStore.kt
@@ -18,8 +18,8 @@ package com.duckduckgo.subscriptions.impl.store
 
 import android.content.SharedPreferences
 import androidx.core.content.edit
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.mobile.android.vpn.prefs.VpnSharedPreferencesProvider
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
 import javax.inject.Inject
@@ -46,11 +46,11 @@ interface SubscriptionsDataStore {
 @ContributesBinding(AppScope::class)
 @SingleInstanceIn(AppScope::class)
 class SubscriptionsEncryptedDataStore @Inject constructor(
-    private val vpnSharedPreferencesProvider: VpnSharedPreferencesProvider,
+    private val sharedPreferencesProvider: SharedPreferencesProvider,
 ) : SubscriptionsDataStore {
     private val encryptedPreferences: SharedPreferences? by lazy { encryptedPreferences() }
     private fun encryptedPreferences(): SharedPreferences? {
-        return vpnSharedPreferencesProvider.getEncryptedSharedPreferences(FILENAME, multiprocess = true)
+        return sharedPreferencesProvider.getEncryptedSharedPreferences(FILENAME, multiprocess = true)
     }
 
     override var productId: String?


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207135101272572/f

### Description
Moves the `VpnSharedPreferencesProvider` to a new `data-store-api/impl` module and renames it to `SharedPreferencesProvider`

### Steps to test this PR
Smoke tests VPN and Subs, as there's no behavior change, just moving classes around
