### PR TITLE
Onboarding: Prevent taps in suggestions until text animation has finished

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -3842,10 +3842,11 @@ class BrowserTabFragment :
         private fun showDaxOnboardingBubbleCta(configuration: DaxBubbleCta) {
             hideHomeBackground()
             configuration.apply {
-                showCta(daxDialogIntroBubbleCta.daxCtaContainer)
-                setOnOptionClicked {
-                    userEnteredQuery(it.link)
-                    pixel.fire(it.pixel)
+                showCta(daxDialogIntroBubbleCta.daxCtaContainer) {
+                    setOnOptionClicked {
+                        userEnteredQuery(it.link)
+                        pixel.fire(it.pixel)
+                    }
                 }
             }
             newBrowserTab.newTabLayout.setOnClickListener { daxDialogIntroBubbleCta.dialogTextCta.finishAnimation() }
@@ -3861,21 +3862,22 @@ class BrowserTabFragment :
         @SuppressLint("ClickableViewAccessibility")
         private fun showOnboardingDialogCta(configuration: OnboardingDaxDialogCta) {
             hideHomeBackground()
-            val onTypingAnimationFinished = if (configuration is OnboardingDaxDialogCta.DaxTrackersBlockedCta) {
-                { viewModel.onOnboardingDaxTypingAnimationFinished() }
-            } else {
-                {}
-            }
-            configuration.showOnboardingCta(binding, { viewModel.onUserClickCtaOkButton() }, onTypingAnimationFinished)
-            if (configuration is OnboardingDaxDialogCta.DaxSiteSuggestionsCta) {
-                configuration.setOnOptionClicked(
-                    daxDialogOnboardingCta,
-                ) {
-                    userEnteredQuery(it.link)
-                    pixel.fire(it.pixel)
-                    viewModel.onUserClickCtaOkButton()
+            configuration.showOnboardingCta(binding, { viewModel.onUserClickCtaOkButton() }, {
+                if (configuration is OnboardingDaxDialogCta.DaxTrackersBlockedCta) {
+                    viewModel.onOnboardingDaxTypingAnimationFinished()
                 }
-            }
+
+                if (configuration is OnboardingDaxDialogCta.DaxSiteSuggestionsCta) {
+                    configuration.setOnOptionClicked(
+                        daxDialogOnboardingCta,
+                    ) {
+                        userEnteredQuery(it.link)
+                        pixel.fire(it.pixel)
+                        viewModel.onUserClickCtaOkButton()
+                    }
+                }
+            },)
+
             if (appTheme.isLightModeEnabled()) {
                 binding.includeOnboardingDaxDialog.onboardingDaxDialogBackground
                     .setBackgroundResource(R.drawable.onboarding_experiment_background_bitmap_light)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -3862,22 +3862,21 @@ class BrowserTabFragment :
         @SuppressLint("ClickableViewAccessibility")
         private fun showOnboardingDialogCta(configuration: OnboardingDaxDialogCta) {
             hideHomeBackground()
-            configuration.showOnboardingCta(binding, { viewModel.onUserClickCtaOkButton() }, {
-                if (configuration is OnboardingDaxDialogCta.DaxTrackersBlockedCta) {
-                    viewModel.onOnboardingDaxTypingAnimationFinished()
+            val onTypingAnimationFinished = if (configuration is OnboardingDaxDialogCta.DaxTrackersBlockedCta) {
+                { viewModel.onOnboardingDaxTypingAnimationFinished() }
+            } else {
+                {}
+            }
+            configuration.showOnboardingCta(binding, { viewModel.onUserClickCtaOkButton() }, onTypingAnimationFinished)
+            if (configuration is OnboardingDaxDialogCta.DaxSiteSuggestionsCta) {
+                configuration.setOnOptionClicked(
+                    daxDialogOnboardingCta,
+                ) {
+                    userEnteredQuery(it.link)
+                    pixel.fire(it.pixel)
+                    viewModel.onUserClickCtaOkButton()
                 }
-
-                if (configuration is OnboardingDaxDialogCta.DaxSiteSuggestionsCta) {
-                    configuration.setOnOptionClicked(
-                        daxDialogOnboardingCta,
-                    ) {
-                        userEnteredQuery(it.link)
-                        pixel.fire(it.pixel)
-                        viewModel.onUserClickCtaOkButton()
-                    }
-                }
-            },)
-
+            }
             if (appTheme.isLightModeEnabled()) {
                 binding.includeOnboardingDaxDialog.onboardingDaxDialogBackground
                     .setBackgroundResource(R.drawable.onboarding_experiment_background_bitmap_light)

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -374,8 +374,6 @@ sealed class OnboardingDaxDialogCta(
                     options[index].setOptionView(buttonView)
                     ViewCompat.animate(buttonView).alpha(MAX_ALPHA).duration = DAX_DIALOG_APPEARANCE_ANIMATION
                 }
-
-                onTypingAnimationFinished()
             }
         }
 

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -49,7 +49,7 @@ import com.duckduckgo.common.utils.baseHost
 import com.duckduckgo.common.utils.extensions.html
 
 interface ViewCta {
-    fun showCta(view: View)
+    fun showCta(view: View, onTypingAnimationFinished: () -> Unit)
 }
 
 interface DaxCta {
@@ -374,6 +374,8 @@ sealed class OnboardingDaxDialogCta(
                     options[index].setOptionView(buttonView)
                     ViewCompat.animate(buttonView).alpha(MAX_ALPHA).duration = DAX_DIALOG_APPEARANCE_ANIMATION
                 }
+
+                onTypingAnimationFinished()
             }
         }
 
@@ -449,7 +451,7 @@ sealed class DaxBubbleCta(
 
     private var ctaView: View? = null
 
-    override fun showCta(view: View) {
+    override fun showCta(view: View, onTypingAnimationFinished: () -> Unit) {
         ctaView = view
         val daxTitle = view.context.getString(title)
         val daxText = view.context.getString(description)
@@ -484,7 +486,9 @@ sealed class DaxBubbleCta(
             .withEndAction {
                 ViewCompat.animate(view.findViewById<DaxTextView>(R.id.daxBubbleDialogTitle)).alpha(1f).setDuration(500)
                     .withEndAction {
-                        view.findViewById<TypeAnimationTextView>(R.id.dialogTextCta).startTypingAnimation(daxText, true)
+                        view.findViewById<TypeAnimationTextView>(R.id.dialogTextCta).startTypingAnimation(daxText, true) {
+                            onTypingAnimationFinished()
+                        }
                     }
             }
     }
@@ -579,7 +583,7 @@ sealed class HomePanelCta(
     override val cancelPixel: Pixel.PixelName?,
 ) : Cta, ViewCta {
 
-    override fun showCta(view: View) {
+    override fun showCta(view: View, onTypingAnimationFinished: () -> Unit) {
         // no-op. We are now using a Bottom Sheet to display this
         // but we want to keep the same classes for pixels, etc
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207610505138605/f

### Description
Prevent early taps on DaxBubble to avoid firing events too quickly.

### Steps to test this PR

_Feature 1_
- [x] Fresh install, start onboarding
- [x] When you see the “Try a search / Try a site: CTAs try to tap on the box, so a link is tapped
- [x] Verify that links are only tappable when the whole CTA is visible
