### PR TITLE
Disable Force Dark Mode when WebView version doesn't support it

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/appearance/AppearanceActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/appearance/AppearanceActivity.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.appearance
 
 import android.os.Bundle
 import android.widget.CompoundButton
+import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -97,6 +98,7 @@ class AppearanceActivity : DuckDuckGoActivity() {
                     binding.changeAppIcon.setImageResource(it.appIcon.icon)
                     binding.experimentalNightMode.quietlySetIsChecked(viewState.forceDarkModeEnabled, forceDarkModeToggleListener)
                     binding.experimentalNightMode.isEnabled = viewState.canForceDarkMode
+                    binding.experimentalNightMode.isVisible = viewState.supportsForceDarkMode
                 }
             }.launchIn(lifecycleScope)
 

--- a/app/src/main/java/com/duckduckgo/app/appearance/AppearanceViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/appearance/AppearanceViewModel.kt
@@ -52,6 +52,7 @@ class AppearanceViewModel @Inject constructor(
         val appIcon: AppIcon = AppIcon.DEFAULT,
         val forceDarkModeEnabled: Boolean = false,
         val canForceDarkMode: Boolean = false,
+        val supportsForceDarkMode: Boolean = true,
     )
 
     sealed class Command {
@@ -71,6 +72,7 @@ class AppearanceViewModel @Inject constructor(
                     appIcon = settingsDataStore.appIcon,
                     forceDarkModeEnabled = settingsDataStore.experimentalWebsiteDarkMode,
                     canForceDarkMode = canForceDarkMode(),
+                    supportsForceDarkMode = WebViewFeature.isFeatureSupported(WebViewFeature.ALGORITHMIC_DARKENING),
                 ),
             )
         }
@@ -81,7 +83,7 @@ class AppearanceViewModel @Inject constructor(
     }
 
     private fun canForceDarkMode(): Boolean {
-        return themingDataStore.theme != DuckDuckGoTheme.LIGHT && WebViewFeature.isFeatureSupported(WebViewFeature.ALGORITHMIC_DARKENING)
+        return themingDataStore.theme != DuckDuckGoTheme.LIGHT
     }
 
     fun userRequestedToChangeTheme() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1157893581871903/1207572180893002/f

### Description
We enabled [✓ Android: Force dark mode in sites that don’t support it](https://app.asana.com/0/276630244458377/1206630026838095/f)
This was causing the app crash in webview versions that didn’t support it. Fixed in[✓ setAlgorithmicDarkeningAllowed crashing the app](https://app.asana.com/0/1125189844152671/1207572075253654/f)
After this fix, devices with webview versions that don’t support algorithmic darkening won’t see the feature.

This PR removes this option in devices that don’t support it

### Steps to test this PR

_WebView not supported_
- [x] Install this branch in an emulator with an old webview version
- [x] Open Settings / Appearance
- [x] Ensure Dark theme is selected
- [x] Verify that Force Dark Mode is not visible

_WebView supported_
- [x] Install this branch in an emulator with a new webview version
- [x] Open Settings / Appearance
- [x] Ensure Dark theme is selected
- [x] Verify that Force Dark Mode is enabled
- [x] Verify that turning it on enabled force dark mode