### PR TITLE
Settings: Remove BETA label for Desktop settings

### DIFF
--- a/app/src/main/res/layout/content_settings_other.xml
+++ b/app/src/main/res/layout/content_settings_other.xml
@@ -38,8 +38,7 @@
         android:layout_height="wrap_content"
         app:primaryText="@string/macos_settings_title"
         app:primaryTextTruncated="false"
-        app:secondaryText="@string/macos_settings_description"
-        app:showBetaPill="true" />
+        app:secondaryText="@string/macos_settings_description" />
 
     <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
         android:id="@+id/windowsSetting"
@@ -47,7 +46,6 @@
         android:layout_height="wrap_content"
         app:primaryText="@string/windows_settings_title"
         app:primaryTextTruncated="false"
-        app:secondaryText="@string/windows_settings_description"
-        app:showBetaPill="true" />
+        app:secondaryText="@string/windows_settings_description" />
 
 </LinearLayout>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201048563534612/1207326238853107/f

### Description
Remove the BETA labels for Desktop browsers

### Steps to test this PR

_Settings_
- [ ] Install app and open settings
- [ ] Verify that BETA label is removed from both desktop settings

### UI changes
| Before  | After |
| ------ | ----- |
![Screenshot_20240512-234555 (1)](https://github.com/duckduckgo/Android/assets/531613/06af6707-2cf5-4064-81e2-d9b86c4ff826)|![Screenshot_20240610_121735](https://github.com/duckduckgo/Android/assets/531613/1e824ad8-a67d-426f-b178-5d684c4eb415)|

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207326238853107