### PR TITLE
Add kill-switch for remote subfeature flag whether to inject Autofill javascript

### DIFF
--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillFeature.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillFeature.kt
@@ -30,6 +30,15 @@ interface AutofillFeature {
     fun self(): Toggle
 
     /**
+     * Kill switch for if we should inject Autofill javascript into the browser.
+     *
+     * @return `true` when the remote config has the global "canIntegrateAutofillInWebView" autofill sub-feature flag enabled
+     * If the remote feature is not present defaults to `true`
+     */
+    @Toggle.DefaultValue(true)
+    fun canIntegrateAutofillInWebView(): Toggle
+
+    /**
      * @return `true` when the remote config has the global "canInjectCredentials" autofill sub-feature flag enabled
      * If the remote feature is not present defaults to `false`
      */

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/AutofillGlobalCapabilityChecker.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/AutofillGlobalCapabilityChecker.kt
@@ -54,7 +54,9 @@ class AutofillGlobalCapabilityCheckerImpl @Inject constructor(
 
     override suspend fun isAutofillEnabledByConfiguration(url: String): Boolean {
         return withContext(dispatcherProvider.io()) {
-            (isInternalTester() || isGlobalFeatureEnabled()) && !isAnException(url)
+            val enabledAtTopLevel = isInternalTester() || isGlobalFeatureEnabled()
+            val canIntegrateAutofill = autofillFeature.canIntegrateAutofillInWebView().isEnabled()
+            enabledAtTopLevel && canIntegrateAutofill && !isAnException(url)
         }
     }
 

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/AutofillGlobalCapabilityCheckerImplGlobalFeatureTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/AutofillGlobalCapabilityCheckerImplGlobalFeatureTest.kt
@@ -58,7 +58,8 @@ class AutofillGlobalCapabilityCheckerImplGlobalFeatureTest(
     @Test
     fun runParameterizedTests() = runTest {
         configureAsInternalTester(testCase.scenario.isInternalTester)
-        configureGlobalAutofillFeatureState(testCase.scenario.isRemotelyEnabled)
+        configureGlobalAutofillFeatureState(testCase.scenario.isGlobalFeatureEnabled)
+        configureCanIntegrateAutofillSubfeature(testCase.scenario.canIntegrateWithWebViewSubfeatureEnabled)
         configureIfUrlIsException(testCase.scenario.urlIsInExceptionList)
 
         assertEquals("${testCase.scenario}", testCase.expectFeatureEnabled, testee.isAutofillEnabledByConfiguration("example.com"))
@@ -73,65 +74,146 @@ class AutofillGlobalCapabilityCheckerImplGlobalFeatureTest(
                 TestCase(
                     expectFeatureEnabled = false,
                     scenario = Scenario(
+                        canIntegrateWithWebViewSubfeatureEnabled = false,
                         urlIsInExceptionList = false,
                         isInternalTester = false,
-                        isRemotelyEnabled = false,
+                        isGlobalFeatureEnabled = false,
+                    ),
+                ),
+                TestCase(
+                    expectFeatureEnabled = false,
+                    scenario = Scenario(
+                        canIntegrateWithWebViewSubfeatureEnabled = false,
+                        urlIsInExceptionList = false,
+                        isInternalTester = false,
+                        isGlobalFeatureEnabled = true,
+                    ),
+                ),
+                TestCase(
+                    expectFeatureEnabled = false,
+                    scenario = Scenario(
+                        canIntegrateWithWebViewSubfeatureEnabled = false,
+                        urlIsInExceptionList = false,
+                        isInternalTester = true,
+                        isGlobalFeatureEnabled = false,
+                    ),
+                ),
+                TestCase(
+                    expectFeatureEnabled = false,
+                    scenario = Scenario(
+                        canIntegrateWithWebViewSubfeatureEnabled = false,
+                        urlIsInExceptionList = false,
+                        isInternalTester = true,
+                        isGlobalFeatureEnabled = true,
+                    ),
+                ),
+                TestCase(
+                    expectFeatureEnabled = false,
+                    scenario = Scenario(
+                        canIntegrateWithWebViewSubfeatureEnabled = false,
+                        urlIsInExceptionList = true,
+                        isInternalTester = false,
+                        isGlobalFeatureEnabled = false,
+                    ),
+                ),
+                TestCase(
+                    expectFeatureEnabled = false,
+                    scenario = Scenario(
+                        canIntegrateWithWebViewSubfeatureEnabled = false,
+                        urlIsInExceptionList = true,
+                        isInternalTester = false,
+                        isGlobalFeatureEnabled = true,
+                    ),
+                ),
+                TestCase(
+                    expectFeatureEnabled = false,
+                    scenario = Scenario(
+                        canIntegrateWithWebViewSubfeatureEnabled = false,
+                        urlIsInExceptionList = true,
+                        isInternalTester = true,
+                        isGlobalFeatureEnabled = false,
+                    ),
+                ),
+                TestCase(
+                    expectFeatureEnabled = false,
+                    scenario = Scenario(
+                        canIntegrateWithWebViewSubfeatureEnabled = false,
+                        urlIsInExceptionList = true,
+                        isInternalTester = true,
+                        isGlobalFeatureEnabled = true,
+                    ),
+                ),
+
+                TestCase(
+                    expectFeatureEnabled = false,
+                    scenario = Scenario(
+                        canIntegrateWithWebViewSubfeatureEnabled = true,
+                        urlIsInExceptionList = false,
+                        isInternalTester = false,
+                        isGlobalFeatureEnabled = false,
                     ),
                 ),
                 TestCase(
                     expectFeatureEnabled = true,
                     scenario = Scenario(
+                        canIntegrateWithWebViewSubfeatureEnabled = true,
                         urlIsInExceptionList = false,
                         isInternalTester = false,
-                        isRemotelyEnabled = true,
+                        isGlobalFeatureEnabled = true,
                     ),
                 ),
                 TestCase(
                     expectFeatureEnabled = true,
                     scenario = Scenario(
+                        canIntegrateWithWebViewSubfeatureEnabled = true,
                         urlIsInExceptionList = false,
                         isInternalTester = true,
-                        isRemotelyEnabled = false,
+                        isGlobalFeatureEnabled = false,
                     ),
                 ),
                 TestCase(
                     expectFeatureEnabled = true,
                     scenario = Scenario(
+                        canIntegrateWithWebViewSubfeatureEnabled = true,
                         urlIsInExceptionList = false,
                         isInternalTester = true,
-                        isRemotelyEnabled = true,
+                        isGlobalFeatureEnabled = true,
                     ),
                 ),
                 TestCase(
                     expectFeatureEnabled = false,
                     scenario = Scenario(
+                        canIntegrateWithWebViewSubfeatureEnabled = true,
                         urlIsInExceptionList = true,
                         isInternalTester = false,
-                        isRemotelyEnabled = false,
+                        isGlobalFeatureEnabled = false,
                     ),
                 ),
                 TestCase(
                     expectFeatureEnabled = false,
                     scenario = Scenario(
+                        canIntegrateWithWebViewSubfeatureEnabled = true,
                         urlIsInExceptionList = true,
                         isInternalTester = false,
-                        isRemotelyEnabled = true,
+                        isGlobalFeatureEnabled = true,
                     ),
                 ),
                 TestCase(
                     expectFeatureEnabled = false,
                     scenario = Scenario(
+                        canIntegrateWithWebViewSubfeatureEnabled = true,
                         urlIsInExceptionList = true,
                         isInternalTester = true,
-                        isRemotelyEnabled = false,
+                        isGlobalFeatureEnabled = false,
                     ),
                 ),
                 TestCase(
                     expectFeatureEnabled = false,
                     scenario = Scenario(
+                        canIntegrateWithWebViewSubfeatureEnabled = true,
                         urlIsInExceptionList = true,
                         isInternalTester = true,
-                        isRemotelyEnabled = true,
+                        isGlobalFeatureEnabled = true,
                     ),
                 ),
 
@@ -143,6 +225,12 @@ class AutofillGlobalCapabilityCheckerImplGlobalFeatureTest(
         val toggle: Toggle = mock()
         whenever(toggle.isEnabled()).thenReturn(isEnabled)
         whenever(autofillFeature.self()).thenReturn(toggle)
+    }
+
+    private fun configureCanIntegrateAutofillSubfeature(isEnabled: Boolean) {
+        val toggle: Toggle = mock()
+        whenever(toggle.isEnabled()).thenReturn(isEnabled)
+        whenever(autofillFeature.canIntegrateAutofillInWebView()).thenReturn(toggle)
     }
 
     private fun configureIfUrlIsException(isException: Boolean) {
@@ -158,7 +246,8 @@ class AutofillGlobalCapabilityCheckerImplGlobalFeatureTest(
 
     data class Scenario(
         val isInternalTester: Boolean,
-        val isRemotelyEnabled: Boolean,
+        val isGlobalFeatureEnabled: Boolean,
+        val canIntegrateWithWebViewSubfeatureEnabled: Boolean,
         val urlIsInExceptionList: Boolean,
     )
 }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/feature/toggles/api/toggle/AutofillTestFeature.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/feature/toggles/api/toggle/AutofillTestFeature.kt
@@ -26,9 +26,11 @@ class AutofillTestFeature : AutofillFeature {
     var canGeneratePassword: Boolean = false
     var canAccessCredentialManagement: Boolean = false
     var onByDefault: Boolean = false
+    var canIntegrateWithWebView: Boolean = false
 
     override fun self(): Toggle = TestToggle(topLevelFeatureEnabled)
     override fun canInjectCredentials(): Toggle = TestToggle(canInjectCredentials)
+    override fun canIntegrateAutofillInWebView() = TestToggle(canIntegrateWithWebView)
     override fun canSaveCredentials(): Toggle = TestToggle(canSaveCredentials)
     override fun canGeneratePasswords(): Toggle = TestToggle(canGeneratePassword)
     override fun canAccessCredentialManagement(): Toggle = TestToggle(canAccessCredentialManagement)

--- a/autofill/autofill-internal/src/main/java/com/duckduckgo/autofill/internal/AutofillInternalSettingsActivity.kt
+++ b/autofill/autofill-internal/src/main/java/com/duckduckgo/autofill/internal/AutofillInternalSettingsActivity.kt
@@ -44,6 +44,7 @@ import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import java.text.SimpleDateFormat
 import javax.inject.Inject
@@ -105,21 +106,31 @@ class AutofillInternalSettingsActivity : DuckDuckGoActivity() {
 
     private fun refreshRemoteConfigSettings() {
         lifecycleScope.launch(dispatchers.io()) {
-            val autofillEnabled = autofillFeature.self().isEnabled()
+            val autofillEnabled = autofillFeature.self()
             val onByDefault = autofillFeature.onByDefault()
+            val canIntegrateAutofill = autofillFeature.canIntegrateAutofillInWebView()
             val canSaveCredentials = autofillFeature.canSaveCredentials()
             val canInjectCredentials = autofillFeature.canInjectCredentials()
             val canGeneratePasswords = autofillFeature.canGeneratePasswords()
             val canAccessCredentialManagement = autofillFeature.canAccessCredentialManagement()
 
             withContext(dispatchers.main()) {
-                binding.autofillTopLevelFeature.setSecondaryText(autofillEnabled.toString())
-                binding.autofillOnByDefaultFeature.setSecondaryText("${onByDefault.isEnabled()} ${onByDefault.getRawStoredState()}")
-                binding.canSaveCredentialsFeature.setSecondaryText(canSaveCredentials.isEnabled().toString())
-                binding.canInjectCredentialsFeature.setSecondaryText(canInjectCredentials.isEnabled().toString())
-                binding.canGeneratePasswordsFeature.setSecondaryText(canGeneratePasswords.isEnabled().toString())
-                binding.canAccessCredentialManagementFeature.setSecondaryText(canAccessCredentialManagement.isEnabled().toString())
+                binding.autofillTopLevelFeature.setSecondaryText(autofillEnabled.description())
+                binding.autofillOnByDefaultFeature.setSecondaryText(onByDefault.description())
+                binding.canIntegrateAutofillWithWebView.setSecondaryText(canIntegrateAutofill.description())
+                binding.canSaveCredentialsFeature.setSecondaryText(canSaveCredentials.description())
+                binding.canInjectCredentialsFeature.setSecondaryText(canInjectCredentials.description())
+                binding.canGeneratePasswordsFeature.setSecondaryText(canGeneratePasswords.description())
+                binding.canAccessCredentialManagementFeature.setSecondaryText(canAccessCredentialManagement.description())
             }
+        }
+    }
+
+    private fun Toggle.description(includeRawState: Boolean = false): String {
+        return if (includeRawState) {
+            "${isEnabled()} ${getRawStoredState()}"
+        } else {
+            isEnabled().toString()
         }
     }
 

--- a/autofill/autofill-internal/src/main/res/layout/activity_autofill_internal_settings.xml
+++ b/autofill/autofill-internal/src/main/res/layout/activity_autofill_internal_settings.xml
@@ -155,6 +155,12 @@
             app:primaryText="Autofill top-level feature" />
 
         <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+            android:id="@+id/canIntegrateAutofillWithWebView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:primaryText="canIntegrateAutofillWithWebView" />
+
+        <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
             android:id="@+id/autofillOnByDefaultFeature"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203822806345703/1207471701495238/f 

### Description
Adds a new check for autofill subfeature flag before injecting autofill Javascript.

Adding this check gives us the ability to selectively disable just the JS injection while keeping other parts of autofill active, namely, access to the stored passwords in the password management screen.

The check is added as a kill-switch, meaning it defaults to `true` unless remote config says otherwise.

### Steps to test this PR

**Check upgrade path**
- [ ] install from `develop`, let it consume remote config
- [ ] install from this branch, let it consume remote config
- [ ] ensure autofill works as expected (e.g., visit https://fill.dev/form/login-simple and attempt a login)
- [ ] ensure password management screen is accessible as normal (`Overflow -> Passwords`)

**[optional] Test kill switch**
- [ ] Create a fake remote config with the flag disabled
- [ ] Launch this branch, and let it consume the fake config
- [ ] verify autofill is disabled in the browser
- [ ] verify password management screen still accessible 