### PR TITLE
Update content scope scripts to version 5.23.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^10.10.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#12.0.1",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.22.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.23.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#3.5.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1708702034"
       },
@@ -266,9 +266,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.14.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
-      "integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
+      "version": "20.14.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
+      "integrity": "sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^10.10.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#12.0.1",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.22.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.23.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#3.5.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1708702034"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207662819078366/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass