### PR TITLE
Update autofill to 12.0.1

### DIFF
--- a/node_modules/@duckduckgo/autofill/dist/autofill-debug.js
+++ b/node_modules/@duckduckgo/autofill/dist/autofill-debug.js
@@ -14751,15 +14751,22 @@ class Settings {
    * @param {{
    *   mainType: SupportedMainTypes
    *   subtype: import('./Form/matching.js').SupportedSubTypes | "unknown"
+   *   variant?: import('./Form/matching.js').SupportedVariants | ""
    * }} types
    * @returns {boolean}
    */
   isTypeUnavailable(_ref) {
     let {
       mainType,
-      subtype
+      subtype,
+      variant
     } = _ref;
     if (mainType === 'unknown') return true;
+
+    // Ensure password generation feature flag is respected
+    if (subtype === 'password' && variant === 'new') {
+      return !this.featureToggles.password_generation;
+    }
     if (!this.featureToggles[`inputType_${mainType}`] && subtype !== 'emailAddress') {
       return true;
     }
@@ -14780,17 +14787,20 @@ class Settings {
    * @param {{
    *   mainType: SupportedMainTypes
    *   subtype: import('./Form/matching.js').SupportedSubTypes | "unknown"
+   *   variant?: import('./Form/matching.js').SupportedVariants | ""
    * }} types
    * @returns {Promise<boolean>}
    */
   async populateDataIfNeeded(_ref2) {
     let {
       mainType,
-      subtype
+      subtype,
+      variant
     } = _ref2;
     if (this.isTypeUnavailable({
       mainType,
-      subtype
+      subtype,
+      variant
     })) return false;
     if (this.availableInputTypes?.[mainType] === undefined) {
       await this.populateData();
@@ -14818,7 +14828,8 @@ class Settings {
     } = _ref3;
     if (this.isTypeUnavailable({
       mainType,
-      subtype
+      subtype,
+      variant
     })) return false;
 
     // If it's an email field and Email Protection is enabled, return true regardless of other options

--- a/node_modules/@duckduckgo/autofill/dist/autofill.js
+++ b/node_modules/@duckduckgo/autofill/dist/autofill.js
@@ -10585,15 +10585,22 @@ class Settings {
    * @param {{
    *   mainType: SupportedMainTypes
    *   subtype: import('./Form/matching.js').SupportedSubTypes | "unknown"
+   *   variant?: import('./Form/matching.js').SupportedVariants | ""
    * }} types
    * @returns {boolean}
    */
   isTypeUnavailable(_ref) {
     let {
       mainType,
-      subtype
+      subtype,
+      variant
     } = _ref;
     if (mainType === 'unknown') return true;
+
+    // Ensure password generation feature flag is respected
+    if (subtype === 'password' && variant === 'new') {
+      return !this.featureToggles.password_generation;
+    }
     if (!this.featureToggles[`inputType_${mainType}`] && subtype !== 'emailAddress') {
       return true;
     }
@@ -10614,17 +10621,20 @@ class Settings {
    * @param {{
    *   mainType: SupportedMainTypes
    *   subtype: import('./Form/matching.js').SupportedSubTypes | "unknown"
+   *   variant?: import('./Form/matching.js').SupportedVariants | ""
    * }} types
    * @returns {Promise<boolean>}
    */
   async populateDataIfNeeded(_ref2) {
     let {
       mainType,
-      subtype
+      subtype,
+      variant
     } = _ref2;
     if (this.isTypeUnavailable({
       mainType,
-      subtype
+      subtype,
+      variant
     })) return false;
     if (this.availableInputTypes?.[mainType] === undefined) {
       await this.populateData();
@@ -10652,7 +10662,8 @@ class Settings {
     } = _ref3;
     if (this.isTypeUnavailable({
       mainType,
-      subtype
+      subtype,
+      variant
     })) return false;
 
     // If it's an email field and Email Protection is enabled, return true regardless of other options

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@duckduckgo/autoconsent": "^10.10.0",
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#12.0.0",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#12.0.1",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.21.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#3.5.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1708702034"
@@ -65,7 +65,7 @@
       "integrity": "sha512-ewY0Rrpp/FiFS8tf7qO4+iuAM5h/nSo8jdBQbpOQ1hI7aCP5pIdrZehJWIO7mkiNboVKAaP3p1WBhydIjfQDFA=="
     },
     "node_modules/@duckduckgo/autofill": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#18dd599f8c39e0c293768ec23316e36b683b3960",
+      "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#2b81745565db09eee8c1cd44d38eefa1011a9f0a",
       "hasInstallScript": true,
       "license": "Apache-2.0"
     },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@duckduckgo/autoconsent": "^10.10.0",
-    "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#12.0.0",
+    "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#12.0.1",
     "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.21.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#3.5.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1708702034"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207634174804391/1207634174804391
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/12.0.1


## Description
Updates Autofill to version [12.0.1](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/12.0.1).

### Autofill 12.0.1 release notes
## What's Changed
* generation: ensure password gen feature flag is respected by @sjbarag in https://github.com/duckduckgo/duckduckgo-autofill/pull/583

**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/12.0.0...12.0.1

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).