### PR TITLE
Fix for IndexOutOfBoundsException

### DIFF
--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/TypeAnimationTextView.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/TypeAnimationTextView.kt
@@ -57,7 +57,7 @@ class TypeAnimationTextView @JvmOverloads constructor(
                 }
             }
         }
-
+        if (typingAnimationJob?.isActive == true) typingAnimationJob?.cancel()
         typingAnimationJob = launch {
             textInDialog?.let { spanned ->
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201807753394693/1207291831514025/f

### Description
Cancel current typing animation if a new one starts

### Steps to test this PR

- [ ] Fresh install
- [ ] Check pre-browser Dax dialogs typing animation works as expected
- [ ] Go to browser
- [ ] Check typing animation for search suggestions Dax dialog works as expected
- [ ] Tap on a search suggestion
- [ ] Check SERP Dax dialog typing animation works as expected
- [ ] Tap on PrimaryCta
- [ ] Check typing animation for site suggestions works as expected
- [ ] Long press on any link in the browser and select "Open in a new tab"
- [ ] Check trackers dialog typing animation works as expected
- [ ] Refresh the page
- [ ] Check typing animation for End dialog works as expected

### No UI changes
