### PR TITLE
Defer the loading of Sync native lib to when necesasry

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/di/SyncModule.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/di/SyncModule.kt
@@ -24,7 +24,6 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.api.favicons.FaviconsFetchingPrompt
 import com.duckduckgo.sync.api.favicons.FaviconsFetchingStore
 import com.duckduckgo.sync.crypto.SyncLib
-import com.duckduckgo.sync.crypto.SyncNativeLib
 import com.duckduckgo.sync.impl.AppQREncoder
 import com.duckduckgo.sync.impl.QREncoder
 import com.duckduckgo.sync.impl.SyncAccountRepository
@@ -85,7 +84,7 @@ object SyncStoreModule {
     @Provides
     @SingleInstanceIn(AppScope::class)
     fun providesNativeLib(context: Context): SyncLib {
-        return SyncNativeLib(context)
+        return SyncLib.create(context)
     }
 
     @Provides


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207535395708800/f

### Description
Defer loading the sync native library to when it's actually used. This avoids:
- loading the library on process launch when not necessary
- loading the library at all for the `:vpn` process

### Steps to test this PR
Filter logcat by `Loading native SYNC library`

_Test_
- [x] build from branch and fresh install/launch app
- [x] verify `Loading native SYNC library` is not logged
- [x] enable sync
- [x] verify `Loading native SYNC library` is logged
- [x] enable AppTP
- [x] verify `Loading native SYNC library` is not logged when AppTP is enabled
- [x] force closed the app (`adb shell am force-stop com.duckduckgo.mobile.android.debug`)
- [x] re-launch app
- [x] verify `Loading native SYNC library` is shown only once, when the main process is created (not when AppTP is enabled aka `:vpn` process is created)

Note: if you repeat the test in `develop` the `Loading native SYNC library` shows every time both the main and `:vpn` processes are created, irregardless of whether sync is enabled or not
