### PR TITLE
Pixels for importing passwords via desktop sync

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
@@ -21,6 +21,13 @@ import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENGAGEMENT
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENGAGEMENT_ENABLED_USER
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENGAGEMENT_ONBOARDED_USER
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENGAGEMENT_STACKED_LOGINS
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_PASSWORDS_COPIED_DESKTOP_LINK
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_PASSWORDS_CTA_BUTTON
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_PASSWORDS_GET_DESKTOP_BROWSER
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_PASSWORDS_OVERFLOW_MENU
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_PASSWORDS_SHARED_DESKTOP_LINK
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_PASSWORDS_SYNC_WITH_DESKTOP
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_PASSWORDS_USER_TOOK_NO_ACTION
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.EMAIL_TOOLTIP_DISMISSED
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.EMAIL_USE_ADDRESS
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.EMAIL_USE_ALIAS
@@ -111,6 +118,14 @@ enum class AutofillPixelNames(override val pixelName: String) : Pixel.PixelName 
     AUTOFILL_ENGAGEMENT_STACKED_LOGINS("m_autofill_logins_stacked"),
     AUTOFILL_TOGGLED_ON_SEARCH("m_autofill_toggled_on"),
     AUTOFILL_TOGGLED_OFF_SEARCH("m_autofill_toggled_off"),
+
+    AUTOFILL_IMPORT_PASSWORDS_CTA_BUTTON("m_autofill_logins_import_no_passwords"),
+    AUTOFILL_IMPORT_PASSWORDS_OVERFLOW_MENU("m_autofill_logins_import"),
+    AUTOFILL_IMPORT_PASSWORDS_GET_DESKTOP_BROWSER("m_autofill_logins_import_get_desktop"),
+    AUTOFILL_IMPORT_PASSWORDS_SYNC_WITH_DESKTOP("m_autofill_logins_import_sync"),
+    AUTOFILL_IMPORT_PASSWORDS_USER_TOOK_NO_ACTION("m_autofill_logins_import_no-action"),
+    AUTOFILL_IMPORT_PASSWORDS_COPIED_DESKTOP_LINK("m_get_desktop_copy"),
+    AUTOFILL_IMPORT_PASSWORDS_SHARED_DESKTOP_LINK("m_get_desktop_share"),
 }
 
 @ContributesMultibinding(
@@ -128,6 +143,14 @@ object AutofillPixelsRequiringDataCleaning : PixelParamRemovalPlugin {
             AUTOFILL_ENGAGEMENT_ENABLED_USER.pixelName to PixelParameter.removeAtb(),
             AUTOFILL_ENGAGEMENT_ONBOARDED_USER.pixelName to PixelParameter.removeAtb(),
             AUTOFILL_ENGAGEMENT_STACKED_LOGINS.pixelName to PixelParameter.removeAtb(),
+
+            AUTOFILL_IMPORT_PASSWORDS_CTA_BUTTON.pixelName to PixelParameter.removeAtb(),
+            AUTOFILL_IMPORT_PASSWORDS_OVERFLOW_MENU.pixelName to PixelParameter.removeAtb(),
+            AUTOFILL_IMPORT_PASSWORDS_GET_DESKTOP_BROWSER.pixelName to PixelParameter.removeAtb(),
+            AUTOFILL_IMPORT_PASSWORDS_SYNC_WITH_DESKTOP.pixelName to PixelParameter.removeAtb(),
+            AUTOFILL_IMPORT_PASSWORDS_USER_TOOK_NO_ACTION.pixelName to PixelParameter.removeAtb(),
+            AUTOFILL_IMPORT_PASSWORDS_COPIED_DESKTOP_LINK.pixelName to PixelParameter.removeAtb(),
+            AUTOFILL_IMPORT_PASSWORDS_SHARED_DESKTOP_LINK.pixelName to PixelParameter.removeAtb(),
         )
     }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/importpassword/ImportPasswordsActivity.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/importpassword/ImportPasswordsActivity.kt
