### PR TITLE
Adapt autocomplete item to system font size

### DIFF
--- a/app/src/main/res/layout/item_autocomplete_search_suggestion.xml
+++ b/app/src/main/res/layout/item_autocomplete_search_suggestion.xml
@@ -41,7 +41,7 @@
     <com.duckduckgo.common.ui.view.text.DaxTextView
         android:id="@+id/phrase"
         android:layout_width="0dp"
-        android:layout_height="0dp"
+        android:layout_height="wrap_content"
         android:layout_marginStart="10dp"
         android:ellipsize="end"
         android:gravity="center_vertical|start"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207407556106269/f

### Description
Fixes the issue reported in https://github.com/duckduckgo/Android/issues/4564

### Steps to test this PR

- [x] Change the system font size to the largest option.
- [x] Type a word in the search bar.
- [x] Verify that the autocomplete item text is not clipped off.

(Tested on a Pixel 2, Android 11)

### UI changes
![scaled_autocomplete_item](https://github.com/duckduckgo/Android/assets/3471025/a07f3000-be7d-4f98-8ef3-dea470af28ac)

