### PR TITLE
Catch HitTestResult NullPointerException

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2713,13 +2713,16 @@ class BrowserTabFragment :
     }
 
     override fun onContextItemSelected(item: MenuItem): Boolean {
-        webView?.hitTestResult?.let {
-            val target = getLongPressTarget(it)
-            if (target != null && viewModel.userSelectedItemFromLongPressMenu(target, item)) {
-                return true
+        runCatching {
+            webView?.hitTestResult?.let {
+                val target = getLongPressTarget(it)
+                if (target != null && viewModel.userSelectedItemFromLongPressMenu(target, item)) {
+                    return true
+                }
             }
+        }.onFailure { exception ->
+            Timber.e(exception, "Failed to get HitTestResult")
         }
-
         return super.onContextItemSelected(item)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1200204095367872/1207702094588632/f

### Description
Catches a `NullPointerException` sometimes thrown by `getHitTestResult`.

### Steps to test this PR
- [x] Long press a link/image on a page
- [x] Select an item from the context menu
- [x] Verify that it works as expected