### PR TITLE
Add WebView version check to no-op WebMessageListener

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2350,7 +2350,7 @@ class BrowserTabFragment :
         lifecycleScope.launch(dispatchers.main()) {
             val (isFeatureEnabled, isSupportedWebViewVersion) = withContext(dispatchers.io()) {
                 val isFeatureEnabled = dummyWebMessageListenerFeature.self().isEnabled()
-                val isSupportedWebViewVersion = webViewVersionProvider.getMajorVersion()
+                val isSupportedWebViewVersion = webViewVersionProvider.getFullVersion()
                     .compareSemanticVersion(WEB_MESSAGE_LISTENER_WEBVIEW_VERSION)?.let { it > 0 } ?: false
                 Pair(isFeatureEnabled, isSupportedWebViewVersion)
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -221,6 +221,7 @@ import com.duckduckgo.autofill.api.credential.saving.DuckAddressLoginCreator
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.api.domain.app.LoginTriggerType
 import com.duckduckgo.autofill.api.emailprotection.EmailInjector
+import com.duckduckgo.browser.api.WebViewVersionProvider
 import com.duckduckgo.browser.api.brokensite.BrokenSiteData
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.DuckDuckGoFragment
@@ -482,6 +483,9 @@ class BrowserTabFragment :
 
     @Inject
     lateinit var dummyWebMessageListenerFeature: DummyWebMessageListenerFeature
+
+    @Inject
+    lateinit var webViewVersionProvider: WebViewVersionProvider
 
     /**
      * We use this to monitor whether the user was seeing the in-context Email Protection signup prompt
@@ -2348,6 +2352,7 @@ class BrowserTabFragment :
             }
 
             if (WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER) &&
+                webViewVersionProvider.getMajorVersion() == "126" &&
                 isFeatureEnabled &&
                 !webView.isDestroyed
             ) {

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/extensions/StringExtensions.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/extensions/StringExtensions.kt
@@ -62,3 +62,28 @@ fun String.asLocationPermissionOrigin(): String {
 fun String.toTldPlusOne(): String? {
     return runCatching { publicSuffixDatabase.getEffectiveTldPlusOne(this) }.getOrNull()
 }
+
+/**
+ * Compares the current semantic version string with the target semantic version string.
+ *
+ * The version strings can have an arbitrary number of parts separated by dots (e.g. "x.y.z").
+ * Each part is expected to be an integer.
+ * If any part of the version string is not a valid integer, the function returns null.
+ *
+ * @param targetVersion The version string to compare against.
+ * @return 1 if the current version is greater, -1 if it is smaller, 0 if they are equal or null if the format is invalid.
+ */
+fun String.compareSemanticVersion(targetVersion: String): Int? {
+    val versionParts = this.split(".")
+    val targetParts = targetVersion.split(".")
+
+    val maxLength = maxOf(versionParts.size, targetParts.size)
+
+    for (i in 0 until maxLength) {
+        val versionPart = versionParts.getOrElse(i) { "0" }.toIntOrNull() ?: return null
+        val targetPart = targetParts.getOrElse(i) { "0" }.toIntOrNull() ?: return null
+
+        if (versionPart != targetPart) return versionPart.compareTo(targetPart)
+    }
+    return 0
+}

--- a/common/common-utils/src/test/java/com/duckduckgo/common/utils/extensions/StringExtensionsTest.kt
+++ b/common/common-utils/src/test/java/com/duckduckgo/common/utils/extensions/StringExtensionsTest.kt
@@ -1,0 +1,47 @@
+package com.duckduckgo.common.utils.extensions
+
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNull
+import org.junit.Test
+
+class StringExtensionsTest {
+
+    @Test
+    fun whenSemanticVersionsAreEqualThenReturnZero() {
+        assertEquals(0, "1.0.0".compareSemanticVersion("1.0.0"))
+        assertEquals(0, "2.1.3.5".compareSemanticVersion("2.1.3.5"))
+        assertEquals(0, "1.0".compareSemanticVersion("1.0.0"))
+        assertEquals(0, "1.0.0".compareSemanticVersion("1.0"))
+    }
+
+    @Test
+    fun whenCurrentSemanticVersionIsGreaterThanTargetSemanticVersionThenReturnOne() {
+        assertEquals(1, "1.2.0".compareSemanticVersion("1.1.9"))
+        assertEquals(1, "1.10.0".compareSemanticVersion("1.2.5"))
+        assertEquals(1, "2.0".compareSemanticVersion("1.9.9"))
+        assertEquals(1, "1.2.1".compareSemanticVersion("1.2"))
+        assertEquals(1, "1.0.1".compareSemanticVersion("1.0"))
+        assertEquals(1, "1.1".compareSemanticVersion("1.0.0"))
+        assertEquals(1, "1.0.0.1".compareSemanticVersion("1.0"))
+    }
+
+    @Test
+    fun whenCurrentSemanticVersionIsSmallerThanTargetSemanticVersionThenReturnNegativeOne() {
+        assertEquals(-1, "1.0.0".compareSemanticVersion("1.0.1"))
+        assertEquals(-1, "1.2.3".compareSemanticVersion("1.2.4"))
+        assertEquals(-1, "1.0".compareSemanticVersion("1.0.1"))
+        assertEquals(-1, "1.0".compareSemanticVersion("1.0.0.1"))
+        assertEquals(-1, "1.0.0".compareSemanticVersion("1.0.0.1"))
+        assertEquals(-1, "1".compareSemanticVersion("1.0.1"))
+    }
+
+    @Test
+    fun whenSemanticVersionsAreInvalidThenReturnNull() {
+        assertNull("1..0".compareSemanticVersion("1.0.0"))
+        assertNull("1.0.a".compareSemanticVersion("1.0.0"))
+        assertNull("1.0.0".compareSemanticVersion("1..0"))
+        assertNull("1.0.0".compareSemanticVersion("1.0.a"))
+        assertNull("a.b.c.d".compareSemanticVersion("1.0.0"))
+        assertNull("1".compareSemanticVersion("a.1.2"))
+    }
+}

--- a/common/common-utils/src/test/java/com/duckduckgo/common/utils/extensions/StringExtensionsTest.kt
+++ b/common/common-utils/src/test/java/com/duckduckgo/common/utils/extensions/StringExtensionsTest.kt
@@ -12,6 +12,8 @@ class StringExtensionsTest {
         assertEquals(0, "2.1.3.5".compareSemanticVersion("2.1.3.5"))
         assertEquals(0, "1.0".compareSemanticVersion("1.0.0"))
         assertEquals(0, "1.0.0".compareSemanticVersion("1.0"))
+        assertEquals(0, "1.0.0".compareSemanticVersion("1.0"))
+        assertEquals(0, "126.0.6478.40".compareSemanticVersion("126.0.6478.40"))
     }
 
     @Test
@@ -23,6 +25,11 @@ class StringExtensionsTest {
         assertEquals(1, "1.0.1".compareSemanticVersion("1.0"))
         assertEquals(1, "1.1".compareSemanticVersion("1.0.0"))
         assertEquals(1, "1.0.0.1".compareSemanticVersion("1.0"))
+        assertEquals(1, "127.0.6478.40".compareSemanticVersion("126.0.6478.40"))
+        assertEquals(1, "126.1.6478.40".compareSemanticVersion("126.0.6478.40"))
+        assertEquals(1, "126.0.6479.40".compareSemanticVersion("126.0.6478.40"))
+        assertEquals(1, "126.0.6478.41".compareSemanticVersion("126.0.6478.40"))
+        assertEquals(1, "127.amazon-webview-v122-6261-tablet.6261.140.26".compareSemanticVersion("126.0.6478.40"))
     }
 
     @Test
@@ -33,6 +40,11 @@ class StringExtensionsTest {
         assertEquals(-1, "1.0".compareSemanticVersion("1.0.0.1"))
         assertEquals(-1, "1.0.0".compareSemanticVersion("1.0.0.1"))
         assertEquals(-1, "1".compareSemanticVersion("1.0.1"))
+        assertEquals(-1, "125.0.6478.40".compareSemanticVersion("126.0.6478.40"))
+        assertEquals(-1, "125.1.6478.40".compareSemanticVersion("126.0.6478.40"))
+        assertEquals(-1, "126.0.6477.40".compareSemanticVersion("126.0.6478.40"))
+        assertEquals(-1, "126.0.6478.39".compareSemanticVersion("126.0.6478.40"))
+        assertEquals(-1, "125.amazon-webview-v122-6261-tablet.6261.140.26".compareSemanticVersion("126.0.6478.40"))
     }
 
     @Test
@@ -43,5 +55,8 @@ class StringExtensionsTest {
         assertNull("1.0.0".compareSemanticVersion("1.0.a"))
         assertNull("a.b.c.d".compareSemanticVersion("1.0.0"))
         assertNull("1".compareSemanticVersion("a.1.2"))
+        assertNull("126.amazon-webview-v122-6261-tablet.6261.140.26".compareSemanticVersion("126.0.6478.40"))
+        assertNull("126.0.6478a.40".compareSemanticVersion("126.0.6478.40"))
+        assertNull("126.0.6478.40a".compareSemanticVersion("126.0.6478.40"))
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1200204095367872/1207470485890046/f

### Description
 - Adds a check for `WebView` v126, so that we can test that `WebMessageListener` is working as expected.
 - See: https://issues.chromium.org/issues/338340758#comment41

### Steps to test this PR

- [ ] Code review