### PR TITLE
Fix priority in active plugin points

### DIFF
--- a/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesActivePluginPointCodeGenerator.kt
+++ b/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesActivePluginPointCodeGenerator.kt
@@ -320,7 +320,7 @@ class ContributesActivePluginPointCodeGenerator : CodeGenerator {
                     pluginPriority?.let {
                         addAnnotation(
                             AnnotationSpec.builder(PriorityKey::class)
-                                .addMember("%L", it)
+                                .addMember("%L", it.toString())
                                 .build(),
                         )
                     }

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesActivePluginPointCodeGeneratorTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesActivePluginPointCodeGeneratorTest.kt
@@ -55,7 +55,7 @@ class ContributesActivePluginPointCodeGeneratorTest {
 
         val priorityAnnotation = clazz.java.getAnnotation(PriorityKey::class.java)!!
         assertNotNull(priorityAnnotation)
-        assertEquals(100, priorityAnnotation.priority)
+        assertEquals(1000, priorityAnnotation.priority)
     }
 
     @Test

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/TestActivePlugins.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/TestActivePlugins.kt
@@ -62,7 +62,7 @@ class FooActivePlugin @Inject constructor() : MyPlugin {
 @ContributesActivePlugin(
     scope = AppScope::class,
     boundType = MyPlugin::class,
-    priority = 100,
+    priority = 1000,
 )
 class BarActivePlugin @Inject constructor() : MyPlugin {
     override fun doSomething() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1198194956794324/1207400224799050/f

### Description
Ensure that `priority` don't have grouping separators

### Steps to test this PR

_Test_
- [ ] Apply changes in `ContributesActivePluginPointCodeGeneratorTest` and `BarActivePlugin` to develop
- [ ] verify `ContributesActivePluginPointCodeGeneratorTest` fails
- [ ] verify `ContributesActivePluginPointCodeGeneratorTest` passes in this branch

