### PR TITLE
Fix: force load config reports success with invalid URLs

### DIFF
--- a/privacy-config/privacy-config-internal/src/main/java/com/duckduckgo/privacy/config/internal/PrivacyConfigInternalViewModel.kt
+++ b/privacy-config/privacy-config-internal/src/main/java/com/duckduckgo/privacy/config/internal/PrivacyConfigInternalViewModel.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.privacy.config.internal.PrivacyConfigInternalViewModel.Com
 import com.duckduckgo.privacy.config.internal.store.DevPrivacyConfigSettingsDataStore
 import com.duckduckgo.privacy.config.store.PrivacyConfig
 import com.duckduckgo.privacy.config.store.PrivacyConfigRepository
+import java.net.URI
 import javax.inject.Inject
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.channels.Channel
@@ -40,7 +41,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
-import java.net.URI
 
 @ContributesViewModel(ActivityScope::class)
 class PrivacyConfigInternalViewModel @Inject constructor(

--- a/privacy-config/privacy-config-internal/src/main/java/com/duckduckgo/privacy/config/internal/PrivacyConfigInternalViewModel.kt
+++ b/privacy-config/privacy-config-internal/src/main/java/com/duckduckgo/privacy/config/internal/PrivacyConfigInternalViewModel.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
+import java.net.URI
 
 @ContributesViewModel(ActivityScope::class)
 class PrivacyConfigInternalViewModel @Inject constructor(
@@ -98,7 +99,8 @@ class PrivacyConfigInternalViewModel @Inject constructor(
     fun canUrlBeChanged(): Boolean {
         val storedUrl = store.remotePrivacyConfigUrl
         val isCustomSettingEnabled = store.useCustomPrivacyConfigUrl
-        val canBeChanged = isCustomSettingEnabled && !storedUrl.isNullOrEmpty() && URLUtil.isValidUrl(storedUrl)
+        val validHost = runCatching { URI(storedUrl).host.isNotEmpty() }.getOrDefault(false)
+        val canBeChanged = isCustomSettingEnabled && !storedUrl.isNullOrEmpty() && URLUtil.isValidUrl(storedUrl) && validHost
         store.canUrlBeChanged = canBeChanged
         return canBeChanged
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204912272578138/1207434405087911/f

### Description
Ditto

### Steps to test this PR
- [x] Go to Developer Settings --> Override Privacy Remote Config URL
- [x] Enable custom config
- [x] Type in an invalid URL e.g., `http://example.com:3000:3000/config`
- [x] "Force load config" should be disabled
