### PR TITLE
Update content scope scripts to version 5.17.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/README.md
+++ b/node_modules/@duckduckgo/content-scope-scripts/README.md
@@ -91,6 +91,23 @@ To handle the difference in scope injection we expose multiple utilities which b
         return await nativeImpl.call(this, queryObject)
     })
     ```
+- `ContentFeature.shimInterface(interfaceName, ImplClass, options)`
+    - API for shimming standard constructors. See the WebCompat feature and JSDoc for more details.
+    - Example usage:
+    ```javascript
+    this.shimInterface('MediaSession', MyMediaSessionClass, {
+        disallowConstructor: true,
+        allowConstructorCall: false,
+        wrapToString: true
+    })
+    ```
+- `ContentFeature.shimProperty(instanceHost, instanceProp, implInstance, readOnly = false)`
+    - API for shimming standard global objects. Usually you want to call `shimInterface()` first, and pass an object instance as `implInstance`. See the WebCompat feature and JSDoc for more details.
+    - Example usage:
+    ```javascript
+    this.shimProperty(Navigator.prototype, 'mediaSession', myMediaSessionInstance, true)
+    ```
+
 - `DDGProxy`
     - Behaves a lot like `new window.Proxy` with a few differences:
         - has an `overload` method to actually apply the function to the native property.

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -7,8 +7,13 @@
     globalThis.customElements?.get.bind(globalThis.customElements);
     globalThis.customElements?.define.bind(globalThis.customElements);
     const getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+    const getOwnPropertyDescriptors = Object.getOwnPropertyDescriptors;
     const objectKeys = Object.keys;
+    const objectEntries = Object.entries;
+    const objectDefineProperty = Object.defineProperty;
     const URL$1 = globalThis.URL;
+    const Proxy$1 = globalThis.Proxy;
+    const functionToString = Function.prototype.toString;
 
     /* global cloneInto, exportFunction, false */
 
@@ -462,8 +467,12 @@
         }
 
         overloadDescriptor () {
+            // TODO: this is not always correct! Use wrap* or shim* methods instead
             this.feature.defineProperty(this.objectScope, this.property, {
-                value: this.internal
+                value: this.internal,
+                writable: true,
+                enumerable: true,
+                configurable: true
             });
         }
     }
@@ -649,7 +658,7 @@
 
         // Copy feature settings from remote config to preferences object
         output.featureSettings = parseFeatureSettings(data, enabledFeatures);
-        output.trackerLookup = {"org":{"cdn77":{"rsc":{"1558334541":1}},"adsrvr":1,"ampproject":1,"browser-update":1,"flowplayer":1,"privacy-center":1,"webvisor":1,"framasoft":1,"do-not-tracker":1,"trackersimulator":1},"io":{"1dmp":1,"1rx":1,"4dex":1,"adnami":1,"aidata":1,"arcspire":1,"bidr":1,"branch":1,"center":1,"cloudimg":1,"concert":1,"connectad":1,"cordial":1,"dcmn":1,"extole":1,"getblue":1,"hbrd":1,"instana":1,"karte":1,"leadsmonitor":1,"litix":1,"lytics":1,"marchex":1,"mediago":1,"mrf":1,"narrative":1,"ntv":1,"optad360":1,"oracleinfinity":1,"oribi":1,"p-n":1,"personalizer":1,"pghub":1,"piano":1,"powr":1,"pzz":1,"searchspring":1,"segment":1,"siteimproveanalytics":1,"sspinc":1,"t13":1,"webgains":1,"wovn":1,"yellowblue":1,"zprk":1,"axept":1,"akstat":1,"clarium":1,"hotjar":1},"com":{"2020mustang":1,"33across":1,"360yield":1,"3lift":1,"4dsply":1,"4strokemedia":1,"8353e36c2a":1,"a-mx":1,"a2z":1,"aamsitecertifier":1,"absorbingband":1,"abstractedauthority":1,"abtasty":1,"acexedge":1,"acidpigs":1,"acsbapp":1,"acuityplatform":1,"ad-score":1,"ad-stir":1,"adalyser":1,"adapf":1,"adara":1,"adblade":1,"addthis":1,"addtoany":1,"adelixir":1,"adentifi":1,"adextrem":1,"adgrx":1,"adhese":1,"adition":1,"adkernel":1,"adlightning":1,"adlooxtracking":1,"admanmedia":1,"admedo":1,"adnium":1,"adnxs-simple":1,"adnxs":1,"adobedtm":1,"adotmob":1,"adpone":1,"adpushup":1,"adroll":1,"adrta":1,"ads-twitter":1,"ads3-adnow":1,"adsafeprotected":1,"adstanding":1,"adswizz":1,"adtdp":1,"adtechus":1,"adtelligent":1,"adthrive":1,"adtlgc":1,"adtng":1,"adultfriendfinder":1,"advangelists":1,"adventive":1,"adventori":1,"advertising":1,"aegpresents":1,"affinity":1,"affirm":1,"agilone":1,"agkn":1,"aimbase":1,"albacross":1,"alcmpn":1,"alexametrics":1,"alicdn":1,"alikeaddition":1,"aliveachiever":1,"aliyuncs":1,"alluringbucket":1,"aloofvest":1,"amazon-adsystem":1,"amazon":1,"ambiguousafternoon":1,"amplitude":1,"analytics-egain":1,"aniview":1,"annoyedairport":1,"annoyingclover":1,"anyclip":1,"anymind360":1,"app-us1":1,"appboycdn":1,"appdynamics":1,"appsflyer":1,"aralego":1,"aspiringattempt":1,"aswpsdkus":1,"atemda":1,"att":1,"attentivemobile":1,"attractionbanana":1,"audioeye":1,"audrte":1,"automaticside":1,"avanser":1,"avmws":1,"aweber":1,"aweprt":1,"azure":1,"b0e8":1,"badgevolcano":1,"bagbeam":1,"ballsbanana":1,"bandborder":1,"batch":1,"bawdybalance":1,"bc0a":1,"bdstatic":1,"bedsberry":1,"beginnerpancake":1,"benchmarkemail":1,"betweendigital":1,"bfmio":1,"bidtheatre":1,"billowybelief":1,"bimbolive":1,"bing":1,"bizographics":1,"bizrate":1,"bkrtx":1,"blismedia":1,"blogherads":1,"bluecava":1,"bluekai":1,"blushingbread":1,"boatwizard":1,"boilingcredit":1,"boldchat":1,"booking":1,"borderfree":1,"bounceexchange":1,"brainlyads":1,"brand-display":1,"brandmetrics":1,"brealtime":1,"brightfunnel":1,"brightspotcdn":1,"btloader":1,"btstatic":1,"bttrack":1,"btttag":1,"bumlam":1,"butterbulb":1,"buttonladybug":1,"buzzfeed":1,"buzzoola":1,"byside":1,"c3tag":1,"cabnnr":1,"calculatorstatement":1,"callrail":1,"calltracks":1,"capablecup":1,"captcha-delivery":1,"carpentercomparison":1,"cartstack":1,"carvecakes":1,"casalemedia":1,"cattlecommittee":1,"cdninstagram":1,"cdnwidget":1,"channeladvisor":1,"chargecracker":1,"chartbeat":1,"chatango":1,"chaturbate":1,"cheqzone":1,"cherriescare":1,"chickensstation":1,"childlikecrowd":1,"childlikeform":1,"chocolateplatform":1,"cintnetworks":1,"circlelevel":1,"ck-ie":1,"clcktrax":1,"cleanhaircut":1,"clearbit":1,"clearbitjs":1,"clickagy":1,"clickcease":1,"clickcertain":1,"clicktripz":1,"clientgear":1,"cloudflare":1,"cloudflareinsights":1,"cloudflarestream":1,"cobaltgroup":1,"cobrowser":1,"cognitivlabs":1,"colossusssp":1,"combativecar":1,"comm100":1,"googleapis":{"commondatastorage":1,"imasdk":1,"storage":1,"fonts":1,"maps":1,"www":1},"company-target":1,"condenastdigital":1,"confusedcart":1,"connatix":1,"contextweb":1,"conversionruler":1,"convertkit":1,"convertlanguage":1,"cootlogix":1,"coveo":1,"cpmstar":1,"cquotient":1,"crabbychin":1,"cratecamera":1,"crazyegg":1,"creative-serving":1,"creativecdn":1,"criteo":1,"crowdedmass":1,"crowdriff":1,"crownpeak":1,"crsspxl":1,"ctnsnet":1,"cudasvc":1,"cuddlethehyena":1,"cumbersomecarpenter":1,"curalate":1,"curvedhoney":1,"cushiondrum":1,"cutechin":1,"cxense":1,"d28dc30335":1,"dailymotion":1,"damdoor":1,"dampdock":1,"dapperfloor":1,"datadoghq-browser-agent":1,"decisivebase":1,"deepintent":1,"defybrick":1,"delivra":1,"demandbase":1,"detectdiscovery":1,"devilishdinner":1,"dimelochat":1,"disagreeabledrop":1,"discreetfield":1,"disqus":1,"dmpxs":1,"dockdigestion":1,"dotomi":1,"doubleverify":1,"drainpaste":1,"dramaticdirection":1,"driftt":1,"dtscdn":1,"dtscout":1,"dwin1":1,"dynamics":1,"dynamicyield":1,"dynatrace":1,"ebaystatic":1,"ecal":1,"eccmp":1,"elfsight":1,"elitrack":1,"eloqua":1,"en25":1,"encouragingthread":1,"enormousearth":1,"ensighten":1,"enviousshape":1,"eqads":1,"ero-advertising":1,"esputnik":1,"evergage":1,"evgnet":1,"exdynsrv":1,"exelator":1,"exoclick":1,"exosrv":1,"expansioneggnog":1,"expedia":1,"expertrec":1,"exponea":1,"exponential":1,"extole":1,"ezodn":1,"ezoic":1,"ezoiccdn":1,"facebook":1,"facil-iti":1,"fadewaves":1,"fallaciousfifth":1,"farmergoldfish":1,"fastly-insights":1,"fearlessfaucet":1,"fiftyt":1,"financefear":1,"fitanalytics":1,"five9":1,"fixedfold":1,"fksnk":1,"flashtalking":1,"flipp":1,"flowerstreatment":1,"floweryflavor":1,"flutteringfireman":1,"flux-cdn":1,"foresee":1,"fortunatemark":1,"fouanalytics":1,"fox":1,"fqtag":1,"frailfruit":1,"freezingbuilding":1,"fronttoad":1,"fullstory":1,"functionalfeather":1,"fuzzybasketball":1,"gammamaximum":1,"gbqofs":1,"geetest":1,"geistm":1,"geniusmonkey":1,"geoip-js":1,"getbread":1,"getcandid":1,"getclicky":1,"getdrip":1,"getelevar":1,"getrockerbox":1,"getshogun":1,"getsitecontrol":1,"giraffepiano":1,"glassdoor":1,"gloriousbeef":1,"godpvqnszo":1,"google-analytics":1,"google":1,"googleadservices":1,"googlehosted":1,"googleoptimize":1,"googlesyndication":1,"googletagmanager":1,"googletagservices":1,"gorgeousedge":1,"govx":1,"grainmass":1,"greasysquare":1,"greylabeldelivery":1,"groovehq":1,"growsumo":1,"gstatic":1,"guarantee-cdn":1,"guiltlessbasketball":1,"gumgum":1,"haltingbadge":1,"hammerhearing":1,"handsomelyhealth":1,"harborcaption":1,"hawksearch":1,"amazonaws":{"us-east-2":{"s3":{"hb-obv2":1}}},"heapanalytics":1,"hellobar":1,"hhbypdoecp":1,"hiconversion":1,"highwebmedia":1,"histats":1,"hlserve":1,"hocgeese":1,"hollowafterthought":1,"honorableland":1,"hotjar":1,"hp":1,"hs-banner":1,"htlbid":1,"htplayground":1,"hubspot":1,"ib-ibi":1,"id5-sync":1,"igodigital":1,"iheart":1,"iljmp":1,"illiweb":1,"impactcdn":1,"impactradius-event":1,"impressionmonster":1,"improvedcontactform":1,"improvedigital":1,"imrworldwide":1,"indexww":1,"infolinks":1,"infusionsoft":1,"inmobi":1,"inq":1,"inside-graph":1,"instagram":1,"intentiq":1,"intergient":1,"investingchannel":1,"invocacdn":1,"iperceptions":1,"iplsc":1,"ipredictive":1,"iteratehq":1,"ivitrack":1,"j93557g":1,"jaavnacsdw":1,"jimstatic":1,"journity":1,"js7k":1,"jscache":1,"juiceadv":1,"juicyads":1,"justanswer":1,"justpremium":1,"jwpcdn":1,"kakao":1,"kampyle":1,"kargo":1,"kissmetrics":1,"klarnaservices":1,"klaviyo":1,"knottyswing":1,"krushmedia":1,"ktkjmp":1,"kxcdn":1,"laboredlocket":1,"ladesk":1,"ladsp":1,"laughablelizards":1,"leadsrx":1,"lendingtree":1,"levexis":1,"liadm":1,"licdn":1,"lightboxcdn":1,"lijit":1,"linkedin":1,"linksynergy":1,"list-manage":1,"listrakbi":1,"livechatinc":1,"livejasmin":1,"localytics":1,"loggly":1,"loop11":1,"looseloaf":1,"lovelydrum":1,"lunchroomlock":1,"lwonclbench":1,"macromill":1,"maddeningpowder":1,"mailchimp":1,"mailchimpapp":1,"mailerlite":1,"maillist-manage":1,"marinsm":1,"marketiq":1,"marketo":1,"marphezis":1,"marriedbelief":1,"materialparcel":1,"matheranalytics":1,"mathtag":1,"maxmind":1,"mczbf":1,"measlymiddle":1,"medallia":1,"meddleplant":1,"media6degrees":1,"mediacategory":1,"mediavine":1,"mediawallahscript":1,"medtargetsystem":1,"megpxs":1,"memberful":1,"memorizematch":1,"mentorsticks":1,"metaffiliation":1,"metricode":1,"metricswpsh":1,"mfadsrvr":1,"mgid":1,"micpn":1,"microadinc":1,"minutemedia-prebid":1,"minutemediaservices":1,"mixpo":1,"mkt932":1,"mktoresp":1,"mktoweb":1,"ml314":1,"moatads":1,"mobtrakk":1,"monsido":1,"mookie1":1,"motionflowers":1,"mountain":1,"mouseflow":1,"mpeasylink":1,"mql5":1,"mrtnsvr":1,"murdoog":1,"mxpnl":1,"mybestpro":1,"myregistry":1,"nappyattack":1,"navistechnologies":1,"neodatagroup":1,"nervoussummer":1,"netmng":1,"newrelic":1,"newscgp":1,"nextdoor":1,"ninthdecimal":1,"nitropay":1,"noibu":1,"nondescriptnote":1,"nosto":1,"npttech":1,"ntvpwpush":1,"nuance":1,"nutritiousbean":1,"nxsttv":1,"omappapi":1,"omnisnippet1":1,"omnisrc":1,"omnitagjs":1,"ondemand":1,"oneall":1,"onesignal":1,"onetag-sys":1,"oo-syringe":1,"ooyala":1,"opecloud":1,"opentext":1,"opera":1,"opmnstr":1,"opti-digital":1,"optimicdn":1,"optimizely":1,"optinmonster":1,"optmnstr":1,"optmstr":1,"optnmnstr":1,"optnmstr":1,"osano":1,"otm-r":1,"outbrain":1,"overconfidentfood":1,"ownlocal":1,"pailpatch":1,"panickypancake":1,"panoramicplane":1,"parastorage":1,"pardot":1,"parsely":1,"partplanes":1,"patreon":1,"paypal":1,"pbstck":1,"pcmag":1,"peerius":1,"perfdrive":1,"perfectmarket":1,"permutive":1,"picreel":1,"pinterest":1,"pippio":1,"piwikpro":1,"pixlee":1,"placidperson":1,"pleasantpump":1,"plotrabbit":1,"pluckypocket":1,"pocketfaucet":1,"possibleboats":1,"postaffiliatepro":1,"postrelease":1,"potatoinvention":1,"powerfulcopper":1,"predictplate":1,"prepareplanes":1,"pricespider":1,"priceypies":1,"pricklydebt":1,"profusesupport":1,"proofpoint":1,"protoawe":1,"providesupport":1,"pswec":1,"psychedelicarithmetic":1,"psyma":1,"ptengine":1,"publir":1,"pubmatic":1,"pubmine":1,"pubnation":1,"qualaroo":1,"qualtrics":1,"quantcast":1,"quantserve":1,"quantummetric":1,"quietknowledge":1,"quizzicalpartner":1,"quizzicalzephyr":1,"quora":1,"r42tag":1,"radiateprose":1,"railwayreason":1,"rakuten":1,"rambunctiousflock":1,"rangeplayground":1,"rating-widget":1,"realsrv":1,"rebelswing":1,"reconditerake":1,"reconditerespect":1,"recruitics":1,"reddit":1,"redditstatic":1,"rehabilitatereason":1,"repeatsweater":1,"reson8":1,"resonantrock":1,"resonate":1,"responsiveads":1,"restrainstorm":1,"restructureinvention":1,"retargetly":1,"revcontent":1,"rezync":1,"rfihub":1,"rhetoricalloss":1,"richaudience":1,"righteouscrayon":1,"rightfulfall":1,"riotgames":1,"riskified":1,"rkdms":1,"rlcdn":1,"rmtag":1,"rogersmedia":1,"rokt":1,"route":1,"rtbsystem":1,"rubiconproject":1,"ruralrobin":1,"s-onetag":1,"saambaa":1,"sablesong":1,"sail-horizon":1,"salesforceliveagent":1,"samestretch":1,"sascdn":1,"satisfycork":1,"savoryorange":1,"scarabresearch":1,"scaredsnakes":1,"scaredsong":1,"scaredstomach":1,"scarfsmash":1,"scene7":1,"scholarlyiq":1,"scintillatingsilver":1,"scorecardresearch":1,"screechingstove":1,"screenpopper":1,"scribblestring":1,"sddan":1,"seatsmoke":1,"securedvisit":1,"seedtag":1,"sefsdvc":1,"segment":1,"sekindo":1,"selectivesummer":1,"selfishsnake":1,"servebom":1,"servedbyadbutler":1,"servenobid":1,"serverbid":1,"serving-sys":1,"shakegoldfish":1,"shamerain":1,"shapecomb":1,"shappify":1,"shareaholic":1,"sharethis":1,"sharethrough":1,"shopifyapps":1,"shopperapproved":1,"shrillspoon":1,"sibautomation":1,"sicksmash":1,"signifyd":1,"singroot":1,"site":1,"siteimprove":1,"siteimproveanalytics":1,"sitescout":1,"sixauthority":1,"skillfuldrop":1,"skimresources":1,"skisofa":1,"sli-spark":1,"slickstream":1,"slopesoap":1,"smadex":1,"smartadserver":1,"smashquartz":1,"smashsurprise":1,"smg":1,"smilewanted":1,"smoggysnakes":1,"snapchat":1,"snapkit":1,"snigelweb":1,"socdm":1,"sojern":1,"songsterritory":1,"sonobi":1,"soundstocking":1,"spectacularstamp":1,"speedcurve":1,"sphereup":1,"spiceworks":1,"spookyexchange":1,"spookyskate":1,"spookysleet":1,"sportradarserving":1,"sportslocalmedia":1,"spotxchange":1,"springserve":1,"srvmath":1,"ssl-images-amazon":1,"stackadapt":1,"stakingsmile":1,"statcounter":1,"steadfastseat":1,"steadfastsound":1,"steadfastsystem":1,"steelhousemedia":1,"steepsquirrel":1,"stereotypedsugar":1,"stickyadstv":1,"stiffgame":1,"stingycrush":1,"straightnest":1,"stripchat":1,"strivesquirrel":1,"strokesystem":1,"stupendoussleet":1,"stupendoussnow":1,"stupidscene":1,"sulkycook":1,"sumo":1,"sumologic":1,"sundaysky":1,"superficialeyes":1,"superficialsquare":1,"surveymonkey":1,"survicate":1,"svonm":1,"swankysquare":1,"symantec":1,"taboola":1,"tailtarget":1,"talkable":1,"tamgrt":1,"tangycover":1,"taobao":1,"tapad":1,"tapioni":1,"taptapnetworks":1,"taskanalytics":1,"tealiumiq":1,"techlab-cdn":1,"technoratimedia":1,"techtarget":1,"tediousticket":1,"teenytinyshirt":1,"tendertest":1,"the-ozone-project":1,"theadex":1,"themoneytizer":1,"theplatform":1,"thestar":1,"thinkitten":1,"threetruck":1,"thrtle":1,"tidaltv":1,"tidiochat":1,"tiktok":1,"tinypass":1,"tiqcdn":1,"tiresomethunder":1,"trackjs":1,"traffichaus":1,"trafficjunky":1,"trafmag":1,"travelaudience":1,"treasuredata":1,"tremorhub":1,"trendemon":1,"tribalfusion":1,"trovit":1,"trueleadid":1,"truoptik":1,"truste":1,"trustpilot":1,"trvdp":1,"tsyndicate":1,"tubemogul":1,"turn":1,"tvpixel":1,"tvsquared":1,"tweakwise":1,"twitter":1,"tynt":1,"typicalteeth":1,"u5e":1,"ubembed":1,"uidapi":1,"ultraoranges":1,"unbecominglamp":1,"unbxdapi":1,"undertone":1,"uninterestedquarter":1,"unpkg":1,"unrulymedia":1,"unwieldyhealth":1,"unwieldyplastic":1,"upsellit":1,"urbanairship":1,"usabilla":1,"usbrowserspeed":1,"usemessages":1,"userreport":1,"uservoice":1,"valuecommerce":1,"vengefulgrass":1,"vidazoo":1,"videoplayerhub":1,"vidoomy":1,"viglink":1,"visualwebsiteoptimizer":1,"vivaclix":1,"vk":1,"vlitag":1,"voicefive":1,"volatilevessel":1,"voraciousgrip":1,"voxmedia":1,"vrtcal":1,"w3counter":1,"walkme":1,"warmafterthought":1,"warmquiver":1,"webcontentassessor":1,"webengage":1,"webeyez":1,"webtraxs":1,"webtrends-optimize":1,"webtrends":1,"wgplayer":1,"woosmap":1,"worldoftulo":1,"wpadmngr":1,"wpshsdk":1,"wpushsdk":1,"wsod":1,"wt-safetag":1,"wysistat":1,"xg4ken":1,"xiti":1,"xlirdr":1,"xlivrdr":1,"xnxx-cdn":1,"y-track":1,"yahoo":1,"yandex":1,"yieldmo":1,"yieldoptimizer":1,"yimg":1,"yotpo":1,"yottaa":1,"youtube-nocookie":1,"youtube":1,"zemanta":1,"zendesk":1,"zeotap":1,"zestycrime":1,"zonos":1,"zoominfo":1,"zopim":1,"createsend1":1,"veoxa":1,"parchedsofa":1,"sooqr":1,"adtraction":1,"addthisedge":1,"adsymptotic":1,"bootstrapcdn":1,"bugsnag":1,"dmxleo":1,"dtssrv":1,"fontawesome":1,"hs-scripts":1,"jwpltx":1,"nereserv":1,"onaudience":1,"outbrainimg":1,"quantcount":1,"rtactivate":1,"shopifysvc":1,"stripe":1,"twimg":1,"vimeo":1,"vimeocdn":1,"wp":1,"4jnzhl0d0":1,"aboardamusement":1,"aboardlevel":1,"absentairport":1,"absorbingcorn":1,"abstractedamount":1,"acceptableauthority":1,"accurateanimal":1,"accuratecoal":1,"actoramusement":1,"actuallysnake":1,"actuallything":1,"adamantsnail":1,"adorableanger":1,"adorableattention":1,"adventurousamount":1,"agreeablearch":1,"agreeabletouch":1,"aheadday":1,"alertarithmetic":1,"aliasanvil":1,"ambientdusk":1,"ambientlagoon":1,"ambiguousdinosaurs":1,"ambrosialsummit":1,"amethystzenith":1,"amuckafternoon":1,"amusedbucket":1,"analyzecorona":1,"ancientact":1,"annoyingacoustics":1,"aquaticowl":1,"arrivegrowth":1,"aspiringapples":1,"astonishingfood":1,"audioarctic":1,"automaticturkey":1,"awarealley":1,"awesomeagreement":1,"awzbijw":1,"axiomaticanger":1,"badgeboat":1,"baitbaseball":1,"balloonbelieve":1,"barbarousbase":1,"basketballbelieve":1,"beamvolcano":1,"beancontrol":1,"begintrain":1,"bestboundary":1,"bikesboard":1,"birthdaybelief":1,"blackbrake":1,"bleachbubble":1,"blesspizzas":1,"blushingbeast":1,"boredcrown":1,"boundarybusiness":1,"boundlessveil":1,"brainybasin":1,"brainynut":1,"branchborder":1,"bravecalculator":1,"breadbalance":1,"breakfastboat":1,"brighttoe":1,"briskstorm":1,"broadborder":1,"brotherslocket":1,"buildingknife":1,"bulbbait":1,"burlywhistle":1,"burnbubble":1,"bushesbag":1,"bustlingbath":1,"bustlingbook":1,"calculatingcircle":1,"callousbrake":1,"calmcactus":1,"calypsocapsule":1,"capriciouscorn":1,"captivatingcanyon":1,"carefuldolls":1,"caringcast":1,"cartkitten":1,"catalogcake":1,"catschickens":1,"causecherry":1,"cautiouscamera":1,"cautiouscherries":1,"cautiouscredit":1,"cavecurtain":1,"ceciliavenus":1,"celestialquasar":1,"celestialspectra":1,"chaireggnog":1,"chairsdonkey":1,"chalkoil":1,"changeablecats":1,"charmingplate":1,"chesscolor":1,"childlikeexample":1,"chinsnakes":1,"chipperisle":1,"chivalrouscord":1,"chunkycactus":1,"cloisteredcord":1,"cloisteredcurve":1,"closedcows":1,"coatfood":1,"cobaltoverture":1,"coldbalance":1,"colossalclouds":1,"colossalcoat":1,"colossalcry":1,"combbit":1,"combcattle":1,"combcompetition":1,"comfortablecheese":1,"concernedchange":1,"concernedchickens":1,"condemnedcomb":1,"conditioncrush":1,"confesschairs":1,"consciouscheese":1,"consciousdirt":1,"coordinatedcoat":1,"copycarpenter":1,"cosmicsculptor":1,"courageousbaby":1,"coverapparatus":1,"cozyhillside":1,"cozytryst":1,"creatorcherry":1,"creatorpassenger":1,"creaturecabbage":1,"crimsonmeadow":1,"critictruck":1,"crookedcreature":1,"crystalboulevard":1,"cubchannel":1,"cuddlylunchroom":1,"currentcollar":1,"curvycry":1,"cushionpig":1,"damagedadvice":1,"damageddistance":1,"daughterstone":1,"dazzlingbook":1,"debonairdust":1,"debonairtree":1,"decisivedrawer":1,"decisiveducks":1,"deerbeginner":1,"defeatedbadge":1,"delicatecascade":1,"deliciousducks":1,"dependenttrip":1,"detailedkitten":1,"dewdroplagoon":1,"digestiondrawer":1,"dinnerquartz":1,"diplomahawaii":1,"discreetquarter":1,"dk4ywix":1,"dollardelta":1,"dq95d35":1,"dreamycanyon":1,"drollwharf":1,"dustydime":1,"dustyhammer":1,"eagerknight":1,"echoinghaven":1,"effervescentcoral":1,"effervescentvista":1,"effulgenttempest":1,"elasticchange":1,"elderlybean":1,"elusivebreeze":1,"eminentbubble":1,"enchantingdiscovery":1,"enchantingmystique":1,"endurablebulb":1,"energeticladybug":1,"engineertrick":1,"enigmaticcanyon":1,"enigmaticvoyage":1,"entertainskin":1,"equablekettle":1,"ethereallagoon":1,"evanescentedge":1,"evasivejar":1,"eventexistence":1,"exampleshake":1,"excitingtub":1,"executeknowledge":1,"exhibitsneeze":1,"exquisiteartisanship":1,"exuberantedge":1,"fadedsnow":1,"fairiesbranch":1,"fancyactivity":1,"farshake":1,"farsnails":1,"fastenfather":1,"fatcoil":1,"faucetfoot":1,"faultycanvas":1,"fearfulmint":1,"featherstage":1,"feignedfaucet":1,"fertilefeeling":1,"fewjuice":1,"fewkittens":1,"firstfrogs":1,"flameuncle":1,"flimsycircle":1,"flimsythought":1,"flourishingcollaboration":1,"flourishinginnovation":1,"flourishingpartnership":1,"flowerycreature":1,"floweryfact":1,"followborder":1,"forgetfulsnail":1,"franticroof":1,"frequentflesh":1,"friendlycrayon":1,"friendwool":1,"fumblingform":1,"furryfork":1,"futuristicfifth":1,"futuristicframe":1,"fuzzyerror":1,"gaudyairplane":1,"generateoffice":1,"giantsvessel":1,"giddycoat":1,"givevacation":1,"gladysway":1,"gleamingcow":1,"glisteningguide":1,"glitteringbrook":1,"goldfishgrowth":1,"gondolagnome":1,"gracefulmilk":1,"grandfatherguitar":1,"grayoranges":1,"grayreceipt":1,"grouchypush":1,"grumpydime":1,"guardeddirection":1,"guidecent":1,"gulliblegrip":1,"gustygrandmother":1,"halcyoncanyon":1,"halcyonsculpture":1,"hallowedinvention":1,"haltingdivision":1,"haltinggold":1,"handsomehose":1,"handsomelythumb":1,"handyfield":1,"handyfireman":1,"handyincrease":1,"haplesshydrant":1,"haplessland":1,"hatefulrequest":1,"headydegree":1,"heartbreakingmind":1,"hearthorn":1,"heavyplayground":1,"historicalbeam":1,"honeybulb":1,"horsenectar":1,"hospitablehall":1,"hospitablehat":1,"humdrumtouch":1,"hystericalcloth":1,"illinvention":1,"importantmeat":1,"impossibleexpansion":1,"impulsejewel":1,"impulselumber":1,"incompetentjoke":1,"inconclusiveaction":1,"inputicicle":1,"inquisitiveice":1,"internalcondition":1,"internalsink":1,"jubilantaura":1,"jubilantcanyon":1,"jubilantcascade":1,"jubilantglimmer":1,"jubilanttempest":1,"jubilantwhisper":1,"kaputquill":1,"keenquill":1,"knitstamp":1,"lameletters":1,"largebrass":1,"leftliquid":1,"liftedknowledge":1,"lightenafterthought":1,"lighttalon":1,"livelumber":1,"livelylaugh":1,"livelyreward":1,"livingsleet":1,"lizardslaugh":1,"loadsurprise":1,"lonelyflavor":1,"longingtrees":1,"lorenzourban":1,"losslace":1,"ludicrousarch":1,"luminousboulevard":1,"luminouscatalyst":1,"lumpylumber":1,"lustroushaven":1,"majesticwaterscape":1,"maliciousmusic":1,"marketspiders":1,"materialisticmoon":1,"materialplayground":1,"meadowlullaby":1,"meatydime":1,"melodiouschorus":1,"melodiouscomposition":1,"meltmilk":1,"memopilot":1,"memorizeneck":1,"merequartz":1,"mightyspiders":1,"minorcattle":1,"mixedreading":1,"modularmental":1,"monacobeatles":1,"moorshoes":1,"motionlessbag":1,"motionlessmeeting":1,"movemeal":1,"mundanenail":1,"mushywaste":1,"muteknife":1,"mysticalagoon":1,"naivestatement":1,"neatshade":1,"nebulacrescent":1,"nebulajubilee":1,"nebulousamusement":1,"nebulousgarden":1,"nebulousquasar":1,"nebulousripple":1,"needlessnorth":1,"niftyhospital":1,"nightwound":1,"nocturnalloom":1,"nondescriptcrowd":1,"nostalgicneed":1,"numberlessring":1,"nuttyorganization":1,"oafishchance":1,"obscenesidewalk":1,"oldfashionedoffer":1,"operationchicken":1,"optimallimit":1,"opulentsylvan":1,"orientedargument":1,"outstandingincome":1,"outstandingsnails":1,"painstakingpickle":1,"pamelarandom":1,"panickycurtain":1,"parallelbulb":1,"parentpicture":1,"passivepolo":1,"peacefullimit":1,"petiteumbrella":1,"piquantgrove":1,"piquantvortex":1,"placidactivity":1,"planebasin":1,"plantdigestion":1,"playfulriver":1,"pluckyzone":1,"poeticpackage":1,"pointdigestion":1,"pointlesspocket":1,"pointlessprofit":1,"polishedfolly":1,"politeplanes":1,"politicalporter":1,"popplantation":1,"possiblepencil":1,"powderjourney":1,"pricklypollution":1,"pristinegale":1,"processplantation":1,"protestcopy":1,"publicsofa":1,"puffypurpose":1,"pulsatingmeadow":1,"pumpedpancake":1,"punyplant":1,"purposepipe":1,"quillkick":1,"quirkysugar":1,"rabbitbreath":1,"rabbitrifle":1,"radiantlullaby":1,"railwaygiraffe":1,"raintwig":1,"rainyhand":1,"rainyrule":1,"rangecake":1,"raresummer":1,"readymoon":1,"rebelhen":1,"rebelsubway":1,"receptivereaction":1,"recessrain":1,"reconditeprison":1,"reflectivestatement":1,"regularplants":1,"regulatesleet":1,"relationrest":1,"rememberdiscussion":1,"replaceroute":1,"resonantbrush":1,"respectrain":1,"resplendentecho":1,"retrievemint":1,"rhetoricalveil":1,"rhymezebra":1,"richstring":1,"rigidrobin":1,"rollconnection":1,"roofrelation":1,"roseincome":1,"rusticprice":1,"sadloaf":1,"samesticks":1,"samplesamba":1,"scarceshock":1,"scaredcomfort":1,"scaredslip":1,"scaredsnake":1,"scarefowl":1,"scatteredstream":1,"scientificshirt":1,"scintillatingscissors":1,"scissorsstatement":1,"scrapesleep":1,"screechingfurniture":1,"screechingstocking":1,"scribbleson":1,"seashoresociety":1,"secondhandfall":1,"secretturtle":1,"seemlysuggestion":1,"separatesort":1,"seraphicjubilee":1,"serenecascade":1,"serenepebble":1,"serioussuit":1,"serpentshampoo":1,"settleshoes":1,"shadeship":1,"shakyseat":1,"shakysurprise":1,"shallowblade":1,"sheargovernor":1,"shesubscriptions":1,"shinypond":1,"shirtsidewalk":1,"shiveringspot":1,"shiverscissors":1,"shockingship":1,"sierrakermit":1,"sillyscrew":1,"simulateswing":1,"sincerebuffalo":1,"sincerepelican":1,"sinceresubstance":1,"sinkbooks":1,"sixscissors":1,"slinksuggestion":1,"smilingswim":1,"smoggysongs":1,"sneakwind":1,"soggysponge":1,"soggyzoo":1,"solarislabyrinth":1,"somberscarecrow":1,"sombersticks":1,"soothingglade":1,"sordidsmile":1,"soresidewalk":1,"soretrain":1,"sortsail":1,"sortsummer":1,"spellmist":1,"spellsalsa":1,"spotlessstamp":1,"spottednoise":1,"sprysummit":1,"spuriousair":1,"spysubstance":1,"squalidscrew":1,"stakingbasket":1,"stakingshock":1,"stalesummer":1,"statuesqueship":1,"steadycopper":1,"stealsteel":1,"steepscale":1,"stepplane":1,"stereoproxy":1,"stimulatingsneeze":1,"stingyshoe":1,"stingyspoon":1,"stockingsleet":1,"stomachscience":1,"stopstomach":1,"stormyfold":1,"strangeclocks":1,"strangersponge":1,"strangesink":1,"stretchsister":1,"stretchsneeze":1,"stretchsquirrel":1,"stripedbat":1,"strivesidewalk":1,"sublimequartz":1,"succeedscene":1,"sugarfriction":1,"suggestionbridge":1,"superficialspring":1,"supportwaves":1,"suspectmark":1,"swellstocking":1,"swelteringsleep":1,"swingslip":1,"synonymousrule":1,"synonymoussticks":1,"synthesizescarecrow":1,"tackytrains":1,"tangyamount":1,"tastelesstrees":1,"tastelesstrucks":1,"tearfulglass":1,"teenytinycellar":1,"teenytinytongue":1,"tempertrick":1,"temptteam":1,"terriblethumb":1,"terrifictooth":1,"thingstaste":1,"thirdrespect":1,"thomastorch":1,"thoughtlessknot":1,"thrivingmarketplace":1,"ticketaunt":1,"tidymitten":1,"tiredthroat":1,"tradetooth":1,"tranquilcan":1,"tranquilcanyon":1,"tranquilplume":1,"tranquilveil":1,"tranquilveranda":1,"tremendousearthquake":1,"tremendousplastic":1,"tritebadge":1,"tritethunder":1,"troubledtail":1,"troubleshade":1,"truculentrate":1,"tumbleicicle":1,"typicalairplane":1,"ubiquitoussea":1,"ubiquitousyard":1,"unablehope":1,"unaccountablepie":1,"unbecominghall":1,"uncoveredexpert":1,"unequalbrake":1,"unequaltrail":1,"unknowncrate":1,"untidyrice":1,"unusedstone":1,"unwieldyimpulse":1,"uppitytime":1,"uselesslumber":1,"vanishmemory":1,"velvetquasar":1,"venomousvessel":1,"venusgloria":1,"verdantanswer":1,"verdantlabyrinth":1,"verdantloom":1,"verseballs":1,"vibrantcelebration":1,"vibrantgale":1,"vibranthaven":1,"vibrantpact":1,"vibranttalisman":1,"virtualvincent":1,"vividcanopy":1,"vividfrost":1,"vividmeadow":1,"vividplume":1,"volatileprofit":1,"wantingwindow":1,"wearbasin":1,"wellgroomedhydrant":1,"whimsicalcanyon":1,"whimsicalgrove":1,"whisperingcascade":1,"whisperingquasar":1,"whisperingsummit":1,"whispermeeting":1,"wildcommittee":1,"wistfulwaste":1,"wittyshack":1,"workoperation":1,"wretchedfloor":1,"wrongwound":1,"zephyrlabyrinth":1,"zestyhorizon":1,"zestyrover":1,"zipperxray":1},"net":{"2mdn":1,"2o7":1,"3gl":1,"a-mo":1,"acint":1,"adform":1,"adhigh":1,"admixer":1,"adobedc":1,"adspeed":1,"adverticum":1,"apicit":1,"appier":1,"akamaized":{"assets-momentum":1},"aticdn":1,"edgekey":{"au":1,"ca":1,"ch":1,"cn":1,"com-v1":1,"es":1,"ihg":1,"in":1,"io":1,"it":1,"jp":1,"net":1,"org":1,"com":{"scene7":1},"uk-v1":1,"uk":1},"azure":1,"azurefd":1,"bannerflow":1,"bf-tools":1,"bidswitch":1,"bitsngo":1,"blueconic":1,"boldapps":1,"buysellads":1,"cachefly":1,"cedexis":1,"certona":1,"confiant-integrations":1,"contentsquare":1,"criteo":1,"crwdcntrl":1,"cloudfront":{"d1af033869koo7":1,"d1cr9zxt7u0sgu":1,"d1s87id6169zda":1,"d1vg5xiq7qffdj":1,"d1y068gyog18cq":1,"d214hhm15p4t1d":1,"d21gpk1vhmjuf5":1,"d2zah9y47r7bi2":1,"d38b8me95wjkbc":1,"d38xvr37kwwhcm":1,"d3fv2pqyjay52z":1,"d3i4yxtzktqr9n":1,"d3odp2r1osuwn0":1,"d5yoctgpv4cpx":1,"d6tizftlrpuof":1,"dbukjj6eu5tsf":1,"dn0qt3r0xannq":1,"dsh7ky7308k4b":1,"d2g3ekl4mwm40k":1},"demdex":1,"dotmetrics":1,"doubleclick":1,"durationmedia":1,"e-planning":1,"edgecastcdn":1,"emsecure":1,"episerver":1,"esm1":1,"eulerian":1,"everestjs":1,"everesttech":1,"eyeota":1,"ezoic":1,"fastly":{"global":{"shared":{"f2":1},"sni":{"j":1}},"map":{"prisa-us-eu":1,"scribd":1},"ssl":{"global":{"qognvtzku-x":1}}},"facebook":1,"fastclick":1,"fonts":1,"azureedge":{"fp-cdn":1,"sdtagging":1},"fuseplatform":1,"fwmrm":1,"go-mpulse":1,"hadronid":1,"hs-analytics":1,"hsleadflows":1,"im-apps":1,"impervadns":1,"iocnt":1,"iprom":1,"jsdelivr":1,"kanade-ad":1,"krxd":1,"line-scdn":1,"listhub":1,"livecom":1,"livedoor":1,"liveperson":1,"lkqd":1,"llnwd":1,"lpsnmedia":1,"magnetmail":1,"marketo":1,"maxymiser":1,"media":1,"microad":1,"mobon":1,"monetate":1,"mxptint":1,"myfonts":1,"myvisualiq":1,"naver":1,"nr-data":1,"ojrq":1,"omtrdc":1,"onecount":1,"openx":1,"openxcdn":1,"opta":1,"owneriq":1,"pages02":1,"pages03":1,"pages04":1,"pages05":1,"pages06":1,"pages08":1,"pingdom":1,"pmdstatic":1,"popads":1,"popcash":1,"primecaster":1,"pro-market":1,"akamaihd":{"pxlclnmdecom-a":1},"rfihub":1,"sancdn":1,"sc-static":1,"semasio":1,"sensic":1,"sexad":1,"smaato":1,"spreadshirts":1,"storygize":1,"tfaforms":1,"trackcmp":1,"trackedlink":1,"tradetracker":1,"truste-svc":1,"uuidksinc":1,"viafoura":1,"visilabs":1,"visx":1,"w55c":1,"wdsvc":1,"witglobal":1,"yandex":1,"yastatic":1,"yieldlab":1,"zencdn":1,"zucks":1,"opencmp":1,"azurewebsites":{"app-fnsp-matomo-analytics-prod":1},"ad-delivery":1,"chartbeat":1,"msecnd":1,"cloudfunctions":{"us-central1-adaptive-growth":1},"eviltracker":1},"co":{"6sc":1,"ayads":1,"getlasso":1,"idio":1,"increasingly":1,"jads":1,"nanorep":1,"nc0":1,"pcdn":1,"prmutv":1,"resetdigital":1,"t":1,"tctm":1,"zip":1},"gt":{"ad":1},"ru":{"adfox":1,"adriver":1,"digitaltarget":1,"mail":1,"mindbox":1,"rambler":1,"rutarget":1,"sape":1,"smi2":1,"tns-counter":1,"top100":1,"ulogin":1,"yandex":1,"yadro":1},"jp":{"adingo":1,"admatrix":1,"auone":1,"co":{"dmm":1,"i-mobile":1,"rakuten":1,"yahoo":1},"fout":1,"genieesspv":1,"gmossp-sp":1,"gsspat":1,"gssprt":1,"ne":{"hatena":1},"i2i":1,"impact-ad":1,"microad":1,"nakanohito":1,"r10s":1,"reemo-ad":1,"rtoaster":1,"shinobi":1,"team-rec":1,"uncn":1,"yimg":1,"yjtag":1},"pl":{"adocean":1,"gemius":1,"nsaudience":1,"onet":1,"salesmanago":1,"wp":1},"pro":{"adpartner":1,"piwik":1,"usocial":1},"de":{"adscale":1,"auswaertiges-amt":1,"fiduciagad":1,"ioam":1,"itzbund":1,"vgwort":1,"werk21system":1},"re":{"adsco":1},"info":{"adxbid":1,"bitrix":1,"navistechnologies":1,"usergram":1,"webantenna":1},"tv":{"affec":1,"attn":1,"iris":1,"ispot":1,"samba":1,"teads":1,"twitch":1,"videohub":1},"dev":{"amazon":1},"us":{"amung":1,"samplicio":1,"slgnt":1,"trkn":1},"media":{"andbeyond":1,"nextday":1,"townsquare":1,"underdog":1},"link":{"app":1},"cloud":{"avct":1,"egain":1,"matomo":1},"delivery":{"ay":1,"monu":1},"ly":{"bit":1},"br":{"com":{"btg360":1,"clearsale":1,"jsuol":1,"shopconvert":1,"shoptarget":1,"soclminer":1},"org":{"ivcbrasil":1}},"ch":{"ch":1,"da-services":1,"google":1},"me":{"channel":1,"contentexchange":1,"grow":1,"line":1,"loopme":1,"t":1},"ms":{"clarity":1},"my":{"cnt":1},"se":{"codigo":1},"to":{"cpx":1,"tawk":1},"chat":{"crisp":1,"gorgias":1},"fr":{"d-bi":1,"open-system":1,"weborama":1},"uk":{"co":{"dailymail":1,"hsbc":1}},"gov":{"dhs":1},"ai":{"e-volution":1,"hybrid":1,"m2":1,"nrich":1,"wknd":1},"be":{"geoedge":1},"au":{"com":{"google":1,"news":1,"nine":1,"zipmoney":1,"telstra":1}},"stream":{"ibclick":1},"cz":{"imedia":1,"seznam":1,"trackad":1},"app":{"infusionsoft":1,"permutive":1,"shop":1},"tech":{"ingage":1,"primis":1},"eu":{"kameleoon":1,"medallia":1,"media01":1,"ocdn":1,"rqtrk":1,"slgnt":1},"fi":{"kesko":1,"simpli":1},"live":{"lura":1},"services":{"marketingautomation":1},"sg":{"mediacorp":1},"bi":{"newsroom":1},"fm":{"pdst":1},"ad":{"pixel":1},"xyz":{"playground":1},"it":{"plug":1,"repstatic":1},"cc":{"popin":1},"network":{"pub":1},"nl":{"rijksoverheid":1},"fyi":{"sda":1},"es":{"socy":1},"im":{"spot":1},"market":{"spotim":1},"am":{"tru":1},"no":{"uio":1,"medietall":1},"at":{"waust":1},"pe":{"shop":1},"ca":{"bc":{"gov":1}},"gg":{"clean":1},"example":{"ad-company":1},"site":{"ad-company":1,"third-party":{"bad":1,"broken":1}},"pw":{"zlp6s":1}};
+        output.trackerLookup = {"org":{"cdn77":{"rsc":{"1558334541":1}},"adsrvr":1,"ampproject":1,"browser-update":1,"flowplayer":1,"privacy-center":1,"webvisor":1,"framasoft":1,"do-not-tracker":1,"trackersimulator":1},"io":{"1dmp":1,"1rx":1,"4dex":1,"adnami":1,"aidata":1,"arcspire":1,"bidr":1,"branch":1,"center":1,"cloudimg":1,"concert":1,"connectad":1,"cordial":1,"dcmn":1,"extole":1,"getblue":1,"hbrd":1,"instana":1,"karte":1,"leadsmonitor":1,"litix":1,"lytics":1,"marchex":1,"mediago":1,"mrf":1,"narrative":1,"ntv":1,"optad360":1,"oracleinfinity":1,"oribi":1,"p-n":1,"personalizer":1,"pghub":1,"piano":1,"powr":1,"pzz":1,"searchspring":1,"segment":1,"siteimproveanalytics":1,"sspinc":1,"t13":1,"webgains":1,"wovn":1,"yellowblue":1,"zprk":1,"axept":1,"akstat":1,"clarium":1,"hotjar":1},"com":{"2020mustang":1,"33across":1,"360yield":1,"3lift":1,"4dsply":1,"4strokemedia":1,"8353e36c2a":1,"a-mx":1,"a2z":1,"aamsitecertifier":1,"absorbingband":1,"abstractedauthority":1,"abtasty":1,"acexedge":1,"acidpigs":1,"acsbapp":1,"acuityplatform":1,"ad-score":1,"ad-stir":1,"adalyser":1,"adapf":1,"adara":1,"adblade":1,"addthis":1,"addtoany":1,"adelixir":1,"adentifi":1,"adextrem":1,"adgrx":1,"adhese":1,"adition":1,"adkernel":1,"adlightning":1,"adlooxtracking":1,"admanmedia":1,"admedo":1,"adnium":1,"adnxs-simple":1,"adnxs":1,"adobedtm":1,"adotmob":1,"adpone":1,"adpushup":1,"adroll":1,"adrta":1,"ads-twitter":1,"ads3-adnow":1,"adsafeprotected":1,"adstanding":1,"adswizz":1,"adtdp":1,"adtechus":1,"adtelligent":1,"adthrive":1,"adtlgc":1,"adtng":1,"adultfriendfinder":1,"advangelists":1,"adventive":1,"adventori":1,"advertising":1,"aegpresents":1,"affinity":1,"affirm":1,"agilone":1,"agkn":1,"aimbase":1,"albacross":1,"alcmpn":1,"alexametrics":1,"alicdn":1,"alikeaddition":1,"aliveachiever":1,"aliyuncs":1,"alluringbucket":1,"aloofvest":1,"amazon-adsystem":1,"amazon":1,"ambiguousafternoon":1,"amplitude":1,"analytics-egain":1,"aniview":1,"annoyedairport":1,"annoyingclover":1,"anyclip":1,"anymind360":1,"app-us1":1,"appboycdn":1,"appdynamics":1,"appsflyer":1,"aralego":1,"aspiringattempt":1,"aswpsdkus":1,"atemda":1,"att":1,"attentivemobile":1,"attractionbanana":1,"audioeye":1,"audrte":1,"automaticside":1,"avanser":1,"avmws":1,"aweber":1,"aweprt":1,"azure":1,"b0e8":1,"badgevolcano":1,"bagbeam":1,"ballsbanana":1,"bandborder":1,"batch":1,"bawdybalance":1,"bc0a":1,"bdstatic":1,"bedsberry":1,"beginnerpancake":1,"benchmarkemail":1,"betweendigital":1,"bfmio":1,"bidtheatre":1,"billowybelief":1,"bimbolive":1,"bing":1,"bizographics":1,"bizrate":1,"bkrtx":1,"blismedia":1,"blogherads":1,"bluecava":1,"bluekai":1,"blushingbread":1,"boatwizard":1,"boilingcredit":1,"boldchat":1,"booking":1,"borderfree":1,"bounceexchange":1,"brainlyads":1,"brand-display":1,"brandmetrics":1,"brealtime":1,"brightfunnel":1,"brightspotcdn":1,"btloader":1,"btstatic":1,"bttrack":1,"btttag":1,"bumlam":1,"butterbulb":1,"buttonladybug":1,"buzzfeed":1,"buzzoola":1,"byside":1,"c3tag":1,"cabnnr":1,"calculatorstatement":1,"callrail":1,"calltracks":1,"capablecup":1,"captcha-delivery":1,"carpentercomparison":1,"cartstack":1,"carvecakes":1,"casalemedia":1,"cattlecommittee":1,"cdninstagram":1,"cdnwidget":1,"channeladvisor":1,"chargecracker":1,"chartbeat":1,"chatango":1,"chaturbate":1,"cheqzone":1,"cherriescare":1,"chickensstation":1,"childlikecrowd":1,"childlikeform":1,"chocolateplatform":1,"cintnetworks":1,"circlelevel":1,"ck-ie":1,"clcktrax":1,"cleanhaircut":1,"clearbit":1,"clearbitjs":1,"clickagy":1,"clickcease":1,"clickcertain":1,"clicktripz":1,"clientgear":1,"cloudflare":1,"cloudflareinsights":1,"cloudflarestream":1,"cobaltgroup":1,"cobrowser":1,"cognitivlabs":1,"colossusssp":1,"combativecar":1,"comm100":1,"googleapis":{"commondatastorage":1,"imasdk":1,"storage":1,"fonts":1,"maps":1,"www":1},"company-target":1,"condenastdigital":1,"confusedcart":1,"connatix":1,"contextweb":1,"conversionruler":1,"convertkit":1,"convertlanguage":1,"cootlogix":1,"coveo":1,"cpmstar":1,"cquotient":1,"crabbychin":1,"cratecamera":1,"crazyegg":1,"creative-serving":1,"creativecdn":1,"criteo":1,"crowdedmass":1,"crowdriff":1,"crownpeak":1,"crsspxl":1,"ctnsnet":1,"cudasvc":1,"cuddlethehyena":1,"cumbersomecarpenter":1,"curalate":1,"curvedhoney":1,"cushiondrum":1,"cutechin":1,"cxense":1,"d28dc30335":1,"dailymotion":1,"damdoor":1,"dampdock":1,"dapperfloor":1,"datadoghq-browser-agent":1,"decisivebase":1,"deepintent":1,"defybrick":1,"delivra":1,"demandbase":1,"detectdiscovery":1,"devilishdinner":1,"dimelochat":1,"disagreeabledrop":1,"discreetfield":1,"disqus":1,"dmpxs":1,"dockdigestion":1,"dotomi":1,"doubleverify":1,"drainpaste":1,"dramaticdirection":1,"driftt":1,"dtscdn":1,"dtscout":1,"dwin1":1,"dynamics":1,"dynamicyield":1,"dynatrace":1,"ebaystatic":1,"ecal":1,"eccmp":1,"elfsight":1,"elitrack":1,"eloqua":1,"en25":1,"encouragingthread":1,"enormousearth":1,"ensighten":1,"enviousshape":1,"eqads":1,"ero-advertising":1,"esputnik":1,"evergage":1,"evgnet":1,"exdynsrv":1,"exelator":1,"exoclick":1,"exosrv":1,"expansioneggnog":1,"expedia":1,"expertrec":1,"exponea":1,"exponential":1,"extole":1,"ezodn":1,"ezoic":1,"ezoiccdn":1,"facebook":1,"facil-iti":1,"fadewaves":1,"fallaciousfifth":1,"farmergoldfish":1,"fastly-insights":1,"fearlessfaucet":1,"fiftyt":1,"financefear":1,"fitanalytics":1,"five9":1,"fixedfold":1,"fksnk":1,"flashtalking":1,"flipp":1,"flowerstreatment":1,"floweryflavor":1,"flutteringfireman":1,"flux-cdn":1,"foresee":1,"fortunatemark":1,"fouanalytics":1,"fox":1,"fqtag":1,"frailfruit":1,"freezingbuilding":1,"fronttoad":1,"fullstory":1,"functionalfeather":1,"fuzzybasketball":1,"gammamaximum":1,"gbqofs":1,"geetest":1,"geistm":1,"geniusmonkey":1,"geoip-js":1,"getbread":1,"getcandid":1,"getclicky":1,"getdrip":1,"getelevar":1,"getrockerbox":1,"getshogun":1,"getsitecontrol":1,"giraffepiano":1,"glassdoor":1,"gloriousbeef":1,"godpvqnszo":1,"google-analytics":1,"google":1,"googleadservices":1,"googlehosted":1,"googleoptimize":1,"googlesyndication":1,"googletagmanager":1,"googletagservices":1,"gorgeousedge":1,"govx":1,"grainmass":1,"greasysquare":1,"greylabeldelivery":1,"groovehq":1,"growsumo":1,"gstatic":1,"guarantee-cdn":1,"guiltlessbasketball":1,"gumgum":1,"haltingbadge":1,"hammerhearing":1,"handsomelyhealth":1,"harborcaption":1,"hawksearch":1,"amazonaws":{"us-east-2":{"s3":{"hb-obv2":1}}},"heapanalytics":1,"hellobar":1,"hhbypdoecp":1,"hiconversion":1,"highwebmedia":1,"histats":1,"hlserve":1,"hocgeese":1,"hollowafterthought":1,"honorableland":1,"hotjar":1,"hp":1,"hs-banner":1,"htlbid":1,"htplayground":1,"hubspot":1,"ib-ibi":1,"id5-sync":1,"igodigital":1,"iheart":1,"iljmp":1,"illiweb":1,"impactcdn":1,"impactradius-event":1,"impressionmonster":1,"improvedcontactform":1,"improvedigital":1,"imrworldwide":1,"indexww":1,"infolinks":1,"infusionsoft":1,"inmobi":1,"inq":1,"inside-graph":1,"instagram":1,"intentiq":1,"intergient":1,"investingchannel":1,"invocacdn":1,"iperceptions":1,"iplsc":1,"ipredictive":1,"iteratehq":1,"ivitrack":1,"j93557g":1,"jaavnacsdw":1,"jimstatic":1,"journity":1,"js7k":1,"jscache":1,"juiceadv":1,"juicyads":1,"justanswer":1,"justpremium":1,"jwpcdn":1,"kakao":1,"kampyle":1,"kargo":1,"kissmetrics":1,"klarnaservices":1,"klaviyo":1,"knottyswing":1,"krushmedia":1,"ktkjmp":1,"kxcdn":1,"laboredlocket":1,"ladesk":1,"ladsp":1,"laughablelizards":1,"leadsrx":1,"lendingtree":1,"levexis":1,"liadm":1,"licdn":1,"lightboxcdn":1,"lijit":1,"linkedin":1,"linksynergy":1,"list-manage":1,"listrakbi":1,"livechatinc":1,"livejasmin":1,"localytics":1,"loggly":1,"loop11":1,"looseloaf":1,"lovelydrum":1,"lunchroomlock":1,"lwonclbench":1,"macromill":1,"maddeningpowder":1,"mailchimp":1,"mailchimpapp":1,"mailerlite":1,"maillist-manage":1,"marinsm":1,"marketiq":1,"marketo":1,"marphezis":1,"marriedbelief":1,"materialparcel":1,"matheranalytics":1,"mathtag":1,"maxmind":1,"mczbf":1,"measlymiddle":1,"medallia":1,"meddleplant":1,"media6degrees":1,"mediacategory":1,"mediavine":1,"mediawallahscript":1,"medtargetsystem":1,"megpxs":1,"memberful":1,"memorizematch":1,"mentorsticks":1,"metaffiliation":1,"metricode":1,"metricswpsh":1,"mfadsrvr":1,"mgid":1,"micpn":1,"microadinc":1,"minutemedia-prebid":1,"minutemediaservices":1,"mixpo":1,"mkt932":1,"mktoresp":1,"mktoweb":1,"ml314":1,"moatads":1,"mobtrakk":1,"monsido":1,"mookie1":1,"motionflowers":1,"mountain":1,"mouseflow":1,"mpeasylink":1,"mql5":1,"mrtnsvr":1,"murdoog":1,"mxpnl":1,"mybestpro":1,"myregistry":1,"nappyattack":1,"navistechnologies":1,"neodatagroup":1,"nervoussummer":1,"netmng":1,"newrelic":1,"newscgp":1,"nextdoor":1,"ninthdecimal":1,"nitropay":1,"noibu":1,"nondescriptnote":1,"nosto":1,"npttech":1,"ntvpwpush":1,"nuance":1,"nutritiousbean":1,"nxsttv":1,"omappapi":1,"omnisnippet1":1,"omnisrc":1,"omnitagjs":1,"ondemand":1,"oneall":1,"onesignal":1,"onetag-sys":1,"oo-syringe":1,"ooyala":1,"opecloud":1,"opentext":1,"opera":1,"opmnstr":1,"opti-digital":1,"optimicdn":1,"optimizely":1,"optinmonster":1,"optmnstr":1,"optmstr":1,"optnmnstr":1,"optnmstr":1,"osano":1,"otm-r":1,"outbrain":1,"overconfidentfood":1,"ownlocal":1,"pailpatch":1,"panickypancake":1,"panoramicplane":1,"parastorage":1,"pardot":1,"parsely":1,"partplanes":1,"patreon":1,"paypal":1,"pbstck":1,"pcmag":1,"peerius":1,"perfdrive":1,"perfectmarket":1,"permutive":1,"picreel":1,"pinterest":1,"pippio":1,"piwikpro":1,"pixlee":1,"placidperson":1,"pleasantpump":1,"plotrabbit":1,"pluckypocket":1,"pocketfaucet":1,"possibleboats":1,"postaffiliatepro":1,"postrelease":1,"potatoinvention":1,"powerfulcopper":1,"predictplate":1,"prepareplanes":1,"pricespider":1,"priceypies":1,"pricklydebt":1,"profusesupport":1,"proofpoint":1,"protoawe":1,"providesupport":1,"pswec":1,"psychedelicarithmetic":1,"psyma":1,"ptengine":1,"publir":1,"pubmatic":1,"pubmine":1,"pubnation":1,"qualaroo":1,"qualtrics":1,"quantcast":1,"quantserve":1,"quantummetric":1,"quietknowledge":1,"quizzicalpartner":1,"quizzicalzephyr":1,"quora":1,"r42tag":1,"radiateprose":1,"railwayreason":1,"rakuten":1,"rambunctiousflock":1,"rangeplayground":1,"rating-widget":1,"realsrv":1,"rebelswing":1,"reconditerake":1,"reconditerespect":1,"recruitics":1,"reddit":1,"redditstatic":1,"rehabilitatereason":1,"repeatsweater":1,"reson8":1,"resonantrock":1,"resonate":1,"responsiveads":1,"restrainstorm":1,"restructureinvention":1,"retargetly":1,"revcontent":1,"rezync":1,"rfihub":1,"rhetoricalloss":1,"richaudience":1,"righteouscrayon":1,"rightfulfall":1,"riotgames":1,"riskified":1,"rkdms":1,"rlcdn":1,"rmtag":1,"rogersmedia":1,"rokt":1,"route":1,"rtbsystem":1,"rubiconproject":1,"ruralrobin":1,"s-onetag":1,"saambaa":1,"sablesong":1,"sail-horizon":1,"salesforceliveagent":1,"samestretch":1,"sascdn":1,"satisfycork":1,"savoryorange":1,"scarabresearch":1,"scaredsnakes":1,"scaredsong":1,"scaredstomach":1,"scarfsmash":1,"scene7":1,"scholarlyiq":1,"scintillatingsilver":1,"scorecardresearch":1,"screechingstove":1,"screenpopper":1,"scribblestring":1,"sddan":1,"seatsmoke":1,"securedvisit":1,"seedtag":1,"sefsdvc":1,"segment":1,"sekindo":1,"selectivesummer":1,"selfishsnake":1,"servebom":1,"servedbyadbutler":1,"servenobid":1,"serverbid":1,"serving-sys":1,"shakegoldfish":1,"shamerain":1,"shapecomb":1,"shappify":1,"shareaholic":1,"sharethis":1,"sharethrough":1,"shopifyapps":1,"shopperapproved":1,"shrillspoon":1,"sibautomation":1,"sicksmash":1,"signifyd":1,"singroot":1,"site":1,"siteimprove":1,"siteimproveanalytics":1,"sitescout":1,"sixauthority":1,"skillfuldrop":1,"skimresources":1,"skisofa":1,"sli-spark":1,"slickstream":1,"slopesoap":1,"smadex":1,"smartadserver":1,"smashquartz":1,"smashsurprise":1,"smg":1,"smilewanted":1,"smoggysnakes":1,"snapchat":1,"snapkit":1,"snigelweb":1,"socdm":1,"sojern":1,"songsterritory":1,"sonobi":1,"soundstocking":1,"spectacularstamp":1,"speedcurve":1,"sphereup":1,"spiceworks":1,"spookyexchange":1,"spookyskate":1,"spookysleet":1,"sportradarserving":1,"sportslocalmedia":1,"spotxchange":1,"springserve":1,"srvmath":1,"ssl-images-amazon":1,"stackadapt":1,"stakingsmile":1,"statcounter":1,"steadfastseat":1,"steadfastsound":1,"steadfastsystem":1,"steelhousemedia":1,"steepsquirrel":1,"stereotypedsugar":1,"stickyadstv":1,"stiffgame":1,"stingycrush":1,"straightnest":1,"stripchat":1,"strivesquirrel":1,"strokesystem":1,"stupendoussleet":1,"stupendoussnow":1,"stupidscene":1,"sulkycook":1,"sumo":1,"sumologic":1,"sundaysky":1,"superficialeyes":1,"superficialsquare":1,"surveymonkey":1,"survicate":1,"svonm":1,"swankysquare":1,"symantec":1,"taboola":1,"tailtarget":1,"talkable":1,"tamgrt":1,"tangycover":1,"taobao":1,"tapad":1,"tapioni":1,"taptapnetworks":1,"taskanalytics":1,"tealiumiq":1,"techlab-cdn":1,"technoratimedia":1,"techtarget":1,"tediousticket":1,"teenytinyshirt":1,"tendertest":1,"the-ozone-project":1,"theadex":1,"themoneytizer":1,"theplatform":1,"thestar":1,"thinkitten":1,"threetruck":1,"thrtle":1,"tidaltv":1,"tidiochat":1,"tiktok":1,"tinypass":1,"tiqcdn":1,"tiresomethunder":1,"trackjs":1,"traffichaus":1,"trafficjunky":1,"trafmag":1,"travelaudience":1,"treasuredata":1,"tremorhub":1,"trendemon":1,"tribalfusion":1,"trovit":1,"trueleadid":1,"truoptik":1,"truste":1,"trustpilot":1,"trvdp":1,"tsyndicate":1,"tubemogul":1,"turn":1,"tvpixel":1,"tvsquared":1,"tweakwise":1,"twitter":1,"tynt":1,"typicalteeth":1,"u5e":1,"ubembed":1,"uidapi":1,"ultraoranges":1,"unbecominglamp":1,"unbxdapi":1,"undertone":1,"uninterestedquarter":1,"unpkg":1,"unrulymedia":1,"unwieldyhealth":1,"unwieldyplastic":1,"upsellit":1,"urbanairship":1,"usabilla":1,"usbrowserspeed":1,"usemessages":1,"userreport":1,"uservoice":1,"valuecommerce":1,"vengefulgrass":1,"vidazoo":1,"videoplayerhub":1,"vidoomy":1,"viglink":1,"visualwebsiteoptimizer":1,"vivaclix":1,"vk":1,"vlitag":1,"voicefive":1,"volatilevessel":1,"voraciousgrip":1,"voxmedia":1,"vrtcal":1,"w3counter":1,"walkme":1,"warmafterthought":1,"warmquiver":1,"webcontentassessor":1,"webengage":1,"webeyez":1,"webtraxs":1,"webtrends-optimize":1,"webtrends":1,"wgplayer":1,"woosmap":1,"worldoftulo":1,"wpadmngr":1,"wpshsdk":1,"wpushsdk":1,"wsod":1,"wt-safetag":1,"wysistat":1,"xg4ken":1,"xiti":1,"xlirdr":1,"xlivrdr":1,"xnxx-cdn":1,"y-track":1,"yahoo":1,"yandex":1,"yieldmo":1,"yieldoptimizer":1,"yimg":1,"yotpo":1,"yottaa":1,"youtube-nocookie":1,"youtube":1,"zemanta":1,"zendesk":1,"zeotap":1,"zestycrime":1,"zonos":1,"zoominfo":1,"zopim":1,"createsend1":1,"veoxa":1,"parchedsofa":1,"sooqr":1,"adtraction":1,"addthisedge":1,"adsymptotic":1,"bootstrapcdn":1,"bugsnag":1,"dmxleo":1,"dtssrv":1,"fontawesome":1,"hs-scripts":1,"jwpltx":1,"nereserv":1,"onaudience":1,"outbrainimg":1,"quantcount":1,"rtactivate":1,"shopifysvc":1,"stripe":1,"twimg":1,"vimeo":1,"vimeocdn":1,"wp":1,"4jnzhl0d0":1,"aboardamusement":1,"aboardlevel":1,"absentairport":1,"absorbingcorn":1,"abstractedamount":1,"acceptableauthority":1,"accurateanimal":1,"accuratecoal":1,"actoramusement":1,"actuallysnake":1,"actuallything":1,"adamantsnail":1,"adorableanger":1,"adorableattention":1,"adventurousamount":1,"agilebreeze":1,"agreeablearch":1,"agreeabletouch":1,"aheadday":1,"alertarithmetic":1,"aliasanvil":1,"ambientdusk":1,"ambientlagoon":1,"ambiguousdinosaurs":1,"ambrosialsummit":1,"amethystzenith":1,"amuckafternoon":1,"amusedbucket":1,"analyzecorona":1,"ancientact":1,"annoyingacoustics":1,"aquaticowl":1,"arrivegrowth":1,"aspiringapples":1,"astonishingfood":1,"audioarctic":1,"automaticturkey":1,"awarealley":1,"awesomeagreement":1,"awzbijw":1,"axiomaticanger":1,"badgeboat":1,"badgerabbit":1,"baitbaseball":1,"balloonbelieve":1,"barbarousbase":1,"basketballbelieve":1,"beamvolcano":1,"beancontrol":1,"begintrain":1,"bestboundary":1,"bikesboard":1,"birthdaybelief":1,"blackbrake":1,"bleachbubble":1,"blesspizzas":1,"blissfullagoon":1,"blushingbeast":1,"boredcrown":1,"boundarybusiness":1,"boundlessveil":1,"brainybasin":1,"brainynut":1,"branchborder":1,"bravecalculator":1,"breadbalance":1,"breakfastboat":1,"brighttoe":1,"briskstorm":1,"broadborder":1,"brotherslocket":1,"buildingknife":1,"bulbbait":1,"burlywhistle":1,"burnbubble":1,"bushesbag":1,"bustlingbath":1,"bustlingbook":1,"calculatingcircle":1,"callousbrake":1,"calmcactus":1,"calypsocapsule":1,"capriciouscorn":1,"captivatingcanyon":1,"carefuldolls":1,"caringcast":1,"cartkitten":1,"catalogcake":1,"catschickens":1,"causecherry":1,"cautiouscamera":1,"cautiouscherries":1,"cautiouscredit":1,"cavecurtain":1,"ceciliavenus":1,"celestialquasar":1,"celestialspectra":1,"chaireggnog":1,"chairsdonkey":1,"chalkoil":1,"changeablecats":1,"charmingplate":1,"cheerycraze":1,"chesscolor":1,"childlikeexample":1,"chinsnakes":1,"chipperisle":1,"chivalrouscord":1,"chunkycactus":1,"cloisteredcord":1,"cloisteredcurve":1,"closedcows":1,"coatfood":1,"cobaltoverture":1,"coldbalance":1,"colossalclouds":1,"colossalcoat":1,"colossalcry":1,"combbit":1,"combcattle":1,"combcompetition":1,"comfortablecheese":1,"concernedchange":1,"concernedchickens":1,"condemnedcomb":1,"conditioncrush":1,"confesschairs":1,"consciouscheese":1,"consciousdirt":1,"cooingcoal":1,"coordinatedcoat":1,"copycarpenter":1,"cosmicsculptor":1,"courageousbaby":1,"coverapparatus":1,"cozyhillside":1,"cozytryst":1,"creatorcherry":1,"creatorpassenger":1,"creaturecabbage":1,"crimsonmeadow":1,"critictruck":1,"crookedcreature":1,"crystalboulevard":1,"cubchannel":1,"cuddlylunchroom":1,"currentcollar":1,"curvycry":1,"cushionpig":1,"damagedadvice":1,"damageddistance":1,"dandydune":1,"dandyglow":1,"daughterstone":1,"dazzlingbook":1,"debonairdust":1,"debonairtree":1,"decisivedrawer":1,"decisiveducks":1,"deerbeginner":1,"defeatedbadge":1,"delicatecascade":1,"deliciousducks":1,"dependenttrip":1,"detailedkitten":1,"dewdroplagoon":1,"digestiondrawer":1,"dinnerquartz":1,"diplomahawaii":1,"discreetquarter":1,"dk4ywix":1,"dollardelta":1,"dq95d35":1,"dreamycanyon":1,"drollwharf":1,"dustydime":1,"dustyhammer":1,"eagereden":1,"eagerknight":1,"echoinghaven":1,"effervescentcoral":1,"effervescentvista":1,"effulgenttempest":1,"elasticchange":1,"elderlybean":1,"elusivebreeze":1,"eminentbubble":1,"enchantingdiscovery":1,"enchantingmystique":1,"endurablebulb":1,"energeticladybug":1,"engineertrick":1,"enigmaticcanyon":1,"enigmaticvoyage":1,"entertainskin":1,"equablekettle":1,"ethereallagoon":1,"evanescentedge":1,"evasivejar":1,"eventexistence":1,"exampleshake":1,"excitingtub":1,"executeknowledge":1,"exhibitsneeze":1,"exquisiteartisanship":1,"exuberantedge":1,"facilitatebreakfast":1,"fadedsnow":1,"fairiesbranch":1,"fairytaleflame":1,"fancyactivity":1,"fancydune":1,"farshake":1,"farsnails":1,"fastenfather":1,"fatcoil":1,"faucetfoot":1,"faultycanvas":1,"fearfulmint":1,"featherstage":1,"feignedfaucet":1,"fertilefeeling":1,"fewjuice":1,"fewkittens":1,"firstfrogs":1,"flameuncle":1,"flimsycircle":1,"flimsythought":1,"flourishingcollaboration":1,"flourishinginnovation":1,"flourishingpartnership":1,"flowerycreature":1,"floweryfact":1,"followborder":1,"forgetfulsnail":1,"franticroof":1,"frequentflesh":1,"friendlycrayon":1,"friendwool":1,"fumblingform":1,"furryfork":1,"futuristicfifth":1,"futuristicframe":1,"fuzzyerror":1,"gaudyairplane":1,"generateoffice":1,"giantsvessel":1,"giddycoat":1,"givevacation":1,"gladysway":1,"gleamingcow":1,"glisteningguide":1,"glitteringbrook":1,"goldfishgrowth":1,"gondolagnome":1,"gracefulmilk":1,"grandfatherguitar":1,"grayoranges":1,"grayreceipt":1,"grouchypush":1,"grumpydime":1,"guardeddirection":1,"guidecent":1,"gulliblegrip":1,"gustygrandmother":1,"halcyoncanyon":1,"halcyonsculpture":1,"hallowedinvention":1,"haltingdivision":1,"haltinggold":1,"handsomehose":1,"handsomelythumb":1,"handyfield":1,"handyfireman":1,"handyincrease":1,"haplesshydrant":1,"haplessland":1,"hatefulrequest":1,"headydegree":1,"heartbreakingmind":1,"hearthorn":1,"heavyplayground":1,"helpcollar":1,"highfalutinhoney":1,"historicalbeam":1,"honeybulb":1,"horsenectar":1,"hospitablehall":1,"hospitablehat":1,"humdrumtouch":1,"hystericalcloth":1,"idyllicjazz":1,"illinvention":1,"importantmeat":1,"impossibleexpansion":1,"impulsejewel":1,"impulselumber":1,"incompetentjoke":1,"inconclusiveaction":1,"inputicicle":1,"inquisitiveice":1,"intelligentscissors":1,"internalcondition":1,"internalsink":1,"irritatingfog":1,"jollylens":1,"joyfulkeen":1,"jubilantaura":1,"jubilantcanyon":1,"jubilantcascade":1,"jubilantglimmer":1,"jubilanttempest":1,"jubilantwhisper":1,"kaputquill":1,"keenquill":1,"knitstamp":1,"lameletters":1,"largebrass":1,"leftliquid":1,"liftedknowledge":1,"lightenafterthought":1,"lighttalon":1,"livelumber":1,"livelylaugh":1,"livelyreward":1,"livingsleet":1,"lizardslaugh":1,"loadsurprise":1,"lonelyflavor":1,"longingtrees":1,"lorenzourban":1,"losslace":1,"ludicrousarch":1,"luminousboulevard":1,"luminouscatalyst":1,"lumpylumber":1,"lustroushaven":1,"magicaljoin":1,"majesticwaterscape":1,"majesticwilderness":1,"maliciousmusic":1,"marketspiders":1,"marriedvalue":1,"materialisticmoon":1,"materialplayground":1,"meadowlullaby":1,"meatydime":1,"melodiouschorus":1,"melodiouscomposition":1,"meltmilk":1,"memopilot":1,"memorizeneck":1,"meremark":1,"merequartz":1,"merryopal":1,"merryvault":1,"mightyspiders":1,"minorcattle":1,"minuteburst":1,"mixedreading":1,"modularmental":1,"monacobeatles":1,"moorshoes":1,"motionlessbag":1,"motionlessmeeting":1,"movemeal":1,"mundanenail":1,"mushywaste":1,"muteknife":1,"mysticalagoon":1,"naivestatement":1,"neatshade":1,"nebulacrescent":1,"nebulajubilee":1,"nebulousamusement":1,"nebulousgarden":1,"nebulousquasar":1,"nebulousripple":1,"needlessnorth":1,"niftyhospital":1,"nightwound":1,"nocturnalloom":1,"nondescriptcrowd":1,"nostalgicneed":1,"numberlessring":1,"nuttyorganization":1,"oafishchance":1,"obscenesidewalk":1,"oldfashionedoffer":1,"opalquill":1,"operationchicken":1,"optimallimit":1,"opulentsylvan":1,"orientedargument":1,"outstandingincome":1,"outstandingsnails":1,"painstakingpickle":1,"pamelarandom":1,"panickycurtain":1,"parallelbulb":1,"parentpicture":1,"passivepolo":1,"peacefullimit":1,"petiteumbrella":1,"piquantgrove":1,"piquantmeadow":1,"piquantvortex":1,"placidactivity":1,"planebasin":1,"plantdigestion":1,"playfulriver":1,"pluckyzone":1,"poeticpackage":1,"pointdigestion":1,"pointlesspocket":1,"pointlessprofit":1,"polishedcrescent":1,"polishedfolly":1,"politeplanes":1,"politicalporter":1,"popplantation":1,"possiblepencil":1,"powderjourney":1,"preciousplanes":1,"pricklypollution":1,"pristinegale":1,"processplantation":1,"protestcopy":1,"publicsofa":1,"puffypurpose":1,"pulsatingmeadow":1,"pumpedpancake":1,"punyplant":1,"purposepipe":1,"quaintlake":1,"quillkick":1,"quirkybliss":1,"quirkysugar":1,"rabbitbreath":1,"rabbitrifle":1,"radiantlullaby":1,"railwaygiraffe":1,"raintwig":1,"rainyhand":1,"rainyrule":1,"rangecake":1,"raresummer":1,"readymoon":1,"rebelhen":1,"rebelsubway":1,"receptivereaction":1,"recessrain":1,"reconditeprison":1,"reflectivestatement":1,"regularplants":1,"regulatesleet":1,"relationrest":1,"rememberdiscussion":1,"replaceroute":1,"resonantbrush":1,"respectrain":1,"resplendentecho":1,"retrievemint":1,"rhetoricalveil":1,"rhymezebra":1,"richstring":1,"rigidrobin":1,"rigidveil":1,"ringplant":1,"rollconnection":1,"roofrelation":1,"roseincome":1,"rusticprice":1,"sadloaf":1,"samesticks":1,"samplesamba":1,"scarceshock":1,"scarcestructure":1,"scaredcomfort":1,"scaredslip":1,"scaredsnake":1,"scarefowl":1,"scatteredstream":1,"scientificshirt":1,"scintillatingscissors":1,"scissorsstatement":1,"scrapesleep":1,"screechingfurniture":1,"screechingstocking":1,"scribbleson":1,"seashoresociety":1,"secondhandfall":1,"secretturtle":1,"seemlysuggestion":1,"separatesort":1,"seraphicjubilee":1,"serenecascade":1,"serenepebble":1,"serenesurf":1,"serioussuit":1,"serpentshampoo":1,"settleshoes":1,"shadeship":1,"shakyseat":1,"shakysurprise":1,"shallowblade":1,"sheargovernor":1,"shesubscriptions":1,"shinypond":1,"shirtsidewalk":1,"shiveringspot":1,"shiverscissors":1,"shockingship":1,"sierrakermit":1,"sillyscrew":1,"simulateswing":1,"sincerebuffalo":1,"sincerepelican":1,"sinceresubstance":1,"sinkbooks":1,"sixscissors":1,"slinksuggestion":1,"smilingswim":1,"smoggysongs":1,"sneakwind":1,"soggysponge":1,"soggyzoo":1,"solarislabyrinth":1,"somberscarecrow":1,"sombersticks":1,"soothingglade":1,"sordidsmile":1,"soresidewalk":1,"soretrain":1,"sortsail":1,"sortsummer":1,"spellmist":1,"spellsalsa":1,"spotlessstamp":1,"spottednoise":1,"sprysummit":1,"spuriousair":1,"spysubstance":1,"squalidscrew":1,"stakingbasket":1,"stakingshock":1,"stalesummer":1,"statuesqueship":1,"steadycopper":1,"stealsteel":1,"steepscale":1,"stepplane":1,"stereoproxy":1,"stimulatingsneeze":1,"stingyshoe":1,"stingyspoon":1,"stockingsleet":1,"stomachscience":1,"stopstomach":1,"stormyfold":1,"strangeclocks":1,"strangersponge":1,"strangesink":1,"stretchsister":1,"stretchsneeze":1,"stretchsquirrel":1,"stripedbat":1,"strivesidewalk":1,"sublimequartz":1,"succeedscene":1,"sugarfriction":1,"suggestionbridge":1,"superficialspring":1,"supportwaves":1,"suspectmark":1,"swellstocking":1,"swelteringsleep":1,"swingslip":1,"synonymousrule":1,"synonymoussticks":1,"synthesizescarecrow":1,"tackytrains":1,"tangyamount":1,"tastelesstrees":1,"tastelesstrucks":1,"tearfulglass":1,"teenytinycellar":1,"teenytinytongue":1,"tempertrick":1,"temptteam":1,"terriblethumb":1,"terrifictooth":1,"thingstaste":1,"thirdrespect":1,"thomastorch":1,"thoughtlessknot":1,"thrivingmarketplace":1,"ticketaunt":1,"tidymitten":1,"tiredthroat":1,"tradetooth":1,"tranquilcan":1,"tranquilcanyon":1,"tranquilplume":1,"tranquilveil":1,"tranquilveranda":1,"tremendousearthquake":1,"tremendousplastic":1,"tritebadge":1,"tritethunder":1,"troubledtail":1,"troubleshade":1,"truculentrate":1,"tumbleicicle":1,"typicalairplane":1,"ubiquitoussea":1,"ubiquitousyard":1,"unablehope":1,"unaccountablepie":1,"unbecominghall":1,"uncoveredexpert":1,"unequalbrake":1,"unequaltrail":1,"unknowncrate":1,"untidyrice":1,"unusedstone":1,"unwieldyimpulse":1,"uppitytime":1,"uselesslumber":1,"vanishmemory":1,"velvetquasar":1,"venomousvessel":1,"venusgloria":1,"verdantanswer":1,"verdantlabyrinth":1,"verdantloom":1,"verseballs":1,"vibrantcelebration":1,"vibrantgale":1,"vibranthaven":1,"vibrantpact":1,"vibranttalisman":1,"vibrantvale":1,"virtualvincent":1,"vividcanopy":1,"vividfrost":1,"vividmeadow":1,"vividplume":1,"volatileprofit":1,"wantingwindow":1,"wearbasin":1,"wellgroomedhydrant":1,"whimsicalcanyon":1,"whimsicalgrove":1,"whisperingcascade":1,"whisperingquasar":1,"whisperingsummit":1,"whispermeeting":1,"wildcommittee":1,"wistfulwaste":1,"wittyshack":1,"workoperation":1,"wretchedfloor":1,"wrongwound":1,"zephyrlabyrinth":1,"zestyhorizon":1,"zestyrover":1,"zipperxray":1},"net":{"2mdn":1,"2o7":1,"3gl":1,"a-mo":1,"acint":1,"adform":1,"adhigh":1,"admixer":1,"adobedc":1,"adspeed":1,"adverticum":1,"apicit":1,"appier":1,"akamaized":{"assets-momentum":1},"aticdn":1,"edgekey":{"au":1,"ca":1,"ch":1,"cn":1,"com-v1":1,"es":1,"ihg":1,"in":1,"io":1,"it":1,"jp":1,"net":1,"org":1,"com":{"scene7":1},"uk-v1":1,"uk":1},"azure":1,"azurefd":1,"bannerflow":1,"bf-tools":1,"bidswitch":1,"bitsngo":1,"blueconic":1,"boldapps":1,"buysellads":1,"cachefly":1,"cedexis":1,"certona":1,"confiant-integrations":1,"contentsquare":1,"criteo":1,"crwdcntrl":1,"cloudfront":{"d1af033869koo7":1,"d1cr9zxt7u0sgu":1,"d1s87id6169zda":1,"d1vg5xiq7qffdj":1,"d1y068gyog18cq":1,"d214hhm15p4t1d":1,"d21gpk1vhmjuf5":1,"d2zah9y47r7bi2":1,"d38b8me95wjkbc":1,"d38xvr37kwwhcm":1,"d3fv2pqyjay52z":1,"d3i4yxtzktqr9n":1,"d3odp2r1osuwn0":1,"d5yoctgpv4cpx":1,"d6tizftlrpuof":1,"dbukjj6eu5tsf":1,"dn0qt3r0xannq":1,"dsh7ky7308k4b":1,"d2g3ekl4mwm40k":1},"demdex":1,"dotmetrics":1,"doubleclick":1,"durationmedia":1,"e-planning":1,"edgecastcdn":1,"emsecure":1,"episerver":1,"esm1":1,"eulerian":1,"everestjs":1,"everesttech":1,"eyeota":1,"ezoic":1,"fastly":{"global":{"shared":{"f2":1},"sni":{"j":1}},"map":{"prisa-us-eu":1,"scribd":1},"ssl":{"global":{"qognvtzku-x":1}}},"facebook":1,"fastclick":1,"fonts":1,"azureedge":{"fp-cdn":1,"sdtagging":1},"fuseplatform":1,"fwmrm":1,"go-mpulse":1,"hadronid":1,"hs-analytics":1,"hsleadflows":1,"im-apps":1,"impervadns":1,"iocnt":1,"iprom":1,"jsdelivr":1,"kanade-ad":1,"krxd":1,"line-scdn":1,"listhub":1,"livecom":1,"livedoor":1,"liveperson":1,"lkqd":1,"llnwd":1,"lpsnmedia":1,"magnetmail":1,"marketo":1,"maxymiser":1,"media":1,"microad":1,"mobon":1,"monetate":1,"mxptint":1,"myfonts":1,"myvisualiq":1,"naver":1,"nr-data":1,"ojrq":1,"omtrdc":1,"onecount":1,"openx":1,"openxcdn":1,"opta":1,"owneriq":1,"pages02":1,"pages03":1,"pages04":1,"pages05":1,"pages06":1,"pages08":1,"pingdom":1,"pmdstatic":1,"popads":1,"popcash":1,"primecaster":1,"pro-market":1,"akamaihd":{"pxlclnmdecom-a":1},"rfihub":1,"sancdn":1,"sc-static":1,"semasio":1,"sensic":1,"sexad":1,"smaato":1,"spreadshirts":1,"storygize":1,"tfaforms":1,"trackcmp":1,"trackedlink":1,"tradetracker":1,"truste-svc":1,"uuidksinc":1,"viafoura":1,"visilabs":1,"visx":1,"w55c":1,"wdsvc":1,"witglobal":1,"yandex":1,"yastatic":1,"yieldlab":1,"zencdn":1,"zucks":1,"opencmp":1,"azurewebsites":{"app-fnsp-matomo-analytics-prod":1},"ad-delivery":1,"chartbeat":1,"msecnd":1,"cloudfunctions":{"us-central1-adaptive-growth":1},"eviltracker":1},"co":{"6sc":1,"ayads":1,"getlasso":1,"idio":1,"increasingly":1,"jads":1,"nanorep":1,"nc0":1,"pcdn":1,"prmutv":1,"resetdigital":1,"t":1,"tctm":1,"zip":1},"gt":{"ad":1},"ru":{"adfox":1,"adriver":1,"digitaltarget":1,"mail":1,"mindbox":1,"rambler":1,"rutarget":1,"sape":1,"smi2":1,"tns-counter":1,"top100":1,"ulogin":1,"yandex":1,"yadro":1},"jp":{"adingo":1,"admatrix":1,"auone":1,"co":{"dmm":1,"i-mobile":1,"rakuten":1,"yahoo":1},"fout":1,"genieesspv":1,"gmossp-sp":1,"gsspat":1,"gssprt":1,"ne":{"hatena":1},"i2i":1,"impact-ad":1,"microad":1,"nakanohito":1,"r10s":1,"reemo-ad":1,"rtoaster":1,"shinobi":1,"team-rec":1,"uncn":1,"yimg":1,"yjtag":1},"pl":{"adocean":1,"gemius":1,"nsaudience":1,"onet":1,"salesmanago":1,"wp":1},"pro":{"adpartner":1,"piwik":1,"usocial":1},"de":{"adscale":1,"auswaertiges-amt":1,"fiduciagad":1,"ioam":1,"itzbund":1,"vgwort":1,"werk21system":1},"re":{"adsco":1},"info":{"adxbid":1,"bitrix":1,"navistechnologies":1,"usergram":1,"webantenna":1},"tv":{"affec":1,"attn":1,"iris":1,"ispot":1,"samba":1,"teads":1,"twitch":1,"videohub":1},"dev":{"amazon":1},"us":{"amung":1,"samplicio":1,"slgnt":1,"trkn":1},"media":{"andbeyond":1,"nextday":1,"townsquare":1,"underdog":1},"link":{"app":1},"cloud":{"avct":1,"egain":1,"matomo":1},"delivery":{"ay":1,"monu":1},"ly":{"bit":1},"br":{"com":{"btg360":1,"clearsale":1,"jsuol":1,"shopconvert":1,"shoptarget":1,"soclminer":1},"org":{"ivcbrasil":1}},"ch":{"ch":1,"da-services":1,"google":1},"me":{"channel":1,"contentexchange":1,"grow":1,"line":1,"loopme":1,"t":1},"ms":{"clarity":1},"my":{"cnt":1},"se":{"codigo":1},"to":{"cpx":1,"tawk":1},"chat":{"crisp":1,"gorgias":1},"fr":{"d-bi":1,"open-system":1,"weborama":1},"uk":{"co":{"dailymail":1,"hsbc":1}},"gov":{"dhs":1},"ai":{"e-volution":1,"hybrid":1,"m2":1,"nrich":1,"wknd":1},"be":{"geoedge":1},"au":{"com":{"google":1,"news":1,"nine":1,"zipmoney":1,"telstra":1}},"stream":{"ibclick":1},"cz":{"imedia":1,"seznam":1,"trackad":1},"app":{"infusionsoft":1,"permutive":1,"shop":1},"tech":{"ingage":1,"primis":1},"eu":{"kameleoon":1,"medallia":1,"media01":1,"ocdn":1,"rqtrk":1,"slgnt":1},"fi":{"kesko":1,"simpli":1},"live":{"lura":1},"services":{"marketingautomation":1},"sg":{"mediacorp":1},"bi":{"newsroom":1},"fm":{"pdst":1},"ad":{"pixel":1},"xyz":{"playground":1},"it":{"plug":1,"repstatic":1},"cc":{"popin":1},"network":{"pub":1},"nl":{"rijksoverheid":1},"fyi":{"sda":1},"es":{"socy":1},"im":{"spot":1},"market":{"spotim":1},"am":{"tru":1},"no":{"uio":1,"medietall":1},"at":{"waust":1},"pe":{"shop":1},"ca":{"bc":{"gov":1}},"gg":{"clean":1},"example":{"ad-company":1},"site":{"ad-company":1,"third-party":{"bad":1,"broken":1}},"pw":{"zlp6s":1}};
         output.bundledConfig = data;
 
         return output
@@ -1306,26 +1315,83 @@
       return parseJSONPointer(fromPointer);
     }
 
-    /* global false */
-    // Tests don't define this variable so fallback to behave like chrome
-    const functionToString = Function.prototype.toString;
+    /* global false, cloneInto, exportFunction */
+
 
     /**
-     * add a fake toString() method to a wrapper function to resemble the original function
+     * Like Object.defineProperty, but with support for Firefox's mozProxies.
+     * @param {any} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.BatteryManager.prototype)
+     * @param {string} propertyName
+     * @param {import('./wrapper-utils').StrictPropertyDescriptor} descriptor - requires all descriptor options to be defined because we can't validate correctness based on TS types
+     */
+    function defineProperty (object, propertyName, descriptor) {
+        {
+            objectDefineProperty(object, propertyName, descriptor);
+        }
+    }
+
+    /**
+     * return a proxy to `newFn` that fakes .toString() and .toString.toString() to resemble the `origFn`.
+     * WARNING: do NOT proxy toString multiple times, as it will not work as expected.
+     *
      * @param {*} newFn
      * @param {*} origFn
+     * @param {string} [mockValue] - when provided, .toString() will return this value
      */
-    function wrapToString (newFn, origFn) {
+    function wrapToString (newFn, origFn, mockValue) {
         if (typeof newFn !== 'function' || typeof origFn !== 'function') {
-            return
+            return newFn
         }
-        newFn.toString = function () {
-            if (this === newFn) {
-                return functionToString.call(origFn)
-            } else {
-                return functionToString.call(this)
+
+        return new Proxy(newFn, { get: toStringGetTrap(origFn, mockValue) })
+    }
+
+    /**
+     * generate a proxy handler trap that fakes .toString() and .toString.toString() to resemble the `targetFn`.
+     * Note that it should be used as the get() trap.
+     * @param {*} targetFn
+     * @param {string} [mockValue] - when provided, .toString() will return this value
+     * @returns { (target: any, prop: string, receiver: any) => any }
+     */
+    function toStringGetTrap (targetFn, mockValue) {
+        // We wrap two levels deep to handle toString.toString() calls
+        return function get (target, prop, receiver) {
+            if (prop === 'toString') {
+                const origToString = Reflect.get(targetFn, 'toString', targetFn);
+                const toStringProxy = new Proxy(origToString, {
+                    apply (target, thisArg, argumentsList) {
+                        // only mock toString() when called on the proxy itself. If the method is applied to some other object, it should behave as a normal toString()
+                        if (thisArg === receiver) {
+                            if (mockValue) {
+                                return mockValue
+                            }
+                            return Reflect.apply(target, targetFn, argumentsList)
+                        } else {
+                            return Reflect.apply(target, thisArg, argumentsList)
+                        }
+                    },
+                    get (target, prop, receiver) {
+                        // handle toString.toString() result
+                        if (prop === 'toString') {
+                            const origToStringToString = Reflect.get(origToString, 'toString', origToString);
+                            const toStringToStringProxy = new Proxy(origToStringToString, {
+                                apply (target, thisArg, argumentsList) {
+                                    if (thisArg === toStringProxy) {
+                                        return Reflect.apply(target, origToString, argumentsList)
+                                    } else {
+                                        return Reflect.apply(target, thisArg, argumentsList)
+                                    }
+                                }
+                            });
+                            return toStringToStringProxy
+                        }
+                        return Reflect.get(target, prop, receiver)
+                    }
+                });
+                return toStringProxy
             }
-        };
+            return Reflect.get(target, prop, receiver)
+        }
     }
 
     /**
@@ -1354,6 +1420,271 @@
             }
         })
     }
+
+    /**
+     * Wrap a `get`/`set` or `value` property descriptor. Only for data properties. For methods, use wrapMethod(). For constructors, use wrapConstructor().
+     * @param {any} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.Screen.prototype)
+     * @param {string} propertyName
+     * @param {Partial<PropertyDescriptor>} descriptor
+     * @param {typeof Object.defineProperty} definePropertyFn - function to use for defining the property
+     * @returns {PropertyDescriptor|undefined} original property descriptor, or undefined if it's not found
+     */
+    function wrapProperty (object, propertyName, descriptor, definePropertyFn) {
+        if (!object) {
+            return
+        }
+
+        /** @type {StrictPropertyDescriptor} */
+        // @ts-expect-error - we check for undefined below
+        const origDescriptor = getOwnPropertyDescriptor(object, propertyName);
+        if (!origDescriptor) {
+            // this happens if the property is not implemented in the browser
+            return
+        }
+
+        if (('value' in origDescriptor && 'value' in descriptor) ||
+            ('get' in origDescriptor && 'get' in descriptor) ||
+            ('set' in origDescriptor && 'set' in descriptor)
+        ) {
+            definePropertyFn(object, propertyName, {
+                ...origDescriptor,
+                ...descriptor
+            });
+            return origDescriptor
+        } else {
+            // if the property is defined with get/set it must be wrapped with a get/set. If it's defined with a `value`, it must be wrapped with a `value`
+            throw new Error(`Property descriptor for ${propertyName} may only include the following keys: ${objectKeys(origDescriptor)}`)
+        }
+    }
+
+    /**
+     * Wrap a method descriptor. Only for function properties. For data properties, use wrapProperty(). For constructors, use wrapConstructor().
+     * @param {any} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.Bluetooth.prototype)
+     * @param {string} propertyName
+     * @param {(originalFn, ...args) => any } wrapperFn - wrapper function receives the original function as the first argument
+     * @param {DefinePropertyFn} definePropertyFn - function to use for defining the property
+     * @returns {PropertyDescriptor|undefined} original property descriptor, or undefined if it's not found
+     */
+    function wrapMethod (object, propertyName, wrapperFn, definePropertyFn) {
+        if (!object) {
+            return
+        }
+
+        /** @type {StrictPropertyDescriptor} */
+        // @ts-expect-error - we check for undefined below
+        const origDescriptor = getOwnPropertyDescriptor(object, propertyName);
+        if (!origDescriptor) {
+            // this happens if the property is not implemented in the browser
+            return
+        }
+
+        // @ts-expect-error - we check for undefined below
+        const origFn = origDescriptor.value;
+        if (!origFn || typeof origFn !== 'function') {
+            // method properties are expected to be defined with a `value`
+            throw new Error(`Property ${propertyName} does not look like a method`)
+        }
+
+        const newFn = wrapToString(function () {
+            return wrapperFn.call(this, origFn, ...arguments)
+        }, origFn);
+
+        definePropertyFn(object, propertyName, {
+            ...origDescriptor,
+            value: newFn
+        });
+        return origDescriptor
+    }
+
+    /**
+     * @template {keyof typeof globalThis} StandardInterfaceName
+     * @param {StandardInterfaceName} interfaceName - the name of the interface to shim (must be some known standard API, e.g. 'MediaSession')
+     * @param {typeof globalThis[StandardInterfaceName]} ImplClass - the class to use as the shim implementation
+     * @param {DefineInterfaceOptions} options - options for defining the interface
+     * @param {DefinePropertyFn} definePropertyFn - function to use for defining the property
+     */
+    function shimInterface (
+        interfaceName,
+        ImplClass,
+        options,
+        definePropertyFn
+    ) {
+
+        /** @type {DefineInterfaceOptions} */
+        const defaultOptions = {
+            allowConstructorCall: false,
+            disallowConstructor: false,
+            constructorErrorMessage: 'Illegal constructor',
+            wrapToString: true
+        };
+
+        const fullOptions = {
+            interfaceDescriptorOptions: { writable: true, enumerable: false, configurable: true, value: ImplClass },
+            ...defaultOptions,
+            ...options
+        };
+
+        // In some cases we can get away without a full proxy, but in many cases below we need it.
+        // For example, we can't redefine `prototype` property on ES6 classes.
+        // Se we just always wrap the class to make the code more maintaibnable
+
+        /** @type {ProxyHandler<Function>} */
+        const proxyHandler = {};
+
+        // handle the case where the constructor is called without new
+        if (fullOptions.allowConstructorCall) {
+            // make the constructor function callable without new
+            proxyHandler.apply = function (target, thisArg, argumentsList) {
+                return Reflect.construct(target, argumentsList, target)
+            };
+        }
+
+        // make the constructor function throw when called without new
+        if (fullOptions.disallowConstructor) {
+            proxyHandler.construct = function () {
+                throw new TypeError(fullOptions.constructorErrorMessage)
+            };
+        }
+
+        if (fullOptions.wrapToString) {
+            // mask toString() on class methods. `ImplClass.prototype` is non-configurable: we can't override or proxy it, so we have to wrap each method individually
+            for (const [prop, descriptor] of objectEntries(getOwnPropertyDescriptors(ImplClass.prototype))) {
+                if (prop !== 'constructor' && descriptor.writable && typeof descriptor.value === 'function') {
+                    ImplClass.prototype[prop] = new Proxy(descriptor.value, {
+                        get: toStringGetTrap(descriptor.value, `function ${prop}() { [native code] }`)
+                    });
+                }
+            }
+
+            // wrap toString on the constructor function itself
+            Object.assign(proxyHandler, {
+                get: toStringGetTrap(ImplClass, `function ${interfaceName}() { [native code] }`)
+            });
+        }
+
+        // Note that instanceof should still work, since the `.prototype` object is proxied too:
+        // Interface() instanceof Interface === true
+        // ImplClass() instanceof Interface === true
+        const Interface = new Proxy(ImplClass, proxyHandler);
+
+        // Make sure that Interface().constructor === Interface (not ImplClass)
+        if (ImplClass.prototype?.constructor === ImplClass) {
+            /** @type {StrictDataDescriptor} */
+            // @ts-expect-error - As long as ImplClass is a normal class, it should have the prototype property
+            const descriptor = getOwnPropertyDescriptor(ImplClass.prototype, 'constructor');
+            if (descriptor.writable) {
+                ImplClass.prototype.constructor = Interface;
+            }
+        }
+
+        // mock the name property
+        definePropertyFn(ImplClass, 'name', {
+            value: interfaceName,
+            configurable: true,
+            enumerable: false,
+            writable: false
+        });
+
+        // interfaces are exposed directly on the global object, not on its prototype
+        definePropertyFn(
+            globalThis,
+            interfaceName,
+            { ...fullOptions.interfaceDescriptorOptions, value: Interface }
+        );
+    }
+
+    /**
+     * Define a missing standard property on a global (prototype) object. Only for data properties.
+     * For constructors, use shimInterface().
+     * Most of the time, you'd want to call shimInterface() first to shim the class itself (MediaSession), and then shimProperty() for the global singleton instance (Navigator.prototype.mediaSession).
+     * @template Base
+     * @template {keyof Base & string} K
+     * @param {Base} baseObject - object whose property we are shimming (most commonly a prototype object, e.g. Navigator.prototype)
+     * @param {K} propertyName - name of the property to shim (e.g. 'mediaSession')
+     * @param {Base[K]} implInstance - instance to use as the shim (e.g. new MyMediaSession())
+     * @param {boolean} readOnly - whether the property should be read-only
+     * @param {DefinePropertyFn} definePropertyFn - function to use for defining the property
+     */
+    function shimProperty (baseObject, propertyName, implInstance, readOnly, definePropertyFn) {
+        // @ts-expect-error - implInstance is a class instance
+        const ImplClass = implInstance.constructor;
+
+        // mask toString() and toString.toString() on the instance
+        const proxiedInstance = new Proxy(implInstance, {
+            get: toStringGetTrap(implInstance, `[object ${ImplClass.name}]`)
+        });
+
+        /** @type {StrictPropertyDescriptor} */
+        let descriptor;
+
+        // Note that we only cover most common cases: a getter for "readonly" properties, and a value descriptor for writable properties.
+        // But there could be other cases, e.g. a property with both a getter and a setter. These could be defined with a raw defineProperty() call.
+        // Important: make sure to cover each new shim with a test that verifies that all descriptors match the standard API.
+        if (readOnly) {
+            const getter = function get () { return proxiedInstance };
+            const proxiedGetter = new Proxy(getter, {
+                get: toStringGetTrap(getter, `function get ${propertyName}() { [native code] }`)
+            });
+            descriptor = {
+                configurable: true,
+                enumerable: true,
+                get: proxiedGetter
+            };
+        } else {
+            descriptor = {
+                configurable: true,
+                enumerable: true,
+                writable: true,
+                value: proxiedInstance
+            };
+        }
+
+        definePropertyFn(baseObject, propertyName, descriptor);
+    }
+
+    /**
+     * @callback DefinePropertyFn
+     * @param {object} baseObj
+     * @param {PropertyKey} propertyName
+     * @param {StrictPropertyDescriptor} descriptor
+     * @returns {object}
+     */
+
+    /**
+     * @typedef {Object} BaseStrictPropertyDescriptor
+     * @property {boolean} configurable
+     * @property {boolean} enumerable
+     */
+
+    /**
+     * @typedef {BaseStrictPropertyDescriptor & { value: any; writable: boolean }} StrictDataDescriptor
+     * @typedef {BaseStrictPropertyDescriptor & { get: () => any; set: (v: any) => void }} StrictAccessorDescriptor
+     * @typedef {BaseStrictPropertyDescriptor & { get: () => any }} StrictGetDescriptor
+     * @typedef {BaseStrictPropertyDescriptor & { set: (v: any) => void }} StrictSetDescriptor
+     * @typedef {StrictDataDescriptor | StrictAccessorDescriptor | StrictGetDescriptor | StrictSetDescriptor} StrictPropertyDescriptor
+     */
+
+    /**
+     * @typedef {Object} BaseDefineInterfaceOptions
+     * @property {string} [constructorErrorMessage]
+     * @property {boolean} wrapToString
+     */
+
+    /**
+     * @typedef {{ allowConstructorCall: true; disallowConstructor: false }} DefineInterfaceOptionsWithAllowConstructorCallMixin
+     */
+
+    /**
+     * @typedef {{ allowConstructorCall: false; disallowConstructor: true }} DefineInterfaceOptionsWithDisallowConstructorMixin
+     */
+
+    /**
+     * @typedef {{ allowConstructorCall: false; disallowConstructor: false }} DefineInterfaceOptionsDefaultMixin
+     */
+
+    /**
+     * @typedef {BaseDefineInterfaceOptions & (DefineInterfaceOptionsWithAllowConstructorCallMixin | DefineInterfaceOptionsWithDisallowConstructorMixin | DefineInterfaceOptionsDefaultMixin)} DefineInterfaceOptions
+     */
 
     /**
      * @description
@@ -2953,8 +3284,19 @@
         }
     }
 
-    /* global cloneInto, exportFunction */
+    /**
+     * @typedef {object} AssetConfig
+     * @property {string} regularFontUrl
+     * @property {string} boldFontUrl
+     */
 
+    /**
+     * @typedef {object} Site
+     * @property {string | null} domain
+     * @property {boolean} [isBroken]
+     * @property {boolean} [allowlisted]
+     * @property {string[]} [enabledFeatures]
+     */
 
     class ContentFeature {
         /** @type {import('./utils.js').RemoteConfig | undefined} */
@@ -3245,10 +3587,11 @@
         }
 
         /**
-         * Define a property descriptor. Mainly used for defining new properties. For overriding existing properties, consider using wrapProperty(), wrapMethod() and wrapConstructor().
-         * @param {any} object - object whose property we are wrapping (most commonly a prototype)
+         * Define a property descriptor with debug flags.
+         * Mainly used for defining new properties. For overriding existing properties, consider using wrapProperty(), wrapMethod() and wrapConstructor().
+         * @param {any} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.BatteryManager.prototype)
          * @param {string} propertyName
-         * @param {PropertyDescriptor} descriptor
+         * @param {import('./wrapper-utils').StrictPropertyDescriptor} descriptor - requires all descriptor options to be defined because we can't validate correctness based on TS types
          */
         defineProperty (object, propertyName, descriptor) {
             // make sure to send a debug flag when the property is used
@@ -3257,88 +3600,68 @@
                 const descriptorProp = descriptor[k];
                 if (typeof descriptorProp === 'function') {
                     const addDebugFlag = this.addDebugFlag.bind(this);
-                    descriptor[k] = function () {
-                        addDebugFlag();
-                        return Reflect.apply(descriptorProp, this, arguments)
-                    };
+                    const wrapper = new Proxy$1(descriptorProp, {
+                        apply (target, thisArg, argumentsList) {
+                            addDebugFlag();
+                            return Reflect$1.apply(descriptorProp, thisArg, argumentsList)
+                        }
+                    });
+                    descriptor[k] = wrapToString(wrapper, descriptorProp);
                 }
             });
 
-            {
-                Object.defineProperty(object, propertyName, descriptor);
-            }
+            return defineProperty(object, propertyName, descriptor)
         }
 
         /**
          * Wrap a `get`/`set` or `value` property descriptor. Only for data properties. For methods, use wrapMethod(). For constructors, use wrapConstructor().
-         * @param {any} object - object whose property we are wrapping (most commonly a prototype)
+         * @param {any} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.Screen.prototype)
          * @param {string} propertyName
          * @param {Partial<PropertyDescriptor>} descriptor
          * @returns {PropertyDescriptor|undefined} original property descriptor, or undefined if it's not found
          */
         wrapProperty (object, propertyName, descriptor) {
-            if (!object) {
-                return
-            }
-
-            const origDescriptor = getOwnPropertyDescriptor(object, propertyName);
-            if (!origDescriptor) {
-                // this happens if the property is not implemented in the browser
-                return
-            }
-
-            if (('value' in origDescriptor && 'value' in descriptor) ||
-                ('get' in origDescriptor && 'get' in descriptor) ||
-                ('set' in origDescriptor && 'set' in descriptor)
-            ) {
-                wrapToString(descriptor.value, origDescriptor.value);
-                wrapToString(descriptor.get, origDescriptor.get);
-                wrapToString(descriptor.set, origDescriptor.set);
-
-                this.defineProperty(object, propertyName, {
-                    ...origDescriptor,
-                    ...descriptor
-                });
-                return origDescriptor
-            } else {
-                // if the property is defined with get/set it must be wrapped with a get/set. If it's defined with a `value`, it must be wrapped with a `value`
-                throw new Error(`Property descriptor for ${propertyName} may only include the following keys: ${objectKeys(origDescriptor)}`)
-            }
+            return wrapProperty(object, propertyName, descriptor, this.defineProperty.bind(this))
         }
 
         /**
          * Wrap a method descriptor. Only for function properties. For data properties, use wrapProperty(). For constructors, use wrapConstructor().
-         * @param {any} object - object whose property we are wrapping (most commonly a prototype)
+         * @param {any} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.Bluetooth.prototype)
          * @param {string} propertyName
          * @param {(originalFn, ...args) => any } wrapperFn - wrapper function receives the original function as the first argument
          * @returns {PropertyDescriptor|undefined} original property descriptor, or undefined if it's not found
          */
         wrapMethod (object, propertyName, wrapperFn) {
-            if (!object) {
-                return
-            }
-            const origDescriptor = getOwnPropertyDescriptor(object, propertyName);
-            if (!origDescriptor) {
-                // this happens if the property is not implemented in the browser
-                return
-            }
+            return wrapMethod(object, propertyName, wrapperFn, this.defineProperty.bind(this))
+        }
 
-            const origFn = origDescriptor.value;
-            if (!origFn || typeof origFn !== 'function') {
-                // method properties are expected to be defined with a `value`
-                throw new Error(`Property ${propertyName} does not look like a method`)
-            }
+        /**
+         * @template {keyof typeof globalThis} StandardInterfaceName
+         * @param {StandardInterfaceName} interfaceName - the name of the interface to shim (must be some known standard API, e.g. 'MediaSession')
+         * @param {typeof globalThis[StandardInterfaceName]} ImplClass - the class to use as the shim implementation
+         * @param {import('./wrapper-utils').DefineInterfaceOptions} options
+         */
+        shimInterface (
+            interfaceName,
+            ImplClass,
+            options
+        ) {
+            return shimInterface(interfaceName, ImplClass, options, this.defineProperty.bind(this))
+        }
 
-            const newFn = function () {
-                return wrapperFn.call(this, origFn, ...arguments)
-            };
-            wrapToString(newFn, origFn);
-
-            this.defineProperty(object, propertyName, {
-                ...origDescriptor,
-                value: newFn
-            });
-            return origDescriptor
+        /**
+         * Define a missing standard property on a global (prototype) object. Only for data properties.
+         * For constructors, use shimInterface().
+         * Most of the time, you'd want to call shimInterface() first to shim the class itself (MediaSession), and then shimProperty() for the global singleton instance (Navigator.prototype.mediaSession).
+         * @template Base
+         * @template {keyof Base & string} K
+         * @param {Base} instanceHost - object whose property we are shimming (most commonly a prototype object, e.g. Navigator.prototype)
+         * @param {K} instanceProp - name of the property to shim (e.g. 'mediaSession')
+         * @param {Base[K]} implInstance - instance to use as the shim (e.g. new MyMediaSession())
+         * @param {boolean} [readOnly] - whether the property should be read-only (default: false)
+         */
+        shimProperty (instanceHost, instanceProp, implInstance, readOnly = false) {
+            return shimProperty(instanceHost, instanceProp, implInstance, readOnly, this.defineProperty.bind(this))
         }
     }
 
@@ -4477,7 +4800,9 @@
                         return storage
                     }
                     return originalStorage
-                }
+                },
+                enumerable: true,
+                configurable: true
             });
         }
 
@@ -4529,6 +4854,7 @@
             if (!defaultGetter) {
                 return
             }
+            // TODO: inner* and outer* should have a setter too
             this.defineProperty(scope, overrideKey, {
                 get () {
                     const defaultVal = Reflect$1.apply(defaultGetter, receiver, []);
@@ -4536,7 +4862,9 @@
                         return returnVal
                     }
                     return defaultVal
-                }
+                },
+                enumerable: true,
+                configurable: true
             });
         }
     }
@@ -5344,6 +5672,8 @@
                 for (const [prop, val] of Object.entries(spoofedValues)) {
                     try {
                         this.defineProperty(BatteryManager.prototype, prop, {
+                            enumerable: true,
+                            configurable: true,
                             get: () => {
                                 return val
                             }
@@ -5353,6 +5683,9 @@
                 for (const eventProp of eventProperties) {
                     try {
                         this.defineProperty(BatteryManager.prototype, eventProp, {
+                            enumerable: true,
+                            configurable: true,
+                            set: x => x, // noop
                             get: () => {
                                 return null
                             }
@@ -6884,7 +7217,8 @@
                     get: () => value,
                     // eslint-disable-next-line @typescript-eslint/no-empty-function
                     set: () => {},
-                    configurable: true
+                    configurable: true,
+                    enumerable: true
                 });
             } catch (e) {}
         }
@@ -6975,7 +7309,11 @@
                         // @ts-expect-error https://app.asana.com/0/1201614831475344/1203979574128023/f
                         org.call(navigator.webkitTemporaryStorage, modifiedCallback, err);
                     };
-                    this.defineProperty(Navigator.prototype, 'webkitTemporaryStorage', { get: () => tStorage });
+                    this.defineProperty(Navigator.prototype, 'webkitTemporaryStorage', {
+                        get: () => tStorage,
+                        enumerable: true,
+                        configurable: true
+                    });
                 } catch (e) {}
             }
         }
@@ -7631,21 +7969,19 @@
                 },
                 writable: true,
                 configurable: true,
-                enumerable: false
+                enumerable: true
             });
 
             this.defineProperty(window.Notification, 'permission', {
-                value: 'denied',
-                writable: true,
+                get: () => 'denied',
                 configurable: true,
                 enumerable: false
             });
 
             this.defineProperty(window.Notification, 'maxActions', {
-                value: 2,
-                writable: true,
+                get: () => 2,
                 configurable: true,
-                enumerable: false
+                enumerable: true
             });
         }
 
@@ -7800,16 +8136,17 @@
                 if ('credentials' in navigator && 'get' in navigator.credentials) {
                     return
                 }
-                // TODO: change the property descriptor shape to match the original
                 const value = {
                     get () {
                         return Promise.reject(new Error())
                     }
                 };
+                // TODO: original property is an accessor descriptor
                 this.defineProperty(Navigator.prototype, 'credentials', {
                     value,
                     configurable: true,
-                    enumerable: true
+                    enumerable: true,
+                    writable: true
                 });
             } catch {
                 // Ignore exceptions that could be caused by conflicting with other extensions
@@ -7876,60 +8213,40 @@
 
         mediaSessionFix () {
             try {
-                if (window.navigator.mediaSession) {
+                if (window.navigator.mediaSession && "android" !== 'integration') {
                     return
                 }
 
-                this.defineProperty(window.navigator, 'mediaSession', {
-                    value: {
-                    },
-                    writable: true,
-                    configurable: true,
-                    enumerable: true
-                });
-                this.defineProperty(window.navigator.mediaSession, 'metadata', {
-                    value: null,
-                    writable: true,
-                    configurable: false,
-                    enumerable: false
-                });
-                this.defineProperty(window.navigator.mediaSession, 'playbackState', {
-                    value: 'none',
-                    writable: true,
-                    configurable: false,
-                    enumerable: false
-                });
-                this.defineProperty(window.navigator.mediaSession, 'setActionHandler', {
-                    value: () => {},
-                    configurable: true,
-                    enumerable: true
-                });
-                this.defineProperty(window.navigator.mediaSession, 'setCameraActive', {
-                    value: () => {},
-                    configurable: true,
-                    enumerable: true
-                });
-                this.defineProperty(window.navigator.mediaSession, 'setMicrophoneActive', {
-                    value: () => {},
-                    configurable: true,
-                    enumerable: true
-                });
-                this.defineProperty(window.navigator.mediaSession, 'setPositionState', {
-                    value: () => {},
-                    configurable: true,
-                    enumerable: true
-                });
+                class MyMediaSession {
+                    metadata = null
+                    /** @type {MediaSession['playbackState']} */
+                    playbackState = 'none'
 
-                class MediaMetadata {
+                    setActionHandler () {}
+                    setCameraActive () {}
+                    setMicrophoneActive () {}
+                    setPositionState () {}
+                }
+
+                this.shimInterface('MediaSession', MyMediaSession, {
+                    disallowConstructor: true,
+                    allowConstructorCall: false,
+                    wrapToString: true
+                });
+                this.shimProperty(Navigator.prototype, 'mediaSession', new MyMediaSession(), true);
+
+                this.shimInterface('MediaMetadata', class {
                     constructor (metadata = {}) {
                         this.title = metadata.title;
                         this.artist = metadata.artist;
                         this.album = metadata.album;
                         this.artwork = metadata.artwork;
                     }
-                }
-
-                window.MediaMetadata = new Proxy(MediaMetadata, {});
+                }, {
+                    disallowConstructor: false,
+                    allowConstructorCall: false,
+                    wrapToString: true
+                });
             } catch {
                 // Ignore exceptions that could be caused by conflicting with other extensions
             }
@@ -7938,29 +8255,55 @@
         presentationFix () {
             try {
                 // @ts-expect-error due to: Property 'presentation' does not exist on type 'Navigator'
-                if (window.navigator.presentation) {
+                if (window.navigator.presentation && "android" !== 'integration') {
                     return
                 }
 
-                this.defineProperty(window.navigator, 'presentation', {
-                    value: {
-                    },
-                    writable: true,
-                    configurable: true,
-                    enumerable: true
+                const MyPresentation = class {
+                    get defaultRequest () {
+                        return null
+                    }
+
+                    get receiver () {
+                        return null
+                    }
+                };
+
+                // @ts-expect-error Presentation API is still experimental, TS types are missing
+                this.shimInterface('Presentation', MyPresentation, {
+                    disallowConstructor: true,
+                    allowConstructorCall: false,
+                    wrapToString: true
                 });
-                // @ts-expect-error due to: Property 'presentation' does not exist on type 'Navigator'
-                this.defineProperty(window.navigator.presentation, 'defaultRequest', {
-                    value: null,
-                    configurable: true,
-                    enumerable: true
+
+                // @ts-expect-error Presentation API is still experimental, TS types are missing
+                this.shimInterface('PresentationAvailability', class {
+                    // class definition is empty because there's no way to get an instance of it anyways
+                }, {
+                    disallowConstructor: true,
+                    allowConstructorCall: false,
+                    wrapToString: true
                 });
-                // @ts-expect-error due to: Property 'presentation' does not exist on type 'Navigator'
-                this.defineProperty(window.navigator.presentation, 'receiver', {
-                    value: null,
-                    configurable: true,
-                    enumerable: true
+
+                // @ts-expect-error Presentation API is still experimental, TS types are missing
+                this.shimInterface('PresentationRequest', class {
+                    // class definition is empty because there's no way to get an instance of it anyways
+                }, {
+                    disallowConstructor: true,
+                    allowConstructorCall: false,
+                    wrapToString: true
                 });
+
+                /** TODO: add shims for other classes in the Presentation API:
+                 * PresentationConnection,
+                 * PresentationReceiver,
+                 * PresentationConnectionList,
+                 * PresentationConnectionAvailableEvent,
+                 * PresentationConnectionCloseEvent
+                 */
+
+                // @ts-expect-error Presentation API is still experimental, TS types are missing
+                this.shimProperty(Navigator.prototype, 'presentation', new MyPresentation(), true);
             } catch {
                 // Ignore exceptions that could be caused by conflicting with other extensions
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^10.8.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.2.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.15.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.17.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#3.5.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1708702034"
       },
@@ -69,7 +69,7 @@
       "hasInstallScript": true
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#bb8e7e62104ed6506c7bfd3ef7aa4aca3686ed4f",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#fa861c4eccb21d235e34070b208b78bdc32ece08",
       "hasInstallScript": true,
       "workspaces": [
         "packages/special-pages",
@@ -266,9 +266,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.12.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.11.tgz",
-      "integrity": "sha512-vDg9PZ/zi+Nqp6boSOT7plNuthRugEKixDv5sFTIpkE89MmNtEArAShI4mxuX2+UrLEe9pxC1vm2cjm9YlWbJw==",
+      "version": "20.12.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
+      "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -837,9 +837,9 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
       "dev": true
     },
     "node_modules/picomatch": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^10.8.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.2.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.15.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.17.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#3.5.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1708702034"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207367485604645/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass