### PR TITLE
Select the last tab and update selection after deleting the current tab

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDao.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDao.kt
@@ -93,7 +93,7 @@ abstract class TabsDao {
         if (selectedTab() != null) {
             return
         }
-        firstTab()?.let {
+        lastTab()?.let {
             insertTabSelection(TabSelectionEntity(tabId = it.tabId))
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabGridItemDecorator.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabGridItemDecorator.kt
@@ -86,7 +86,7 @@ class TabGridItemDecorator(
     }
 
     companion object {
-        private val BORDER_RADIUS = 9.toPx().toFloat()
+        private val BORDER_RADIUS = 15.toPx().toFloat()
         private val BORDER_WIDTH = 2.toPx().toFloat()
         private val BORDER_PADDING = 3.toPx().toFloat()
     }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabGridItemDecorator.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabGridItemDecorator.kt
@@ -86,7 +86,7 @@ class TabGridItemDecorator(
     }
 
     companion object {
-        private val BORDER_RADIUS = 15.toPx().toFloat()
+        private val BORDER_RADIUS = 9.toPx().toFloat()
         private val BORDER_WIDTH = 2.toPx().toFloat()
         private val BORDER_PADDING = 3.toPx().toFloat()
     }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -148,8 +148,18 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
     }
 
     private fun configureObservers() {
-        viewModel.tabs.observe(this) {
-            render(it)
+        viewModel.tabs.observe(this) { tabs ->
+            render(tabs)
+
+            val noTabSelected = tabs.none { it.tabId == tabGridItemDecorator.selectedTabId }
+            if (noTabSelected) {
+                updateTabGridItemDecorator(tabs.last())
+            }
+        }
+        viewModel.activeTab.observe(this) { tab ->
+            if (tab.tabId != tabGridItemDecorator.selectedTabId && !tab.deletable) {
+                updateTabGridItemDecorator(tab)
+            }
         }
         viewModel.deletableTabs.observe(this) {
             if (it.isNotEmpty()) {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -152,7 +152,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
             render(tabs)
 
             val noTabSelected = tabs.none { it.tabId == tabGridItemDecorator.selectedTabId }
-            if (noTabSelected) {
+            if (noTabSelected && tabs.isNotEmpty()) {
                 updateTabGridItemDecorator(tabs.last())
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -157,7 +157,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
             }
         }
         viewModel.activeTab.observe(this) { tab ->
-            if (tab.tabId != tabGridItemDecorator.selectedTabId && !tab.deletable) {
+            if (tab != null && tab.tabId != tabGridItemDecorator.selectedTabId && !tab.deletable) {
                 updateTabGridItemDecorator(tab)
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -40,6 +40,7 @@ class TabSwitcherViewModel @Inject constructor(
 ) : ViewModel() {
 
     var tabs: LiveData<List<TabEntity>> = tabRepository.liveTabs
+    val activeTab = tabRepository.liveSelectedTab
     var deletableTabs: LiveData<List<TabEntity>> = tabRepository.flowDeletableTabs.asLiveData(
         context = viewModelScope.coroutineContext,
     )


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202552961248957/1202148076467684/f

### Description
This PR selects the last tab in the list after the currently-selected tab is deleted. This fixes the behaviour when no tab was selected and when the user went back to the browser, the first tab was shown.

### Steps to test this PR

1. Create at least 3 tabs (with the last tab being selected)
2. Delete the last (selected) tab
3. Notice the tab is removed and the last of the remaining tab is selected
4. Tap on `Undo`
5. Notice the previous tab is shown and selected again
6. Delete the selected tab again
7. Tap on the back button
8. Notice the correct tab is shown

### UI changes
[Screen_recording_20240626_151442.webm](https://github.com/duckduckgo/Android/assets/1522856/2ae2fe33-275b-4eb8-a33c-62b647715d09)