### PR TITLE
Update fastlane to upload APK straight to production to reduce wasted time on double reviews

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -52,7 +52,7 @@ platform :android do
     end
 
 
-  desc "Upload APK to Play Store, in pre-production staging track"
+  desc "Upload APK to Play Store, in production track with a very small rollout percentage"
   lane :deploy_playstore do
 
     update_fastlane_release_notes()
@@ -63,7 +63,8 @@ platform :android do
 
     upload_to_play_store(
       apk: apkPath,
-      track: 'Staging',
+      track: 'production',
+      rollout: '0.001', # ie. 0.1%
       skip_upload_screenshots: true,
       skip_upload_images: true,
       validate_only: false

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -21,7 +21,7 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 [bundle exec] fastlane android deploy_playstore
 ```
 
-Upload APK to Play Store, in pre-production staging track
+Upload APK to Play Store, in production track with a very small rollout percentage
 
 ### android deploy_dogfood
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207360448878908/f 

### Description
We experience lengthy Play Store reviews and pay the price twice for each release:
- one review is triggered when we upload our APK to the `staging` track
- a second review is triggered when we promote from `staging` to begin the `production` rollout

Each of the reviews can amount to many hours each. This PR changes it so that we skip `staging` and go straight to production at 0.01% rollout so that the review clock starts immediately and we only have to wait for a single app review instead of needlessly waiting on two for the same release.

### Steps to test this PR
- [x] Sense-check the change. Can't really test until we next do a release. 