### PR TITLE
Update library version for appcompat (to 1.7.0)

### DIFF
--- a/anrs/anrs-internal/src/main/java/com/duckduckgo/app/anr/internal/setting/CrashANRsListView.kt
+++ b/anrs/anrs-internal/src/main/java/com/duckduckgo/app/anr/internal/setting/CrashANRsListView.kt
@@ -20,7 +20,7 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.View
 import android.widget.FrameLayout
-import androidx.lifecycle.ViewTreeLifecycleOwner
+import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.duckduckgo.anvil.annotations.InjectWith
@@ -71,7 +71,7 @@ class CrashANRsListView @JvmOverloads constructor(
 
         configureANRList()
 
-        ViewTreeLifecycleOwner.get(this)?.lifecycleScope?.launch {
+        findViewTreeLifecycleOwner()?.lifecycleScope?.launch {
             crashANRsRepository.getANRs().combine(crashANRsRepository.getCrashes()) { anrs, crashes ->
                 (
                     anrs.map {

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -226,10 +226,9 @@ import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.ArgumentCaptor
-import org.mockito.Captor
+import org.mockito.ArgumentMatchers.anyBoolean
+import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mock
-import org.mockito.Mockito.*
 import org.mockito.Mockito.never
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
@@ -397,11 +396,9 @@ class BrowserTabViewModelTest {
 
     private lateinit var ctaViewModel: CtaViewModel
 
-    @Captor
-    private lateinit var commandCaptor: ArgumentCaptor<Command>
+    private val commandCaptor = argumentCaptor<Command>()
 
-    @Captor
-    private lateinit var appLinkCaptor: ArgumentCaptor<() -> Unit>
+    private val appLinkCaptor = argumentCaptor<() -> Unit>()
 
     private lateinit var db: AppDatabase
 
@@ -1458,7 +1455,7 @@ class BrowserTabViewModelTest {
     @Test
     fun whenEnteringEmptyQueryThenHideKeyboardCommandNotIssued() {
         testee.onUserSubmittedQuery("")
-        verify(mockCommandObserver, never()).onChanged(any(Command.HideKeyboard.javaClass))
+        verify(mockCommandObserver, never()).onChanged(any<Command.HideKeyboard>())
     }
 
     @Test
@@ -1868,7 +1865,7 @@ class BrowserTabViewModelTest {
         val mockMenItem: MenuItem = mock()
         val longPressTarget = LongPressTarget(url = "http://example.com", type = WebView.HitTestResult.SRC_ANCHOR_TYPE)
         testee.userSelectedItemFromLongPressMenu(longPressTarget, mockMenItem)
-        val command = captureCommands().value as Command.OpenInNewTab
+        val command = captureCommands().lastValue as Command.OpenInNewTab
         assertEquals("http://example.com", command.query)
 
         assertCommandIssued<Command.OpenInNewTab> {
@@ -1891,7 +1888,7 @@ class BrowserTabViewModelTest {
         loadUrl(url = url)
         testee.titleReceived(newTitle = title, url = url)
         testee.onBookmarkMenuClicked()
-        val command = captureCommands().value as Command.ShowSavedSiteAddedConfirmation
+        val command = captureCommands().lastValue as Command.ShowSavedSiteAddedConfirmation
         assertEquals(url, command.savedSiteChangedViewState.savedSite.url)
         assertEquals(title, command.savedSiteChangedViewState.savedSite.title)
     }
@@ -1972,14 +1969,14 @@ class BrowserTabViewModelTest {
     fun whenOnSiteAndBrokenSiteSelectedThenBrokenSiteFeedbackCommandSentWithUrl() = runTest {
         loadUrl("foo.com", isBrowserShowing = true)
         testee.onBrokenSiteSelected()
-        val command = captureCommands().value as Command.BrokenSiteFeedback
+        val command = captureCommands().lastValue as Command.BrokenSiteFeedback
         assertEquals("foo.com", command.data.url)
     }
 
     @Test
     fun whenNoSiteAndBrokenSiteSelectedThenBrokenSiteFeedbackCommandSentWithoutUrl() {
         testee.onBrokenSiteSelected()
-        val command = captureCommands().value as Command.BrokenSiteFeedback
+        val command = captureCommands().lastValue as Command.BrokenSiteFeedback
         assertEquals("", command.data.url)
     }
 
@@ -1987,7 +1984,7 @@ class BrowserTabViewModelTest {
     fun whenUserSelectsToShareLinkThenShareLinkCommandSent() {
         loadUrl("foo.com")
         testee.onShareSelected()
-        val command = captureCommands().value as Command.ShareLink
+        val command = captureCommands().lastValue as Command.ShareLink
         assertEquals("foo.com", command.url)
     }
 
@@ -2067,7 +2064,7 @@ class BrowserTabViewModelTest {
         givenOneActiveTabSelected()
         testee.recoverFromRenderProcessGone()
         verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
-        val showErrorWithAction = commandCaptor.value as Command.ShowErrorWithAction
+        val showErrorWithAction = commandCaptor.lastValue as Command.ShowErrorWithAction
 
         showErrorWithAction.action()
 
@@ -2082,7 +2079,7 @@ class BrowserTabViewModelTest {
         givenOneActiveTabSelected()
         testee.recoverFromRenderProcessGone()
         verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
-        val showErrorWithAction = commandCaptor.value as Command.ShowErrorWithAction
+        val showErrorWithAction = commandCaptor.lastValue as Command.ShowErrorWithAction
 
         showErrorWithAction.action()
 
@@ -3754,8 +3751,8 @@ class BrowserTabViewModelTest {
         testee.handleAppLink(urlType, isForMainFrame = true)
         whenever(mockAppLinksHandler.isUserQuery()).thenReturn(false)
         whenever(mockSettingsStore.showAppLinksPrompt).thenReturn(true)
-        verify(mockAppLinksHandler).handleAppLink(eq(true), eq("http://example.com"), eq(false), eq(true), capture(appLinkCaptor))
-        appLinkCaptor.value.invoke()
+        verify(mockAppLinksHandler).handleAppLink(eq(true), eq("http://example.com"), eq(false), eq(true), appLinkCaptor.capture())
+        appLinkCaptor.lastValue.invoke()
         assertCommandIssued<Command.ShowAppLinkPrompt>()
         verify(mockAppLinksHandler).setUserQueryState(false)
     }
@@ -3766,8 +3763,8 @@ class BrowserTabViewModelTest {
         testee.handleAppLink(urlType, isForMainFrame = true)
         whenever(mockAppLinksHandler.isUserQuery()).thenReturn(true)
         whenever(mockSettingsStore.showAppLinksPrompt).thenReturn(false)
-        verify(mockAppLinksHandler).handleAppLink(eq(true), eq("http://example.com"), eq(false), eq(true), capture(appLinkCaptor))
-        appLinkCaptor.value.invoke()
+        verify(mockAppLinksHandler).handleAppLink(eq(true), eq("http://example.com"), eq(false), eq(true), appLinkCaptor.capture())
+        appLinkCaptor.lastValue.invoke()
         assertCommandIssued<Command.ShowAppLinkPrompt>()
         verify(mockAppLinksHandler).setUserQueryState(false)
     }
@@ -3778,8 +3775,8 @@ class BrowserTabViewModelTest {
         testee.handleAppLink(urlType, isForMainFrame = true)
         whenever(mockAppLinksHandler.isUserQuery()).thenReturn(false)
         whenever(mockSettingsStore.showAppLinksPrompt).thenReturn(false)
-        verify(mockAppLinksHandler).handleAppLink(eq(true), eq("http://example.com"), eq(false), eq(true), capture(appLinkCaptor))
-        appLinkCaptor.value.invoke()
+        verify(mockAppLinksHandler).handleAppLink(eq(true), eq("http://example.com"), eq(false), eq(true), appLinkCaptor.capture())
+        appLinkCaptor.lastValue.invoke()
         assertCommandIssued<Command.OpenAppLink>()
     }
 
@@ -3815,7 +3812,7 @@ class BrowserTabViewModelTest {
         whenever(mockDeviceInfo.country).thenReturn("US")
         loadUrl("foo.com")
         testee.onPrintSelected()
-        val command = captureCommands().value as Command.PrintLink
+        val command = captureCommands().lastValue as Command.PrintLink
         assertEquals("foo.com", command.url)
         assertEquals(PrintAttributes.MediaSize.NA_LETTER, command.mediaSize)
     }
@@ -3825,7 +3822,7 @@ class BrowserTabViewModelTest {
         whenever(mockDeviceInfo.country).thenReturn("FR")
         loadUrl("foo.com")
         testee.onPrintSelected()
-        val command = captureCommands().value as Command.PrintLink
+        val command = captureCommands().lastValue as Command.PrintLink
         assertEquals("foo.com", command.url)
         assertEquals(PrintAttributes.MediaSize.ISO_A4, command.mediaSize)
     }
@@ -3835,7 +3832,7 @@ class BrowserTabViewModelTest {
         whenever(mockDeviceInfo.country).thenReturn("")
         loadUrl("foo.com")
         testee.onPrintSelected()
-        val command = captureCommands().value as Command.PrintLink
+        val command = captureCommands().lastValue as Command.PrintLink
         assertEquals("foo.com", command.url)
         assertEquals(PrintAttributes.MediaSize.ISO_A4, command.mediaSize)
     }
@@ -5474,7 +5471,7 @@ class BrowserTabViewModelTest {
         testee.navigationStateChanged(nav)
     }
 
-    private fun captureCommands(): ArgumentCaptor<Command> {
+    private fun captureCommands(): KArgumentCaptor<Command> {
         verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
         return commandCaptor
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/fire/fireproofwebsite/ui/FireproofWebsitesViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/fire/fireproofwebsite/ui/FireproofWebsitesViewModelTest.kt
@@ -41,8 +41,8 @@ import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.ArgumentCaptor
 import org.mockito.Mockito.verify
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
@@ -65,9 +65,9 @@ class FireproofWebsitesViewModelTest {
 
     private lateinit var db: AppDatabase
 
-    private val commandCaptor = ArgumentCaptor.forClass(FireproofWebsitesViewModel.Command::class.java)
+    private val commandCaptor = argumentCaptor<FireproofWebsitesViewModel.Command>()
 
-    private val viewStateCaptor = ArgumentCaptor.forClass(FireproofWebsitesViewModel.ViewState::class.java)
+    private val viewStateCaptor = argumentCaptor<FireproofWebsitesViewModel.ViewState>()
 
     private val mockCommandObserver: Observer<FireproofWebsitesViewModel.Command> = mock()
 
@@ -113,7 +113,7 @@ class FireproofWebsitesViewModelTest {
     fun whenViewModelCreateThenInitialisedWithDefaultViewState() {
         val defaultViewState = FireproofWebsitesViewModel.ViewState(AutomaticFireproofSetting.ASK_EVERY_TIME, emptyList())
         verify(mockViewStateObserver, atLeastOnce()).onChanged(viewStateCaptor.capture())
-        assertEquals(defaultViewState, viewStateCaptor.value)
+        assertEquals(defaultViewState, viewStateCaptor.lastValue)
     }
 
     @Test
@@ -133,7 +133,7 @@ class FireproofWebsitesViewModelTest {
         viewModel.remove(FireproofWebsiteEntity("domain.com"))
 
         verify(mockViewStateObserver, atLeastOnce()).onChanged(viewStateCaptor.capture())
-        assertTrue(viewStateCaptor.value.fireproofWebsitesEntities.isEmpty())
+        assertTrue(viewStateCaptor.lastValue.fireproofWebsitesEntities.isEmpty())
     }
 
     @Test
@@ -144,7 +144,7 @@ class FireproofWebsitesViewModelTest {
         viewModel.removeAllWebsites()
 
         verify(mockViewStateObserver, atLeastOnce()).onChanged(viewStateCaptor.capture())
-        assertTrue(viewStateCaptor.value.fireproofWebsitesEntities.isEmpty())
+        assertTrue(viewStateCaptor.lastValue.fireproofWebsitesEntities.isEmpty())
     }
 
     @Test
@@ -161,7 +161,7 @@ class FireproofWebsitesViewModelTest {
         givenFireproofWebsiteDomain("domain.com")
 
         verify(mockViewStateObserver, atLeastOnce()).onChanged(viewStateCaptor.capture())
-        assertTrue(viewStateCaptor.value.fireproofWebsitesEntities.size == 1)
+        assertTrue(viewStateCaptor.lastValue.fireproofWebsitesEntities.size == 1)
     }
 
     @Test
@@ -176,7 +176,7 @@ class FireproofWebsitesViewModelTest {
         viewModel.onAutomaticFireproofSettingChanged(AutomaticFireproofSetting.ALWAYS)
 
         verify(mockViewStateObserver, atLeastOnce()).onChanged(viewStateCaptor.capture())
-        assertTrue(viewStateCaptor.value.automaticFireproofSetting == AutomaticFireproofSetting.ALWAYS)
+        assertTrue(viewStateCaptor.lastValue.automaticFireproofSetting == AutomaticFireproofSetting.ALWAYS)
     }
 
     @Test
@@ -200,7 +200,7 @@ class FireproofWebsitesViewModelTest {
         viewModel.onSnackBarUndoFireproof(entity)
 
         verify(mockViewStateObserver, atLeastOnce()).onChanged(viewStateCaptor.capture())
-        assertTrue(viewStateCaptor.value.fireproofWebsitesEntities.isNotEmpty())
+        assertTrue(viewStateCaptor.lastValue.fireproofWebsitesEntities.isNotEmpty())
     }
 
     @Test
@@ -212,7 +212,7 @@ class FireproofWebsitesViewModelTest {
         viewModel.onSnackBarUndoRemoveAllWebsites(removedWebsites)
 
         verify(mockViewStateObserver, atLeastOnce()).onChanged(viewStateCaptor.capture())
-        assertTrue(viewStateCaptor.value.fireproofWebsitesEntities.isNotEmpty())
+        assertTrue(viewStateCaptor.lastValue.fireproofWebsitesEntities.isNotEmpty())
     }
 
     private inline fun <reified T : FireproofWebsitesViewModel.Command> assertCommandIssued(instanceAssertions: T.() -> Unit = {}) {

--- a/app/src/androidTest/java/com/duckduckgo/app/icon/ui/ChangeIconViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/icon/ui/ChangeIconViewModelTest.kt
@@ -29,6 +29,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -79,7 +80,7 @@ class ChangeIconViewModelTest {
         val selectedIconViewData = ChangeIconViewModel.IconViewData(selectedIcon, true)
         testee.onIconSelected(selectedIconViewData)
 
-        verify(mockCommandObserver).onChanged(Mockito.any(ChangeIconViewModel.Command.ShowConfirmationDialog::class.java))
+        verify(mockCommandObserver).onChanged(any<ChangeIconViewModel.Command.ShowConfirmationDialog>())
     }
 
     @Test
@@ -94,6 +95,6 @@ class ChangeIconViewModelTest {
 
         verify(mockAppIconModifier).changeIcon(previousIcon, selectedIcon)
         verify(mockSettingsDataStore).appIcon = selectedIcon
-        verify(mockCommandObserver).onChanged(Mockito.any(ChangeIconViewModel.Command.IconChanged::class.java))
+        verify(mockCommandObserver).onChanged(any<ChangeIconViewModel.Command.IconChanged>())
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/widget/ui/AddWidgetInstructionsViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/widget/ui/AddWidgetInstructionsViewModelTest.kt
@@ -27,11 +27,9 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.ArgumentCaptor
-import org.mockito.Captor
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
-import org.mockito.kotlin.lastValue
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.verify
 
 class AddWidgetInstructionsViewModelTest {
@@ -49,8 +47,7 @@ class AddWidgetInstructionsViewModelTest {
     @Mock
     private lateinit var mockCommandObserver: Observer<Command>
 
-    @Captor
-    private lateinit var commandCaptor: ArgumentCaptor<Command>
+    private val commandCaptor = argumentCaptor<Command>()
 
     @Before
     fun before() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2448,10 +2448,13 @@ class BrowserTabViewModel @Inject constructor(
 
     fun onUserClickCtaOkButton(cta: Cta) {
         ctaViewModel.onUserClickCtaOkButton(cta)
-        command.value = when (cta) {
+        val onboardingCommand = when (cta) {
             is HomePanelCta.AddWidgetAuto, is HomePanelCta.AddWidgetInstructions -> LaunchAddWidget
             is OnboardingDaxDialogCta -> onOnboardingCtaOkButtonClicked(cta)
-            else -> return
+            else -> null
+        }
+        onboardingCommand?.let {
+            command.value = it
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/FocusedLegacyView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/FocusedLegacyView.kt
@@ -24,7 +24,7 @@ import android.widget.LinearLayout
 import androidx.core.text.toSpannable
 import androidx.fragment.app.findFragment
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewTreeLifecycleOwner
+import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.ItemTouchHelper
@@ -109,7 +109,7 @@ class FocusedLegacyView @JvmOverloads constructor(
         AndroidSupportInjection.inject(this)
         super.onAttachedToWindow()
 
-        ViewTreeLifecycleOwner.get(this)?.lifecycle?.addObserver(viewModel)
+        findViewTreeLifecycleOwner()?.lifecycle?.addObserver(viewModel)
 
         @SuppressLint("NoHardcodedCoroutineDispatcher")
         coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
@@ -128,7 +128,7 @@ class FocusedLegacyView @JvmOverloads constructor(
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
 
-        ViewTreeLifecycleOwner.get(this)?.lifecycle?.removeObserver(viewModel)
+        findViewTreeLifecycleOwner()?.lifecycle?.removeObserver(viewModel)
         coroutineScope?.cancel()
         coroutineScope = null
     }
@@ -154,7 +154,7 @@ class FocusedLegacyView @JvmOverloads constructor(
         onMoveListener: (RecyclerView.ViewHolder) -> Unit,
     ): FavoritesQuickAccessAdapter {
         return FavoritesQuickAccessAdapter(
-            ViewTreeLifecycleOwner.get(this)!!,
+            findViewTreeLifecycleOwner()!!,
             faviconManager,
             onMoveListener,
             {

--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageView.kt
@@ -28,7 +28,7 @@ import androidx.core.text.toSpannable
 import androidx.core.view.isGone
 import androidx.fragment.app.findFragment
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewTreeLifecycleOwner
+import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.ItemTouchHelper
@@ -130,7 +130,7 @@ class NewTabLegacyPageView @JvmOverloads constructor(
         AndroidSupportInjection.inject(this)
         super.onAttachedToWindow()
 
-        ViewTreeLifecycleOwner.get(this)?.lifecycle?.addObserver(viewModel)
+        findViewTreeLifecycleOwner()?.lifecycle?.addObserver(viewModel)
 
         @SuppressLint("NoHardcodedCoroutineDispatcher")
         coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
@@ -149,7 +149,7 @@ class NewTabLegacyPageView @JvmOverloads constructor(
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
 
-        ViewTreeLifecycleOwner.get(this)?.lifecycle?.removeObserver(viewModel)
+        findViewTreeLifecycleOwner()?.lifecycle?.removeObserver(viewModel)
         coroutineScope?.cancel()
         coroutineScope = null
     }
@@ -175,7 +175,7 @@ class NewTabLegacyPageView @JvmOverloads constructor(
         onMoveListener: (RecyclerView.ViewHolder) -> Unit,
     ): FavoritesQuickAccessAdapter {
         return FavoritesQuickAccessAdapter(
-            ViewTreeLifecycleOwner.get(this)!!,
+            findViewTreeLifecycleOwner()!!,
             faviconManager,
             onMoveListener,
             {

--- a/app/src/test/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/bookmarks/ui/BookmarksViewModelTest.kt
@@ -41,7 +41,6 @@ import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.kotlin.*
 
@@ -59,8 +58,8 @@ class BookmarksViewModelTest {
     @Suppress("unused")
     val coroutineRule = CoroutineTestRule()
 
-    private val commandCaptor: ArgumentCaptor<BookmarksViewModel.Command> = ArgumentCaptor.forClass(BookmarksViewModel.Command::class.java)
-    private val viewStateCaptor: ArgumentCaptor<BookmarksViewModel.ViewState> = ArgumentCaptor.forClass(BookmarksViewModel.ViewState::class.java)
+    private val commandCaptor = argumentCaptor<BookmarksViewModel.Command>()
+    private val viewStateCaptor = argumentCaptor<BookmarksViewModel.ViewState>()
 
     private val commandObserver: Observer<BookmarksViewModel.Command> = mock()
 
@@ -146,8 +145,8 @@ class BookmarksViewModelTest {
         testee.onDeleteSavedSiteRequested(bookmark)
 
         verify(commandObserver).onChanged(commandCaptor.capture())
-        assertNotNull(commandCaptor.value)
-        assertTrue(commandCaptor.value is BookmarksViewModel.Command.ConfirmDeleteSavedSite)
+        assertNotNull(commandCaptor.lastValue)
+        assertTrue(commandCaptor.lastValue is BookmarksViewModel.Command.ConfirmDeleteSavedSite)
     }
 
     @Test
@@ -173,8 +172,8 @@ class BookmarksViewModelTest {
         testee.onDeleteSavedSiteRequested(favorite)
 
         verify(commandObserver).onChanged(commandCaptor.capture())
-        assertNotNull(commandCaptor.value)
-        assertTrue(commandCaptor.value is BookmarksViewModel.Command.ConfirmDeleteSavedSite)
+        assertNotNull(commandCaptor.lastValue)
+        assertTrue(commandCaptor.lastValue is BookmarksViewModel.Command.ConfirmDeleteSavedSite)
     }
 
     @Test
@@ -196,8 +195,8 @@ class BookmarksViewModelTest {
         testee.onSelected(bookmark)
 
         verify(commandObserver).onChanged(commandCaptor.capture())
-        assertNotNull(commandCaptor.value)
-        assertTrue(commandCaptor.value is BookmarksViewModel.Command.OpenSavedSite)
+        assertNotNull(commandCaptor.lastValue)
+        assertTrue(commandCaptor.lastValue is BookmarksViewModel.Command.OpenSavedSite)
     }
 
     @Test
@@ -212,8 +211,8 @@ class BookmarksViewModelTest {
         testee.onDeleteSavedSiteRequested(bookmark)
 
         verify(commandObserver).onChanged(commandCaptor.capture())
-        assertNotNull(commandCaptor.value)
-        assertTrue(commandCaptor.value is BookmarksViewModel.Command.ConfirmDeleteSavedSite)
+        assertNotNull(commandCaptor.lastValue)
+        assertTrue(commandCaptor.lastValue is BookmarksViewModel.Command.ConfirmDeleteSavedSite)
     }
 
     @Test
@@ -221,7 +220,7 @@ class BookmarksViewModelTest {
         testee.onBookmarkFolderSelected(bookmarkFolder)
 
         verify(commandObserver).onChanged(commandCaptor.capture())
-        assertEquals(bookmarkFolder, (commandCaptor.value as BookmarksViewModel.Command.OpenBookmarkFolder).bookmarkFolder)
+        assertEquals(bookmarkFolder, (commandCaptor.lastValue as BookmarksViewModel.Command.OpenBookmarkFolder).bookmarkFolder)
     }
 
     @Test
@@ -283,7 +282,7 @@ class BookmarksViewModelTest {
         testee.onEditBookmarkFolderRequested(bookmarkFolder)
 
         verify(commandObserver).onChanged(commandCaptor.capture())
-        assertEquals(bookmarkFolder, (commandCaptor.value as BookmarksViewModel.Command.ShowEditBookmarkFolder).bookmarkFolder)
+        assertEquals(bookmarkFolder, (commandCaptor.lastValue as BookmarksViewModel.Command.ShowEditBookmarkFolder).bookmarkFolder)
     }
 
     @Test
@@ -297,7 +296,7 @@ class BookmarksViewModelTest {
     fun whenDeleteEmptyFolderRequestedThenCommandIssued() = runTest {
         testee.onDeleteBookmarkFolderRequested(bookmarkFolder)
         verify(commandObserver).onChanged(commandCaptor.capture())
-        assertEquals(bookmarkFolder, (commandCaptor.value as BookmarksViewModel.Command.ConfirmDeleteBookmarkFolder).bookmarkFolder)
+        assertEquals(bookmarkFolder, (commandCaptor.lastValue as BookmarksViewModel.Command.ConfirmDeleteBookmarkFolder).bookmarkFolder)
     }
 
     @Test
@@ -306,7 +305,7 @@ class BookmarksViewModelTest {
         testee.onDeleteBookmarkFolderRequested(bookmarkFolder)
 
         verify(commandObserver).onChanged(commandCaptor.capture())
-        assertEquals(bookmarkFolder, (commandCaptor.value as BookmarksViewModel.Command.DeleteBookmarkFolder).bookmarkFolder)
+        assertEquals(bookmarkFolder, (commandCaptor.lastValue as BookmarksViewModel.Command.DeleteBookmarkFolder).bookmarkFolder)
     }
 
     @Test
@@ -339,7 +338,7 @@ class BookmarksViewModelTest {
         verify(savedSitesRepository).deleteFolderBranch(bookmarkFolder)
 
         verify(commandObserver).onChanged(commandCaptor.capture())
-        assertEquals(bookmarkFolder, (commandCaptor.value as BookmarksViewModel.Command.ConfirmDeleteBookmarkFolder).bookmarkFolder)
+        assertEquals(bookmarkFolder, (commandCaptor.lastValue as BookmarksViewModel.Command.ConfirmDeleteBookmarkFolder).bookmarkFolder)
     }
 
     @Test
@@ -355,7 +354,7 @@ class BookmarksViewModelTest {
         testee.onDeleteBookmarkFolderRequested(nonEmptyBookmarkFolder)
 
         verify(commandObserver).onChanged(commandCaptor.capture())
-        assertEquals(nonEmptyBookmarkFolder, (commandCaptor.value as BookmarksViewModel.Command.DeleteBookmarkFolder).bookmarkFolder)
+        assertEquals(nonEmptyBookmarkFolder, (commandCaptor.lastValue as BookmarksViewModel.Command.DeleteBookmarkFolder).bookmarkFolder)
     }
 
     @Test
@@ -365,7 +364,7 @@ class BookmarksViewModelTest {
         testee.onBookmarkFoldersActivityResult(savedSiteUrl)
 
         verify(commandObserver).onChanged(commandCaptor.capture())
-        assertEquals(savedSiteUrl, (commandCaptor.value as BookmarksViewModel.Command.OpenSavedSite).savedSiteUrl)
+        assertEquals(savedSiteUrl, (commandCaptor.lastValue as BookmarksViewModel.Command.OpenSavedSite).savedSiteUrl)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/bookmarks/ui/bookmarkfolders/BookmarkFoldersViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/bookmarks/ui/bookmarkfolders/BookmarkFoldersViewModelTest.kt
@@ -29,7 +29,6 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.kotlin.*
 
@@ -52,10 +51,8 @@ class BookmarkFoldersViewModelTest {
     private val viewStateObserver: Observer<BookmarkFoldersViewModel.ViewState> = mock()
     private val commandObserver: Observer<BookmarkFoldersViewModel.Command> = mock()
 
-    private val viewStateCaptor: ArgumentCaptor<BookmarkFoldersViewModel.ViewState> =
-        ArgumentCaptor.forClass(BookmarkFoldersViewModel.ViewState::class.java)
-    private val commandCaptor: ArgumentCaptor<BookmarkFoldersViewModel.Command> =
-        ArgumentCaptor.forClass(BookmarkFoldersViewModel.Command::class.java)
+    private val viewStateCaptor = argumentCaptor<BookmarkFoldersViewModel.ViewState>()
+    private val commandCaptor = argumentCaptor<BookmarkFoldersViewModel.Command>()
 
     private val folderStructure = mutableListOf(
         BookmarkFolderItem(1, BookmarkFolder("folder1", "folder", SavedSitesNames.BOOKMARKS_ROOT, 0, 0, "timestamp"), true),
@@ -97,7 +94,7 @@ class BookmarkFoldersViewModelTest {
 
         verify(commandObserver).onChanged(commandCaptor.capture())
 
-        assertEquals(folder, (commandCaptor.value as BookmarkFoldersViewModel.Command.SelectFolder).selectedBookmarkFolder)
+        assertEquals(folder, (commandCaptor.lastValue as BookmarkFoldersViewModel.Command.SelectFolder).selectedBookmarkFolder)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
@@ -40,8 +40,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.ArgumentCaptor
-import org.mockito.Captor
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.*
@@ -58,8 +56,7 @@ class BrowserViewModelTest {
     @Mock
     private lateinit var mockCommandObserver: Observer<Command>
 
-    @Captor
-    private lateinit var commandCaptor: ArgumentCaptor<Command>
+    private val commandCaptor = argumentCaptor<Command>()
 
     @Mock
     private lateinit var mockTabRepository: TabRepository

--- a/app/src/test/java/com/duckduckgo/app/globalprivacycontrol/ui/GlobalPrivacyControlViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/globalprivacycontrol/ui/GlobalPrivacyControlViewModelTest.kt
@@ -28,7 +28,7 @@ import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.ArgumentCaptor
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.lastValue
 import org.mockito.kotlin.mock
@@ -45,8 +45,8 @@ class GlobalPrivacyControlViewModelTest {
     private val mockPixel: Pixel = mock()
     private val mockFeatureToggle: FeatureToggle = mock()
     private val mockGpc: Gpc = mock()
-    private val commandCaptor = ArgumentCaptor.forClass(GlobalPrivacyControlViewModel.Command::class.java)
-    private val viewStateCaptor = ArgumentCaptor.forClass(GlobalPrivacyControlViewModel.ViewState::class.java)
+    private val commandCaptor = argumentCaptor<GlobalPrivacyControlViewModel.Command>()
+    private val viewStateCaptor = argumentCaptor<GlobalPrivacyControlViewModel.ViewState>()
     private val mockCommandObserver: Observer<GlobalPrivacyControlViewModel.Command> = mock()
     private val mockViewStateObserver: Observer<GlobalPrivacyControlViewModel.ViewState> = mock()
     lateinit var testee: GlobalPrivacyControlViewModel
@@ -68,7 +68,7 @@ class GlobalPrivacyControlViewModelTest {
     fun whenViewModelCreateThenInitialisedWithDefaultViewState() {
         val defaultViewState = GlobalPrivacyControlViewModel.ViewState()
         verify(mockViewStateObserver, atLeastOnce()).onChanged(viewStateCaptor.capture())
-        assertEquals(defaultViewState, viewStateCaptor.value)
+        assertEquals(defaultViewState, viewStateCaptor.lastValue)
     }
 
     @Test
@@ -117,7 +117,7 @@ class GlobalPrivacyControlViewModelTest {
         testee.onUserToggleGlobalPrivacyControl(true)
 
         verify(mockViewStateObserver, atLeastOnce()).onChanged(viewStateCaptor.capture())
-        assertTrue(viewStateCaptor.value.globalPrivacyControlEnabled)
+        assertTrue(viewStateCaptor.lastValue.globalPrivacyControlEnabled)
     }
 
     @Test
@@ -125,6 +125,6 @@ class GlobalPrivacyControlViewModelTest {
         testee.onUserToggleGlobalPrivacyControl(false)
 
         verify(mockViewStateObserver, atLeastOnce()).onChanged(viewStateCaptor.capture())
-        assertFalse(viewStateCaptor.value.globalPrivacyControlEnabled)
+        assertFalse(viewStateCaptor.lastValue.globalPrivacyControlEnabled)
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/launch/LaunchViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/launch/LaunchViewModelTest.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.Mockito.any
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -63,7 +63,7 @@ class LaunchViewModelTest {
 
         testee.determineViewToShow()
 
-        verify(mockCommandObserver).onChanged(any(Onboarding::class.java))
+        verify(mockCommandObserver).onChanged(any<Onboarding>())
     }
 
     @Test
@@ -77,7 +77,7 @@ class LaunchViewModelTest {
 
         testee.determineViewToShow()
 
-        verify(mockCommandObserver).onChanged(any(Onboarding::class.java))
+        verify(mockCommandObserver).onChanged(any<Onboarding>())
     }
 
     @Test
@@ -91,7 +91,7 @@ class LaunchViewModelTest {
 
         testee.determineViewToShow()
 
-        verify(mockCommandObserver).onChanged(any(Onboarding::class.java))
+        verify(mockCommandObserver).onChanged(any<Onboarding>())
     }
 
     @Test
@@ -100,7 +100,7 @@ class LaunchViewModelTest {
         whenever(userStageStore.getUserAppStage()).thenReturn(AppStage.DAX_ONBOARDING)
         testee.command.observeForever(mockCommandObserver)
         testee.determineViewToShow()
-        verify(mockCommandObserver).onChanged(any(Home::class.java))
+        verify(mockCommandObserver).onChanged(any<Home>())
     }
 
     @Test
@@ -112,7 +112,7 @@ class LaunchViewModelTest {
         whenever(userStageStore.getUserAppStage()).thenReturn(AppStage.DAX_ONBOARDING)
         testee.command.observeForever(mockCommandObserver)
         testee.determineViewToShow()
-        verify(mockCommandObserver).onChanged(any(Home::class.java))
+        verify(mockCommandObserver).onChanged(any<Home>())
     }
 
     @Test
@@ -124,6 +124,6 @@ class LaunchViewModelTest {
         whenever(userStageStore.getUserAppStage()).thenReturn(AppStage.DAX_ONBOARDING)
         testee.command.observeForever(mockCommandObserver)
         testee.determineViewToShow()
-        verify(mockCommandObserver).onChanged(any(Home::class.java))
+        verify(mockCommandObserver).onChanged(any<Home>())
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPageViewModelTest.kt
@@ -34,8 +34,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.ArgumentCaptor
-import org.mockito.Captor
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.*
@@ -57,8 +55,7 @@ class DefaultBrowserPageViewModelTest {
     @Mock
     private lateinit var mockCommandObserver: Observer<Command>
 
-    @Captor
-    private lateinit var commandCaptor: ArgumentCaptor<Command>
+    private val commandCaptor = argumentCaptor<Command>()
 
     private lateinit var testee: DefaultBrowserPageViewModel
 
@@ -365,7 +362,7 @@ class DefaultBrowserPageViewModelTest {
         assertEquals(0, testee.timesPressedJustOnce)
     }
 
-    private fun captureCommands(): ArgumentCaptor<Command> {
+    private fun captureCommands(): KArgumentCaptor<Command> {
         verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
         return commandCaptor
     }

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -36,8 +36,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.ArgumentCaptor
-import org.mockito.Captor
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.*
@@ -54,8 +52,7 @@ class TabSwitcherViewModelTest {
     @Mock
     private lateinit var mockCommandObserver: Observer<Command>
 
-    @Captor
-    private lateinit var commandCaptor: ArgumentCaptor<Command>
+    private val commandCaptor = argumentCaptor<Command>()
 
     @Mock
     private lateinit var mockTabRepository: TabRepository

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsInvalidItemsView.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsInvalidItemsView.kt
@@ -23,7 +23,7 @@ import android.util.AttributeSet
 import android.widget.FrameLayout
 import androidx.core.view.isVisible
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewTreeLifecycleOwner
+import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.autofill.api.AutofillScreens.AutofillSettingsScreen
@@ -77,7 +77,7 @@ class CredentialsInvalidItemsView @JvmOverloads constructor(
         AndroidSupportInjection.inject(this)
         super.onAttachedToWindow()
 
-        ViewTreeLifecycleOwner.get(this)?.lifecycle?.addObserver(viewModel)
+        findViewTreeLifecycleOwner()?.lifecycle?.addObserver(viewModel)
 
         @SuppressLint("NoHardcodedCoroutineDispatcher")
         coroutineScope = CoroutineScope(SupervisorJob() + dispatcherProvider.main())
@@ -93,7 +93,7 @@ class CredentialsInvalidItemsView @JvmOverloads constructor(
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
-        ViewTreeLifecycleOwner.get(this)?.lifecycle?.removeObserver(viewModel)
+        findViewTreeLifecycleOwner()?.lifecycle?.removeObserver(viewModel)
         coroutineScope?.cancel()
         job.cancel()
         coroutineScope = null

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsSyncPausedView.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsSyncPausedView.kt
@@ -22,7 +22,7 @@ import android.util.AttributeSet
 import android.widget.FrameLayout
 import androidx.core.view.isVisible
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewTreeLifecycleOwner
+import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.autofill.api.AutofillScreens.AutofillSettingsScreen
@@ -72,7 +72,7 @@ class CredentialsSyncPausedView @JvmOverloads constructor(
         AndroidSupportInjection.inject(this)
         super.onAttachedToWindow()
 
-        ViewTreeLifecycleOwner.get(this)?.lifecycle?.addObserver(viewModel)
+        findViewTreeLifecycleOwner()?.lifecycle?.addObserver(viewModel)
 
         @SuppressLint("NoHardcodedCoroutineDispatcher")
         coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
@@ -88,7 +88,7 @@ class CredentialsSyncPausedView @JvmOverloads constructor(
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
-        ViewTreeLifecycleOwner.get(this)?.lifecycle?.removeObserver(viewModel)
+        findViewTreeLifecycleOwner()?.lifecycle?.removeObserver(viewModel)
         coroutineScope?.cancel()
         job.cancel()
         coroutineScope = null

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/notifyme/NotifyMeView.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/notifyme/NotifyMeView.kt
@@ -36,7 +36,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.ContextCompat.startActivity
 import androidx.core.view.updateLayoutParams
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewTreeLifecycleOwner
+import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.notifyme.NotifyMeView.Orientation.Center
@@ -115,7 +115,7 @@ class NotifyMeView @JvmOverloads constructor(
 
         addViewTreeObserverOnGlobalLayoutListener()
 
-        ViewTreeLifecycleOwner.get(this)?.lifecycle?.addObserver(viewModel)
+        findViewTreeLifecycleOwner()?.lifecycle?.addObserver(viewModel)
 
         @SuppressLint("NoHardcodedCoroutineDispatcher")
         coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
@@ -138,7 +138,7 @@ class NotifyMeView @JvmOverloads constructor(
 
         removeViewTreeObserverOnGlobalLayoutListener()
 
-        ViewTreeLifecycleOwner.get(this)?.lifecycle?.removeObserver(viewModel)
+        findViewTreeLifecycleOwner()?.lifecycle?.removeObserver(viewModel)
 
         coroutineScope?.cancel()
         coroutineScope = null

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/settings/custom_dns/VpnCustomDnsSettingView.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/settings/custom_dns/VpnCustomDnsSettingView.kt
@@ -21,7 +21,6 @@ import android.util.AttributeSet
 import android.view.View
 import android.widget.FrameLayout
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewTreeLifecycleOwner
 import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
 import androidx.lifecycle.lifecycleScope
@@ -85,7 +84,7 @@ class VpnCustomDnsSettingView @JvmOverloads constructor(
             globalActivityStarter.start(context, VpnCustomDnsScreen.Default)
         }
 
-        ViewTreeLifecycleOwner.get(this)?.lifecycleScope?.launch {
+        findViewTreeLifecycleOwner()?.lifecycleScope?.launch {
             events
                 .flatMapLatest { viewModel.reduce(it) }
                 .flowOn(dispatcherProvider.io())

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/subscription/settings/ProSettingNetPView.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/subscription/settings/ProSettingNetPView.kt
@@ -21,7 +21,7 @@ import android.content.Context
 import android.util.AttributeSet
 import android.widget.FrameLayout
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewTreeLifecycleOwner
+import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.view.gone
@@ -72,7 +72,7 @@ class ProSettingNetPView @JvmOverloads constructor(
         AndroidSupportInjection.inject(this)
         super.onAttachedToWindow()
 
-        ViewTreeLifecycleOwner.get(this)?.lifecycle?.addObserver(viewModel)
+        findViewTreeLifecycleOwner()?.lifecycle?.addObserver(viewModel)
 
         binding.netpPSetting.setClickListener {
             viewModel.onNetPSettingClicked()
@@ -110,7 +110,7 @@ class ProSettingNetPView @JvmOverloads constructor(
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
-        ViewTreeLifecycleOwner.get(this)?.lifecycle?.removeObserver(viewModel)
+        findViewTreeLifecycleOwner()?.lifecycle?.removeObserver(viewModel)
         coroutineScope?.cancel()
         coroutineScope = null
     }

--- a/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/feature/unsafe_wifi/UnsafeWifiDetectionSettingView.kt
+++ b/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/feature/unsafe_wifi/UnsafeWifiDetectionSettingView.kt
@@ -24,7 +24,7 @@ import android.view.View
 import android.widget.CompoundButton.OnCheckedChangeListener
 import android.widget.FrameLayout
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewTreeLifecycleOwner
+import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
 import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.InjectWith
@@ -99,7 +99,7 @@ class UnsafeWifiDetectionSettingView @JvmOverloads constructor(
 
         binding.unsafeWifiDetection.setOnCheckedChangeListener(toggleListener)
 
-        ViewTreeLifecycleOwner.get(this)?.lifecycleScope?.launch {
+        findViewTreeLifecycleOwner()?.lifecycleScope?.launch {
             events
                 .flatMapLatest { viewModel.reduce(it) }
                 .flowOn(dispatcherProvider.io())

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/shortcuts/ShortcutsNewTabSectionView.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/shortcuts/ShortcutsNewTabSectionView.kt
@@ -22,7 +22,7 @@ import android.util.AttributeSet
 import android.view.View
 import android.widget.LinearLayout
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewTreeLifecycleOwner
+import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -87,7 +87,7 @@ class ShortcutsNewTabSectionView @JvmOverloads constructor(
         AndroidSupportInjection.inject(this)
         super.onAttachedToWindow()
 
-        ViewTreeLifecycleOwner.get(this)?.lifecycle?.addObserver(viewModel)
+        findViewTreeLifecycleOwner()?.lifecycle?.addObserver(viewModel)
 
         @SuppressLint("NoHardcodedCoroutineDispatcher")
         coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/newtab/RemoteMessageView.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/newtab/RemoteMessageView.kt
@@ -28,7 +28,7 @@ import android.widget.LinearLayout
 import android.widget.Toast
 import androidx.core.os.bundleOf
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewTreeLifecycleOwner
+import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
 import com.duckduckgo.anvil.annotations.ContributesActivePlugin
 import com.duckduckgo.anvil.annotations.InjectWith
@@ -94,7 +94,7 @@ class RemoteMessageView @JvmOverloads constructor(
         AndroidSupportInjection.inject(this)
         super.onAttachedToWindow()
 
-        ViewTreeLifecycleOwner.get(this)?.lifecycle?.addObserver(viewModel)
+        findViewTreeLifecycleOwner()?.lifecycle?.addObserver(viewModel)
 
         @SuppressLint("NoHardcodedCoroutineDispatcher")
         coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionView.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionView.kt
@@ -28,7 +28,7 @@ import android.widget.PopupWindow
 import androidx.core.text.HtmlCompat
 import androidx.core.text.toSpannable
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewTreeLifecycleOwner
+import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.ItemTouchHelper
@@ -108,7 +108,7 @@ class FavouritesNewTabSectionView @JvmOverloads constructor(
         AndroidSupportInjection.inject(this)
         super.onAttachedToWindow()
 
-        ViewTreeLifecycleOwner.get(this)?.lifecycle?.addObserver(viewModel)
+        findViewTreeLifecycleOwner()?.lifecycle?.addObserver(viewModel)
 
         @SuppressLint("NoHardcodedCoroutineDispatcher")
         coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
@@ -200,7 +200,7 @@ class FavouritesNewTabSectionView @JvmOverloads constructor(
         onMoveListener: (RecyclerView.ViewHolder) -> Unit,
     ): FavouritesNewTabSectionsAdapter {
         return FavouritesNewTabSectionsAdapter(
-            ViewTreeLifecycleOwner.get(this)!!,
+            findViewTreeLifecycleOwner()!!,
             faviconManager,
             onMoveListener,
             {

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSiteInvalidItemsView.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSiteInvalidItemsView.kt
@@ -23,7 +23,7 @@ import android.util.AttributeSet
 import android.widget.FrameLayout
 import androidx.core.view.isVisible
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewTreeLifecycleOwner
+import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.browser.api.ui.BrowserScreens.BookmarksScreenNoParams
@@ -73,7 +73,7 @@ class SavedSiteInvalidItemsView @JvmOverloads constructor(
         AndroidSupportInjection.inject(this)
         super.onAttachedToWindow()
 
-        ViewTreeLifecycleOwner.get(this)?.lifecycle?.addObserver(viewModel)
+        findViewTreeLifecycleOwner()?.lifecycle?.addObserver(viewModel)
 
         @SuppressLint("NoHardcodedCoroutineDispatcher")
         coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
@@ -89,7 +89,7 @@ class SavedSiteInvalidItemsView @JvmOverloads constructor(
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
-        ViewTreeLifecycleOwner.get(this)?.lifecycle?.removeObserver(viewModel)
+        findViewTreeLifecycleOwner()?.lifecycle?.removeObserver(viewModel)
         coroutineScope?.cancel()
         job.cancel()
         coroutineScope = null

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSiteSyncPausedView.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/SavedSiteSyncPausedView.kt
@@ -22,7 +22,7 @@ import android.util.AttributeSet
 import android.widget.FrameLayout
 import androidx.core.view.isVisible
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewTreeLifecycleOwner
+import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.browser.api.ui.BrowserScreens.BookmarksScreenNoParams
@@ -71,7 +71,7 @@ class SavedSiteSyncPausedView @JvmOverloads constructor(
         AndroidSupportInjection.inject(this)
         super.onAttachedToWindow()
 
-        ViewTreeLifecycleOwner.get(this)?.lifecycle?.addObserver(viewModel)
+        findViewTreeLifecycleOwner()?.lifecycle?.addObserver(viewModel)
 
         @SuppressLint("NoHardcodedCoroutineDispatcher")
         coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
@@ -87,7 +87,7 @@ class SavedSiteSyncPausedView @JvmOverloads constructor(
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
-        ViewTreeLifecycleOwner.get(this)?.lifecycle?.removeObserver(viewModel)
+        findViewTreeLifecycleOwner()?.lifecycle?.removeObserver(viewModel)
         coroutineScope?.cancel()
         job.cancel()
         coroutineScope = null

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/settings/views/ItrSettingView.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/settings/views/ItrSettingView.kt
@@ -21,7 +21,7 @@ import android.content.Context
 import android.util.AttributeSet
 import android.widget.FrameLayout
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewTreeLifecycleOwner
+import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.view.gone
@@ -73,7 +73,7 @@ class ItrSettingView @JvmOverloads constructor(
         AndroidSupportInjection.inject(this)
         super.onAttachedToWindow()
 
-        ViewTreeLifecycleOwner.get(this)?.lifecycle?.addObserver(viewModel)
+        findViewTreeLifecycleOwner()?.lifecycle?.addObserver(viewModel)
 
         binding.itrSettings.setClickListener {
             viewModel.onItr()
@@ -93,7 +93,7 @@ class ItrSettingView @JvmOverloads constructor(
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
-        ViewTreeLifecycleOwner.get(this)?.lifecycle?.removeObserver(viewModel)
+        findViewTreeLifecycleOwner()?.lifecycle?.removeObserver(viewModel)
         coroutineScope?.cancel()
         job.cancel()
         coroutineScope = null

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/settings/views/PirSettingView.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/settings/views/PirSettingView.kt
@@ -21,7 +21,7 @@ import android.content.Context
 import android.util.AttributeSet
 import android.widget.FrameLayout
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewTreeLifecycleOwner
+import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.view.gone
@@ -72,7 +72,7 @@ class PirSettingView @JvmOverloads constructor(
         AndroidSupportInjection.inject(this)
         super.onAttachedToWindow()
 
-        ViewTreeLifecycleOwner.get(this)?.lifecycle?.addObserver(viewModel)
+        findViewTreeLifecycleOwner()?.lifecycle?.addObserver(viewModel)
 
         binding.pirSettings.setClickListener {
             viewModel.onPir()
@@ -92,7 +92,7 @@ class PirSettingView @JvmOverloads constructor(
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
-        ViewTreeLifecycleOwner.get(this)?.lifecycle?.removeObserver(viewModel)
+        findViewTreeLifecycleOwner()?.lifecycle?.removeObserver(viewModel)
         coroutineScope?.cancel()
         job.cancel()
         coroutineScope = null

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/settings/views/ProSettingView.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/settings/views/ProSettingView.kt
@@ -23,7 +23,7 @@ import android.view.MotionEvent
 import android.widget.FrameLayout
 import android.widget.LinearLayout
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewTreeLifecycleOwner
+import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.view.gone
@@ -89,7 +89,7 @@ class ProSettingView @JvmOverloads constructor(
         AndroidSupportInjection.inject(this)
         super.onAttachedToWindow()
 
-        ViewTreeLifecycleOwner.get(this)?.lifecycle?.addObserver(viewModel)
+        findViewTreeLifecycleOwner()?.lifecycle?.addObserver(viewModel)
 
         @SuppressLint("NoHardcodedCoroutineDispatcher")
         coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
@@ -126,7 +126,7 @@ class ProSettingView @JvmOverloads constructor(
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
-        ViewTreeLifecycleOwner.get(this)?.lifecycle?.removeObserver(viewModel)
+        findViewTreeLifecycleOwner()?.lifecycle?.removeObserver(viewModel)
         coroutineScope?.cancel()
         job.cancel()
         coroutineScope = null

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncDisabledView.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncDisabledView.kt
@@ -22,7 +22,7 @@ import android.util.AttributeSet
 import android.widget.FrameLayout
 import androidx.core.view.isVisible
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewTreeLifecycleOwner
+import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.viewbinding.viewBinding
@@ -60,7 +60,7 @@ class SyncDisabledView @JvmOverloads constructor(
         AndroidSupportInjection.inject(this)
         super.onAttachedToWindow()
 
-        ViewTreeLifecycleOwner.get(this)?.lifecycle?.addObserver(viewModel)
+        findViewTreeLifecycleOwner()?.lifecycle?.addObserver(viewModel)
 
         @SuppressLint("NoHardcodedCoroutineDispatcher")
         coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
@@ -72,7 +72,7 @@ class SyncDisabledView @JvmOverloads constructor(
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
-        ViewTreeLifecycleOwner.get(this)?.lifecycle?.removeObserver(viewModel)
+        findViewTreeLifecycleOwner()?.lifecycle?.removeObserver(viewModel)
         coroutineScope?.cancel()
         coroutineScope = null
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncErrorView.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncErrorView.kt
@@ -22,7 +22,7 @@ import android.util.AttributeSet
 import android.widget.FrameLayout
 import androidx.core.view.isVisible
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewTreeLifecycleOwner
+import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.viewbinding.viewBinding
@@ -61,7 +61,7 @@ class SyncErrorView @JvmOverloads constructor(
         AndroidSupportInjection.inject(this)
         super.onAttachedToWindow()
 
-        ViewTreeLifecycleOwner.get(this)?.lifecycle?.addObserver(viewModel)
+        findViewTreeLifecycleOwner()?.lifecycle?.addObserver(viewModel)
 
         @SuppressLint("NoHardcodedCoroutineDispatcher")
         coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
@@ -73,7 +73,7 @@ class SyncErrorView @JvmOverloads constructor(
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
-        ViewTreeLifecycleOwner.get(this)?.lifecycle?.removeObserver(viewModel)
+        findViewTreeLifecycleOwner()?.lifecycle?.removeObserver(viewModel)
         coroutineScope?.cancel()
         coroutineScope = null
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/qrcode/SyncBarcodeView.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/qrcode/SyncBarcodeView.kt
@@ -31,7 +31,7 @@ import android.widget.FrameLayout
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewTreeLifecycleOwner
+import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.viewbinding.viewBinding
@@ -88,7 +88,7 @@ constructor(
         AndroidSupportInjection.inject(this)
         super.onAttachedToWindow()
 
-        ViewTreeLifecycleOwner.get(this)?.lifecycle?.addObserver(viewModel)
+        findViewTreeLifecycleOwner()?.lifecycle?.addObserver(viewModel)
 
         @SuppressLint("NoHardcodedCoroutineDispatcher")
         coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/qrcode/SyncBarcodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/qrcode/SyncBarcodeViewModelTest.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.sync.impl.ui.qrcode
 
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
@@ -42,20 +42,9 @@ class SyncBarcodeViewModelTest {
     var coroutineRule = CoroutineTestRule()
 
     private val permissionDeniedWrapper = PermissionDeniedWrapper()
-    private val fakeLifecycleOwner = {
-        object : Lifecycle() {
-            override fun addObserver(observer: LifecycleObserver) {
-                TODO("Not yet implemented")
-            }
-
-            override fun removeObserver(observer: LifecycleObserver) {
-                TODO("Not yet implemented")
-            }
-
-            override fun getCurrentState(): State {
-                TODO("Not yet implemented")
-            }
-        }
+    private val fakeLifecycleOwner = object : LifecycleOwner {
+        override val lifecycle: Lifecycle
+            get() = TODO("Not yet implemented")
     }
 
     private val testee: SquareDecoratedBarcodeViewModel by lazy {

--- a/versions.properties
+++ b/versions.properties
@@ -9,7 +9,7 @@
 
 version.android.billingclient=6.0.1
 
-version.androidx.appcompat=1.5.1
+version.androidx.appcompat=1.7.0
 
 version.androidx.arch.core=2.2.0
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207701481229686/1207715036746087/f 

### Description
Updates `AppCompat` from `1.5.1` to `1.7.0`.

The production code changes are minimal but it required a bunch of changes to the tests to get them working.

### Steps to test this PR

- Since `AppCompat` is so broadly used, need to **smoke test** the whole app. 
- Make sure to hit a page where `findViewTreeLifecycleOwner()` is called, e.g., in `NewTabLegacyPageView`