### PR TITLE
Fix printing IllegalStateException

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -5246,6 +5246,20 @@ class BrowserTabViewModelTest {
         verify(mockPixel).fire(ONBOARDING_VISIT_SITE_CUSTOM, type = UNIQUE)
     }
 
+    @Test
+    fun whenOnStartPrintThenIsPrintingTrue() {
+        testee.onStartPrint()
+        assertTrue(browserViewState().isPrinting)
+        assertTrue(testee.isPrinting())
+    }
+
+    @Test
+    fun whenOnStartPrintThenIsPrintingFalse() {
+        testee.onFinishPrint()
+        assertFalse(browserViewState().isPrinting)
+        assertFalse(testee.isPrinting())
+    }
+
     private fun aCredential(): LoginCredentials {
         return LoginCredentials(domain = null, username = null, password = null)
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -5254,7 +5254,7 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenOnStartPrintThenIsPrintingFalse() {
+    fun whenOnFinishPrintThenIsPrintingFalse() {
         testee.onFinishPrint()
         assertFalse(browserViewState().isPrinting)
         assertFalse(testee.isPrinting())

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -132,6 +132,7 @@ import com.duckduckgo.app.browser.omnibar.OmnibarScrolling
 import com.duckduckgo.app.browser.omnibar.animations.BrowserTrackersAnimatorHelper
 import com.duckduckgo.app.browser.omnibar.animations.PrivacyShieldAnimationHelper
 import com.duckduckgo.app.browser.omnibar.animations.TrackersAnimatorListener
+import com.duckduckgo.app.browser.print.PrintDocumentAdapterFactory
 import com.duckduckgo.app.browser.print.PrintInjector
 import com.duckduckgo.app.browser.remotemessage.SharePromoLinkRMFBroadCastReceiver
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
@@ -3990,8 +3991,15 @@ class BrowserTabFragment :
         url: String,
         defaultMediaSize: PrintAttributes.MediaSize,
     ) {
+        if (viewModel.isPrinting()) return
+
         (activity?.getSystemService(Context.PRINT_SERVICE) as? PrintManager)?.let { printManager ->
-            webView?.createPrintDocumentAdapter(url)?.let { printAdapter ->
+            webView?.createPrintDocumentAdapter(url)?.let { webViewPrintDocumentAdapter ->
+                val printAdapter = PrintDocumentAdapterFactory.createPrintDocumentAdapter(
+                    webViewPrintDocumentAdapter,
+                    onStartCallback = { viewModel.onStartPrint() },
+                    onFinishCallback = { viewModel.onFinishPrint() },
+                )
                 printManager.print(
                     url,
                     printAdapter,

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -3239,6 +3239,20 @@ class BrowserTabViewModel @Inject constructor(
         replyProxyMap[originUrl] = replyProxy
     }
 
+    fun onStartPrint() {
+        Timber.d("Print started")
+        browserViewState.value = currentBrowserViewState().copy(isPrinting = true)
+    }
+
+    fun onFinishPrint() {
+        Timber.d("Print finished")
+        browserViewState.value = currentBrowserViewState().copy(isPrinting = false)
+    }
+
+    fun isPrinting(): Boolean {
+        return currentBrowserViewState().isPrinting
+    }
+
     companion object {
         private const val FIXED_PROGRESS = 50
 

--- a/app/src/main/java/com/duckduckgo/app/browser/print/PrintDocumentAdapterFactory.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/print/PrintDocumentAdapterFactory.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.print
+
+import android.os.Bundle
+import android.os.CancellationSignal
+import android.os.ParcelFileDescriptor
+import android.print.PageRange
+import android.print.PrintAttributes
+import android.print.PrintDocumentAdapter
+
+class PrintDocumentAdapterFactory {
+    companion object {
+        fun createPrintDocumentAdapter(
+            printDocumentAdapter: PrintDocumentAdapter,
+            onStartCallback: () -> Unit,
+            onFinishCallback: () -> Unit,
+        ): PrintDocumentAdapter {
+            return object : PrintDocumentAdapter() {
+                override fun onStart() {
+                    printDocumentAdapter.onStart()
+                    onStartCallback()
+                }
+
+                override fun onLayout(
+                    oldAttributes: PrintAttributes?,
+                    newAttributes: PrintAttributes?,
+                    cancellationSignal: CancellationSignal?,
+                    callback: LayoutResultCallback?,
+                    extras: Bundle?,
+                ) {
+                    printDocumentAdapter.onLayout(oldAttributes, newAttributes, cancellationSignal, callback, extras)
+                }
+
+                override fun onWrite(
+                    pages: Array<out PageRange>?,
+                    destination: ParcelFileDescriptor?,
+                    cancellationSignal: CancellationSignal?,
+                    callback: WriteResultCallback?,
+                ) {
+                    printDocumentAdapter.onWrite(pages, destination, cancellationSignal, callback)
+                }
+
+                override fun onFinish() {
+                    printDocumentAdapter.onFinish()
+                    onFinishCallback()
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/print/SinglePrintSafeguardFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/print/SinglePrintSafeguardFeature.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.print
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "singlePrintSafeguard",
+)
+
+interface SinglePrintSafeguardFeature {
+
+    @Toggle.DefaultValue(true)
+    fun self(): Toggle
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/viewstate/BrowserViewState.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/viewstate/BrowserViewState.kt
@@ -53,6 +53,7 @@ data class BrowserViewState(
     val canFindInPage: Boolean = false,
     val forceRenderingTicker: Long = System.currentTimeMillis(),
     val canPrintPage: Boolean = false,
+    val isPrinting: Boolean = false,
     val showAutofill: Boolean = false,
     val browserError: WebViewErrorResponse = WebViewErrorResponse.OMITTED,
     val sslError: SSLErrorType = SSLErrorType.NONE,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1200204095367872/1207700638247735/f

### Description
Fixes an IllegalStateException that is thrown when a printing job is already pending.

### Steps to test this PR

_Printing pages_
- [x] Visit a web site
- [x] Select “Print Page"
- [x] Verify that you see “Print started” in logcat
- [x] Print the page (I tested to PDF)
- [x] Verify that the page prints successfully
- [x] Verify that you see “Print finished” in logcat
- [x] Repeat the above steps

_Cancelling a print_
- [x] Visit a web site
- [x] Select “Print Page"
- [x] Verify that you see “Print started” in logcat
- [x] Go back
- [x] Verify that you see “Print finished” in logcat

_Feature toggle (Disabled)_
- [x] Point at the JSON blob linked in the task
- [x] Visit a web site
- [x] Select “Print Page"
- [x] Verify that you do not see “Print started” in logcat
- [x] Go back
- [x] Verify that you do not see “Print finished” in logcat

