### PR TITLE
Fix subscription settings screen bottom padding

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/res/layout/activity_subscription_settings.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/layout/activity_subscription_settings.xml
@@ -34,6 +34,7 @@
         <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:paddingBottom="@dimen/keyline_5"
                 android:orientation="vertical">
 
             <ImageView


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205648422731273/1207605998461325/f

### Description

This PR increases bottom padding on subscriptions settings screen to match top-level settings screen.

### Steps to test this PR

(Optional) Navigate to subscription settings screen and verify the bottom padding matches the top-level settings screen.

### UI changes
| Before  | After |
| ------ | ----- |
|![Screenshot_20240618_235937](https://github.com/duckduckgo/Android/assets/4212474/7550a285-ccbc-419a-ab47-f173ab945b44)|![Screenshot_20240619_000123](https://github.com/duckduckgo/Android/assets/4212474/eb9f93fb-345d-4173-9f37-eefe62fb83ff)|