### PR TITLE
Check possible active plugin or plugin point naming clashes

### DIFF
--- a/lint-rules/src/main/java/com/duckduckgo/lint/WrongPluginPointCollectorDetector.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/WrongPluginPointCollectorDetector.kt
@@ -84,7 +84,7 @@ class WrongPluginPointCollectorDetector : Detector(), SourceCodeScanner {
         }
 
         private fun PsiClass.isActivePlugin(): Boolean {
-            return this.isSubtypeOf("com.duckduckgo.common.utils.plugins.ActivePluginPoint.ActivePlugin")
+            return this.isSubtypeOf("com.duckduckgo.common.utils.plugins.ActivePlugin")
         }
         private fun handleField(node: UField) {
             node.type.let { psiType ->
@@ -95,7 +95,7 @@ class WrongPluginPointCollectorDetector : Detector(), SourceCodeScanner {
                         for (typeArgument in typeArguments) {
                             val typeArgumentClass = (typeArgument as? PsiClassType)?.resolve()
                             if (typeArgumentClass?.isSubtypeOf(
-                                    "com.duckduckgo.common.utils.plugins.ActivePluginPoint.ActivePlugin"
+                                    "com.duckduckgo.common.utils.plugins.ActivePlugin"
                                 ) == true) {
                                 context.reportError(node, WRONG_PLUGIN_POINT_ISSUE)
                             }

--- a/lint-rules/src/test/java/com/duckduckgo/lint/WrongPluginPointCollectorDetectorTest.kt
+++ b/lint-rules/src/test/java/com/duckduckgo/lint/WrongPluginPointCollectorDetectorTest.kt
@@ -19,40 +19,40 @@ package com.duckduckgo.lint
 import com.android.tools.lint.checks.infrastructure.TestFiles.kt
 import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
 import com.duckduckgo.lint.WrongPluginPointCollectorDetector.Companion.WRONG_PLUGIN_POINT_ISSUE
+import com.duckduckgo.lint.utils.PLUGIN_POINT_ANNOTATIONS_API
+import com.duckduckgo.lint.utils.PLUGIN_POINT_API
 import org.junit.Test
 
 class WrongPluginPointCollectorDetectorTest {
     @Test
     fun `test normal plugin point constructor parameter collecting active plugins`() {
         lint()
-            .files(kt("""
-                package com.duckduckgo.common.utils.plugins
-
-                interface PluginPoint<T> {
-                    fun getPlugins(): Collection<T>
-                }
-                
-                interface ActivePluginPoint<out T : ActivePluginPoint.ActivePlugin> {
-                    interface ActivePlugin {
-                        suspend fun isActive(): Boolean = true
-                    }
-                }
-
-                interface MyPlugin
-                interface MyPluginActivePlugin : ActivePluginPoint.ActivePlugin
+            .files(
+                PLUGIN_POINT_API,
+                PLUGIN_POINT_ANNOTATIONS_API,
+                kt("""
+                    package com.test.plugins
     
-                class Duck(private val pp: PluginPoint<MyPluginActivePlugin>) {
-                    fun quack() {                    
+                    import com.duckduckgo.common.utils.plugins.ActivePlugin
+                    import com.duckduckgo.common.utils.plugins.PluginPoint
+                    import com.duckduckgo.anvil.annotations.ContributesActivePlugin
+
+                    interface MyPlugin
+                    interface MyPluginActivePlugin : ActivePlugin
+        
+                    class Duck(private val pp: PluginPoint<MyPluginActivePlugin>) {
+                        fun quack() {                    
+                        }
                     }
-                }
-            """).indented())
+            """).indented()
+            )
             .issues(WRONG_PLUGIN_POINT_ISSUE)
             .run()
             .expect("""
-                src/com/duckduckgo/common/utils/plugins/PluginPoint.kt:16: Error: PluginPoint cannot be collector of ActivePlugin(s) [WrongPluginPointCollectorDetector]
+                src/com/test/plugins/MyPlugin.kt:10: Error: PluginPoint cannot be collector of ActivePlugin(s) [WrongPluginPointCollectorDetector]
                 class Duck(private val pp: PluginPoint<MyPluginActivePlugin>) {
                       ~~~~
-                src/com/duckduckgo/common/utils/plugins/PluginPoint.kt:16: Error: PluginPoint cannot be collector of ActivePlugin(s) [WrongPluginPointCollectorDetector]
+                src/com/test/plugins/MyPlugin.kt:10: Error: PluginPoint cannot be collector of ActivePlugin(s) [WrongPluginPointCollectorDetector]
                 class Duck(private val pp: PluginPoint<MyPluginActivePlugin>) {
                                        ~~
                 2 errors, 0 warnings
@@ -62,26 +62,23 @@ class WrongPluginPointCollectorDetectorTest {
     @Test
     fun `test active plugin point constructor parameter collecting active plugins`() {
         lint()
-            .files(kt("""
-                package com.duckduckgo.common.utils.plugins
-
-                interface PluginPoint<T> {
-                    fun getPlugins(): Collection<T>
-                }
-                
-                interface ActivePluginPoint<out T : ActivePluginPoint.ActivePlugin> {
-                    interface ActivePlugin {
-                        suspend fun isActive(): Boolean = true
-                    }
-                }
-
-                interface MyPlugin
-                interface MyPluginActivePlugin : ActivePluginPoint.ActivePlugin
+            .files(
+                PLUGIN_POINT_API,
+                PLUGIN_POINT_ANNOTATIONS_API,
+                kt("""
+                    package com.test.plugins
     
-                class Duck(private val pp: PluginPoint<MyPlugin>) {
-                    fun quack() {                    
+                    import com.duckduckgo.common.utils.plugins.ActivePlugin
+                    import com.duckduckgo.common.utils.plugins.PluginPoint
+                    import com.duckduckgo.anvil.annotations.ContributesActivePlugin
+    
+                    interface MyPlugin
+                    interface MyPluginActivePlugin : ActivePlugin
+        
+                    class Duck(private val pp: PluginPoint<MyPlugin>) {
+                        fun quack() {                    
+                        }
                     }
-                }
             """).indented())
             .issues(WRONG_PLUGIN_POINT_ISSUE)
             .run()
@@ -91,33 +88,30 @@ class WrongPluginPointCollectorDetectorTest {
     @Test
     fun `test normal plugin point field collecting active plugins`() {
         lint()
-            .files(kt("""
-                package com.duckduckgo.common.utils.plugins
+            .files(
+                PLUGIN_POINT_API,
+                PLUGIN_POINT_ANNOTATIONS_API,
+                kt("""
+                    package com.test.plugins
 
-                interface PluginPoint<T> {
-                    fun getPlugins(): Collection<T>
-                }
-                
-                interface ActivePluginPoint<out T : ActivePluginPoint.ActivePlugin> {
-                    interface ActivePlugin {
-                        suspend fun isActive(): Boolean = true
-                    }
-                }
-
-                interface MyPlugin
-                interface MyPluginActivePlugin : ActivePluginPoint.ActivePlugin
+                    import com.duckduckgo.common.utils.plugins.ActivePlugin
+                    import com.duckduckgo.common.utils.plugins.PluginPoint
+                    import com.duckduckgo.anvil.annotations.ContributesActivePlugin
     
-                class Duck {
-                    private val pp: PluginPoint<MyPluginActivePlugin>
-                    
-                    fun quack() {                    
+                    interface MyPlugin
+                    interface MyPluginActivePlugin : ActivePlugin
+        
+                    class Duck {
+                        private val pp: PluginPoint<MyPluginActivePlugin>
+                        
+                        fun quack() {                    
+                        }
                     }
-                }
             """).indented())
             .issues(WRONG_PLUGIN_POINT_ISSUE)
             .run()
             .expect("""
-                src/com/duckduckgo/common/utils/plugins/PluginPoint.kt:17: Error: PluginPoint cannot be collector of ActivePlugin(s) [WrongPluginPointCollectorDetector]
+                src/com/test/plugins/MyPlugin.kt:11: Error: PluginPoint cannot be collector of ActivePlugin(s) [WrongPluginPointCollectorDetector]
                     private val pp: PluginPoint<MyPluginActivePlugin>
                                 ~~
                 1 errors, 0 warnings
@@ -127,28 +121,22 @@ class WrongPluginPointCollectorDetectorTest {
     @Test
     fun `test active plugin point field collecting active plugins`() {
         lint()
-            .files(kt("""
-                package com.duckduckgo.common.utils.plugins
-
-                interface PluginPoint<T> {
-                    fun getPlugins(): Collection<T>
-                }
-                
-                interface ActivePluginPoint<out T : ActivePluginPoint.ActivePlugin> {
-                    interface ActivePlugin {
-                        suspend fun isActive(): Boolean = true
-                    }
-                }
-
-                interface MyPlugin
-                interface MyPluginActivePlugin : ActivePluginPoint.ActivePlugin
+            .files(
+                PLUGIN_POINT_API,
+                PLUGIN_POINT_ANNOTATIONS_API,
+                kt("""
+                    package com.test.plugins
     
-                class Duck {
-                    private val pp: PluginPoint<MyPlugin>
-                    
-                    fun quack() {                    
+                    import com.duckduckgo.common.utils.plugins.ActivePlugin
+                    import com.duckduckgo.common.utils.plugins.PluginPoint
+                    import com.duckduckgo.anvil.annotations.ContributesActivePlugin
+        
+                    class Duck {
+                        private val pp: PluginPoint<MyPlugin>
+                        
+                        fun quack() {                    
+                        }
                     }
-                }
             """).indented())
             .issues(WRONG_PLUGIN_POINT_ISSUE)
             .run()

--- a/lint-rules/src/test/java/com/duckduckgo/lint/utils/PluginUtils.kt
+++ b/lint-rules/src/test/java/com/duckduckgo/lint/utils/PluginUtils.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint.utils
+
+import com.android.tools.lint.checks.infrastructure.TestFiles
+
+internal val PLUGIN_POINT_API = TestFiles.kt(
+    """
+                    package com.duckduckgo.common.utils.plugins
+    
+                    interface PluginPoint<T> {
+                        fun getPlugins(): Collection<T>
+                    }
+                    interface InternalActivePluginPoint<out T : ActivePluginPoint.ActivePlugin> {
+                        suspend fun getPlugins(): Collection<T>
+                    }
+                    interface ActivePlugin {
+                        suspend fun isActive(): Boolean = true
+                    }
+                    typealias ActivePluginPoint<T> = InternalActivePluginPoint<@JvmSuppressWildcards T>
+            """
+).indented()
+internal val PLUGIN_POINT_ANNOTATIONS_API = TestFiles.kt(
+    """
+                    package com.duckduckgo.anvil.annotations
+    
+                    annotation class ContributesActivePlugin
+                    annotation class ContributesActivePluginPoint(
+                        val boundType: KClass<*> = Unit::class,
+                    )
+
+            """
+).indented()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207420696744032/f

### Description
Detect active plugin point naming clash and break build.

The PR incidentally fixes `WrongPluginPointCollectorDetector` that was obsolete after #4585

### Steps to test this PR

_Test_
- [x] Apply the following patch to this branch
```diff
Index: feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/api/Test.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/api/Test.kt b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/api/Test.kt
new file mode 100644
--- /dev/null	(date 1716970458191)
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/api/Test.kt	(date 1716970458191)
@@ -0,0 +1,43 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.feature.toggles.api
+
+import com.duckduckgo.anvil.annotations.ContributesActivePlugin
+import com.duckduckgo.anvil.annotations.ContributesActivePluginPoint
+import com.duckduckgo.common.utils.plugins.ActivePlugin
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.codegen.MyPlugin
+import com.duckduckgo.feature.toggles.codegen.TriggeredMyPlugin
+import javax.inject.Inject
+
+@ContributesActivePluginPoint(
+    scope = AppScope::class,
+    boundType = MyPlugin::class,
+)
+interface TriggerMyPlugin : ActivePlugin {
+    fun doSomething()
+}
+
+@ContributesActivePlugin(
+    scope = AppScope::class,
+    boundType = TriggeredMyPlugin::class,
+    defaultActiveValue = false,
+)
+class FooActiveTriggeredMyPlugin @Inject constructor() : TriggeredMyPlugin {
+    override fun doSomething() {
+    }
+}
```
- [x] First comment out `TriggerMyPlugin`
- [x] Run `ContributesActivePluginPointCodeGeneratorTest` tests
- [x] verify build breaks with `com.squareup.anvil.compiler.api.AnvilCompilationException: Back-end (JVM) Internal error: com.duckduckgo.feature.toggles.codegen.FooActiveTriggeredMyPlugin plugin name is duplicated, previous found in com.duckduckgo.feature.toggles.api.FooActiveTriggeredMyPlugin` message
- [x] Uncomment `TriggerMyPlugin` and comment out `FooActiveTriggeredMyPlugin`
- [x] Run `ContributesActivePluginPointCodeGeneratorTest` tests
- [x] verify build breaks with `com.squareup.anvil.compiler.api.AnvilCompilationException: Back-end (JVM) Internal error: com.duckduckgo.feature.toggles.codegen.MyPlugin plugin point naming is duplicated, previous found in com.duckduckgo.feature.toggles.api.TriggerMyPlugin` message
- [x] repeating the same test in develop should pass
