### PR TITLE
Add autofill secondary KPIs

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -196,6 +196,7 @@ import com.duckduckgo.autofill.api.AutofillEventListener
 import com.duckduckgo.autofill.api.AutofillFragmentResultsPlugin
 import com.duckduckgo.autofill.api.AutofillScreens.AutofillSettingsScreenDirectlyViewCredentialsParams
 import com.duckduckgo.autofill.api.AutofillScreens.AutofillSettingsScreenShowSuggestionsForSiteParams
+import com.duckduckgo.autofill.api.AutofillSettingsLaunchSource
 import com.duckduckgo.autofill.api.BrowserAutofill
 import com.duckduckgo.autofill.api.Callback
 import com.duckduckgo.autofill.api.CredentialAutofillDialogFactory
@@ -2496,7 +2497,11 @@ class BrowserTabFragment :
             if (includeShortcutToViewCredential) {
                 snackbar.setAction(R.string.autofillSnackbarAction) {
                     context?.let {
-                        globalActivityStarter.start(it, AutofillSettingsScreenDirectlyViewCredentialsParams(loginCredentials))
+                        val screen = AutofillSettingsScreenDirectlyViewCredentialsParams(
+                            loginCredentials = loginCredentials,
+                            source = AutofillSettingsLaunchSource.BrowserSnackbar,
+                        )
+                        globalActivityStarter.start(it, screen)
                     }
                 }
             }
@@ -2505,7 +2510,11 @@ class BrowserTabFragment :
     }
 
     private fun launchAutofillManagementScreen() {
-        globalActivityStarter.start(requireContext(), AutofillSettingsScreenShowSuggestionsForSiteParams(webView?.url))
+        val screen = AutofillSettingsScreenShowSuggestionsForSiteParams(
+            currentUrl = webView?.url,
+            source = AutofillSettingsLaunchSource.BrowserOverflow,
+        )
+        globalActivityStarter.start(requireContext(), screen)
     }
 
     private fun showDialogHidingPrevious(
@@ -3427,6 +3436,7 @@ class BrowserTabFragment :
                     viewModel.onPrintSelected()
                 }
                 onMenuItemClicked(menuBinding.autofillMenuItem) {
+                    pixel.fire(AppPixelName.MENU_ACTION_AUTOFILL_PRESSED)
                     viewModel.onAutofillMenuSelected()
                 }
 

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -224,6 +224,7 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     MENU_ACTION_SETTINGS_PRESSED("m_nav_s_p"),
     MENU_ACTION_APP_LINKS_OPEN_PRESSED("m_nav_app_links_open_menu_item_pressed"),
     MENU_ACTION_DOWNLOADS_PRESSED("m_nav_downloads_menu_item_pressed"),
