### PR TITLE
Round PopupMenu ripple corners

### DIFF
--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/menu/PopupMenu.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/menu/PopupMenu.kt
@@ -19,8 +19,11 @@ package com.duckduckgo.common.ui.menu
 import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import android.widget.PopupWindow
+import com.duckduckgo.common.ui.view.PopupMenuItemView
+import com.duckduckgo.mobile.android.R
 
 open class PopupMenu(
     layoutInflater: LayoutInflater,
@@ -33,6 +36,25 @@ open class PopupMenu(
     init {
         elevation = ELEVATION
         animationStyle = android.R.style.Animation_Dialog
+        applyRoundedRippleCorners()
+    }
+
+    private fun applyRoundedRippleCorners() {
+        (contentView as? ViewGroup)?.let { content ->
+            for (i in 0 until content.childCount) {
+                val childLabel = (content.getChildAt(i) as? PopupMenuItemView)
+                    ?.findViewById<com.duckduckgo.common.ui.view.text.DaxTextView>(R.id.label)
+
+                when {
+                    content.childCount == 1 -> R.drawable.ripple_rectangle_rounded
+                    i == 0 -> R.drawable.ripple_top_rounded
+                    i == content.childCount - 1 -> R.drawable.ripple_bottom_rounded
+                    else -> null
+                }?.let {
+                    childLabel?.setBackgroundResource(it)
+                }
+            }
+        }
     }
 
     fun onMenuItemClicked(

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/menu/PopupMenu.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/menu/PopupMenu.kt
@@ -23,6 +23,7 @@ import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import android.widget.PopupWindow
 import com.duckduckgo.common.ui.view.PopupMenuItemView
+import com.duckduckgo.common.ui.view.text.DaxTextView
 import com.duckduckgo.mobile.android.R
 
 open class PopupMenu(
@@ -43,7 +44,7 @@ open class PopupMenu(
         (contentView as? ViewGroup)?.let { content ->
             for (i in 0 until content.childCount) {
                 val childLabel = (content.getChildAt(i) as? PopupMenuItemView)
-                    ?.findViewById<com.duckduckgo.common.ui.view.text.DaxTextView>(R.id.label)
+                    ?.findViewById<DaxTextView>(R.id.label)
 
                 when {
                     content.childCount == 1 -> R.drawable.ripple_rectangle_rounded

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/menu/PopupMenu.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/menu/PopupMenu.kt
@@ -51,8 +51,8 @@ open class PopupMenu(
                     i == 0 -> R.drawable.ripple_top_rounded
                     i == content.childCount - 1 -> R.drawable.ripple_bottom_rounded
                     else -> null
-                }?.let {
-                    childLabel?.setBackgroundResource(it)
+                }?.let { backgroundResource ->
+                    childLabel?.setBackgroundResource(backgroundResource)
                 }
             }
         }

--- a/common/common-ui/src/main/res/drawable/ripple_bottom_rounded.xml
+++ b/common/common-ui/src/main/res/drawable/ripple_bottom_rounded.xml
@@ -19,7 +19,7 @@
     <item android:id="@android:id/mask">
         <shape android:shape="rectangle">
             <solid android:color="@color/black" />
-            <corners android:bottomLeftRadius=“@dimen/smallShapeCornerRadius" android:bottomRightRadius="@dimen/smallShapeCornerRadius" />
+            <corners android:bottomLeftRadius="@dimen/smallShapeCornerRadius" android:bottomRightRadius="@dimen/smallShapeCornerRadius" />
         </shape>
     </item>
 </ripple>

--- a/common/common-ui/src/main/res/drawable/ripple_bottom_rounded.xml
+++ b/common/common-ui/src/main/res/drawable/ripple_bottom_rounded.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2024 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?colorControlHighlight">
+    <item android:id="@android:id/mask">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/black" />
+            <corners android:bottomLeftRadius="8dp" android:bottomRightRadius="8dp" />
+        </shape>
+    </item>
+</ripple>

--- a/common/common-ui/src/main/res/drawable/ripple_bottom_rounded.xml
+++ b/common/common-ui/src/main/res/drawable/ripple_bottom_rounded.xml
@@ -19,7 +19,7 @@
     <item android:id="@android:id/mask">
         <shape android:shape="rectangle">
             <solid android:color="@color/black" />
-            <corners android:bottomLeftRadius="8dp" android:bottomRightRadius="8dp" />
+            <corners android:bottomLeftRadius=“@dimen/smallShapeCornerRadius" android:bottomRightRadius="@dimen/smallShapeCornerRadius" />
         </shape>
     </item>
 </ripple>

--- a/common/common-ui/src/main/res/drawable/ripple_rectangle_rounded.xml
+++ b/common/common-ui/src/main/res/drawable/ripple_rectangle_rounded.xml
@@ -19,7 +19,7 @@
     <item android:id="@android:id/mask">
         <shape android:shape="rectangle">
             <solid android:color="@color/black" />
-            <corners android:radius="8dp" />
+            <corners android:radius="@dimen/smallShapeCornerRadius" />
         </shape>
     </item>
 </ripple>

--- a/common/common-ui/src/main/res/drawable/ripple_top_rounded.xml
+++ b/common/common-ui/src/main/res/drawable/ripple_top_rounded.xml
@@ -19,7 +19,7 @@
     <item android:id="@android:id/mask">
         <shape android:shape="rectangle">
             <solid android:color="@color/black" />
-            <corners android:topLeftRadius=""@dimen/smallShapeCornerRadius" android:topRightRadius=""@dimen/smallShapeCornerRadius" />
+            <corners android:topLeftRadius="@dimen/smallShapeCornerRadius" android:topRightRadius="@dimen/smallShapeCornerRadius" />
         </shape>
     </item>
 </ripple>

--- a/common/common-ui/src/main/res/drawable/ripple_top_rounded.xml
+++ b/common/common-ui/src/main/res/drawable/ripple_top_rounded.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2024 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?colorControlHighlight">
+    <item android:id="@android:id/mask">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/black" />
+            <corners android:topLeftRadius="8dp" android:topRightRadius="8dp" />
+        </shape>
+    </item>
+</ripple>

--- a/common/common-ui/src/main/res/drawable/ripple_top_rounded.xml
+++ b/common/common-ui/src/main/res/drawable/ripple_top_rounded.xml
@@ -19,7 +19,7 @@
     <item android:id="@android:id/mask">
         <shape android:shape="rectangle">
             <solid android:color="@color/black" />
-            <corners android:topLeftRadius="8dp" android:topRightRadius="8dp" />
+            <corners android:topLeftRadius=""@dimen/smallShapeCornerRadius" android:topRightRadius=""@dimen/smallShapeCornerRadius" />
         </shape>
     </item>
 </ripple>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1200204095367872/1201672589972569/f

### Description

- Ensures that the first item's ripple has rounded corners on the top left and top right.

- Ensures that the last item's ripple has rounded corners on the bottom left and bottom right.

- If there is only one item in the `PopupMenu`, all of the ripple corners are rounded.

### Steps to test this PR

- [x] Add a favorite
- [x] Long press the favorite on a new tab
- [x] Long press the items in the `PopupMenu`
- [x] Verify that the ripple does not extend past the corners of the `PopupMenu`

### UI changes
| Before  | After |
| ------ | ----- |
![Screenshot_20240624_100616](https://github.com/duckduckgo/Android/assets/3471025/d0971784-d3af-4bca-b838-55299c89d880)|![Screenshot_20240624_100715](https://github.com/duckduckgo/Android/assets/3471025/e0b546b0-477a-44d8-9a7b-78cbd0398ffc)

