### PR TITLE
Enforce that Active plugins can't be collected by normal plugin point

### DIFF
--- a/anvil/anvil-annotations/src/main/java/com/duckduckgo/anvil/annotations/ContributesActivePlugin.kt
+++ b/anvil/anvil-annotations/src/main/java/com/duckduckgo/anvil/annotations/ContributesActivePlugin.kt
@@ -31,7 +31,7 @@ import kotlin.reflect.KClass
  *
  * }
  *
- * interface MyPlugin : ActivePluginPoint.ActivePlugin {...}
+ * interface MyPlugin : ActivePlugin {...}
  * ```
  */
 @Target(AnnotationTarget.CLASS)

--- a/anvil/anvil-annotations/src/main/java/com/duckduckgo/anvil/annotations/ContributesActivePluginPoint.kt
+++ b/anvil/anvil-annotations/src/main/java/com/duckduckgo/anvil/annotations/ContributesActivePluginPoint.kt
@@ -21,12 +21,12 @@ import kotlin.reflect.KClass
 /**
  * Anvil annotation to generate plugin points that are guarded by a remote feature flag.
  *
- * Active plugins need to extend from [ActivePluginPoint.ActivePlugin]
+ * Active plugins need to extend from [ActivePlugin]
  *
  * Usage:
  * ```kotlin
  * @ContributesActivePluginPoint(SomeDaggerScope::class)
