### PR TITLE
Show host in download confirmation dialog

### DIFF
--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DownloadConfirmationFragment.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DownloadConfirmationFragment.kt
@@ -17,11 +17,14 @@
 package com.duckduckgo.downloads.impl
 
 import android.content.Context
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.common.utils.baseHost
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.downloads.api.DownloadConfirmationDialogListener
 import com.duckduckgo.downloads.api.FileDownloader.PendingFileDownload
@@ -89,6 +92,12 @@ class DownloadConfirmationFragment : BottomSheetDialogFragment() {
         (dialog as BottomSheetDialog).behavior.state = BottomSheetBehavior.STATE_EXPANDED
         val fileName = file?.name ?: ""
         binding.downloadMessage.text = fileName
+        binding.downloadMessageSubtitle.run {
+            val host = runCatching { Uri.parse(pendingDownload.url).baseHost }.getOrNull()
+
+            isVisible = !host.isNullOrBlank()
+            text = getString(R.string.downloadConfirmationSubtitle, host)
+        }
         binding.continueDownload.setOnClickListener {
             listener.continueDownload(pendingDownload)
             dismiss()

--- a/downloads/downloads-impl/src/main/res/layout/download_confirmation.xml
+++ b/downloads/downloads-impl/src/main/res/layout/download_confirmation.xml
@@ -28,18 +28,32 @@
         android:id="@+id/downloadMessage"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:maxLines="1"
         android:paddingStart="@dimen/keyline_4"
         android:paddingTop="@dimen/keyline_4"
         android:paddingEnd="@dimen/keyline_4"
-        android:paddingBottom="@dimen/keyline_4"
+        app:textType="secondary"
+        app:typography="body1_bold"
+        tools:text="sample-file.pdf" />
+
+    <com.duckduckgo.common.ui.view.text.DaxTextView
+        android:id="@+id/downloadMessageSubtitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:paddingStart="@dimen/keyline_4"
+        android:paddingEnd="@dimen/keyline_4"
         app:textType="secondary"
         app:typography="body1"
-        tools:text="sample-file.pdf" />
+        tools:text="From: example.com" />
 
     <com.duckduckgo.common.ui.view.listitem.OneLineListItem
         android:id="@+id/continueDownload"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/keyline_4"
         app:leadingIcon="@drawable/ic_downloads_24"
         app:primaryText="@string/downloadConfirmationContinue" />
 

--- a/downloads/downloads-impl/src/main/res/values-bg/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-bg/strings-downloads.xml
@@ -33,4 +33,5 @@
     <string name="notificationDownloadFailed">Неуспешно изтегляне.</string>
 
     <string name="downloadConfirmationContinue">Запазване в Изтеглени файлове</string>
+    <string name="downloadConfirmationSubtitle" instruction="Placeholder is the address of a website">От: %1$s</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-cs/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-cs/strings-downloads.xml
@@ -33,4 +33,5 @@
     <string name="notificationDownloadFailed">Stahování se nezdařilo.</string>
 
     <string name="downloadConfirmationContinue">Uložit do Stahování</string>
+    <string name="downloadConfirmationSubtitle" instruction="Placeholder is the address of a website">Ze stránky %1$s</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-da/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-da/strings-downloads.xml
@@ -33,4 +33,5 @@
     <string name="notificationDownloadFailed">Det var ikke muligt at downloade.</string>
 
     <string name="downloadConfirmationContinue">Gem i downloads</string>
+    <string name="downloadConfirmationSubtitle" instruction="Placeholder is the address of a website">Fra: %1$s</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-de/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-de/strings-downloads.xml
@@ -33,4 +33,5 @@
     <string name="notificationDownloadFailed">Download fehlgeschlagen.</string>
 
     <string name="downloadConfirmationContinue">In Downloads speichern</string>
+    <string name="downloadConfirmationSubtitle" instruction="Placeholder is the address of a website">Von: %1$s</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-el/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-el/strings-downloads.xml
@@ -33,4 +33,5 @@
     <string name="notificationDownloadFailed">Αποτυχία λήψης.</string>
 
     <string name="downloadConfirmationContinue">Αποθήκευση στις λήψεις</string>
+    <string name="downloadConfirmationSubtitle" instruction="Placeholder is the address of a website">Από: %1$s</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-es/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-es/strings-downloads.xml
@@ -33,4 +33,5 @@
     <string name="notificationDownloadFailed">No se ha podido descargar.</string>
 
     <string name="downloadConfirmationContinue">Guardar en descargas</string>
+    <string name="downloadConfirmationSubtitle" instruction="Placeholder is the address of a website">Desde: %1$s</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-et/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-et/strings-downloads.xml
@@ -33,4 +33,5 @@
     <string name="notificationDownloadFailed">Allalaadimine nurjus.</string>
 
     <string name="downloadConfirmationContinue">Salvesta allalaadimistesse</string>
+    <string name="downloadConfirmationSubtitle" instruction="Placeholder is the address of a website">Saidilt: %1$s</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-fi/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-fi/strings-downloads.xml
@@ -33,4 +33,5 @@
     <string name="notificationDownloadFailed">Lataus epäonnistui.</string>
 
     <string name="downloadConfirmationContinue">Tallenna latauksiin</string>
+    <string name="downloadConfirmationSubtitle" instruction="Placeholder is the address of a website">Sivustolta %1$s</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-fr/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-fr/strings-downloads.xml
@@ -33,4 +33,5 @@
     <string name="notificationDownloadFailed">Échec du téléchargement.</string>
 
     <string name="downloadConfirmationContinue">Enregistrer dans les téléchargements</string>
+    <string name="downloadConfirmationSubtitle" instruction="Placeholder is the address of a website">À partir de : %1$s</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-hr/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-hr/strings-downloads.xml
@@ -33,4 +33,5 @@
     <string name="notificationDownloadFailed">Preuzimanje nije uspjelo.</string>
 
     <string name="downloadConfirmationContinue">Spremi u Preuzimanja</string>
+    <string name="downloadConfirmationSubtitle" instruction="Placeholder is the address of a website">Izvor: %1$s</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-hu/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-hu/strings-downloads.xml
@@ -33,4 +33,5 @@
     <string name="notificationDownloadFailed">A letöltés sikertelen.</string>
 
     <string name="downloadConfirmationContinue">Mentés a Letöltések közé</string>
+    <string name="downloadConfirmationSubtitle" instruction="Placeholder is the address of a website">Innen: %1$s</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-it/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-it/strings-downloads.xml
@@ -33,4 +33,5 @@
     <string name="notificationDownloadFailed">Download non riuscito.</string>
 
     <string name="downloadConfirmationContinue">Salva in Download</string>
+    <string name="downloadConfirmationSubtitle" instruction="Placeholder is the address of a website">Da: %1$s</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-lt/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-lt/strings-downloads.xml
@@ -33,4 +33,5 @@
     <string name="notificationDownloadFailed">Nepavyko atsisiųsti.</string>
 
     <string name="downloadConfirmationContinue">Išsaugoti Atsisiuntimuose</string>
+    <string name="downloadConfirmationSubtitle" instruction="Placeholder is the address of a website">Iš: %1$s</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-lv/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-lv/strings-downloads.xml
@@ -33,4 +33,5 @@
     <string name="notificationDownloadFailed">Neizdevās lejupielādēt.</string>
 
     <string name="downloadConfirmationContinue">Lejupielādēt</string>
+    <string name="downloadConfirmationSubtitle" instruction="Placeholder is the address of a website">No: %1$s</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-nb/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-nb/strings-downloads.xml
@@ -33,4 +33,5 @@
     <string name="notificationDownloadFailed">Nedlastingen mislyktes.</string>
 
     <string name="downloadConfirmationContinue">Lagre til nedlastinger</string>
+    <string name="downloadConfirmationSubtitle" instruction="Placeholder is the address of a website">Fra: %1$s</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-nl/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-nl/strings-downloads.xml
@@ -33,4 +33,5 @@
     <string name="notificationDownloadFailed">Downloaden mislukt.</string>
 
     <string name="downloadConfirmationContinue">Opslaan in downloads</string>
+    <string name="downloadConfirmationSubtitle" instruction="Placeholder is the address of a website">Van: %1$s</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-pl/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-pl/strings-downloads.xml
@@ -33,4 +33,5 @@
     <string name="notificationDownloadFailed">Nie udało się pobrać.</string>
 
     <string name="downloadConfirmationContinue">Zapisz w Pobranych</string>
+    <string name="downloadConfirmationSubtitle" instruction="Placeholder is the address of a website">Z: %1$s</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-pt/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-pt/strings-downloads.xml
@@ -33,4 +33,5 @@
     <string name="notificationDownloadFailed">Ocorreu uma falha na transferência.</string>
 
     <string name="downloadConfirmationContinue">Guardar em Transferências</string>
+    <string name="downloadConfirmationSubtitle" instruction="Placeholder is the address of a website">De: %1$s</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-ro/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-ro/strings-downloads.xml
@@ -33,4 +33,5 @@
     <string name="notificationDownloadFailed">Nu s-a putut descărca.</string>
 
     <string name="downloadConfirmationContinue">Salvează în Descărcări</string>
+    <string name="downloadConfirmationSubtitle" instruction="Placeholder is the address of a website">De la: %1$s</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-ru/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-ru/strings-downloads.xml
@@ -33,4 +33,5 @@
     <string name="notificationDownloadFailed">Сбой загрузки.</string>
 
     <string name="downloadConfirmationContinue">Сохранить в «Загрузки»</string>
+    <string name="downloadConfirmationSubtitle" instruction="Placeholder is the address of a website">Источник: %1$s</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-sk/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-sk/strings-downloads.xml
@@ -33,4 +33,5 @@
     <string name="notificationDownloadFailed">Sťahovanie zlyhalo.</string>
 
     <string name="downloadConfirmationContinue">Uložiť do stiahnutých</string>
+    <string name="downloadConfirmationSubtitle" instruction="Placeholder is the address of a website">Z: %1$s</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-sl/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-sl/strings-downloads.xml
@@ -33,4 +33,5 @@
     <string name="notificationDownloadFailed">Prenos ni uspel.</string>
 
     <string name="downloadConfirmationContinue">Shrani med prenose</string>
+    <string name="downloadConfirmationSubtitle" instruction="Placeholder is the address of a website">S spletnega mesta: %1$s</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-sv/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-sv/strings-downloads.xml
@@ -33,4 +33,5 @@
     <string name="notificationDownloadFailed">Det gick inte att ladda ner.</string>
 
     <string name="downloadConfirmationContinue">Spara till Nerladdningar</string>
+    <string name="downloadConfirmationSubtitle" instruction="Placeholder is the address of a website">Från: %1$s</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-tr/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-tr/strings-downloads.xml
@@ -33,4 +33,5 @@
     <string name="notificationDownloadFailed">İndirme başarısız oldu.</string>
 
     <string name="downloadConfirmationContinue">İndirilenlere Kaydet</string>
+    <string name="downloadConfirmationSubtitle" instruction="Placeholder is the address of a website">Şu adresten: %1$s</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values/strings-downloads.xml
@@ -33,4 +33,5 @@
     <string name="notificationDownloadFailed">Failed to download.</string>
 
     <string name="downloadConfirmationContinue">Save to Downloads</string>
+    <string name="downloadConfirmationSubtitle" instruction="Placeholder is the address of a website">From: %1$s</string>
 </resources>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1142021229838617/1207476479082856/f

### Description

This PR modifies the download confirmation dialog to show host extracted from download url.

### Steps to test this PR

- [x] Smoke test triggering file download on a few different sites.

### UI changes
| Before  | After |
| ------ | ----- |
![Screenshot_20240703_130800](https://github.com/duckduckgo/Android/assets/4212474/866ccbe3-e367-4c17-85c0-614ef5bc78e8)|![Screenshot_20240703_130346](https://github.com/duckduckgo/Android/assets/4212474/e5ed109e-1449-47d1-9f00-0000650fa989)|