### PR TITLE
Onboarding end Dax dialog

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -710,6 +710,20 @@ class CtaViewModelTest {
         assertFalse(value is DaxBubbleCta.DaxIntroVisitSiteOptionsCta)
     }
 
+    @Test
+    fun whenCtaShownIfCtaIsNotMarkedAsReadOnShowAThenCtaNotInsertedInDatabase() {
+        testee.onCtaShown(OnboardingDaxDialogCta.DaxSerpCta(mockOnboardingStore, mockAppInstallStore))
+
+        verify(mockDismissedCtaDao, never()).insert(DismissedCta(CtaId.DAX_DIALOG_SERP))
+    }
+
+    @Test
+    fun whenCtaShownIfCtaIsMarkedAsReadOnShowAThenCtaInsertedInDatabase() {
+        testee.onCtaShown(OnboardingDaxDialogCta.DaxEndCta(mockOnboardingStore, mockAppInstallStore))
+
+        verify(mockDismissedCtaDao).insert(DismissedCta(CtaId.DAX_END))
+    }
+
     private suspend fun givenDaxOnboardingActive() {
         whenever(mockUserStageStore.getUserAppStage()).thenReturn(AppStage.DAX_ONBOARDING)
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -467,7 +467,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenRefreshOnboardingCtaAndCanShowDaxCtaEndOfJourneyButNotFireDialogShonThenOnboardingEndCtaDontShow() = runTest {
+    fun whenRefreshOnboardingCtaAndCanShowDaxCtaEndOfJourneyButNotFireDialogShownThenOnboardingEndCtaDontShow() = runTest {
         givenDaxOnboardingActive()
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_DIALOG_TRACKERS_FOUND)).thenReturn(true)

--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -711,7 +711,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenCtaShownIfCtaIsNotMarkedAsReadOnShowAThenCtaNotInsertedInDatabase() {
+    fun whenCtaShownIfCtaIsNotMarkedAsReadOnShowThenCtaNotInsertedInDatabase() {
         testee.onCtaShown(OnboardingDaxDialogCta.DaxSerpCta(mockOnboardingStore, mockAppInstallStore))
 
         verify(mockDismissedCtaDao, never()).insert(DismissedCta(CtaId.DAX_DIALOG_SERP))

--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -718,7 +718,7 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenCtaShownIfCtaIsMarkedAsReadOnShowAThenCtaInsertedInDatabase() {
+    fun whenCtaShownIfCtaIsMarkedAsReadOnShowThenCtaInsertedInDatabase() {
         testee.onCtaShown(OnboardingDaxDialogCta.DaxEndCta(mockOnboardingStore, mockAppInstallStore))
 
         verify(mockDismissedCtaDao).insert(DismissedCta(CtaId.DAX_END))

--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -467,6 +467,29 @@ class CtaViewModelTest {
     }
 
     @Test
+    fun whenRefreshOnboardingCtaAndCanShowDaxCtaEndOfJourneyButNotFireDialogShonThenOnboardingEndCtaDontShow() = runTest {
+        givenDaxOnboardingActive()
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_DIALOG_TRACKERS_FOUND)).thenReturn(true)
+
+        val site = site(url = "http://www.cnn.com", trackerCount = 1)
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true, site = site)
+        assertFalse(value is OnboardingDaxDialogCta.DaxEndCta)
+    }
+
+    @Test
+    fun whenRefreshOnboardingCtaAndCanShowDaxCtaEndThenOnboardingEndCtaShown() = runTest {
+        givenDaxOnboardingActive()
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_DIALOG_TRACKERS_FOUND)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_FIRE_BUTTON)).thenReturn(true)
+
+        val site = site(url = "http://www.cnn.com", trackerCount = 1)
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true, site = site)
+        assertTrue(value is OnboardingDaxDialogCta.DaxEndCta)
+    }
+
+    @Test
     fun whenRefreshCtaOnHomeTabAndIntroCtaWasNotPreviouslyShownThenIntroCtaShown() = runTest {
         givenDaxOnboardingActive()
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(false)

--- a/app/src/internal/res/values/donottranslate.xml
+++ b/app/src/internal/res/values/donottranslate.xml
@@ -85,4 +85,6 @@
     <string name="customTabsUrlHint">Add your URL here</string>
     <string name="customTabsInvalidUrl">Invalid URL</string>
 
+
+
 </resources>

--- a/app/src/internal/res/values/donottranslate.xml
+++ b/app/src/internal/res/values/donottranslate.xml
@@ -85,6 +85,4 @@
     <string name="customTabsUrlHint">Add your URL here</string>
     <string name="customTabsInvalidUrl">Invalid URL</string>
 
-
-
 </resources>

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -79,6 +79,8 @@ interface Cta {
 }
 
 interface OnboardingDaxCta {
+    val markAsReadOnShow: Boolean
+
     fun showOnboardingCta(
         binding: FragmentBrowserTabBinding,
         onPrimaryCtaClicked: () -> Unit,
@@ -157,6 +159,8 @@ sealed class OnboardingDaxDialogCta(
         onboardingStore,
         appInstallStore,
     ) {
+        override val markAsReadOnShow: Boolean = false
+
         override fun showOnboardingCta(
             binding: FragmentBrowserTabBinding,
             onPrimaryCtaClicked: () -> Unit,
@@ -187,6 +191,8 @@ sealed class OnboardingDaxDialogCta(
         onboardingStore,
         appInstallStore,
     ) {
+        override val markAsReadOnShow: Boolean = false
+
         override fun showOnboardingCta(
             binding: FragmentBrowserTabBinding,
             onPrimaryCtaClicked: () -> Unit,
@@ -240,6 +246,7 @@ sealed class OnboardingDaxDialogCta(
         onboardingStore,
         appInstallStore,
     ) {
+        override val markAsReadOnShow: Boolean = false
 
         override fun showOnboardingCta(
             binding: FragmentBrowserTabBinding,
@@ -291,6 +298,8 @@ sealed class OnboardingDaxDialogCta(
         onboardingStore,
         appInstallStore,
     ) {
+        override val markAsReadOnShow: Boolean = false
+
         override fun showOnboardingCta(
             binding: FragmentBrowserTabBinding,
             onPrimaryCtaClicked: () -> Unit,
@@ -320,6 +329,8 @@ sealed class OnboardingDaxDialogCta(
         onboardingStore,
         appInstallStore,
     ) {
+        override val markAsReadOnShow: Boolean = false
+
         override fun showOnboardingCta(
             binding: FragmentBrowserTabBinding,
             onPrimaryCtaClicked: () -> Unit,
@@ -351,6 +362,8 @@ sealed class OnboardingDaxDialogCta(
         onboardingStore,
         appInstallStore,
     ) {
+        override val markAsReadOnShow: Boolean = false
+
         override fun showOnboardingCta(
             binding: FragmentBrowserTabBinding,
             onPrimaryCtaClicked: () -> Unit,
@@ -407,6 +420,8 @@ sealed class OnboardingDaxDialogCta(
         onboardingStore,
         appInstallStore,
     ) {
+        override val markAsReadOnShow: Boolean = true
+
         override fun showOnboardingCta(
             binding: FragmentBrowserTabBinding,
             onPrimaryCtaClicked: () -> Unit,

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -113,6 +113,7 @@ sealed class OnboardingDaxDialogCta(
     }
 
     internal fun setOnboardingDialogView(
+        daxTitle: String? = null,
         daxText: String,
         buttonText: String?,
         binding: FragmentBrowserTabBinding,
@@ -122,7 +123,12 @@ sealed class OnboardingDaxDialogCta(
 
         daxDialog.root.show()
         daxDialog.dialogTextCta.text = ""
+        daxDialog.dialogTextCta.text = ""
         daxDialog.hiddenTextCta.text = daxText.html(binding.root.context)
+        daxTitle?.let {
+            daxDialog.onboardingDialogTitle.show()
+            daxDialog.onboardingDialogTitle.text = daxTitle
+        } ?: daxDialog.onboardingDialogTitle.gone()
         buttonText?.let {
             daxDialog.primaryCta.show()
             daxDialog.primaryCta.alpha = MIN_ALPHA
@@ -384,6 +390,36 @@ sealed class OnboardingDaxDialogCta(
             daxDialog.daxDialogOption2.setOnClickListener { onOptionClicked.invoke(options[1]) }
             daxDialog.daxDialogOption3.setOnClickListener { onOptionClicked.invoke(options[2]) }
             daxDialog.daxDialogOption4.setOnClickListener { onOptionClicked.invoke(options[3]) }
+        }
+    }
+
+    class DaxEndCta(
+        override val onboardingStore: OnboardingStore,
+        override val appInstallStore: AppInstallStore,
+    ) : OnboardingDaxDialogCta(
+        CtaId.DAX_END,
+        R.string.onboardingEndDaxDialogDescription,
+        R.string.daxDialogHighFive,
+        AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
+        AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
+        null,
+        Pixel.PixelValues.DAX_END_CTA,
+        onboardingStore,
+        appInstallStore,
+    ) {
+        override fun showOnboardingCta(
+            binding: FragmentBrowserTabBinding,
+            onPrimaryCtaClicked: () -> Unit,
+            onTypingAnimationFinished: () -> Unit,
+        ) {
+            val context = binding.root.context
+            setOnboardingDialogView(
+                daxTitle = context.getString(R.string.onboardingEndDaxDialogTitle),
+                daxText = description?.let { context.getString(it) }.orEmpty(),
+                buttonText = buttonText?.let { context.getString(it) },
+                binding = binding,
+            )
+            binding.includeOnboardingDaxDialog.primaryCta.setOnClickListener { onPrimaryCtaClicked.invoke() }
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -403,7 +403,7 @@ sealed class OnboardingDaxDialogCta(
         AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
         AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
         null,
-        Pixel.PixelValues.DAX_END_CTA,
+        Pixel.PixelValues.DAX_ONBOARDING_END_CTA,
         onboardingStore,
         appInstallStore,
     ) {

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -80,6 +80,7 @@ interface Cta {
 
 interface OnboardingDaxCta {
     val markAsReadOnShow: Boolean
+        get() = false
 
     fun showOnboardingCta(
         binding: FragmentBrowserTabBinding,
@@ -125,7 +126,6 @@ sealed class OnboardingDaxDialogCta(
 
         daxDialog.root.show()
         daxDialog.dialogTextCta.text = ""
-        daxDialog.dialogTextCta.text = ""
         daxDialog.hiddenTextCta.text = daxText.html(binding.root.context)
         daxTitle?.let {
             daxDialog.onboardingDialogTitle.show()
@@ -159,8 +159,6 @@ sealed class OnboardingDaxDialogCta(
         onboardingStore,
         appInstallStore,
     ) {
-        override val markAsReadOnShow: Boolean = false
-
         override fun showOnboardingCta(
             binding: FragmentBrowserTabBinding,
             onPrimaryCtaClicked: () -> Unit,
@@ -191,8 +189,6 @@ sealed class OnboardingDaxDialogCta(
         onboardingStore,
         appInstallStore,
     ) {
-        override val markAsReadOnShow: Boolean = false
-
         override fun showOnboardingCta(
             binding: FragmentBrowserTabBinding,
             onPrimaryCtaClicked: () -> Unit,
@@ -246,8 +242,6 @@ sealed class OnboardingDaxDialogCta(
         onboardingStore,
         appInstallStore,
     ) {
-        override val markAsReadOnShow: Boolean = false
-
         override fun showOnboardingCta(
             binding: FragmentBrowserTabBinding,
             onPrimaryCtaClicked: () -> Unit,
@@ -298,8 +292,6 @@ sealed class OnboardingDaxDialogCta(
         onboardingStore,
         appInstallStore,
     ) {
-        override val markAsReadOnShow: Boolean = false
-
         override fun showOnboardingCta(
             binding: FragmentBrowserTabBinding,
             onPrimaryCtaClicked: () -> Unit,
@@ -329,8 +321,6 @@ sealed class OnboardingDaxDialogCta(
         onboardingStore,
         appInstallStore,
     ) {
-        override val markAsReadOnShow: Boolean = false
-
         override fun showOnboardingCta(
             binding: FragmentBrowserTabBinding,
             onPrimaryCtaClicked: () -> Unit,
@@ -362,8 +352,6 @@ sealed class OnboardingDaxDialogCta(
         onboardingStore,
         appInstallStore,
     ) {
-        override val markAsReadOnShow: Boolean = false
-
         override fun showOnboardingCta(
             binding: FragmentBrowserTabBinding,
             onPrimaryCtaClicked: () -> Unit,
@@ -618,7 +606,10 @@ sealed class BubbleCta(
             super.showCta(view)
             val accessibilityDelegate: View.AccessibilityDelegate =
                 object : View.AccessibilityDelegate() {
-                    override fun onInitializeAccessibilityNodeInfo(host: View, info: AccessibilityNodeInfo) {
+                    override fun onInitializeAccessibilityNodeInfo(
+                        host: View,
+                        info: AccessibilityNodeInfo,
+                    ) {
                         super.onInitializeAccessibilityNodeInfo(host, info)
                         info.text = host.context?.getString(R.string.daxFavoritesOnboardingCtaContentDescription)
                     }

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -300,6 +300,11 @@ class CtaViewModel @Inject constructor(
                 if (!isSerpUrl(it.url) && !daxDialogOtherShown() && !daxDialogTrackersFoundShown() && !daxDialogNetworkShown()) {
                     return OnboardingDaxDialogCta.DaxNoTrackersCta(onboardingStore, appInstallStore)
                 }
+
+                // End
+                if (canShowDaxCtaEndOfJourney() && daxDialogFireEducationShown()) {
+                    return OnboardingDaxDialogCta.DaxEndCta(onboardingStore, appInstallStore)
+                }
             }
             return null
         }

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -118,6 +118,9 @@ class CtaViewModel @Inject constructor(
                 pixel.fire(it, cta.pixelShownParameters())
             }
         }
+        if (cta is OnboardingDaxDialogCta && cta.markAsReadOnShow) {
+            dismissedCtaDao.insert(DismissedCta(cta.ctaId))
+        }
     }
 
     suspend fun registerDaxBubbleCtaDismissed(cta: Cta) {

--- a/app/src/main/res/layout/include_onboarding_view_dax_dialog.xml
+++ b/app/src/main/res/layout/include_onboarding_view_dax_dialog.xml
@@ -63,6 +63,14 @@
                     android:layout_height="wrap_content"
                     android:orientation="vertical">
 
+                    <com.duckduckgo.common.ui.view.text.DaxTextView
+                        android:id="@+id/onboardingDialogTitle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/onboardingEndDaxDialogTitle"
+                        android:layout_marginBottom="@dimen/keyline_1"
+                        app:typography="h2" />
+
                     <FrameLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content">

--- a/app/src/main/res/layout/pre_onboarding_comparison_chart.xml
+++ b/app/src/main/res/layout/pre_onboarding_comparison_chart.xml
@@ -79,7 +79,7 @@
         app:layout_constraintEnd_toStartOf="@id/chromeLogo"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/chromeLogo"
-        app:typography="body2" />
+        app:typography="body1" />
 
     <com.duckduckgo.common.ui.view.divider.HorizontalDivider
         android:layout_width="0dp"
@@ -118,7 +118,7 @@
         app:layout_constraintEnd_toStartOf="@id/chromeLogo"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/feature1"
-        app:typography="body2" />
+        app:typography="body1" />
 
     <com.duckduckgo.common.ui.view.divider.HorizontalDivider
         android:layout_width="0dp"
@@ -157,7 +157,7 @@
         app:layout_constraintEnd_toStartOf="@id/chromeLogo"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/feature2"
-        app:typography="body2" />
+        app:typography="body1" />
 
     <com.duckduckgo.common.ui.view.divider.HorizontalDivider
         android:layout_width="0dp"
@@ -196,7 +196,7 @@
         app:layout_constraintEnd_toStartOf="@id/chromeLogo"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/feature3"
-        app:typography="body2" />
+        app:typography="body1" />
 
     <com.duckduckgo.common.ui.view.divider.HorizontalDivider
         android:layout_width="0dp"
@@ -235,6 +235,6 @@
         app:layout_constraintEnd_toStartOf="@id/chromeLogo"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/feature4"
-        app:typography="body2" />
+        app:typography="body1" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/pre_onboarding_comparison_chart.xml
+++ b/app/src/main/res/layout/pre_onboarding_comparison_chart.xml
@@ -36,7 +36,7 @@
         android:id="@+id/chromeLogo"
         android:layout_width="wrap_content"
         android:layout_height="55dp"
-        android:layout_marginEnd="@dimen/keyline_5"
+        android:layout_marginEnd="@dimen/keyline_2"
         android:adjustViewBounds="true"
         app:layout_constraintEnd_toStartOf="@id/ddgLogo"
         app:layout_constraintTop_toTopOf="parent"

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -81,6 +81,7 @@ interface Pixel {
         const val DAX_INITIAL_CTA = "i"
         const val DAX_INITIAL_VISIT_SITE_CTA = "visit_site"
         const val DAX_END_CTA = "e"
+        const val DAX_ONBOARDING_END_CTA = "end"
         const val DAX_SERP_CTA = "s"
         const val DAX_NETWORK_CTA_1 = "n"
         const val DAX_TRACKERS_BLOCKED_CTA = "t"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201807753394693/1207353075657638/f

### Description
Add new onboarding _End_ dialog when the onboarding flow finishes without the fire button animation

### Steps to test this PR

- [x] Fresh install
- [x] Go to the browser
- [x] Select a search suggestion
- [x] Tap on 'Got it!' button in the onboarding dialog
- [x] Select a site suggestion
- [x] Tap on 'Got It!' button in the onboarding dialog
- [x] Fire dialog should appear
- [x] Navigate away tapping on a site link or typing something in the search bar
- [x] Check new End dialog will appear ('You've got this!')
- [x] Open a new tap (without dismissing the dialog)
- [x] Check End dialog won't appear in the new tab page

### UI changes
| Light  | Dark |
| ------ | ----- |
![Screenshot_20240605_164050_DuckDuckGo](https://github.com/duckduckgo/Android/assets/20798495/26064df3-9998-438b-bc01-8c32e8028481)|![Screenshot_20240605_164107_DuckDuckGo](https://github.com/duckduckgo/Android/assets/20798495/aa75c135-a30d-49ff-a7a4-eba7d886759d)|
