### PR TITLE
Add sync api errors daily pixels

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/error/SyncApiErrorRecorder.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/error/SyncApiErrorRecorder.kt
@@ -68,5 +68,6 @@ class RealSyncApiErrorRecorder @Inject constructor(
                 syncApiErrorRepository.addError(feature, TOO_MANY_REQUESTS)
             }
         }
+        syncPixels.fireDailySyncApiErrorPixel(feature, apiError)
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/error/SyncApiErrorRecorderTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/error/SyncApiErrorRecorderTest.kt
@@ -43,6 +43,7 @@ internal class SyncApiErrorRecorderTest {
         apiErrorReporter.record(feature, error)
 
         verify(syncApiErrorRepository).addError(feature, OBJECT_LIMIT_EXCEEDED)
+        verify(syncPixels).fireDailySyncApiErrorPixel(feature, error)
     }
 
     @Test
@@ -53,6 +54,7 @@ internal class SyncApiErrorRecorderTest {
         apiErrorReporter.record(feature, error)
 
         verify(syncApiErrorRepository).addError(feature, REQUEST_SIZE_LIMIT_EXCEEDED)
+        verify(syncPixels).fireDailySyncApiErrorPixel(feature, error)
     }
 
     @Test
@@ -63,6 +65,7 @@ internal class SyncApiErrorRecorderTest {
         apiErrorReporter.record(feature, error)
 
         verify(syncApiErrorRepository).addError(feature, VALIDATION_ERROR)
+        verify(syncPixels).fireDailySyncApiErrorPixel(feature, error)
     }
 
     @Test
@@ -73,6 +76,7 @@ internal class SyncApiErrorRecorderTest {
         apiErrorReporter.record(feature, error)
 
         verify(syncApiErrorRepository).addError(feature, TOO_MANY_REQUESTS)
+        verify(syncPixels).fireDailySyncApiErrorPixel(feature, error)
     }
 
     @Test
@@ -83,5 +87,6 @@ internal class SyncApiErrorRecorderTest {
         apiErrorReporter.record(feature, error)
 
         verify(syncApiErrorRepository).addError(feature, TOO_MANY_REQUESTS)
+        verify(syncPixels).fireDailySyncApiErrorPixel(feature, error)
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/pixels/SyncPixelsTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/pixels/SyncPixelsTest.kt
@@ -20,6 +20,9 @@ import android.content.SharedPreferences
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.test.api.InMemorySharedPreferences
 import com.duckduckgo.common.utils.formatters.time.DatabaseDateFormatter
+import com.duckduckgo.sync.api.engine.SyncableType
+import com.duckduckgo.sync.impl.API_CODE
+import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.stats.DailyStats
 import com.duckduckgo.sync.impl.stats.SyncStatsRepository
 import com.duckduckgo.sync.store.SharedPrefsProvider
@@ -31,7 +34,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
-class SyncPixelsTest {
+class RealSyncPixelsTest {
 
     private var pixel: Pixel = mock()
     private var syncStatsRepository: SyncStatsRepository = mock()
@@ -102,6 +105,35 @@ class SyncPixelsTest {
         testee.fireSignupConnectPixel()
 
         verify(pixel).fire(SyncPixelName.SYNC_SIGNUP_CONNECT)
+    }
+
+    @Test
+    fun whenfireDailyApiErrorForObjectLimitExceededThenPixelSent() {
+        testee.fireDailySyncApiErrorPixel(SyncableType.BOOKMARKS, Error(code = API_CODE.COUNT_LIMIT.code))
+
+        verify(pixel).fire("m_sync_bookmarks_object_limit_exceeded_daily", emptyMap(), emptyMap(), type = Pixel.PixelType.DAILY)
+    }
+
+    @Test
+    fun whenfireDailyApiErrorForRequestSizeLimitExceededThenPixelSent() {
+        testee.fireDailySyncApiErrorPixel(SyncableType.BOOKMARKS, Error(code = API_CODE.CONTENT_TOO_LARGE.code))
+
+        verify(pixel).fire("m_sync_bookmarks_request_size_limit_exceeded_daily", emptyMap(), emptyMap(), type = Pixel.PixelType.DAILY)
+    }
+
+    @Test
+    fun whenfireDailyApiErrorForValidationErrorThenPixelSent() {
+        testee.fireDailySyncApiErrorPixel(SyncableType.BOOKMARKS, Error(code = API_CODE.VALIDATION_ERROR.code))
+
+        verify(pixel).fire("m_sync_bookmarks_validation_error_daily", emptyMap(), emptyMap(), type = Pixel.PixelType.DAILY)
+    }
+
+    @Test
+    fun whenfireDailyApiErrorForTooManyRequestsThenPixelSent() {
+        testee.fireDailySyncApiErrorPixel(SyncableType.BOOKMARKS, Error(code = API_CODE.TOO_MANY_REQUESTS_1.code))
+        testee.fireDailySyncApiErrorPixel(SyncableType.BOOKMARKS, Error(code = API_CODE.TOO_MANY_REQUESTS_2.code))
+
+        verify(pixel, times(2)).fire("m_sync_bookmarks_too_many_requests_daily", emptyMap(), emptyMap(), type = Pixel.PixelType.DAILY)
     }
 
     private fun givenSomeDailyStats(): DailyStats {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1207559244852257/f 

### Description
Fires a pixel on first event of api error per day.

### Steps to test this PR

Suggestion: Use `message~:"Pixel sent"` filter

_Feature 1_
Just one scenario for manual QA, other scenario should behave similar but more difficult to test. Tests cover all scenarios.
- [x] fresh install
- [ ] change to sync dev env inside internal settings
- [x] create a sync account
- [x] go to autofill internal settings
- [x] add 1000 credentials around 4-5 times
- [x] at some point you should see in the logs the pixel `m_sync_credentials_object_limit_exceeded_daily``
(if you lose the logs, you can check directly in db if the pixel was sent. Go to database inspector -> pixels.db -> daily_pixels_fired)

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
