### PR TITLE
Fix when forcing dark mode

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -79,6 +79,7 @@ import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import androidx.webkit.WebSettingsCompat
 import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
 import com.duckduckgo.anvil.annotations.InjectWith
@@ -2587,7 +2588,9 @@ class BrowserTabFragment :
     @Suppress("NewApi") // This API and the behaviour described only apply to apps with targetSdkVersion ≥ TIRAMISU.
     private fun setAlgorithmicDarkeningAllowed(settings: WebSettings) {
         // https://developer.android.com/reference/androidx/webkit/WebSettingsCompat#setAlgorithmicDarkeningAllowed(android.webkit.WebSettings,boolean)
-        settings.isAlgorithmicDarkeningAllowed = settingsDataStore.experimentalWebsiteDarkMode
+        if (WebViewFeature.isFeatureSupported(WebViewFeature.ALGORITHMIC_DARKENING)) {
+            WebSettingsCompat.setAlgorithmicDarkeningAllowed(settings, settingsDataStore.experimentalWebsiteDarkMode)
+        }
     }
 
     private fun addTextChangedListeners() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1125189844152671/1207572075253654/f 

### Description
Fixes a crash when Webview doesn't support algorithmic darkening.

### Steps to test this PR

- [ ] Test darkening on an emulator (I tested with API 29) with an old webview version and app shouldn't crash
- [ ] Test darkening on a devide with a new webview version and dark mode should work as expected

