### PR TITLE
Custom DNS fixes in VPN Screen

### DIFF
--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/management/NetworkProtectionManagementActivity.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/management/NetworkProtectionManagementActivity.kt
@@ -41,6 +41,7 @@ import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.extensions.isPrivateDnsStrict
 import com.duckduckgo.common.utils.extensions.launchAlwaysOnSystemSettings
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
@@ -63,6 +64,7 @@ import com.duckduckgo.networkprotection.impl.management.NetworkProtectionManagem
 import com.duckduckgo.networkprotection.impl.management.NetworkProtectionManagementViewModel.ViewState
 import com.duckduckgo.networkprotection.impl.management.alwayson.NetworkProtectionAlwaysOnDialogFragment
 import com.duckduckgo.networkprotection.impl.settings.NetPVpnSettingsScreenNoParams
+import com.duckduckgo.networkprotection.impl.settings.custom_dns.VpnCustomDnsScreen
 import com.duckduckgo.networkprotection.impl.settings.geoswitching.NetpGeoswitchingScreenNoParams
 import javax.inject.Inject
 import kotlinx.coroutines.flow.launchIn
@@ -152,6 +154,10 @@ class NetworkProtectionManagementActivity : DuckDuckGoActivity() {
                     WebViewActivityWithParams(url = VPN_HELP_CENTER_URL, screenTitle = getString(R.string.netpFaqTitle)),
                 )
             }
+        }
+
+        binding.connectionDetails.connectionDetailsDns.setClickListener {
+            globalActivityStarter.start(this, VpnCustomDnsScreen.Default)
         }
         configureHeaderAnimation()
     }
@@ -251,7 +257,7 @@ class NetworkProtectionManagementActivity : DuckDuckGoActivity() {
         connectionDetails.transmittedText.text = formatFileSize(applicationContext, connectionDetailsData.transmittedData)
         connectionDetails.receivedText.text = formatFileSize(applicationContext, connectionDetailsData.receivedData)
 
-        if (connectionDetailsData.customDns.isNullOrEmpty()) {
+        if (connectionDetailsData.customDns.isNullOrEmpty() || this@NetworkProtectionManagementActivity.isPrivateDnsStrict()) {
             connectionDetails.connectionDetailsDns.gone()
         } else {
             connectionDetails.connectionDetailsDns.show()

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/settings/custom_dns/VpnCustomDnsSettingView.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/settings/custom_dns/VpnCustomDnsSettingView.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.anvil.annotations.PriorityKey
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.extensions.isPrivateDnsStrict
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
@@ -105,10 +106,14 @@ class VpnCustomDnsSettingView @JvmOverloads constructor(
     }
 
     private fun render(state: State) {
-        when (state) {
-            Idle -> { }
-            is CustomDns -> binding.customDnsSetting.setSecondaryText(state.serverName)
-            Default -> binding.customDnsSetting.setSecondaryText(context.getString(R.string.netpCustomDnsDefault))
+        if (this@VpnCustomDnsSettingView.context.isPrivateDnsStrict()) {
+            binding.customDnsSetting.setSecondaryText(context.getString(R.string.netpPrivateDns))
+        } else {
+            when (state) {
+                Idle -> {}
+                is CustomDns -> binding.customDnsSetting.setSecondaryText(state.serverName)
+                Default -> binding.customDnsSetting.setSecondaryText(context.getString(R.string.netpCustomDnsDefault))
+            }
         }
     }
 

--- a/network-protection/network-protection-impl/src/main/res/values/donottranslate.xml
+++ b/network-protection/network-protection-impl/src/main/res/values/donottranslate.xml
@@ -215,6 +215,7 @@
     <!-- Custom DNS -->
     <string name="netpSetttingDnsHeader">DNS</string>
     <string name="netpCustomDnsSettingText">DNS Server</string>
+    <string name="netpPrivateDns">Private DNS</string>
     <string name="netpCustomDnsDefault">DuckDuckGo</string>
     <string name="netpCustomDnsDefaultOption">DuckDuckGo (Recommended)</string>
     <string name="netpCustomDnsCustom">Custom</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207614156872048/f

### Description

### Steps to test this PR
- [x] Apply patch https://app.asana.com/0/0/1207703837738314/f
- [x] Install build
- [x] Buy subscription
- [x] Enable VPN
- [x] Open VPN Screen
- [x] Verify the DNS is not visible in connection details 
- [x] Go to VPN Screen > VPN Settings > DNS Server
- [x] Set custom DNS to `1.1.1.1` (Cloudflare)
- [x] Go back to VPN Screen
- [x] Verify the DNS shows in connection details with `1.1.1.1` value.
- [x] Click on Connection Details DNS Server
- [x] Verify that Custom DNS screen is shown
- [x] Go back to VPN Screen
- [x] Go to Android System Settings
- [x] Set Private DNS to `dns.google`.
- [x] Go back to VPN Screen
- [x] Verify that connection details DNS server is not shown 
- [x] Go to VPN Screen > VPN Settings > DNS Server
- [x] Verify it is disabled with Private DNS warning.

