### PR TITLE
Use dummy subscriptions for fdroid flavor

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -308,7 +308,10 @@ dependencies {
 
     implementation project(':subscriptions-api')
 
-    implementation project(':subscriptions-impl')
+    internalImplementation project(':subscriptions-impl')
+    playImplementation project(':subscriptions-impl')
+    fdroidImplementation project(':subscriptions-dummy-impl')
+
     internalImplementation project(':subscriptions-internal')
 
     implementation project(':user-agent-api')

--- a/subscriptions/subscriptions-dummy-impl/build.gradle
+++ b/subscriptions/subscriptions-dummy-impl/build.gradle
@@ -39,9 +39,6 @@ android {
     anvil {
         generateDaggerFactories = true // default is false
     }
-    lint {
-        baseline file("lint-baseline.xml")
-    }
     testOptions {
         unitTests {
             includeAndroidResources = true

--- a/subscriptions/subscriptions-dummy-impl/build.gradle
+++ b/subscriptions/subscriptions-dummy-impl/build.gradle
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+    id 'com.squareup.anvil'
+}
+
+apply from: "$rootProject.projectDir/gradle/android-library.gradle"
+
+dependencies {
+    anvil project(path: ':anvil-compiler')
+    implementation project(':anvil-annotations')
+    implementation project(':di')
+    implementation project(':subscriptions-api')
+
+    implementation KotlinX.coroutines.android
+    implementation Google.dagger
+
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
+}
+
+android {
+    namespace "com.duckduckgo.subscriptions.dummy.impl"
+    anvil {
+        generateDaggerFactories = true // default is false
+    }
+    lint {
+        baseline file("lint-baseline.xml")
+    }
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
+    compileOptions {
+        coreLibraryDesugaringEnabled = true
+    }
+}
+

--- a/subscriptions/subscriptions-dummy-impl/lint-baseline.xml
+++ b/subscriptions/subscriptions-dummy-impl/lint-baseline.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.1.2" type="baseline" client="gradle" dependencies="false" name="AGP (8.1.2)" variant="all" version="8.1.2">
-
-</issues>

--- a/subscriptions/subscriptions-dummy-impl/lint-baseline.xml
+++ b/subscriptions/subscriptions-dummy-impl/lint-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.1.2" type="baseline" client="gradle" dependencies="false" name="AGP (8.1.2)" variant="all" version="8.1.2">
+
+</issues>

--- a/subscriptions/subscriptions-dummy-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsDummy.kt
+++ b/subscriptions/subscriptions-dummy-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsDummy.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl
+
+import android.content.Context
+import android.net.Uri
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.subscriptions.api.Product
+import com.duckduckgo.subscriptions.api.SubscriptionStatus
+import com.duckduckgo.subscriptions.api.SubscriptionStatus.UNKNOWN
+import com.duckduckgo.subscriptions.api.Subscriptions
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+@ContributesBinding(AppScope::class)
+class SubscriptionsDummy @Inject constructor() : Subscriptions {
+    override suspend fun getAccessToken(): String? = null
+
+    override fun getEntitlementStatus(): Flow<List<Product>> = flowOf(emptyList())
+
+    override suspend fun isEligible(): Boolean = false
+
+    override suspend fun getSubscriptionStatus(): SubscriptionStatus = UNKNOWN
+
+    override fun shouldLaunchPrivacyProForUrl(url: String): Boolean = false
+
+    override fun launchPrivacyPro(
+        context: Context,
+        uri: Uri?,
+    ) {
+        // no-op
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205648422731273/1207600736669442/f

### Description

This PR adds dummy implementation of subscriptions-api and makes the fdroid flavor of the app depend on it instead of the actual implementation. The goal is to remove dependency on Google Play Billing Library from the F-Droid builds of the app.

### Steps to test this PR

See task.

### No UI changes
