### PR TITLE
Update autoconsent to v10.10.0

### DIFF
--- a/autoconsent/autoconsent-impl/libs/rules.json
+++ b/autoconsent/autoconsent-impl/libs/rules.json
@@ -2595,6 +2595,39 @@
       ]
     },
     {
+      "name": "ebay",
+      "vendorUrl": "https://ebay.com",
+      "cosmetic": false,
+      "runContext": {
+        "main": true,
+        "frame": false,
+        "urlPattern": "^https://(www\\.)?ebay\\.([.a-z]+)/"
+      },
+      "prehideSelectors": [
+        "#gdpr-banner"
+      ],
+      "detectCmp": [
+        {
+          "exists": "#gdpr-banner"
+        }
+      ],
+      "detectPopup": [
+        {
+          "visible": "#gdpr-banner"
+        }
+      ],
+      "optIn": [
+        {
+          "waitForThenClick": "#gdpr-banner-accept"
+        }
+      ],
+      "optOut": [
+        {
+          "waitForThenClick": "#gdpr-banner-decline"
+        }
+      ]
+    },
+    {
       "name": "ecosia",
       "vendorUrl": "https://www.ecosia.org/",
       "runContext": {
@@ -2636,7 +2669,7 @@
       ],
       "detectPopup": [
         {
-          "visible": ".ensModal"
+          "visible": "#ensModalWrapper[style*=block]"
         }
       ],
       "optIn": [
@@ -2645,6 +2678,12 @@
         }
       ],
       "optOut": [
+        {
+          "wait": 500
+        },
+        {
+          "visible": "#ensModalWrapper[style*=block]"
+        },
         {
           "waitForThenClick": ".ensCheckbox:checked",
           "all": true
@@ -2666,7 +2705,7 @@
       ],
       "detectPopup": [
         {
-          "visible": "#ensNotifyBanner"
+          "visible": "#ensNotifyBanner[style*=block]"
         }
       ],
       "optIn": [
@@ -2676,7 +2715,13 @@
       ],
       "optOut": [
         {
-          "waitForThenClick": "#ensRejectAll,#rejectAll,#ensRejectBanner"
+          "wait": 500
+        },
+        {
+          "visible": "#ensNotifyBanner[style*=block]"
+        },
+        {
+          "waitForThenClick": "#ensRejectAll,#rejectAll,#ensRejectBanner,.rejectAll"
         }
       ]
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ddg-android",
       "version": "1.0.0",
       "dependencies": {
-        "@duckduckgo/autoconsent": "^10.9.0",
+        "@duckduckgo/autoconsent": "^10.10.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.2.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.19.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#3.5.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "rollup-plugin-terser": "^7.0.2"
   },
   "dependencies": {
-    "@duckduckgo/autoconsent": "^10.9.0",
+    "@duckduckgo/autoconsent": "^10.10.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.2.0",
     "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.19.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#3.5.0",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207512946126800/1207512946126800
Autoconsent Release: https://github.com/duckduckgo/autoconsent/releases/tag/v10.10.0


## Description
Updates Autoconsent to version [v10.10.0](https://github.com/duckduckgo/autoconsent/releases/tag/v10.10.0).

### Autoconsent v10.10.0 release notes
See release notes [here](https://github.com/duckduckgo/autoconsent/blob/v10.10.0/CHANGELOG.md)

## Steps to test
This release has been tested during Autoconsent development. You can check the release notes for more information.
1. Make sure that there's no unexpected failures in CI checks
2. (optional) smoke test some of the sites mentioned in the release notes
3. If there are problems, reach out to a CPM DRI