### PR TITLE
Force Algorithmically dark mode

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/appearance/AppearanceActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/appearance/AppearanceActivity.kt
@@ -86,7 +86,6 @@ class AppearanceActivity : DuckDuckGoActivity() {
     private fun configureUiEventHandlers() {
         binding.selectedThemeSetting.setClickListener { viewModel.userRequestedToChangeTheme() }
         binding.changeAppIconSetting.setOnClickListener { viewModel.userRequestedToChangeIcon() }
-        binding.experimentalNightMode.setOnCheckedChangeListener(forceDarkModeToggleListener)
     }
 
     private fun observeViewModel() {

--- a/app/src/main/java/com/duckduckgo/app/appearance/AppearanceActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/appearance/AppearanceActivity.kt
@@ -79,6 +79,7 @@ class AppearanceActivity : DuckDuckGoActivity() {
                     updateSelectedTheme(it.theme)
                     binding.changeAppIcon.setImageResource(it.appIcon.icon)
                     binding.experimentalNightMode.quietlySetIsChecked(viewState.forceDarkModeEnabled, forceDarkModeToggleListener)
+                    binding.experimentalNightMode.isEnabled = viewState.canForceDarkMode
                 }
             }.launchIn(lifecycleScope)
 

--- a/app/src/main/java/com/duckduckgo/app/appearance/AppearanceActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/appearance/AppearanceActivity.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.appearance
 
 import android.os.Bundle
+import android.widget.CompoundButton
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -31,6 +32,7 @@ import com.duckduckgo.common.ui.sendThemeChangedBroadcast
 import com.duckduckgo.common.ui.view.dialog.RadioListAlertDialogBuilder
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.ActivityScope
+import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import timber.log.Timber
@@ -41,6 +43,11 @@ class AppearanceActivity : DuckDuckGoActivity() {
 
     private val viewModel: AppearanceViewModel by bindViewModel()
     private val binding: ActivityAppearanceBinding by viewBinding()
+
+    private val forceDarkModeToggleListener = CompoundButton.OnCheckedChangeListener { view, isChecked ->
+        viewModel.onForceDarkModeSettingChanged(isChecked)
+        Snackbar.make(view, getString(R.string.appearanceNightModeWarning), Snackbar.LENGTH_SHORT).show()
+    }
 
     private val changeIconFlow = registerForActivityResult(ChangeIconContract()) { resultOk ->
         if (resultOk) {
@@ -61,6 +68,7 @@ class AppearanceActivity : DuckDuckGoActivity() {
     private fun configureUiEventHandlers() {
         binding.selectedThemeSetting.setClickListener { viewModel.userRequestedToChangeTheme() }
         binding.changeAppIconSetting.setOnClickListener { viewModel.userRequestedToChangeIcon() }
+        binding.experimentalNightMode.setOnCheckedChangeListener(forceDarkModeToggleListener)
     }
 
     private fun observeViewModel() {
@@ -70,6 +78,7 @@ class AppearanceActivity : DuckDuckGoActivity() {
                 viewState.let {
                     updateSelectedTheme(it.theme)
                     binding.changeAppIcon.setImageResource(it.appIcon.icon)
+                    binding.experimentalNightMode.quietlySetIsChecked(viewState.forceDarkModeEnabled, forceDarkModeToggleListener)
                 }
             }.launchIn(lifecycleScope)
 

--- a/app/src/main/java/com/duckduckgo/app/appearance/AppearanceActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/appearance/AppearanceActivity.kt
@@ -26,13 +26,14 @@ import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.appearance.AppearanceViewModel.Command
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.ActivityAppearanceBinding
+import com.duckduckgo.app.fire.FireActivity
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.DuckDuckGoTheme
 import com.duckduckgo.common.ui.sendThemeChangedBroadcast
 import com.duckduckgo.common.ui.view.dialog.RadioListAlertDialogBuilder
+import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.ActivityScope
-import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import timber.log.Timber
@@ -46,7 +47,24 @@ class AppearanceActivity : DuckDuckGoActivity() {
 
     private val forceDarkModeToggleListener = CompoundButton.OnCheckedChangeListener { view, isChecked ->
         viewModel.onForceDarkModeSettingChanged(isChecked)
-        Snackbar.make(view, getString(R.string.appearanceNightModeWarning), Snackbar.LENGTH_SHORT).show()
+
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.appearanceNightModeDialogTitle)
+            .setMessage(R.string.appearanceNightModeDialogMessage)
+            .setPositiveButton(R.string.appearanceNightModeDialogPrimaryCTA)
+            .setNegativeButton(R.string.appearanceNightModeDialogSecondaryCTA)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() {
+                        FireActivity.triggerRestart(baseContext, false)
+                    }
+
+                    override fun onNegativeButtonClicked() {
+                        // no-op
+                    }
+                },
+            )
+            .show()
     }
 
     private val changeIconFlow = registerForActivityResult(ChangeIconContract()) { resultOk ->

--- a/app/src/main/java/com/duckduckgo/app/appearance/AppearanceViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/appearance/AppearanceViewModel.kt
@@ -46,6 +46,7 @@ class AppearanceViewModel @Inject constructor(
     data class ViewState(
         val theme: DuckDuckGoTheme = DuckDuckGoTheme.LIGHT,
         val appIcon: AppIcon = AppIcon.DEFAULT,
+        val forceDarkModeEnabled: Boolean = false,
     )
 
     sealed class Command {
@@ -63,6 +64,7 @@ class AppearanceViewModel @Inject constructor(
                 currentViewState().copy(
                     theme = themingDataStore.theme,
                     appIcon = settingsDataStore.appIcon,
+                    forceDarkModeEnabled = settingsDataStore.experimentalWebsiteDarkMode,
                 ),
             )
         }
@@ -105,5 +107,9 @@ class AppearanceViewModel @Inject constructor(
 
     private fun currentViewState(): ViewState {
         return viewState.value
+    }
+
+    fun onForceDarkModeSettingChanged(checked: Boolean) {
+        settingsDataStore.experimentalWebsiteDarkMode = checked
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/appearance/AppearanceViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/appearance/AppearanceViewModel.kt
@@ -100,7 +100,7 @@ class AppearanceViewModel @Inject constructor(
         viewModelScope.launch(dispatcherProvider.io()) {
             themingDataStore.theme = selectedTheme
             withContext(dispatcherProvider.main()) {
-                viewState.emit(currentViewState().copy(theme = selectedTheme))
+                viewState.emit(currentViewState().copy(theme = selectedTheme, forceDarkModeEnabled = !appTheme.isLightModeEnabled()))
                 command.send(Command.UpdateTheme)
             }
         }
@@ -120,6 +120,11 @@ class AppearanceViewModel @Inject constructor(
 
     fun onForceDarkModeSettingChanged(checked: Boolean) {
         viewModelScope.launch(dispatcherProvider.io()) {
+            if (checked) {
+                pixel.fire(AppPixelName.FORCE_DARK_MODE_ENABLED)
+            } else {
+                pixel.fire(AppPixelName.FORCE_DARK_MODE_DISABLED)
+            }
             settingsDataStore.experimentalWebsiteDarkMode = checked
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/appearance/AppearanceViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/appearance/AppearanceViewModel.kt
@@ -24,7 +24,6 @@ import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.ui.DuckDuckGoTheme
-import com.duckduckgo.common.ui.store.AppTheme
 import com.duckduckgo.common.ui.store.ThemingDataStore
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
@@ -42,7 +41,6 @@ import timber.log.Timber
 @ContributesViewModel(ActivityScope::class)
 class AppearanceViewModel @Inject constructor(
     private val themingDataStore: ThemingDataStore,
-    private val appTheme: AppTheme,
     private val settingsDataStore: SettingsDataStore,
     private val pixel: Pixel,
     private val dispatcherProvider: DispatcherProvider,
@@ -71,7 +69,7 @@ class AppearanceViewModel @Inject constructor(
                     theme = themingDataStore.theme,
                     appIcon = settingsDataStore.appIcon,
                     forceDarkModeEnabled = settingsDataStore.experimentalWebsiteDarkMode,
-                    canForceDarkMode = !appTheme.isLightModeEnabled(),
+                    canForceDarkMode = themingDataStore.theme != DuckDuckGoTheme.LIGHT,
                 ),
             )
         }
@@ -100,7 +98,7 @@ class AppearanceViewModel @Inject constructor(
         viewModelScope.launch(dispatcherProvider.io()) {
             themingDataStore.theme = selectedTheme
             withContext(dispatcherProvider.main()) {
-                viewState.emit(currentViewState().copy(theme = selectedTheme, forceDarkModeEnabled = !appTheme.isLightModeEnabled()))
+                viewState.emit(currentViewState().copy(theme = selectedTheme, forceDarkModeEnabled = selectedTheme != DuckDuckGoTheme.LIGHT))
                 command.send(Command.UpdateTheme)
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/appearance/AppearanceViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/appearance/AppearanceViewModel.kt
@@ -47,6 +47,7 @@ class AppearanceViewModel @Inject constructor(
         val theme: DuckDuckGoTheme = DuckDuckGoTheme.LIGHT,
         val appIcon: AppIcon = AppIcon.DEFAULT,
         val forceDarkModeEnabled: Boolean = false,
+        val canForceDarkMode: Boolean = false,
     )
 
     sealed class Command {
@@ -65,6 +66,7 @@ class AppearanceViewModel @Inject constructor(
                     theme = themingDataStore.theme,
                     appIcon = settingsDataStore.appIcon,
                     forceDarkModeEnabled = settingsDataStore.experimentalWebsiteDarkMode,
+                    canForceDarkMode = themingDataStore.theme != DuckDuckGoTheme.LIGHT,
                 ),
             )
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -181,6 +181,7 @@ import com.duckduckgo.app.location.data.LocationPermissionType
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.playstore.PlayStoreUtils
 import com.duckduckgo.app.privatesearch.PrivateSearchScreenNoParams
+import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.FIRE_BUTTON_STATE
 import com.duckduckgo.app.survey.model.Survey
@@ -484,6 +485,9 @@ class BrowserTabFragment :
 
     @Inject
     lateinit var dummyWebMessageListenerFeature: DummyWebMessageListenerFeature
+
+    @Inject
+    lateinit var settingsDataStore: SettingsDataStore
 
     @Inject
     lateinit var webViewVersionProvider: WebViewVersionProvider
@@ -2295,6 +2299,7 @@ class BrowserTabFragment :
                 if (accessibilitySettingsDataStore.overrideSystemFontSize) {
                     textZoom = accessibilitySettingsDataStore.fontSize.toInt()
                 }
+                isAlgorithmicDarkeningAllowed = settingsDataStore.experimentalWebsiteDarkMode
             }
 
             it.setDownloadListener { url, _, contentDisposition, mimeType, _ ->

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1194,7 +1194,10 @@ class BrowserTabFragment :
         sslErrorView.gone()
     }
 
-    private fun showError(errorType: WebViewErrorResponse, url: String?) {
+    private fun showError(
+        errorType: WebViewErrorResponse,
+        url: String?,
+    ) {
         webViewContainer.gone()
         newBrowserTab.newTabLayout.gone()
         sslErrorView.gone()
@@ -1567,7 +1570,10 @@ class BrowserTabFragment :
         }
     }
 
-    private fun showWebPageTitleInCustomTab(title: String, url: String?) {
+    private fun showWebPageTitleInCustomTab(
+        title: String,
+        url: String?,
+    ) {
         if (isActiveCustomTab()) {
             omnibar.customTabToolbarContainer.customTabTitle.text = title
 
@@ -2299,7 +2305,7 @@ class BrowserTabFragment :
                 if (accessibilitySettingsDataStore.overrideSystemFontSize) {
                     textZoom = accessibilitySettingsDataStore.fontSize.toInt()
                 }
-                isAlgorithmicDarkeningAllowed = settingsDataStore.experimentalWebsiteDarkMode
+                setAlgorithmicDarkeningAllowed(this)
             }
 
             it.setDownloadListener { url, _, contentDisposition, mimeType, _ ->
@@ -2583,6 +2589,12 @@ class BrowserTabFragment :
         settings.databaseEnabled = false
     }
 
+    @Suppress("NewApi") // This API and the behaviour described only apply to apps with targetSdkVersion ≥ TIRAMISU.
+    private fun setAlgorithmicDarkeningAllowed(settings: WebSettings) {
+        // https://developer.android.com/reference/androidx/webkit/WebSettingsCompat#setAlgorithmicDarkeningAllowed(android.webkit.WebSettings,boolean)
+        settings.isAlgorithmicDarkeningAllowed = settingsDataStore.experimentalWebsiteDarkMode
+    }
+
     private fun addTextChangedListeners() {
         findInPage.findInPageInput.replaceTextChangedListener(findInPageTextWatcher)
         omnibar.omnibarTextInput.replaceTextChangedListener(omnibarInputTextWatcher)
@@ -2766,7 +2778,10 @@ class BrowserTabFragment :
         ).show()
     }
 
-    private fun launchSharePageChooser(url: String, title: String) {
+    private fun launchSharePageChooser(
+        url: String,
+        title: String,
+    ) {
         val intent = Intent(Intent.ACTION_SEND).also {
             it.type = "text/plain"
             it.putExtra(Intent.EXTRA_TEXT, url)
@@ -2780,7 +2795,10 @@ class BrowserTabFragment :
         }
     }
 
-    private fun launchSharePromoRMFPageChooser(url: String, shareTitle: String) {
+    private fun launchSharePromoRMFPageChooser(
+        url: String,
+        shareTitle: String,
+    ) {
         val share = Intent().apply {
             action = Intent.ACTION_SEND
             putExtra(Intent.EXTRA_TEXT, url)
@@ -3008,14 +3026,21 @@ class BrowserTabFragment :
         showDialogHidingPrevious(downloadConfirmationFragment, DOWNLOAD_CONFIRMATION_TAG)
     }
 
-    private fun launchFilePicker(filePathCallback: ValueCallback<Array<Uri>>, fileChooserParams: FileChooserRequestedParams) {
+    private fun launchFilePicker(
+        filePathCallback: ValueCallback<Array<Uri>>,
+        fileChooserParams: FileChooserRequestedParams,
+    ) {
         pendingUploadTask = filePathCallback
         val canChooseMultipleFiles = fileChooserParams.filePickingMode == FileChooserParams.MODE_OPEN_MULTIPLE
         val intent = fileChooserIntentBuilder.intent(fileChooserParams.acceptMimeTypes.toTypedArray(), canChooseMultipleFiles)
         startActivityForResult(intent, REQUEST_CODE_CHOOSE_FILE)
     }
 
-    private fun launchCameraCapture(filePathCallback: ValueCallback<Array<Uri>>, fileChooserParams: FileChooserRequestedParams, inputAction: String) {
+    private fun launchCameraCapture(
+        filePathCallback: ValueCallback<Array<Uri>>,
+        fileChooserParams: FileChooserRequestedParams,
+        inputAction: String,
+    ) {
         if (Intent(inputAction).resolveActivity(requireContext().packageManager) == null) {
             launchFilePicker(filePathCallback, fileChooserParams)
             return
@@ -4018,7 +4043,10 @@ class BrowserTabFragment :
             (!viewState.isEditing || omnibarInput.isNullOrEmpty()) && omnibar.omnibarTextInput.isDifferent(omnibarInput)
     }
 
-    private fun launchPrint(url: String, defaultMediaSize: PrintAttributes.MediaSize) {
+    private fun launchPrint(
+        url: String,
+        defaultMediaSize: PrintAttributes.MediaSize,
+    ) {
         (activity?.getSystemService(Context.PRINT_SERVICE) as? PrintManager)?.let { printManager ->
             webView?.createPrintDocumentAdapter(url)?.let { printAdapter ->
                 printManager.print(
@@ -4074,7 +4102,10 @@ private class JsOrientationHandler {
      *
      * @return response data
      */
-    fun updateOrientation(data: JsCallbackData, browserTabFragment: BrowserTabFragment): JsCallbackData {
+    fun updateOrientation(
+        data: JsCallbackData,
+        browserTabFragment: BrowserTabFragment,
+    ): JsCallbackData {
         val activity = browserTabFragment.activity
         val response = if (activity == null) {
             NO_ACTIVITY_ERROR
@@ -4100,7 +4131,10 @@ private class JsOrientationHandler {
         )
     }
 
-    private enum class JsToNativeScreenOrientationMap(val jsValue: String, val nativeValue: Int) {
+    private enum class JsToNativeScreenOrientationMap(
+        val jsValue: String,
+        val nativeValue: Int,
+    ) {
         ANY("any", ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED),
         NATURAL("natural", ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED),
         LANDSCAPE("landscape", ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE),

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -297,4 +297,7 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
 
     DMA_CHOICE_SCREEN_SEARCH_CHOICE_LEGACY_INSTALL("m_dma_search_choice_legacy_install"),
     DMA_CHOICE_SCREEN_DEFAULT_BROWSER_LEGACY_INSTALL("m_dma_default_browser_legacy_install"),
+
+    FORCE_DARK_MODE_ENABLED("ms_forced_dark_toggled_on"),
+    FORCE_DARK_MODE_DISABLED("ms_forced_dark_toggled_off"),
 }

--- a/app/src/main/java/com/duckduckgo/app/settings/db/SettingsDataStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/db/SettingsDataStore.kt
@@ -66,6 +66,7 @@ interface SettingsDataStore {
     var appBackgroundedTimestamp: Long
     var appNotificationsEnabled: Boolean
     var notifyMeInDownloadsDismissed: Boolean
+    var experimentalWebsiteDarkMode: Boolean
 
     fun isCurrentlySelected(clearWhatOption: ClearWhatOption): Boolean
     fun isCurrentlySelected(clearWhenOption: ClearWhenOption): Boolean
@@ -221,6 +222,10 @@ class SettingsSharedPreferences @Inject constructor(
         }
     }
 
+    override var experimentalWebsiteDarkMode: Boolean
+        get() = preferences.getBoolean(KEY_EXPERIMENTAL_SITE_DARK_MODE, false)
+        set(enabled) = preferences.edit { putBoolean(KEY_EXPERIMENTAL_SITE_DARK_MODE, enabled) }
+
     companion object {
         const val FILENAME = "com.duckduckgo.app.settings_activity.settings"
         const val KEY_BACKGROUND_JOB_ID = "BACKGROUND_JOB_ID"
@@ -242,6 +247,7 @@ class SettingsSharedPreferences @Inject constructor(
         const val SHOW_APP_LINKS_PROMPT = "SHOW_APP_LINKS_PROMPT"
         const val SHOW_AUTOMATIC_FIREPROOF_DIALOG = "SHOW_AUTOMATIC_FIREPROOF_DIALOG"
         const val KEY_NOTIFY_ME_IN_DOWNLOADS_DISMISSED = "KEY_NOTIFY_ME_IN_DOWNLOADS_DISMISSED"
+        const val KEY_EXPERIMENTAL_SITE_DARK_MODE = "KEY_EXPERIMENTAL_SITE_DARK_MODE"
     }
 
     private class FireAnimationPrefsMapper {

--- a/app/src/main/res/layout/activity_appearance.xml
+++ b/app/src/main/res/layout/activity_appearance.xml
@@ -77,6 +77,17 @@
                     tools:srcCompat="@mipmap/ic_launcher_red_round" />
 
             </LinearLayout>
+
+            <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+                android:id="@+id/experimentalNightMode"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/keyline_4"
+                app:primaryText="@string/appearanceNightModeTitle"
+                app:primaryTextTruncated="false"
+                app:showSwitch="true"
+                app:secondaryText="@string/appearanceNightModeSecondary" />
+
         </LinearLayout>
     </ScrollView>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_appearance.xml
+++ b/app/src/main/res/layout/activity_appearance.xml
@@ -47,6 +47,15 @@
                 app:primaryTextTruncated="false"
                 app:secondaryText="@string/settingsSystemTheme" />
 
+            <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+                android:id="@+id/experimentalNightMode"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="@string/appearanceNightModeTitle"
+                app:primaryTextTruncated="false"
+                app:showSwitch="true"
+                app:secondaryText="@string/appearanceNightModeSecondary" />
+
             <LinearLayout
                 android:id="@+id/changeAppIconSetting"
                 android:layout_width="match_parent"
@@ -77,16 +86,6 @@
                     tools:srcCompat="@mipmap/ic_launcher_red_round" />
 
             </LinearLayout>
-
-            <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
-                android:id="@+id/experimentalNightMode"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/keyline_4"
-                app:primaryText="@string/appearanceNightModeTitle"
-                app:primaryTextTruncated="false"
-                app:showSwitch="true"
-                app:secondaryText="@string/appearanceNightModeSecondary" />
 
         </LinearLayout>
     </ScrollView>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -55,8 +55,8 @@
     <string name="openAutoCompleteSettings">Open Settings</string>
 
     <!-- Force Dark Mode -->
-    <string name="appearanceNightModeTitle">Force Experimental Dark Mode</string>
-    <string name="appearanceNightModeSecondary">Websites render with the styling modified to dark colors by an algorithm if allowed by the content author.</string>
-    <string name="appearanceNightModeWarning">These changes will take effect the next time you relaunch Brave or a New Tab is created</string>
+    <string name="appearanceNightModeTitle">Auto Dark Mode on Web Sites (experimental)</string>
+    <string name="appearanceNightModeSecondary">Display websites in a dark theme if allowed by the website.</string>
+    <string name="appearanceNightModeWarning">These changes will take effect the next time you relaunch DuckDuckGo or create a New Tab</string>
 
 </resources>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -46,4 +46,17 @@
     <string name="audioCaptureSoundRecorderPermissionDeniedTitle">Allow DuckDuckGo to ask for sound recorder access on this device</string>
     <string name="audioCaptureSoundRecorderPermissionDeniedMessage">Sites can only use the sound recorder if you allow DuckDuckGo to ask for access.</string>
 
+    <!-- Private Search -->
+    <string name="privateSearchAutocompleteRecentlyVisitedSitesToggle">Include Recently Visited Sites</string>
+    <string name="privateSearchAutocompleteHint">See private search suggestions as you type, including your bookmarks</string>
+    <string name="privateSearchAutocompleteRecentlyVisitedSitesHint">Also include recently visited sites in private search suggestions. Recent sites are only stored on your device and can be cleared with the Fire Button</string>
+    <string name="improvedAutoCompleteIAMTitle">Same privacy.\nBetter search suggestions!</string>
+    <string name="improvedAutoCompleteIAMContent">Suggestions now include recently visited sites. These are stored on your device and never on DuckDuckGo\'s servers. Turn off in settings or clear any time with the 🔥 Fire Button.</string>
+    <string name="openAutoCompleteSettings">Open Settings</string>
+
+    <!-- Force Dark Mode -->
+    <string name="appearanceNightModeTitle">Force Experimental Dark Mode</string>
+    <string name="appearanceNightModeSecondary">Websites render with the styling modified to dark colors by an algorithm if allowed by the content author.</string>
+    <string name="appearanceNightModeWarning">These changes will take effect the next time you relaunch Brave or a New Tab is created</string>
+
 </resources>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -57,6 +57,9 @@
     <!-- Force Dark Mode -->
     <string name="appearanceNightModeTitle">Auto Dark Mode on Web Sites (experimental)</string>
     <string name="appearanceNightModeSecondary">Display websites in a dark theme if allowed by the website.</string>
-    <string name="appearanceNightModeWarning">These changes will take effect the next time you relaunch DuckDuckGo or create a New Tab</string>
+    <string name="appearanceNightModeDialogTitle">Relaunch app?</string>
+    <string name="appearanceNightModeDialogMessage">These changes will take effect the next time you relaunch DuckDuckGo or create a New Tab</string>
+    <string name="appearanceNightModeDialogPrimaryCTA">Relaunch now</string>
+    <string name="appearanceNightModeDialogSecondaryCTA">Not now</string>
 
 </resources>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -47,11 +47,11 @@
     <string name="audioCaptureSoundRecorderPermissionDeniedMessage">Sites can only use the sound recorder if you allow DuckDuckGo to ask for access.</string>
 
     <!-- Force Dark Mode -->
-    <string name="appearanceNightModeTitle">Force Dark Theme on Websites</string>
+    <string name="appearanceNightModeTitle">Force Websites To Use Dark Theme</string>
     <string name="appearanceNightModeSecondary">Supported sites will use a darker theme when the app is in dark mode</string>
     <string name="appearanceNightModeDialogTitle">Relaunch app?</string>
     <string name="appearanceNightModeDialogMessage">This will take effect for new tabs or after relaunching DuckDuckGo.</string>
-    <string name="appearanceNightModeDialogPrimaryCTA">Relaunch now</string>
+    <string name="appearanceNightModeDialogPrimaryCTA">Relaunch Now</string>
     <string name="appearanceNightModeDialogSecondaryCTA">Dismiss</string>
 
 </resources>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -46,20 +46,12 @@
     <string name="audioCaptureSoundRecorderPermissionDeniedTitle">Allow DuckDuckGo to ask for sound recorder access on this device</string>
     <string name="audioCaptureSoundRecorderPermissionDeniedMessage">Sites can only use the sound recorder if you allow DuckDuckGo to ask for access.</string>
 
-    <!-- Private Search -->
-    <string name="privateSearchAutocompleteRecentlyVisitedSitesToggle">Include Recently Visited Sites</string>
-    <string name="privateSearchAutocompleteHint">See private search suggestions as you type, including your bookmarks</string>
-    <string name="privateSearchAutocompleteRecentlyVisitedSitesHint">Also include recently visited sites in private search suggestions. Recent sites are only stored on your device and can be cleared with the Fire Button</string>
-    <string name="improvedAutoCompleteIAMTitle">Same privacy.\nBetter search suggestions!</string>
-    <string name="improvedAutoCompleteIAMContent">Suggestions now include recently visited sites. These are stored on your device and never on DuckDuckGo\'s servers. Turn off in settings or clear any time with the 🔥 Fire Button.</string>
-    <string name="openAutoCompleteSettings">Open Settings</string>
-
     <!-- Force Dark Mode -->
-    <string name="appearanceNightModeTitle">Auto Dark Mode on Web Sites (experimental)</string>
-    <string name="appearanceNightModeSecondary">Display websites in a dark theme if allowed by the website.</string>
+    <string name="appearanceNightModeTitle">Force Dark Theme on Websites</string>
+    <string name="appearanceNightModeSecondary">Supported sites will use a darker theme when the app is in dark mode</string>
     <string name="appearanceNightModeDialogTitle">Relaunch app?</string>
-    <string name="appearanceNightModeDialogMessage">These changes will take effect the next time you relaunch DuckDuckGo or create a New Tab</string>
+    <string name="appearanceNightModeDialogMessage">This will take effect for new tabs or after relaunching DuckDuckGo.</string>
     <string name="appearanceNightModeDialogPrimaryCTA">Relaunch now</string>
-    <string name="appearanceNightModeDialogSecondaryCTA">Not now</string>
+    <string name="appearanceNightModeDialogSecondaryCTA">Dismiss</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -654,7 +654,7 @@
 
     <!-- MacOs Settings -->
     <string name="macos_settings_description">Browse privately with our app for Mac</string>
-    <string name="macos_settings_title">DuckDuckGo Mac App</string>
+    <string name="macos_settings_title">DuckDuckGo Mac Browser</string>
 
     <!-- Downloads -->
     <string name="downloadsMenuItem">Downloads</string>
@@ -716,7 +716,7 @@
     <string name="downloadsNotifyMeSubtitle">Get a notification when downloads complete.</string>
 
     <!-- Windows Settings -->
-    <string name="windows_settings_title">DuckDuckGo Windows App</string>
+    <string name="windows_settings_title">DuckDuckGo Windows Browser</string>
     <string name="windows_settings_description">Browse privately with our app for Windows</string>
     <string name="windows_settings_description_ready">Download available</string>
     <string name="windows_settings_description_list">You\'re on the list!</string>

--- a/app/src/test/java/com/duckduckgo/app/appearance/AppearanceViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/appearance/AppearanceViewModelTest.kt
@@ -170,9 +170,17 @@ internal class AppearanceViewModelTest {
     }
 
     @Test
-    fun whenForceDarkModeSettingChangeThenStoreUpdated() = runTest {
+    fun whenForceDarkModeSettingEnabledChangeThenStoreUpdated() = runTest {
         testee.onForceDarkModeSettingChanged(true)
         verify(mockAppSettingsDataStore).experimentalWebsiteDarkMode = true
+        verify(mockPixel).fire(AppPixelName.FORCE_DARK_MODE_ENABLED)
+    }
+
+    @Test
+    fun whenForceDarkModeSettingDisabledChangeThenStoreUpdated() = runTest {
+        testee.onForceDarkModeSettingChanged(false)
+        verify(mockAppSettingsDataStore).experimentalWebsiteDarkMode = false
+        verify(mockPixel).fire(AppPixelName.FORCE_DARK_MODE_DISABLED)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/appearance/AppearanceViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/appearance/AppearanceViewModelTest.kt
@@ -71,7 +71,6 @@ internal class AppearanceViewModelTest {
 
         testee = AppearanceViewModel(
             mockThemeSettingsDataStore,
-            mockAppTheme,
             mockAppSettingsDataStore,
             mockPixel,
             coroutineTestRule.testDispatcherProvider,

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/store/AppTheme.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/store/AppTheme.kt
@@ -25,7 +25,6 @@ import dagger.SingleInstanceIn
 import javax.inject.Inject
 
 interface AppTheme {
-    fun getAppTheme(): DuckDuckGoTheme
     fun isLightModeEnabled(): Boolean
 }
 
@@ -35,10 +34,6 @@ class BrowserAppTheme @Inject constructor(
     private val context: Context,
     private val themeDataStore: ThemingDataStore,
 ) : AppTheme {
-
-    override fun getAppTheme(): DuckDuckGoTheme {
-        return getAppTheme()
-    }
 
     override fun isLightModeEnabled(): Boolean {
         return when (themeDataStore.theme) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/715106103902962/1206630026838095/f

### Description
This PR adds support for [algorithmically forced dark mode.](https://developer.android.com/reference/androidx/webkit/WebSettingsCompat#setAlgorithmicDarkeningAllowed(android.webkit.WebSettings,boolean))

### Steps to test this PR

_Dark mode_
- [x] Launch app and enable dark theme.
- [x] Open http://permission.site.
- [x] Verify site is displayed in light theme.
- [x] Open Settings / Appearance and enable Force Dark Mode.
- [x] Restart the app so changes take effect.
- [x] Open http://permission.site.
- [x] Verify site is displayed in dark theme.

### UI changes
| Before  | After |
| ------ | ------
|![Screenshot_20240605_125706](https://github.com/duckduckgo/Android/assets/531613/e4b1c23d-b64d-4ff4-baf3-0c0b844c1524)|![Screenshot_20240605_125744](https://github.com/duckduckgo/Android/assets/531613/32ecb093-80ec-4435-8ace-ee407f1eab1c)|