### PR TITLE
Add meta viewport for plain text

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/accessibility/plaintextmetaviewport/PlainTextMetaViewportFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/accessibility/plaintextmetaviewport/PlainTextMetaViewportFeature.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.accessibility.plaintextmetaviewport
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "plainTextMetaViewport",
+)
+
+interface PlainTextMetaViewportFeature {
+
+    @Toggle.DefaultValue(true)
+    fun self(): Toggle
+}

--- a/app/src/main/java/com/duckduckgo/app/accessibility/plaintextmetaviewport/PlainTextMetaViewportJsInjectorPlugin.kt
+++ b/app/src/main/java/com/duckduckgo/app/accessibility/plaintextmetaviewport/PlainTextMetaViewportJsInjectorPlugin.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.accessibility.plaintextmetaviewport
+
+import android.content.Context
+import android.webkit.WebView
+import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.global.model.Site
+import com.duckduckgo.browser.api.JsInjectorPlugin
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+class PlainTextMetaViewportJsInjectorPlugin @Inject constructor(
+    private val plainTextMetaViewportFeature: PlainTextMetaViewportFeature,
+) : JsInjectorPlugin {
+    private val javaScriptInjector = JavaScriptInjector()
+
+    override fun onPageStarted(webView: WebView, url: String?, site: Site?) {
+        if (plainTextMetaViewportFeature.self().isEnabled()) {
+            webView.evaluateJavascript("javascript:${javaScriptInjector.getFunctionsJS(webView.context)}", null)
+        }
+    }
+
+    override fun onPageFinished(webView: WebView, url: String?, site: Site?) {
+        // No-op
+    }
+
+    private class JavaScriptInjector {
+        private lateinit var functions: String
+
+        fun getFunctionsJS(
+            context: Context,
+        ): String {
+            if (!this::functions.isInitialized) {
+                functions = context.resources.openRawResource(R.raw.plain_text_meta_viewport).bufferedReader().use { it.readText() }
+            }
+            return functions
+        }
+    }
+}

--- a/app/src/main/res/raw/plain_text_meta_viewport.js
+++ b/app/src/main/res/raw/plain_text_meta_viewport.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+(function() {
+    if (document.contentType === 'text/plain') {
+        var meta = document.createElement('meta');
+        meta.name = 'viewport';
+        meta.content = 'width=device-width, initial-scale=1.0';
+        document.getElementsByTagName('head')[0].appendChild(meta);
+    }
+})();

--- a/app/src/test/java/com/duckduckgo/app/accessibility/plaintextmetaviewport/PlainTextMetaViewportJsInjectorPluginTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/accessibility/plaintextmetaviewport/PlainTextMetaViewportJsInjectorPluginTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.accessibility.plaintextmetaviewport
+
+import android.content.Context
+import android.content.res.Resources
+import android.webkit.WebView
+import com.duckduckgo.feature.toggles.api.Toggle
+import java.io.ByteArrayInputStream
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+
+class PlainTextMetaViewportJsInjectorPluginTest {
+
+    private val mockWebView: WebView = mock()
+    private val plainTextMetaViewportFeature: PlainTextMetaViewportFeature = mock()
+    private val toggle: Toggle = mock()
+
+    private lateinit var plainTextMetaViewportJsInjectorPlugin: PlainTextMetaViewportJsInjectorPlugin
+
+    @Before
+    fun setUp() {
+        plainTextMetaViewportJsInjectorPlugin = PlainTextMetaViewportJsInjectorPlugin(plainTextMetaViewportFeature)
+        whenever(plainTextMetaViewportFeature.self()).thenReturn(toggle)
+        val context = mock<Context>()
+        val resources = mock<Resources>()
+        val inputStream = ByteArrayInputStream(JS.toByteArray())
+        whenever(context.resources).thenReturn(resources)
+        whenever(resources.openRawResource(anyInt())).thenReturn(inputStream)
+        whenever(mockWebView.context).thenReturn(context)
+    }
+
+    @Test
+    fun whenDisabledAndInjectPlainTextMetaViewportThenDoNothing() {
+        whenever(toggle.isEnabled()).thenReturn(false)
+
+        plainTextMetaViewportJsInjectorPlugin.onPageStarted(mockWebView, null, null)
+
+        verifyNoInteractions(mockWebView)
+    }
+
+    @Test
+    fun whenEnabledAndInjectPlainTextMetaViewportThenInjectJs() {
+        whenever(toggle.isEnabled()).thenReturn(true)
+
+        plainTextMetaViewportJsInjectorPlugin.onPageStarted(mockWebView, null, null)
+
+        verify(mockWebView).evaluateJavascript("javascript:$JS", null)
+    }
+
+    companion object {
+        private const val JS = "plain text meta viewport js"
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207407556106243/f

### Description
Fixes the issue reported in https://github.com/duckduckgo/Android/issues/4555

### Steps to test this PR

- [ ] Visit http://textfiles.com/stories/13chil.txt (Or any other plain text link)
- [ ] Go to Settings > Accessibility
- [ ] Change the text size
- [ ] Verify that the text size of the file changes as expected

### UI changes
![default_text_size](https://github.com/duckduckgo/Android/assets/3471025/73b9a620-d9f2-4d0a-a624-a63303dbc47f)

![wrapping](https://github.com/duckduckgo/Android/assets/3471025/166cca8d-34a2-4471-821b-f2bd21174d1d)
