### PR TITLE
Allow custom DNS on opportunistic DoT

### DIFF
--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/extensions/ContextExtensions.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/extensions/ContextExtensions.kt
@@ -24,15 +24,36 @@ import android.provider.Settings
 import androidx.core.content.ContextCompat
 import timber.log.Timber
 
+/**
+ * Constants for PrivateDnsMode
+ *
+ * "off" return when private DNS is off
+ * "opportunistic" return when private DNS is set to "automatic" aka opportunistic
+ * "hostname" return when private DNS is set to strict mode, aka user set a DNS
+ */
+private const val PRIVATE_DNS_MODE_OFF = "off"
+private const val PRIVATE_DNS_MODE_OPPORTUNISTIC = "opportunistic"
+private const val PRIVATE_DNS_MODE_STRICT = "hostname"
+
 fun Context.isPrivateDnsActive(): Boolean {
     var dnsMode = Settings.Global.getString(contentResolver, "private_dns_mode")
-    if (dnsMode == null) dnsMode = "off"
-    return "off" != dnsMode
+    if (dnsMode == null) dnsMode = PRIVATE_DNS_MODE_OFF
+    return PRIVATE_DNS_MODE_OFF != dnsMode
+}
+
+fun Context.isPrivateDnsAutomatic(): Boolean {
+    var dnsMode = Settings.Global.getString(contentResolver, "private_dns_mode")
+    return dnsMode == PRIVATE_DNS_MODE_OPPORTUNISTIC
+}
+
+fun Context.isPrivateDnsStrict(): Boolean {
+    var dnsMode = Settings.Global.getString(contentResolver, "private_dns_mode")
+    return dnsMode == PRIVATE_DNS_MODE_STRICT
 }
 
 fun Context.getPrivateDnsServerName(): String? {
     val dnsMode = Settings.Global.getString(contentResolver, "private_dns_mode")
-    return if ("hostname" == dnsMode) Settings.Global.getString(contentResolver, "private_dns_specifier") else null
+    return if (PRIVATE_DNS_MODE_STRICT == dnsMode) Settings.Global.getString(contentResolver, "private_dns_specifier") else null
 }
 
 fun Context.isAirplaneModeOn(): Boolean {

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/settings/custom_dns/VpnCustomDnsActivity.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/settings/custom_dns/VpnCustomDnsActivity.kt
@@ -31,7 +31,7 @@ import com.duckduckgo.common.ui.view.setEnabledOpacity
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
-import com.duckduckgo.common.utils.extensions.isPrivateDnsActive
+import com.duckduckgo.common.utils.extensions.isPrivateDnsStrict
 import com.duckduckgo.common.utils.extensions.launchSettings
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter.ActivityParams
@@ -125,7 +125,7 @@ class VpnCustomDnsActivity : DuckDuckGoActivity() {
             events
                 .flatMapLatest { viewModel.reduce(it) }
                 .flowOn(dispatcherProvider.io())
-                .onStart { events.emit(Init(this@VpnCustomDnsActivity.isPrivateDnsActive())) }
+                .onStart { events.emit(Init(this@VpnCustomDnsActivity.isPrivateDnsStrict())) }
                 .collect(::render)
         }
         binding.defaultDnsOption.setOnCheckedChangeListener(defaultDnsListener)

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/settings/custom_dns/VpnCustomDnsViewModel.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/settings/custom_dns/VpnCustomDnsViewModel.kt
@@ -53,11 +53,11 @@ class VpnCustomDnsViewModel @Inject constructor(
             CustomDnsSelected -> handleCustomDnsSelected()
             is CustomDnsEntered -> handleCustomDnsEntered(event)
             OnApply -> handleOnApply()
-            ForceApplyIfReset -> handleforceApply()
+            ForceApplyIfReset -> handleForceApply()
         }
     }
 
-    private fun handleforceApply() = flow {
+    private fun handleForceApply() = flow {
         if (netpVpnSettingsDataStore.customDns != null && currentState == DefaultDns) {
             netpVpnSettingsDataStore.customDns = null
             networkProtectionPixels.reportDefaultDnsSet()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202552961248957/1207692081807518/f

### Description
Remove the warning on custom DNS screen when private DNS is set to automatic

### Steps to test this PR

_Test automatic mode_
- [x] install from this branch
- [x] ensure private DNS is set to off
- [x] enable VPN and set VPN custom DNS to 1.1.1.1
- [x] verify custom DNS is correctly enabled
- [x] go android settings -> private DNS and set to `dns.google`
- [x] back to DDG app -> VPN custom DNS screen
- [x] verify warning "private DNS is already specified...turn off private DNS..." shows
- [x] verify internet connection works
- [x] verify DNS traffic is routed through Google (dnsleaktest.com)
- [x] go android settings -> private DNS and set to automatic
- [x] back to DDG app, VPN custom DNS screen
- [x] verify warning "private DNS is already specified...turn off private DNS..." does NOT show
- [x] verify internet connection works
- [x] verify DNS traffic is routed through Cloudflare (dnsleaktest.com)

