### PR TITLE
Fix CustomTab crash/anr attribution

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/customtabs/CustomTabActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/customtabs/CustomTabActivity.kt
@@ -48,6 +48,7 @@ class CustomTabActivity : DuckDuckGoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        viewModel.onShowCustomTab()
 
         setContentView(binding.root)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1200581511062568/1207587829937580/f

### Description
Set the custom tab mode from `onCreate` in `CustomTabActivity`.

### Steps to test this PR

Check testing done on https://github.com/duckduckgo/Android/pull/4469

### NO UI changes
