### PR TITLE
Add default browser shortcut to Custom Tabs dev setting

### DIFF
--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/customtabs/CustomTabsInternalSettingsActivity.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/customtabs/CustomTabsInternalSettingsActivity.kt
@@ -39,7 +39,7 @@ import timber.log.Timber
 class CustomTabsInternalSettingsActivity : DuckDuckGoActivity() {
 
     private val binding: ActivityCustomTabsInternalSettingsBinding by viewBinding()
-    private lateinit var defaultBrowserActivityResultLauncher: ActivityResultLauncher<Intent>
+    private lateinit var defaultAppActivityResultLauncher: ActivityResultLauncher<Intent>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -51,7 +51,7 @@ class CustomTabsInternalSettingsActivity : DuckDuckGoActivity() {
     }
 
     private fun registerActivityResultLauncher() {
-        defaultBrowserActivityResultLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+        defaultAppActivityResultLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
             updateDefaultBrowserLabel()
         }
     }
@@ -71,7 +71,7 @@ class CustomTabsInternalSettingsActivity : DuckDuckGoActivity() {
         }
 
         binding.defaultBrowser.setOnClickListener {
-            launchDefaultAppActivityForResult(defaultBrowserActivityResultLauncher)
+            launchDefaultAppActivityForResult(defaultAppActivityResultLauncher)
         }
     }
 

--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/customtabs/CustomTabsInternalSettingsActivity.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/customtabs/CustomTabsInternalSettingsActivity.kt
@@ -16,29 +16,47 @@
 
 package com.duckduckgo.app.dev.settings.customtabs
 
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Bundle
 import android.widget.Toast
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.browser.customtabs.CustomTabsIntent
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.ActivityCustomTabsInternalSettingsBinding
+import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserSystemSettings
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.ActivityScope
+import timber.log.Timber
 
 @InjectWith(ActivityScope::class)
 class CustomTabsInternalSettingsActivity : DuckDuckGoActivity() {
 
     private val binding: ActivityCustomTabsInternalSettingsBinding by viewBinding()
+    private lateinit var defaultBrowserActivityResultLauncher: ActivityResultLauncher<Intent>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
         setupToolbar(binding.toolbar)
+        registerActivityResultLauncher()
+        configureListeners()
+        updateDefaultBrowserLabel()
+    }
 
+    private fun registerActivityResultLauncher() {
+        defaultBrowserActivityResultLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+            updateDefaultBrowserLabel()
+        }
+    }
+
+    private fun configureListeners() {
         binding.load.setOnClickListener {
             val url = binding.urlInput.text
             if (url.isNotBlank()) {
@@ -47,6 +65,31 @@ class CustomTabsInternalSettingsActivity : DuckDuckGoActivity() {
                 } else {
                     openCustomTab(url)
                 }
+            } else {
+                Toast.makeText(this, getString(R.string.customTabsEmptyUrl), Toast.LENGTH_SHORT).show()
+            }
+        }
+
+        binding.defaultBrowser.setOnClickListener {
+            launchDefaultAppActivityForResult(defaultBrowserActivityResultLauncher)
+        }
+    }
+
+    private fun updateDefaultBrowserLabel() {
+        binding.defaultBrowser.setSecondaryText(getDefaultBrowserLabel())
+    }
+
+    private fun getDefaultBrowserLabel(): String? {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://duckduckgo.com/"))
+        val resolveInfo = packageManager.resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY)
+
+        return resolveInfo?.let {
+            try {
+                val appInfo = packageManager.getApplicationInfo(it.activityInfo.packageName, 0)
+                packageManager.getApplicationLabel(appInfo).toString()
+            } catch (e: PackageManager.NameNotFoundException) {
+                e.printStackTrace()
+                null
             }
         }
     }
@@ -57,6 +100,17 @@ class CustomTabsInternalSettingsActivity : DuckDuckGoActivity() {
             customTabsIntent.launchUrl(this, Uri.parse(url))
         }.onFailure {
             Toast.makeText(this, getString(R.string.customTabsInvalidUrl), Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun launchDefaultAppActivityForResult(activityLauncher: ActivityResultLauncher<Intent>) {
+        try {
+            val intent = DefaultBrowserSystemSettings.intent()
+            activityLauncher.launch(intent)
+        } catch (e: ActivityNotFoundException) {
+            val errorMessage = getString(R.string.cannotLaunchDefaultAppSettings)
+            Timber.w(errorMessage)
+            Toast.makeText(this, errorMessage, Toast.LENGTH_SHORT).show()
         }
     }
 

--- a/app/src/internal/res/layout/activity_custom_tabs_internal_settings.xml
+++ b/app/src/internal/res/layout/activity_custom_tabs_internal_settings.xml
@@ -63,4 +63,13 @@
         app:layout_constraintTop_toBottomOf="@id/urlInput"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
+
+    <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+        android:id="@+id/defaultBrowser"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@id/load"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:primaryText="@string/customTabsDefaultBrowserTitle" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/internal/res/values/donottranslate.xml
+++ b/app/src/internal/res/values/donottranslate.xml
@@ -84,5 +84,7 @@
     <string name="customTabsLoad">Load Custom Tab</string>
     <string name="customTabsUrlHint">Add your URL here</string>
     <string name="customTabsInvalidUrl">Invalid URL</string>
+    <string name="customTabsEmptyUrl">Enter a URL</string>
+    <string name="customTabsDefaultBrowserTitle">Default Browser</string>
 
 </resources>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207482546194311/f

### Description
Adds a default browser shortcut to easily change the default browser when testing Custom Tabs.

### Steps to test this PR

- [x] Go to Developer Settings > Custom Tabs
- [x] Tap “Default Browser"
- [x] Choose a default browser
- [x] Go back to the Custom Tabs dev screen
- [x] Verify that the selected browser’s name is displayed

### UI changes
| Before  | After |
| ------ | ----- |
![Screenshot_20240605_000905](https://github.com/duckduckgo/Android/assets/3471025/6dae2e67-920b-43f4-a926-4be35dfcb771)|![Screenshot_20240604_234704](https://github.com/duckduckgo/Android/assets/3471025/1d35cb94-4a91-4aff-b92e-83c889e65f83)


