### PR TITLE
Update mockito to 5.12.0 and fix failing tests

### DIFF
--- a/remote-messaging/remote-messaging-impl/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/remote-messaging/remote-messaging-impl/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsTest.kt
@@ -16,6 +16,8 @@
 
 package com.duckduckgo.subscriptions.impl
 
+import android.content.Intent
+import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
 import androidx.core.net.toUri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -23,6 +25,7 @@ import app.cash.turbine.test
 import com.duckduckgo.browser.api.ui.BrowserScreens.SettingsScreenNoParams
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.navigation.api.GlobalActivityStarter
+import com.duckduckgo.navigation.api.GlobalActivityStarter.ActivityParams
 import com.duckduckgo.subscriptions.api.Product.NetP
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.AUTO_RENEWABLE
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.INACTIVE
@@ -197,23 +200,29 @@ class RealSubscriptionsTest {
 
     @Test
     fun whenLaunchPrivacyProWithOriginThenPassTheOriginToActivity() = runTest {
-        whenever(globalActivityStarter.startIntent(any(), any<SettingsScreenNoParams>())).thenReturn(mock())
+        whenever(globalActivityStarter.startIntent(any(), any<SettingsScreenNoParams>())).thenReturn(fakeIntent())
+        whenever(globalActivityStarter.startIntent(any(), any<SubscriptionsWebViewActivityWithParams>())).thenReturn(fakeIntent())
 
-        val captor = argumentCaptor<SubscriptionsWebViewActivityWithParams>()
+        val captor = argumentCaptor<ActivityParams>()
         subscriptions.launchPrivacyPro(context, "https://duckduckgo.com/pro?origin=test".toUri())
 
         verify(globalActivityStarter, times(2)).startIntent(eq(context), captor.capture())
-        assertEquals("test", captor.lastValue.origin)
+        assertEquals("test", (captor.lastValue as SubscriptionsWebViewActivityWithParams).origin)
     }
 
     @Test
     fun whenLaunchPrivacyProWithNoOriginThenDoNotPassTheOriginToActivity() = runTest {
-        whenever(globalActivityStarter.startIntent(any(), any<SettingsScreenNoParams>())).thenReturn(mock())
+        whenever(globalActivityStarter.startIntent(any(), any<SettingsScreenNoParams>())).thenReturn(fakeIntent())
+        whenever(globalActivityStarter.startIntent(any(), any<SubscriptionsWebViewActivityWithParams>())).thenReturn(fakeIntent())
 
-        val captor = argumentCaptor<SubscriptionsWebViewActivityWithParams>()
+        val captor = argumentCaptor<ActivityParams>()
         subscriptions.launchPrivacyPro(context, "https://duckduckgo.com/pro".toUri())
 
         verify(globalActivityStarter, times(2)).startIntent(eq(context), captor.capture())
-        assertNull(captor.lastValue.origin)
+        assertNull((captor.lastValue as SubscriptionsWebViewActivityWithParams).origin)
+    }
+
+    private fun fakeIntent(): Intent {
+        return Intent().also { it.addFlags(FLAG_ACTIVITY_NEW_TASK) }
     }
 }

--- a/subscriptions/subscriptions-impl/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/subscriptions/subscriptions-impl/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline

--- a/versions.properties
+++ b/versions.properties
@@ -95,7 +95,7 @@ version.leakcanary=2.10
 
 version.logcat=0.1
 
-version.mockito=4.4.0
+version.mockito=5.12.0
 
 version.moshi=1.8.0
 
@@ -109,7 +109,7 @@ version.org.apache.commons..commons-math3=3.6.1
 
 version.org.json..json=20230227
 
-version.org.mockito.kotlin..mockito-kotlin=4.0.0
+version.org.mockito.kotlin..mockito-kotlin=5.3.1
 
 version.retrofit2=2.9.0
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207701481229686/1207716076931920/f 

### Description
Updates Mockito to latest version. This lets us run the tests on all Android APIs instead of being limited to ~API 30 like we are now.

### Steps to test this PR
- [ ] Make sure CI is all green
- [ ] Make sure you can run tests locally