@@ -20,6 +20,7 @@ import android.os.Bundle
 import androidx.annotation.StringRes
 import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
 import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.autofill.impl.R
 import com.duckduckgo.autofill.impl.databinding.ActivityImportPasswordsBinding
 import com.duckduckgo.autofill.impl.ui.credential.management.importpassword.desktopapp.GetDesktopAppParams
@@ -37,10 +38,14 @@ import javax.inject.Inject
 @ContributeToActivityStarter(ImportPasswordActivityParams::class)
 class ImportPasswordsActivity : DuckDuckGoActivity() {
 
-    val binding: ActivityImportPasswordsBinding by viewBinding()
+    private val viewModel: ImportPasswordsViewModel by bindViewModel()
+    private val binding: ActivityImportPasswordsBinding by viewBinding()
 
     @Inject
     lateinit var globalActivityStarter: GlobalActivityStarter
+
+    @Inject
+    lateinit var pixel: Pixel
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -54,9 +59,11 @@ class ImportPasswordsActivity : DuckDuckGoActivity() {
     private fun configureEventHandlers() {
         binding.getDesktopBrowserButton.setOnClickListener {
             globalActivityStarter.start(this, GetDesktopAppParams)
+            viewModel.onUserClickedGetDesktopAppButton()
         }
         binding.syncWithDesktopButton.setOnClickListener {
             globalActivityStarter.start(this, SyncActivityWithEmptyParams)
+            viewModel.onUserClickedSyncWithDesktopButton()
         }
     }
 
@@ -66,6 +73,15 @@ class ImportPasswordsActivity : DuckDuckGoActivity() {
             importFromDesktopInstructions2.applyHtml(R.string.autofillManagementImportPasswordsImportFromDesktopInstructionTwo)
             importFromDesktopInstructions3.applyHtml(R.string.autofillManagementImportPasswordsImportFromDesktopInstructionThree)
             importFromDesktopInstructions4.applyHtml(R.string.autofillManagementImportPasswordsImportFromDesktopInstructionFour)
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+
+        // if user is choosing to leave the screen
+        if (!isChangingConfigurations) {
+            viewModel.userLeavingScreen()
         }
     }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/importpassword/ImportPasswordsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/importpassword/ImportPasswordsViewModel.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.ui.credential.management.importpassword
+
+import androidx.lifecycle.ViewModel
+import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_PASSWORDS_GET_DESKTOP_BROWSER
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_PASSWORDS_SYNC_WITH_DESKTOP
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_PASSWORDS_USER_TOOK_NO_ACTION
+import com.duckduckgo.di.scopes.AppScope
+import javax.inject.Inject
+
+@ContributesViewModel(AppScope::class)
+class ImportPasswordsViewModel @Inject constructor(
+    private val pixel: Pixel,
+) : ViewModel() {
+
+    private var userTookAction = false
+
+    fun userLeavingScreen() {
+        if (!userTookAction) {
+            pixel.fire(AUTOFILL_IMPORT_PASSWORDS_USER_TOOK_NO_ACTION)
+        }
+    }
+
+    fun onUserClickedGetDesktopAppButton() {
+        pixel.fire(AUTOFILL_IMPORT_PASSWORDS_GET_DESKTOP_BROWSER)
+        userTookAction = true
+    }
+
+    fun onUserClickedSyncWithDesktopButton() {
+        pixel.fire(AUTOFILL_IMPORT_PASSWORDS_SYNC_WITH_DESKTOP)
+        userTookAction = true
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/importpassword/desktopapp/ImportPasswordsGetDesktopAppViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/importpassword/desktopapp/ImportPasswordsGetDesktopAppViewModel.kt
@@ -20,6 +20,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_PASSWORDS_COPIED_DESKTOP_LINK
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_PASSWORDS_SHARED_DESKTOP_LINK
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillClipboardInteractor
 import com.duckduckgo.autofill.impl.ui.credential.management.importpassword.desktopapp.ImportPasswordsGetDesktopAppViewModel.Command.ShareLink
 import com.duckduckgo.autofill.impl.ui.credential.management.importpassword.desktopapp.ImportPasswordsGetDesktopAppViewModel.Command.ShowCopiedNotification
@@ -51,6 +53,8 @@ class ImportPasswordsGetDesktopAppViewModel @Inject constructor(
     fun onShareClicked() {
         viewModelScope.launch {
             commandChannel.send(ShareLink(buildLink()))
+
+            pixel.fire(AUTOFILL_IMPORT_PASSWORDS_SHARED_DESKTOP_LINK)
         }
     }
 
@@ -61,6 +65,8 @@ class ImportPasswordsGetDesktopAppViewModel @Inject constructor(
             if (autofillClipboardInteractor.shouldShowCopyNotification()) {
                 commandChannel.send(ShowCopiedNotification)
             }
+
+            pixel.fire(AUTOFILL_IMPORT_PASSWORDS_COPIED_DESKTOP_LINK)
         }
     }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementListMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementListMode.kt
@@ -34,6 +34,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.RecyclerView
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.browser.favicon.FaviconManager
+import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.BrowserNav
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.impl.R
@@ -41,6 +42,8 @@ import com.duckduckgo.autofill.impl.databinding.FragmentAutofillManagementListMo
 import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator
 import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator.AuthConfiguration
 import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator.AuthResult.Success
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_PASSWORDS_CTA_BUTTON
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_PASSWORDS_OVERFLOW_MENU
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillManagementActivity
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillManagementRecyclerAdapter
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillManagementRecyclerAdapter.ContextMenuAction.CopyPassword
@@ -110,6 +113,9 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
     @Inject
     lateinit var globalActivityStarter: GlobalActivityStarter
 
+    @Inject
+    lateinit var pixel: Pixel
+
     val viewModel by lazy {
         ViewModelProvider(requireActivity(), viewModelFactory)[AutofillSettingsViewModel::class.java]
     }
@@ -151,6 +157,7 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
     private fun configureImportPasswordsButton() {
         binding.emptyStateLayout.importPasswordsButton.setOnClickListener {
             viewModel.onImportPasswords()
+            pixel.fire(AUTOFILL_IMPORT_PASSWORDS_CTA_BUTTON)
         }
     }
 
@@ -197,6 +204,7 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
 
                         R.id.importPasswords -> {
                             viewModel.onImportPasswords()
+                            pixel.fire(AUTOFILL_IMPORT_PASSWORDS_OVERFLOW_MENU)
                             true
                         }
 

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/importpassword/ImportPasswordsViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/importpassword/ImportPasswordsViewModelTest.kt
@@ -1,0 +1,34 @@
+package com.duckduckgo.autofill.impl.ui.credential.management.importpassword
+
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_PASSWORDS_USER_TOOK_NO_ACTION
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+
+class ImportPasswordsViewModelTest {
+
+    private val pixel: Pixel = mock()
+    private val testee = ImportPasswordsViewModel(pixel = pixel)
+
+    @Test
+    fun whenUserLeavesScreenWithoutTakingActionThenPixelSent() {
+        testee.userLeavingScreen()
+        verify(pixel).fire(AUTOFILL_IMPORT_PASSWORDS_USER_TOOK_NO_ACTION)
+    }
+
+    @Test
+    fun whenUserLeavesScreenAfterClickingDesktopAppButtonThenNoPixelSent() {
+        testee.onUserClickedGetDesktopAppButton()
+        testee.userLeavingScreen()
+        verify(pixel, never()).fire(AUTOFILL_IMPORT_PASSWORDS_USER_TOOK_NO_ACTION)
+    }
+
+    @Test
+    fun whenUserLeavesScreenAfterClickingSyncButtonThenNoPixelSent() {
+        testee.onUserClickedSyncWithDesktopButton()
+        testee.userLeavingScreen()
+        verify(pixel, never()).fire(AUTOFILL_IMPORT_PASSWORDS_USER_TOOK_NO_ACTION)
+    }
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/importpassword/desktopapp/ImportPasswordsGetDesktopAppViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/importpassword/desktopapp/ImportPasswordsGetDesktopAppViewModelTest.kt
@@ -1,0 +1,81 @@
+package com.duckduckgo.autofill.impl.ui.credential.management.importpassword.desktopapp
+
+import app.cash.turbine.test
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_PASSWORDS_COPIED_DESKTOP_LINK
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_PASSWORDS_SHARED_DESKTOP_LINK
+import com.duckduckgo.autofill.impl.ui.credential.management.AutofillClipboardInteractor
+import com.duckduckgo.autofill.impl.ui.credential.management.importpassword.desktopapp.ImportPasswordsGetDesktopAppViewModel.Command
+import com.duckduckgo.autofill.impl.ui.credential.management.importpassword.desktopapp.ImportPasswordsGetDesktopAppViewModel.Command.ShareLink
+import com.duckduckgo.autofill.impl.ui.credential.management.importpassword.desktopapp.ImportPasswordsGetDesktopAppViewModel.Command.ShowCopiedNotification
+import com.duckduckgo.common.test.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class ImportPasswordsGetDesktopAppViewModelTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+
+    private lateinit var testee: ImportPasswordsGetDesktopAppViewModel
+    private val pixel: Pixel = mock()
+    private val autofillClipboardInteractor: AutofillClipboardInteractor = mock()
+
+    @Before
+    fun setup() {
+        testee = ImportPasswordsGetDesktopAppViewModel(
+            pixel = pixel,
+            dispatchers = coroutineTestRule.testDispatcherProvider,
+            autofillClipboardInteractor = autofillClipboardInteractor,
+        )
+    }
+
+    @Test
+    fun whenLinkClickedThenCopiedToClipboard() = runTest {
+        testee.onLinkClicked()
+        verify(autofillClipboardInteractor).copyToClipboard(toCopy = any(), isSensitive = eq(false))
+    }
+
+    @Test
+    fun whenLinkCopiedToClipboardAndSystemNotificationNotShownThenWeShowOurOwnNotification() = runTest {
+        whenever(autofillClipboardInteractor.shouldShowCopyNotification()).thenReturn(true)
+        testee.onLinkClicked()
+        testee.commands.test {
+            awaitItem().assertIsShowNotification()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenLinkClickedThenPixelFired() = runTest {
+        testee.onLinkClicked()
+        verify(pixel).fire(AUTOFILL_IMPORT_PASSWORDS_COPIED_DESKTOP_LINK)
+    }
+
+    @Test
+    fun whenShareClickedThenCommandSent() = runTest {
+        testee.onShareClicked()
+        testee.commands.test {
+            val command = awaitItem().assertIsShareLink()
+            assertEquals("https://duckduckgo.com/browser?origin=funnel_browser_android_sync", command.link)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenShareClickedThenPixelFired() = runTest {
+        testee.onShareClicked()
+        verify(pixel).fire(AUTOFILL_IMPORT_PASSWORDS_SHARED_DESKTOP_LINK)
+    }
+
+    private fun Command.assertIsShareLink() = this as ShareLink
+    private fun Command.assertIsShowNotification() = this as ShowCopiedNotification
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1207657337829081/f 

### Description
General pixels for importing via desktop sync.

### Steps to test this PR

Suggested logcat filter: `"Pixel sent: "`

- [ ] Fresh install
- [ ] Visit password management screen

**Import Passwords (blue button)**
- [ ] Tap on blue "Import Passwords" button
- [ ] Verify `m_autofill_logins_import_no_passwords` in log

**No action taken**
- [ ] Tap back without doing anything else; verify `m_autofill_logins_import_no-action` in log

**Import Passwords (from overflow menu)**
- [ ] Manually add a password. Then return to password management screen
- [ ] Tap on overflow menu "Import Passwords"; verify `m_autofill_logins_import` in log

**Get Desktop Browser**
- [ ] Tap on `Get Desktop Browser` button; verify `m_autofill_logins_import_get_desktop` in log
- [ ] Tap blue `Share Download Link` button; verify `m_get_desktop_share` in log. Cancel share sheet.
- [ ] Tap on `duckduckgo.com/browser` link; verify `m_get_desktop_copy` in log


**Sync With Desktop**
- [ ] Tap back
- [ ] Tap `Sync With Desktop` button; verify `m_autofill_logins_import_sync` in log

