### PR TITLE
Update autofill engagement metrics

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
@@ -104,6 +104,8 @@ enum class AutofillPixelNames(override val pixelName: String) : Pixel.PixelName 
     AUTOFILL_ENGAGEMENT_ENABLED_USER("m_autofill_enableduser"),
     AUTOFILL_ENGAGEMENT_ONBOARDED_USER("m_autofill_onboardeduser"),
     AUTOFILL_ENGAGEMENT_STACKED_LOGINS("m_autofill_logins_stacked"),
+    AUTOFILL_TOGGLED_ON_SEARCH("m_autofill_toggled_on"),
+    AUTOFILL_TOGGLED_OFF_SEARCH("m_autofill_toggled_off"),
 }
 
 @ContributesMultibinding(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1149059203486286/1207512213117499/f
and: https://app.asana.com/0/0/1207512940049066/f

### Description
Updates existing enabled user metric.
New metric for search dau autofill.

### Steps to test this PR

_Feature 1_
- [x] fresh install
- [x] Don't perform any search!
- [x] in logcat use this filter `package:mine message~:"m_autofill_"`
- [x] got to autofill internal settings and add "few sample logins"
- [x] perform a search
- [x] ensure logs report `m_autofill_toggled_on` with some logins as param

_Feature 2_
- [x] fresh install (or clear data)
- [x] Don't perform any search!
- [x] in logcat use this filter `package:mine message~:"m_autofill_"`
- [x] got to autofill internal settings and add "few sample logins"
- [x] go to password settings and disable autofill
- [x] perform a search
- [x] ensure logs report `m_autofill_toggled_off` with some logins as param

_Feature 3_
- [x] fresh install (or clear data)
- [x] Don't perform any search!
- [x] in logcat use this filter `package:mine message~:"m_autofill_"`
- [x] got to autofill internal settings and add "lot of sample logins"
- [x] go to password settings and disable autofill
- [x] perform a search
- [x] ensure logs don't report `m_autofill_enableduser`

_Feature 3_
- [x] fresh install (or clear data)
- [x] Don't perform any search!
- [x] in logcat use this filter `package:mine message~:"m_autofill_"`
- [x] got to autofill internal settings and add "lot of sample logins"
- [x] go to password settings and enable autofill
- [x] perform a search
- [x] ensure logs report `m_autofill_enableduser`


### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
