### PR TITLE
Fix RecyclerView.disableAnimation() crash

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/view/RecyclerViewExtension.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/RecyclerViewExtension.kt
@@ -21,9 +21,21 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.ItemAnimator
 
 fun RecyclerView.disableAnimation() {
-    this.itemAnimator = null
+    if (isComputingLayout) {
+        post {
+            itemAnimator = null
+        }
+    } else {
+        itemAnimator = null
+    }
 }
 
 fun RecyclerView.enableAnimation(animator: ItemAnimator? = DefaultItemAnimator()) {
-    this.itemAnimator = DefaultItemAnimator()
+    if (isComputingLayout) {
+        post {
+            itemAnimator = animator
+        }
+    } else {
+        itemAnimator = animator
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207526694527888/f

### Description

- Fix for an `IllegalArgumentException` when re-arranging the favorites grid (By checking `isComputingLayout` before updating the `itemAnimator` in a `post`)
- Also updates `enableAnimation` with the same logic.

### Steps to test this PR

- [ ] Add at least two favorites.
- [ ] Re-arrange the favorites grid.
