### PR TITLE
Prevent onboarded autofill metric overfiring if called multiple times quickly

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/engagement/EngagementPasswordAddedListener.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/engagement/EngagementPasswordAddedListener.kt
@@ -38,7 +38,15 @@ class EngagementPasswordAddedListener @Inject constructor(
     private val pixel: Pixel,
 ) : PasswordStoreEventListener {
 
+    // keep in-memory state to avoid sending the pixel multiple times if called repeatedly in a short time
+    private var credentialAdded = false
+
+    @Synchronized
     override fun onCredentialAdded(id: Long) {
+        if (credentialAdded) return
+
+        credentialAdded = true
+
         appCoroutineScope.launch(dispatchers.io()) {
             val daysInstalled = userBrowserProperties.daysSinceInstalled()
             Timber.v("onCredentialAdded. daysInstalled: $daysInstalled")

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/engagement/EngagementPasswordAddedListenerTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/engagement/EngagementPasswordAddedListenerTest.kt
@@ -31,7 +31,7 @@ class EngagementPasswordAddedListenerTest {
     fun whenDaysInstalledLessThan7ThenPixelSent() {
         whenever(userBrowserProperties.daysSinceInstalled()).thenReturn(0)
         testee.onCredentialAdded(0)
-        verifyPixelSent()
+        verifyPixelSentOnce()
     }
 
     @Test
@@ -48,7 +48,16 @@ class EngagementPasswordAddedListenerTest {
         verifyPixelNotSent()
     }
 
-    private fun verifyPixelSent() {
+    @Test
+    fun whenCalledMultipleTimesThenOnlySendsPixelOnce() {
+        whenever(userBrowserProperties.daysSinceInstalled()).thenReturn(0)
+        repeat(10) {
+            testee.onCredentialAdded(0)
+        }
+        verifyPixelSentOnce()
+    }
+
+    private fun verifyPixelSentOnce() {
         verify(pixel).fire(AUTOFILL_ENGAGEMENT_ONBOARDED_USER, type = UNIQUE)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/608920331025315/1207360368013215/f 

### Description
Prevent onboarding metric getting over-triggered if multiple credentials added quickly in a short amount of time

### Steps to test this PR
QA-optional