### PR TITLE
Update DataStore, from 1.0.0 to 1.1.1

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -21,7 +21,7 @@ version.androidx.constraintlayout=2.1.4
 
 version.androidx.biometric=1.1.0
 
-version.androidx.datastore=1.0.0
+version.androidx.datastore=1.1.1
 
 version.androidx.localbroadcastmanager=1.1.0
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207701481229686/1207706722437057/f 

### Description
Updates `DataStore` dependency to `1.1.1`. 
No breaking changes reported in the changelog. 

### Steps to test this PR

- [x] Ensure the privacy protections popup functions as expected (currently only feature to use `DataStore`)