- * interface MyPlugin : ActivePluginPoint.ActivePlugin {
+ * interface MyPlugin : ActivePlugin {
  *
  * }
  * ```
@@ -49,7 +49,7 @@ annotation class ContributesActivePluginPoint(
      * )
      * interface MyPluginPoint : MyPlugin
      *
-     * interface MyPlugin : ActivePluginPoint.ActivePlugin {...}
+     * interface MyPlugin : ActivePlugin {...}
      * ```
      */
     val boundType: KClass<*> = Unit::class,

--- a/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesActivePluginPointCodeGenerator.kt
+++ b/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesActivePluginPointCodeGenerator.kt
@@ -572,7 +572,7 @@ class ContributesActivePluginPointCodeGenerator : CodeGenerator {
     companion object {
         private val pluginPointFqName = FqName("com.duckduckgo.common.utils.plugins.PluginPoint")
         private val dispatcherProviderFqName = FqName("com.duckduckgo.common.utils.DispatcherProvider")
-        private val activePluginPointFqName = FqName("com.duckduckgo.common.utils.plugins.ActivePluginPoint")
+        private val activePluginPointFqName = FqName("com.duckduckgo.common.utils.plugins.InternalActivePluginPoint")
         private val coroutineScopeFqName = FqName("kotlinx.coroutines.CoroutineScope")
         private val sharedPreferencesProviderFqName = FqName("com.duckduckgo.data.store.api.SharedPreferencesProvider")
         private val moshiFqName = FqName("com.squareup.moshi.Moshi")

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/plugins/ActivePluginPoint.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/plugins/ActivePluginPoint.kt
@@ -16,12 +16,44 @@
 
 package com.duckduckgo.common.utils.plugins
 
-/** A PluginPoint provides a list of plugins of a particular type T */
-interface ActivePluginPoint<out T : @JvmSuppressWildcards ActivePluginPoint.ActivePlugin> {
+@Deprecated(
+    message = "Use \"ActivePluginPoint\" instead to ensure \"JvmSuppressWildcards\" is not forgotten",
+    replaceWith = ReplaceWith("ActivePluginPoint"),
+)
+interface InternalActivePluginPoint<out T : @JvmSuppressWildcards ActivePlugin> {
     /** @return the list of plugins of type <T> */
     suspend fun getPlugins(): Collection<T>
-
-    interface ActivePlugin {
-        suspend fun isActive(): Boolean = true
-    }
 }
+
+/**
+ * Active plugins SHALL extend from [ActivePlugin]
+ *
+ * Usage:
+ * ```kotlin
+ * @ContributesActivePluginPoint(
+ *     scope = SomeScope::class,
+ * )
+ * interface MyActivePlugin : ActivePlugin {...}
+ *
+ * @ContributesActivePlugin(
+ *     scope = SomeScope::class,
+ *     boundType = MyActivePlugin::class,
+ * )
+ * class FooMyActivePlugin @Inject constructor() : MyActivePlugin {...}
+ * ```
+ */
+interface ActivePlugin {
+    suspend fun isActive(): Boolean = true
+}
+
+/**
+ * Use this typealias to collect your [ActivePlugin]s
+ *
+ * Usage:
+ * ```kotlin
+ * class MyClass @Inject constructor(
+ *   private val pp: ActivePluginPoint<MyActivePlugin>,
+ * ) {...}
+ * ```
+ */
+typealias ActivePluginPoint<T> = InternalActivePluginPoint<@JvmSuppressWildcards T>

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/TestActivePlugins.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/TestActivePlugins.kt
@@ -18,18 +18,18 @@ package com.duckduckgo.feature.toggles.codegen
 
 import com.duckduckgo.anvil.annotations.ContributesActivePlugin
 import com.duckduckgo.anvil.annotations.ContributesActivePluginPoint
-import com.duckduckgo.common.utils.plugins.ActivePluginPoint
+import com.duckduckgo.common.utils.plugins.ActivePlugin
 import com.duckduckgo.di.scopes.AppScope
 import javax.inject.Inject
 
 @ContributesActivePluginPoint(
     scope = AppScope::class,
 )
-interface MyPlugin : ActivePluginPoint.ActivePlugin {
+interface MyPlugin : ActivePlugin {
     fun doSomething()
 }
 
-interface TriggeredMyPlugin : ActivePluginPoint.ActivePlugin {
+interface TriggeredMyPlugin : ActivePlugin {
     fun doSomething()
 }
 

--- a/lint-rules/src/main/java/com/duckduckgo/lint/WrongPluginPointCollectorDetector.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/WrongPluginPointCollectorDetector.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope.JAVA_FILE
+import com.android.tools.lint.detector.api.Scope.TEST_SOURCES
+import com.android.tools.lint.detector.api.Severity.ERROR
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.TextFormat.TEXT
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiClassType
+import com.intellij.psi.PsiModifierListOwner
+import com.intellij.psi.PsiType
+import com.intellij.psi.search.GlobalSearchScope
+import org.jetbrains.uast.UClass
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UField
+import org.jetbrains.uast.UMethod
+import org.jetbrains.uast.UParameter
+import org.jetbrains.uast.visitor.AbstractUastVisitor
+import java.util.*
+
+@Suppress("UnstableApiUsage")
+class WrongPluginPointCollectorDetector : Detector(), SourceCodeScanner {
+    override fun getApplicableUastTypes() = listOf(UClass::class.java)
+
+    override fun createUastHandler(context: JavaContext): UElementHandler = NoInternalImportHandler(context)
+
+    internal class NoInternalImportHandler(private val context: JavaContext) : UElementHandler() {
+
+        override fun visitClass(node: UClass) {
+            // travers class to find constructors
+            node.accept(
+                object : AbstractUastVisitor() {
+                    override fun visitMethod(node: UMethod): Boolean {
+                        if (node.isConstructor) {
+                            handleConstructor(node)
+                        }
+                        return super.visitMethod(node)
+                    }
+
+                    override fun visitField(node: UField): Boolean {
+                        // handle field
+                        handleField(node)
+                        return super.visitField(node)
+                    }
+                },
+            )
+        }
+        private fun handleConstructor(node: UMethod) {
+            node.parameterList.parameters.map { it.type }.forEach { psiType ->
+                if (psiType is PsiClassType) {
+                    val resolvedClass = psiType.resolve()
+                    if (resolvedClass?.qualifiedName == "com.duckduckgo.common.utils.plugins.PluginPoint") {
+                        psiType.parameters.forEach { typeArgument ->
+                            val typeArgumentClass = (typeArgument as? PsiClassType)?.resolve()
+                            if (typeArgumentClass?.isActivePlugin() == true) {
+                                context.reportError(node, WRONG_PLUGIN_POINT_ISSUE)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        private fun PsiClass.isActivePlugin(): Boolean {
+            return this.isSubtypeOf("com.duckduckgo.common.utils.plugins.ActivePluginPoint.ActivePlugin")
+        }
+        private fun handleField(node: UField) {
+            node.type.let { psiType ->
+                if (psiType is PsiClassType) {
+                    val resolvedClass = psiType.resolve()
+                    if (resolvedClass?.qualifiedName == "com.duckduckgo.common.utils.plugins.PluginPoint") {
+                        val typeArguments = psiType.parameters
+                        for (typeArgument in typeArguments) {
+                            val typeArgumentClass = (typeArgument as? PsiClassType)?.resolve()
+                            if (typeArgumentClass?.isSubtypeOf(
+                                    "com.duckduckgo.common.utils.plugins.ActivePluginPoint.ActivePlugin"
+                                ) == true) {
+                                context.reportError(node, WRONG_PLUGIN_POINT_ISSUE)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        private fun PsiClass.isSubtypeOf(superClassQualifiedName: String): Boolean {
+            if (this.qualifiedName == superClassQualifiedName) {
+                return true
+            }
+            for (superType in this.supers) {
+                if (superType.isSubtypeOf(superClassQualifiedName)) {
+                    return true
+                }
+            }
+            return false
+        }
+
+        private fun JavaContext.reportError(node: UElement, issue: Issue) {
+            report(
+                issue,
+                node,
+                context.getNameLocation(node),
+                issue.getBriefDescription(TEXT),
+            )
+
+        }
+    }
+
+    companion object {
+        val WRONG_PLUGIN_POINT_ISSUE = Issue.create("WrongPluginPointCollectorDetector",
+            "PluginPoint cannot be collector of ActivePlugin(s)",
+            """
+                PluginPoint cannot be collector of ActivePlugin(s). Use ActivePluginPoint instead
+            """.trimIndent(),
+            Category.CORRECTNESS, 10, ERROR,
+            Implementation(WrongPluginPointCollectorDetector::class.java, EnumSet.of(JAVA_FILE, TEST_SOURCES))
+        )
+    }
+}

--- a/lint-rules/src/main/java/com/duckduckgo/lint/registry/DuckDuckGoIssueRegistry.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/registry/DuckDuckGoIssueRegistry.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.lint.NoRetrofitCreateMethodCallDetector.Companion.NO_RETRO
 import com.duckduckgo.lint.NoRobolectricTestRunnerDetector.Companion.NO_ROBOLECTRIC_TEST_RUNNER_ISSUE
 import com.duckduckgo.lint.NoSingletonDetector.Companion.NO_SINGLETON_ISSUE
 import com.duckduckgo.lint.NoSystemLoadLibraryDetector.Companion.NO_SYSTEM_LOAD_LIBRARY
+import com.duckduckgo.lint.WrongPluginPointCollectorDetector.Companion.WRONG_PLUGIN_POINT_ISSUE
 import com.duckduckgo.lint.strings.MissingInstructionDetector.Companion.MISSING_INSTRUCTION
 import com.duckduckgo.lint.strings.PlaceholderDetector.Companion.PLACEHOLDER_MISSING_POSITION
 import com.duckduckgo.lint.ui.ColorAttributeInXmlDetector.Companion.INVALID_COLOR_ATTRIBUTE
@@ -49,6 +50,7 @@ import com.duckduckgo.lint.ui.WrongStyleDetector.Companion.WRONG_STYLE_PARAMETER
 class DuckDuckGoIssueRegistry : IssueRegistry() {
     override val issues: List<Issue>
         get() = listOf(
+            WRONG_PLUGIN_POINT_ISSUE,
             NO_SINGLETON_ISSUE,
             NO_LIFECYCLE_OBSERVER_ISSUE,
             NO_FRAGMENT_ISSUE,

--- a/lint-rules/src/test/java/com/duckduckgo/lint/WrongPluginPointCollectorDetectorTest.kt
+++ b/lint-rules/src/test/java/com/duckduckgo/lint/WrongPluginPointCollectorDetectorTest.kt
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint
+
+import com.android.tools.lint.checks.infrastructure.TestFiles.kt
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import com.duckduckgo.lint.WrongPluginPointCollectorDetector.Companion.WRONG_PLUGIN_POINT_ISSUE
+import org.junit.Test
+
+class WrongPluginPointCollectorDetectorTest {
+    @Test
+    fun `test normal plugin point constructor parameter collecting active plugins`() {
+        lint()
+            .files(kt("""
+                package com.duckduckgo.common.utils.plugins
+
+                interface PluginPoint<T> {
+                    fun getPlugins(): Collection<T>
+                }
+                
+                interface ActivePluginPoint<out T : ActivePluginPoint.ActivePlugin> {
+                    interface ActivePlugin {
+                        suspend fun isActive(): Boolean = true
+                    }
+                }
+
+                interface MyPlugin
+                interface MyPluginActivePlugin : ActivePluginPoint.ActivePlugin
+    
+                class Duck(private val pp: PluginPoint<MyPluginActivePlugin>) {
+                    fun quack() {                    
+                    }
+                }
+            """).indented())
+            .issues(WRONG_PLUGIN_POINT_ISSUE)
+            .run()
+            .expect("""
+                src/com/duckduckgo/common/utils/plugins/PluginPoint.kt:16: Error: PluginPoint cannot be collector of ActivePlugin(s) [WrongPluginPointCollectorDetector]
+                class Duck(private val pp: PluginPoint<MyPluginActivePlugin>) {
+                      ~~~~
+                src/com/duckduckgo/common/utils/plugins/PluginPoint.kt:16: Error: PluginPoint cannot be collector of ActivePlugin(s) [WrongPluginPointCollectorDetector]
+                class Duck(private val pp: PluginPoint<MyPluginActivePlugin>) {
+                                       ~~
+                2 errors, 0 warnings
+            """.trimMargin())
+    }
+
+    @Test
+    fun `test active plugin point constructor parameter collecting active plugins`() {
+        lint()
+            .files(kt("""
+                package com.duckduckgo.common.utils.plugins
+
+                interface PluginPoint<T> {
+                    fun getPlugins(): Collection<T>
+                }
+                
+                interface ActivePluginPoint<out T : ActivePluginPoint.ActivePlugin> {
+                    interface ActivePlugin {
+                        suspend fun isActive(): Boolean = true
+                    }
+                }
+
+                interface MyPlugin
+                interface MyPluginActivePlugin : ActivePluginPoint.ActivePlugin
+    
+                class Duck(private val pp: PluginPoint<MyPlugin>) {
+                    fun quack() {                    
+                    }
+                }
+            """).indented())
+            .issues(WRONG_PLUGIN_POINT_ISSUE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `test normal plugin point field collecting active plugins`() {
+        lint()
+            .files(kt("""
+                package com.duckduckgo.common.utils.plugins
+
+                interface PluginPoint<T> {
+                    fun getPlugins(): Collection<T>
+                }
+                
+                interface ActivePluginPoint<out T : ActivePluginPoint.ActivePlugin> {
+                    interface ActivePlugin {
+                        suspend fun isActive(): Boolean = true
+                    }
+                }
+
+                interface MyPlugin
+                interface MyPluginActivePlugin : ActivePluginPoint.ActivePlugin
+    
+                class Duck {
+                    private val pp: PluginPoint<MyPluginActivePlugin>
+                    
+                    fun quack() {                    
+                    }
+                }
+            """).indented())
+            .issues(WRONG_PLUGIN_POINT_ISSUE)
+            .run()
+            .expect("""
+                src/com/duckduckgo/common/utils/plugins/PluginPoint.kt:17: Error: PluginPoint cannot be collector of ActivePlugin(s) [WrongPluginPointCollectorDetector]
+                    private val pp: PluginPoint<MyPluginActivePlugin>
+                                ~~
+                1 errors, 0 warnings
+            """.trimMargin())
+    }
+
+    @Test
+    fun `test active plugin point field collecting active plugins`() {
+        lint()
+            .files(kt("""
+                package com.duckduckgo.common.utils.plugins
+
+                interface PluginPoint<T> {
+                    fun getPlugins(): Collection<T>
+                }
+                
+                interface ActivePluginPoint<out T : ActivePluginPoint.ActivePlugin> {
+                    interface ActivePlugin {
+                        suspend fun isActive(): Boolean = true
+                    }
+                }
+
+                interface MyPlugin
+                interface MyPluginActivePlugin : ActivePluginPoint.ActivePlugin
+    
+                class Duck {
+                    private val pp: PluginPoint<MyPlugin>
+                    
+                    fun quack() {                    
+                    }
+                }
+            """).indented())
+            .issues(WRONG_PLUGIN_POINT_ISSUE)
+            .run()
+            .expectClean()
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207400224799044/f

### Description
Ensure that normal plugin points can't collect active plugins

### Steps to test this PR
See lint test.
You can also try to collect an ActivePlugin (aka, plugin interface that extends from ActivePlugin) in a normal `PluginPoint<T>` and see lint failing
