### PR TITLE
Fix url state when input url is different than loaded url

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -437,8 +437,10 @@ dependencies {
     androidTestImplementation "androidx.test.ext:junit-ktx:_"
     androidTestImplementation "androidx.test.espresso:espresso-core:_"
     androidTestImplementation "androidx.test.espresso:espresso-web:_"
+    androidTestImplementation project(':feature-toggles-test')
 
     testImplementation project(':vpn-api-test')
+    testImplementation project(':feature-toggles-test')
     testImplementation "org.mockito.kotlin:mockito-kotlin:_"
     testImplementation Testing.junit4
     testImplementation AndroidX.archCore.testing

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1093,13 +1093,28 @@ class BrowserTabViewModel @Inject constructor(
             is WebNavigationStateChange.PageCleared -> pageCleared()
             is WebNavigationStateChange.UrlUpdated -> urlUpdated(stateChange.url)
             is WebNavigationStateChange.PageNavigationCleared -> disableUserNavigation()
-            else -> {}
+            is WebNavigationStateChange.Unchanged -> {
+                stateChange.url?.let {
+                    updateWhenInputUrlIsDifferentThanLoadedUrl(it)
+                }
+            }
+            is WebNavigationStateChange.Other -> {
+                stateChange.url?.let {
+                    updateWhenInputUrlIsDifferentThanLoadedUrl(it)
+                }
+            }
         }
 
         if ((newWebNavigationState.progress ?: 0) >= SHOW_CONTENT_MIN_PROGRESS) {
             showWebContent()
         }
         navigationAwareLoginDetector.onEvent(NavigationEvent.WebNavigationEvent(stateChange))
+    }
+
+    private fun updateWhenInputUrlIsDifferentThanLoadedUrl(loadedUrl: String) {
+        if (loadedUrl != site?.url) {
+            urlUpdated(loadedUrl)
+        }
     }
 
     override fun onPageContentStart(url: String) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -269,6 +269,7 @@ class BrowserTabViewModel @Inject constructor(
     private val userBrowserProperties: UserBrowserProperties,
     private val history: NavigationHistory,
     private val commandActionMapper: CommandActionMapper,
+    private val newStateKillSwitch: NewStateKillSwitch,
 ) : WebViewClientListener,
     EditSavedSiteListener,
     DeleteBookmarkListener,
@@ -1112,7 +1113,7 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     private fun updateWhenInputUrlIsDifferentThanLoadedUrl(loadedUrl: String) {
-        if (loadedUrl != site?.url) {
+        if (newStateKillSwitch.self().isEnabled() && loadedUrl != site?.url) {
             urlUpdated(loadedUrl)
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/NewStateKillSwitch.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/NewStateKillSwitch.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "androidNewStateKillSwitch",
+)
+interface NewStateKillSwitch {
+    @Toggle.DefaultValue(true)
+    fun self(): Toggle
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/WebNavigationState.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebNavigationState.kt
@@ -41,14 +41,14 @@ sealed class WebNavigationStateChange {
 
     data class UrlUpdated(val url: String) : WebNavigationStateChange()
     object PageCleared : WebNavigationStateChange()
-    object Unchanged : WebNavigationStateChange()
+    data class Unchanged(val url: String?) : WebNavigationStateChange()
     object PageNavigationCleared : WebNavigationStateChange()
-    object Other : WebNavigationStateChange()
+    data class Other(val url: String?) : WebNavigationStateChange()
 }
 
 fun WebNavigationState.compare(previous: WebNavigationState?): WebNavigationStateChange {
     if (this == previous) {
-        return WebNavigationStateChange.Unchanged
+        return WebNavigationStateChange.Unchanged(currentUrl)
     }
 
     if (this is EmptyNavigationState) {
@@ -59,7 +59,7 @@ fun WebNavigationState.compare(previous: WebNavigationState?): WebNavigationStat
         return WebNavigationStateChange.PageCleared
     }
 
-    val latestUrl = currentUrl ?: return WebNavigationStateChange.Other
+    val latestUrl = currentUrl ?: return WebNavigationStateChange.Other(null)
 
     // A new page load is identified by the original url changing
     if (originalUrl != previous?.originalUrl) {
@@ -76,7 +76,7 @@ fun WebNavigationState.compare(previous: WebNavigationState?): WebNavigationStat
         return WebNavigationStateChange.UrlUpdated(latestUrl)
     }
 
-    return WebNavigationStateChange.Other
+    return WebNavigationStateChange.Other(currentUrl)
 }
 
 data class WebViewNavigationState(

--- a/app/src/test/java/com/duckduckgo/app/browser/WebNavigationStateComparisonTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/WebNavigationStateComparisonTest.kt
@@ -33,14 +33,14 @@ class WebNavigationStateComparisonTest {
     @Test
     fun whenPreviousStateAndLatestStateSameThenCompareReturnsUnchanged() {
         val state = buildState("http://foo.com", "http://subdomain.foo.com")
-        assertEquals(Unchanged, state.compare(state))
+        assertEquals(Unchanged("http://subdomain.foo.com"), state.compare(state))
     }
 
     @Test
     fun whenPreviousStateAndLatestStateEqualThenCompareReturnsUnchanged() {
         val previousState = buildState("http://foo.com", "http://subdomain.foo.com")
         val latestState = buildState("http://foo.com", "http://subdomain.foo.com")
-        assertEquals(Unchanged, latestState.compare(previousState))
+        assertEquals(Unchanged("http://subdomain.foo.com"), latestState.compare(previousState))
     }
 
     @Test
@@ -124,14 +124,14 @@ class WebNavigationStateComparisonTest {
     fun whenPreviousContainsAnOriginalUrlAndCurrentUrlAndLatestContainsSameOriginalUrlAndNoCurrentUrlThenCompareReturnsOther() {
         val previousState = buildState("http://same.com", "http://subdomain.previous.com")
         val latestState = buildState("http://same.com", null)
-        assertEquals(Other, latestState.compare(previousState))
+        assertEquals(Other(null), latestState.compare(previousState))
     }
 
     @Test
     fun whenPreviousContainsAnOriginalUrlAndCurrentUrlAndLatestStateContainsDifferentOriginalUrlAndNoCurrentUrlThenCompareReturnsOther() {
         val previousState = buildState("http://previous.com", "http://subdomain.previous.com")
         val latestState = buildState("http://latest.com", null)
-        assertEquals(Other, latestState.compare(previousState))
+        assertEquals(Other(null), latestState.compare(previousState))
     }
 
     private fun buildState(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414730916066338/1207666379072710/f

### Description
Change URL state when input URL is different than URL loaded

### Steps to test this PR

- [x] Go to https://weather.com
- [x] Change URL to http://weather.com
- [x] URL bar should change to https:
- [x] Change again to http://
- [x] URL bar should change again to https and show the shield



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207666379072710