### PR TITLE
Resize Dax logo in new tab page

### DIFF
--- a/app/src/main/res/layout/include_new_browser_tab.xml
+++ b/app/src/main/res/layout/include_new_browser_tab.xml
@@ -54,9 +54,10 @@
 
                 <ImageView
                     android:id="@+id/ddgLogo"
-                    android:layout_width="wrap_content"
+                    android:layout_width="140dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/homeTabDdgLogoTopMargin"
+                    android:adjustViewBounds="true"
                     android:alpha="0"
                     android:contentDescription="@string/duckDuckGoLogoDescription"
                     android:maxWidth="180dp"

--- a/app/src/main/res/layout/include_new_browser_tab.xml
+++ b/app/src/main/res/layout/include_new_browser_tab.xml
@@ -54,7 +54,7 @@
 
                 <ImageView
                     android:id="@+id/ddgLogo"
-                    android:layout_width="140dp"
+                    android:layout_width="@dimen/ntpDaxLogoIconWidth"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/homeTabDdgLogoTopMargin"
                     android:adjustViewBounds="true"

--- a/common/common-ui/src/main/res/values/design-system-dimensions.xml
+++ b/common/common-ui/src/main/res/values/design-system-dimensions.xml
@@ -120,6 +120,7 @@
     <dimen name="changeAppIconSize">75dp</dimen>
     <dimen name="homeTabDdgLogoTopMargin">100dp</dimen>
     <dimen name="savedSiteGridItemFavicon">56dp</dimen>
+    <dimen name="ntpDaxLogoIconWidth">140dp</dimen>
 
     <dimen name="searchWidgetFavoritesSideMargin">6dp</dimen>
     <dimen name="searchWidgetPadding">16dp</dimen>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1207453843423098/f

### Description
Make new tab page Dax logo smaller

### Steps to test this PR

- [ ] Fresh install
- [ ] Go to bbc.co.uk
- [ ] Dismiss trackers blocked onboarding dialog
- [ ] Open a new tab
- [ ] Perform a search
- [ ] Open a new tab
- [ ] Check Dax icon looks correct

### UI changes
| Before  | After |
| ------ | ----- |
![Screenshot_20240620_131300_DuckDuckGo](https://github.com/duckduckgo/Android/assets/20798495/1e9a618d-e7e6-4607-b03d-66fdd88a7818)|![Screenshot_20240620_131731_DuckDuckGo](https://github.com/duckduckgo/Android/assets/20798495/90833e05-01ef-4daf-9a72-d644784ebf36)|
