### PR TITLE
Left-align text in individual overflow menus in password manager

### DIFF
--- a/autofill/autofill-impl/src/main/res/layout/overflow_menu_list_item.xml
+++ b/autofill/autofill-impl/src/main/res/layout/overflow_menu_list_item.xml
@@ -18,37 +18,36 @@
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
               xmlns:app="http://schemas.android.com/apk/res-auto"
-              xmlns:tools="http://schemas.android.com/tools"
               android:orientation="vertical"
               android:background="@drawable/popup_menu_bg">
 
-    <TextView
-        tools:ignore="DeprecatedWidgetInXml"
+    <com.duckduckgo.common.ui.view.PopupMenuItemView
         android:id="@+id/item_copy_username"
-        style="@style/Widget.DuckDuckGo.PopupMenuItem"
-        android:text="@string/credentialManagementEditButtonCopyUsername" />
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:primaryText="@string/credentialManagementEditButtonCopyUsername" />
 
-    <TextView
-        tools:ignore="DeprecatedWidgetInXml"
+    <com.duckduckgo.common.ui.view.PopupMenuItemView
         android:id="@+id/item_copy_password"
-        style="@style/Widget.DuckDuckGo.PopupMenuItem"
-        android:text="@string/credentialManagementEditButtonCopyPassword" />
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:primaryText="@string/credentialManagementEditButtonCopyPassword" />
 
     <com.duckduckgo.common.ui.view.divider.HorizontalDivider
         app:defaultPadding="false"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content" />
 
-    <TextView
-        tools:ignore="DeprecatedWidgetInXml"
+    <com.duckduckgo.common.ui.view.PopupMenuItemView
         android:id="@+id/item_overflow_edit"
-        style="@style/Widget.DuckDuckGo.PopupMenuItem"
-        android:text="@string/credentialManagementViewMenuEdit" />
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:primaryText="@string/credentialManagementViewMenuEdit" />
 
-    <TextView
-        tools:ignore="DeprecatedWidgetInXml"
+    <com.duckduckgo.common.ui.view.PopupMenuItemView
         android:id="@+id/item_overflow_delete"
-        style="@style/Widget.DuckDuckGo.PopupMenuItem"
-        android:text="@string/credentialManagementViewMenuDelete" />
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:primaryText="@string/credentialManagementViewMenuDelete" />
 
 </LinearLayout>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/608920331025315/1207675108702975/f 

### Description
Left-aligns the text for overflow menus of the individual passwords in the password management screen. This makes it consistent with such menus used elsewhere.

### Steps to test this PR
QA-optional

### UI changes
![combined](https://github.com/duckduckgo/Android/assets/1336281/1e0feb67-b31e-4650-bd36-aa24a3892794)