+    MENU_ACTION_AUTOFILL_PRESSED("m_nav_autofill_menu_item_pressed"),
 
     FIREPROOF_WEBSITE_ADDED("m_fw_a"),
     FIREPROOF_WEBSITE_REMOVE("m_fw_r"),

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
@@ -47,7 +47,8 @@ import com.duckduckgo.app.webtrackingprotection.WebTrackingProtectionScreenNoPar
 import com.duckduckgo.app.widget.AddWidgetLauncher
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.autoconsent.impl.ui.AutoconsentSettingsActivity
-import com.duckduckgo.autofill.api.AutofillScreens.AutofillSettingsScreenNoParams
+import com.duckduckgo.autofill.api.AutofillScreens.AutofillSettingsScreen
+import com.duckduckgo.autofill.api.AutofillSettingsLaunchSource
 import com.duckduckgo.browser.api.ui.BrowserScreens.SettingsScreenNoParams
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.view.gone
@@ -316,7 +317,7 @@ class SettingsActivity : DuckDuckGoActivity() {
 
     private fun launchAutofillSettings() {
         val options = ActivityOptions.makeSceneTransitionAnimation(this).toBundle()
-        globalActivityStarter.start(this, AutofillSettingsScreenNoParams, options)
+        globalActivityStarter.start(this, AutofillSettingsScreen(source = AutofillSettingsLaunchSource.SettingsActivity), options)
     }
 
     private fun launchAccessibilitySettings() {

--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillScreens.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillScreens.kt
@@ -23,20 +23,36 @@ sealed interface AutofillScreens {
 
     /**
      * Launch the Autofill management activity, which will show the full list of available credentials
+     * @param source is used to indicate from where in the app Autofill management activity was launched
      */
-    object AutofillSettingsScreenNoParams : ActivityParams {
-        private fun readResolve(): Any = AutofillSettingsScreenNoParams
-    }
+    data class AutofillSettingsScreen(val source: AutofillSettingsLaunchSource) : ActivityParams
 
     /**
      * Launch the Autofill management activity, which will show suggestions for the current url and the full list of available credentials
      * @param currentUrl The current URL the user is viewing. This is used to show suggestions for the current site if available.
+     * @param source is used to indicate from where in the app Autofill management activity was launched
      */
-    data class AutofillSettingsScreenShowSuggestionsForSiteParams(val currentUrl: String?) : ActivityParams
+    data class AutofillSettingsScreenShowSuggestionsForSiteParams(
+        val currentUrl: String?,
+        val source: AutofillSettingsLaunchSource,
+    ) : ActivityParams
 
     /**
      * Launch the Autofill management activity, directly showing particular credentials
      * @param loginCredentials jump directly into viewing mode for these credentials
+     * @param source is used to indicate from where in the app Autofill management activity was launched
      */
-    data class AutofillSettingsScreenDirectlyViewCredentialsParams(val loginCredentials: LoginCredentials) : ActivityParams
+    data class AutofillSettingsScreenDirectlyViewCredentialsParams(
+        val loginCredentials: LoginCredentials,
+        val source: AutofillSettingsLaunchSource,
+    ) : ActivityParams
+}
+
+enum class AutofillSettingsLaunchSource {
+    SettingsActivity,
+    BrowserOverflow,
+    Sync,
+    BrowserSnackbar,
+    InternalDevSettings,
+    Unknown,
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
@@ -67,8 +67,13 @@ enum class AutofillPixelNames(override val pixelName: String) : Pixel.PixelName 
     AUTOFILL_ENABLE_AUTOFILL_TOGGLE_MANUALLY_ENABLED("m_autofill_logins_settings_enabled"),
     AUTOFILL_ENABLE_AUTOFILL_TOGGLE_MANUALLY_DISABLED("m_autofill_logins_settings_disabled"),
 
-    MENU_ACTION_AUTOFILL_PRESSED("m_nav_autofill_menu_item_pressed"),
-    SETTINGS_AUTOFILL_MANAGEMENT_OPENED("m_autofill_settings_opened"),
+    AUTOFILL_MANAGEMENT_SCREEN_OPENED("m_autofill_management_opened"),
+    AUTOFILL_DELETE_LOGIN("m_autofill_management_delete_login"),
+    AUTOFILL_DELETE_ALL_LOGINS("m_autofill_management_delete_all_logins"),
+    AUTOFILL_MANUALLY_UPDATE_CREDENTIAL("m_autofill_management_update_login"),
+    AUTOFILL_MANUALLY_SAVE_CREDENTIAL("m_autofill_management_save_login"),
+    AUTOFILL_COPY_USERNAME("m_autofill_management_copy_username"),
+    AUTOFILL_COPY_PASSWORD("m_autofill_management_copy_password"),
 
     EMAIL_USE_ALIAS("email_filled_random"),
     EMAIL_USE_ADDRESS("email_filled_main"),

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModel.kt
@@ -22,19 +22,24 @@ import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.autofill.api.AutofillSettingsLaunchSource
+import com.duckduckgo.autofill.api.AutofillSettingsLaunchSource.BrowserOverflow
+import com.duckduckgo.autofill.api.AutofillSettingsLaunchSource.SettingsActivity
+import com.duckduckgo.autofill.api.AutofillSettingsLaunchSource.Sync
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.api.email.EmailManager
 import com.duckduckgo.autofill.impl.R
 import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator
 import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator.AuthConfiguration
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_DELETE_LOGIN
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENABLE_AUTOFILL_TOGGLE_MANUALLY_DISABLED
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENABLE_AUTOFILL_TOGGLE_MANUALLY_ENABLED
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_MANAGEMENT_SCREEN_OPENED
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_MANUALLY_SAVE_CREDENTIAL
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_NEVER_SAVE_FOR_THIS_SITE_CONFIRMATION_PROMPT_CONFIRMED
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_NEVER_SAVE_FOR_THIS_SITE_CONFIRMATION_PROMPT_DISMISSED
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_NEVER_SAVE_FOR_THIS_SITE_CONFIRMATION_PROMPT_DISPLAYED
-import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.MENU_ACTION_AUTOFILL_PRESSED
-import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.SETTINGS_AUTOFILL_MANAGEMENT_OPENED
 import com.duckduckgo.autofill.impl.store.InternalAutofillStore
 import com.duckduckgo.autofill.impl.store.NeverSavedSiteRepository
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsViewModel.Command.ExitCredentialMode
@@ -140,11 +145,13 @@ class AutofillSettingsViewModel @Inject constructor(
 
     fun onCopyUsername(username: String?) {
         username?.let { clipboardInteractor.copyToClipboard(it, isSensitive = false) }
+        pixel.fire(AutofillPixelNames.AUTOFILL_COPY_USERNAME)
         addCommand(ShowUserUsernameCopied())
     }
 
     fun onCopyPassword(password: String?) {
         password?.let { clipboardInteractor.copyToClipboard(it, isSensitive = true) }
+        pixel.fire(AutofillPixelNames.AUTOFILL_COPY_PASSWORD)
         addCommand(ShowUserPasswordCopied())
     }
 
@@ -424,6 +431,8 @@ class AutofillSettingsViewModel @Inject constructor(
     }
 
     fun onDeleteCredentials(loginCredentials: LoginCredentials) {
+        pixel.fire(AUTOFILL_DELETE_LOGIN)
+
         val credentialsId = loginCredentials.id ?: return
 
         viewModelScope.launch(dispatchers.io()) {
@@ -480,6 +489,8 @@ class AutofillSettingsViewModel @Inject constructor(
                 ),
             )
         }
+
+        pixel.fire(AutofillPixelNames.AUTOFILL_MANUALLY_UPDATE_CREDENTIAL)
     }
 
     private suspend fun saveNewCredential(updatedCredentials: LoginCredentials) {
@@ -494,6 +505,8 @@ class AutofillSettingsViewModel @Inject constructor(
                 ),
             )
         }
+
+        pixel.fire(AUTOFILL_MANUALLY_SAVE_CREDENTIAL)
     }
 
     fun onEnableAutofill() {
@@ -607,25 +620,21 @@ class AutofillSettingsViewModel @Inject constructor(
     }
 
     /**
-     * Responsible for sending pixels which were previously managed in the app module.
-     *
-     * There are multiple ways to launch this screen, which should map to existing pixels where they exist.
+     * There are multiple ways to launch this screen, so we include a source parameter to differentiate between them.
      */
-    fun sendLaunchPixel(
-        launchedFromBrowser: Boolean,
-        directLinkToCredentials: Boolean,
-    ) {
-        // no existing pixel for this scenario; don't want it to inflate other existing pixels
-        if (directLinkToCredentials) return
+    fun sendLaunchPixel(launchSource: AutofillSettingsLaunchSource) {
+        Timber.v("Opened autofill management screen from from %s", launchSource)
 
-        // map scenario onto existing pixels
-        val pixelName = if (launchedFromBrowser) {
-            MENU_ACTION_AUTOFILL_PRESSED
-        } else {
-            SETTINGS_AUTOFILL_MANAGEMENT_OPENED
+        val source = when (launchSource) {
+            SettingsActivity -> "settings"
+            BrowserOverflow -> "overflow_menu"
+            Sync -> "sync"
+            else -> null
         }
 
-        pixel.fire(pixelName)
+        if (source != null) {
+            pixel.fire(AUTOFILL_MANAGEMENT_SCREEN_OPENED, mapOf("source" to source))
+        }
     }
 
     fun onUserConfirmationToClearNeverSavedSites() {
@@ -669,6 +678,8 @@ class AutofillSettingsViewModel @Inject constructor(
             if (removedCredentials.isNotEmpty()) {
                 addCommand(OfferUserUndoMassDeletion(removedCredentials))
             }
+
+            pixel.fire(AutofillPixelNames.AUTOFILL_DELETE_ALL_LOGINS)
         }
     }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
@@ -27,6 +27,7 @@ import android.widget.CompoundButton
 import androidx.appcompat.app.ActionBar
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
+import androidx.core.content.ContextCompat.startActivity
 import androidx.core.graphics.drawable.toBitmap
 import androidx.core.view.MenuProvider
 import androidx.lifecycle.Lifecycle

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsInvalidItemsView.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsInvalidItemsView.kt
@@ -26,7 +26,8 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewTreeLifecycleOwner
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
 import com.duckduckgo.anvil.annotations.InjectWith
-import com.duckduckgo.autofill.api.AutofillScreens.AutofillSettingsScreenNoParams
+import com.duckduckgo.autofill.api.AutofillScreens.AutofillSettingsScreen
+import com.duckduckgo.autofill.api.AutofillSettingsLaunchSource
 import com.duckduckgo.autofill.impl.R
 import com.duckduckgo.autofill.impl.databinding.ViewCredentialsInvalidItemsWarningBinding
 import com.duckduckgo.autofill.sync.CredentialsInvalidItemsViewModel.Command
@@ -126,6 +127,6 @@ class CredentialsInvalidItemsView @JvmOverloads constructor(
     }
 
     private fun navigateToCredentials() {
-        globalActivityStarter.start(this.context, AutofillSettingsScreenNoParams)
+        globalActivityStarter.start(this.context, AutofillSettingsScreen(source = AutofillSettingsLaunchSource.Sync))
     }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsSyncPausedView.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsSyncPausedView.kt
@@ -25,7 +25,8 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewTreeLifecycleOwner
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
 import com.duckduckgo.anvil.annotations.InjectWith
-import com.duckduckgo.autofill.api.AutofillScreens.AutofillSettingsScreenNoParams
+import com.duckduckgo.autofill.api.AutofillScreens.AutofillSettingsScreen
+import com.duckduckgo.autofill.api.AutofillSettingsLaunchSource
 import com.duckduckgo.autofill.impl.databinding.ViewCredentialsSyncPausedWarningBinding
 import com.duckduckgo.autofill.sync.CredentialsSyncPausedViewModel.Command
 import com.duckduckgo.autofill.sync.CredentialsSyncPausedViewModel.Command.NavigateToCredentials
@@ -115,7 +116,7 @@ class CredentialsSyncPausedView @JvmOverloads constructor(
     }
 
     private fun navigateToCredentials() {
-        globalActivityStarter.start(this.context, AutofillSettingsScreenNoParams)
+        globalActivityStarter.start(this.context, AutofillSettingsScreen(source = AutofillSettingsLaunchSource.Sync))
     }
 
     companion object {

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModelTest.kt
@@ -21,16 +21,23 @@ import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelName
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
+import com.duckduckgo.autofill.api.AutofillSettingsLaunchSource.BrowserOverflow
+import com.duckduckgo.autofill.api.AutofillSettingsLaunchSource.BrowserSnackbar
+import com.duckduckgo.autofill.api.AutofillSettingsLaunchSource.SettingsActivity
+import com.duckduckgo.autofill.api.AutofillSettingsLaunchSource.Sync
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.api.email.EmailManager
 import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_COPY_PASSWORD
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_COPY_USERNAME
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_DELETE_LOGIN
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENABLE_AUTOFILL_TOGGLE_MANUALLY_DISABLED
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENABLE_AUTOFILL_TOGGLE_MANUALLY_ENABLED
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_MANAGEMENT_SCREEN_OPENED
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_NEVER_SAVE_FOR_THIS_SITE_CONFIRMATION_PROMPT_CONFIRMED
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_NEVER_SAVE_FOR_THIS_SITE_CONFIRMATION_PROMPT_DISMISSED
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_NEVER_SAVE_FOR_THIS_SITE_CONFIRMATION_PROMPT_DISPLAYED
-import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.MENU_ACTION_AUTOFILL_PRESSED
-import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.SETTINGS_AUTOFILL_MANAGEMENT_OPENED
 import com.duckduckgo.autofill.impl.store.InternalAutofillStore
 import com.duckduckgo.autofill.impl.store.NeverSavedSiteRepository
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsViewModel.Command
@@ -164,6 +171,12 @@ class AutofillSettingsViewModelTest {
     }
 
     @Test
+    fun whenUserCopiesPasswordPixelSent() = runTest {
+        testee.onCopyPassword("hello")
+        verify(pixel).fire(AUTOFILL_COPY_PASSWORD)
+    }
+
+    @Test
     fun whenUserCopiesUsernameThenCommandIssuedToShowChange() = runTest {
         testee.onCopyUsername("username")
 
@@ -175,10 +188,23 @@ class AutofillSettingsViewModelTest {
     }
 
     @Test
+    fun whenUserCopiesUsernameThenPixelSent() = runTest {
+        testee.onCopyUsername("username")
+        verify(pixel).fire(AUTOFILL_COPY_USERNAME)
+    }
+
+    @Test
     fun whenUserDeletesViewedCredentialsThenStoreDeletionCalled() = runTest {
         val credentials = someCredentials()
         testee.onDeleteCredentials(credentials)
         verify(mockStore).deleteCredentials(credentials.id!!)
+    }
+
+    @Test
+    fun whenUserDeletesViewedCredentialsThenPixelSent() = runTest {
+        val credentials = someCredentials()
+        testee.onDeleteCredentials(credentials)
+        verify(pixel).fire(AUTOFILL_DELETE_LOGIN)
     }
 
     @Test
@@ -370,6 +396,14 @@ class AutofillSettingsViewModelTest {
     }
 
     @Test
+    fun whenSaveNewCredentialsThenPixelSent() = runTest {
+        testee.onCreateNewCredentials()
+        val credentials = someCredentials()
+        testee.saveOrUpdateCredentials(credentials)
+        verify(pixel).fire(AutofillPixelNames.AUTOFILL_MANUALLY_SAVE_CREDENTIAL)
+    }
+
+    @Test
     fun whenUpdateCredentialsCalledThenUpdateAutofillStore() = runTest {
         val credentials = someCredentials()
         testee.onEditCredentials(credentials)
@@ -379,6 +413,18 @@ class AutofillSettingsViewModelTest {
         testee.saveOrUpdateCredentials(updatedCredentials)
 
         verify(mockStore).updateCredentials(updatedCredentials)
+    }
+
+    @Test
+    fun whenUpdateCredentialsCalledThenUpdatePixelSent() = runTest {
+        val credentials = someCredentials()
+        testee.onEditCredentials(credentials)
+
+        val updatedCredentials = credentials.copy(username = "helloworld123")
+        whenever(mockStore.updateCredentials(credentials)).thenReturn(updatedCredentials)
+        testee.saveOrUpdateCredentials(updatedCredentials)
+
+        verify(pixel).fire(AutofillPixelNames.AUTOFILL_MANUALLY_UPDATE_CREDENTIAL)
     }
 
     @Test
@@ -619,35 +665,27 @@ class AutofillSettingsViewModelTest {
     }
 
     @Test
-    fun whenScreenLaunchedDirectlyIntoCredentialViewThenNoLaunchPixelSent() {
-        val launchedFromBrowser = false
-        val directLinkToCredentials = true
-        testee.sendLaunchPixel(launchedFromBrowser, directLinkToCredentials)
+    fun whenScreenLaunchedFromSnackbarThenNoLaunchPixelSent() {
+        testee.sendLaunchPixel(BrowserSnackbar)
         verify(pixel, never()).fire(any<PixelName>(), any(), any(), eq(COUNT))
     }
 
     @Test
-    fun whenScreenLaunchedDirectlyIntoCredentialViewAndLaunchedFromBrowserThenNoLaunchPixelSent() {
-        val launchedFromBrowser = true
-        val directLinkToCredentials = true
-        testee.sendLaunchPixel(launchedFromBrowser, directLinkToCredentials)
-        verify(pixel, never()).fire(any<PixelName>(), any(), any(), eq(COUNT))
+    fun whenScreenLaunchedFromBrowserThenCorrectLaunchPixelSent() {
+        testee.sendLaunchPixel(BrowserOverflow)
+        verify(pixel).fire(eq(AUTOFILL_MANAGEMENT_SCREEN_OPENED), any(), any(), eq(COUNT))
     }
 
     @Test
-    fun whenScreenLaunchedFromBrowserAndNotDirectLinkThenCorrectLaunchPixelSent() {
-        val launchedFromBrowser = true
-        val directLinkToCredentials = false
-        testee.sendLaunchPixel(launchedFromBrowser, directLinkToCredentials)
-        verify(pixel).fire(eq(MENU_ACTION_AUTOFILL_PRESSED), any(), any(), eq(COUNT))
+    fun whenScreenLaunchedFromSyncThenCorrectLaunchPixelSent() {
+        testee.sendLaunchPixel(Sync)
+        verify(pixel).fire(eq(AUTOFILL_MANAGEMENT_SCREEN_OPENED), any(), any(), eq(COUNT))
     }
 
     @Test
-    fun whenScreenLaunchedNotFromBrowserAndNotDirectLinkThenCorrectLaunchPixelSent() {
-        val launchedFromBrowser = false
-        val directLinkToCredentials = false
-        testee.sendLaunchPixel(launchedFromBrowser, directLinkToCredentials)
-        verify(pixel).fire(eq(SETTINGS_AUTOFILL_MANAGEMENT_OPENED), any(), any(), eq(COUNT))
+    fun whenScreenLaunchedFromSettingsActivityThenCorrectLaunchPixelSent() {
+        testee.sendLaunchPixel(SettingsActivity)
+        verify(pixel).fire(eq(AUTOFILL_MANAGEMENT_SCREEN_OPENED), any(), any(), eq(COUNT))
     }
 
     @Test
@@ -723,6 +761,13 @@ class AutofillSettingsViewModelTest {
             awaitItem().verifyDoesHaveCommandToShowUndoDeletionSnackbar(1)
             cancelAndIgnoreRemainingEvents()
         }
+    }
+
+    @Test
+    fun whenAuthenticationSucceedsToMassDeletePasswordsThenPixelSent() = runTest {
+        whenever(mockStore.deleteAllCredentials()).thenReturn(listOf(someCredentials()))
+        testee.onAuthenticatedToDeleteAllPasswords()
+        verify(pixel).fire(AutofillPixelNames.AUTOFILL_DELETE_ALL_LOGINS)
     }
 
     @Test

--- a/autofill/autofill-internal/src/main/java/com/duckduckgo/autofill/internal/AutofillInternalSettingsActivity.kt
+++ b/autofill/autofill-internal/src/main/java/com/duckduckgo/autofill/internal/AutofillInternalSettingsActivity.kt
@@ -26,7 +26,8 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.autofill.api.AutofillFeature
-import com.duckduckgo.autofill.api.AutofillScreens.AutofillSettingsScreenNoParams
+import com.duckduckgo.autofill.api.AutofillScreens.AutofillSettingsScreen
+import com.duckduckgo.autofill.api.AutofillSettingsLaunchSource.InternalDevSettings
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.api.email.EmailManager
 import com.duckduckgo.autofill.impl.configuration.AutofillJavascriptEnvironmentConfiguration
@@ -272,7 +273,7 @@ class AutofillInternalSettingsActivity : DuckDuckGoActivity() {
         }
 
         binding.viewSavedLoginsButton.setClickListener {
-            globalActivityStarter.start(this, AutofillSettingsScreenNoParams)
+            globalActivityStarter.start(this, AutofillSettingsScreen(source = InternalDevSettings))
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203822806345703/1207602891714016/f 

### Description
Adds secondary KPIs for autofill.

### Steps to test this PR

Add the following logcat filter: 
```
"Opened autofill management screen" | "Pixel sent: m_autofill_management_opened" | "Pixel sent: m_autofill_management_delete_login" | "Pixel sent: m_autofill_management_delete_all_logins" | "Pixel sent: m_autofill_management_update_login" | "Pixel sent: m_autofill_management_save_login  | "Pixel sent: m_autofill_management_copy_username  | "Pixel sent: m_autofill_management_copy_password" 
```

#### Open password management screen, via browser overflow menu
- [x] From the browser activity, tap on the overflow button then `Passwords`
- [x] Verify you see `m_autofill_management_opened` in the logs, and source is `overflow_menu`

#### Open password management screen, via browser overflow menu
- [x] From the settings activity, tap on `Passwords`
- [x] Verify you see `m_autofill_management_opened` in the logs, and source is `settings`

#### Manually add password
- [x] From the password management screen, tap on ➕  button
- [x] Enter some details in the fields, and tap the ✔️  button
- [x] Verify you see `m_autofill_management_save_login` in the logs

#### Manually edit password (when viewing a credential)
- [x] When viewing a particular saved password (this is what you'll see after following last step), choose `overflow->Edit`
- [x] Edit some fields, and tap the ✔️  button
- [x] Verify you see `m_autofill_management_update_login` in the logs

#### Copy username
- [x] When viewing a particular saved password, tap the `copy` button in the username field
- [x] Verify you see `m_autofill_management_copy_username` in the logs

#### Copy password
- [x] When viewing a particular saved password, tap the `copy` button in the password field
- [x] Verify you see `m_autofill_management_copy_password ` in the logs

#### Delete password
- [x] Ensure you have >= 1 saved password
- [x] When viewing a particular saved password, choose `overflow->Delete`, and confirm when prompted
- [x] Verify you see `m_autofill_management_delete_login` in the logs


#### Delete all passwords
- [x] Ensure you have >= 1 saved password
- [x] From the password management screen, tap on overflow -> `Delete All Passwords`
- [x] Confirm and authenticate when prompted
- [x] Verify you see `m_autofill_management_delete_all_logins` in the logs