### PR TITLE
Update autofill to 12.0.0

### DIFF
--- a/node_modules/@duckduckgo/autofill/README.md
+++ b/node_modules/@duckduckgo/autofill/README.md
@@ -25,6 +25,11 @@ On Apple clients, autofill is included as part of the [BrowserServicesKit](https
 
 The easiest way to override the client version of autofill is to drag-and-drop your local autofill folder from the Finder right into Xcode project navigator, at the root level. If you're working in BSK, you can drag-and-drop autofill in the BSK project and then drag-and-drop BSK itself in the platform project.
 
+### Updating Translations
+Translations are stored in `src/locales/${language}/${namespace}.json`, e.g. `src/locales/xa/autofill.json` for the psuedo-locale "xa" and namespace "autofill". Using these translations requires updating those JSON files and rebuilding this project.
+
+If a new language or namespace is added, the `translations.js` file must be rebuilt to import the new languages/namespaces. This is available via `npm run build:translations`. Because languages and namespaces are rarely added, it is not run automatically at any point of the build process.
+
 ## Start a release using the CI pipeline
 
 We have GitHub Action to facilitate releases. Remember to test on all platforms before proceeding. 

--- a/node_modules/@duckduckgo/autofill/dist/autofill-debug.js
+++ b/node_modules/@duckduckgo/autofill/dist/autofill-debug.js
@@ -5828,7 +5828,7 @@ const DEFAULT_MIN_LENGTH = 20;
 const DEFAULT_MAX_LENGTH = 30;
 const DEFAULT_REQUIRED_CHARS = '-!?$&#%';
 const DEFAULT_UNAMBIGUOUS_CHARS = 'abcdefghijkmnopqrstuvwxyzABCDEFGHIJKLMNPQRSTUVWXYZ0123456789';
-const DEFAULT_PASSWORD_RULES = [`minlength: ${DEFAULT_MIN_LENGTH}`, `maxlength: ${DEFAULT_MAX_LENGTH}`, `required: [${DEFAULT_REQUIRED_CHARS}]`, `allowed: [${DEFAULT_UNAMBIGUOUS_CHARS}]`].join('; ');
+const DEFAULT_PASSWORD_RULES = [`minlength: ${DEFAULT_MIN_LENGTH}`, `maxlength: ${DEFAULT_MAX_LENGTH}`, `required: [${DEFAULT_REQUIRED_CHARS}]`, `required: digit`, `allowed: [${DEFAULT_UNAMBIGUOUS_CHARS}]`].join('; ');
 const constants = exports.constants = {
   DEFAULT_MIN_LENGTH,
   DEFAULT_MAX_LENGTH,
@@ -6444,6 +6444,9 @@ module.exports={
   "access.service.gov.uk": {
     "password-rules": "minlength: 10; required: lower; required: upper; required: digit; required: special;"
   },
+  "account.samsung.com": {
+    "password-rules": "minlength: 8; maxlength: 15; required: digit; required: special; required: upper,lower;"
+  },
   "admiral.com": {
     "password-rules": "minlength: 8; required: digit; required: [- !\"#$&'()*+,.:;<=>?@[^_`{|}~]]; allowed: lower, upper;"
   },
@@ -6476,6 +6479,9 @@ module.exports={
   },
   "americanexpress.com": {
     "password-rules": "minlength: 8; maxlength: 20; max-consecutive: 4; required: lower, upper; required: digit; allowed: [%&_?#=];"
+  },
+  "ana.co.jp": {
+    "password-rules": "minlength: 8; maxlength: 16; required: digit; required: upper,lower;"
   },
   "anatel.gov.br": {
     "password-rules": "minlength: 6; maxlength: 15; allowed: lower, upper, digit;"
@@ -6619,7 +6625,7 @@ module.exports={
     "password-rules": "minlength: 5; required: lower, upper; required: digit;"
   },
   "cogmembers.org": {
-    "password-rules": "minlength: 8; maxlength: 14; required: upper; required: digit, allowed: lower;"
+    "password-rules": "minlength: 8; maxlength: 14; required: upper; required: digit; allowed: lower;"
   },
   "collectivehealth.com": {
     "password-rules": "minlength: 8; required: lower; required: upper; required: digit;"
@@ -6640,7 +6646,7 @@ module.exports={
     "password-rules": "minlength: 6; maxlength: 15; allowed: lower, upper, digit, [-.];"
   },
   "costco.com": {
-    "password-rules": "minlength: 8; maxlength: 20; required: lower, upper; allowed: digit, [-!#$%&'()*+/:;=?@[^_`{|}~]];"
+    "password-rules": "minlength: 8; maxlength: 16; required: lower, upper; allowed: digit, [-!#$%&'()*+/:;=?@[^_`{|}~]];"
   },
   "coursera.com": {
     "password-rules": "minlength: 8; maxlength: 72;"
@@ -6689,6 +6695,9 @@ module.exports={
   },
   "dmm.com": {
     "password-rules": "minlength: 4; maxlength: 16; required: lower; required: upper; required: digit;"
+  },
+  "dodgeridge.com": {
+    "password-rules": "minlength: 8; maxlength: 12; required: lower; required: upper; required: digit;"
   },
   "dowjones.com": {
     "password-rules": "maxlength: 15;"
@@ -7347,6 +7356,9 @@ module.exports={
   "udel.edu": {
     "password-rules": "minlength: 12; maxlength: 30; required: lower; required: upper; required: digit; required: [!@#$%^&*()+];"
   },
+  "umterps.evenue.net": {
+    "password-rules": "minlength: 4; maxlength: 12;"
+  },
   "user.ornl.gov": {
     "password-rules": "minlength: 8; maxlength: 30; max-consecutive: 3; required: lower, upper; required: digit; allowed: [!#$%./_];"
   },
@@ -7878,6 +7890,20 @@ class AppleDeviceInterface extends _InterfacePrototype.default {
   }
 
   /**
+   * Opens the native UI for managing identities
+   */
+  openManageIdentities() {
+    return this.deviceApi.notify((0, _index.createNotification)('pmHandlerOpenManageIdentities'));
+  }
+
+  /**
+   * Opens the native UI for managing credit cards
+   */
+  openManageCreditCards() {
+    return this.deviceApi.notify((0, _index.createNotification)('pmHandlerOpenManageCreditCards'));
+  }
+
+  /**
    * Gets a single identity obj once the user requests it
    * @param {IdentityObject['id']} id
    * @returns {Promise<{success: IdentityObject|undefined}>}
@@ -8341,6 +8367,7 @@ var _index = require("../../packages/device-api/index.js");
 var _deviceApiCalls = require("../deviceApiCalls/__generated__/deviceApiCalls.js");
 var _initFormSubmissionsApi = require("./initFormSubmissionsApi.js");
 var _EmailProtection = require("../EmailProtection.js");
+var _strings = require("../locales/strings.js");
 /**
  * @typedef {import('../deviceApiCalls/__generated__/validators-ts').StoreFormData} StoreFormData
  */
@@ -8386,6 +8413,13 @@ class InterfacePrototype {
   /** @type {import("../../packages/device-api").DeviceApi} */
   deviceApi;
 
+  /**
+   * Translates a string to the current language, replacing each placeholder
+   * with a key present in `opts` with the corresponding value.
+   * @type {import('../locales/strings').TranslateFn}
+   */
+  t;
+
   /** @type {boolean} */
   isInitializationStarted;
 
@@ -8401,6 +8435,7 @@ class InterfacePrototype {
     this.globalConfig = config;
     this.deviceApi = deviceApi;
     this.settings = settings;
+    this.t = (0, _strings.getTranslator)(settings);
     this.uiController = null;
     this.scanner = (0, _Scanner.createScanner)(this, {
       initialDelay: this.initialSetupDelayMs
@@ -8488,13 +8523,13 @@ class InterfacePrototype {
       newIdentities.push({
         id: 'personalAddress',
         emailAddress: personalAddress,
-        title: 'Block email trackers'
+        title: this.t('autofill:blockEmailTrackers')
       });
     }
     newIdentities.push({
       id: 'privateAddress',
       emailAddress: privateAddress,
-      title: 'Block email trackers & hide address'
+      title: this.t('autofill:blockEmailTrackersAndHideAddress')
     });
     return [...identities, ...newIdentities];
   }
@@ -8735,7 +8770,7 @@ class InterfacePrototype {
     this.activeForm = form;
     const inputType = (0, _matching.getInputType)(input);
 
-    /** @type {PosFn} */
+    /** @type {import('../UI/interfaces.js').PosFn} */
     const getPosition = () => {
       // In extensions, the tooltip is centered on the Dax icon
       const alignLeft = this.globalConfig.isApp || this.globalConfig.isWindows;
@@ -9139,7 +9174,7 @@ class InterfacePrototype {
 }
 var _default = exports.default = InterfacePrototype;
 
-},{"../../packages/device-api/index.js":12,"../EmailProtection.js":32,"../Form/formatters.js":36,"../Form/matching.js":43,"../InputTypes/Credentials.js":45,"../PasswordGenerator.js":48,"../Scanner.js":49,"../Settings.js":50,"../UI/controllers/NativeUIController.js":57,"../autofill-utils.js":62,"../config.js":64,"../deviceApiCalls/__generated__/deviceApiCalls.js":66,"../deviceApiCalls/transports/transports.js":72,"./initFormSubmissionsApi.js":30}],28:[function(require,module,exports){
+},{"../../packages/device-api/index.js":12,"../EmailProtection.js":32,"../Form/formatters.js":36,"../Form/matching.js":43,"../InputTypes/Credentials.js":45,"../PasswordGenerator.js":48,"../Scanner.js":49,"../Settings.js":50,"../UI/controllers/NativeUIController.js":57,"../autofill-utils.js":62,"../config.js":64,"../deviceApiCalls/__generated__/deviceApiCalls.js":66,"../deviceApiCalls/transports/transports.js":72,"../locales/strings.js":97,"./initFormSubmissionsApi.js":30}],28:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -12391,7 +12426,7 @@ const matchingConfiguration = exports.matchingConfiguration = {
         formInputsSelector: 'input:not([type=button]):not([type=checkbox]):not([type=color]):not([type=file]):not([type=hidden]):not([type=radio]):not([type=range]):not([type=reset]):not([type=image]):not([type=search]):not([type=submit]):not([type=time]):not([type=url]):not([type=week]):not([name^=fake i]):not([data-description^=dummy i]):not([name*=otp]):not([autocomplete="fake"]):not([placeholder^=search i]):not([type=date]):not([type=datetime-local]):not([type=datetime]):not([type=month]),[autocomplete=username],select',
         safeUniversalSelector: '*:not(select):not(option):not(script):not(noscript):not(style):not(br)',
         emailAddress: 'input:not([type])[name*=email i]:not([placeholder*=search i]):not([placeholder*=filter i]):not([placeholder*=subject i]):not([name*=code i]), input[type=""][name*=email i]:not([placeholder*=search i]):not([placeholder*=filter i]):not([placeholder*=subject i]):not([type=tel]), input[type=text][name*=email i]:not([placeholder*=search i]):not([placeholder*=filter i]):not([placeholder*=subject i]):not([name*=title i]):not([name*=tab i]):not([name*=code i]), input:not([type])[placeholder*=email i]:not([placeholder*=search i]):not([placeholder*=filter i]):not([placeholder*=subject i]):not([name*=code i]), input[type=text][placeholder*=email i]:not([placeholder*=search i]):not([placeholder*=filter i]):not([placeholder*=subject i]), input[type=""][placeholder*=email i]:not([placeholder*=search i]):not([placeholder*=filter i]):not([placeholder*=subject i]), input[type=email], input[type=text][aria-label*=email i]:not([aria-label*=search i]), input:not([type])[aria-label*=email i]:not([aria-label*=search i]), input[name=username][type=email], input[autocomplete=username][type=email], input[autocomplete=username][placeholder*=email i], input[autocomplete=email],input[name="mail_tel" i],input[value=email i]',
-        username: 'input:not([type=button]):not([type=checkbox]):not([type=color]):not([type=file]):not([type=hidden]):not([type=radio]):not([type=range]):not([type=reset]):not([type=image]):not([type=search]):not([type=submit]):not([type=time]):not([type=url]):not([type=week]):not([name^=fake i]):not([data-description^=dummy i]):not([name*=otp]):not([autocomplete="fake"]):not([placeholder^=search i]):not([type=date]):not([type=datetime-local]):not([type=datetime]):not([type=month])[autocomplete^=user i],input[name=username i],input[name="loginId" i],input[name="userid" i],input[id="userid" i],input[name="user_id" i],input[name="user-id" i],input[id="login-id" i],input[id="login_id" i],input[id="loginid" i],input[name="login" i],input[name=accountname i],input[autocomplete=username i],input[name*=accountid i],input[name="j_username" i],input[id="j_username" i],input[name="uwinid" i],input[name="livedoor_id" i],input[name="ssousername" i],input[name="j_userlogin_pwd" i],input[name="user[login]" i],input[name="user" i],input[name$="_username" i],input[id="lmSsoinput" i],input[name="account_subdomain" i],input[name="masterid" i],input[name="tridField" i],input[id="signInName" i],input[id="w3c_accountsbundle_accountrequeststep1_login" i],input[id="username" i],input[name="_user" i],input[name="login_username" i],input[name^="login-user-account" i],input[id="loginusuario" i],input[name="usuario" i],input[id="UserLoginFormUsername" i],input[id="nw_username" i],input[can-field="accountName"],input[placeholder^="username" i]',
+        username: 'input:not([type=button]):not([type=checkbox]):not([type=color]):not([type=file]):not([type=hidden]):not([type=radio]):not([type=range]):not([type=reset]):not([type=image]):not([type=search]):not([type=submit]):not([type=time]):not([type=url]):not([type=week]):not([name^=fake i]):not([data-description^=dummy i]):not([name*=otp]):not([autocomplete="fake"]):not([placeholder^=search i]):not([type=date]):not([type=datetime-local]):not([type=datetime]):not([type=month])[autocomplete^=user i],input[name=username i],input[name="loginId" i],input[name="userid" i],input[id="userid" i],input[name="user_id" i],input[name="user-id" i],input[id="login-id" i],input[id="login_id" i],input[id="loginid" i],input[name="login" i],input[name=accountname i],input[autocomplete=username i],input[name*=accountid i],input[name="j_username" i],input[id="j_username" i],input[name="uwinid" i],input[name="livedoor_id" i],input[name="ssousername" i],input[name="j_userlogin_pwd" i],input[name="user[login]" i],input[name="user" i],input[name$="_username" i],input[id="lmSsoinput" i],input[name="account_subdomain" i],input[name="masterid" i],input[name="tridField" i],input[id="signInName" i],input[id="w3c_accountsbundle_accountrequeststep1_login" i],input[id="username" i],input[name="_user" i],input[name="login_username" i],input[name^="login-user-account" i],input[id="loginusuario" i],input[name="usuario" i],input[id="UserLoginFormUsername" i],input[id="nw_username" i],input[can-field="accountName"],input[name="login[username]"],input[placeholder^="username" i]',
         password: 'input[type=password]:not([autocomplete*=cc]):not([autocomplete=one-time-code]):not([name*=answer i]):not([name*=mfa i]):not([name*=tin i]):not([name*=card i]):not([name*=cvv i]),input.js-cloudsave-phrase',
         cardName: 'input[autocomplete="cc-name" i], input[autocomplete="ccname" i], input[name="ccname" i], input[name="cc-name" i], input[name="ppw-accountHolderName" i], input[id*=cardname i], input[id*=card-name i], input[id*=card_name i]',
         cardNumber: 'input[autocomplete="cc-number" i], input[autocomplete="ccnumber" i], input[autocomplete="cardnumber" i], input[autocomplete="card-number" i], input[name="ccnumber" i], input[name="cc-number" i], input[name*=card i][name*=number i], input[name*=cardnumber i], input[id*=cardnumber i], input[id*=card-number i], input[id*=card_number i]',
@@ -12418,7 +12453,7 @@ const matchingConfiguration = exports.matchingConfiguration = {
     ddgMatcher: {
       matchers: {
         unknown: {
-          match: /search|filter|subject|title|captcha|mfa|2fa|(two|2).?factor|one-time|otp|cerca|filtr|oggetto|titolo|(due|2|più).?fattori|suche|filtern|betreff|zoeken|filter|onderwerp|titel|chercher|filtrer|objet|titre|authentification multifacteur|double authentification|à usage unique|busca|busqueda|filtra|dos pasos|un solo uso|sök|filter|ämne|multifaktorsautentisering|tvåfaktorsautentisering|två.?faktor|engångs/iu,
+          match: /search|find|filter|subject|title|captcha|mfa|2fa|(two|2).?factor|one-time|otp|social security number|ssn|cerca|filtr|oggetto|titolo|(due|2|più).?fattori|suche|filtern|betreff|zoeken|filter|onderwerp|titel|chercher|filtrer|objet|titre|authentification multifacteur|double authentification|à usage unique|busca|busqueda|filtra|dos pasos|un solo uso|sök|filter|ämne|multifaktorsautentisering|tvåfaktorsautentisering|två.?faktor|engångs/iu,
           skip: /phone|mobile|email|password/iu
         },
         emailAddress: {
@@ -12428,7 +12463,7 @@ const matchingConfiguration = exports.matchingConfiguration = {
         },
         password: {
           match: /password|passwort|kennwort|wachtwoord|mot de passe|clave|contraseña|lösenord/iu,
-          skip: /email|one-time|error|hint/iu,
+          skip: /email|one-time|error|hint|^username$/iu,
           forceUnknown: /captcha|mfa|2fa|two factor|otp|pin/iu
         },
         newPassword: {
@@ -12438,7 +12473,7 @@ const matchingConfiguration = exports.matchingConfiguration = {
           match: /current|old|previous|expired|existing/iu
         },
         username: {
-          match: /(user|account|online.?id|log(i|o)n|net)((.)?(name|i.?d.?|log(i|o)n).?)?(.?((or|\/).+|\*|:)( required)?)?$|(nome|id|login).?utente|(nome|id) (dell.)?account|codice cliente|nutzername|anmeldename|gebruikersnaam|nom d.utilisateur|identifiant|pseudo|usuari|cuenta|identificador|apodo|\bdni\b|\bnie\b| del? documento|documento de identidad|användarnamn|kontonamn|användar-id/iu,
+          match: /(user|account|online.?id|membership.?id|log(i|o)n|net)((.)?(name|i.?d.?|log(i|o)n).?)?(.?((or|\/).+|\*|:)( required)?)?$|(nome|id|login).?utente|(nome|id) (dell.)?account|codice (cliente|uten)|nutzername|anmeldename|gebruikersnaam|nom d.utilisateur|identifiant|pseudo|usuari|cuenta|identificador|apodo|\bdni\b|\bnie\b| del? documento|documento de identidad|användarnamn|kontonamn|användar-id/iu,
           skip: /phone/iu,
           forceUnknown: /search|policy|choose a user\b/iu
         },
@@ -13595,6 +13630,8 @@ const recursiveGetPreviousElSibling = el => {
 const getRelatedText = (el, form, cssSelector) => {
   let scope = getLargestMeaningfulContainer(el, form, cssSelector);
 
+  // TODO: We should try and simplify this, the logic has become very hard to follow over time
+
   // If we didn't find a container, try looking for an adjacent label
   if (scope === el) {
     let previousEl = recursiveGetPreviousElSibling(el);
@@ -13621,7 +13658,7 @@ const getRelatedText = (el, form, cssSelector) => {
   const label = scope.querySelector('label');
   if (label) {
     // Try searching for a label first
-    trimmedText = (0, _autofillUtils.getTextShallow)(label);
+    trimmedText = (0, _labelUtil.extractElementStrings)(label).join(' ');
   } else {
     // If the container has a select element, remove its contents to avoid noise
     trimmedText = (0, _labelUtil.extractElementStrings)(scope).join(' ');
@@ -13648,6 +13685,11 @@ const getLargestMeaningfulContainer = (el, form, cssSelector) => {
   const inputsInParentsScope = parentElement.querySelectorAll(cssSelector);
   // To avoid noise, ensure that our input is the only in scope
   if (inputsInParentsScope.length === 1) {
+    // If the parent has only 1 input and a label with text, we've found our meaningful container
+    const labelInParentScope = parentElement.querySelector('label');
+    if (labelInParentScope?.textContent?.trim()) {
+      return parentElement;
+    }
     return getLargestMeaningfulContainer(parentElement, form, cssSelector);
   }
   return el;
@@ -13831,6 +13873,8 @@ exports.appendGeneratedKey = appendGeneratedKey;
 exports.createCredentialsTooltipItem = createCredentialsTooltipItem;
 exports.fromPassword = fromPassword;
 var _autofillUtils = require("../autofill-utils.js");
+/** @typedef {import("../UI/interfaces").TooltipItemRenderer} TooltipItemRenderer */
+
 const AUTOGENERATED_KEY = exports.AUTOGENERATED_KEY = 'autogenerated';
 const PROVIDER_LOCKED = exports.PROVIDER_LOCKED = 'provider_locked';
 
@@ -13845,16 +13889,19 @@ class CredentialsTooltipItem {
     this.#data = data;
   }
   id = () => String(this.#data.id);
-  labelMedium = _subtype => {
+  /** @param {import('../locales/strings.js').TranslateFn} t */
+  labelMedium = t => {
     if (this.#data.username) {
       return this.#data.username;
     }
     if (this.#data.origin?.url) {
-      return `Password for ${(0, _autofillUtils.truncateFromMiddle)(this.#data.origin.url)}`;
+      return t('autofill:passwordForUrl', {
+        url: (0, _autofillUtils.truncateFromMiddle)(this.#data.origin.url)
+      });
     }
     return '';
   };
-  labelSmall = _subtype => {
+  labelSmall = () => {
     if (this.#data.origin?.url) {
       return (0, _autofillUtils.truncateFromMiddle)(this.#data.origin.url);
     }
@@ -13875,8 +13922,10 @@ class AutoGeneratedCredential {
   }
   id = () => String(this.#data.id);
   label = _subtype => this.#data.password;
-  labelMedium = _subtype => 'Generated password';
-  labelSmall = _subtype => 'Password will be saved for this website';
+  /** @param {import('../locales/strings.js').TranslateFn} t */
+  labelMedium = t => t('autofill:generatedPassword');
+  /** @param {import('../locales/strings.js').TranslateFn} t */
+  labelSmall = t => t('autofill:passwordWillBeSaved');
 }
 
 /**
@@ -13906,8 +13955,10 @@ class ProviderLockedItem {
     this.#data = data;
   }
   id = () => String(this.#data.id);
-  labelMedium = _subtype => 'Bitwarden is locked';
-  labelSmall = _subtype => 'Unlock your vault to access credentials or generate passwords';
+  /** @param {import('../locales/strings.js').TranslateFn} t */
+  labelMedium = t => t('autofill:bitwardenIsLocked');
+  /** @param {import('../locales/strings.js').TranslateFn} t */
+  labelSmall = t => t('autofill:unlockYourVault');
   credentialsProvider = () => this.#data.credentialsProvider;
 }
 
@@ -13974,6 +14025,8 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.CreditCardTooltipItem = void 0;
+/** @typedef {import("../UI/interfaces").TooltipItemRenderer} TooltipItemRenderer */
+
 /**
  * @implements {TooltipItemRenderer}
  */
@@ -13985,8 +14038,8 @@ class CreditCardTooltipItem {
     this.#data = data;
   }
   id = () => String(this.#data.id);
-  labelMedium = _ => this.#data.title;
-  labelSmall = _ => this.#data.displayNumber;
+  labelMedium = () => this.#data.title;
+  labelSmall = () => this.#data.displayNumber;
 }
 exports.CreditCardTooltipItem = CreditCardTooltipItem;
 
@@ -13998,6 +14051,8 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.IdentityTooltipItem = void 0;
 var _formatters = require("../Form/formatters.js");
+/** @typedef {import("../UI/interfaces").TooltipItemRenderer} TooltipItemRenderer */
+
 /**
  * @implements {TooltipItemRenderer}
  */
@@ -14009,16 +14064,20 @@ class IdentityTooltipItem {
     this.#data = data;
   }
   id = () => String(this.#data.id);
-  labelMedium = subtype => {
+  /**
+   * @param {import('../locales/strings.js').TranslateFn} t
+   * @param {string} subtype
+   */
+  labelMedium = (t, subtype) => {
     if (subtype === 'addressCountryCode') {
       return (0, _formatters.getCountryDisplayName)('en', this.#data.addressCountryCode || '');
     }
     if (this.#data.id === 'privateAddress') {
-      return 'Generate Private Duck Address';
+      return t('autofill:generatePrivateDuckAddr');
     }
     return this.#data[subtype];
   };
-  label(subtype) {
+  label(_t, subtype) {
     if (this.#data.id === 'privateAddress') {
       return this.#data[subtype];
     }
@@ -14529,6 +14588,8 @@ class Settings {
   _runtimeConfiguration = null;
   /** @type {boolean | null} */
   _enabled = null;
+  /** @type {string} */
+  _language = 'en';
 
   /**
    * @param {GlobalConfig} config
@@ -14586,6 +14647,35 @@ class Settings {
   }
 
   /**
+   * Retrieves the user's language from the current platform's `RuntimeConfiguration`. If the
+   * platform doesn't include a two-character `.userPreferences.language` property in its runtime
+   * configuration, or if an error occurs, 'en' is used as a fallback.
+   *
+   * NOTE: This function returns the two-character 'language' code of a typical POSIX locale
+   * (e.g. 'en', 'de', 'fr') listed in ISO 639-1[1].
+   *
+   * [1] https://en.wikipedia.org/wiki/ISO_639-1
+   *
+   * @returns {Promise<string>} the device's current language code, or 'en' if something goes wrong
+   */
+  async getLanguage() {
+    try {
+      const conf = await this._getRuntimeConfiguration();
+      const language = conf.userPreferences.language ?? 'en';
+      if (language.length !== 2) {
+        console.warn(`config.userPreferences.language must be two characters, but received '${language}'`);
+        return 'en';
+      }
+      return language;
+    } catch (e) {
+      if (this.globalConfig.isDDGTestMode) {
+        console.log('isDDGTestMode: getLanguage: ❌', e);
+      }
+      return 'en';
+    }
+  }
+
+  /**
    * Get runtime configuration, but only once.
    *
    * Some platforms may be reading this directly from inlined variables, whilst others
@@ -14628,7 +14718,8 @@ class Settings {
 
   /**
    * To 'refresh' settings means to re-call APIs to determine new state. This may
-   * only occur once per page, but it must be done before any page scanning/decorating can happen
+   * only occur once per page, but it must be done before any page scanning/decorating
+   * or translation can happen.
    *
    * @returns {Promise<{
    *      availableInputTypes: AvailableInputTypes,
@@ -14640,6 +14731,7 @@ class Settings {
     this.setEnabled(await this.getEnabled());
     this.setFeatureToggles(await this.getFeatureToggles());
     this.setAvailableInputTypes(await this.getAvailableInputTypes());
+    this.setLanguage(await this.getLanguage());
 
     // If 'this.enabled' is a boolean it means we were able to set it correctly and therefor respect its value
     if (typeof this.enabled === 'boolean') {
@@ -14774,6 +14866,19 @@ class Settings {
       ...this._availableInputTypes,
       ...value
     };
+  }
+
+  /** @returns {string} the user's current two-character language code, as provided by the platform */
+  get language() {
+    return this._language;
+  }
+
+  /**
+   * Sets the current two-character language code.
+   * @param {string} language - the language
+   */
+  setLanguage(language) {
+    this._language = language;
   }
   static defaults = {
     /** @type {AutofillFeatureToggles} */
@@ -14943,8 +15048,27 @@ var _autofillUtils = require("../autofill-utils.js");
 var _HTMLTooltip = _interopRequireDefault(require("./HTMLTooltip.js"));
 var _Credentials = require("../InputTypes/Credentials.js");
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+/**
+ * A mapping of main autofill item type to the 'Manage XYZ…' string ID for that
+ * item.
+ * @type {Record<SupportedMainTypes, import('../locales/strings').AutofillKeys>}
+ *
+ * @example
+ * const id = manageItemStringIds['credentials'] // => 'autofill:managePasswords'
+ * const str = t(id);                            // => 'Manage passwords…' in English
+ */
+const manageItemStringIds = {
+  credentials: 'autofill:managePasswords',
+  creditCards: 'autofill:manageCreditCards',
+  identities: 'autofill:manageIdentities',
+  unknown: 'autofill:manageSavedItems'
+};
 class DataHTMLTooltip extends _HTMLTooltip.default {
-  renderEmailProtectionIncontextSignup(isOtherItems) {
+  /**
+   * @param {import("../locales/strings").TranslateFn} t
+   * @param {boolean} isOtherItems
+   */
+  renderEmailProtectionIncontextSignup(t, isOtherItems) {
     const dataTypeClass = `tooltip__button--data--identities`;
     const providerIconClass = 'tooltip__button--data--duckduckgo';
     return `
@@ -14952,10 +15076,10 @@ class DataHTMLTooltip extends _HTMLTooltip.default {
             <button id="incontextSignup" class="tooltip__button tooltip__button--data ${dataTypeClass} ${providerIconClass} js-get-email-signup">
                 <span class="tooltip__button__text-container">
                     <span class="label label--medium">
-                        Hide your email and block trackers
+                        ${t('autofill:hideEmailAndBlockTrackers')}
                     </span>
                     <span class="label label--small">
-                        Create a unique, random address that also removes hidden trackers and forwards email to your inbox.
+                        ${t('autofill:createUniqueRandomAddr')}
                     </span>
                 </span>
             </button>
@@ -14963,8 +15087,9 @@ class DataHTMLTooltip extends _HTMLTooltip.default {
   }
 
   /**
+   * @param {import("../DeviceInterface/InterfacePrototype").default} device
    * @param {InputTypeConfigs} config
-   * @param {TooltipItemRenderer[]} items
+   * @param {import('./interfaces.js').TooltipItemRenderer[]} items
    * @param {{
    *   onSelect(id:string): void
    *   onManage(type:InputTypeConfigs['type']): void
@@ -14974,7 +15099,8 @@ class DataHTMLTooltip extends _HTMLTooltip.default {
    *   onIncontextSignup?(): void
    * }} callbacks
    */
-  render(config, items, callbacks) {
+  render(device, config, items, callbacks) {
+    const t = device.t;
     const {
       wrapperClass,
       css
@@ -15003,25 +15129,27 @@ ${css}
       const credentialsProvider = item.credentialsProvider?.();
       const providerIconClass = credentialsProvider ? `tooltip__button--data--${credentialsProvider}` : '';
       // these 2 are optional
-      const labelSmall = item.labelSmall?.(this.subtype);
-      const label = item.label?.(this.subtype);
+      const labelSmall = item.labelSmall?.(t, this.subtype);
+      const label = item.label?.(t, this.subtype);
       return `
             ${shouldShowSeparator(item.id(), index) ? '<hr />' : ''}
             <button id="${item.id()}" class="tooltip__button tooltip__button--data ${dataTypeClass} ${providerIconClass} js-autofill-button">
                 <span class="tooltip__button__text-container">
-                    <span class="label label--medium">${(0, _autofillUtils.escapeXML)(item.labelMedium(this.subtype))}</span>
+                    <span class="label label--medium">${(0, _autofillUtils.escapeXML)(item.labelMedium(t, this.subtype))}</span>
                     ${label ? `<span class="label">${(0, _autofillUtils.escapeXML)(label)}</span>` : ''}
                     ${labelSmall ? `<span class="label label--small">${(0, _autofillUtils.escapeXML)(labelSmall)}</span>` : ''}
                 </span>
             </button>
         `;
     }).join('')}
-        ${this.options.isIncontextSignupAvailable() ? this.renderEmailProtectionIncontextSignup(items.length > 0) : ''}
+        ${this.options.isIncontextSignupAvailable() ? this.renderEmailProtectionIncontextSignup(t, items.length > 0) : ''}
         ${shouldShowManageButton ? `
             <hr />
             <button id="manage-button" class="tooltip__button tooltip__button--manage" type="button">
                 <span class="tooltip__button__text-container">
-                    <span class="label label--medium">Manage ${config.displayName}…</span>
+                    <span class="label label--medium">
+                        ${t(manageItemStringIds[config.type] ?? 'autofill:manageSavedItems')}
+                    </span>
                 </span>
             </button>` : ''}
     </div>
@@ -15083,13 +15211,15 @@ ${this.options.css}
     <div class="tooltip tooltip--email">
         <button class="tooltip__button tooltip__button--email js-use-personal">
             <span class="tooltip__button--email__primary-text">
-                Use <span class="js-address">${(0, _autofillUtils.formatDuckAddress)((0, _autofillUtils.escapeXML)(this.addresses.personalAddress))}</span>
+                ${this.device.t('autofill:usePersonalDuckAddr', {
+      email: (0, _autofillUtils.formatDuckAddress)((0, _autofillUtils.escapeXML)(this.addresses.personalAddress))
+    })}
             </span>
-            <span class="tooltip__button--email__secondary-text">Block email trackers</span>
+            <span class="tooltip__button--email__secondary-text">${this.device.t('autofill:blockEmailTrackers')}</span>
         </button>
         <button class="tooltip__button tooltip__button--email js-use-private">
-            <span class="tooltip__button--email__primary-text">Generate a Private Duck Address</span>
-            <span class="tooltip__button--email__secondary-text">Block email trackers & hide address</span>
+            <span class="tooltip__button--email__primary-text">${this.device.t('autofill:generateDuckAddr')}</span>
+            <span class="tooltip__button--email__secondary-text">${this.device.t('autofill:blockEmailTrackersAndHideAddress')}</span>
         </button>
     </div>
     <div class="tooltip--email__caret"></div>
@@ -15098,11 +15228,13 @@ ${this.options.css}
     this.tooltip = this.shadow.querySelector('.tooltip');
     this.usePersonalButton = this.shadow.querySelector('.js-use-personal');
     this.usePrivateButton = this.shadow.querySelector('.js-use-private');
-    this.addressEl = this.shadow.querySelector('.js-address');
+    this.usePersonalCta = this.shadow.querySelector('.js-use-personal > span:first-of-type');
     this.updateAddresses = addresses => {
-      if (addresses && this.addressEl) {
+      if (addresses && this.usePersonalCta) {
         this.addresses = addresses;
-        this.addressEl.textContent = (0, _autofillUtils.formatDuckAddress)(addresses.personalAddress);
+        this.usePersonalCta.textContent = this.device.t('autofill:usePersonalDuckAddr', {
+          email: (0, _autofillUtils.formatDuckAddress)(addresses.personalAddress)
+        });
       }
     };
     const firePixel = this.device.firePixel.bind(this.device);
@@ -15153,23 +15285,20 @@ class EmailSignupHTMLTooltip extends _HTMLTooltip.default {
    */
   render(device) {
     this.device = device;
+    const t = this.device.t;
     this.shadow.innerHTML = `
 ${this.options.css}
 <div class="wrapper wrapper--email" hidden>
     <div class="tooltip tooltip--email tooltip--email-signup">
         <button class="close-tooltip js-close-email-signup" aria-label="Close"></button>
-        <h1>
-            Hide your email and block trackers
-        </h1>
-        <p>
-            Create a unique, random address that also removes hidden trackers and forwards email to your inbox.
-        </p>
+        <h1>${t('autofill:hideEmailAndBlockTrackers')}</h1>
+        <p>${t('autofill:createUniqueRandomAddr')}</p>
         <div class="notice-controls">
             <a href="https://duckduckgo.com/email/start-incontext" target="_blank" class="primary js-get-email-signup">
-                Protect My Email
+                ${t('autofill:protectMyEmail')}
             </a>
             <button class="ghost js-dismiss-email-signup">
-                Don't Show Again
+                ${t('autofill:dontShowAgain')}
             </button>
         </div>
     </div>
@@ -15680,7 +15809,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
 
   /**
    * Actually create the HTML Tooltip
-   * @param {PosFn} getPosition
+   * @param {import('../interfaces.js').PosFn} getPosition
    * @param {TopContextData} topContextData
    * @return {import("../HTMLTooltip").HTMLTooltip}
    */
@@ -15720,7 +15849,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
     const asRenderers = data.map(d => config.tooltipItem(d));
 
     // construct the autofill
-    return new _DataHTMLTooltip.default(config, topContextData.inputType, getPosition, tooltipOptions).render(config, asRenderers, {
+    return new _DataHTMLTooltip.default(config, topContextData.inputType, getPosition, tooltipOptions).render(this._options.device, config, asRenderers, {
       onSelect: id => {
         this._onSelect(topContextData.inputType, data, id);
       },
@@ -15743,7 +15872,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
     const asRenderers = data.map(d => config.tooltipItem(d));
     const activeTooltip = this.getActiveTooltip();
     if (activeTooltip instanceof _DataHTMLTooltip.default) {
-      activeTooltip?.render(config, asRenderers, {
+      activeTooltip?.render(this._options.device, config, asRenderers, {
         onSelect: id => {
           this._onSelect(this._activeInputType, data, id);
         },
@@ -16378,7 +16507,7 @@ class UIController {
    * For example, in an 'overlay' on macOS/Windows this is needed since
    * there's no page information to call 'attach' above.
    *
-   * @param {PosFn} _pos
+   * @param {import("../interfaces").PosFn} _pos
    * @param {TopContextData} _topContextData
    * @returns {any | null}
    */
@@ -16446,7 +16575,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.CSS_STYLES = void 0;
-const CSS_STYLES = exports.CSS_STYLES = ":root {\n    color-scheme: light dark;\n}\n\n.wrapper *, .wrapper *::before, .wrapper *::after {\n    box-sizing: border-box;\n}\n.wrapper {\n    position: fixed;\n    top: 0;\n    left: 0;\n    padding: 0;\n    font-family: 'DDG_ProximaNova', 'Proxima Nova', system-ui, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',\n    'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;\n    -webkit-font-smoothing: antialiased;\n    z-index: 2147483647;\n}\n.wrapper--data {\n    font-family: 'SF Pro Text', system-ui, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',\n    'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;\n}\n:not(.top-autofill) .tooltip {\n    position: absolute;\n    width: 300px;\n    max-width: calc(100vw - 25px);\n    transform: translate(-1000px, -1000px);\n    z-index: 2147483647;\n}\n.tooltip--data, #topAutofill {\n    background-color: rgba(242, 240, 240, 1);\n    -webkit-backdrop-filter: blur(40px);\n    backdrop-filter: blur(40px);\n}\n@media (prefers-color-scheme: dark) {\n    .tooltip--data, #topAutofill {\n        background: rgb(100, 98, 102, .9);\n    }\n}\n.tooltip--data {\n    padding: 6px;\n    font-size: 13px;\n    line-height: 14px;\n    width: 315px;\n    max-height: 290px;\n    overflow-y: auto;\n}\n.top-autofill .tooltip--data {\n    min-height: 100vh;\n}\n.tooltip--data.tooltip--incontext-signup {\n    width: 360px;\n}\n:not(.top-autofill) .tooltip--data {\n    top: 100%;\n    left: 100%;\n    border: 0.5px solid rgba(255, 255, 255, 0.2);\n    border-radius: 6px;\n    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.32);\n}\n@media (prefers-color-scheme: dark) {\n    :not(.top-autofill) .tooltip--data {\n        border: 1px solid rgba(255, 255, 255, 0.2);\n    }\n}\n:not(.top-autofill) .tooltip--email {\n    top: calc(100% + 6px);\n    right: calc(100% - 48px);\n    padding: 8px;\n    border: 1px solid #D0D0D0;\n    border-radius: 10px;\n    background-color: #FFFFFF;\n    font-size: 14px;\n    line-height: 1.3;\n    color: #333333;\n    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);\n}\n.tooltip--email__caret {\n    position: absolute;\n    transform: translate(-1000px, -1000px);\n    z-index: 2147483647;\n}\n.tooltip--email__caret::before,\n.tooltip--email__caret::after {\n    content: \"\";\n    width: 0;\n    height: 0;\n    border-left: 10px solid transparent;\n    border-right: 10px solid transparent;\n    display: block;\n    border-bottom: 8px solid #D0D0D0;\n    position: absolute;\n    right: -28px;\n}\n.tooltip--email__caret::before {\n    border-bottom-color: #D0D0D0;\n    top: -1px;\n}\n.tooltip--email__caret::after {\n    border-bottom-color: #FFFFFF;\n    top: 0px;\n}\n\n/* Buttons */\n.tooltip__button {\n    display: flex;\n    width: 100%;\n    padding: 8px 8px 8px 0px;\n    font-family: inherit;\n    color: inherit;\n    background: transparent;\n    border: none;\n    border-radius: 6px;\n}\n.tooltip__button.currentFocus,\n.wrapper:not(.top-autofill) .tooltip__button:hover {\n    background-color: #3969EF;\n    color: #FFFFFF;\n}\n\n/* Data autofill tooltip specific */\n.tooltip__button--data {\n    position: relative;\n    min-height: 48px;\n    flex-direction: row;\n    justify-content: flex-start;\n    font-size: inherit;\n    font-weight: 500;\n    line-height: 16px;\n    text-align: left;\n    border-radius: 3px;\n}\n.tooltip--data__item-container {\n    max-height: 220px;\n    overflow: auto;\n}\n.tooltip__button--data:first-child {\n    margin-top: 0;\n}\n.tooltip__button--data:last-child {\n    margin-bottom: 0;\n}\n.tooltip__button--data::before {\n    content: '';\n    flex-shrink: 0;\n    display: block;\n    width: 32px;\n    height: 32px;\n    margin: 0 8px;\n    background-size: 20px 20px;\n    background-repeat: no-repeat;\n    background-position: center center;\n}\n#provider_locked::after {\n    position: absolute;\n    content: '';\n    flex-shrink: 0;\n    display: block;\n    width: 32px;\n    height: 32px;\n    margin: 0 8px;\n    background-size: 11px 13px;\n    background-repeat: no-repeat;\n    background-position: right bottom;\n}\n.tooltip__button--data.currentFocus:not(.tooltip__button--data--bitwarden)::before,\n.wrapper:not(.top-autofill) .tooltip__button--data:not(.tooltip__button--data--bitwarden):hover::before {\n    filter: invert(100%);\n}\n@media (prefers-color-scheme: dark) {\n    .tooltip__button--data:not(.tooltip__button--data--bitwarden)::before,\n    .tooltip__button--data:not(.tooltip__button--data--bitwarden)::before {\n        filter: invert(100%);\n        opacity: .9;\n    }\n}\n.tooltip__button__text-container {\n    margin: auto 0;\n}\n.label {\n    display: block;\n    font-weight: 400;\n    letter-spacing: -0.25px;\n    color: rgba(0,0,0,.8);\n    font-size: 13px;\n    line-height: 1;\n}\n.label + .label {\n    margin-top: 2px;\n}\n.label.label--medium {\n    font-weight: 500;\n    letter-spacing: -0.25px;\n    color: rgba(0,0,0,.9);\n}\n.label.label--small {\n    font-size: 11px;\n    font-weight: 400;\n    letter-spacing: 0.06px;\n    color: rgba(0,0,0,0.6);\n}\n@media (prefers-color-scheme: dark) {\n    .tooltip--data .label {\n        color: #ffffff;\n    }\n    .tooltip--data .label--medium {\n        color: #ffffff;\n    }\n    .tooltip--data .label--small {\n        color: #cdcdcd;\n    }\n}\n.tooltip__button.currentFocus .label,\n.wrapper:not(.top-autofill) .tooltip__button:hover .label {\n    color: #FFFFFF;\n}\n\n.tooltip__button--manage {\n    font-size: 13px;\n    padding: 5px 9px;\n    border-radius: 3px;\n    margin: 0;\n}\n\n/* Icons */\n.tooltip__button--data--credentials::before,\n.tooltip__button--data--credentials__current::before {\n    background-size: 28px 28px;\n    background-image: url('data:image/svg+xml;base64,PHN2ZyBmaWxsPSJub25lIiB2aWV3Qm94PSIwIDAgMjQgMjQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgICA8cGF0aCBmaWxsPSIjMDAwIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xNS4zMzQgNi42NjdhMiAyIDAgMSAwIDAgNCAyIDIgMCAwIDAgMC00Wm0tLjY2NyAyYS42NjcuNjY3IDAgMSAxIDEuMzMzIDAgLjY2Ny42NjcgMCAwIDEtMS4zMzMgMFoiIGNsaXAtcnVsZT0iZXZlbm9kZCIvPgogICAgPHBhdGggZmlsbD0iIzAwMCIgZmlsbC1ydWxlPSJldmVub2RkIiBkPSJNMTQuNjY3IDRhNS4zMzMgNS4zMzMgMCAwIDAtNS4xODggNi41NzhsLTUuMjg0IDUuMjg0YS42NjcuNjY3IDAgMCAwLS4xOTUuNDcxdjNjMCAuMzY5LjI5OC42NjcuNjY3LjY2N2gyLjY2NmMuNzM3IDAgMS4zMzQtLjU5NyAxLjMzNC0xLjMzM1YxOGguNjY2Yy43MzcgMCAxLjMzNC0uNTk3IDEuMzM0LTEuMzMzdi0xLjMzNEgxMmMuMTc3IDAgLjM0Ni0uMDcuNDcxLS4xOTVsLjY4OC0uNjg4QTUuMzMzIDUuMzMzIDAgMSAwIDE0LjY2NyA0Wm0tNCA1LjMzM2E0IDQgMCAxIDEgMi41NTUgMy43MzIuNjY3LjY2NyAwIDAgMC0uNzEzLjE1bC0uNzg1Ljc4NUgxMGEuNjY3LjY2NyAwIDAgMC0uNjY3LjY2N3YySDhhLjY2Ny42NjcgMCAwIDAtLjY2Ny42NjZ2MS4zMzRoLTJ2LTIuMDU4bDUuMzY1LTUuMzY0YS42NjcuNjY3IDAgMCAwIC4xNjMtLjY3NyAzLjk5NiAzLjk5NiAwIDAgMS0uMTk0LTEuMjM1WiIgY2xpcC1ydWxlPSJldmVub2RkIi8+Cjwvc3ZnPgo=');\n}\n.tooltip__button--data--credentials__new::before {\n    background-size: 28px 28px;\n    background-image: url('data:image/svg+xml;base64,PHN2ZyBmaWxsPSJub25lIiB2aWV3Qm94PSIwIDAgMjQgMjQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgICA8cGF0aCBmaWxsPSIjMDAwIiBkPSJNOC4wNDcgNC42MjVDNy45MzcgNC4xMjUgNy44NjIgNCA3LjUgNGMtLjM2MiAwLS40MzguMTI1LS41NDcuNjI1LS4wNjguMzEtLjE3NyAxLjMzOC0uMjUxIDIuMDc3LS43MzguMDc0LTEuNzY3LjE4My0yLjA3Ny4yNTEtLjUuMTEtLjYyNS4xODQtLjYyNS41NDcgMCAuMzYyLjEyNS40MzcuNjI1LjU0Ny4zMS4wNjcgMS4zMzYuMTc3IDIuMDc0LjI1LjA3My43NjcuMTg1IDEuODQyLjI1NCAyLjA3OC4xMS4zNzUuMTg1LjYyNS41NDcuNjI1LjM2MiAwIC40MzgtLjEyNS41NDctLjYyNS4wNjgtLjMxLjE3Ny0xLjMzNi4yNS0yLjA3NC43NjctLjA3MyAxLjg0Mi0uMTg1IDIuMDc4LS4yNTQuMzc1LS4xMS42MjUtLjE4NS42MjUtLjU0NyAwLS4zNjMtLjEyNS0uNDM4LS42MjUtLjU0Ny0uMzEtLjA2OC0xLjMzOS0uMTc3LTIuMDc3LS4yNTEtLjA3NC0uNzM5LS4xODMtMS43NjctLjI1MS0yLjA3N1oiLz4KICAgIDxwYXRoIGZpbGw9IiMwMDAiIGQ9Ik0xNC42ODEgNS4xOTljLS43NjYgMC0xLjQ4Mi4yMS0yLjA5My41NzhhLjYzNi42MzYgMCAwIDEtLjY1NS0xLjA5IDUuMzQgNS4zNCAwIDEgMSAxLjMwMiA5LjcyMmwtLjc3NS43NzZhLjYzNi42MzYgMCAwIDEtLjQ1LjE4NmgtMS4zOTh2MS42NWMwIC40OTMtLjQuODkzLS44OTMuODkzSDguNTc4djEuMTQxYzAgLjQ5NC0uNC44OTMtLjg5NC44OTNINC42MzZBLjYzNi42MzYgMCAwIDEgNCAxOS4zMTNWMTYuMjZjMC0uMTY5LjA2Ny0uMzMuMTg2LS40NWw1LjU2Mi01LjU2MmEuNjM2LjYzNiAwIDEgMSAuOS45bC01LjM3NiA1LjM3NXYyLjE1M2gyLjAzNHYtMS4zOTljMC0uMzUuMjg1LS42MzYuNjM2LS42MzZIOS4zNHYtMS45MDdjMC0uMzUxLjI4NC0uNjM2LjYzNS0uNjM2aDEuNzcxbC44NjQtLjg2M2EuNjM2LjYzNiAwIDAgMSAuNjY4LS4xNDcgNC4wNjkgNC4wNjkgMCAxIDAgMS40MDItNy44OVoiLz4KICAgIDxwYXRoIGZpbGw9IiMwMDAiIGZpbGwtcnVsZT0iZXZlbm9kZCIgZD0iTTEzLjYyNSA4LjQ5OWExLjg3NSAxLjg3NSAwIDEgMSAzLjc1IDAgMS44NzUgMS44NzUgMCAwIDEtMy43NSAwWm0xLjg3NS0uNjI1YS42MjUuNjI1IDAgMSAwIDAgMS4yNS42MjUuNjI1IDAgMCAwIDAtMS4yNVoiIGNsaXAtcnVsZT0iZXZlbm9kZCIvPgogICAgPHBhdGggZmlsbD0iIzAwMCIgZD0iTTQuNjI1IDEyLjEyNWEuNjI1LjYyNSAwIDEgMCAwLTEuMjUuNjI1LjYyNSAwIDAgMCAwIDEuMjVaIi8+Cjwvc3ZnPgo=');\n}\n.tooltip__button--data--creditCards::before {\n    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0ibm9uZSI+CiAgICA8cGF0aCBkPSJNNSA5Yy0uNTUyIDAtMSAuNDQ4LTEgMXYyYzAgLjU1Mi40NDggMSAxIDFoM2MuNTUyIDAgMS0uNDQ4IDEtMXYtMmMwLS41NTItLjQ0OC0xLTEtMUg1eiIgZmlsbD0iIzAwMCIvPgogICAgPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xIDZjMC0yLjIxIDEuNzktNCA0LTRoMTRjMi4yMSAwIDQgMS43OSA0IDR2MTJjMCAyLjIxLTEuNzkgNC00IDRINWMtMi4yMSAwLTQtMS43OS00LTRWNnptNC0yYy0xLjEwNSAwLTIgLjg5NS0yIDJ2OWgxOFY2YzAtMS4xMDUtLjg5NS0yLTItMkg1em0wIDE2Yy0xLjEwNSAwLTItLjg5NS0yLTJoMThjMCAxLjEwNS0uODk1IDItMiAySDV6IiBmaWxsPSIjMDAwIi8+Cjwvc3ZnPgo=');\n}\n.tooltip__button--data--identities::before {\n    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0ibm9uZSI+CiAgICA8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTEyIDIxYzIuMTQzIDAgNC4xMTEtLjc1IDUuNjU3LTItLjYyNi0uNTA2LTEuMzE4LS45MjctMi4wNi0xLjI1LTEuMS0uNDgtMi4yODUtLjczNS0zLjQ4Ni0uNzUtMS4yLS4wMTQtMi4zOTIuMjExLTMuNTA0LjY2NC0uODE3LjMzMy0xLjU4Ljc4My0yLjI2NCAxLjMzNiAxLjU0NiAxLjI1IDMuNTE0IDIgNS42NTcgMnptNC4zOTctNS4wODNjLjk2Ny40MjIgMS44NjYuOTggMi42NzIgMS42NTVDMjAuMjc5IDE2LjAzOSAyMSAxNC4xMDQgMjEgMTJjMC00Ljk3LTQuMDMtOS05LTlzLTkgNC4wMy05IDljMCAyLjEwNC43MjIgNC4wNCAxLjkzMiA1LjU3Mi44NzQtLjczNCAxLjg2LTEuMzI4IDIuOTIxLTEuNzYgMS4zNi0uNTU0IDIuODE2LS44MyA0LjI4My0uODExIDEuNDY3LjAxOCAyLjkxNi4zMyA0LjI2LjkxNnpNMTIgMjNjNi4wNzUgMCAxMS00LjkyNSAxMS0xMVMxOC4wNzUgMSAxMiAxIDEgNS45MjUgMSAxMnM0LjkyNSAxMSAxMSAxMXptMy0xM2MwIDEuNjU3LTEuMzQzIDMtMyAzcy0zLTEuMzQzLTMtMyAxLjM0My0zIDMtMyAzIDEuMzQzIDMgM3ptMiAwYzAgMi43NjEtMi4yMzkgNS01IDVzLTUtMi4yMzktNS01IDIuMjM5LTUgNS01IDUgMi4yMzkgNSA1eiIgZmlsbD0iIzAwMCIvPgo8L3N2Zz4=');\n}\n.tooltip__button--data--credentials.tooltip__button--data--bitwarden::before,\n.tooltip__button--data--credentials__current.tooltip__button--data--bitwarden::before {\n    background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0IiByeD0iOCIgZmlsbD0iIzE3NUREQyIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTE4LjU2OTYgNS40MzM1NUMxOC41MDg0IDUuMzc0NDIgMTguNDM0NyA1LjMyNzYzIDE4LjM1MzEgNS4yOTYxMUMxOC4yNzE1IDUuMjY0NiAxOC4xODM3IDUuMjQ5MDQgMTguMDk1MyA1LjI1MDQxSDUuOTIxOTFDNS44MzMyNiA1LjI0NzI5IDUuNzQ0OTMgNS4yNjIwNSA1LjY2MzA0IDUuMjkzNjdDNS41ODExNSA1LjMyNTI5IDUuNTA3NjUgNS4zNzMwMiA1LjQ0NzYyIDUuNDMzNTVDNS4zMjE3IDUuNTUwMTMgNS4yNTA2NSA1LjcwODE1IDUuMjUgNS44NzMxVjEzLjM4MjFDNS4yNTMzNiAxMy45NTM1IDUuMzc0MDggMTQuNTE5MSA1LjYwNTcyIDE1LjA0ODdDNS44MTkzMSAxNS41NzI4IDYuMTEyMDcgMTYuMDY2MSA2LjQ3NTI0IDE2LjUxMzlDNi44NDIgMTYuOTY4MyA3LjI1OTI5IDE3LjM4NTcgNy43MjAyNSAxNy43NTkzQzguMTQwNTMgMTguMTI1NiA4LjU4OTcxIDE4LjQ2MjMgOS4wNjQwNyAxOC43NjY2QzkuNDU5MzEgMTkuMDIzIDkuOTEzODMgMTkuMjc5NCAxMC4zNDg2IDE5LjUxNzVDMTAuNzgzNCAxOS43NTU2IDExLjA5OTYgMTkuOTIwNCAxMS4yNzc0IDE5Ljk5MzdDMTEuNDU1MyAyMC4wNjY5IDExLjYxMzQgMjAuMTQwMiAxMS43MTIyIDIwLjE5NTFDMTEuNzk5MiAyMC4yMzEzIDExLjg5MzUgMjAuMjUgMTEuOTg4OCAyMC4yNUMxMi4wODQyIDIwLjI1IDEyLjE3ODUgMjAuMjMxMyAxMi4yNjU1IDIwLjE5NTFDMTIuNDIxMiAyMC4xMzYzIDEyLjU3MjkgMjAuMDY5IDEyLjcyIDE5Ljk5MzdDMTIuNzcxMSAxOS45Njc0IDEyLjgzMzUgMTkuOTM2NiAxMi45MDY5IDE5LjkwMDRDMTMuMDg5MSAxOS44MTA1IDEzLjMzODggMTkuNjg3MiAxMy42NDg5IDE5LjUxNzVDMTQuMDgzNiAxOS4yNzk0IDE0LjUxODQgMTkuMDIzIDE0LjkzMzQgMTguNzY2NkMxNS40MDQgMTguNDU3NyAxNS44NTI4IDE4LjEyMTIgMTYuMjc3MiAxNy43NTkzQzE2LjczMzEgMTcuMzgwOSAxNy4xNDk5IDE2Ljk2NCAxNy41MjIyIDE2LjUxMzlDMTcuODc4IDE2LjA2MTcgMTguMTcwMiAxNS41NjkzIDE4LjM5MTcgMTUuMDQ4N0MxOC42MjM0IDE0LjUxOTEgMTguNzQ0MSAxMy45NTM1IDE4Ljc0NzQgMTMuMzgyMVY1Ljg3MzFDMTguNzU1NyA1Ljc5MjE0IDE4Ljc0MzkgNS43MTA1IDE4LjcxMzEgNS42MzQzNUMxOC42ODIzIDUuNTU4MiAxOC42MzMyIDUuNDg5NTQgMTguNTY5NiA1LjQzMzU1Wk0xNy4wMDg0IDEzLjQ1NTNDMTcuMDA4NCAxNi4xODQyIDEyLjAwODYgMTguNTI4NSAxMi4wMDg2IDE4LjUyODVWNi44NjIwOUgxNy4wMDg0VjEzLjQ1NTNaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K');\n}\n#provider_locked:after {\n    background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTEiIGhlaWdodD0iMTMiIHZpZXdCb3g9IjAgMCAxMSAxMyIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTEgNy42MDA1N1Y3LjYwMjVWOS41MjI1QzEgMTAuMDgwMSAxLjIyMTUxIDEwLjYxNDkgMS42MTU4MSAxMS4wMDkyQzIuMDEwMSAxMS40MDM1IDIuNTQ0ODggMTEuNjI1IDMuMTAyNSAxMS42MjVINy4yNzI1QzcuNTQ4NjEgMTEuNjI1IDcuODIyMDEgMTEuNTcwNiA4LjA3NzA5IDExLjQ2NUM4LjMzMjE4IDExLjM1OTMgOC41NjM5NiAxMS4yMDQ0IDguNzU5MTkgMTEuMDA5MkM4Ljk1NDQzIDEwLjgxNCA5LjEwOTMgMTAuNTgyMiA5LjIxNDk2IDEwLjMyNzFDOS4zMjA2MiAxMC4wNzIgOS4zNzUgOS43OTg2MSA5LjM3NSA5LjUyMjVMOS4zNzUgNy42MDI1TDkuMzc1IDcuNjAwNTdDOS4zNzQxNSA3LjE2MTMxIDkuMjM1NzQgNi43MzMzNSA4Ljk3OTIyIDYuMzc2NzhDOC44NzY4MyA2LjIzNDQ2IDguNzU3NjggNi4xMDYzNyA4LjYyNSA1Ljk5NDg5VjUuMTg3NUM4LjYyNSA0LjI3NTgyIDguMjYyODQgMy40MDE0OCA3LjYxODE4IDIuNzU2ODJDNi45NzM1MiAyLjExMjE2IDYuMDk5MTggMS43NSA1LjE4NzUgMS43NUM0LjI3NTgyIDEuNzUgMy40MDE0OCAyLjExMjE2IDIuNzU2ODIgMi43NTY4MkMyLjExMjE2IDMuNDAxNDggMS43NSA0LjI3NTgyIDEuNzUgNS4xODc1VjUuOTk0ODlDMS42MTczMiA2LjEwNjM3IDEuNDk4MTcgNi4yMzQ0NiAxLjM5NTc4IDYuMzc2NzhDMS4xMzkyNiA2LjczMzM1IDEuMDAwODUgNy4xNjEzMSAxIDcuNjAwNTdaTTQuOTY4NyA0Ljk2ODdDNS4wMjY5NCA0LjkxMDQ3IDUuMTA1MzIgNC44NzY5OSA1LjE4NzUgNC44NzUwN0M1LjI2OTY4IDQuODc2OTkgNS4zNDgwNiA0LjkxMDQ3IDUuNDA2MyA0Ljk2ODdDNS40NjU0MiA1LjAyNzgzIDUuNDk5MDQgNS4xMDc3NCA1LjUgNS4xOTEzVjUuNUg0Ljg3NVY1LjE5MTNDNC44NzU5NiA1LjEwNzc0IDQuOTA5NTggNS4wMjc4MyA0Ljk2ODcgNC45Njg3WiIgZmlsbD0iIzIyMjIyMiIgc3Ryb2tlPSJ3aGl0ZSIgc3Ryb2tlLXdpZHRoPSIyIi8+Cjwvc3ZnPgo=');\n}\n\nhr {\n    display: block;\n    margin: 5px 9px;\n    border: none; /* reset the border */\n    border-top: 1px solid rgba(0,0,0,.1);\n}\n\nhr:first-child {\n    display: none;\n}\n\n@media (prefers-color-scheme: dark) {\n    hr {\n        border-top: 1px solid rgba(255,255,255,.2);\n    }\n}\n\n#privateAddress {\n    align-items: flex-start;\n}\n#personalAddress::before,\n#privateAddress::before,\n#incontextSignup::before,\n#personalAddress.currentFocus::before,\n#personalAddress:hover::before,\n#privateAddress.currentFocus::before,\n#privateAddress:hover::before {\n    filter: none;\n    /* This is the same icon as `daxBase64` in `src/Form/logo-svg.js` */\n    background-image: url('data:image/svg+xml;base64,PHN2ZyBmaWxsPSJub25lIiB2aWV3Qm94PSIwIDAgMTI4IDEyOCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxwYXRoIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0ibTY0IDEyOGMzNS4zNDYgMCA2NC0yOC42NTQgNjQtNjRzLTI4LjY1NC02NC02NC02NC02NCAyOC42NTQtNjQgNjQgMjguNjU0IDY0IDY0IDY0eiIgZmlsbD0iI2RlNTgzMyIgZmlsbC1ydWxlPSJldmVub2RkIi8+CiAgICA8cGF0aCBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Im03MyAxMTEuNzVjMC0uNS4xMjMtLjYxNC0xLjQ2Ni0zLjc4Mi00LjIyNC04LjQ1OS04LjQ3LTIwLjM4NC02LjU0LTI4LjA3NS4zNTMtMS4zOTctMy45NzgtNTEuNzQ0LTcuMDQtNTMuMzY1LTMuNDAyLTEuODEzLTcuNTg4LTQuNjktMTEuNDE4LTUuMzMtMS45NDMtLjMxLTQuNDktLjE2NC02LjQ4Mi4xMDUtLjM1My4wNDctLjM2OC42ODMtLjAzLjc5OCAxLjMwOC40NDMgMi44OTUgMS4yMTIgMy44MyAyLjM3NS4xNzguMjItLjA2LjU2Ni0uMzQyLjU3Ny0uODgyLjAzMi0yLjQ4Mi40MDItNC41OTMgMi4xOTUtLjI0NC4yMDctLjA0MS41OTIuMjczLjUzIDQuNTM2LS44OTcgOS4xNy0uNDU1IDExLjkgMi4wMjcuMTc3LjE2LjA4NC40NS0uMTQ3LjUxMi0yMy42OTQgNi40NC0xOS4wMDMgMjcuMDUtMTIuNjk2IDUyLjM0NCA1LjYxOSAyMi41MyA3LjczMyAyOS43OTIgOC40IDMyLjAwNGEuNzE4LjcxOCAwIDAgMCAuNDIzLjQ2N2M4LjE1NiAzLjI0OCAyNS45MjggMy4zOTIgMjUuOTI4LTIuMTMyeiIgZmlsbD0iI2RkZCIgZmlsbC1ydWxlPSJldmVub2RkIi8+CiAgICA8cGF0aCBkPSJtNzYuMjUgMTE2LjVjLTIuODc1IDEuMTI1LTguNSAxLjYyNS0xMS43NSAxLjYyNS00Ljc2NCAwLTExLjYyNS0uNzUtMTQuMTI1LTEuODc1LTEuNTQ0LTQuNzUxLTYuMTY0LTE5LjQ4LTEwLjcyNy0zOC4xODVsLS40NDctMS44MjctLjAwNC0uMDE1Yy01LjQyNC0yMi4xNTctOS44NTUtNDAuMjUzIDE0LjQyNy00NS45MzguMjIyLS4wNTIuMzMtLjMxNy4xODQtLjQ5Mi0yLjc4Ni0zLjMwNS04LjAwNS00LjM4OC0xNC42MDUtMi4xMTEtLjI3LjA5My0uNTA2LS4xOC0uMzM3LS40MTIgMS4yOTQtMS43ODMgMy44MjMtMy4xNTUgNS4wNzEtMy43NTYuMjU4LS4xMjQuMjQyLS41MDItLjAzLS41ODhhMjcuODc3IDI3Ljg3NyAwIDAgMCAtMy43NzItLjljLS4zNy0uMDU5LS40MDMtLjY5My0uMDMyLS43NDMgOS4zNTYtMS4yNTkgMTkuMTI1IDEuNTUgMjQuMDI4IDcuNzI2YS4zMjYuMzI2IDAgMCAwIC4xODYuMTE0YzE3Ljk1MiAzLjg1NiAxOS4yMzggMzIuMjM1IDE3LjE3IDMzLjUyOC0uNDA4LjI1NS0xLjcxNS4xMDgtMy40MzgtLjA4NS02Ljk4Ni0uNzgxLTIwLjgxOC0yLjMyOS05LjQwMiAxOC45NDguMTEzLjIxLS4wMzYuNDg4LS4yNzIuNTI1LTYuNDM4IDEgMS44MTIgMjEuMTczIDcuODc1IDM0LjQ2MXoiIGZpbGw9IiNmZmYiLz4KICAgIDxwYXRoIGQ9Im04NC4yOCA5MC42OThjLTEuMzY3LS42MzMtNi42MjEgMy4xMzUtMTAuMTEgNi4wMjgtLjcyOC0xLjAzMS0yLjEwMy0xLjc4LTUuMjAzLTEuMjQyLTIuNzEzLjQ3Mi00LjIxMSAxLjEyNi00Ljg4IDIuMjU0LTQuMjgzLTEuNjIzLTExLjQ4OC00LjEzLTEzLjIyOS0xLjcxLTEuOTAyIDIuNjQ2LjQ3NiAxNS4xNjEgMy4wMDMgMTYuNzg2IDEuMzIuODQ5IDcuNjMtMy4yMDggMTAuOTI2LTYuMDA1LjUzMi43NDkgMS4zODggMS4xNzggMy4xNDggMS4xMzcgMi42NjItLjA2MiA2Ljk3OS0uNjgxIDcuNjQ5LTEuOTIxLjA0LS4wNzUuMDc1LS4xNjQuMTA1LS4yNjYgMy4zODggMS4yNjYgOS4zNSAyLjYwNiAxMC42ODIgMi40MDYgMy40Ny0uNTIxLS40ODQtMTYuNzIzLTIuMDktMTcuNDY3eiIgZmlsbD0iIzNjYTgyYiIvPgogICAgPHBhdGggZD0ibTc0LjQ5IDk3LjA5N2MuMTQ0LjI1Ni4yNi41MjYuMzU4LjguNDgzIDEuMzUyIDEuMjcgNS42NDguNjc0IDYuNzA5LS41OTUgMS4wNjItNC40NTkgMS41NzQtNi44NDMgMS42MTVzLTIuOTItLjgzMS0zLjQwMy0yLjE4MWMtLjM4Ny0xLjA4MS0uNTc3LTMuNjIxLS41NzItNS4wNzUtLjA5OC0yLjE1OC42OS0yLjkxNiA0LjMzNC0zLjUwNiAyLjY5Ni0uNDM2IDQuMTIxLjA3MSA0Ljk0NC45NCAzLjgyOC0yLjg1NyAxMC4yMTUtNi44ODkgMTAuODM4LTYuMTUyIDMuMTA2IDMuNjc0IDMuNDk5IDEyLjQyIDIuODI2IDE1LjkzOS0uMjIgMS4xNTEtMTAuNTA1LTEuMTM5LTEwLjUwNS0yLjM4IDAtNS4xNTItMS4zMzctNi41NjUtMi42NS02Ljcxem0tMjIuNTMtMS42MDljLjg0My0xLjMzMyA3LjY3NC4zMjUgMTEuNDI0IDEuOTkzIDAgMC0uNzcgMy40OTEuNDU2IDcuNjA0LjM1OSAxLjIwMy04LjYyNyA2LjU1OC05LjggNS42MzctMS4zNTUtMS4wNjUtMy44NS0xMi40MzItMi4wOC0xNS4yMzR6IiBmaWxsPSIjNGNiYTNjIi8+CiAgICA8cGF0aCBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Im01NS4yNjkgNjguNDA2Yy41NTMtMi40MDMgMy4xMjctNi45MzIgMTIuMzIxLTYuODIyIDQuNjQ4LS4wMTkgMTAuNDIyLS4wMDIgMTQuMjUtLjQzNmE1MS4zMTIgNTEuMzEyIDAgMCAwIDEyLjcyNi0zLjA5NWMzLjk4LTEuNTE5IDUuMzkyLTEuMTggNS44ODctLjI3Mi41NDQuOTk5LS4wOTcgMi43MjItMS40ODggNC4zMDktMi42NTYgMy4wMy03LjQzMSA1LjM4LTE1Ljg2NSA2LjA3Ni04LjQzMy42OTgtMTQuMDItMS41NjUtMTYuNDI1IDIuMTE4LTEuMDM4IDEuNTg5LS4yMzYgNS4zMzMgNy45MiA2LjUxMiAxMS4wMiAxLjU5IDIwLjA3Mi0xLjkxNyAyMS4xOS4yMDEgMS4xMTkgMi4xMTgtNS4zMjMgNi40MjgtMTYuMzYyIDYuNTE4cy0xNy45MzQtMy44NjUtMjAuMzc5LTUuODNjLTMuMTAyLTIuNDk1LTQuNDktNi4xMzMtMy43NzUtOS4yNzl6IiBmaWxsPSIjZmMzIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiLz4KICAgIDxnIGZpbGw9IiMxNDMwN2UiIG9wYWNpdHk9Ii44Ij4KICAgICAgPHBhdGggZD0ibTY5LjMyNyA0Mi4xMjdjLjYxNi0xLjAwOCAxLjk4MS0xLjc4NiA0LjIxNi0xLjc4NiAyLjIzNCAwIDMuMjg1Ljg4OSA0LjAxMyAxLjg4LjE0OC4yMDItLjA3Ni40NC0uMzA2LjM0YTU5Ljg2OSA1OS44NjkgMCAwIDEgLS4xNjgtLjA3M2MtLjgxNy0uMzU3LTEuODItLjc5NS0zLjU0LS44Mi0xLjgzOC0uMDI2LTIuOTk3LjQzNS0zLjcyNy44MzEtLjI0Ni4xMzQtLjYzNC0uMTMzLS40ODgtLjM3MnptLTI1LjE1NyAxLjI5YzIuMTctLjkwNyAzLjg3Ni0uNzkgNS4wODEtLjUwNC4yNTQuMDYuNDMtLjIxMy4yMjctLjM3Ny0uOTM1LS43NTUtMy4wMy0xLjY5Mi01Ljc2LS42NzQtMi40MzcuOTA5LTMuNTg1IDIuNzk2LTMuNTkyIDQuMDM4LS4wMDIuMjkyLjYuMzE3Ljc1Ni4wNy40Mi0uNjcgMS4xMi0xLjY0NiAzLjI4OS0yLjU1M3oiLz4KICAgICAgPHBhdGggY2xpcC1ydWxlPSJldmVub2RkIiBkPSJtNzUuNDQgNTUuOTJhMy40NyAzLjQ3IDAgMCAxIC0zLjQ3NC0zLjQ2MiAzLjQ3IDMuNDcgMCAwIDEgMy40NzUtMy40NiAzLjQ3IDMuNDcgMCAwIDEgMy40NzQgMy40NiAzLjQ3IDMuNDcgMCAwIDEgLTMuNDc1IDMuNDYyem0yLjQ0Ny00LjYwOGEuODk5Ljg5OSAwIDAgMCAtMS43OTkgMGMwIC40OTQuNDA1Ljg5NS45Ljg5NS40OTkgMCAuOS0uNC45LS44OTV6bS0yNS40NjQgMy41NDJhNC4wNDIgNC4wNDIgMCAwIDEgLTQuMDQ5IDQuMDM3IDQuMDQ1IDQuMDQ1IDAgMCAxIC00LjA1LTQuMDM3IDQuMDQ1IDQuMDQ1IDAgMCAxIDQuMDUtNC4wMzcgNC4wNDUgNC4wNDUgMCAwIDEgNC4wNSA0LjAzN3ptLTEuMTkzLTEuMzM4YTEuMDUgMS4wNSAwIDAgMCAtMi4wOTcgMCAxLjA0OCAxLjA0OCAwIDAgMCAyLjA5NyAweiIgZmlsbC1ydWxlPSJldmVub2RkIi8+CiAgICA8L2c+CiAgICA8cGF0aCBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Im02NCAxMTcuNzVjMjkuNjg1IDAgNTMuNzUtMjQuMDY1IDUzLjc1LTUzLjc1cy0yNC4wNjUtNTMuNzUtNTMuNzUtNTMuNzUtNTMuNzUgMjQuMDY1LTUzLjc1IDUzLjc1IDI0LjA2NSA1My43NSA1My43NSA1My43NXptMCA1YzMyLjQ0NyAwIDU4Ljc1LTI2LjMwMyA1OC43NS01OC43NXMtMjYuMzAzLTU4Ljc1LTU4Ljc1LTU4Ljc1LTU4Ljc1IDI2LjMwMy01OC43NSA1OC43NSAyNi4zMDMgNTguNzUgNTguNzUgNTguNzV6IiBmaWxsPSIjZmZmIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiLz4KPC9zdmc+');\n}\n\n/* Email tooltip specific */\n.tooltip__button--email {\n    flex-direction: column;\n    justify-content: center;\n    align-items: flex-start;\n    font-size: 14px;\n    padding: 4px 8px;\n}\n.tooltip__button--email__primary-text {\n    font-weight: bold;\n}\n.tooltip__button--email__secondary-text {\n    font-size: 12px;\n}\n\n/* Email Protection signup notice */\n:not(.top-autofill) .tooltip--email-signup {\n    text-align: left;\n    color: #222222;\n    padding: 16px 20px;\n    width: 380px;\n}\n\n.tooltip--email-signup h1 {\n    font-weight: 700;\n    font-size: 16px;\n    line-height: 1.5;\n    margin: 0;\n}\n\n.tooltip--email-signup p {\n    font-weight: 400;\n    font-size: 14px;\n    line-height: 1.4;\n}\n\n.notice-controls {\n    display: flex;\n}\n\n.tooltip--email-signup .notice-controls > * {\n    border-radius: 8px;\n    border: 0;\n    cursor: pointer;\n    display: inline-block;\n    font-family: inherit;\n    font-style: normal;\n    font-weight: bold;\n    padding: 8px 12px;\n    text-decoration: none;\n}\n\n.notice-controls .ghost {\n    margin-left: 1rem;\n}\n\n.tooltip--email-signup a.primary {\n    background: #3969EF;\n    color: #fff;\n}\n\n.tooltip--email-signup a.primary:hover,\n.tooltip--email-signup a.primary:focus {\n    background: #2b55ca;\n}\n\n.tooltip--email-signup a.primary:active {\n    background: #1e42a4;\n}\n\n.tooltip--email-signup button.ghost {\n    background: transparent;\n    color: #3969EF;\n}\n\n.tooltip--email-signup button.ghost:hover,\n.tooltip--email-signup button.ghost:focus {\n    background-color: rgba(0, 0, 0, 0.06);\n    color: #2b55ca;\n}\n\n.tooltip--email-signup button.ghost:active {\n    background-color: rgba(0, 0, 0, 0.12);\n    color: #1e42a4;\n}\n\n.tooltip--email-signup button.close-tooltip {\n    background-color: transparent;\n    background-image: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iMTMiIHZpZXdCb3g9IjAgMCAxMiAxMyIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0wLjI5Mjg5NCAwLjY1NjkwN0MwLjY4MzQxOCAwLjI2NjM4MyAxLjMxNjU4IDAuMjY2MzgzIDEuNzA3MTEgMC42NTY5MDdMNiA0Ljk0OThMMTAuMjkyOSAwLjY1NjkwN0MxMC42ODM0IDAuMjY2MzgzIDExLjMxNjYgMC4yNjYzODMgMTEuNzA3MSAwLjY1NjkwN0MxMi4wOTc2IDEuMDQ3NDMgMTIuMDk3NiAxLjY4MDYgMTEuNzA3MSAyLjA3MTEyTDcuNDE0MjEgNi4zNjQwMUwxMS43MDcxIDEwLjY1NjlDMTIuMDk3NiAxMS4wNDc0IDEyLjA5NzYgMTEuNjgwNiAxMS43MDcxIDEyLjA3MTFDMTEuMzE2NiAxMi40NjE2IDEwLjY4MzQgMTIuNDYxNiAxMC4yOTI5IDEyLjA3MTFMNiA3Ljc3ODIzTDEuNzA3MTEgMTIuMDcxMUMxLjMxNjU4IDEyLjQ2MTYgMC42ODM0MTcgMTIuNDYxNiAwLjI5Mjg5MyAxMi4wNzExQy0wLjA5NzYzMTEgMTEuNjgwNiAtMC4wOTc2MzExIDExLjA0NzQgMC4yOTI4OTMgMTAuNjU2OUw0LjU4NTc5IDYuMzY0MDFMMC4yOTI4OTQgMi4wNzExMkMtMC4wOTc2MzA2IDEuNjgwNiAtMC4wOTc2MzA2IDEuMDQ3NDMgMC4yOTI4OTQgMC42NTY5MDdaIiBmaWxsPSJibGFjayIgZmlsbC1vcGFjaXR5PSIwLjg0Ii8+Cjwvc3ZnPgo=);\n    background-position: center center;\n    background-repeat: no-repeat;\n    border: 0;\n    cursor: pointer;\n    padding: 16px;\n    position: absolute;\n    right: 12px;\n    top: 12px;\n}\n";
+const CSS_STYLES = exports.CSS_STYLES = ":root {\n    color-scheme: light dark;\n}\n\n.wrapper *, .wrapper *::before, .wrapper *::after {\n    box-sizing: border-box;\n}\n.wrapper {\n    position: fixed;\n    top: 0;\n    left: 0;\n    padding: 0;\n    font-family: 'DDG_ProximaNova', 'Proxima Nova', system-ui, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',\n    'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;\n    -webkit-font-smoothing: antialiased;\n    z-index: 2147483647;\n}\n.wrapper--data {\n    font-family: 'SF Pro Text', system-ui, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',\n    'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;\n}\n.wrapper:not(.top-autofill) .tooltip {\n    position: absolute;\n    width: 300px;\n    max-width: calc(100vw - 25px);\n    transform: translate(-1000px, -1000px);\n    z-index: 2147483647;\n}\n.tooltip--data, #topAutofill {\n    background-color: rgba(242, 240, 240, 1);\n    -webkit-backdrop-filter: blur(40px);\n    backdrop-filter: blur(40px);\n}\n@media (prefers-color-scheme: dark) {\n    .tooltip--data, #topAutofill {\n        background: rgb(100, 98, 102, .9);\n    }\n}\n.tooltip--data {\n    padding: 6px;\n    font-size: 13px;\n    line-height: 14px;\n    width: 315px;\n    max-height: 290px;\n    overflow-y: auto;\n}\n.top-autofill .tooltip--data {\n    min-height: 100vh;\n}\n.tooltip--data.tooltip--incontext-signup {\n    width: 360px;\n}\n.wrapper:not(.top-autofill) .tooltip--data {\n    top: 100%;\n    left: 100%;\n    border: 0.5px solid rgba(255, 255, 255, 0.2);\n    border-radius: 6px;\n    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.32);\n}\n@media (prefers-color-scheme: dark) {\n    .wrapper:not(.top-autofill) .tooltip--data {\n        border: 1px solid rgba(255, 255, 255, 0.2);\n    }\n}\n.wrapper:not(.top-autofill) .tooltip--email {\n    top: calc(100% + 6px);\n    right: calc(100% - 48px);\n    padding: 8px;\n    border: 1px solid #D0D0D0;\n    border-radius: 10px;\n    background-color: #FFFFFF;\n    font-size: 14px;\n    line-height: 1.3;\n    color: #333333;\n    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);\n}\n.tooltip--email__caret {\n    position: absolute;\n    transform: translate(-1000px, -1000px);\n    z-index: 2147483647;\n}\n.tooltip--email__caret::before,\n.tooltip--email__caret::after {\n    content: \"\";\n    width: 0;\n    height: 0;\n    border-left: 10px solid transparent;\n    border-right: 10px solid transparent;\n    display: block;\n    border-bottom: 8px solid #D0D0D0;\n    position: absolute;\n    right: -28px;\n}\n.tooltip--email__caret::before {\n    border-bottom-color: #D0D0D0;\n    top: -1px;\n}\n.tooltip--email__caret::after {\n    border-bottom-color: #FFFFFF;\n    top: 0px;\n}\n\n/* Buttons */\n.tooltip__button {\n    display: flex;\n    width: 100%;\n    padding: 8px 8px 8px 0px;\n    font-family: inherit;\n    color: inherit;\n    background: transparent;\n    border: none;\n    border-radius: 6px;\n    text-align: left;\n}\n.tooltip__button.currentFocus,\n.wrapper:not(.top-autofill) .tooltip__button:hover {\n    background-color: #3969EF;\n    color: #FFFFFF;\n}\n\n/* Data autofill tooltip specific */\n.tooltip__button--data {\n    position: relative;\n    min-height: 48px;\n    flex-direction: row;\n    justify-content: flex-start;\n    font-size: inherit;\n    font-weight: 500;\n    line-height: 16px;\n    text-align: left;\n    border-radius: 3px;\n}\n.tooltip--data__item-container {\n    max-height: 220px;\n    overflow: auto;\n}\n.tooltip__button--data:first-child {\n    margin-top: 0;\n}\n.tooltip__button--data:last-child {\n    margin-bottom: 0;\n}\n.tooltip__button--data::before {\n    content: '';\n    flex-shrink: 0;\n    display: block;\n    width: 32px;\n    height: 32px;\n    margin: 0 8px;\n    background-size: 20px 20px;\n    background-repeat: no-repeat;\n    background-position: center center;\n}\n#provider_locked::after {\n    position: absolute;\n    content: '';\n    flex-shrink: 0;\n    display: block;\n    width: 32px;\n    height: 32px;\n    margin: 0 8px;\n    background-size: 11px 13px;\n    background-repeat: no-repeat;\n    background-position: right bottom;\n}\n.tooltip__button--data.currentFocus:not(.tooltip__button--data--bitwarden)::before,\n.wrapper:not(.top-autofill) .tooltip__button--data:not(.tooltip__button--data--bitwarden):hover::before {\n    filter: invert(100%);\n}\n@media (prefers-color-scheme: dark) {\n    .tooltip__button--data:not(.tooltip__button--data--bitwarden)::before,\n    .tooltip__button--data:not(.tooltip__button--data--bitwarden)::before {\n        filter: invert(100%);\n        opacity: .9;\n    }\n}\n.tooltip__button__text-container {\n    margin: auto 0;\n}\n.label {\n    display: block;\n    font-weight: 400;\n    letter-spacing: -0.25px;\n    color: rgba(0,0,0,.8);\n    font-size: 13px;\n    line-height: 1;\n}\n.label + .label {\n    margin-top: 2px;\n}\n.label.label--medium {\n    font-weight: 500;\n    letter-spacing: -0.25px;\n    color: rgba(0,0,0,.9);\n}\n.label.label--small {\n    font-size: 11px;\n    font-weight: 400;\n    letter-spacing: 0.06px;\n    color: rgba(0,0,0,0.6);\n}\n@media (prefers-color-scheme: dark) {\n    .tooltip--data .label {\n        color: #ffffff;\n    }\n    .tooltip--data .label--medium {\n        color: #ffffff;\n    }\n    .tooltip--data .label--small {\n        color: #cdcdcd;\n    }\n}\n.tooltip__button.currentFocus .label,\n.wrapper:not(.top-autofill) .tooltip__button:hover .label {\n    color: #FFFFFF;\n}\n\n.tooltip__button--manage {\n    font-size: 13px;\n    padding: 5px 9px;\n    border-radius: 3px;\n    margin: 0;\n}\n\n/* Icons */\n.tooltip__button--data--credentials::before,\n.tooltip__button--data--credentials__current::before {\n    background-size: 28px 28px;\n    background-image: url('data:image/svg+xml;base64,PHN2ZyBmaWxsPSJub25lIiB2aWV3Qm94PSIwIDAgMjQgMjQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgICA8cGF0aCBmaWxsPSIjMDAwIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xNS4zMzQgNi42NjdhMiAyIDAgMSAwIDAgNCAyIDIgMCAwIDAgMC00Wm0tLjY2NyAyYS42NjcuNjY3IDAgMSAxIDEuMzMzIDAgLjY2Ny42NjcgMCAwIDEtMS4zMzMgMFoiIGNsaXAtcnVsZT0iZXZlbm9kZCIvPgogICAgPHBhdGggZmlsbD0iIzAwMCIgZmlsbC1ydWxlPSJldmVub2RkIiBkPSJNMTQuNjY3IDRhNS4zMzMgNS4zMzMgMCAwIDAtNS4xODggNi41NzhsLTUuMjg0IDUuMjg0YS42NjcuNjY3IDAgMCAwLS4xOTUuNDcxdjNjMCAuMzY5LjI5OC42NjcuNjY3LjY2N2gyLjY2NmMuNzM3IDAgMS4zMzQtLjU5NyAxLjMzNC0xLjMzM1YxOGguNjY2Yy43MzcgMCAxLjMzNC0uNTk3IDEuMzM0LTEuMzMzdi0xLjMzNEgxMmMuMTc3IDAgLjM0Ni0uMDcuNDcxLS4xOTVsLjY4OC0uNjg4QTUuMzMzIDUuMzMzIDAgMSAwIDE0LjY2NyA0Wm0tNCA1LjMzM2E0IDQgMCAxIDEgMi41NTUgMy43MzIuNjY3LjY2NyAwIDAgMC0uNzEzLjE1bC0uNzg1Ljc4NUgxMGEuNjY3LjY2NyAwIDAgMC0uNjY3LjY2N3YySDhhLjY2Ny42NjcgMCAwIDAtLjY2Ny42NjZ2MS4zMzRoLTJ2LTIuMDU4bDUuMzY1LTUuMzY0YS42NjcuNjY3IDAgMCAwIC4xNjMtLjY3NyAzLjk5NiAzLjk5NiAwIDAgMS0uMTk0LTEuMjM1WiIgY2xpcC1ydWxlPSJldmVub2RkIi8+Cjwvc3ZnPgo=');\n}\n.tooltip__button--data--credentials__new::before {\n    background-size: 28px 28px;\n    background-image: url('data:image/svg+xml;base64,PHN2ZyBmaWxsPSJub25lIiB2aWV3Qm94PSIwIDAgMjQgMjQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgICA8cGF0aCBmaWxsPSIjMDAwIiBkPSJNOC4wNDcgNC42MjVDNy45MzcgNC4xMjUgNy44NjIgNCA3LjUgNGMtLjM2MiAwLS40MzguMTI1LS41NDcuNjI1LS4wNjguMzEtLjE3NyAxLjMzOC0uMjUxIDIuMDc3LS43MzguMDc0LTEuNzY3LjE4My0yLjA3Ny4yNTEtLjUuMTEtLjYyNS4xODQtLjYyNS41NDcgMCAuMzYyLjEyNS40MzcuNjI1LjU0Ny4zMS4wNjcgMS4zMzYuMTc3IDIuMDc0LjI1LjA3My43NjcuMTg1IDEuODQyLjI1NCAyLjA3OC4xMS4zNzUuMTg1LjYyNS41NDcuNjI1LjM2MiAwIC40MzgtLjEyNS41NDctLjYyNS4wNjgtLjMxLjE3Ny0xLjMzNi4yNS0yLjA3NC43NjctLjA3MyAxLjg0Mi0uMTg1IDIuMDc4LS4yNTQuMzc1LS4xMS42MjUtLjE4NS42MjUtLjU0NyAwLS4zNjMtLjEyNS0uNDM4LS42MjUtLjU0Ny0uMzEtLjA2OC0xLjMzOS0uMTc3LTIuMDc3LS4yNTEtLjA3NC0uNzM5LS4xODMtMS43NjctLjI1MS0yLjA3N1oiLz4KICAgIDxwYXRoIGZpbGw9IiMwMDAiIGQ9Ik0xNC42ODEgNS4xOTljLS43NjYgMC0xLjQ4Mi4yMS0yLjA5My41NzhhLjYzNi42MzYgMCAwIDEtLjY1NS0xLjA5IDUuMzQgNS4zNCAwIDEgMSAxLjMwMiA5LjcyMmwtLjc3NS43NzZhLjYzNi42MzYgMCAwIDEtLjQ1LjE4NmgtMS4zOTh2MS42NWMwIC40OTMtLjQuODkzLS44OTMuODkzSDguNTc4djEuMTQxYzAgLjQ5NC0uNC44OTMtLjg5NC44OTNINC42MzZBLjYzNi42MzYgMCAwIDEgNCAxOS4zMTNWMTYuMjZjMC0uMTY5LjA2Ny0uMzMuMTg2LS40NWw1LjU2Mi01LjU2MmEuNjM2LjYzNiAwIDEgMSAuOS45bC01LjM3NiA1LjM3NXYyLjE1M2gyLjAzNHYtMS4zOTljMC0uMzUuMjg1LS42MzYuNjM2LS42MzZIOS4zNHYtMS45MDdjMC0uMzUxLjI4NC0uNjM2LjYzNS0uNjM2aDEuNzcxbC44NjQtLjg2M2EuNjM2LjYzNiAwIDAgMSAuNjY4LS4xNDcgNC4wNjkgNC4wNjkgMCAxIDAgMS40MDItNy44OVoiLz4KICAgIDxwYXRoIGZpbGw9IiMwMDAiIGZpbGwtcnVsZT0iZXZlbm9kZCIgZD0iTTEzLjYyNSA4LjQ5OWExLjg3NSAxLjg3NSAwIDEgMSAzLjc1IDAgMS44NzUgMS44NzUgMCAwIDEtMy43NSAwWm0xLjg3NS0uNjI1YS42MjUuNjI1IDAgMSAwIDAgMS4yNS42MjUuNjI1IDAgMCAwIDAtMS4yNVoiIGNsaXAtcnVsZT0iZXZlbm9kZCIvPgogICAgPHBhdGggZmlsbD0iIzAwMCIgZD0iTTQuNjI1IDEyLjEyNWEuNjI1LjYyNSAwIDEgMCAwLTEuMjUuNjI1LjYyNSAwIDAgMCAwIDEuMjVaIi8+Cjwvc3ZnPgo=');\n}\n.tooltip__button--data--creditCards::before {\n    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0ibm9uZSI+CiAgICA8cGF0aCBkPSJNNSA5Yy0uNTUyIDAtMSAuNDQ4LTEgMXYyYzAgLjU1Mi40NDggMSAxIDFoM2MuNTUyIDAgMS0uNDQ4IDEtMXYtMmMwLS41NTItLjQ0OC0xLTEtMUg1eiIgZmlsbD0iIzAwMCIvPgogICAgPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xIDZjMC0yLjIxIDEuNzktNCA0LTRoMTRjMi4yMSAwIDQgMS43OSA0IDR2MTJjMCAyLjIxLTEuNzkgNC00IDRINWMtMi4yMSAwLTQtMS43OS00LTRWNnptNC0yYy0xLjEwNSAwLTIgLjg5NS0yIDJ2OWgxOFY2YzAtMS4xMDUtLjg5NS0yLTItMkg1em0wIDE2Yy0xLjEwNSAwLTItLjg5NS0yLTJoMThjMCAxLjEwNS0uODk1IDItMiAySDV6IiBmaWxsPSIjMDAwIi8+Cjwvc3ZnPgo=');\n}\n.tooltip__button--data--identities::before {\n    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0ibm9uZSI+CiAgICA8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTEyIDIxYzIuMTQzIDAgNC4xMTEtLjc1IDUuNjU3LTItLjYyNi0uNTA2LTEuMzE4LS45MjctMi4wNi0xLjI1LTEuMS0uNDgtMi4yODUtLjczNS0zLjQ4Ni0uNzUtMS4yLS4wMTQtMi4zOTIuMjExLTMuNTA0LjY2NC0uODE3LjMzMy0xLjU4Ljc4My0yLjI2NCAxLjMzNiAxLjU0NiAxLjI1IDMuNTE0IDIgNS42NTcgMnptNC4zOTctNS4wODNjLjk2Ny40MjIgMS44NjYuOTggMi42NzIgMS42NTVDMjAuMjc5IDE2LjAzOSAyMSAxNC4xMDQgMjEgMTJjMC00Ljk3LTQuMDMtOS05LTlzLTkgNC4wMy05IDljMCAyLjEwNC43MjIgNC4wNCAxLjkzMiA1LjU3Mi44NzQtLjczNCAxLjg2LTEuMzI4IDIuOTIxLTEuNzYgMS4zNi0uNTU0IDIuODE2LS44MyA0LjI4My0uODExIDEuNDY3LjAxOCAyLjkxNi4zMyA0LjI2LjkxNnpNMTIgMjNjNi4wNzUgMCAxMS00LjkyNSAxMS0xMVMxOC4wNzUgMSAxMiAxIDEgNS45MjUgMSAxMnM0LjkyNSAxMSAxMSAxMXptMy0xM2MwIDEuNjU3LTEuMzQzIDMtMyAzcy0zLTEuMzQzLTMtMyAxLjM0My0zIDMtMyAzIDEuMzQzIDMgM3ptMiAwYzAgMi43NjEtMi4yMzkgNS01IDVzLTUtMi4yMzktNS01IDIuMjM5LTUgNS01IDUgMi4yMzkgNSA1eiIgZmlsbD0iIzAwMCIvPgo8L3N2Zz4=');\n}\n.tooltip__button--data--credentials.tooltip__button--data--bitwarden::before,\n.tooltip__button--data--credentials__current.tooltip__button--data--bitwarden::before {\n    background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0IiByeD0iOCIgZmlsbD0iIzE3NUREQyIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTE4LjU2OTYgNS40MzM1NUMxOC41MDg0IDUuMzc0NDIgMTguNDM0NyA1LjMyNzYzIDE4LjM1MzEgNS4yOTYxMUMxOC4yNzE1IDUuMjY0NiAxOC4xODM3IDUuMjQ5MDQgMTguMDk1MyA1LjI1MDQxSDUuOTIxOTFDNS44MzMyNiA1LjI0NzI5IDUuNzQ0OTMgNS4yNjIwNSA1LjY2MzA0IDUuMjkzNjdDNS41ODExNSA1LjMyNTI5IDUuNTA3NjUgNS4zNzMwMiA1LjQ0NzYyIDUuNDMzNTVDNS4zMjE3IDUuNTUwMTMgNS4yNTA2NSA1LjcwODE1IDUuMjUgNS44NzMxVjEzLjM4MjFDNS4yNTMzNiAxMy45NTM1IDUuMzc0MDggMTQuNTE5MSA1LjYwNTcyIDE1LjA0ODdDNS44MTkzMSAxNS41NzI4IDYuMTEyMDcgMTYuMDY2MSA2LjQ3NTI0IDE2LjUxMzlDNi44NDIgMTYuOTY4MyA3LjI1OTI5IDE3LjM4NTcgNy43MjAyNSAxNy43NTkzQzguMTQwNTMgMTguMTI1NiA4LjU4OTcxIDE4LjQ2MjMgOS4wNjQwNyAxOC43NjY2QzkuNDU5MzEgMTkuMDIzIDkuOTEzODMgMTkuMjc5NCAxMC4zNDg2IDE5LjUxNzVDMTAuNzgzNCAxOS43NTU2IDExLjA5OTYgMTkuOTIwNCAxMS4yNzc0IDE5Ljk5MzdDMTEuNDU1MyAyMC4wNjY5IDExLjYxMzQgMjAuMTQwMiAxMS43MTIyIDIwLjE5NTFDMTEuNzk5MiAyMC4yMzEzIDExLjg5MzUgMjAuMjUgMTEuOTg4OCAyMC4yNUMxMi4wODQyIDIwLjI1IDEyLjE3ODUgMjAuMjMxMyAxMi4yNjU1IDIwLjE5NTFDMTIuNDIxMiAyMC4xMzYzIDEyLjU3MjkgMjAuMDY5IDEyLjcyIDE5Ljk5MzdDMTIuNzcxMSAxOS45Njc0IDEyLjgzMzUgMTkuOTM2NiAxMi45MDY5IDE5LjkwMDRDMTMuMDg5MSAxOS44MTA1IDEzLjMzODggMTkuNjg3MiAxMy42NDg5IDE5LjUxNzVDMTQuMDgzNiAxOS4yNzk0IDE0LjUxODQgMTkuMDIzIDE0LjkzMzQgMTguNzY2NkMxNS40MDQgMTguNDU3NyAxNS44NTI4IDE4LjEyMTIgMTYuMjc3MiAxNy43NTkzQzE2LjczMzEgMTcuMzgwOSAxNy4xNDk5IDE2Ljk2NCAxNy41MjIyIDE2LjUxMzlDMTcuODc4IDE2LjA2MTcgMTguMTcwMiAxNS41NjkzIDE4LjM5MTcgMTUuMDQ4N0MxOC42MjM0IDE0LjUxOTEgMTguNzQ0MSAxMy45NTM1IDE4Ljc0NzQgMTMuMzgyMVY1Ljg3MzFDMTguNzU1NyA1Ljc5MjE0IDE4Ljc0MzkgNS43MTA1IDE4LjcxMzEgNS42MzQzNUMxOC42ODIzIDUuNTU4MiAxOC42MzMyIDUuNDg5NTQgMTguNTY5NiA1LjQzMzU1Wk0xNy4wMDg0IDEzLjQ1NTNDMTcuMDA4NCAxNi4xODQyIDEyLjAwODYgMTguNTI4NSAxMi4wMDg2IDE4LjUyODVWNi44NjIwOUgxNy4wMDg0VjEzLjQ1NTNaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K');\n}\n#provider_locked:after {\n    background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTEiIGhlaWdodD0iMTMiIHZpZXdCb3g9IjAgMCAxMSAxMyIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTEgNy42MDA1N1Y3LjYwMjVWOS41MjI1QzEgMTAuMDgwMSAxLjIyMTUxIDEwLjYxNDkgMS42MTU4MSAxMS4wMDkyQzIuMDEwMSAxMS40MDM1IDIuNTQ0ODggMTEuNjI1IDMuMTAyNSAxMS42MjVINy4yNzI1QzcuNTQ4NjEgMTEuNjI1IDcuODIyMDEgMTEuNTcwNiA4LjA3NzA5IDExLjQ2NUM4LjMzMjE4IDExLjM1OTMgOC41NjM5NiAxMS4yMDQ0IDguNzU5MTkgMTEuMDA5MkM4Ljk1NDQzIDEwLjgxNCA5LjEwOTMgMTAuNTgyMiA5LjIxNDk2IDEwLjMyNzFDOS4zMjA2MiAxMC4wNzIgOS4zNzUgOS43OTg2MSA5LjM3NSA5LjUyMjVMOS4zNzUgNy42MDI1TDkuMzc1IDcuNjAwNTdDOS4zNzQxNSA3LjE2MTMxIDkuMjM1NzQgNi43MzMzNSA4Ljk3OTIyIDYuMzc2NzhDOC44NzY4MyA2LjIzNDQ2IDguNzU3NjggNi4xMDYzNyA4LjYyNSA1Ljk5NDg5VjUuMTg3NUM4LjYyNSA0LjI3NTgyIDguMjYyODQgMy40MDE0OCA3LjYxODE4IDIuNzU2ODJDNi45NzM1MiAyLjExMjE2IDYuMDk5MTggMS43NSA1LjE4NzUgMS43NUM0LjI3NTgyIDEuNzUgMy40MDE0OCAyLjExMjE2IDIuNzU2ODIgMi43NTY4MkMyLjExMjE2IDMuNDAxNDggMS43NSA0LjI3NTgyIDEuNzUgNS4xODc1VjUuOTk0ODlDMS42MTczMiA2LjEwNjM3IDEuNDk4MTcgNi4yMzQ0NiAxLjM5NTc4IDYuMzc2NzhDMS4xMzkyNiA2LjczMzM1IDEuMDAwODUgNy4xNjEzMSAxIDcuNjAwNTdaTTQuOTY4NyA0Ljk2ODdDNS4wMjY5NCA0LjkxMDQ3IDUuMTA1MzIgNC44NzY5OSA1LjE4NzUgNC44NzUwN0M1LjI2OTY4IDQuODc2OTkgNS4zNDgwNiA0LjkxMDQ3IDUuNDA2MyA0Ljk2ODdDNS40NjU0MiA1LjAyNzgzIDUuNDk5MDQgNS4xMDc3NCA1LjUgNS4xOTEzVjUuNUg0Ljg3NVY1LjE5MTNDNC44NzU5NiA1LjEwNzc0IDQuOTA5NTggNS4wMjc4MyA0Ljk2ODcgNC45Njg3WiIgZmlsbD0iIzIyMjIyMiIgc3Ryb2tlPSJ3aGl0ZSIgc3Ryb2tlLXdpZHRoPSIyIi8+Cjwvc3ZnPgo=');\n}\n\nhr {\n    display: block;\n    margin: 5px 9px;\n    border: none; /* reset the border */\n    border-top: 1px solid rgba(0,0,0,.1);\n}\n\nhr:first-child {\n    display: none;\n}\n\n@media (prefers-color-scheme: dark) {\n    hr {\n        border-top: 1px solid rgba(255,255,255,.2);\n    }\n}\n\n#privateAddress {\n    align-items: flex-start;\n}\n#personalAddress::before,\n#privateAddress::before,\n#incontextSignup::before,\n#personalAddress.currentFocus::before,\n#personalAddress:hover::before,\n#privateAddress.currentFocus::before,\n#privateAddress:hover::before {\n    filter: none;\n    /* This is the same icon as `daxBase64` in `src/Form/logo-svg.js` */\n    background-image: url('data:image/svg+xml;base64,PHN2ZyBmaWxsPSJub25lIiB2aWV3Qm94PSIwIDAgMTI4IDEyOCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxwYXRoIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0ibTY0IDEyOGMzNS4zNDYgMCA2NC0yOC42NTQgNjQtNjRzLTI4LjY1NC02NC02NC02NC02NCAyOC42NTQtNjQgNjQgMjguNjU0IDY0IDY0IDY0eiIgZmlsbD0iI2RlNTgzMyIgZmlsbC1ydWxlPSJldmVub2RkIi8+CiAgICA8cGF0aCBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Im03MyAxMTEuNzVjMC0uNS4xMjMtLjYxNC0xLjQ2Ni0zLjc4Mi00LjIyNC04LjQ1OS04LjQ3LTIwLjM4NC02LjU0LTI4LjA3NS4zNTMtMS4zOTctMy45NzgtNTEuNzQ0LTcuMDQtNTMuMzY1LTMuNDAyLTEuODEzLTcuNTg4LTQuNjktMTEuNDE4LTUuMzMtMS45NDMtLjMxLTQuNDktLjE2NC02LjQ4Mi4xMDUtLjM1My4wNDctLjM2OC42ODMtLjAzLjc5OCAxLjMwOC40NDMgMi44OTUgMS4yMTIgMy44MyAyLjM3NS4xNzguMjItLjA2LjU2Ni0uMzQyLjU3Ny0uODgyLjAzMi0yLjQ4Mi40MDItNC41OTMgMi4xOTUtLjI0NC4yMDctLjA0MS41OTIuMjczLjUzIDQuNTM2LS44OTcgOS4xNy0uNDU1IDExLjkgMi4wMjcuMTc3LjE2LjA4NC40NS0uMTQ3LjUxMi0yMy42OTQgNi40NC0xOS4wMDMgMjcuMDUtMTIuNjk2IDUyLjM0NCA1LjYxOSAyMi41MyA3LjczMyAyOS43OTIgOC40IDMyLjAwNGEuNzE4LjcxOCAwIDAgMCAuNDIzLjQ2N2M4LjE1NiAzLjI0OCAyNS45MjggMy4zOTIgMjUuOTI4LTIuMTMyeiIgZmlsbD0iI2RkZCIgZmlsbC1ydWxlPSJldmVub2RkIi8+CiAgICA8cGF0aCBkPSJtNzYuMjUgMTE2LjVjLTIuODc1IDEuMTI1LTguNSAxLjYyNS0xMS43NSAxLjYyNS00Ljc2NCAwLTExLjYyNS0uNzUtMTQuMTI1LTEuODc1LTEuNTQ0LTQuNzUxLTYuMTY0LTE5LjQ4LTEwLjcyNy0zOC4xODVsLS40NDctMS44MjctLjAwNC0uMDE1Yy01LjQyNC0yMi4xNTctOS44NTUtNDAuMjUzIDE0LjQyNy00NS45MzguMjIyLS4wNTIuMzMtLjMxNy4xODQtLjQ5Mi0yLjc4Ni0zLjMwNS04LjAwNS00LjM4OC0xNC42MDUtMi4xMTEtLjI3LjA5My0uNTA2LS4xOC0uMzM3LS40MTIgMS4yOTQtMS43ODMgMy44MjMtMy4xNTUgNS4wNzEtMy43NTYuMjU4LS4xMjQuMjQyLS41MDItLjAzLS41ODhhMjcuODc3IDI3Ljg3NyAwIDAgMCAtMy43NzItLjljLS4zNy0uMDU5LS40MDMtLjY5My0uMDMyLS43NDMgOS4zNTYtMS4yNTkgMTkuMTI1IDEuNTUgMjQuMDI4IDcuNzI2YS4zMjYuMzI2IDAgMCAwIC4xODYuMTE0YzE3Ljk1MiAzLjg1NiAxOS4yMzggMzIuMjM1IDE3LjE3IDMzLjUyOC0uNDA4LjI1NS0xLjcxNS4xMDgtMy40MzgtLjA4NS02Ljk4Ni0uNzgxLTIwLjgxOC0yLjMyOS05LjQwMiAxOC45NDguMTEzLjIxLS4wMzYuNDg4LS4yNzIuNTI1LTYuNDM4IDEgMS44MTIgMjEuMTczIDcuODc1IDM0LjQ2MXoiIGZpbGw9IiNmZmYiLz4KICAgIDxwYXRoIGQ9Im04NC4yOCA5MC42OThjLTEuMzY3LS42MzMtNi42MjEgMy4xMzUtMTAuMTEgNi4wMjgtLjcyOC0xLjAzMS0yLjEwMy0xLjc4LTUuMjAzLTEuMjQyLTIuNzEzLjQ3Mi00LjIxMSAxLjEyNi00Ljg4IDIuMjU0LTQuMjgzLTEuNjIzLTExLjQ4OC00LjEzLTEzLjIyOS0xLjcxLTEuOTAyIDIuNjQ2LjQ3NiAxNS4xNjEgMy4wMDMgMTYuNzg2IDEuMzIuODQ5IDcuNjMtMy4yMDggMTAuOTI2LTYuMDA1LjUzMi43NDkgMS4zODggMS4xNzggMy4xNDggMS4xMzcgMi42NjItLjA2MiA2Ljk3OS0uNjgxIDcuNjQ5LTEuOTIxLjA0LS4wNzUuMDc1LS4xNjQuMTA1LS4yNjYgMy4zODggMS4yNjYgOS4zNSAyLjYwNiAxMC42ODIgMi40MDYgMy40Ny0uNTIxLS40ODQtMTYuNzIzLTIuMDktMTcuNDY3eiIgZmlsbD0iIzNjYTgyYiIvPgogICAgPHBhdGggZD0ibTc0LjQ5IDk3LjA5N2MuMTQ0LjI1Ni4yNi41MjYuMzU4LjguNDgzIDEuMzUyIDEuMjcgNS42NDguNjc0IDYuNzA5LS41OTUgMS4wNjItNC40NTkgMS41NzQtNi44NDMgMS42MTVzLTIuOTItLjgzMS0zLjQwMy0yLjE4MWMtLjM4Ny0xLjA4MS0uNTc3LTMuNjIxLS41NzItNS4wNzUtLjA5OC0yLjE1OC42OS0yLjkxNiA0LjMzNC0zLjUwNiAyLjY5Ni0uNDM2IDQuMTIxLjA3MSA0Ljk0NC45NCAzLjgyOC0yLjg1NyAxMC4yMTUtNi44ODkgMTAuODM4LTYuMTUyIDMuMTA2IDMuNjc0IDMuNDk5IDEyLjQyIDIuODI2IDE1LjkzOS0uMjIgMS4xNTEtMTAuNTA1LTEuMTM5LTEwLjUwNS0yLjM4IDAtNS4xNTItMS4zMzctNi41NjUtMi42NS02Ljcxem0tMjIuNTMtMS42MDljLjg0My0xLjMzMyA3LjY3NC4zMjUgMTEuNDI0IDEuOTkzIDAgMC0uNzcgMy40OTEuNDU2IDcuNjA0LjM1OSAxLjIwMy04LjYyNyA2LjU1OC05LjggNS42MzctMS4zNTUtMS4wNjUtMy44NS0xMi40MzItMi4wOC0xNS4yMzR6IiBmaWxsPSIjNGNiYTNjIi8+CiAgICA8cGF0aCBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Im01NS4yNjkgNjguNDA2Yy41NTMtMi40MDMgMy4xMjctNi45MzIgMTIuMzIxLTYuODIyIDQuNjQ4LS4wMTkgMTAuNDIyLS4wMDIgMTQuMjUtLjQzNmE1MS4zMTIgNTEuMzEyIDAgMCAwIDEyLjcyNi0zLjA5NWMzLjk4LTEuNTE5IDUuMzkyLTEuMTggNS44ODctLjI3Mi41NDQuOTk5LS4wOTcgMi43MjItMS40ODggNC4zMDktMi42NTYgMy4wMy03LjQzMSA1LjM4LTE1Ljg2NSA2LjA3Ni04LjQzMy42OTgtMTQuMDItMS41NjUtMTYuNDI1IDIuMTE4LTEuMDM4IDEuNTg5LS4yMzYgNS4zMzMgNy45MiA2LjUxMiAxMS4wMiAxLjU5IDIwLjA3Mi0xLjkxNyAyMS4xOS4yMDEgMS4xMTkgMi4xMTgtNS4zMjMgNi40MjgtMTYuMzYyIDYuNTE4cy0xNy45MzQtMy44NjUtMjAuMzc5LTUuODNjLTMuMTAyLTIuNDk1LTQuNDktNi4xMzMtMy43NzUtOS4yNzl6IiBmaWxsPSIjZmMzIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiLz4KICAgIDxnIGZpbGw9IiMxNDMwN2UiIG9wYWNpdHk9Ii44Ij4KICAgICAgPHBhdGggZD0ibTY5LjMyNyA0Mi4xMjdjLjYxNi0xLjAwOCAxLjk4MS0xLjc4NiA0LjIxNi0xLjc4NiAyLjIzNCAwIDMuMjg1Ljg4OSA0LjAxMyAxLjg4LjE0OC4yMDItLjA3Ni40NC0uMzA2LjM0YTU5Ljg2OSA1OS44NjkgMCAwIDEgLS4xNjgtLjA3M2MtLjgxNy0uMzU3LTEuODItLjc5NS0zLjU0LS44Mi0xLjgzOC0uMDI2LTIuOTk3LjQzNS0zLjcyNy44MzEtLjI0Ni4xMzQtLjYzNC0uMTMzLS40ODgtLjM3MnptLTI1LjE1NyAxLjI5YzIuMTctLjkwNyAzLjg3Ni0uNzkgNS4wODEtLjUwNC4yNTQuMDYuNDMtLjIxMy4yMjctLjM3Ny0uOTM1LS43NTUtMy4wMy0xLjY5Mi01Ljc2LS42NzQtMi40MzcuOTA5LTMuNTg1IDIuNzk2LTMuNTkyIDQuMDM4LS4wMDIuMjkyLjYuMzE3Ljc1Ni4wNy40Mi0uNjcgMS4xMi0xLjY0NiAzLjI4OS0yLjU1M3oiLz4KICAgICAgPHBhdGggY2xpcC1ydWxlPSJldmVub2RkIiBkPSJtNzUuNDQgNTUuOTJhMy40NyAzLjQ3IDAgMCAxIC0zLjQ3NC0zLjQ2MiAzLjQ3IDMuNDcgMCAwIDEgMy40NzUtMy40NiAzLjQ3IDMuNDcgMCAwIDEgMy40NzQgMy40NiAzLjQ3IDMuNDcgMCAwIDEgLTMuNDc1IDMuNDYyem0yLjQ0Ny00LjYwOGEuODk5Ljg5OSAwIDAgMCAtMS43OTkgMGMwIC40OTQuNDA1Ljg5NS45Ljg5NS40OTkgMCAuOS0uNC45LS44OTV6bS0yNS40NjQgMy41NDJhNC4wNDIgNC4wNDIgMCAwIDEgLTQuMDQ5IDQuMDM3IDQuMDQ1IDQuMDQ1IDAgMCAxIC00LjA1LTQuMDM3IDQuMDQ1IDQuMDQ1IDAgMCAxIDQuMDUtNC4wMzcgNC4wNDUgNC4wNDUgMCAwIDEgNC4wNSA0LjAzN3ptLTEuMTkzLTEuMzM4YTEuMDUgMS4wNSAwIDAgMCAtMi4wOTcgMCAxLjA0OCAxLjA0OCAwIDAgMCAyLjA5NyAweiIgZmlsbC1ydWxlPSJldmVub2RkIi8+CiAgICA8L2c+CiAgICA8cGF0aCBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Im02NCAxMTcuNzVjMjkuNjg1IDAgNTMuNzUtMjQuMDY1IDUzLjc1LTUzLjc1cy0yNC4wNjUtNTMuNzUtNTMuNzUtNTMuNzUtNTMuNzUgMjQuMDY1LTUzLjc1IDUzLjc1IDI0LjA2NSA1My43NSA1My43NSA1My43NXptMCA1YzMyLjQ0NyAwIDU4Ljc1LTI2LjMwMyA1OC43NS01OC43NXMtMjYuMzAzLTU4Ljc1LTU4Ljc1LTU4Ljc1LTU4Ljc1IDI2LjMwMy01OC43NSA1OC43NSAyNi4zMDMgNTguNzUgNTguNzUgNTguNzV6IiBmaWxsPSIjZmZmIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiLz4KPC9zdmc+');\n}\n\n/* Email tooltip specific */\n.tooltip__button--email {\n    flex-direction: column;\n    justify-content: center;\n    align-items: flex-start;\n    font-size: 14px;\n    padding: 4px 8px;\n}\n.tooltip__button--email__primary-text {\n    font-weight: bold;\n}\n.tooltip__button--email__secondary-text {\n    font-size: 12px;\n}\n\n/* Email Protection signup notice */\n:not(.top-autofill) .tooltip--email-signup {\n    text-align: left;\n    color: #222222;\n    padding: 16px 20px;\n    width: 380px;\n}\n\n.tooltip--email-signup h1 {\n    font-weight: 700;\n    font-size: 16px;\n    line-height: 1.5;\n    margin: 0;\n}\n\n.tooltip--email-signup p {\n    font-weight: 400;\n    font-size: 14px;\n    line-height: 1.4;\n}\n\n.notice-controls {\n    display: flex;\n}\n\n.tooltip--email-signup .notice-controls > * {\n    border-radius: 8px;\n    border: 0;\n    cursor: pointer;\n    display: inline-block;\n    font-family: inherit;\n    font-style: normal;\n    font-weight: bold;\n    padding: 8px 12px;\n    text-decoration: none;\n}\n\n.notice-controls .ghost {\n    margin-left: 1rem;\n}\n\n.tooltip--email-signup a.primary {\n    background: #3969EF;\n    color: #fff;\n}\n\n.tooltip--email-signup a.primary:hover,\n.tooltip--email-signup a.primary:focus {\n    background: #2b55ca;\n}\n\n.tooltip--email-signup a.primary:active {\n    background: #1e42a4;\n}\n\n.tooltip--email-signup button.ghost {\n    background: transparent;\n    color: #3969EF;\n}\n\n.tooltip--email-signup button.ghost:hover,\n.tooltip--email-signup button.ghost:focus {\n    background-color: rgba(0, 0, 0, 0.06);\n    color: #2b55ca;\n}\n\n.tooltip--email-signup button.ghost:active {\n    background-color: rgba(0, 0, 0, 0.12);\n    color: #1e42a4;\n}\n\n.tooltip--email-signup button.close-tooltip {\n    background-color: transparent;\n    background-image: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iMTMiIHZpZXdCb3g9IjAgMCAxMiAxMyIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0wLjI5Mjg5NCAwLjY1NjkwN0MwLjY4MzQxOCAwLjI2NjM4MyAxLjMxNjU4IDAuMjY2MzgzIDEuNzA3MTEgMC42NTY5MDdMNiA0Ljk0OThMMTAuMjkyOSAwLjY1NjkwN0MxMC42ODM0IDAuMjY2MzgzIDExLjMxNjYgMC4yNjYzODMgMTEuNzA3MSAwLjY1NjkwN0MxMi4wOTc2IDEuMDQ3NDMgMTIuMDk3NiAxLjY4MDYgMTEuNzA3MSAyLjA3MTEyTDcuNDE0MjEgNi4zNjQwMUwxMS43MDcxIDEwLjY1NjlDMTIuMDk3NiAxMS4wNDc0IDEyLjA5NzYgMTEuNjgwNiAxMS43MDcxIDEyLjA3MTFDMTEuMzE2NiAxMi40NjE2IDEwLjY4MzQgMTIuNDYxNiAxMC4yOTI5IDEyLjA3MTFMNiA3Ljc3ODIzTDEuNzA3MTEgMTIuMDcxMUMxLjMxNjU4IDEyLjQ2MTYgMC42ODM0MTcgMTIuNDYxNiAwLjI5Mjg5MyAxMi4wNzExQy0wLjA5NzYzMTEgMTEuNjgwNiAtMC4wOTc2MzExIDExLjA0NzQgMC4yOTI4OTMgMTAuNjU2OUw0LjU4NTc5IDYuMzY0MDFMMC4yOTI4OTQgMi4wNzExMkMtMC4wOTc2MzA2IDEuNjgwNiAtMC4wOTc2MzA2IDEuMDQ3NDMgMC4yOTI4OTQgMC42NTY5MDdaIiBmaWxsPSJibGFjayIgZmlsbC1vcGFjaXR5PSIwLjg0Ii8+Cjwvc3ZnPgo=);\n    background-position: center center;\n    background-repeat: no-repeat;\n    border: 0;\n    cursor: pointer;\n    padding: 16px;\n    position: absolute;\n    right: 12px;\n    top: 12px;\n}\n";
 
 },{}],62:[function(require,module,exports){
 "use strict";
@@ -17098,7 +17227,7 @@ var _autofillUtils = require("./autofill-utils.js");
   }
 })();
 
-},{"./DeviceInterface.js":22,"./autofill-utils.js":62,"./requestIdleCallback.js":74}],64:[function(require,module,exports){
+},{"./DeviceInterface.js":22,"./autofill-utils.js":62,"./requestIdleCallback.js":102}],64:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -17557,6 +17686,7 @@ const userPreferencesSchema = exports.userPreferencesSchema = _zod.z.object({
   globalPrivacyControlValue: _zod.z.boolean().optional(),
   sessionKey: _zod.z.string().optional(),
   debug: _zod.z.boolean(),
+  language: _zod.z.string().optional(),
   platform: _zod.z.object({
     name: _zod.z.union([_zod.z.literal("ios"), _zod.z.literal("macos"), _zod.z.literal("windows"), _zod.z.literal("extension"), _zod.z.literal("android"), _zod.z.literal("unknown")])
   }),
@@ -18121,6 +18251,8 @@ async function extensionSpecificRuntimeConfiguration(deviceApi) {
       contentScope: contentScope,
       // @ts-ignore
       userPreferences: {
+        // Copy locale to user preferences as 'language' to match expected payload
+        language: contentScope.locale,
         features: {
           autofill: {
             settings: {
@@ -18342,6 +18474,2632 @@ function waitForWindowsResponse(responseId, options) {
 }
 
 },{"../../../packages/device-api/index.js":12}],74:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Здравей, свят",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Използване на {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Блокиране на имейл тракери",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Парола за {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Генерирана парола",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Паролата за този уебсайт ще бъде запазена",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Приложението Bitwarden е заключено",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Отключете своя трезор, за да получите достъп до идентификационни данни или да генерирате пароли",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Генериране на личен Duck Address",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Скрийте имейл адреса си и блокирайте тракерите",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Създайте уникален, произволен адрес, който премахва скритите тракери и препраща имейлите към пощенската Ви кутия.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Управление на запазените елементи…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Управление на кредитните карти…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Управление на самоличностите…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Управление на пароли…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Генериране на поверителен Duck Address",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Блокиране на имейл тракерите и скриване на адреса",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Защита на моя имейл",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Не показвай отново",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],75:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Ahoj, světe",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Použít {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Blokuj e-mailové trackery",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Heslo pro {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Vygenerované heslo",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Heslo pro tenhle web se uloží",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Aplikace Bitwarden je zamčená",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Pro přístup k přihlašovacím údajům a generování hesel je potřeba odemknout aplikaci Bitwarden",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Vygenerovat soukromou Duck Address",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Skryj svůj e-mail a blokuj trackery",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Vytvoř si jedinečnou, náhodnou adresu, která bude odstraňovat skryté trackery a přeposílat e-maily do tvé schránky.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Spravovat uložené položky…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Spravovat platební karty…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Spravovat identity…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Spravovat hesla…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Vygenerovat soukromou Duck Address",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Blokuj e-mailové trackery a skryj svou adresu",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Chránit můj e-mail",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Už neukazovat",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],76:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Hej verden",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Brug {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Blokerer e-mailtrackere",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Adgangskode til {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Genereret adgangskode",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Adgangskoden bliver gemt for dette websted",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Bitwarden er låst",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Lås din boks op for at få adgang til legitimationsoplysninger eller generere adgangskoder",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Opret privat Duck-adresse",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Skjul din e-mail og bloker trackere",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Opret en unik, tilfældig adresse, der også fjerner skjulte trackere og videresender e-mails til din indbakke.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Administrer gemte elementer…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Administrer kreditkort…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Administrer identiteter…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Administrer adgangskoder…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Opret en privat Duck-adresse",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Bloker e-mailtrackere og skjul adresse",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Beskyt min e-mail",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Vis ikke igen",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],77:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Hallo Welt",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "{email} verwenden",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "E-Mail-Tracker blockieren",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Passwort für {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Generiertes Passwort",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Passwort wird für diese Website gespeichert",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Bitwarden ist verschlossen",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Entsperre deinen Bitwarden-Datentresor, um auf deine Zugangsdaten zuzugreifen oder Passwörter zu generieren",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Private Duck-Adresse generieren",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "E-Mail-Adresse verbergen und Tracker blockieren",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Einmalige, zufällige Adresse erstellen, die versteckte Tracker entfernt und E-Mails an deinen Posteingang weiterleitet.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Gespeicherte Elemente verwalten …",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Kreditkarten verwalten …",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Identitäten verwalten …",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Passwörter verwalten …",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Private Duck Address generieren",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "E-Mail-Tracker blockieren & Adresse verbergen",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Meine E-Mail-Adresse schützen",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Nicht erneut anzeigen",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],78:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Γεια σου κόσμε",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Χρησιμοποιήστε τη διεύθυνση {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Αποκλεισμός εφαρμογών παρακολούθησης email",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Κωδικός πρόσβασης για {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Δημιουργήθηκε κωδικός πρόσβασης",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Ο κωδικός πρόσβασης θα αποθηκευτεί για τον ιστότοπο αυτό",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Το Bitwarden είναι κλειδωμένο",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Ξεκλειδώστε το θησαυροφυλάκιό σας για πρόσβαση σε διαπιστευτήρια ή δημιουργία κωδικών πρόσβασης",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Δημιουργήστε ιδιωτική Duck Address",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Απόκρυψη του email σας και αποκλεισμός εφαρμογών παρακολούθησης",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Δημιουργήστε μια μοναδική, τυχαία διεύθυνση η οποία αφαιρεί επίσης κρυφές εφαρμογές παρακολούθησης και προωθεί email στα εισερχόμενά σας.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Διαχείριση αποθηκευμένων στοιχείων…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Διαχείριση πιστωτικών καρτών…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Διαχείριση ταυτοτήτων…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Διαχείριση κωδικών πρόσβασης…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Δημιουργήστε μια ιδιωτική Duck Address",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Αποκλεισμός εφαρμογών παρακολούθησης email και απόκρυψη διεύθυνσης",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Προστασία του email μου",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Να μην εμφανιστεί ξανά",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],79:[function(require,module,exports){
+module.exports={
+  "smartling": {
+    "string_format": "icu",
+    "translate_paths": [
+      {
+        "path": "*/title",
+        "key": "{*}/title",
+        "instruction": "*/note"
+      }
+    ]
+  },
+  "hello": {
+    "title": "Hello world",
+    "note": "Static text for testing."
+  },
+  "lipsum": {
+    "title": "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note": "Placeholder text."
+  },
+  "usePersonalDuckAddr": {
+    "title": "Use {email}",
+    "note": "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers": {
+    "title": "Block email trackers",
+    "note": "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl": {
+    "title": "Password for {url}",
+    "note": "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword": {
+    "title": "Generated password",
+    "note": "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved": {
+    "title": "Password will be saved for this website",
+    "note": "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked": {
+    "title": "Bitwarden is locked",
+    "note": "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault": {
+    "title": "Unlock your vault to access credentials or generate passwords",
+    "note": "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr": {
+    "title": "Generate Private Duck Address",
+    "note": "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers": {
+    "title": "Hide your email and block trackers",
+    "note": "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr": {
+    "title": "Create a unique, random address that also removes hidden trackers and forwards email to your inbox.",
+    "note": "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems": {
+    "title": "Manage saved items…",
+    "note": "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards": {
+    "title": "Manage credit cards…",
+    "note": "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities": {
+    "title": "Manage identities…",
+    "note": "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords": {
+    "title": "Manage passwords…",
+    "note": "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr": {
+    "title": "Generate a Private Duck Address",
+    "note": "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress": {
+    "title": "Block email trackers & hide address",
+    "note": "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail": {
+    "title": "Protect My Email",
+    "note": "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain": {
+    "title": "Don't Show Again",
+    "note": "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],80:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Hola mundo",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Usar {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Bloquea de rastreadores de correo electrónico",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Contraseña para {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Contraseña generada",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Se guardará la contraseña de este sitio web",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Bitwarden está bloqueado",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Desbloquea tu caja fuerte para acceder a las credenciales o generar contraseñas",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Generar Duck Address privada",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Ocultar tu correo electrónico y bloquear rastreadores",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Crea una dirección aleatoria única que también elimine los rastreadores ocultos y reenvíe el correo electrónico a tu bandeja de entrada.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Gestionar elementos guardados…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Gestionar tarjetas de crédito…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Gestionar identidades…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Administrar contraseñas…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Generar Duck Address privada",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Bloquea rastreadores de correo electrónico y oculta la dirección",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Proteger mi correo electrónico",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "No volver a mostrar",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],81:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Tere maailm",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Kasutage {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Blokeeri e-posti jälgijad",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Saidi {url} parool",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Loodud parool",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Parool salvestatakse selle veebilehe jaoks",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Bitwarden on lukustatud",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Ava mandaatidele juurdepääsuks või paroolide loomiseks oma varamu",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Loo privaatne Duck Address",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Peida oma e-post ja blokeeri jälgijad",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Loo unikaalne, juhuslik aadress, mis eemaldab ka varjatud jäglijad ja edastab e-kirjad sinu postkasti.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Halda salvestatud üksuseid…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Halda krediitkaarte…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Halda identiteete…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Halda paroole…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Loo privaatne Duck Address",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Blokeeri e-posti jälgijad ja peida aadress",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Kaitse minu e-posti aadressi",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Ära enam näita",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],82:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Hei, maailma",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Käytä {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Estä sähköpostin seurantaohjelmat",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Sivuston {url} salasana",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Luotu salasana",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Salasana tallennetaan tälle verkkosivustolle",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Bitwarden on lukittu",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Avaa holvin lukitus päästäksesi käsiksi tunnistetietoihin tai luodaksesi salasanoja",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Luo yksityinen Duck Address",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Piilota sähköpostisi ja Estä seurantaohjelmat",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Luo yksilöllinen, satunnainen osoite, joka lisäksi poistaa piilotetut seurantaohjelmat ja välittää sähköpostin omaan postilaatikkoosi.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Hallitse tallennettuja kohteita…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Hallitse luottokortteja…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Hallitse käyttäjätietoja…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Hallitse salasanoja…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Luo yksityinen Duck Address",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Estä sähköpostin seurantaohjelmat ja piilota osoite",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Suojaa sähköpostini",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Älä näytä enää",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],83:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Bonjour à tous",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Utiliser {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Bloquer les traqueurs d'e-mails",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Mot de passe pour {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Mot de passe généré",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Le mot de passe sera enregistré pour ce site",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Bitwarden est verrouillé",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Déverrouillez votre coffre-fort pour accéder à vos informations d'identification ou générer des mots de passe",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Générer une Duck Address privée",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Masquez votre adresse e-mail et bloquez les traqueurs",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Créez une adresse unique et aléatoire qui supprime les traqueurs masqués et transfère les e-mails vers votre boîte de réception.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Gérez les éléments enregistrés…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Gérez les cartes bancaires…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Gérez les identités…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Gérer les mots de passe…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Générer une Duck Address privée",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Bloquer les traqueurs d'e-mails et masquer l'adresse",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Protéger mon adresse e-mail",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Ne plus afficher",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],84:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Pozdrav svijete",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Upotrijebite {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Blokiranje alata za praćenje e-pošte",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Lozinka za {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Generirana lozinka",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Lozinka će biti spremljena za ovo web-mjesto",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Bitwarden je zaključan",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Otključaj svoj trezor za pristup vjerodajnicama ili generiranje lozinki",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Generiraj privatnu adresu Duck Address",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Sakrij svoju e-poštu i blokiraj tragače",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Izradi jedinstvenu, nasumičnu adresu koja također uklanja skrivene alate za praćenje (\"tragače\") i prosljeđuje e-poštu u tvoj sandučić za pristiglu poštu.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Upravljanje spremljenim stavkama…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Upravljanje kreditnim karticama…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Upravljanje identitetima…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Upravljanje lozinkama…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Generiraj privatnu adresu Duck Address",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Blokiraj praćenje e-pošte i sakrij adresu",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Zaštiti moju e-poštu",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Nemoj ponovno prikazivati",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],85:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Helló, világ!",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "{email} használata",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "E-mail nyomkövetők blokkolása",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "{url} jelszava",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Generált jelszó",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "A webhelyhez tartozó jelszó mentve lesz",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "A Bitwarden zárolva van",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "A hitelesítő adatok eléréséhez vagy a jelszavak generálásához oldd fel a tárolót",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Privát Duck Address létrehozása",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "E-mail elrejtése és nyomkövetők blokkolása",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Hozz létre egy egyedi, véletlenszerű címet, amely eltávolítja a rejtett nyomkövetőket is, és a postafiókodba továbbítja az e-maileket.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Mentett elemek kezelése…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Hitelkártyák kezelése…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Identitások kezelése…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Jelszavak kezelése…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Privát Duck Address létrehozása",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "E-mail nyomkövetők blokkolása, és a cím elrejtése",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "E-mail védelme",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Ne jelenjen meg újra",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],86:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Ciao mondo",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Usa {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Blocca i sistemi di tracciamento e-mail",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Password per {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Password generata",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "La password verrà salvata per questo sito web",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Bitwarden è bloccato",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Sblocca la tua cassaforte per accedere alle credenziali o generare password",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Genera Duck Address privato",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Nascondi il tuo indirizzo e-mail e blocca i sistemi di tracciamento",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Crea un indirizzo univoco e casuale che rimuove anche i sistemi di tracciamento nascosti e inoltra le e-mail alla tua casella di posta.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Gestisci gli elementi salvati…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Gestisci carte di credito…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Gestisci identità…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Gestisci password…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Genera un Duck Address privato",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Blocca i sistemi di tracciamento e-mail e nascondi il tuo indirizzo",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Proteggi la mia e-mail",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Non mostrare più",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],87:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Labas pasauli",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Naudoti {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Blokuoti el. pašto sekimo priemones",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "„{url}“ slaptažodis",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Sugeneruotas slaptažodis",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Slaptažodis bus išsaugotas šiai svetainei",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "„Bitwarden“ užrakinta",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Atrakinkite saugyklą, kad pasiektumėte prisijungimo duomenis arba sugeneruotumėte slaptažodžius",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Generuoti privatų „Duck Address“",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Paslėpkite savo el. paštą ir blokuokite stebėjimo priemones",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Sukurkite unikalų atsitiktinį adresą, kuriuo taip pat pašalinamos slaptos sekimo priemonės ir el. laiškai persiunčiami į pašto dėžutę.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Tvarkykite išsaugotus elementus…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Tvarkykite kredito korteles…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Tvarkykite tapatybes…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Slaptažodžių valdymas…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Generuoti privatų „Duck Address“",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Blokuoti el. pašto stebėjimo priemones ir slėpti adresą",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Apsaugoti mano el. paštą",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Daugiau nerodyti",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],88:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Sveika, pasaule",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Izmantot {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Bloķē e-pasta izsekotājus",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "{url} parole",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Ģenerēta parole",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Parole tiks saglabāta šai vietnei",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Bitwarden ir bloķēts",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Atbloķē glabātavu, lai piekļūtu pieteikšanās datiem vai ģenerētu paroles",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Ģenerēt privātu Duck adresi",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Paslēp savu e-pastu un bloķē izsekotājus",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Izveido unikālu, nejauši izvēlētu adresi, kas arī aizvāc slēptos izsekotājus un pārsūta e-pastus uz tavu pastkastīti.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Pārvaldīt saglabātos vienumus…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Pārvaldīt kredītkartes…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Pārvaldīt identitātes",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Pārvaldīt paroles…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Ģenerēt privātu Duck adresi",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Bloķē e-pasta izsekotājus un paslēp adresi",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Aizsargāt manu e-pastu",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Turpmāk nerādīt",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],89:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Hallo verden",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Bruk {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Blokker e-postsporere",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Passord for {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Generert passord",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Passordet blir lagret for dette nettstedet",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Bitwarden er låst",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Lås opp hvelvet ditt for å få tilgang til legitimasjon eller generere passord",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Generer privat Duck Address",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Skjul e-postadressen din og blokker sporere",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Opprett en unik, tilfeldig adresse som også fjerner skjulte sporere og videresender e-post til innboksen din.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Administrer lagrede elementer…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Administrer kredittkort…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Administrer identiteter…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Administrer passord…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Generer en privat Duck Address",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Blokker e-postsporere og skjul adresse",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Beskytt e-postadressen min",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Ikke vis igjen",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],90:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Hallo wereld",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "{email} gebruiken",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "E-mailtrackers blokkeren",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Wachtwoord voor {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Gegenereerd wachtwoord",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Wachtwoord wordt opgeslagen voor deze website",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Bitwarden is vergrendeld",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Ontgrendelt je kluis om toegang te krijgen tot inloggegevens of om wachtwoorden te genereren",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Privé-Duck Address genereren",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Je e-mailadres verbergen en trackers blokkeren",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Maak een uniek, willekeurig adres dat ook verborgen trackers verwijdert en e-mails doorstuurt naar je inbox.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Opgeslagen items beheren…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Creditcards beheren…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Identiteiten beheren…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Wachtwoorden beheren…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Privé-Duck Address genereren",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "E-mailtrackers blokkeren en adres verbergen",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Mijn e-mailadres beschermen",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Niet meer weergeven",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],91:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Witajcie",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Użyj {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Blokuj mechanizmy śledzące pocztę e-mail",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Hasło do witryny {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Wygenerowane hasło",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Hasło zostanie zapisane na potrzeby tej witryny",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Aplikacja Bitwarden jest zablokowana",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Odblokuj sejf, aby uzyskać dostęp do poświadczeń lub generować hasła",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Wygeneruj prywatny adres Duck Address",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Ukryj swój adres e-mail i blokuj skrypty śledzące",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Utwórz unikalny, losowy adres, który usuwa ukryte mechanizmy śledzące i przekazuje wiadomości e-mail do Twojej skrzynki odbiorczej.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Zarządzaj zapisanymi elementami…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Zarządzaj kartami kredytowymi…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Zarządzaj tożsamościami…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Zarządzaj hasłami…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Wygeneruj prywatny adres Duck Address",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Zablokuj mechanizmy śledzące pocztę e-mail i ukryj adres",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Chroń moją pocztę e-mail",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Nie pokazuj więcej",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],92:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Olá, mundo",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Usar {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Bloquear rastreadores de e-mail",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Palavra-passe de {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Palavra-passe gerada",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "A palavra-passe deste site será guardada",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "O Bitwarden está bloqueado",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Desbloqueia o teu cofre para aceder a credenciais ou gerar palavras-passe",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Gerar um Duck Address privado",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Ocultar o teu e-mail e bloquear rastreadores",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Criar um endereço aleatório exclusivo que também remove rastreadores escondidos e encaminha o e-mail para a tua caixa de entrada.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Gerir itens guardados…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Gerir cartões de crédito…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Gerir identidades…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Gerir palavras-passe…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Gerar um Duck Address Privado",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Bloquear rastreadores de e-mail e ocultar endereço",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Proteger o meu e-mail",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Não mostrar novamente",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],93:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Salut!",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Utilizează {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Blochează tehnologiile de urmărire din e-mail",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Parola pentru {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Parola generată",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Parola va fi salvată pentru acest site",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Bitwarden este blocat",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Deblochează seiful pentru a accesa datele de conectare sau pentru a genera parole",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Generează o Duck Address privată",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Ascunde-ți e-mailul și blochează tehnologiile de urmărire",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Creează o adresă unică, aleatorie, care elimină și tehnologiile de urmărire ascunse și redirecționează e-mailurile către căsuța ta de inbox.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Gestionează elementele salvate…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Gestionează cardurile de credit…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Gestionează identitățile…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Gestionează parolele…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Generează o Duck Address privată",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Blochează tehnologiile de urmărire din e-mailuri și ascunde adresa",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Protejează-mi adresa de e-mail",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Nu mai afișa",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],94:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Привет, мир!",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Использовать {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Блокирует почтовые трекеры",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Пароль для {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Сгенерированный пароль",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Пароль будет сохранен для этого сайта",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Приложение Bitwarden заблокировано",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Разблокируйте хранилище, чтобы пользоваться учетными данными и генерировать пароли.",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Сгенерировать Duck Address",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Скрытие адреса почты и блокировка трекеров",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Создайте уникальный случайный адрес, который также удалит скрытые трекеры и перенаправит электронную почту на ваш ящик.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Настроить сохраненные данные…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Настроить платежные карты…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Настроить учетные данные…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Управление паролями…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Сгенерировать Duck Address",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Скрывает ваш адрес и Блокирует почтовые трекеры",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Защитить почту",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Больше не показывать",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],95:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Ahoj, svet!",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Použiť {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Blokuje e-mailové sledovače",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Heslo pre {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Vygenerované heslo",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Heslo pre túto webovú stránku bude uložené",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Bitwarden je uzamknutý",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Odomknite trezor pre prístup k prihlasovacím údajom alebo generovaniu hesiel",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Generovať súkromnú Duck Address",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Skryte svoj e-mail a blokujte sledovače",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Vytvorte si náhodnú jedinečnú adresu, ktorá odstráni aj skryté sledovacie prvky a prepošle e-maily do vašej schránky.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Spravovať uložené položky…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Spravovať kreditné karty…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Spravovať identity…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Spravovať heslá…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Generovať súkromnú Duck Address",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Blokujte sledovače e-mailov a skryte adresu",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Ochrana môjho e-mailu",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Nabudúce už neukazovať",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],96:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Pozdravljen, svet",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Uporabite {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Blokirajte sledilnike e-pošte",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Geslo za spletno mesto {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Ustvarjeno geslo",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Geslo bo shranjeno za to spletno mesto",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Bitwarden je zaklenjen",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Odklenite trezor za dostop do poverilnic ali ustvarjanje gesel",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Ustvarjanje zasebnega naslova Duck Address",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Skrijte svojo e-pošto in blokirajte sledilnike",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Ustvarite edinstven, naključen naslov, ki odstrani tudi skrite sledilnike in posreduje e-pošto v vaš e-poštni predal.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Upravljaj shranjene elemente…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Upravljaj kreditne kartice…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Upravljaj identitete…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Upravljanje gesel…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Ustvari zasebni naslov Duck Address",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Blokirajte sledilnike e-pošte in skrijte naslov",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Zaščiti mojo e-pošto",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Ne prikaži več",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],97:[function(require,module,exports){
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.getTranslator = getTranslator;
+var _translations = _interopRequireDefault(require("./translations.js"));
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+/** @typedef {`autofill:${keyof typeof translations["en"]["autofill"]}`} AutofillKeys */
+
+/**
+ * @callback TranslateFn
+ * Translates a string with the provided namespaced ID to the current language,
+ * replacing each placeholder with a key present in `opts` with the
+ * corresponding value.
+ *
+ * @param {AutofillKeys} id - the namespaced string ID to look up
+ * @param {Record<string, string>} [opts] - a set of optional replacements to perform
+ * @returns {string} the string with namespaced ID `id`, translated to the current language
+ */
+
+/**
+ * Builds a reusable translation function bound to the language provided by
+ * `settings`. That language isn't read until the first translation is
+ * requested, so it's safe to use this statically and assign `settings.language`
+ * later.
+ *
+ * @param {{ language: string }} settings - a settings object containing the current language
+ * @returns {TranslateFn} a translation function
+ */
+function getTranslator(settings) {
+  /** @type typeof translations["en"] */
+  let library;
+  return function t(id, opts) {
+    // Retrieve the library when the first string is translated, to allow
+    // InterfacePrototype.t() to be statically initialized.
+    if (!library) {
+      const {
+        language
+      } = settings;
+      library = _translations.default[language];
+      if (!library) {
+        console.warn(`Received unsupported locale '${language}'. Falling back to 'en'.`);
+        library = _translations.default.en;
+      }
+    }
+    return translateImpl(library, id, opts);
+  };
+}
+
+/**
+ * Looks up the string with the provided `id` in a `library`, performing
+ * key-value replacements on the translated string. If no string with ID `id` is
+ * found, `id` is returned unmodified.
+ * @param {typeof translations["en"]} library - a map of string IDs to translation
+ * @param {AutofillKeys} namespacedId - the namespaced string ID to translate (e.g. "autofill:hello")
+ * @param {Record<string, string>} [opts] - a set of optional replacements to perform
+ * @returns {string} the string with ID `id`, translated to the current language
+ */
+function translateImpl(library, namespacedId, opts) {
+  const [namespace, id] = namespacedId.split(':', 2);
+  const namespacedLibrary = library[namespace];
+
+  // Fall back to the message ID if an unsupported namespace is provided.
+  if (!namespacedLibrary) {
+    return id;
+  }
+  const msg = namespacedLibrary[id];
+  // Fall back to the message ID if an unsupported message is provided.
+  if (!msg) {
+    return id;
+  }
+
+  // Fast path: don't loop over opts if no replacements are provided.
+  if (!opts) {
+    return msg.title;
+  }
+
+  // Repeatedly replace all instances of '{SOME_REPLACEMENT_NAME}' with the
+  // corresponding value.
+  let out = msg.title;
+  for (const [name, value] of Object.entries(opts)) {
+    out = out.replaceAll(`{${name}}`, value);
+  }
+  return out;
+}
+
+},{"./translations.js":100}],98:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Hej världen",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Använd {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Blockera e-postspårare",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Lösenord för {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Genererat lösenord",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Lösenordet sparas för den här webbplatsen",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Bitwarden är låst",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Lås upp ditt valv för att komma åt inloggningsuppgifter eller generera lösenord",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Generera privat Duck Address",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Dölj din e-postadress och blockera spårare",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Skapa en unik, slumpmässig adress som också tar bort dolda spårare och vidarebefordrar e-post till din inkorg.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Hantera sparade objekt…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Hantera kreditkort…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Hantera identiteter…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Hantera lösenord…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Generera en privat Duck Address",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Blockera e-postspårare och dölj din adress",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Skydda min e-postadress",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Visa inte igen",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],99:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Hello world",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "{email} kullan",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "E-posta izleyicileri engelleyin",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "{url} şifresi",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Oluşturulan şifre",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Şifre bu web sitesi için kaydedilecek",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Bitwarden kilitlendi",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Kimlik bilgilerine erişmek veya şifre oluşturmak için kasanızın kilidini açın",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Özel Duck Address Oluştur",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "E-postanızı Gizleyin ve İzleyicileri Engelleyin",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Gizli izleyicileri de kaldıran ve e-postaları gelen kutunuza ileten benzersiz, rastgele bir adres oluşturun.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Kaydedilen öğeleri yönetin…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Kredi kartlarını yönetin…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Kimlikleri yönetin…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Şifreleri yönet…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Özel Duck Address Oluştur",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "E-posta izleyicileri engelleyin ve adresi gizleyin",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "E-postamı Koru",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Bir Daha Gösterme",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],100:[function(require,module,exports){
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+var _autofill = _interopRequireDefault(require("./bg/autofill.json"));
+var _autofill2 = _interopRequireDefault(require("./cs/autofill.json"));
+var _autofill3 = _interopRequireDefault(require("./da/autofill.json"));
+var _autofill4 = _interopRequireDefault(require("./de/autofill.json"));
+var _autofill5 = _interopRequireDefault(require("./el/autofill.json"));
+var _autofill6 = _interopRequireDefault(require("./en/autofill.json"));
+var _autofill7 = _interopRequireDefault(require("./es/autofill.json"));
+var _autofill8 = _interopRequireDefault(require("./et/autofill.json"));
+var _autofill9 = _interopRequireDefault(require("./fi/autofill.json"));
+var _autofill10 = _interopRequireDefault(require("./fr/autofill.json"));
+var _autofill11 = _interopRequireDefault(require("./hr/autofill.json"));
+var _autofill12 = _interopRequireDefault(require("./hu/autofill.json"));
+var _autofill13 = _interopRequireDefault(require("./it/autofill.json"));
+var _autofill14 = _interopRequireDefault(require("./lt/autofill.json"));
+var _autofill15 = _interopRequireDefault(require("./lv/autofill.json"));
+var _autofill16 = _interopRequireDefault(require("./nb/autofill.json"));
+var _autofill17 = _interopRequireDefault(require("./nl/autofill.json"));
+var _autofill18 = _interopRequireDefault(require("./pl/autofill.json"));
+var _autofill19 = _interopRequireDefault(require("./pt/autofill.json"));
+var _autofill20 = _interopRequireDefault(require("./ro/autofill.json"));
+var _autofill21 = _interopRequireDefault(require("./ru/autofill.json"));
+var _autofill22 = _interopRequireDefault(require("./sk/autofill.json"));
+var _autofill23 = _interopRequireDefault(require("./sl/autofill.json"));
+var _autofill24 = _interopRequireDefault(require("./sv/autofill.json"));
+var _autofill25 = _interopRequireDefault(require("./tr/autofill.json"));
+var _autofill26 = _interopRequireDefault(require("./xa/autofill.json"));
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+/**
+ * This file is auto-generated by scripts/bundle-locales.mjs, based on the contents of the src/locales/ directory.
+ * Any manual changes in here will be overwritten on build!
+ */
+var _default = exports.default = {
+  bg: {
+    autofill: _autofill.default
+  },
+  cs: {
+    autofill: _autofill2.default
+  },
+  da: {
+    autofill: _autofill3.default
+  },
+  de: {
+    autofill: _autofill4.default
+  },
+  el: {
+    autofill: _autofill5.default
+  },
+  en: {
+    autofill: _autofill6.default
+  },
+  es: {
+    autofill: _autofill7.default
+  },
+  et: {
+    autofill: _autofill8.default
+  },
+  fi: {
+    autofill: _autofill9.default
+  },
+  fr: {
+    autofill: _autofill10.default
+  },
+  hr: {
+    autofill: _autofill11.default
+  },
+  hu: {
+    autofill: _autofill12.default
+  },
+  it: {
+    autofill: _autofill13.default
+  },
+  lt: {
+    autofill: _autofill14.default
+  },
+  lv: {
+    autofill: _autofill15.default
+  },
+  nb: {
+    autofill: _autofill16.default
+  },
+  nl: {
+    autofill: _autofill17.default
+  },
+  pl: {
+    autofill: _autofill18.default
+  },
+  pt: {
+    autofill: _autofill19.default
+  },
+  ro: {
+    autofill: _autofill20.default
+  },
+  ru: {
+    autofill: _autofill21.default
+  },
+  sk: {
+    autofill: _autofill22.default
+  },
+  sl: {
+    autofill: _autofill23.default
+  },
+  sv: {
+    autofill: _autofill24.default
+  },
+  tr: {
+    autofill: _autofill25.default
+  },
+  xa: {
+    autofill: _autofill26.default
+  }
+};
+
+},{"./bg/autofill.json":74,"./cs/autofill.json":75,"./da/autofill.json":76,"./de/autofill.json":77,"./el/autofill.json":78,"./en/autofill.json":79,"./es/autofill.json":80,"./et/autofill.json":81,"./fi/autofill.json":82,"./fr/autofill.json":83,"./hr/autofill.json":84,"./hu/autofill.json":85,"./it/autofill.json":86,"./lt/autofill.json":87,"./lv/autofill.json":88,"./nb/autofill.json":89,"./nl/autofill.json":90,"./pl/autofill.json":91,"./pt/autofill.json":92,"./ro/autofill.json":93,"./ru/autofill.json":94,"./sk/autofill.json":95,"./sl/autofill.json":96,"./sv/autofill.json":98,"./tr/autofill.json":99,"./xa/autofill.json":101}],101:[function(require,module,exports){
+module.exports={
+  "smartling": {
+    "string_format": "icu",
+    "translate_paths": [
+      {
+        "path": "*/title",
+        "key": "{*}/title",
+        "instruction": "*/note"
+      }
+    ]
+  },
+  "hello": {
+    "title": "H33ll00 wºrrld",
+    "note": "Static text for testing."
+  },
+  "lipsum": {
+    "title": "Lºrr3e3m 1p$$$um d00l1loor s!t @@mett, {foo} {bar}",
+    "note": "Placeholder text."
+  },
+  "usePersonalDuckAddr": {
+    "title": "Ü55££ {email}",
+    "note": "Shown when a user can choose their personal @duck.com address."
+  },
+  "blockEmailTrackers": {
+    "title": "Bl000ck €m@@@i1il1l träáåck33rr55",
+    "note": "Shown when a user can choose their personal @duck.com address on native platforms."
+  },
+  "passwordForUrl": {
+    "title": "Pa@assw0rdd ffoör {url}",
+    "note": "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword": {
+    "title": "Gen33ratéééd pa@assw0rdd",
+    "note": "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved": {
+    "title": "Pa@assw0rdd wi11lll ß3 $avvved for thîï$s website",
+    "note": "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked": {
+    "title": "Bitwarden iiss löøcçk3d∂",
+    "note": "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault": {
+    "title": "Unlock yo0ur va@uült to acceé$$s crédeññtïåååls or gééneraåte pass55wººrds5",
+    "note": "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr": {
+    "title": "Geññëérååte Priiivate Duck Addddrrreess",
+    "note": "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form."
+  },
+  "hideEmailAndBlockTrackers": {
+    "title": "Hîïíde yo0øur ££m@il an∂∂∂ bllºck tr@cçck3rs",
+    "note": "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr": {
+    "title": "ÇÇr3£ate @ üûún11que, r@@nd0øm ad∂dr3s5s that als0º r3mov3s hidd££n tr@cker$5$ and forwards em@@1l to your 1ñb0x.",
+    "note": "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems": {
+    "title": "Måanñageé s@@ved 17733m5…",
+    "note": "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards": {
+    "title": "Måanñageé ¢¢r£d17 ca®®®∂∂s…",
+    "note": "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities": {
+    "title": "Måanñageé ¡d££nt11ties…",
+    "note": "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords": {
+    "title": "Måanñageé p@å$$$wººr∂∂s…",
+    "note": "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr": {
+    "title": "Géééner@te a Prîîîvate DDDuck Addréés$s",
+    "note": "Button that when clicked creates a new private email address and fills the corresponding field with the generated address."
+  },
+  "blockEmailTrackersAndHideAddress": {
+    "title": "Bloºøck £mååil tr@åack££rs && hïïïdéé ad∂dr33s5s$",
+    "note": "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail": {
+    "title": "Prºº††£ct M¥¥ Em@@iîl",
+    "note": "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain": {
+    "title": "Doøºnñ't Sh00w Ag@ååîn",
+    "note": "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+},{}],102:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {

--- a/node_modules/@duckduckgo/autofill/dist/autofill.css
+++ b/node_modules/@duckduckgo/autofill/dist/autofill.css
@@ -19,7 +19,7 @@
     font-family: 'SF Pro Text', system-ui, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
     'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
 }
-:not(.top-autofill) .tooltip {
+.wrapper:not(.top-autofill) .tooltip {
     position: absolute;
     width: 300px;
     max-width: calc(100vw - 25px);
@@ -50,7 +50,7 @@
 .tooltip--data.tooltip--incontext-signup {
     width: 360px;
 }
-:not(.top-autofill) .tooltip--data {
+.wrapper:not(.top-autofill) .tooltip--data {
     top: 100%;
     left: 100%;
     border: 0.5px solid rgba(255, 255, 255, 0.2);
@@ -58,11 +58,11 @@
     box-shadow: 0 10px 20px rgba(0, 0, 0, 0.32);
 }
 @media (prefers-color-scheme: dark) {
-    :not(.top-autofill) .tooltip--data {
+    .wrapper:not(.top-autofill) .tooltip--data {
         border: 1px solid rgba(255, 255, 255, 0.2);
     }
 }
-:not(.top-autofill) .tooltip--email {
+.wrapper:not(.top-autofill) .tooltip--email {
     top: calc(100% + 6px);
     right: calc(100% - 48px);
     padding: 8px;
@@ -110,6 +110,7 @@
     background: transparent;
     border: none;
     border-radius: 6px;
+    text-align: left;
 }
 .tooltip__button.currentFocus,
 .wrapper:not(.top-autofill) .tooltip__button:hover {

--- a/node_modules/@duckduckgo/autofill/dist/autofill.js
+++ b/node_modules/@duckduckgo/autofill/dist/autofill.js
@@ -1662,7 +1662,7 @@ const DEFAULT_MIN_LENGTH = 20;
 const DEFAULT_MAX_LENGTH = 30;
 const DEFAULT_REQUIRED_CHARS = '-!?$&#%';
 const DEFAULT_UNAMBIGUOUS_CHARS = 'abcdefghijkmnopqrstuvwxyzABCDEFGHIJKLMNPQRSTUVWXYZ0123456789';
-const DEFAULT_PASSWORD_RULES = [`minlength: ${DEFAULT_MIN_LENGTH}`, `maxlength: ${DEFAULT_MAX_LENGTH}`, `required: [${DEFAULT_REQUIRED_CHARS}]`, `allowed: [${DEFAULT_UNAMBIGUOUS_CHARS}]`].join('; ');
+const DEFAULT_PASSWORD_RULES = [`minlength: ${DEFAULT_MIN_LENGTH}`, `maxlength: ${DEFAULT_MAX_LENGTH}`, `required: [${DEFAULT_REQUIRED_CHARS}]`, `required: digit`, `allowed: [${DEFAULT_UNAMBIGUOUS_CHARS}]`].join('; ');
 const constants = exports.constants = {
   DEFAULT_MIN_LENGTH,
   DEFAULT_MAX_LENGTH,
@@ -2278,6 +2278,9 @@ module.exports={
   "access.service.gov.uk": {
     "password-rules": "minlength: 10; required: lower; required: upper; required: digit; required: special;"
   },
+  "account.samsung.com": {
+    "password-rules": "minlength: 8; maxlength: 15; required: digit; required: special; required: upper,lower;"
+  },
   "admiral.com": {
     "password-rules": "minlength: 8; required: digit; required: [- !\"#$&'()*+,.:;<=>?@[^_`{|}~]]; allowed: lower, upper;"
   },
@@ -2310,6 +2313,9 @@ module.exports={
   },
   "americanexpress.com": {
     "password-rules": "minlength: 8; maxlength: 20; max-consecutive: 4; required: lower, upper; required: digit; allowed: [%&_?#=];"
+  },
+  "ana.co.jp": {
+    "password-rules": "minlength: 8; maxlength: 16; required: digit; required: upper,lower;"
   },
   "anatel.gov.br": {
     "password-rules": "minlength: 6; maxlength: 15; allowed: lower, upper, digit;"
@@ -2453,7 +2459,7 @@ module.exports={
     "password-rules": "minlength: 5; required: lower, upper; required: digit;"
   },
   "cogmembers.org": {
-    "password-rules": "minlength: 8; maxlength: 14; required: upper; required: digit, allowed: lower;"
+    "password-rules": "minlength: 8; maxlength: 14; required: upper; required: digit; allowed: lower;"
   },
   "collectivehealth.com": {
     "password-rules": "minlength: 8; required: lower; required: upper; required: digit;"
@@ -2474,7 +2480,7 @@ module.exports={
     "password-rules": "minlength: 6; maxlength: 15; allowed: lower, upper, digit, [-.];"
   },
   "costco.com": {
-    "password-rules": "minlength: 8; maxlength: 20; required: lower, upper; allowed: digit, [-!#$%&'()*+/:;=?@[^_`{|}~]];"
+    "password-rules": "minlength: 8; maxlength: 16; required: lower, upper; allowed: digit, [-!#$%&'()*+/:;=?@[^_`{|}~]];"
   },
   "coursera.com": {
     "password-rules": "minlength: 8; maxlength: 72;"
@@ -2523,6 +2529,9 @@ module.exports={
   },
   "dmm.com": {
     "password-rules": "minlength: 4; maxlength: 16; required: lower; required: upper; required: digit;"
+  },
+  "dodgeridge.com": {
+    "password-rules": "minlength: 8; maxlength: 12; required: lower; required: upper; required: digit;"
   },
   "dowjones.com": {
     "password-rules": "maxlength: 15;"
@@ -3181,6 +3190,9 @@ module.exports={
   "udel.edu": {
     "password-rules": "minlength: 12; maxlength: 30; required: lower; required: upper; required: digit; required: [!@#$%^&*()+];"
   },
+  "umterps.evenue.net": {
+    "password-rules": "minlength: 4; maxlength: 12;"
+  },
   "user.ornl.gov": {
     "password-rules": "minlength: 8; maxlength: 30; max-consecutive: 3; required: lower, upper; required: digit; allowed: [!#$%./_];"
   },
@@ -3712,6 +3724,20 @@ class AppleDeviceInterface extends _InterfacePrototype.default {
   }
 
   /**
+   * Opens the native UI for managing identities
+   */
+  openManageIdentities() {
+    return this.deviceApi.notify((0, _index.createNotification)('pmHandlerOpenManageIdentities'));
+  }
+
+  /**
+   * Opens the native UI for managing credit cards
+   */
+  openManageCreditCards() {
+    return this.deviceApi.notify((0, _index.createNotification)('pmHandlerOpenManageCreditCards'));
+  }
+
+  /**
    * Gets a single identity obj once the user requests it
    * @param {IdentityObject['id']} id
    * @returns {Promise<{success: IdentityObject|undefined}>}
@@ -4175,6 +4201,7 @@ var _index = require("../../packages/device-api/index.js");
 var _deviceApiCalls = require("../deviceApiCalls/__generated__/deviceApiCalls.js");
 var _initFormSubmissionsApi = require("./initFormSubmissionsApi.js");
 var _EmailProtection = require("../EmailProtection.js");
+var _strings = require("../locales/strings.js");
 /**
  * @typedef {import('../deviceApiCalls/__generated__/validators-ts').StoreFormData} StoreFormData
  */
@@ -4220,6 +4247,13 @@ class InterfacePrototype {
   /** @type {import("../../packages/device-api").DeviceApi} */
   deviceApi;
 
+  /**
+   * Translates a string to the current language, replacing each placeholder
+   * with a key present in `opts` with the corresponding value.
+   * @type {import('../locales/strings').TranslateFn}
+   */
+  t;
+
   /** @type {boolean} */
   isInitializationStarted;
 
@@ -4235,6 +4269,7 @@ class InterfacePrototype {
     this.globalConfig = config;
     this.deviceApi = deviceApi;
     this.settings = settings;
+    this.t = (0, _strings.getTranslator)(settings);
     this.uiController = null;
     this.scanner = (0, _Scanner.createScanner)(this, {
       initialDelay: this.initialSetupDelayMs
@@ -4322,13 +4357,13 @@ class InterfacePrototype {
       newIdentities.push({
         id: 'personalAddress',
         emailAddress: personalAddress,
-        title: 'Block email trackers'
+        title: this.t('autofill:blockEmailTrackers')
       });
     }
     newIdentities.push({
       id: 'privateAddress',
       emailAddress: privateAddress,
-      title: 'Block email trackers & hide address'
+      title: this.t('autofill:blockEmailTrackersAndHideAddress')
     });
     return [...identities, ...newIdentities];
   }
@@ -4569,7 +4604,7 @@ class InterfacePrototype {
     this.activeForm = form;
     const inputType = (0, _matching.getInputType)(input);
 
-    /** @type {PosFn} */
+    /** @type {import('../UI/interfaces.js').PosFn} */
     const getPosition = () => {
       // In extensions, the tooltip is centered on the Dax icon
       const alignLeft = this.globalConfig.isApp || this.globalConfig.isWindows;
@@ -4973,7 +5008,7 @@ class InterfacePrototype {
 }
 var _default = exports.default = InterfacePrototype;
 
-},{"../../packages/device-api/index.js":2,"../EmailProtection.js":22,"../Form/formatters.js":26,"../Form/matching.js":33,"../InputTypes/Credentials.js":35,"../PasswordGenerator.js":38,"../Scanner.js":39,"../Settings.js":40,"../UI/controllers/NativeUIController.js":47,"../autofill-utils.js":52,"../config.js":54,"../deviceApiCalls/__generated__/deviceApiCalls.js":56,"../deviceApiCalls/transports/transports.js":62,"./initFormSubmissionsApi.js":20}],18:[function(require,module,exports){
+},{"../../packages/device-api/index.js":2,"../EmailProtection.js":22,"../Form/formatters.js":26,"../Form/matching.js":33,"../InputTypes/Credentials.js":35,"../PasswordGenerator.js":38,"../Scanner.js":39,"../Settings.js":40,"../UI/controllers/NativeUIController.js":47,"../autofill-utils.js":52,"../config.js":54,"../deviceApiCalls/__generated__/deviceApiCalls.js":56,"../deviceApiCalls/transports/transports.js":62,"../locales/strings.js":87,"./initFormSubmissionsApi.js":20}],18:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -8225,7 +8260,7 @@ const matchingConfiguration = exports.matchingConfiguration = {
         formInputsSelector: 'input:not([type=button]):not([type=checkbox]):not([type=color]):not([type=file]):not([type=hidden]):not([type=radio]):not([type=range]):not([type=reset]):not([type=image]):not([type=search]):not([type=submit]):not([type=time]):not([type=url]):not([type=week]):not([name^=fake i]):not([data-description^=dummy i]):not([name*=otp]):not([autocomplete="fake"]):not([placeholder^=search i]):not([type=date]):not([type=datetime-local]):not([type=datetime]):not([type=month]),[autocomplete=username],select',
         safeUniversalSelector: '*:not(select):not(option):not(script):not(noscript):not(style):not(br)',
         emailAddress: 'input:not([type])[name*=email i]:not([placeholder*=search i]):not([placeholder*=filter i]):not([placeholder*=subject i]):not([name*=code i]), input[type=""][name*=email i]:not([placeholder*=search i]):not([placeholder*=filter i]):not([placeholder*=subject i]):not([type=tel]), input[type=text][name*=email i]:not([placeholder*=search i]):not([placeholder*=filter i]):not([placeholder*=subject i]):not([name*=title i]):not([name*=tab i]):not([name*=code i]), input:not([type])[placeholder*=email i]:not([placeholder*=search i]):not([placeholder*=filter i]):not([placeholder*=subject i]):not([name*=code i]), input[type=text][placeholder*=email i]:not([placeholder*=search i]):not([placeholder*=filter i]):not([placeholder*=subject i]), input[type=""][placeholder*=email i]:not([placeholder*=search i]):not([placeholder*=filter i]):not([placeholder*=subject i]), input[type=email], input[type=text][aria-label*=email i]:not([aria-label*=search i]), input:not([type])[aria-label*=email i]:not([aria-label*=search i]), input[name=username][type=email], input[autocomplete=username][type=email], input[autocomplete=username][placeholder*=email i], input[autocomplete=email],input[name="mail_tel" i],input[value=email i]',
-        username: 'input:not([type=button]):not([type=checkbox]):not([type=color]):not([type=file]):not([type=hidden]):not([type=radio]):not([type=range]):not([type=reset]):not([type=image]):not([type=search]):not([type=submit]):not([type=time]):not([type=url]):not([type=week]):not([name^=fake i]):not([data-description^=dummy i]):not([name*=otp]):not([autocomplete="fake"]):not([placeholder^=search i]):not([type=date]):not([type=datetime-local]):not([type=datetime]):not([type=month])[autocomplete^=user i],input[name=username i],input[name="loginId" i],input[name="userid" i],input[id="userid" i],input[name="user_id" i],input[name="user-id" i],input[id="login-id" i],input[id="login_id" i],input[id="loginid" i],input[name="login" i],input[name=accountname i],input[autocomplete=username i],input[name*=accountid i],input[name="j_username" i],input[id="j_username" i],input[name="uwinid" i],input[name="livedoor_id" i],input[name="ssousername" i],input[name="j_userlogin_pwd" i],input[name="user[login]" i],input[name="user" i],input[name$="_username" i],input[id="lmSsoinput" i],input[name="account_subdomain" i],input[name="masterid" i],input[name="tridField" i],input[id="signInName" i],input[id="w3c_accountsbundle_accountrequeststep1_login" i],input[id="username" i],input[name="_user" i],input[name="login_username" i],input[name^="login-user-account" i],input[id="loginusuario" i],input[name="usuario" i],input[id="UserLoginFormUsername" i],input[id="nw_username" i],input[can-field="accountName"],input[placeholder^="username" i]',
+        username: 'input:not([type=button]):not([type=checkbox]):not([type=color]):not([type=file]):not([type=hidden]):not([type=radio]):not([type=range]):not([type=reset]):not([type=image]):not([type=search]):not([type=submit]):not([type=time]):not([type=url]):not([type=week]):not([name^=fake i]):not([data-description^=dummy i]):not([name*=otp]):not([autocomplete="fake"]):not([placeholder^=search i]):not([type=date]):not([type=datetime-local]):not([type=datetime]):not([type=month])[autocomplete^=user i],input[name=username i],input[name="loginId" i],input[name="userid" i],input[id="userid" i],input[name="user_id" i],input[name="user-id" i],input[id="login-id" i],input[id="login_id" i],input[id="loginid" i],input[name="login" i],input[name=accountname i],input[autocomplete=username i],input[name*=accountid i],input[name="j_username" i],input[id="j_username" i],input[name="uwinid" i],input[name="livedoor_id" i],input[name="ssousername" i],input[name="j_userlogin_pwd" i],input[name="user[login]" i],input[name="user" i],input[name$="_username" i],input[id="lmSsoinput" i],input[name="account_subdomain" i],input[name="masterid" i],input[name="tridField" i],input[id="signInName" i],input[id="w3c_accountsbundle_accountrequeststep1_login" i],input[id="username" i],input[name="_user" i],input[name="login_username" i],input[name^="login-user-account" i],input[id="loginusuario" i],input[name="usuario" i],input[id="UserLoginFormUsername" i],input[id="nw_username" i],input[can-field="accountName"],input[name="login[username]"],input[placeholder^="username" i]',
         password: 'input[type=password]:not([autocomplete*=cc]):not([autocomplete=one-time-code]):not([name*=answer i]):not([name*=mfa i]):not([name*=tin i]):not([name*=card i]):not([name*=cvv i]),input.js-cloudsave-phrase',
         cardName: 'input[autocomplete="cc-name" i], input[autocomplete="ccname" i], input[name="ccname" i], input[name="cc-name" i], input[name="ppw-accountHolderName" i], input[id*=cardname i], input[id*=card-name i], input[id*=card_name i]',
         cardNumber: 'input[autocomplete="cc-number" i], input[autocomplete="ccnumber" i], input[autocomplete="cardnumber" i], input[autocomplete="card-number" i], input[name="ccnumber" i], input[name="cc-number" i], input[name*=card i][name*=number i], input[name*=cardnumber i], input[id*=cardnumber i], input[id*=card-number i], input[id*=card_number i]',
@@ -8252,7 +8287,7 @@ const matchingConfiguration = exports.matchingConfiguration = {
     ddgMatcher: {
       matchers: {
         unknown: {
-          match: /search|filter|subject|title|captcha|mfa|2fa|(two|2).?factor|one-time|otp|cerca|filtr|oggetto|titolo|(due|2|più).?fattori|suche|filtern|betreff|zoeken|filter|onderwerp|titel|chercher|filtrer|objet|titre|authentification multifacteur|double authentification|à usage unique|busca|busqueda|filtra|dos pasos|un solo uso|sök|filter|ämne|multifaktorsautentisering|tvåfaktorsautentisering|två.?faktor|engångs/iu,
+          match: /search|find|filter|subject|title|captcha|mfa|2fa|(two|2).?factor|one-time|otp|social security number|ssn|cerca|filtr|oggetto|titolo|(due|2|più).?fattori|suche|filtern|betreff|zoeken|filter|onderwerp|titel|chercher|filtrer|objet|titre|authentification multifacteur|double authentification|à usage unique|busca|busqueda|filtra|dos pasos|un solo uso|sök|filter|ämne|multifaktorsautentisering|tvåfaktorsautentisering|två.?faktor|engångs/iu,
           skip: /phone|mobile|email|password/iu
         },
         emailAddress: {
@@ -8262,7 +8297,7 @@ const matchingConfiguration = exports.matchingConfiguration = {
         },
         password: {
           match: /password|passwort|kennwort|wachtwoord|mot de passe|clave|contraseña|lösenord/iu,
-          skip: /email|one-time|error|hint/iu,
+          skip: /email|one-time|error|hint|^username$/iu,
           forceUnknown: /captcha|mfa|2fa|two factor|otp|pin/iu
         },
         newPassword: {
@@ -8272,7 +8307,7 @@ const matchingConfiguration = exports.matchingConfiguration = {
           match: /current|old|previous|expired|existing/iu
         },
         username: {
-          match: /(user|account|online.?id|log(i|o)n|net)((.)?(name|i.?d.?|log(i|o)n).?)?(.?((or|\/).+|\*|:)( required)?)?$|(nome|id|login).?utente|(nome|id) (dell.)?account|codice cliente|nutzername|anmeldename|gebruikersnaam|nom d.utilisateur|identifiant|pseudo|usuari|cuenta|identificador|apodo|\bdni\b|\bnie\b| del? documento|documento de identidad|användarnamn|kontonamn|användar-id/iu,
+          match: /(user|account|online.?id|membership.?id|log(i|o)n|net)((.)?(name|i.?d.?|log(i|o)n).?)?(.?((or|\/).+|\*|:)( required)?)?$|(nome|id|login).?utente|(nome|id) (dell.)?account|codice (cliente|uten)|nutzername|anmeldename|gebruikersnaam|nom d.utilisateur|identifiant|pseudo|usuari|cuenta|identificador|apodo|\bdni\b|\bnie\b| del? documento|documento de identidad|användarnamn|kontonamn|användar-id/iu,
           skip: /phone/iu,
           forceUnknown: /search|policy|choose a user\b/iu
         },
@@ -9429,6 +9464,8 @@ const recursiveGetPreviousElSibling = el => {
 const getRelatedText = (el, form, cssSelector) => {
   let scope = getLargestMeaningfulContainer(el, form, cssSelector);
 
+  // TODO: We should try and simplify this, the logic has become very hard to follow over time
+
   // If we didn't find a container, try looking for an adjacent label
   if (scope === el) {
     let previousEl = recursiveGetPreviousElSibling(el);
@@ -9455,7 +9492,7 @@ const getRelatedText = (el, form, cssSelector) => {
   const label = scope.querySelector('label');
   if (label) {
     // Try searching for a label first
-    trimmedText = (0, _autofillUtils.getTextShallow)(label);
+    trimmedText = (0, _labelUtil.extractElementStrings)(label).join(' ');
   } else {
     // If the container has a select element, remove its contents to avoid noise
     trimmedText = (0, _labelUtil.extractElementStrings)(scope).join(' ');
@@ -9482,6 +9519,11 @@ const getLargestMeaningfulContainer = (el, form, cssSelector) => {
   const inputsInParentsScope = parentElement.querySelectorAll(cssSelector);
   // To avoid noise, ensure that our input is the only in scope
   if (inputsInParentsScope.length === 1) {
+    // If the parent has only 1 input and a label with text, we've found our meaningful container
+    const labelInParentScope = parentElement.querySelector('label');
+    if (labelInParentScope?.textContent?.trim()) {
+      return parentElement;
+    }
     return getLargestMeaningfulContainer(parentElement, form, cssSelector);
   }
   return el;
@@ -9665,6 +9707,8 @@ exports.appendGeneratedKey = appendGeneratedKey;
 exports.createCredentialsTooltipItem = createCredentialsTooltipItem;
 exports.fromPassword = fromPassword;
 var _autofillUtils = require("../autofill-utils.js");
+/** @typedef {import("../UI/interfaces").TooltipItemRenderer} TooltipItemRenderer */
+
 const AUTOGENERATED_KEY = exports.AUTOGENERATED_KEY = 'autogenerated';
 const PROVIDER_LOCKED = exports.PROVIDER_LOCKED = 'provider_locked';
 
@@ -9679,16 +9723,19 @@ class CredentialsTooltipItem {
     this.#data = data;
   }
   id = () => String(this.#data.id);
-  labelMedium = _subtype => {
+  /** @param {import('../locales/strings.js').TranslateFn} t */
+  labelMedium = t => {
     if (this.#data.username) {
       return this.#data.username;
     }
     if (this.#data.origin?.url) {
-      return `Password for ${(0, _autofillUtils.truncateFromMiddle)(this.#data.origin.url)}`;
+      return t('autofill:passwordForUrl', {
+        url: (0, _autofillUtils.truncateFromMiddle)(this.#data.origin.url)
+      });
     }
     return '';
   };
-  labelSmall = _subtype => {
+  labelSmall = () => {
     if (this.#data.origin?.url) {
       return (0, _autofillUtils.truncateFromMiddle)(this.#data.origin.url);
     }
@@ -9709,8 +9756,10 @@ class AutoGeneratedCredential {
   }
   id = () => String(this.#data.id);
   label = _subtype => this.#data.password;
-  labelMedium = _subtype => 'Generated password';
-  labelSmall = _subtype => 'Password will be saved for this website';
+  /** @param {import('../locales/strings.js').TranslateFn} t */
+  labelMedium = t => t('autofill:generatedPassword');
+  /** @param {import('../locales/strings.js').TranslateFn} t */
+  labelSmall = t => t('autofill:passwordWillBeSaved');
 }
 
 /**
@@ -9740,8 +9789,10 @@ class ProviderLockedItem {
     this.#data = data;
   }
   id = () => String(this.#data.id);
-  labelMedium = _subtype => 'Bitwarden is locked';
-  labelSmall = _subtype => 'Unlock your vault to access credentials or generate passwords';
+  /** @param {import('../locales/strings.js').TranslateFn} t */
+  labelMedium = t => t('autofill:bitwardenIsLocked');
+  /** @param {import('../locales/strings.js').TranslateFn} t */
+  labelSmall = t => t('autofill:unlockYourVault');
   credentialsProvider = () => this.#data.credentialsProvider;
 }
 
@@ -9808,6 +9859,8 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.CreditCardTooltipItem = void 0;
+/** @typedef {import("../UI/interfaces").TooltipItemRenderer} TooltipItemRenderer */
+
 /**
  * @implements {TooltipItemRenderer}
  */
@@ -9819,8 +9872,8 @@ class CreditCardTooltipItem {
     this.#data = data;
   }
   id = () => String(this.#data.id);
-  labelMedium = _ => this.#data.title;
-  labelSmall = _ => this.#data.displayNumber;
+  labelMedium = () => this.#data.title;
+  labelSmall = () => this.#data.displayNumber;
 }
 exports.CreditCardTooltipItem = CreditCardTooltipItem;
 
@@ -9832,6 +9885,8 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.IdentityTooltipItem = void 0;
 var _formatters = require("../Form/formatters.js");
+/** @typedef {import("../UI/interfaces").TooltipItemRenderer} TooltipItemRenderer */
+
 /**
  * @implements {TooltipItemRenderer}
  */
@@ -9843,16 +9898,20 @@ class IdentityTooltipItem {
     this.#data = data;
   }
   id = () => String(this.#data.id);
-  labelMedium = subtype => {
+  /**
+   * @param {import('../locales/strings.js').TranslateFn} t
+   * @param {string} subtype
+   */
+  labelMedium = (t, subtype) => {
     if (subtype === 'addressCountryCode') {
       return (0, _formatters.getCountryDisplayName)('en', this.#data.addressCountryCode || '');
     }
     if (this.#data.id === 'privateAddress') {
-      return 'Generate Private Duck Address';
+      return t('autofill:generatePrivateDuckAddr');
     }
     return this.#data[subtype];
   };
-  label(subtype) {
+  label(_t, subtype) {
     if (this.#data.id === 'privateAddress') {
       return this.#data[subtype];
     }
@@ -10363,6 +10422,8 @@ class Settings {
   _runtimeConfiguration = null;
   /** @type {boolean | null} */
   _enabled = null;
+  /** @type {string} */
+  _language = 'en';
 
   /**
    * @param {GlobalConfig} config
@@ -10420,6 +10481,35 @@ class Settings {
   }
 
   /**
+   * Retrieves the user's language from the current platform's `RuntimeConfiguration`. If the
+   * platform doesn't include a two-character `.userPreferences.language` property in its runtime
+   * configuration, or if an error occurs, 'en' is used as a fallback.
+   *
+   * NOTE: This function returns the two-character 'language' code of a typical POSIX locale
+   * (e.g. 'en', 'de', 'fr') listed in ISO 639-1[1].
+   *
+   * [1] https://en.wikipedia.org/wiki/ISO_639-1
+   *
+   * @returns {Promise<string>} the device's current language code, or 'en' if something goes wrong
+   */
+  async getLanguage() {
+    try {
+      const conf = await this._getRuntimeConfiguration();
+      const language = conf.userPreferences.language ?? 'en';
+      if (language.length !== 2) {
+        console.warn(`config.userPreferences.language must be two characters, but received '${language}'`);
+        return 'en';
+      }
+      return language;
+    } catch (e) {
+      if (this.globalConfig.isDDGTestMode) {
+        console.log('isDDGTestMode: getLanguage: ❌', e);
+      }
+      return 'en';
+    }
+  }
+
+  /**
    * Get runtime configuration, but only once.
    *
    * Some platforms may be reading this directly from inlined variables, whilst others
@@ -10462,7 +10552,8 @@ class Settings {
 
   /**
    * To 'refresh' settings means to re-call APIs to determine new state. This may
-   * only occur once per page, but it must be done before any page scanning/decorating can happen
+   * only occur once per page, but it must be done before any page scanning/decorating
+   * or translation can happen.
    *
    * @returns {Promise<{
    *      availableInputTypes: AvailableInputTypes,
@@ -10474,6 +10565,7 @@ class Settings {
     this.setEnabled(await this.getEnabled());
     this.setFeatureToggles(await this.getFeatureToggles());
     this.setAvailableInputTypes(await this.getAvailableInputTypes());
+    this.setLanguage(await this.getLanguage());
 
     // If 'this.enabled' is a boolean it means we were able to set it correctly and therefor respect its value
     if (typeof this.enabled === 'boolean') {
@@ -10608,6 +10700,19 @@ class Settings {
       ...this._availableInputTypes,
       ...value
     };
+  }
+
+  /** @returns {string} the user's current two-character language code, as provided by the platform */
+  get language() {
+    return this._language;
+  }
+
+  /**
+   * Sets the current two-character language code.
+   * @param {string} language - the language
+   */
+  setLanguage(language) {
+    this._language = language;
   }
   static defaults = {
     /** @type {AutofillFeatureToggles} */
@@ -10777,8 +10882,27 @@ var _autofillUtils = require("../autofill-utils.js");
 var _HTMLTooltip = _interopRequireDefault(require("./HTMLTooltip.js"));
 var _Credentials = require("../InputTypes/Credentials.js");
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+/**
+ * A mapping of main autofill item type to the 'Manage XYZ…' string ID for that
+ * item.
+ * @type {Record<SupportedMainTypes, import('../locales/strings').AutofillKeys>}
+ *
+ * @example
+ * const id = manageItemStringIds['credentials'] // => 'autofill:managePasswords'
+ * const str = t(id);                            // => 'Manage passwords…' in English
+ */
+const manageItemStringIds = {
+  credentials: 'autofill:managePasswords',
+  creditCards: 'autofill:manageCreditCards',
+  identities: 'autofill:manageIdentities',
+  unknown: 'autofill:manageSavedItems'
+};
 class DataHTMLTooltip extends _HTMLTooltip.default {
-  renderEmailProtectionIncontextSignup(isOtherItems) {
+  /**
+   * @param {import("../locales/strings").TranslateFn} t
+   * @param {boolean} isOtherItems
+   */
+  renderEmailProtectionIncontextSignup(t, isOtherItems) {
     const dataTypeClass = `tooltip__button--data--identities`;
     const providerIconClass = 'tooltip__button--data--duckduckgo';
     return `
@@ -10786,10 +10910,10 @@ class DataHTMLTooltip extends _HTMLTooltip.default {
             <button id="incontextSignup" class="tooltip__button tooltip__button--data ${dataTypeClass} ${providerIconClass} js-get-email-signup">
                 <span class="tooltip__button__text-container">
                     <span class="label label--medium">
-                        Hide your email and block trackers
+                        ${t('autofill:hideEmailAndBlockTrackers')}
                     </span>
                     <span class="label label--small">
-                        Create a unique, random address that also removes hidden trackers and forwards email to your inbox.
+                        ${t('autofill:createUniqueRandomAddr')}
                     </span>
                 </span>
             </button>
@@ -10797,8 +10921,9 @@ class DataHTMLTooltip extends _HTMLTooltip.default {
   }
 
   /**
+   * @param {import("../DeviceInterface/InterfacePrototype").default} device
    * @param {InputTypeConfigs} config
-   * @param {TooltipItemRenderer[]} items
+   * @param {import('./interfaces.js').TooltipItemRenderer[]} items
    * @param {{
    *   onSelect(id:string): void
    *   onManage(type:InputTypeConfigs['type']): void
@@ -10808,7 +10933,8 @@ class DataHTMLTooltip extends _HTMLTooltip.default {
    *   onIncontextSignup?(): void
    * }} callbacks
    */
-  render(config, items, callbacks) {
+  render(device, config, items, callbacks) {
+    const t = device.t;
     const {
       wrapperClass,
       css
@@ -10837,25 +10963,27 @@ ${css}
       const credentialsProvider = item.credentialsProvider?.();
       const providerIconClass = credentialsProvider ? `tooltip__button--data--${credentialsProvider}` : '';
       // these 2 are optional
-      const labelSmall = item.labelSmall?.(this.subtype);
-      const label = item.label?.(this.subtype);
+      const labelSmall = item.labelSmall?.(t, this.subtype);
+      const label = item.label?.(t, this.subtype);
       return `
             ${shouldShowSeparator(item.id(), index) ? '<hr />' : ''}
             <button id="${item.id()}" class="tooltip__button tooltip__button--data ${dataTypeClass} ${providerIconClass} js-autofill-button">
                 <span class="tooltip__button__text-container">
-                    <span class="label label--medium">${(0, _autofillUtils.escapeXML)(item.labelMedium(this.subtype))}</span>
+                    <span class="label label--medium">${(0, _autofillUtils.escapeXML)(item.labelMedium(t, this.subtype))}</span>
                     ${label ? `<span class="label">${(0, _autofillUtils.escapeXML)(label)}</span>` : ''}
                     ${labelSmall ? `<span class="label label--small">${(0, _autofillUtils.escapeXML)(labelSmall)}</span>` : ''}
                 </span>
             </button>
         `;
     }).join('')}
-        ${this.options.isIncontextSignupAvailable() ? this.renderEmailProtectionIncontextSignup(items.length > 0) : ''}
+        ${this.options.isIncontextSignupAvailable() ? this.renderEmailProtectionIncontextSignup(t, items.length > 0) : ''}
         ${shouldShowManageButton ? `
             <hr />
             <button id="manage-button" class="tooltip__button tooltip__button--manage" type="button">
                 <span class="tooltip__button__text-container">
-                    <span class="label label--medium">Manage ${config.displayName}…</span>
+                    <span class="label label--medium">
+                        ${t(manageItemStringIds[config.type] ?? 'autofill:manageSavedItems')}
+                    </span>
                 </span>
             </button>` : ''}
     </div>
@@ -10917,13 +11045,15 @@ ${this.options.css}
     <div class="tooltip tooltip--email">
         <button class="tooltip__button tooltip__button--email js-use-personal">
             <span class="tooltip__button--email__primary-text">
-                Use <span class="js-address">${(0, _autofillUtils.formatDuckAddress)((0, _autofillUtils.escapeXML)(this.addresses.personalAddress))}</span>
+                ${this.device.t('autofill:usePersonalDuckAddr', {
+      email: (0, _autofillUtils.formatDuckAddress)((0, _autofillUtils.escapeXML)(this.addresses.personalAddress))
+    })}
             </span>
-            <span class="tooltip__button--email__secondary-text">Block email trackers</span>
+            <span class="tooltip__button--email__secondary-text">${this.device.t('autofill:blockEmailTrackers')}</span>
         </button>
         <button class="tooltip__button tooltip__button--email js-use-private">
-            <span class="tooltip__button--email__primary-text">Generate a Private Duck Address</span>
-            <span class="tooltip__button--email__secondary-text">Block email trackers & hide address</span>
+            <span class="tooltip__button--email__primary-text">${this.device.t('autofill:generateDuckAddr')}</span>
+            <span class="tooltip__button--email__secondary-text">${this.device.t('autofill:blockEmailTrackersAndHideAddress')}</span>
         </button>
     </div>
     <div class="tooltip--email__caret"></div>
@@ -10932,11 +11062,13 @@ ${this.options.css}
     this.tooltip = this.shadow.querySelector('.tooltip');
     this.usePersonalButton = this.shadow.querySelector('.js-use-personal');
     this.usePrivateButton = this.shadow.querySelector('.js-use-private');
-    this.addressEl = this.shadow.querySelector('.js-address');
+    this.usePersonalCta = this.shadow.querySelector('.js-use-personal > span:first-of-type');
     this.updateAddresses = addresses => {
-      if (addresses && this.addressEl) {
+      if (addresses && this.usePersonalCta) {
         this.addresses = addresses;
-        this.addressEl.textContent = (0, _autofillUtils.formatDuckAddress)(addresses.personalAddress);
+        this.usePersonalCta.textContent = this.device.t('autofill:usePersonalDuckAddr', {
+          email: (0, _autofillUtils.formatDuckAddress)(addresses.personalAddress)
+        });
       }
     };
     const firePixel = this.device.firePixel.bind(this.device);
@@ -10987,23 +11119,20 @@ class EmailSignupHTMLTooltip extends _HTMLTooltip.default {
    */
   render(device) {
     this.device = device;
+    const t = this.device.t;
     this.shadow.innerHTML = `
 ${this.options.css}
 <div class="wrapper wrapper--email" hidden>
     <div class="tooltip tooltip--email tooltip--email-signup">
         <button class="close-tooltip js-close-email-signup" aria-label="Close"></button>
-        <h1>
-            Hide your email and block trackers
-        </h1>
-        <p>
-            Create a unique, random address that also removes hidden trackers and forwards email to your inbox.
-        </p>
+        <h1>${t('autofill:hideEmailAndBlockTrackers')}</h1>
+        <p>${t('autofill:createUniqueRandomAddr')}</p>
         <div class="notice-controls">
             <a href="https://duckduckgo.com/email/start-incontext" target="_blank" class="primary js-get-email-signup">
-                Protect My Email
+                ${t('autofill:protectMyEmail')}
             </a>
             <button class="ghost js-dismiss-email-signup">
-                Don't Show Again
+                ${t('autofill:dontShowAgain')}
             </button>
         </div>
     </div>
@@ -11514,7 +11643,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
 
   /**
    * Actually create the HTML Tooltip
-   * @param {PosFn} getPosition
+   * @param {import('../interfaces.js').PosFn} getPosition
    * @param {TopContextData} topContextData
    * @return {import("../HTMLTooltip").HTMLTooltip}
    */
@@ -11554,7 +11683,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
     const asRenderers = data.map(d => config.tooltipItem(d));
 
     // construct the autofill
-    return new _DataHTMLTooltip.default(config, topContextData.inputType, getPosition, tooltipOptions).render(config, asRenderers, {
+    return new _DataHTMLTooltip.default(config, topContextData.inputType, getPosition, tooltipOptions).render(this._options.device, config, asRenderers, {
       onSelect: id => {
         this._onSelect(topContextData.inputType, data, id);
       },
@@ -11577,7 +11706,7 @@ class HTMLTooltipUIController extends _UIController.UIController {
     const asRenderers = data.map(d => config.tooltipItem(d));
     const activeTooltip = this.getActiveTooltip();
     if (activeTooltip instanceof _DataHTMLTooltip.default) {
-      activeTooltip?.render(config, asRenderers, {
+      activeTooltip?.render(this._options.device, config, asRenderers, {
         onSelect: id => {
           this._onSelect(this._activeInputType, data, id);
         },
@@ -12212,7 +12341,7 @@ class UIController {
    * For example, in an 'overlay' on macOS/Windows this is needed since
    * there's no page information to call 'attach' above.
    *
-   * @param {PosFn} _pos
+   * @param {import("../interfaces").PosFn} _pos
    * @param {TopContextData} _topContextData
    * @returns {any | null}
    */
@@ -12280,7 +12409,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.CSS_STYLES = void 0;
-const CSS_STYLES = exports.CSS_STYLES = ":root {\n    color-scheme: light dark;\n}\n\n.wrapper *, .wrapper *::before, .wrapper *::after {\n    box-sizing: border-box;\n}\n.wrapper {\n    position: fixed;\n    top: 0;\n    left: 0;\n    padding: 0;\n    font-family: 'DDG_ProximaNova', 'Proxima Nova', system-ui, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',\n    'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;\n    -webkit-font-smoothing: antialiased;\n    z-index: 2147483647;\n}\n.wrapper--data {\n    font-family: 'SF Pro Text', system-ui, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',\n    'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;\n}\n:not(.top-autofill) .tooltip {\n    position: absolute;\n    width: 300px;\n    max-width: calc(100vw - 25px);\n    transform: translate(-1000px, -1000px);\n    z-index: 2147483647;\n}\n.tooltip--data, #topAutofill {\n    background-color: rgba(242, 240, 240, 1);\n    -webkit-backdrop-filter: blur(40px);\n    backdrop-filter: blur(40px);\n}\n@media (prefers-color-scheme: dark) {\n    .tooltip--data, #topAutofill {\n        background: rgb(100, 98, 102, .9);\n    }\n}\n.tooltip--data {\n    padding: 6px;\n    font-size: 13px;\n    line-height: 14px;\n    width: 315px;\n    max-height: 290px;\n    overflow-y: auto;\n}\n.top-autofill .tooltip--data {\n    min-height: 100vh;\n}\n.tooltip--data.tooltip--incontext-signup {\n    width: 360px;\n}\n:not(.top-autofill) .tooltip--data {\n    top: 100%;\n    left: 100%;\n    border: 0.5px solid rgba(255, 255, 255, 0.2);\n    border-radius: 6px;\n    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.32);\n}\n@media (prefers-color-scheme: dark) {\n    :not(.top-autofill) .tooltip--data {\n        border: 1px solid rgba(255, 255, 255, 0.2);\n    }\n}\n:not(.top-autofill) .tooltip--email {\n    top: calc(100% + 6px);\n    right: calc(100% - 48px);\n    padding: 8px;\n    border: 1px solid #D0D0D0;\n    border-radius: 10px;\n    background-color: #FFFFFF;\n    font-size: 14px;\n    line-height: 1.3;\n    color: #333333;\n    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);\n}\n.tooltip--email__caret {\n    position: absolute;\n    transform: translate(-1000px, -1000px);\n    z-index: 2147483647;\n}\n.tooltip--email__caret::before,\n.tooltip--email__caret::after {\n    content: \"\";\n    width: 0;\n    height: 0;\n    border-left: 10px solid transparent;\n    border-right: 10px solid transparent;\n    display: block;\n    border-bottom: 8px solid #D0D0D0;\n    position: absolute;\n    right: -28px;\n}\n.tooltip--email__caret::before {\n    border-bottom-color: #D0D0D0;\n    top: -1px;\n}\n.tooltip--email__caret::after {\n    border-bottom-color: #FFFFFF;\n    top: 0px;\n}\n\n/* Buttons */\n.tooltip__button {\n    display: flex;\n    width: 100%;\n    padding: 8px 8px 8px 0px;\n    font-family: inherit;\n    color: inherit;\n    background: transparent;\n    border: none;\n    border-radius: 6px;\n}\n.tooltip__button.currentFocus,\n.wrapper:not(.top-autofill) .tooltip__button:hover {\n    background-color: #3969EF;\n    color: #FFFFFF;\n}\n\n/* Data autofill tooltip specific */\n.tooltip__button--data {\n    position: relative;\n    min-height: 48px;\n    flex-direction: row;\n    justify-content: flex-start;\n    font-size: inherit;\n    font-weight: 500;\n    line-height: 16px;\n    text-align: left;\n    border-radius: 3px;\n}\n.tooltip--data__item-container {\n    max-height: 220px;\n    overflow: auto;\n}\n.tooltip__button--data:first-child {\n    margin-top: 0;\n}\n.tooltip__button--data:last-child {\n    margin-bottom: 0;\n}\n.tooltip__button--data::before {\n    content: '';\n    flex-shrink: 0;\n    display: block;\n    width: 32px;\n    height: 32px;\n    margin: 0 8px;\n    background-size: 20px 20px;\n    background-repeat: no-repeat;\n    background-position: center center;\n}\n#provider_locked::after {\n    position: absolute;\n    content: '';\n    flex-shrink: 0;\n    display: block;\n    width: 32px;\n    height: 32px;\n    margin: 0 8px;\n    background-size: 11px 13px;\n    background-repeat: no-repeat;\n    background-position: right bottom;\n}\n.tooltip__button--data.currentFocus:not(.tooltip__button--data--bitwarden)::before,\n.wrapper:not(.top-autofill) .tooltip__button--data:not(.tooltip__button--data--bitwarden):hover::before {\n    filter: invert(100%);\n}\n@media (prefers-color-scheme: dark) {\n    .tooltip__button--data:not(.tooltip__button--data--bitwarden)::before,\n    .tooltip__button--data:not(.tooltip__button--data--bitwarden)::before {\n        filter: invert(100%);\n        opacity: .9;\n    }\n}\n.tooltip__button__text-container {\n    margin: auto 0;\n}\n.label {\n    display: block;\n    font-weight: 400;\n    letter-spacing: -0.25px;\n    color: rgba(0,0,0,.8);\n    font-size: 13px;\n    line-height: 1;\n}\n.label + .label {\n    margin-top: 2px;\n}\n.label.label--medium {\n    font-weight: 500;\n    letter-spacing: -0.25px;\n    color: rgba(0,0,0,.9);\n}\n.label.label--small {\n    font-size: 11px;\n    font-weight: 400;\n    letter-spacing: 0.06px;\n    color: rgba(0,0,0,0.6);\n}\n@media (prefers-color-scheme: dark) {\n    .tooltip--data .label {\n        color: #ffffff;\n    }\n    .tooltip--data .label--medium {\n        color: #ffffff;\n    }\n    .tooltip--data .label--small {\n        color: #cdcdcd;\n    }\n}\n.tooltip__button.currentFocus .label,\n.wrapper:not(.top-autofill) .tooltip__button:hover .label {\n    color: #FFFFFF;\n}\n\n.tooltip__button--manage {\n    font-size: 13px;\n    padding: 5px 9px;\n    border-radius: 3px;\n    margin: 0;\n}\n\n/* Icons */\n.tooltip__button--data--credentials::before,\n.tooltip__button--data--credentials__current::before {\n    background-size: 28px 28px;\n    background-image: url('data:image/svg+xml;base64,PHN2ZyBmaWxsPSJub25lIiB2aWV3Qm94PSIwIDAgMjQgMjQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgICA8cGF0aCBmaWxsPSIjMDAwIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xNS4zMzQgNi42NjdhMiAyIDAgMSAwIDAgNCAyIDIgMCAwIDAgMC00Wm0tLjY2NyAyYS42NjcuNjY3IDAgMSAxIDEuMzMzIDAgLjY2Ny42NjcgMCAwIDEtMS4zMzMgMFoiIGNsaXAtcnVsZT0iZXZlbm9kZCIvPgogICAgPHBhdGggZmlsbD0iIzAwMCIgZmlsbC1ydWxlPSJldmVub2RkIiBkPSJNMTQuNjY3IDRhNS4zMzMgNS4zMzMgMCAwIDAtNS4xODggNi41NzhsLTUuMjg0IDUuMjg0YS42NjcuNjY3IDAgMCAwLS4xOTUuNDcxdjNjMCAuMzY5LjI5OC42NjcuNjY3LjY2N2gyLjY2NmMuNzM3IDAgMS4zMzQtLjU5NyAxLjMzNC0xLjMzM1YxOGguNjY2Yy43MzcgMCAxLjMzNC0uNTk3IDEuMzM0LTEuMzMzdi0xLjMzNEgxMmMuMTc3IDAgLjM0Ni0uMDcuNDcxLS4xOTVsLjY4OC0uNjg4QTUuMzMzIDUuMzMzIDAgMSAwIDE0LjY2NyA0Wm0tNCA1LjMzM2E0IDQgMCAxIDEgMi41NTUgMy43MzIuNjY3LjY2NyAwIDAgMC0uNzEzLjE1bC0uNzg1Ljc4NUgxMGEuNjY3LjY2NyAwIDAgMC0uNjY3LjY2N3YySDhhLjY2Ny42NjcgMCAwIDAtLjY2Ny42NjZ2MS4zMzRoLTJ2LTIuMDU4bDUuMzY1LTUuMzY0YS42NjcuNjY3IDAgMCAwIC4xNjMtLjY3NyAzLjk5NiAzLjk5NiAwIDAgMS0uMTk0LTEuMjM1WiIgY2xpcC1ydWxlPSJldmVub2RkIi8+Cjwvc3ZnPgo=');\n}\n.tooltip__button--data--credentials__new::before {\n    background-size: 28px 28px;\n    background-image: url('data:image/svg+xml;base64,PHN2ZyBmaWxsPSJub25lIiB2aWV3Qm94PSIwIDAgMjQgMjQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgICA8cGF0aCBmaWxsPSIjMDAwIiBkPSJNOC4wNDcgNC42MjVDNy45MzcgNC4xMjUgNy44NjIgNCA3LjUgNGMtLjM2MiAwLS40MzguMTI1LS41NDcuNjI1LS4wNjguMzEtLjE3NyAxLjMzOC0uMjUxIDIuMDc3LS43MzguMDc0LTEuNzY3LjE4My0yLjA3Ny4yNTEtLjUuMTEtLjYyNS4xODQtLjYyNS41NDcgMCAuMzYyLjEyNS40MzcuNjI1LjU0Ny4zMS4wNjcgMS4zMzYuMTc3IDIuMDc0LjI1LjA3My43NjcuMTg1IDEuODQyLjI1NCAyLjA3OC4xMS4zNzUuMTg1LjYyNS41NDcuNjI1LjM2MiAwIC40MzgtLjEyNS41NDctLjYyNS4wNjgtLjMxLjE3Ny0xLjMzNi4yNS0yLjA3NC43NjctLjA3MyAxLjg0Mi0uMTg1IDIuMDc4LS4yNTQuMzc1LS4xMS42MjUtLjE4NS42MjUtLjU0NyAwLS4zNjMtLjEyNS0uNDM4LS42MjUtLjU0Ny0uMzEtLjA2OC0xLjMzOS0uMTc3LTIuMDc3LS4yNTEtLjA3NC0uNzM5LS4xODMtMS43NjctLjI1MS0yLjA3N1oiLz4KICAgIDxwYXRoIGZpbGw9IiMwMDAiIGQ9Ik0xNC42ODEgNS4xOTljLS43NjYgMC0xLjQ4Mi4yMS0yLjA5My41NzhhLjYzNi42MzYgMCAwIDEtLjY1NS0xLjA5IDUuMzQgNS4zNCAwIDEgMSAxLjMwMiA5LjcyMmwtLjc3NS43NzZhLjYzNi42MzYgMCAwIDEtLjQ1LjE4NmgtMS4zOTh2MS42NWMwIC40OTMtLjQuODkzLS44OTMuODkzSDguNTc4djEuMTQxYzAgLjQ5NC0uNC44OTMtLjg5NC44OTNINC42MzZBLjYzNi42MzYgMCAwIDEgNCAxOS4zMTNWMTYuMjZjMC0uMTY5LjA2Ny0uMzMuMTg2LS40NWw1LjU2Mi01LjU2MmEuNjM2LjYzNiAwIDEgMSAuOS45bC01LjM3NiA1LjM3NXYyLjE1M2gyLjAzNHYtMS4zOTljMC0uMzUuMjg1LS42MzYuNjM2LS42MzZIOS4zNHYtMS45MDdjMC0uMzUxLjI4NC0uNjM2LjYzNS0uNjM2aDEuNzcxbC44NjQtLjg2M2EuNjM2LjYzNiAwIDAgMSAuNjY4LS4xNDcgNC4wNjkgNC4wNjkgMCAxIDAgMS40MDItNy44OVoiLz4KICAgIDxwYXRoIGZpbGw9IiMwMDAiIGZpbGwtcnVsZT0iZXZlbm9kZCIgZD0iTTEzLjYyNSA4LjQ5OWExLjg3NSAxLjg3NSAwIDEgMSAzLjc1IDAgMS44NzUgMS44NzUgMCAwIDEtMy43NSAwWm0xLjg3NS0uNjI1YS42MjUuNjI1IDAgMSAwIDAgMS4yNS42MjUuNjI1IDAgMCAwIDAtMS4yNVoiIGNsaXAtcnVsZT0iZXZlbm9kZCIvPgogICAgPHBhdGggZmlsbD0iIzAwMCIgZD0iTTQuNjI1IDEyLjEyNWEuNjI1LjYyNSAwIDEgMCAwLTEuMjUuNjI1LjYyNSAwIDAgMCAwIDEuMjVaIi8+Cjwvc3ZnPgo=');\n}\n.tooltip__button--data--creditCards::before {\n    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0ibm9uZSI+CiAgICA8cGF0aCBkPSJNNSA5Yy0uNTUyIDAtMSAuNDQ4LTEgMXYyYzAgLjU1Mi40NDggMSAxIDFoM2MuNTUyIDAgMS0uNDQ4IDEtMXYtMmMwLS41NTItLjQ0OC0xLTEtMUg1eiIgZmlsbD0iIzAwMCIvPgogICAgPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xIDZjMC0yLjIxIDEuNzktNCA0LTRoMTRjMi4yMSAwIDQgMS43OSA0IDR2MTJjMCAyLjIxLTEuNzkgNC00IDRINWMtMi4yMSAwLTQtMS43OS00LTRWNnptNC0yYy0xLjEwNSAwLTIgLjg5NS0yIDJ2OWgxOFY2YzAtMS4xMDUtLjg5NS0yLTItMkg1em0wIDE2Yy0xLjEwNSAwLTItLjg5NS0yLTJoMThjMCAxLjEwNS0uODk1IDItMiAySDV6IiBmaWxsPSIjMDAwIi8+Cjwvc3ZnPgo=');\n}\n.tooltip__button--data--identities::before {\n    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0ibm9uZSI+CiAgICA8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTEyIDIxYzIuMTQzIDAgNC4xMTEtLjc1IDUuNjU3LTItLjYyNi0uNTA2LTEuMzE4LS45MjctMi4wNi0xLjI1LTEuMS0uNDgtMi4yODUtLjczNS0zLjQ4Ni0uNzUtMS4yLS4wMTQtMi4zOTIuMjExLTMuNTA0LjY2NC0uODE3LjMzMy0xLjU4Ljc4My0yLjI2NCAxLjMzNiAxLjU0NiAxLjI1IDMuNTE0IDIgNS42NTcgMnptNC4zOTctNS4wODNjLjk2Ny40MjIgMS44NjYuOTggMi42NzIgMS42NTVDMjAuMjc5IDE2LjAzOSAyMSAxNC4xMDQgMjEgMTJjMC00Ljk3LTQuMDMtOS05LTlzLTkgNC4wMy05IDljMCAyLjEwNC43MjIgNC4wNCAxLjkzMiA1LjU3Mi44NzQtLjczNCAxLjg2LTEuMzI4IDIuOTIxLTEuNzYgMS4zNi0uNTU0IDIuODE2LS44MyA0LjI4My0uODExIDEuNDY3LjAxOCAyLjkxNi4zMyA0LjI2LjkxNnpNMTIgMjNjNi4wNzUgMCAxMS00LjkyNSAxMS0xMVMxOC4wNzUgMSAxMiAxIDEgNS45MjUgMSAxMnM0LjkyNSAxMSAxMSAxMXptMy0xM2MwIDEuNjU3LTEuMzQzIDMtMyAzcy0zLTEuMzQzLTMtMyAxLjM0My0zIDMtMyAzIDEuMzQzIDMgM3ptMiAwYzAgMi43NjEtMi4yMzkgNS01IDVzLTUtMi4yMzktNS01IDIuMjM5LTUgNS01IDUgMi4yMzkgNSA1eiIgZmlsbD0iIzAwMCIvPgo8L3N2Zz4=');\n}\n.tooltip__button--data--credentials.tooltip__button--data--bitwarden::before,\n.tooltip__button--data--credentials__current.tooltip__button--data--bitwarden::before {\n    background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0IiByeD0iOCIgZmlsbD0iIzE3NUREQyIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTE4LjU2OTYgNS40MzM1NUMxOC41MDg0IDUuMzc0NDIgMTguNDM0NyA1LjMyNzYzIDE4LjM1MzEgNS4yOTYxMUMxOC4yNzE1IDUuMjY0NiAxOC4xODM3IDUuMjQ5MDQgMTguMDk1MyA1LjI1MDQxSDUuOTIxOTFDNS44MzMyNiA1LjI0NzI5IDUuNzQ0OTMgNS4yNjIwNSA1LjY2MzA0IDUuMjkzNjdDNS41ODExNSA1LjMyNTI5IDUuNTA3NjUgNS4zNzMwMiA1LjQ0NzYyIDUuNDMzNTVDNS4zMjE3IDUuNTUwMTMgNS4yNTA2NSA1LjcwODE1IDUuMjUgNS44NzMxVjEzLjM4MjFDNS4yNTMzNiAxMy45NTM1IDUuMzc0MDggMTQuNTE5MSA1LjYwNTcyIDE1LjA0ODdDNS44MTkzMSAxNS41NzI4IDYuMTEyMDcgMTYuMDY2MSA2LjQ3NTI0IDE2LjUxMzlDNi44NDIgMTYuOTY4MyA3LjI1OTI5IDE3LjM4NTcgNy43MjAyNSAxNy43NTkzQzguMTQwNTMgMTguMTI1NiA4LjU4OTcxIDE4LjQ2MjMgOS4wNjQwNyAxOC43NjY2QzkuNDU5MzEgMTkuMDIzIDkuOTEzODMgMTkuMjc5NCAxMC4zNDg2IDE5LjUxNzVDMTAuNzgzNCAxOS43NTU2IDExLjA5OTYgMTkuOTIwNCAxMS4yNzc0IDE5Ljk5MzdDMTEuNDU1MyAyMC4wNjY5IDExLjYxMzQgMjAuMTQwMiAxMS43MTIyIDIwLjE5NTFDMTEuNzk5MiAyMC4yMzEzIDExLjg5MzUgMjAuMjUgMTEuOTg4OCAyMC4yNUMxMi4wODQyIDIwLjI1IDEyLjE3ODUgMjAuMjMxMyAxMi4yNjU1IDIwLjE5NTFDMTIuNDIxMiAyMC4xMzYzIDEyLjU3MjkgMjAuMDY5IDEyLjcyIDE5Ljk5MzdDMTIuNzcxMSAxOS45Njc0IDEyLjgzMzUgMTkuOTM2NiAxMi45MDY5IDE5LjkwMDRDMTMuMDg5MSAxOS44MTA1IDEzLjMzODggMTkuNjg3MiAxMy42NDg5IDE5LjUxNzVDMTQuMDgzNiAxOS4yNzk0IDE0LjUxODQgMTkuMDIzIDE0LjkzMzQgMTguNzY2NkMxNS40MDQgMTguNDU3NyAxNS44NTI4IDE4LjEyMTIgMTYuMjc3MiAxNy43NTkzQzE2LjczMzEgMTcuMzgwOSAxNy4xNDk5IDE2Ljk2NCAxNy41MjIyIDE2LjUxMzlDMTcuODc4IDE2LjA2MTcgMTguMTcwMiAxNS41NjkzIDE4LjM5MTcgMTUuMDQ4N0MxOC42MjM0IDE0LjUxOTEgMTguNzQ0MSAxMy45NTM1IDE4Ljc0NzQgMTMuMzgyMVY1Ljg3MzFDMTguNzU1NyA1Ljc5MjE0IDE4Ljc0MzkgNS43MTA1IDE4LjcxMzEgNS42MzQzNUMxOC42ODIzIDUuNTU4MiAxOC42MzMyIDUuNDg5NTQgMTguNTY5NiA1LjQzMzU1Wk0xNy4wMDg0IDEzLjQ1NTNDMTcuMDA4NCAxNi4xODQyIDEyLjAwODYgMTguNTI4NSAxMi4wMDg2IDE4LjUyODVWNi44NjIwOUgxNy4wMDg0VjEzLjQ1NTNaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K');\n}\n#provider_locked:after {\n    background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTEiIGhlaWdodD0iMTMiIHZpZXdCb3g9IjAgMCAxMSAxMyIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTEgNy42MDA1N1Y3LjYwMjVWOS41MjI1QzEgMTAuMDgwMSAxLjIyMTUxIDEwLjYxNDkgMS42MTU4MSAxMS4wMDkyQzIuMDEwMSAxMS40MDM1IDIuNTQ0ODggMTEuNjI1IDMuMTAyNSAxMS42MjVINy4yNzI1QzcuNTQ4NjEgMTEuNjI1IDcuODIyMDEgMTEuNTcwNiA4LjA3NzA5IDExLjQ2NUM4LjMzMjE4IDExLjM1OTMgOC41NjM5NiAxMS4yMDQ0IDguNzU5MTkgMTEuMDA5MkM4Ljk1NDQzIDEwLjgxNCA5LjEwOTMgMTAuNTgyMiA5LjIxNDk2IDEwLjMyNzFDOS4zMjA2MiAxMC4wNzIgOS4zNzUgOS43OTg2MSA5LjM3NSA5LjUyMjVMOS4zNzUgNy42MDI1TDkuMzc1IDcuNjAwNTdDOS4zNzQxNSA3LjE2MTMxIDkuMjM1NzQgNi43MzMzNSA4Ljk3OTIyIDYuMzc2NzhDOC44NzY4MyA2LjIzNDQ2IDguNzU3NjggNi4xMDYzNyA4LjYyNSA1Ljk5NDg5VjUuMTg3NUM4LjYyNSA0LjI3NTgyIDguMjYyODQgMy40MDE0OCA3LjYxODE4IDIuNzU2ODJDNi45NzM1MiAyLjExMjE2IDYuMDk5MTggMS43NSA1LjE4NzUgMS43NUM0LjI3NTgyIDEuNzUgMy40MDE0OCAyLjExMjE2IDIuNzU2ODIgMi43NTY4MkMyLjExMjE2IDMuNDAxNDggMS43NSA0LjI3NTgyIDEuNzUgNS4xODc1VjUuOTk0ODlDMS42MTczMiA2LjEwNjM3IDEuNDk4MTcgNi4yMzQ0NiAxLjM5NTc4IDYuMzc2NzhDMS4xMzkyNiA2LjczMzM1IDEuMDAwODUgNy4xNjEzMSAxIDcuNjAwNTdaTTQuOTY4NyA0Ljk2ODdDNS4wMjY5NCA0LjkxMDQ3IDUuMTA1MzIgNC44NzY5OSA1LjE4NzUgNC44NzUwN0M1LjI2OTY4IDQuODc2OTkgNS4zNDgwNiA0LjkxMDQ3IDUuNDA2MyA0Ljk2ODdDNS40NjU0MiA1LjAyNzgzIDUuNDk5MDQgNS4xMDc3NCA1LjUgNS4xOTEzVjUuNUg0Ljg3NVY1LjE5MTNDNC44NzU5NiA1LjEwNzc0IDQuOTA5NTggNS4wMjc4MyA0Ljk2ODcgNC45Njg3WiIgZmlsbD0iIzIyMjIyMiIgc3Ryb2tlPSJ3aGl0ZSIgc3Ryb2tlLXdpZHRoPSIyIi8+Cjwvc3ZnPgo=');\n}\n\nhr {\n    display: block;\n    margin: 5px 9px;\n    border: none; /* reset the border */\n    border-top: 1px solid rgba(0,0,0,.1);\n}\n\nhr:first-child {\n    display: none;\n}\n\n@media (prefers-color-scheme: dark) {\n    hr {\n        border-top: 1px solid rgba(255,255,255,.2);\n    }\n}\n\n#privateAddress {\n    align-items: flex-start;\n}\n#personalAddress::before,\n#privateAddress::before,\n#incontextSignup::before,\n#personalAddress.currentFocus::before,\n#personalAddress:hover::before,\n#privateAddress.currentFocus::before,\n#privateAddress:hover::before {\n    filter: none;\n    /* This is the same icon as `daxBase64` in `src/Form/logo-svg.js` */\n    background-image: url('data:image/svg+xml;base64,PHN2ZyBmaWxsPSJub25lIiB2aWV3Qm94PSIwIDAgMTI4IDEyOCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxwYXRoIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0ibTY0IDEyOGMzNS4zNDYgMCA2NC0yOC42NTQgNjQtNjRzLTI4LjY1NC02NC02NC02NC02NCAyOC42NTQtNjQgNjQgMjguNjU0IDY0IDY0IDY0eiIgZmlsbD0iI2RlNTgzMyIgZmlsbC1ydWxlPSJldmVub2RkIi8+CiAgICA8cGF0aCBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Im03MyAxMTEuNzVjMC0uNS4xMjMtLjYxNC0xLjQ2Ni0zLjc4Mi00LjIyNC04LjQ1OS04LjQ3LTIwLjM4NC02LjU0LTI4LjA3NS4zNTMtMS4zOTctMy45NzgtNTEuNzQ0LTcuMDQtNTMuMzY1LTMuNDAyLTEuODEzLTcuNTg4LTQuNjktMTEuNDE4LTUuMzMtMS45NDMtLjMxLTQuNDktLjE2NC02LjQ4Mi4xMDUtLjM1My4wNDctLjM2OC42ODMtLjAzLjc5OCAxLjMwOC40NDMgMi44OTUgMS4yMTIgMy44MyAyLjM3NS4xNzguMjItLjA2LjU2Ni0uMzQyLjU3Ny0uODgyLjAzMi0yLjQ4Mi40MDItNC41OTMgMi4xOTUtLjI0NC4yMDctLjA0MS41OTIuMjczLjUzIDQuNTM2LS44OTcgOS4xNy0uNDU1IDExLjkgMi4wMjcuMTc3LjE2LjA4NC40NS0uMTQ3LjUxMi0yMy42OTQgNi40NC0xOS4wMDMgMjcuMDUtMTIuNjk2IDUyLjM0NCA1LjYxOSAyMi41MyA3LjczMyAyOS43OTIgOC40IDMyLjAwNGEuNzE4LjcxOCAwIDAgMCAuNDIzLjQ2N2M4LjE1NiAzLjI0OCAyNS45MjggMy4zOTIgMjUuOTI4LTIuMTMyeiIgZmlsbD0iI2RkZCIgZmlsbC1ydWxlPSJldmVub2RkIi8+CiAgICA8cGF0aCBkPSJtNzYuMjUgMTE2LjVjLTIuODc1IDEuMTI1LTguNSAxLjYyNS0xMS43NSAxLjYyNS00Ljc2NCAwLTExLjYyNS0uNzUtMTQuMTI1LTEuODc1LTEuNTQ0LTQuNzUxLTYuMTY0LTE5LjQ4LTEwLjcyNy0zOC4xODVsLS40NDctMS44MjctLjAwNC0uMDE1Yy01LjQyNC0yMi4xNTctOS44NTUtNDAuMjUzIDE0LjQyNy00NS45MzguMjIyLS4wNTIuMzMtLjMxNy4xODQtLjQ5Mi0yLjc4Ni0zLjMwNS04LjAwNS00LjM4OC0xNC42MDUtMi4xMTEtLjI3LjA5My0uNTA2LS4xOC0uMzM3LS40MTIgMS4yOTQtMS43ODMgMy44MjMtMy4xNTUgNS4wNzEtMy43NTYuMjU4LS4xMjQuMjQyLS41MDItLjAzLS41ODhhMjcuODc3IDI3Ljg3NyAwIDAgMCAtMy43NzItLjljLS4zNy0uMDU5LS40MDMtLjY5My0uMDMyLS43NDMgOS4zNTYtMS4yNTkgMTkuMTI1IDEuNTUgMjQuMDI4IDcuNzI2YS4zMjYuMzI2IDAgMCAwIC4xODYuMTE0YzE3Ljk1MiAzLjg1NiAxOS4yMzggMzIuMjM1IDE3LjE3IDMzLjUyOC0uNDA4LjI1NS0xLjcxNS4xMDgtMy40MzgtLjA4NS02Ljk4Ni0uNzgxLTIwLjgxOC0yLjMyOS05LjQwMiAxOC45NDguMTEzLjIxLS4wMzYuNDg4LS4yNzIuNTI1LTYuNDM4IDEgMS44MTIgMjEuMTczIDcuODc1IDM0LjQ2MXoiIGZpbGw9IiNmZmYiLz4KICAgIDxwYXRoIGQ9Im04NC4yOCA5MC42OThjLTEuMzY3LS42MzMtNi42MjEgMy4xMzUtMTAuMTEgNi4wMjgtLjcyOC0xLjAzMS0yLjEwMy0xLjc4LTUuMjAzLTEuMjQyLTIuNzEzLjQ3Mi00LjIxMSAxLjEyNi00Ljg4IDIuMjU0LTQuMjgzLTEuNjIzLTExLjQ4OC00LjEzLTEzLjIyOS0xLjcxLTEuOTAyIDIuNjQ2LjQ3NiAxNS4xNjEgMy4wMDMgMTYuNzg2IDEuMzIuODQ5IDcuNjMtMy4yMDggMTAuOTI2LTYuMDA1LjUzMi43NDkgMS4zODggMS4xNzggMy4xNDggMS4xMzcgMi42NjItLjA2MiA2Ljk3OS0uNjgxIDcuNjQ5LTEuOTIxLjA0LS4wNzUuMDc1LS4xNjQuMTA1LS4yNjYgMy4zODggMS4yNjYgOS4zNSAyLjYwNiAxMC42ODIgMi40MDYgMy40Ny0uNTIxLS40ODQtMTYuNzIzLTIuMDktMTcuNDY3eiIgZmlsbD0iIzNjYTgyYiIvPgogICAgPHBhdGggZD0ibTc0LjQ5IDk3LjA5N2MuMTQ0LjI1Ni4yNi41MjYuMzU4LjguNDgzIDEuMzUyIDEuMjcgNS42NDguNjc0IDYuNzA5LS41OTUgMS4wNjItNC40NTkgMS41NzQtNi44NDMgMS42MTVzLTIuOTItLjgzMS0zLjQwMy0yLjE4MWMtLjM4Ny0xLjA4MS0uNTc3LTMuNjIxLS41NzItNS4wNzUtLjA5OC0yLjE1OC42OS0yLjkxNiA0LjMzNC0zLjUwNiAyLjY5Ni0uNDM2IDQuMTIxLjA3MSA0Ljk0NC45NCAzLjgyOC0yLjg1NyAxMC4yMTUtNi44ODkgMTAuODM4LTYuMTUyIDMuMTA2IDMuNjc0IDMuNDk5IDEyLjQyIDIuODI2IDE1LjkzOS0uMjIgMS4xNTEtMTAuNTA1LTEuMTM5LTEwLjUwNS0yLjM4IDAtNS4xNTItMS4zMzctNi41NjUtMi42NS02Ljcxem0tMjIuNTMtMS42MDljLjg0My0xLjMzMyA3LjY3NC4zMjUgMTEuNDI0IDEuOTkzIDAgMC0uNzcgMy40OTEuNDU2IDcuNjA0LjM1OSAxLjIwMy04LjYyNyA2LjU1OC05LjggNS42MzctMS4zNTUtMS4wNjUtMy44NS0xMi40MzItMi4wOC0xNS4yMzR6IiBmaWxsPSIjNGNiYTNjIi8+CiAgICA8cGF0aCBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Im01NS4yNjkgNjguNDA2Yy41NTMtMi40MDMgMy4xMjctNi45MzIgMTIuMzIxLTYuODIyIDQuNjQ4LS4wMTkgMTAuNDIyLS4wMDIgMTQuMjUtLjQzNmE1MS4zMTIgNTEuMzEyIDAgMCAwIDEyLjcyNi0zLjA5NWMzLjk4LTEuNTE5IDUuMzkyLTEuMTggNS44ODctLjI3Mi41NDQuOTk5LS4wOTcgMi43MjItMS40ODggNC4zMDktMi42NTYgMy4wMy03LjQzMSA1LjM4LTE1Ljg2NSA2LjA3Ni04LjQzMy42OTgtMTQuMDItMS41NjUtMTYuNDI1IDIuMTE4LTEuMDM4IDEuNTg5LS4yMzYgNS4zMzMgNy45MiA2LjUxMiAxMS4wMiAxLjU5IDIwLjA3Mi0xLjkxNyAyMS4xOS4yMDEgMS4xMTkgMi4xMTgtNS4zMjMgNi40MjgtMTYuMzYyIDYuNTE4cy0xNy45MzQtMy44NjUtMjAuMzc5LTUuODNjLTMuMTAyLTIuNDk1LTQuNDktNi4xMzMtMy43NzUtOS4yNzl6IiBmaWxsPSIjZmMzIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiLz4KICAgIDxnIGZpbGw9IiMxNDMwN2UiIG9wYWNpdHk9Ii44Ij4KICAgICAgPHBhdGggZD0ibTY5LjMyNyA0Mi4xMjdjLjYxNi0xLjAwOCAxLjk4MS0xLjc4NiA0LjIxNi0xLjc4NiAyLjIzNCAwIDMuMjg1Ljg4OSA0LjAxMyAxLjg4LjE0OC4yMDItLjA3Ni40NC0uMzA2LjM0YTU5Ljg2OSA1OS44NjkgMCAwIDEgLS4xNjgtLjA3M2MtLjgxNy0uMzU3LTEuODItLjc5NS0zLjU0LS44Mi0xLjgzOC0uMDI2LTIuOTk3LjQzNS0zLjcyNy44MzEtLjI0Ni4xMzQtLjYzNC0uMTMzLS40ODgtLjM3MnptLTI1LjE1NyAxLjI5YzIuMTctLjkwNyAzLjg3Ni0uNzkgNS4wODEtLjUwNC4yNTQuMDYuNDMtLjIxMy4yMjctLjM3Ny0uOTM1LS43NTUtMy4wMy0xLjY5Mi01Ljc2LS42NzQtMi40MzcuOTA5LTMuNTg1IDIuNzk2LTMuNTkyIDQuMDM4LS4wMDIuMjkyLjYuMzE3Ljc1Ni4wNy40Mi0uNjcgMS4xMi0xLjY0NiAzLjI4OS0yLjU1M3oiLz4KICAgICAgPHBhdGggY2xpcC1ydWxlPSJldmVub2RkIiBkPSJtNzUuNDQgNTUuOTJhMy40NyAzLjQ3IDAgMCAxIC0zLjQ3NC0zLjQ2MiAzLjQ3IDMuNDcgMCAwIDEgMy40NzUtMy40NiAzLjQ3IDMuNDcgMCAwIDEgMy40NzQgMy40NiAzLjQ3IDMuNDcgMCAwIDEgLTMuNDc1IDMuNDYyem0yLjQ0Ny00LjYwOGEuODk5Ljg5OSAwIDAgMCAtMS43OTkgMGMwIC40OTQuNDA1Ljg5NS45Ljg5NS40OTkgMCAuOS0uNC45LS44OTV6bS0yNS40NjQgMy41NDJhNC4wNDIgNC4wNDIgMCAwIDEgLTQuMDQ5IDQuMDM3IDQuMDQ1IDQuMDQ1IDAgMCAxIC00LjA1LTQuMDM3IDQuMDQ1IDQuMDQ1IDAgMCAxIDQuMDUtNC4wMzcgNC4wNDUgNC4wNDUgMCAwIDEgNC4wNSA0LjAzN3ptLTEuMTkzLTEuMzM4YTEuMDUgMS4wNSAwIDAgMCAtMi4wOTcgMCAxLjA0OCAxLjA0OCAwIDAgMCAyLjA5NyAweiIgZmlsbC1ydWxlPSJldmVub2RkIi8+CiAgICA8L2c+CiAgICA8cGF0aCBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Im02NCAxMTcuNzVjMjkuNjg1IDAgNTMuNzUtMjQuMDY1IDUzLjc1LTUzLjc1cy0yNC4wNjUtNTMuNzUtNTMuNzUtNTMuNzUtNTMuNzUgMjQuMDY1LTUzLjc1IDUzLjc1IDI0LjA2NSA1My43NSA1My43NSA1My43NXptMCA1YzMyLjQ0NyAwIDU4Ljc1LTI2LjMwMyA1OC43NS01OC43NXMtMjYuMzAzLTU4Ljc1LTU4Ljc1LTU4Ljc1LTU4Ljc1IDI2LjMwMy01OC43NSA1OC43NSAyNi4zMDMgNTguNzUgNTguNzUgNTguNzV6IiBmaWxsPSIjZmZmIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiLz4KPC9zdmc+');\n}\n\n/* Email tooltip specific */\n.tooltip__button--email {\n    flex-direction: column;\n    justify-content: center;\n    align-items: flex-start;\n    font-size: 14px;\n    padding: 4px 8px;\n}\n.tooltip__button--email__primary-text {\n    font-weight: bold;\n}\n.tooltip__button--email__secondary-text {\n    font-size: 12px;\n}\n\n/* Email Protection signup notice */\n:not(.top-autofill) .tooltip--email-signup {\n    text-align: left;\n    color: #222222;\n    padding: 16px 20px;\n    width: 380px;\n}\n\n.tooltip--email-signup h1 {\n    font-weight: 700;\n    font-size: 16px;\n    line-height: 1.5;\n    margin: 0;\n}\n\n.tooltip--email-signup p {\n    font-weight: 400;\n    font-size: 14px;\n    line-height: 1.4;\n}\n\n.notice-controls {\n    display: flex;\n}\n\n.tooltip--email-signup .notice-controls > * {\n    border-radius: 8px;\n    border: 0;\n    cursor: pointer;\n    display: inline-block;\n    font-family: inherit;\n    font-style: normal;\n    font-weight: bold;\n    padding: 8px 12px;\n    text-decoration: none;\n}\n\n.notice-controls .ghost {\n    margin-left: 1rem;\n}\n\n.tooltip--email-signup a.primary {\n    background: #3969EF;\n    color: #fff;\n}\n\n.tooltip--email-signup a.primary:hover,\n.tooltip--email-signup a.primary:focus {\n    background: #2b55ca;\n}\n\n.tooltip--email-signup a.primary:active {\n    background: #1e42a4;\n}\n\n.tooltip--email-signup button.ghost {\n    background: transparent;\n    color: #3969EF;\n}\n\n.tooltip--email-signup button.ghost:hover,\n.tooltip--email-signup button.ghost:focus {\n    background-color: rgba(0, 0, 0, 0.06);\n    color: #2b55ca;\n}\n\n.tooltip--email-signup button.ghost:active {\n    background-color: rgba(0, 0, 0, 0.12);\n    color: #1e42a4;\n}\n\n.tooltip--email-signup button.close-tooltip {\n    background-color: transparent;\n    background-image: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iMTMiIHZpZXdCb3g9IjAgMCAxMiAxMyIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0wLjI5Mjg5NCAwLjY1NjkwN0MwLjY4MzQxOCAwLjI2NjM4MyAxLjMxNjU4IDAuMjY2MzgzIDEuNzA3MTEgMC42NTY5MDdMNiA0Ljk0OThMMTAuMjkyOSAwLjY1NjkwN0MxMC42ODM0IDAuMjY2MzgzIDExLjMxNjYgMC4yNjYzODMgMTEuNzA3MSAwLjY1NjkwN0MxMi4wOTc2IDEuMDQ3NDMgMTIuMDk3NiAxLjY4MDYgMTEuNzA3MSAyLjA3MTEyTDcuNDE0MjEgNi4zNjQwMUwxMS43MDcxIDEwLjY1NjlDMTIuMDk3NiAxMS4wNDc0IDEyLjA5NzYgMTEuNjgwNiAxMS43MDcxIDEyLjA3MTFDMTEuMzE2NiAxMi40NjE2IDEwLjY4MzQgMTIuNDYxNiAxMC4yOTI5IDEyLjA3MTFMNiA3Ljc3ODIzTDEuNzA3MTEgMTIuMDcxMUMxLjMxNjU4IDEyLjQ2MTYgMC42ODM0MTcgMTIuNDYxNiAwLjI5Mjg5MyAxMi4wNzExQy0wLjA5NzYzMTEgMTEuNjgwNiAtMC4wOTc2MzExIDExLjA0NzQgMC4yOTI4OTMgMTAuNjU2OUw0LjU4NTc5IDYuMzY0MDFMMC4yOTI4OTQgMi4wNzExMkMtMC4wOTc2MzA2IDEuNjgwNiAtMC4wOTc2MzA2IDEuMDQ3NDMgMC4yOTI4OTQgMC42NTY5MDdaIiBmaWxsPSJibGFjayIgZmlsbC1vcGFjaXR5PSIwLjg0Ii8+Cjwvc3ZnPgo=);\n    background-position: center center;\n    background-repeat: no-repeat;\n    border: 0;\n    cursor: pointer;\n    padding: 16px;\n    position: absolute;\n    right: 12px;\n    top: 12px;\n}\n";
+const CSS_STYLES = exports.CSS_STYLES = ":root {\n    color-scheme: light dark;\n}\n\n.wrapper *, .wrapper *::before, .wrapper *::after {\n    box-sizing: border-box;\n}\n.wrapper {\n    position: fixed;\n    top: 0;\n    left: 0;\n    padding: 0;\n    font-family: 'DDG_ProximaNova', 'Proxima Nova', system-ui, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',\n    'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;\n    -webkit-font-smoothing: antialiased;\n    z-index: 2147483647;\n}\n.wrapper--data {\n    font-family: 'SF Pro Text', system-ui, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',\n    'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;\n}\n.wrapper:not(.top-autofill) .tooltip {\n    position: absolute;\n    width: 300px;\n    max-width: calc(100vw - 25px);\n    transform: translate(-1000px, -1000px);\n    z-index: 2147483647;\n}\n.tooltip--data, #topAutofill {\n    background-color: rgba(242, 240, 240, 1);\n    -webkit-backdrop-filter: blur(40px);\n    backdrop-filter: blur(40px);\n}\n@media (prefers-color-scheme: dark) {\n    .tooltip--data, #topAutofill {\n        background: rgb(100, 98, 102, .9);\n    }\n}\n.tooltip--data {\n    padding: 6px;\n    font-size: 13px;\n    line-height: 14px;\n    width: 315px;\n    max-height: 290px;\n    overflow-y: auto;\n}\n.top-autofill .tooltip--data {\n    min-height: 100vh;\n}\n.tooltip--data.tooltip--incontext-signup {\n    width: 360px;\n}\n.wrapper:not(.top-autofill) .tooltip--data {\n    top: 100%;\n    left: 100%;\n    border: 0.5px solid rgba(255, 255, 255, 0.2);\n    border-radius: 6px;\n    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.32);\n}\n@media (prefers-color-scheme: dark) {\n    .wrapper:not(.top-autofill) .tooltip--data {\n        border: 1px solid rgba(255, 255, 255, 0.2);\n    }\n}\n.wrapper:not(.top-autofill) .tooltip--email {\n    top: calc(100% + 6px);\n    right: calc(100% - 48px);\n    padding: 8px;\n    border: 1px solid #D0D0D0;\n    border-radius: 10px;\n    background-color: #FFFFFF;\n    font-size: 14px;\n    line-height: 1.3;\n    color: #333333;\n    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);\n}\n.tooltip--email__caret {\n    position: absolute;\n    transform: translate(-1000px, -1000px);\n    z-index: 2147483647;\n}\n.tooltip--email__caret::before,\n.tooltip--email__caret::after {\n    content: \"\";\n    width: 0;\n    height: 0;\n    border-left: 10px solid transparent;\n    border-right: 10px solid transparent;\n    display: block;\n    border-bottom: 8px solid #D0D0D0;\n    position: absolute;\n    right: -28px;\n}\n.tooltip--email__caret::before {\n    border-bottom-color: #D0D0D0;\n    top: -1px;\n}\n.tooltip--email__caret::after {\n    border-bottom-color: #FFFFFF;\n    top: 0px;\n}\n\n/* Buttons */\n.tooltip__button {\n    display: flex;\n    width: 100%;\n    padding: 8px 8px 8px 0px;\n    font-family: inherit;\n    color: inherit;\n    background: transparent;\n    border: none;\n    border-radius: 6px;\n    text-align: left;\n}\n.tooltip__button.currentFocus,\n.wrapper:not(.top-autofill) .tooltip__button:hover {\n    background-color: #3969EF;\n    color: #FFFFFF;\n}\n\n/* Data autofill tooltip specific */\n.tooltip__button--data {\n    position: relative;\n    min-height: 48px;\n    flex-direction: row;\n    justify-content: flex-start;\n    font-size: inherit;\n    font-weight: 500;\n    line-height: 16px;\n    text-align: left;\n    border-radius: 3px;\n}\n.tooltip--data__item-container {\n    max-height: 220px;\n    overflow: auto;\n}\n.tooltip__button--data:first-child {\n    margin-top: 0;\n}\n.tooltip__button--data:last-child {\n    margin-bottom: 0;\n}\n.tooltip__button--data::before {\n    content: '';\n    flex-shrink: 0;\n    display: block;\n    width: 32px;\n    height: 32px;\n    margin: 0 8px;\n    background-size: 20px 20px;\n    background-repeat: no-repeat;\n    background-position: center center;\n}\n#provider_locked::after {\n    position: absolute;\n    content: '';\n    flex-shrink: 0;\n    display: block;\n    width: 32px;\n    height: 32px;\n    margin: 0 8px;\n    background-size: 11px 13px;\n    background-repeat: no-repeat;\n    background-position: right bottom;\n}\n.tooltip__button--data.currentFocus:not(.tooltip__button--data--bitwarden)::before,\n.wrapper:not(.top-autofill) .tooltip__button--data:not(.tooltip__button--data--bitwarden):hover::before {\n    filter: invert(100%);\n}\n@media (prefers-color-scheme: dark) {\n    .tooltip__button--data:not(.tooltip__button--data--bitwarden)::before,\n    .tooltip__button--data:not(.tooltip__button--data--bitwarden)::before {\n        filter: invert(100%);\n        opacity: .9;\n    }\n}\n.tooltip__button__text-container {\n    margin: auto 0;\n}\n.label {\n    display: block;\n    font-weight: 400;\n    letter-spacing: -0.25px;\n    color: rgba(0,0,0,.8);\n    font-size: 13px;\n    line-height: 1;\n}\n.label + .label {\n    margin-top: 2px;\n}\n.label.label--medium {\n    font-weight: 500;\n    letter-spacing: -0.25px;\n    color: rgba(0,0,0,.9);\n}\n.label.label--small {\n    font-size: 11px;\n    font-weight: 400;\n    letter-spacing: 0.06px;\n    color: rgba(0,0,0,0.6);\n}\n@media (prefers-color-scheme: dark) {\n    .tooltip--data .label {\n        color: #ffffff;\n    }\n    .tooltip--data .label--medium {\n        color: #ffffff;\n    }\n    .tooltip--data .label--small {\n        color: #cdcdcd;\n    }\n}\n.tooltip__button.currentFocus .label,\n.wrapper:not(.top-autofill) .tooltip__button:hover .label {\n    color: #FFFFFF;\n}\n\n.tooltip__button--manage {\n    font-size: 13px;\n    padding: 5px 9px;\n    border-radius: 3px;\n    margin: 0;\n}\n\n/* Icons */\n.tooltip__button--data--credentials::before,\n.tooltip__button--data--credentials__current::before {\n    background-size: 28px 28px;\n    background-image: url('data:image/svg+xml;base64,PHN2ZyBmaWxsPSJub25lIiB2aWV3Qm94PSIwIDAgMjQgMjQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgICA8cGF0aCBmaWxsPSIjMDAwIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xNS4zMzQgNi42NjdhMiAyIDAgMSAwIDAgNCAyIDIgMCAwIDAgMC00Wm0tLjY2NyAyYS42NjcuNjY3IDAgMSAxIDEuMzMzIDAgLjY2Ny42NjcgMCAwIDEtMS4zMzMgMFoiIGNsaXAtcnVsZT0iZXZlbm9kZCIvPgogICAgPHBhdGggZmlsbD0iIzAwMCIgZmlsbC1ydWxlPSJldmVub2RkIiBkPSJNMTQuNjY3IDRhNS4zMzMgNS4zMzMgMCAwIDAtNS4xODggNi41NzhsLTUuMjg0IDUuMjg0YS42NjcuNjY3IDAgMCAwLS4xOTUuNDcxdjNjMCAuMzY5LjI5OC42NjcuNjY3LjY2N2gyLjY2NmMuNzM3IDAgMS4zMzQtLjU5NyAxLjMzNC0xLjMzM1YxOGguNjY2Yy43MzcgMCAxLjMzNC0uNTk3IDEuMzM0LTEuMzMzdi0xLjMzNEgxMmMuMTc3IDAgLjM0Ni0uMDcuNDcxLS4xOTVsLjY4OC0uNjg4QTUuMzMzIDUuMzMzIDAgMSAwIDE0LjY2NyA0Wm0tNCA1LjMzM2E0IDQgMCAxIDEgMi41NTUgMy43MzIuNjY3LjY2NyAwIDAgMC0uNzEzLjE1bC0uNzg1Ljc4NUgxMGEuNjY3LjY2NyAwIDAgMC0uNjY3LjY2N3YySDhhLjY2Ny42NjcgMCAwIDAtLjY2Ny42NjZ2MS4zMzRoLTJ2LTIuMDU4bDUuMzY1LTUuMzY0YS42NjcuNjY3IDAgMCAwIC4xNjMtLjY3NyAzLjk5NiAzLjk5NiAwIDAgMS0uMTk0LTEuMjM1WiIgY2xpcC1ydWxlPSJldmVub2RkIi8+Cjwvc3ZnPgo=');\n}\n.tooltip__button--data--credentials__new::before {\n    background-size: 28px 28px;\n    background-image: url('data:image/svg+xml;base64,PHN2ZyBmaWxsPSJub25lIiB2aWV3Qm94PSIwIDAgMjQgMjQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgICA8cGF0aCBmaWxsPSIjMDAwIiBkPSJNOC4wNDcgNC42MjVDNy45MzcgNC4xMjUgNy44NjIgNCA3LjUgNGMtLjM2MiAwLS40MzguMTI1LS41NDcuNjI1LS4wNjguMzEtLjE3NyAxLjMzOC0uMjUxIDIuMDc3LS43MzguMDc0LTEuNzY3LjE4My0yLjA3Ny4yNTEtLjUuMTEtLjYyNS4xODQtLjYyNS41NDcgMCAuMzYyLjEyNS40MzcuNjI1LjU0Ny4zMS4wNjcgMS4zMzYuMTc3IDIuMDc0LjI1LjA3My43NjcuMTg1IDEuODQyLjI1NCAyLjA3OC4xMS4zNzUuMTg1LjYyNS41NDcuNjI1LjM2MiAwIC40MzgtLjEyNS41NDctLjYyNS4wNjgtLjMxLjE3Ny0xLjMzNi4yNS0yLjA3NC43NjctLjA3MyAxLjg0Mi0uMTg1IDIuMDc4LS4yNTQuMzc1LS4xMS42MjUtLjE4NS42MjUtLjU0NyAwLS4zNjMtLjEyNS0uNDM4LS42MjUtLjU0Ny0uMzEtLjA2OC0xLjMzOS0uMTc3LTIuMDc3LS4yNTEtLjA3NC0uNzM5LS4xODMtMS43NjctLjI1MS0yLjA3N1oiLz4KICAgIDxwYXRoIGZpbGw9IiMwMDAiIGQ9Ik0xNC42ODEgNS4xOTljLS43NjYgMC0xLjQ4Mi4yMS0yLjA5My41NzhhLjYzNi42MzYgMCAwIDEtLjY1NS0xLjA5IDUuMzQgNS4zNCAwIDEgMSAxLjMwMiA5LjcyMmwtLjc3NS43NzZhLjYzNi42MzYgMCAwIDEtLjQ1LjE4NmgtMS4zOTh2MS42NWMwIC40OTMtLjQuODkzLS44OTMuODkzSDguNTc4djEuMTQxYzAgLjQ5NC0uNC44OTMtLjg5NC44OTNINC42MzZBLjYzNi42MzYgMCAwIDEgNCAxOS4zMTNWMTYuMjZjMC0uMTY5LjA2Ny0uMzMuMTg2LS40NWw1LjU2Mi01LjU2MmEuNjM2LjYzNiAwIDEgMSAuOS45bC01LjM3NiA1LjM3NXYyLjE1M2gyLjAzNHYtMS4zOTljMC0uMzUuMjg1LS42MzYuNjM2LS42MzZIOS4zNHYtMS45MDdjMC0uMzUxLjI4NC0uNjM2LjYzNS0uNjM2aDEuNzcxbC44NjQtLjg2M2EuNjM2LjYzNiAwIDAgMSAuNjY4LS4xNDcgNC4wNjkgNC4wNjkgMCAxIDAgMS40MDItNy44OVoiLz4KICAgIDxwYXRoIGZpbGw9IiMwMDAiIGZpbGwtcnVsZT0iZXZlbm9kZCIgZD0iTTEzLjYyNSA4LjQ5OWExLjg3NSAxLjg3NSAwIDEgMSAzLjc1IDAgMS44NzUgMS44NzUgMCAwIDEtMy43NSAwWm0xLjg3NS0uNjI1YS42MjUuNjI1IDAgMSAwIDAgMS4yNS42MjUuNjI1IDAgMCAwIDAtMS4yNVoiIGNsaXAtcnVsZT0iZXZlbm9kZCIvPgogICAgPHBhdGggZmlsbD0iIzAwMCIgZD0iTTQuNjI1IDEyLjEyNWEuNjI1LjYyNSAwIDEgMCAwLTEuMjUuNjI1LjYyNSAwIDAgMCAwIDEuMjVaIi8+Cjwvc3ZnPgo=');\n}\n.tooltip__button--data--creditCards::before {\n    background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0ibm9uZSI+CiAgICA8cGF0aCBkPSJNNSA5Yy0uNTUyIDAtMSAuNDQ4LTEgMXYyYzAgLjU1Mi40NDggMSAxIDFoM2MuNTUyIDAgMS0uNDQ4IDEtMXYtMmMwLS41NTItLjQ0OC0xLTEtMUg1eiIgZmlsbD0iIzAwMCIvPgogICAgPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xIDZjMC0yLjIxIDEuNzktNCA0LTRoMTRjMi4yMSAwIDQgMS43OSA0IDR2MTJjMCAyLjIxLTEuNzkgNC00IDRINWMtMi4yMSAwLTQtMS43OS00LTRWNnptNC0yYy0xLjEwNSAwLTIgLjg5NS0yIDJ2OWgxOFY2YzAtMS4xMDUtLjg5NS0yLTItMkg1em0wIDE2Yy0xLjEwNSAwLTItLjg5NS0yLTJoMThjMCAxLjEwNS0uODk1IDItMiAySDV6IiBmaWxsPSIjMDAwIi8+Cjwvc3ZnPgo=');\n}\n.tooltip__button--data--identities::before {\n    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0ibm9uZSI+CiAgICA8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTEyIDIxYzIuMTQzIDAgNC4xMTEtLjc1IDUuNjU3LTItLjYyNi0uNTA2LTEuMzE4LS45MjctMi4wNi0xLjI1LTEuMS0uNDgtMi4yODUtLjczNS0zLjQ4Ni0uNzUtMS4yLS4wMTQtMi4zOTIuMjExLTMuNTA0LjY2NC0uODE3LjMzMy0xLjU4Ljc4My0yLjI2NCAxLjMzNiAxLjU0NiAxLjI1IDMuNTE0IDIgNS42NTcgMnptNC4zOTctNS4wODNjLjk2Ny40MjIgMS44NjYuOTggMi42NzIgMS42NTVDMjAuMjc5IDE2LjAzOSAyMSAxNC4xMDQgMjEgMTJjMC00Ljk3LTQuMDMtOS05LTlzLTkgNC4wMy05IDljMCAyLjEwNC43MjIgNC4wNCAxLjkzMiA1LjU3Mi44NzQtLjczNCAxLjg2LTEuMzI4IDIuOTIxLTEuNzYgMS4zNi0uNTU0IDIuODE2LS44MyA0LjI4My0uODExIDEuNDY3LjAxOCAyLjkxNi4zMyA0LjI2LjkxNnpNMTIgMjNjNi4wNzUgMCAxMS00LjkyNSAxMS0xMVMxOC4wNzUgMSAxMiAxIDEgNS45MjUgMSAxMnM0LjkyNSAxMSAxMSAxMXptMy0xM2MwIDEuNjU3LTEuMzQzIDMtMyAzcy0zLTEuMzQzLTMtMyAxLjM0My0zIDMtMyAzIDEuMzQzIDMgM3ptMiAwYzAgMi43NjEtMi4yMzkgNS01IDVzLTUtMi4yMzktNS01IDIuMjM5LTUgNS01IDUgMi4yMzkgNSA1eiIgZmlsbD0iIzAwMCIvPgo8L3N2Zz4=');\n}\n.tooltip__button--data--credentials.tooltip__button--data--bitwarden::before,\n.tooltip__button--data--credentials__current.tooltip__button--data--bitwarden::before {\n    background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0IiByeD0iOCIgZmlsbD0iIzE3NUREQyIvPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTE4LjU2OTYgNS40MzM1NUMxOC41MDg0IDUuMzc0NDIgMTguNDM0NyA1LjMyNzYzIDE4LjM1MzEgNS4yOTYxMUMxOC4yNzE1IDUuMjY0NiAxOC4xODM3IDUuMjQ5MDQgMTguMDk1MyA1LjI1MDQxSDUuOTIxOTFDNS44MzMyNiA1LjI0NzI5IDUuNzQ0OTMgNS4yNjIwNSA1LjY2MzA0IDUuMjkzNjdDNS41ODExNSA1LjMyNTI5IDUuNTA3NjUgNS4zNzMwMiA1LjQ0NzYyIDUuNDMzNTVDNS4zMjE3IDUuNTUwMTMgNS4yNTA2NSA1LjcwODE1IDUuMjUgNS44NzMxVjEzLjM4MjFDNS4yNTMzNiAxMy45NTM1IDUuMzc0MDggMTQuNTE5MSA1LjYwNTcyIDE1LjA0ODdDNS44MTkzMSAxNS41NzI4IDYuMTEyMDcgMTYuMDY2MSA2LjQ3NTI0IDE2LjUxMzlDNi44NDIgMTYuOTY4MyA3LjI1OTI5IDE3LjM4NTcgNy43MjAyNSAxNy43NTkzQzguMTQwNTMgMTguMTI1NiA4LjU4OTcxIDE4LjQ2MjMgOS4wNjQwNyAxOC43NjY2QzkuNDU5MzEgMTkuMDIzIDkuOTEzODMgMTkuMjc5NCAxMC4zNDg2IDE5LjUxNzVDMTAuNzgzNCAxOS43NTU2IDExLjA5OTYgMTkuOTIwNCAxMS4yNzc0IDE5Ljk5MzdDMTEuNDU1MyAyMC4wNjY5IDExLjYxMzQgMjAuMTQwMiAxMS43MTIyIDIwLjE5NTFDMTEuNzk5MiAyMC4yMzEzIDExLjg5MzUgMjAuMjUgMTEuOTg4OCAyMC4yNUMxMi4wODQyIDIwLjI1IDEyLjE3ODUgMjAuMjMxMyAxMi4yNjU1IDIwLjE5NTFDMTIuNDIxMiAyMC4xMzYzIDEyLjU3MjkgMjAuMDY5IDEyLjcyIDE5Ljk5MzdDMTIuNzcxMSAxOS45Njc0IDEyLjgzMzUgMTkuOTM2NiAxMi45MDY5IDE5LjkwMDRDMTMuMDg5MSAxOS44MTA1IDEzLjMzODggMTkuNjg3MiAxMy42NDg5IDE5LjUxNzVDMTQuMDgzNiAxOS4yNzk0IDE0LjUxODQgMTkuMDIzIDE0LjkzMzQgMTguNzY2NkMxNS40MDQgMTguNDU3NyAxNS44NTI4IDE4LjEyMTIgMTYuMjc3MiAxNy43NTkzQzE2LjczMzEgMTcuMzgwOSAxNy4xNDk5IDE2Ljk2NCAxNy41MjIyIDE2LjUxMzlDMTcuODc4IDE2LjA2MTcgMTguMTcwMiAxNS41NjkzIDE4LjM5MTcgMTUuMDQ4N0MxOC42MjM0IDE0LjUxOTEgMTguNzQ0MSAxMy45NTM1IDE4Ljc0NzQgMTMuMzgyMVY1Ljg3MzFDMTguNzU1NyA1Ljc5MjE0IDE4Ljc0MzkgNS43MTA1IDE4LjcxMzEgNS42MzQzNUMxOC42ODIzIDUuNTU4MiAxOC42MzMyIDUuNDg5NTQgMTguNTY5NiA1LjQzMzU1Wk0xNy4wMDg0IDEzLjQ1NTNDMTcuMDA4NCAxNi4xODQyIDEyLjAwODYgMTguNTI4NSAxMi4wMDg2IDE4LjUyODVWNi44NjIwOUgxNy4wMDg0VjEzLjQ1NTNaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4K');\n}\n#provider_locked:after {\n    background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTEiIGhlaWdodD0iMTMiIHZpZXdCb3g9IjAgMCAxMSAxMyIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTEgNy42MDA1N1Y3LjYwMjVWOS41MjI1QzEgMTAuMDgwMSAxLjIyMTUxIDEwLjYxNDkgMS42MTU4MSAxMS4wMDkyQzIuMDEwMSAxMS40MDM1IDIuNTQ0ODggMTEuNjI1IDMuMTAyNSAxMS42MjVINy4yNzI1QzcuNTQ4NjEgMTEuNjI1IDcuODIyMDEgMTEuNTcwNiA4LjA3NzA5IDExLjQ2NUM4LjMzMjE4IDExLjM1OTMgOC41NjM5NiAxMS4yMDQ0IDguNzU5MTkgMTEuMDA5MkM4Ljk1NDQzIDEwLjgxNCA5LjEwOTMgMTAuNTgyMiA5LjIxNDk2IDEwLjMyNzFDOS4zMjA2MiAxMC4wNzIgOS4zNzUgOS43OTg2MSA5LjM3NSA5LjUyMjVMOS4zNzUgNy42MDI1TDkuMzc1IDcuNjAwNTdDOS4zNzQxNSA3LjE2MTMxIDkuMjM1NzQgNi43MzMzNSA4Ljk3OTIyIDYuMzc2NzhDOC44NzY4MyA2LjIzNDQ2IDguNzU3NjggNi4xMDYzNyA4LjYyNSA1Ljk5NDg5VjUuMTg3NUM4LjYyNSA0LjI3NTgyIDguMjYyODQgMy40MDE0OCA3LjYxODE4IDIuNzU2ODJDNi45NzM1MiAyLjExMjE2IDYuMDk5MTggMS43NSA1LjE4NzUgMS43NUM0LjI3NTgyIDEuNzUgMy40MDE0OCAyLjExMjE2IDIuNzU2ODIgMi43NTY4MkMyLjExMjE2IDMuNDAxNDggMS43NSA0LjI3NTgyIDEuNzUgNS4xODc1VjUuOTk0ODlDMS42MTczMiA2LjEwNjM3IDEuNDk4MTcgNi4yMzQ0NiAxLjM5NTc4IDYuMzc2NzhDMS4xMzkyNiA2LjczMzM1IDEuMDAwODUgNy4xNjEzMSAxIDcuNjAwNTdaTTQuOTY4NyA0Ljk2ODdDNS4wMjY5NCA0LjkxMDQ3IDUuMTA1MzIgNC44NzY5OSA1LjE4NzUgNC44NzUwN0M1LjI2OTY4IDQuODc2OTkgNS4zNDgwNiA0LjkxMDQ3IDUuNDA2MyA0Ljk2ODdDNS40NjU0MiA1LjAyNzgzIDUuNDk5MDQgNS4xMDc3NCA1LjUgNS4xOTEzVjUuNUg0Ljg3NVY1LjE5MTNDNC44NzU5NiA1LjEwNzc0IDQuOTA5NTggNS4wMjc4MyA0Ljk2ODcgNC45Njg3WiIgZmlsbD0iIzIyMjIyMiIgc3Ryb2tlPSJ3aGl0ZSIgc3Ryb2tlLXdpZHRoPSIyIi8+Cjwvc3ZnPgo=');\n}\n\nhr {\n    display: block;\n    margin: 5px 9px;\n    border: none; /* reset the border */\n    border-top: 1px solid rgba(0,0,0,.1);\n}\n\nhr:first-child {\n    display: none;\n}\n\n@media (prefers-color-scheme: dark) {\n    hr {\n        border-top: 1px solid rgba(255,255,255,.2);\n    }\n}\n\n#privateAddress {\n    align-items: flex-start;\n}\n#personalAddress::before,\n#privateAddress::before,\n#incontextSignup::before,\n#personalAddress.currentFocus::before,\n#personalAddress:hover::before,\n#privateAddress.currentFocus::before,\n#privateAddress:hover::before {\n    filter: none;\n    /* This is the same icon as `daxBase64` in `src/Form/logo-svg.js` */\n    background-image: url('data:image/svg+xml;base64,PHN2ZyBmaWxsPSJub25lIiB2aWV3Qm94PSIwIDAgMTI4IDEyOCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICAgIDxwYXRoIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0ibTY0IDEyOGMzNS4zNDYgMCA2NC0yOC42NTQgNjQtNjRzLTI4LjY1NC02NC02NC02NC02NCAyOC42NTQtNjQgNjQgMjguNjU0IDY0IDY0IDY0eiIgZmlsbD0iI2RlNTgzMyIgZmlsbC1ydWxlPSJldmVub2RkIi8+CiAgICA8cGF0aCBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Im03MyAxMTEuNzVjMC0uNS4xMjMtLjYxNC0xLjQ2Ni0zLjc4Mi00LjIyNC04LjQ1OS04LjQ3LTIwLjM4NC02LjU0LTI4LjA3NS4zNTMtMS4zOTctMy45NzgtNTEuNzQ0LTcuMDQtNTMuMzY1LTMuNDAyLTEuODEzLTcuNTg4LTQuNjktMTEuNDE4LTUuMzMtMS45NDMtLjMxLTQuNDktLjE2NC02LjQ4Mi4xMDUtLjM1My4wNDctLjM2OC42ODMtLjAzLjc5OCAxLjMwOC40NDMgMi44OTUgMS4yMTIgMy44MyAyLjM3NS4xNzguMjItLjA2LjU2Ni0uMzQyLjU3Ny0uODgyLjAzMi0yLjQ4Mi40MDItNC41OTMgMi4xOTUtLjI0NC4yMDctLjA0MS41OTIuMjczLjUzIDQuNTM2LS44OTcgOS4xNy0uNDU1IDExLjkgMi4wMjcuMTc3LjE2LjA4NC40NS0uMTQ3LjUxMi0yMy42OTQgNi40NC0xOS4wMDMgMjcuMDUtMTIuNjk2IDUyLjM0NCA1LjYxOSAyMi41MyA3LjczMyAyOS43OTIgOC40IDMyLjAwNGEuNzE4LjcxOCAwIDAgMCAuNDIzLjQ2N2M4LjE1NiAzLjI0OCAyNS45MjggMy4zOTIgMjUuOTI4LTIuMTMyeiIgZmlsbD0iI2RkZCIgZmlsbC1ydWxlPSJldmVub2RkIi8+CiAgICA8cGF0aCBkPSJtNzYuMjUgMTE2LjVjLTIuODc1IDEuMTI1LTguNSAxLjYyNS0xMS43NSAxLjYyNS00Ljc2NCAwLTExLjYyNS0uNzUtMTQuMTI1LTEuODc1LTEuNTQ0LTQuNzUxLTYuMTY0LTE5LjQ4LTEwLjcyNy0zOC4xODVsLS40NDctMS44MjctLjAwNC0uMDE1Yy01LjQyNC0yMi4xNTctOS44NTUtNDAuMjUzIDE0LjQyNy00NS45MzguMjIyLS4wNTIuMzMtLjMxNy4xODQtLjQ5Mi0yLjc4Ni0zLjMwNS04LjAwNS00LjM4OC0xNC42MDUtMi4xMTEtLjI3LjA5My0uNTA2LS4xOC0uMzM3LS40MTIgMS4yOTQtMS43ODMgMy44MjMtMy4xNTUgNS4wNzEtMy43NTYuMjU4LS4xMjQuMjQyLS41MDItLjAzLS41ODhhMjcuODc3IDI3Ljg3NyAwIDAgMCAtMy43NzItLjljLS4zNy0uMDU5LS40MDMtLjY5My0uMDMyLS43NDMgOS4zNTYtMS4yNTkgMTkuMTI1IDEuNTUgMjQuMDI4IDcuNzI2YS4zMjYuMzI2IDAgMCAwIC4xODYuMTE0YzE3Ljk1MiAzLjg1NiAxOS4yMzggMzIuMjM1IDE3LjE3IDMzLjUyOC0uNDA4LjI1NS0xLjcxNS4xMDgtMy40MzgtLjA4NS02Ljk4Ni0uNzgxLTIwLjgxOC0yLjMyOS05LjQwMiAxOC45NDguMTEzLjIxLS4wMzYuNDg4LS4yNzIuNTI1LTYuNDM4IDEgMS44MTIgMjEuMTczIDcuODc1IDM0LjQ2MXoiIGZpbGw9IiNmZmYiLz4KICAgIDxwYXRoIGQ9Im04NC4yOCA5MC42OThjLTEuMzY3LS42MzMtNi42MjEgMy4xMzUtMTAuMTEgNi4wMjgtLjcyOC0xLjAzMS0yLjEwMy0xLjc4LTUuMjAzLTEuMjQyLTIuNzEzLjQ3Mi00LjIxMSAxLjEyNi00Ljg4IDIuMjU0LTQuMjgzLTEuNjIzLTExLjQ4OC00LjEzLTEzLjIyOS0xLjcxLTEuOTAyIDIuNjQ2LjQ3NiAxNS4xNjEgMy4wMDMgMTYuNzg2IDEuMzIuODQ5IDcuNjMtMy4yMDggMTAuOTI2LTYuMDA1LjUzMi43NDkgMS4zODggMS4xNzggMy4xNDggMS4xMzcgMi42NjItLjA2MiA2Ljk3OS0uNjgxIDcuNjQ5LTEuOTIxLjA0LS4wNzUuMDc1LS4xNjQuMTA1LS4yNjYgMy4zODggMS4yNjYgOS4zNSAyLjYwNiAxMC42ODIgMi40MDYgMy40Ny0uNTIxLS40ODQtMTYuNzIzLTIuMDktMTcuNDY3eiIgZmlsbD0iIzNjYTgyYiIvPgogICAgPHBhdGggZD0ibTc0LjQ5IDk3LjA5N2MuMTQ0LjI1Ni4yNi41MjYuMzU4LjguNDgzIDEuMzUyIDEuMjcgNS42NDguNjc0IDYuNzA5LS41OTUgMS4wNjItNC40NTkgMS41NzQtNi44NDMgMS42MTVzLTIuOTItLjgzMS0zLjQwMy0yLjE4MWMtLjM4Ny0xLjA4MS0uNTc3LTMuNjIxLS41NzItNS4wNzUtLjA5OC0yLjE1OC42OS0yLjkxNiA0LjMzNC0zLjUwNiAyLjY5Ni0uNDM2IDQuMTIxLjA3MSA0Ljk0NC45NCAzLjgyOC0yLjg1NyAxMC4yMTUtNi44ODkgMTAuODM4LTYuMTUyIDMuMTA2IDMuNjc0IDMuNDk5IDEyLjQyIDIuODI2IDE1LjkzOS0uMjIgMS4xNTEtMTAuNTA1LTEuMTM5LTEwLjUwNS0yLjM4IDAtNS4xNTItMS4zMzctNi41NjUtMi42NS02Ljcxem0tMjIuNTMtMS42MDljLjg0My0xLjMzMyA3LjY3NC4zMjUgMTEuNDI0IDEuOTkzIDAgMC0uNzcgMy40OTEuNDU2IDcuNjA0LjM1OSAxLjIwMy04LjYyNyA2LjU1OC05LjggNS42MzctMS4zNTUtMS4wNjUtMy44NS0xMi40MzItMi4wOC0xNS4yMzR6IiBmaWxsPSIjNGNiYTNjIi8+CiAgICA8cGF0aCBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Im01NS4yNjkgNjguNDA2Yy41NTMtMi40MDMgMy4xMjctNi45MzIgMTIuMzIxLTYuODIyIDQuNjQ4LS4wMTkgMTAuNDIyLS4wMDIgMTQuMjUtLjQzNmE1MS4zMTIgNTEuMzEyIDAgMCAwIDEyLjcyNi0zLjA5NWMzLjk4LTEuNTE5IDUuMzkyLTEuMTggNS44ODctLjI3Mi41NDQuOTk5LS4wOTcgMi43MjItMS40ODggNC4zMDktMi42NTYgMy4wMy03LjQzMSA1LjM4LTE1Ljg2NSA2LjA3Ni04LjQzMy42OTgtMTQuMDItMS41NjUtMTYuNDI1IDIuMTE4LTEuMDM4IDEuNTg5LS4yMzYgNS4zMzMgNy45MiA2LjUxMiAxMS4wMiAxLjU5IDIwLjA3Mi0xLjkxNyAyMS4xOS4yMDEgMS4xMTkgMi4xMTgtNS4zMjMgNi40MjgtMTYuMzYyIDYuNTE4cy0xNy45MzQtMy44NjUtMjAuMzc5LTUuODNjLTMuMTAyLTIuNDk1LTQuNDktNi4xMzMtMy43NzUtOS4yNzl6IiBmaWxsPSIjZmMzIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiLz4KICAgIDxnIGZpbGw9IiMxNDMwN2UiIG9wYWNpdHk9Ii44Ij4KICAgICAgPHBhdGggZD0ibTY5LjMyNyA0Mi4xMjdjLjYxNi0xLjAwOCAxLjk4MS0xLjc4NiA0LjIxNi0xLjc4NiAyLjIzNCAwIDMuMjg1Ljg4OSA0LjAxMyAxLjg4LjE0OC4yMDItLjA3Ni40NC0uMzA2LjM0YTU5Ljg2OSA1OS44NjkgMCAwIDEgLS4xNjgtLjA3M2MtLjgxNy0uMzU3LTEuODItLjc5NS0zLjU0LS44Mi0xLjgzOC0uMDI2LTIuOTk3LjQzNS0zLjcyNy44MzEtLjI0Ni4xMzQtLjYzNC0uMTMzLS40ODgtLjM3MnptLTI1LjE1NyAxLjI5YzIuMTctLjkwNyAzLjg3Ni0uNzkgNS4wODEtLjUwNC4yNTQuMDYuNDMtLjIxMy4yMjctLjM3Ny0uOTM1LS43NTUtMy4wMy0xLjY5Mi01Ljc2LS42NzQtMi40MzcuOTA5LTMuNTg1IDIuNzk2LTMuNTkyIDQuMDM4LS4wMDIuMjkyLjYuMzE3Ljc1Ni4wNy40Mi0uNjcgMS4xMi0xLjY0NiAzLjI4OS0yLjU1M3oiLz4KICAgICAgPHBhdGggY2xpcC1ydWxlPSJldmVub2RkIiBkPSJtNzUuNDQgNTUuOTJhMy40NyAzLjQ3IDAgMCAxIC0zLjQ3NC0zLjQ2MiAzLjQ3IDMuNDcgMCAwIDEgMy40NzUtMy40NiAzLjQ3IDMuNDcgMCAwIDEgMy40NzQgMy40NiAzLjQ3IDMuNDcgMCAwIDEgLTMuNDc1IDMuNDYyem0yLjQ0Ny00LjYwOGEuODk5Ljg5OSAwIDAgMCAtMS43OTkgMGMwIC40OTQuNDA1Ljg5NS45Ljg5NS40OTkgMCAuOS0uNC45LS44OTV6bS0yNS40NjQgMy41NDJhNC4wNDIgNC4wNDIgMCAwIDEgLTQuMDQ5IDQuMDM3IDQuMDQ1IDQuMDQ1IDAgMCAxIC00LjA1LTQuMDM3IDQuMDQ1IDQuMDQ1IDAgMCAxIDQuMDUtNC4wMzcgNC4wNDUgNC4wNDUgMCAwIDEgNC4wNSA0LjAzN3ptLTEuMTkzLTEuMzM4YTEuMDUgMS4wNSAwIDAgMCAtMi4wOTcgMCAxLjA0OCAxLjA0OCAwIDAgMCAyLjA5NyAweiIgZmlsbC1ydWxlPSJldmVub2RkIi8+CiAgICA8L2c+CiAgICA8cGF0aCBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Im02NCAxMTcuNzVjMjkuNjg1IDAgNTMuNzUtMjQuMDY1IDUzLjc1LTUzLjc1cy0yNC4wNjUtNTMuNzUtNTMuNzUtNTMuNzUtNTMuNzUgMjQuMDY1LTUzLjc1IDUzLjc1IDI0LjA2NSA1My43NSA1My43NSA1My43NXptMCA1YzMyLjQ0NyAwIDU4Ljc1LTI2LjMwMyA1OC43NS01OC43NXMtMjYuMzAzLTU4Ljc1LTU4Ljc1LTU4Ljc1LTU4Ljc1IDI2LjMwMy01OC43NSA1OC43NSAyNi4zMDMgNTguNzUgNTguNzUgNTguNzV6IiBmaWxsPSIjZmZmIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiLz4KPC9zdmc+');\n}\n\n/* Email tooltip specific */\n.tooltip__button--email {\n    flex-direction: column;\n    justify-content: center;\n    align-items: flex-start;\n    font-size: 14px;\n    padding: 4px 8px;\n}\n.tooltip__button--email__primary-text {\n    font-weight: bold;\n}\n.tooltip__button--email__secondary-text {\n    font-size: 12px;\n}\n\n/* Email Protection signup notice */\n:not(.top-autofill) .tooltip--email-signup {\n    text-align: left;\n    color: #222222;\n    padding: 16px 20px;\n    width: 380px;\n}\n\n.tooltip--email-signup h1 {\n    font-weight: 700;\n    font-size: 16px;\n    line-height: 1.5;\n    margin: 0;\n}\n\n.tooltip--email-signup p {\n    font-weight: 400;\n    font-size: 14px;\n    line-height: 1.4;\n}\n\n.notice-controls {\n    display: flex;\n}\n\n.tooltip--email-signup .notice-controls > * {\n    border-radius: 8px;\n    border: 0;\n    cursor: pointer;\n    display: inline-block;\n    font-family: inherit;\n    font-style: normal;\n    font-weight: bold;\n    padding: 8px 12px;\n    text-decoration: none;\n}\n\n.notice-controls .ghost {\n    margin-left: 1rem;\n}\n\n.tooltip--email-signup a.primary {\n    background: #3969EF;\n    color: #fff;\n}\n\n.tooltip--email-signup a.primary:hover,\n.tooltip--email-signup a.primary:focus {\n    background: #2b55ca;\n}\n\n.tooltip--email-signup a.primary:active {\n    background: #1e42a4;\n}\n\n.tooltip--email-signup button.ghost {\n    background: transparent;\n    color: #3969EF;\n}\n\n.tooltip--email-signup button.ghost:hover,\n.tooltip--email-signup button.ghost:focus {\n    background-color: rgba(0, 0, 0, 0.06);\n    color: #2b55ca;\n}\n\n.tooltip--email-signup button.ghost:active {\n    background-color: rgba(0, 0, 0, 0.12);\n    color: #1e42a4;\n}\n\n.tooltip--email-signup button.close-tooltip {\n    background-color: transparent;\n    background-image: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iMTMiIHZpZXdCb3g9IjAgMCAxMiAxMyIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0wLjI5Mjg5NCAwLjY1NjkwN0MwLjY4MzQxOCAwLjI2NjM4MyAxLjMxNjU4IDAuMjY2MzgzIDEuNzA3MTEgMC42NTY5MDdMNiA0Ljk0OThMMTAuMjkyOSAwLjY1NjkwN0MxMC42ODM0IDAuMjY2MzgzIDExLjMxNjYgMC4yNjYzODMgMTEuNzA3MSAwLjY1NjkwN0MxMi4wOTc2IDEuMDQ3NDMgMTIuMDk3NiAxLjY4MDYgMTEuNzA3MSAyLjA3MTEyTDcuNDE0MjEgNi4zNjQwMUwxMS43MDcxIDEwLjY1NjlDMTIuMDk3NiAxMS4wNDc0IDEyLjA5NzYgMTEuNjgwNiAxMS43MDcxIDEyLjA3MTFDMTEuMzE2NiAxMi40NjE2IDEwLjY4MzQgMTIuNDYxNiAxMC4yOTI5IDEyLjA3MTFMNiA3Ljc3ODIzTDEuNzA3MTEgMTIuMDcxMUMxLjMxNjU4IDEyLjQ2MTYgMC42ODM0MTcgMTIuNDYxNiAwLjI5Mjg5MyAxMi4wNzExQy0wLjA5NzYzMTEgMTEuNjgwNiAtMC4wOTc2MzExIDExLjA0NzQgMC4yOTI4OTMgMTAuNjU2OUw0LjU4NTc5IDYuMzY0MDFMMC4yOTI4OTQgMi4wNzExMkMtMC4wOTc2MzA2IDEuNjgwNiAtMC4wOTc2MzA2IDEuMDQ3NDMgMC4yOTI4OTQgMC42NTY5MDdaIiBmaWxsPSJibGFjayIgZmlsbC1vcGFjaXR5PSIwLjg0Ii8+Cjwvc3ZnPgo=);\n    background-position: center center;\n    background-repeat: no-repeat;\n    border: 0;\n    cursor: pointer;\n    padding: 16px;\n    position: absolute;\n    right: 12px;\n    top: 12px;\n}\n";
 
 },{}],52:[function(require,module,exports){
 "use strict";
@@ -12932,7 +13061,7 @@ var _autofillUtils = require("./autofill-utils.js");
   }
 })();
 
-},{"./DeviceInterface.js":12,"./autofill-utils.js":52,"./requestIdleCallback.js":64}],54:[function(require,module,exports){
+},{"./DeviceInterface.js":12,"./autofill-utils.js":52,"./requestIdleCallback.js":92}],54:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -13601,6 +13730,8 @@ async function extensionSpecificRuntimeConfiguration(deviceApi) {
       contentScope: contentScope,
       // @ts-ignore
       userPreferences: {
+        // Copy locale to user preferences as 'language' to match expected payload
+        language: contentScope.locale,
         features: {
           autofill: {
             settings: {
@@ -13822,6 +13953,2632 @@ function waitForWindowsResponse(responseId, options) {
 }
 
 },{"../../../packages/device-api/index.js":2}],64:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Здравей, свят",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Използване на {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Блокиране на имейл тракери",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Парола за {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Генерирана парола",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Паролата за този уебсайт ще бъде запазена",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Приложението Bitwarden е заключено",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Отключете своя трезор, за да получите достъп до идентификационни данни или да генерирате пароли",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Генериране на личен Duck Address",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Скрийте имейл адреса си и блокирайте тракерите",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Създайте уникален, произволен адрес, който премахва скритите тракери и препраща имейлите към пощенската Ви кутия.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Управление на запазените елементи…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Управление на кредитните карти…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Управление на самоличностите…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Управление на пароли…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Генериране на поверителен Duck Address",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Блокиране на имейл тракерите и скриване на адреса",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Защита на моя имейл",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Не показвай отново",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],65:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Ahoj, světe",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Použít {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Blokuj e-mailové trackery",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Heslo pro {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Vygenerované heslo",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Heslo pro tenhle web se uloží",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Aplikace Bitwarden je zamčená",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Pro přístup k přihlašovacím údajům a generování hesel je potřeba odemknout aplikaci Bitwarden",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Vygenerovat soukromou Duck Address",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Skryj svůj e-mail a blokuj trackery",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Vytvoř si jedinečnou, náhodnou adresu, která bude odstraňovat skryté trackery a přeposílat e-maily do tvé schránky.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Spravovat uložené položky…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Spravovat platební karty…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Spravovat identity…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Spravovat hesla…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Vygenerovat soukromou Duck Address",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Blokuj e-mailové trackery a skryj svou adresu",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Chránit můj e-mail",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Už neukazovat",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],66:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Hej verden",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Brug {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Blokerer e-mailtrackere",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Adgangskode til {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Genereret adgangskode",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Adgangskoden bliver gemt for dette websted",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Bitwarden er låst",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Lås din boks op for at få adgang til legitimationsoplysninger eller generere adgangskoder",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Opret privat Duck-adresse",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Skjul din e-mail og bloker trackere",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Opret en unik, tilfældig adresse, der også fjerner skjulte trackere og videresender e-mails til din indbakke.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Administrer gemte elementer…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Administrer kreditkort…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Administrer identiteter…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Administrer adgangskoder…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Opret en privat Duck-adresse",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Bloker e-mailtrackere og skjul adresse",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Beskyt min e-mail",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Vis ikke igen",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],67:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Hallo Welt",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "{email} verwenden",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "E-Mail-Tracker blockieren",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Passwort für {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Generiertes Passwort",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Passwort wird für diese Website gespeichert",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Bitwarden ist verschlossen",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Entsperre deinen Bitwarden-Datentresor, um auf deine Zugangsdaten zuzugreifen oder Passwörter zu generieren",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Private Duck-Adresse generieren",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "E-Mail-Adresse verbergen und Tracker blockieren",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Einmalige, zufällige Adresse erstellen, die versteckte Tracker entfernt und E-Mails an deinen Posteingang weiterleitet.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Gespeicherte Elemente verwalten …",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Kreditkarten verwalten …",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Identitäten verwalten …",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Passwörter verwalten …",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Private Duck Address generieren",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "E-Mail-Tracker blockieren & Adresse verbergen",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Meine E-Mail-Adresse schützen",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Nicht erneut anzeigen",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],68:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Γεια σου κόσμε",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Χρησιμοποιήστε τη διεύθυνση {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Αποκλεισμός εφαρμογών παρακολούθησης email",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Κωδικός πρόσβασης για {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Δημιουργήθηκε κωδικός πρόσβασης",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Ο κωδικός πρόσβασης θα αποθηκευτεί για τον ιστότοπο αυτό",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Το Bitwarden είναι κλειδωμένο",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Ξεκλειδώστε το θησαυροφυλάκιό σας για πρόσβαση σε διαπιστευτήρια ή δημιουργία κωδικών πρόσβασης",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Δημιουργήστε ιδιωτική Duck Address",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Απόκρυψη του email σας και αποκλεισμός εφαρμογών παρακολούθησης",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Δημιουργήστε μια μοναδική, τυχαία διεύθυνση η οποία αφαιρεί επίσης κρυφές εφαρμογές παρακολούθησης και προωθεί email στα εισερχόμενά σας.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Διαχείριση αποθηκευμένων στοιχείων…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Διαχείριση πιστωτικών καρτών…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Διαχείριση ταυτοτήτων…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Διαχείριση κωδικών πρόσβασης…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Δημιουργήστε μια ιδιωτική Duck Address",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Αποκλεισμός εφαρμογών παρακολούθησης email και απόκρυψη διεύθυνσης",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Προστασία του email μου",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Να μην εμφανιστεί ξανά",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],69:[function(require,module,exports){
+module.exports={
+  "smartling": {
+    "string_format": "icu",
+    "translate_paths": [
+      {
+        "path": "*/title",
+        "key": "{*}/title",
+        "instruction": "*/note"
+      }
+    ]
+  },
+  "hello": {
+    "title": "Hello world",
+    "note": "Static text for testing."
+  },
+  "lipsum": {
+    "title": "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note": "Placeholder text."
+  },
+  "usePersonalDuckAddr": {
+    "title": "Use {email}",
+    "note": "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers": {
+    "title": "Block email trackers",
+    "note": "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl": {
+    "title": "Password for {url}",
+    "note": "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword": {
+    "title": "Generated password",
+    "note": "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved": {
+    "title": "Password will be saved for this website",
+    "note": "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked": {
+    "title": "Bitwarden is locked",
+    "note": "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault": {
+    "title": "Unlock your vault to access credentials or generate passwords",
+    "note": "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr": {
+    "title": "Generate Private Duck Address",
+    "note": "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers": {
+    "title": "Hide your email and block trackers",
+    "note": "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr": {
+    "title": "Create a unique, random address that also removes hidden trackers and forwards email to your inbox.",
+    "note": "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems": {
+    "title": "Manage saved items…",
+    "note": "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards": {
+    "title": "Manage credit cards…",
+    "note": "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities": {
+    "title": "Manage identities…",
+    "note": "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords": {
+    "title": "Manage passwords…",
+    "note": "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr": {
+    "title": "Generate a Private Duck Address",
+    "note": "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress": {
+    "title": "Block email trackers & hide address",
+    "note": "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail": {
+    "title": "Protect My Email",
+    "note": "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain": {
+    "title": "Don't Show Again",
+    "note": "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],70:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Hola mundo",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Usar {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Bloquea de rastreadores de correo electrónico",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Contraseña para {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Contraseña generada",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Se guardará la contraseña de este sitio web",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Bitwarden está bloqueado",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Desbloquea tu caja fuerte para acceder a las credenciales o generar contraseñas",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Generar Duck Address privada",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Ocultar tu correo electrónico y bloquear rastreadores",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Crea una dirección aleatoria única que también elimine los rastreadores ocultos y reenvíe el correo electrónico a tu bandeja de entrada.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Gestionar elementos guardados…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Gestionar tarjetas de crédito…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Gestionar identidades…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Administrar contraseñas…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Generar Duck Address privada",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Bloquea rastreadores de correo electrónico y oculta la dirección",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Proteger mi correo electrónico",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "No volver a mostrar",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],71:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Tere maailm",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Kasutage {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Blokeeri e-posti jälgijad",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Saidi {url} parool",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Loodud parool",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Parool salvestatakse selle veebilehe jaoks",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Bitwarden on lukustatud",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Ava mandaatidele juurdepääsuks või paroolide loomiseks oma varamu",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Loo privaatne Duck Address",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Peida oma e-post ja blokeeri jälgijad",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Loo unikaalne, juhuslik aadress, mis eemaldab ka varjatud jäglijad ja edastab e-kirjad sinu postkasti.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Halda salvestatud üksuseid…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Halda krediitkaarte…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Halda identiteete…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Halda paroole…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Loo privaatne Duck Address",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Blokeeri e-posti jälgijad ja peida aadress",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Kaitse minu e-posti aadressi",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Ära enam näita",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],72:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Hei, maailma",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Käytä {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Estä sähköpostin seurantaohjelmat",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Sivuston {url} salasana",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Luotu salasana",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Salasana tallennetaan tälle verkkosivustolle",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Bitwarden on lukittu",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Avaa holvin lukitus päästäksesi käsiksi tunnistetietoihin tai luodaksesi salasanoja",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Luo yksityinen Duck Address",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Piilota sähköpostisi ja Estä seurantaohjelmat",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Luo yksilöllinen, satunnainen osoite, joka lisäksi poistaa piilotetut seurantaohjelmat ja välittää sähköpostin omaan postilaatikkoosi.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Hallitse tallennettuja kohteita…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Hallitse luottokortteja…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Hallitse käyttäjätietoja…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Hallitse salasanoja…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Luo yksityinen Duck Address",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Estä sähköpostin seurantaohjelmat ja piilota osoite",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Suojaa sähköpostini",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Älä näytä enää",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],73:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Bonjour à tous",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Utiliser {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Bloquer les traqueurs d'e-mails",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Mot de passe pour {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Mot de passe généré",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Le mot de passe sera enregistré pour ce site",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Bitwarden est verrouillé",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Déverrouillez votre coffre-fort pour accéder à vos informations d'identification ou générer des mots de passe",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Générer une Duck Address privée",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Masquez votre adresse e-mail et bloquez les traqueurs",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Créez une adresse unique et aléatoire qui supprime les traqueurs masqués et transfère les e-mails vers votre boîte de réception.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Gérez les éléments enregistrés…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Gérez les cartes bancaires…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Gérez les identités…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Gérer les mots de passe…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Générer une Duck Address privée",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Bloquer les traqueurs d'e-mails et masquer l'adresse",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Protéger mon adresse e-mail",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Ne plus afficher",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],74:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Pozdrav svijete",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Upotrijebite {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Blokiranje alata za praćenje e-pošte",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Lozinka za {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Generirana lozinka",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Lozinka će biti spremljena za ovo web-mjesto",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Bitwarden je zaključan",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Otključaj svoj trezor za pristup vjerodajnicama ili generiranje lozinki",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Generiraj privatnu adresu Duck Address",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Sakrij svoju e-poštu i blokiraj tragače",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Izradi jedinstvenu, nasumičnu adresu koja također uklanja skrivene alate za praćenje (\"tragače\") i prosljeđuje e-poštu u tvoj sandučić za pristiglu poštu.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Upravljanje spremljenim stavkama…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Upravljanje kreditnim karticama…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Upravljanje identitetima…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Upravljanje lozinkama…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Generiraj privatnu adresu Duck Address",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Blokiraj praćenje e-pošte i sakrij adresu",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Zaštiti moju e-poštu",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Nemoj ponovno prikazivati",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],75:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Helló, világ!",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "{email} használata",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "E-mail nyomkövetők blokkolása",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "{url} jelszava",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Generált jelszó",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "A webhelyhez tartozó jelszó mentve lesz",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "A Bitwarden zárolva van",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "A hitelesítő adatok eléréséhez vagy a jelszavak generálásához oldd fel a tárolót",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Privát Duck Address létrehozása",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "E-mail elrejtése és nyomkövetők blokkolása",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Hozz létre egy egyedi, véletlenszerű címet, amely eltávolítja a rejtett nyomkövetőket is, és a postafiókodba továbbítja az e-maileket.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Mentett elemek kezelése…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Hitelkártyák kezelése…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Identitások kezelése…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Jelszavak kezelése…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Privát Duck Address létrehozása",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "E-mail nyomkövetők blokkolása, és a cím elrejtése",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "E-mail védelme",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Ne jelenjen meg újra",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],76:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Ciao mondo",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Usa {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Blocca i sistemi di tracciamento e-mail",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Password per {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Password generata",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "La password verrà salvata per questo sito web",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Bitwarden è bloccato",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Sblocca la tua cassaforte per accedere alle credenziali o generare password",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Genera Duck Address privato",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Nascondi il tuo indirizzo e-mail e blocca i sistemi di tracciamento",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Crea un indirizzo univoco e casuale che rimuove anche i sistemi di tracciamento nascosti e inoltra le e-mail alla tua casella di posta.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Gestisci gli elementi salvati…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Gestisci carte di credito…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Gestisci identità…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Gestisci password…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Genera un Duck Address privato",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Blocca i sistemi di tracciamento e-mail e nascondi il tuo indirizzo",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Proteggi la mia e-mail",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Non mostrare più",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],77:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Labas pasauli",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Naudoti {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Blokuoti el. pašto sekimo priemones",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "„{url}“ slaptažodis",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Sugeneruotas slaptažodis",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Slaptažodis bus išsaugotas šiai svetainei",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "„Bitwarden“ užrakinta",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Atrakinkite saugyklą, kad pasiektumėte prisijungimo duomenis arba sugeneruotumėte slaptažodžius",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Generuoti privatų „Duck Address“",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Paslėpkite savo el. paštą ir blokuokite stebėjimo priemones",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Sukurkite unikalų atsitiktinį adresą, kuriuo taip pat pašalinamos slaptos sekimo priemonės ir el. laiškai persiunčiami į pašto dėžutę.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Tvarkykite išsaugotus elementus…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Tvarkykite kredito korteles…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Tvarkykite tapatybes…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Slaptažodžių valdymas…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Generuoti privatų „Duck Address“",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Blokuoti el. pašto stebėjimo priemones ir slėpti adresą",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Apsaugoti mano el. paštą",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Daugiau nerodyti",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],78:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Sveika, pasaule",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Izmantot {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Bloķē e-pasta izsekotājus",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "{url} parole",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Ģenerēta parole",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Parole tiks saglabāta šai vietnei",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Bitwarden ir bloķēts",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Atbloķē glabātavu, lai piekļūtu pieteikšanās datiem vai ģenerētu paroles",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Ģenerēt privātu Duck adresi",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Paslēp savu e-pastu un bloķē izsekotājus",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Izveido unikālu, nejauši izvēlētu adresi, kas arī aizvāc slēptos izsekotājus un pārsūta e-pastus uz tavu pastkastīti.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Pārvaldīt saglabātos vienumus…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Pārvaldīt kredītkartes…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Pārvaldīt identitātes",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Pārvaldīt paroles…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Ģenerēt privātu Duck adresi",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Bloķē e-pasta izsekotājus un paslēp adresi",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Aizsargāt manu e-pastu",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Turpmāk nerādīt",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],79:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Hallo verden",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Bruk {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Blokker e-postsporere",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Passord for {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Generert passord",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Passordet blir lagret for dette nettstedet",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Bitwarden er låst",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Lås opp hvelvet ditt for å få tilgang til legitimasjon eller generere passord",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Generer privat Duck Address",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Skjul e-postadressen din og blokker sporere",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Opprett en unik, tilfeldig adresse som også fjerner skjulte sporere og videresender e-post til innboksen din.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Administrer lagrede elementer…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Administrer kredittkort…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Administrer identiteter…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Administrer passord…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Generer en privat Duck Address",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Blokker e-postsporere og skjul adresse",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Beskytt e-postadressen min",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Ikke vis igjen",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],80:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Hallo wereld",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "{email} gebruiken",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "E-mailtrackers blokkeren",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Wachtwoord voor {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Gegenereerd wachtwoord",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Wachtwoord wordt opgeslagen voor deze website",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Bitwarden is vergrendeld",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Ontgrendelt je kluis om toegang te krijgen tot inloggegevens of om wachtwoorden te genereren",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Privé-Duck Address genereren",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Je e-mailadres verbergen en trackers blokkeren",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Maak een uniek, willekeurig adres dat ook verborgen trackers verwijdert en e-mails doorstuurt naar je inbox.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Opgeslagen items beheren…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Creditcards beheren…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Identiteiten beheren…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Wachtwoorden beheren…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Privé-Duck Address genereren",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "E-mailtrackers blokkeren en adres verbergen",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Mijn e-mailadres beschermen",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Niet meer weergeven",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],81:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Witajcie",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Użyj {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Blokuj mechanizmy śledzące pocztę e-mail",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Hasło do witryny {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Wygenerowane hasło",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Hasło zostanie zapisane na potrzeby tej witryny",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Aplikacja Bitwarden jest zablokowana",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Odblokuj sejf, aby uzyskać dostęp do poświadczeń lub generować hasła",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Wygeneruj prywatny adres Duck Address",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Ukryj swój adres e-mail i blokuj skrypty śledzące",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Utwórz unikalny, losowy adres, który usuwa ukryte mechanizmy śledzące i przekazuje wiadomości e-mail do Twojej skrzynki odbiorczej.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Zarządzaj zapisanymi elementami…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Zarządzaj kartami kredytowymi…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Zarządzaj tożsamościami…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Zarządzaj hasłami…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Wygeneruj prywatny adres Duck Address",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Zablokuj mechanizmy śledzące pocztę e-mail i ukryj adres",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Chroń moją pocztę e-mail",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Nie pokazuj więcej",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],82:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Olá, mundo",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Usar {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Bloquear rastreadores de e-mail",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Palavra-passe de {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Palavra-passe gerada",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "A palavra-passe deste site será guardada",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "O Bitwarden está bloqueado",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Desbloqueia o teu cofre para aceder a credenciais ou gerar palavras-passe",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Gerar um Duck Address privado",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Ocultar o teu e-mail e bloquear rastreadores",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Criar um endereço aleatório exclusivo que também remove rastreadores escondidos e encaminha o e-mail para a tua caixa de entrada.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Gerir itens guardados…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Gerir cartões de crédito…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Gerir identidades…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Gerir palavras-passe…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Gerar um Duck Address Privado",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Bloquear rastreadores de e-mail e ocultar endereço",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Proteger o meu e-mail",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Não mostrar novamente",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],83:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Salut!",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Utilizează {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Blochează tehnologiile de urmărire din e-mail",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Parola pentru {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Parola generată",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Parola va fi salvată pentru acest site",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Bitwarden este blocat",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Deblochează seiful pentru a accesa datele de conectare sau pentru a genera parole",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Generează o Duck Address privată",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Ascunde-ți e-mailul și blochează tehnologiile de urmărire",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Creează o adresă unică, aleatorie, care elimină și tehnologiile de urmărire ascunse și redirecționează e-mailurile către căsuța ta de inbox.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Gestionează elementele salvate…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Gestionează cardurile de credit…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Gestionează identitățile…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Gestionează parolele…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Generează o Duck Address privată",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Blochează tehnologiile de urmărire din e-mailuri și ascunde adresa",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Protejează-mi adresa de e-mail",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Nu mai afișa",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],84:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Привет, мир!",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Использовать {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Блокирует почтовые трекеры",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Пароль для {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Сгенерированный пароль",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Пароль будет сохранен для этого сайта",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Приложение Bitwarden заблокировано",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Разблокируйте хранилище, чтобы пользоваться учетными данными и генерировать пароли.",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Сгенерировать Duck Address",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Скрытие адреса почты и блокировка трекеров",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Создайте уникальный случайный адрес, который также удалит скрытые трекеры и перенаправит электронную почту на ваш ящик.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Настроить сохраненные данные…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Настроить платежные карты…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Настроить учетные данные…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Управление паролями…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Сгенерировать Duck Address",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Скрывает ваш адрес и Блокирует почтовые трекеры",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Защитить почту",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Больше не показывать",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],85:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Ahoj, svet!",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Použiť {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Blokuje e-mailové sledovače",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Heslo pre {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Vygenerované heslo",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Heslo pre túto webovú stránku bude uložené",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Bitwarden je uzamknutý",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Odomknite trezor pre prístup k prihlasovacím údajom alebo generovaniu hesiel",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Generovať súkromnú Duck Address",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Skryte svoj e-mail a blokujte sledovače",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Vytvorte si náhodnú jedinečnú adresu, ktorá odstráni aj skryté sledovacie prvky a prepošle e-maily do vašej schránky.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Spravovať uložené položky…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Spravovať kreditné karty…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Spravovať identity…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Spravovať heslá…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Generovať súkromnú Duck Address",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Blokujte sledovače e-mailov a skryte adresu",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Ochrana môjho e-mailu",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Nabudúce už neukazovať",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],86:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Pozdravljen, svet",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Uporabite {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Blokirajte sledilnike e-pošte",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Geslo za spletno mesto {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Ustvarjeno geslo",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Geslo bo shranjeno za to spletno mesto",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Bitwarden je zaklenjen",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Odklenite trezor za dostop do poverilnic ali ustvarjanje gesel",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Ustvarjanje zasebnega naslova Duck Address",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Skrijte svojo e-pošto in blokirajte sledilnike",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Ustvarite edinstven, naključen naslov, ki odstrani tudi skrite sledilnike in posreduje e-pošto v vaš e-poštni predal.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Upravljaj shranjene elemente…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Upravljaj kreditne kartice…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Upravljaj identitete…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Upravljanje gesel…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Ustvari zasebni naslov Duck Address",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Blokirajte sledilnike e-pošte in skrijte naslov",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Zaščiti mojo e-pošto",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Ne prikaži več",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],87:[function(require,module,exports){
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.getTranslator = getTranslator;
+var _translations = _interopRequireDefault(require("./translations.js"));
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+/** @typedef {`autofill:${keyof typeof translations["en"]["autofill"]}`} AutofillKeys */
+
+/**
+ * @callback TranslateFn
+ * Translates a string with the provided namespaced ID to the current language,
+ * replacing each placeholder with a key present in `opts` with the
+ * corresponding value.
+ *
+ * @param {AutofillKeys} id - the namespaced string ID to look up
+ * @param {Record<string, string>} [opts] - a set of optional replacements to perform
+ * @returns {string} the string with namespaced ID `id`, translated to the current language
+ */
+
+/**
+ * Builds a reusable translation function bound to the language provided by
+ * `settings`. That language isn't read until the first translation is
+ * requested, so it's safe to use this statically and assign `settings.language`
+ * later.
+ *
+ * @param {{ language: string }} settings - a settings object containing the current language
+ * @returns {TranslateFn} a translation function
+ */
+function getTranslator(settings) {
+  /** @type typeof translations["en"] */
+  let library;
+  return function t(id, opts) {
+    // Retrieve the library when the first string is translated, to allow
+    // InterfacePrototype.t() to be statically initialized.
+    if (!library) {
+      const {
+        language
+      } = settings;
+      library = _translations.default[language];
+      if (!library) {
+        console.warn(`Received unsupported locale '${language}'. Falling back to 'en'.`);
+        library = _translations.default.en;
+      }
+    }
+    return translateImpl(library, id, opts);
+  };
+}
+
+/**
+ * Looks up the string with the provided `id` in a `library`, performing
+ * key-value replacements on the translated string. If no string with ID `id` is
+ * found, `id` is returned unmodified.
+ * @param {typeof translations["en"]} library - a map of string IDs to translation
+ * @param {AutofillKeys} namespacedId - the namespaced string ID to translate (e.g. "autofill:hello")
+ * @param {Record<string, string>} [opts] - a set of optional replacements to perform
+ * @returns {string} the string with ID `id`, translated to the current language
+ */
+function translateImpl(library, namespacedId, opts) {
+  const [namespace, id] = namespacedId.split(':', 2);
+  const namespacedLibrary = library[namespace];
+
+  // Fall back to the message ID if an unsupported namespace is provided.
+  if (!namespacedLibrary) {
+    return id;
+  }
+  const msg = namespacedLibrary[id];
+  // Fall back to the message ID if an unsupported message is provided.
+  if (!msg) {
+    return id;
+  }
+
+  // Fast path: don't loop over opts if no replacements are provided.
+  if (!opts) {
+    return msg.title;
+  }
+
+  // Repeatedly replace all instances of '{SOME_REPLACEMENT_NAME}' with the
+  // corresponding value.
+  let out = msg.title;
+  for (const [name, value] of Object.entries(opts)) {
+    out = out.replaceAll(`{${name}}`, value);
+  }
+  return out;
+}
+
+},{"./translations.js":90}],88:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Hej världen",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "Använd {email}",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "Blockera e-postspårare",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "Lösenord för {url}",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Genererat lösenord",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Lösenordet sparas för den här webbplatsen",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Bitwarden är låst",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Lås upp ditt valv för att komma åt inloggningsuppgifter eller generera lösenord",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Generera privat Duck Address",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "Dölj din e-postadress och blockera spårare",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Skapa en unik, slumpmässig adress som också tar bort dolda spårare och vidarebefordrar e-post till din inkorg.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Hantera sparade objekt…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Hantera kreditkort…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Hantera identiteter…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Hantera lösenord…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Generera en privat Duck Address",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "Blockera e-postspårare och dölj din adress",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "Skydda min e-postadress",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Visa inte igen",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],89:[function(require,module,exports){
+module.exports={
+  "smartling" : {
+    "string_format" : "icu",
+    "translate_paths" : [
+    {
+      "path" : "*/title",
+      "key" : "{*}/title",
+      "instruction" : "*/note"
+    }]
+  },
+  "hello" : {
+    "title" : "Hello world",
+    "note" : "Static text for testing."
+  },
+  "lipsum" : {
+    "title" : "Lorem ipsum dolor sit amet, {foo} {bar}",
+    "note" : "Placeholder text."
+  },
+  "usePersonalDuckAddr" : {
+    "title" : "{email} kullan",
+    "note" : "Button that fills a form using a specific email address. The placeholder is the email address, e.g. \"Use test@duck.com\"."
+  },
+  "blockEmailTrackers" : {
+    "title" : "E-posta izleyicileri engelleyin",
+    "note" : "Label explaining that by using a duck.com address, email trackers will be blocked. \"Block\" is a verb in imperative form."
+  },
+  "passwordForUrl" : {
+    "title" : "{url} şifresi",
+    "note" : "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword" : {
+    "title" : "Oluşturulan şifre",
+    "note" : "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved" : {
+    "title" : "Şifre bu web sitesi için kaydedilecek",
+    "note" : "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked" : {
+    "title" : "Bitwarden kilitlendi",
+    "note" : "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault" : {
+    "title" : "Kimlik bilgilerine erişmek veya şifre oluşturmak için kasanızın kilidini açın",
+    "note" : "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr" : {
+    "title" : "Özel Duck Address Oluştur",
+    "note" : "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "hideEmailAndBlockTrackers" : {
+    "title" : "E-postanızı Gizleyin ve İzleyicileri Engelleyin",
+    "note" : "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr" : {
+    "title" : "Gizli izleyicileri de kaldıran ve e-postaları gelen kutunuza ileten benzersiz, rastgele bir adres oluşturun.",
+    "note" : "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems" : {
+    "title" : "Kaydedilen öğeleri yönetin…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards" : {
+    "title" : "Kredi kartlarını yönetin…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities" : {
+    "title" : "Kimlikleri yönetin…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords" : {
+    "title" : "Şifreleri yönet…",
+    "note" : "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr" : {
+    "title" : "Özel Duck Address Oluştur",
+    "note" : "Button that when clicked creates a new private email address and fills the corresponding field with the generated address. \"Generate\" is a verb in imperative form, and \"Duck Address\" is a proper noun that should not be translated."
+  },
+  "blockEmailTrackersAndHideAddress" : {
+    "title" : "E-posta izleyicileri engelleyin ve adresi gizleyin",
+    "note" : "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail" : {
+    "title" : "E-postamı Koru",
+    "note" : "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain" : {
+    "title" : "Bir Daha Gösterme",
+    "note" : "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+
+},{}],90:[function(require,module,exports){
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+var _autofill = _interopRequireDefault(require("./bg/autofill.json"));
+var _autofill2 = _interopRequireDefault(require("./cs/autofill.json"));
+var _autofill3 = _interopRequireDefault(require("./da/autofill.json"));
+var _autofill4 = _interopRequireDefault(require("./de/autofill.json"));
+var _autofill5 = _interopRequireDefault(require("./el/autofill.json"));
+var _autofill6 = _interopRequireDefault(require("./en/autofill.json"));
+var _autofill7 = _interopRequireDefault(require("./es/autofill.json"));
+var _autofill8 = _interopRequireDefault(require("./et/autofill.json"));
+var _autofill9 = _interopRequireDefault(require("./fi/autofill.json"));
+var _autofill10 = _interopRequireDefault(require("./fr/autofill.json"));
+var _autofill11 = _interopRequireDefault(require("./hr/autofill.json"));
+var _autofill12 = _interopRequireDefault(require("./hu/autofill.json"));
+var _autofill13 = _interopRequireDefault(require("./it/autofill.json"));
+var _autofill14 = _interopRequireDefault(require("./lt/autofill.json"));
+var _autofill15 = _interopRequireDefault(require("./lv/autofill.json"));
+var _autofill16 = _interopRequireDefault(require("./nb/autofill.json"));
+var _autofill17 = _interopRequireDefault(require("./nl/autofill.json"));
+var _autofill18 = _interopRequireDefault(require("./pl/autofill.json"));
+var _autofill19 = _interopRequireDefault(require("./pt/autofill.json"));
+var _autofill20 = _interopRequireDefault(require("./ro/autofill.json"));
+var _autofill21 = _interopRequireDefault(require("./ru/autofill.json"));
+var _autofill22 = _interopRequireDefault(require("./sk/autofill.json"));
+var _autofill23 = _interopRequireDefault(require("./sl/autofill.json"));
+var _autofill24 = _interopRequireDefault(require("./sv/autofill.json"));
+var _autofill25 = _interopRequireDefault(require("./tr/autofill.json"));
+var _autofill26 = _interopRequireDefault(require("./xa/autofill.json"));
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+/**
+ * This file is auto-generated by scripts/bundle-locales.mjs, based on the contents of the src/locales/ directory.
+ * Any manual changes in here will be overwritten on build!
+ */
+var _default = exports.default = {
+  bg: {
+    autofill: _autofill.default
+  },
+  cs: {
+    autofill: _autofill2.default
+  },
+  da: {
+    autofill: _autofill3.default
+  },
+  de: {
+    autofill: _autofill4.default
+  },
+  el: {
+    autofill: _autofill5.default
+  },
+  en: {
+    autofill: _autofill6.default
+  },
+  es: {
+    autofill: _autofill7.default
+  },
+  et: {
+    autofill: _autofill8.default
+  },
+  fi: {
+    autofill: _autofill9.default
+  },
+  fr: {
+    autofill: _autofill10.default
+  },
+  hr: {
+    autofill: _autofill11.default
+  },
+  hu: {
+    autofill: _autofill12.default
+  },
+  it: {
+    autofill: _autofill13.default
+  },
+  lt: {
+    autofill: _autofill14.default
+  },
+  lv: {
+    autofill: _autofill15.default
+  },
+  nb: {
+    autofill: _autofill16.default
+  },
+  nl: {
+    autofill: _autofill17.default
+  },
+  pl: {
+    autofill: _autofill18.default
+  },
+  pt: {
+    autofill: _autofill19.default
+  },
+  ro: {
+    autofill: _autofill20.default
+  },
+  ru: {
+    autofill: _autofill21.default
+  },
+  sk: {
+    autofill: _autofill22.default
+  },
+  sl: {
+    autofill: _autofill23.default
+  },
+  sv: {
+    autofill: _autofill24.default
+  },
+  tr: {
+    autofill: _autofill25.default
+  },
+  xa: {
+    autofill: _autofill26.default
+  }
+};
+
+},{"./bg/autofill.json":64,"./cs/autofill.json":65,"./da/autofill.json":66,"./de/autofill.json":67,"./el/autofill.json":68,"./en/autofill.json":69,"./es/autofill.json":70,"./et/autofill.json":71,"./fi/autofill.json":72,"./fr/autofill.json":73,"./hr/autofill.json":74,"./hu/autofill.json":75,"./it/autofill.json":76,"./lt/autofill.json":77,"./lv/autofill.json":78,"./nb/autofill.json":79,"./nl/autofill.json":80,"./pl/autofill.json":81,"./pt/autofill.json":82,"./ro/autofill.json":83,"./ru/autofill.json":84,"./sk/autofill.json":85,"./sl/autofill.json":86,"./sv/autofill.json":88,"./tr/autofill.json":89,"./xa/autofill.json":91}],91:[function(require,module,exports){
+module.exports={
+  "smartling": {
+    "string_format": "icu",
+    "translate_paths": [
+      {
+        "path": "*/title",
+        "key": "{*}/title",
+        "instruction": "*/note"
+      }
+    ]
+  },
+  "hello": {
+    "title": "H33ll00 wºrrld",
+    "note": "Static text for testing."
+  },
+  "lipsum": {
+    "title": "Lºrr3e3m 1p$$$um d00l1loor s!t @@mett, {foo} {bar}",
+    "note": "Placeholder text."
+  },
+  "usePersonalDuckAddr": {
+    "title": "Ü55££ {email}",
+    "note": "Shown when a user can choose their personal @duck.com address."
+  },
+  "blockEmailTrackers": {
+    "title": "Bl000ck €m@@@i1il1l träáåck33rr55",
+    "note": "Shown when a user can choose their personal @duck.com address on native platforms."
+  },
+  "passwordForUrl": {
+    "title": "Pa@assw0rdd ffoör {url}",
+    "note": "Button that fills a form's password field with the saved password for that site. The placeholder 'url' is URL of the matched site, e.g. 'https://example.duckduckgo.com'."
+  },
+  "generatedPassword": {
+    "title": "Gen33ratéééd pa@assw0rdd",
+    "note": "Label on a button that, when clicked, fills an automatically-created password into a signup form. \"Generated\" is an adjective in past tense."
+  },
+  "passwordWillBeSaved": {
+    "title": "Pa@assw0rdd wi11lll ß3 $avvved for thîï$s website",
+    "note": "Label explaining that the associated automatically-created password will be persisted for the current site when the form is submitted"
+  },
+  "bitwardenIsLocked": {
+    "title": "Bitwarden iiss löøcçk3d∂",
+    "note": "Label explaining that passwords are not available because the vault provided by third-party application Bitwarden has not been unlocked"
+  },
+  "unlockYourVault": {
+    "title": "Unlock yo0ur va@uült to acceé$$s crédeññtïåååls or gééneraåte pass55wººrds5",
+    "note": "Label explaining that users must unlock the third-party password manager Bitwarden before they can use passwords stored there or create new passwords"
+  },
+  "generatePrivateDuckAddr": {
+    "title": "Geññëérååte Priiivate Duck Addddrrreess",
+    "note": "Button that creates a new single-use email address and fills a form with that address. \"Generate\" is a verb in imperative form."
+  },
+  "hideEmailAndBlockTrackers": {
+    "title": "Hîïíde yo0øur ££m@il an∂∂∂ bllºck tr@cçck3rs",
+    "note": "Button title prompting users to use an randomly-generated email address. \"Hide\" and \"block\" are imperative verbs."
+  },
+  "createUniqueRandomAddr": {
+    "title": "ÇÇr3£ate @ üûún11que, r@@nd0øm ad∂dr3s5s that als0º r3mov3s hidd££n tr@cker$5$ and forwards em@@1l to your 1ñb0x.",
+    "note": "Button subtitle (paired with \"hideEmailAndBlockTrackers\") explaining that by creating a randomly-generated address, trackers within emails will also be blocked."
+  },
+  "manageSavedItems": {
+    "title": "Måanñageé s@@ved 17733m5…",
+    "note": "Button that when clicked allows users to add, edit, or delete one or more saved items used to fill forms on web pages. The type of item is indeterminate, so this is intentionally more vague than \"manageCreditCards\", \"manageIdentities\", and \"managePassworeds\". \"Manage\" is an imperative verb."
+  },
+  "manageCreditCards": {
+    "title": "Måanñageé ¢¢r£d17 ca®®®∂∂s…",
+    "note": "Button that when clicked allows users to add, edit, or delete one or more credit cards used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "manageIdentities": {
+    "title": "Måanñageé ¡d££nt11ties…",
+    "note": "Button that when clicked allows users to add, edit, or delete one or more identities. \"Manage\" is an imperative verb. An \"Identity\" (singular of \"identities\") is a noun representing the combiantion of name, birthday, physical address, email address, and phone number used to fill forms on a web page."
+  },
+  "managePasswords": {
+    "title": "Måanñageé p@å$$$wººr∂∂s…",
+    "note": "Button that when clicked allows users to add, edit, or delete one or more saved passwords used to fill forms on a web page. \"Manage\" is an imperative verb."
+  },
+  "generateDuckAddr": {
+    "title": "Géééner@te a Prîîîvate DDDuck Addréés$s",
+    "note": "Button that when clicked creates a new private email address and fills the corresponding field with the generated address."
+  },
+  "blockEmailTrackersAndHideAddress": {
+    "title": "Bloºøck £mååil tr@åack££rs && hïïïdéé ad∂dr33s5s$",
+    "note": "Label (paired with \"generateDuckAddr\") explaining the benefits of creating a private DuckDuckGo email address. \"Block\" and \"hide\" are imperative verbs."
+  },
+  "protectMyEmail": {
+    "title": "Prºº††£ct M¥¥ Em@@iîl",
+    "note": "Link that takes users to \"https://duckduckgo.com/email/start-incontext\", where they can sign up for DuckDuckGo email protection."
+  },
+  "dontShowAgain": {
+    "title": "Doøºnñ't Sh00w Ag@ååîn",
+    "note": "Button that prevents the DuckDuckGo email protection signup prompt from appearing again."
+  }
+}
+},{}],92:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {

--- a/node_modules/@duckduckgo/autofill/dist/shared-credentials.json
+++ b/node_modules/@duckduckgo/autofill/dist/shared-credentials.json
@@ -410,6 +410,15 @@
     "fromDomainsAreObsoleted": false
   },
   {
+    "from": [
+      "twitter.com"
+    ],
+    "to": [
+      "x.com"
+    ],
+    "fromDomainsAreObsoleted": true
+  },
+  {
     "shared": [
       "uspowerboating.com",
       "ussailing.org"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@duckduckgo/autoconsent": "^10.10.0",
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.2.0",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#12.0.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.21.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#3.5.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1708702034"
@@ -65,8 +65,9 @@
       "integrity": "sha512-ewY0Rrpp/FiFS8tf7qO4+iuAM5h/nSo8jdBQbpOQ1hI7aCP5pIdrZehJWIO7mkiNboVKAaP3p1WBhydIjfQDFA=="
     },
     "node_modules/@duckduckgo/autofill": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#6493e296934bf09277c03df45f11f4619711cb24",
-      "hasInstallScript": true
+      "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#18dd599f8c39e0c293768ec23316e36b683b3960",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
       "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#4689746e42b24c40c18896d697ea02b854e90d35",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@duckduckgo/autoconsent": "^10.10.0",
-    "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#10.2.0",
+    "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#12.0.0",
     "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.21.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#3.5.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1708702034"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207623126907992/1207623126907992
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/12.0.0


## Description
Updates Autofill to version [12.0.0](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/12.0.0).

### Autofill 12.0.0 release notes
* Major version bump to 12.0.0 caused by #396, which impacts only Android.
* This release also translates the autofill experience to the following language codes:
    * bg
    * cs
    * da
    * de
    * el
    * en
    * es
    * et
    * fi
    * fr
    * hr
    * hu
    * it
    * lt
    * lv
    * nb
    * nl
    * pl
    * pt
    * ro
    * ru
    * sk
    * sl
    * sv
    * tr


## What's Changed
* Ema/more minor fixes by @GioSensation in https://github.com/duckduckgo/duckduckgo-autofill/pull/556
* l10n: extract remaining strings to prepare for localization by @sjbarag in https://github.com/duckduckgo/duckduckgo-autofill/pull/558
* l10n: pull translated strings into separate JSON files by @sjbarag in https://github.com/duckduckgo/duckduckgo-autofill/pull/559
* Update password-related json files (2024-05-13) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/561
* Update password-related json files (2024-05-19) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/569
* vcs: ignore .helix directory by @sjbarag in https://github.com/duckduckgo/duckduckgo-autofill/pull/565
* l10n: remove placeholder from 'Manage ${ITEM}…' string by @sjbarag in https://github.com/duckduckgo/duckduckgo-autofill/pull/560
* real-world: remove expected failure from clientssp.fnfis.com test by @sjbarag in https://github.com/duckduckgo/duckduckgo-autofill/pull/563
* real-world: remove expected failure for agile.appian.com by @sjbarag in https://github.com/duckduckgo/duckduckgo-autofill/pull/567
* autofill: left-align HTML autofill buttons by @sjbarag in https://github.com/duckduckgo/duckduckgo-autofill/pull/571
* l10n: add translated messages by @sjbarag in https://github.com/duckduckgo/duckduckgo-autofill/pull/572
* passwords: require a digit in passwords generated from default rules by @sjbarag in https://github.com/duckduckgo/duckduckgo-autofill/pull/562
* classifiers: fix another batch of test page expected username failures by @sjbarag in https://github.com/duckduckgo/duckduckgo-autofill/pull/573
* Update password-related json files (2024-05-30) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/577
* Update password-related json files (2024-05-31) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/578
* l10n: update translations based on ship review feedback by @sjbarag in https://github.com/duckduckgo/duckduckgo-autofill/pull/581
* android: Revert "Android: enable iframe support (#536)" by @sjbarag in https://github.com/duckduckgo/duckduckgo-autofill/pull/582

## New Contributors
* @sjbarag made their first contribution in https://github.com/duckduckgo/duckduckgo-autofill/pull/558

**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/11.0.2...12.0.0

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).