### PR TITLE
Add HTML support in RMF title

### DIFF
--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/MessageCta.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/MessageCta.kt
@@ -79,7 +79,7 @@ class MessageCta : FrameLayout {
             remoteMessageBinding.topIllustration.show()
         }
 
-        remoteMessageBinding.messageTitle.text = message.title
+        remoteMessageBinding.messageTitle.text = HtmlCompat.fromHtml(message.title, HtmlCompat.FROM_HTML_MODE_LEGACY)
         remoteMessageBinding.messageSubtitle.text = HtmlCompat.fromHtml(message.subtitle, HtmlCompat.FROM_HTML_MODE_LEGACY)
 
         if (message.action2.isEmpty()) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201807753394693/1207619945513388/f

### Description
Support HTML text in RMF title

### Steps to test this PR

- [ ] Change endpoint in `RemoteMessagingService` to `https://www.jsonblob.com/api/1248254773076811776`
- [ ] Fresh install
- [ ] Finish onboarding
- [ ] Check new message appears and title looks fine
- [ ] Tap fire button and clear data
- [ ] Check the same message appears but with a line break in the title

### No UI changes
