### PR TITLE
Remove not-auto-renewable from ACTIVE mapping

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/rmf/RMFPProSubscriptionStatusMatchingAttribute.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/rmf/RMFPProSubscriptionStatusMatchingAttribute.kt
@@ -55,7 +55,7 @@ class RMFPProSubscriptionStatusMatchingAttribute @Inject constructor(
     private fun SubscriptionStatus.matchesRmfValue(value: List<String>): Boolean {
         value.forEach {
             val shouldMatch = when (it) {
-                STATUS_ACTIVE -> this == AUTO_RENEWABLE || this == NOT_AUTO_RENEWABLE || this == GRACE_PERIOD
+                STATUS_ACTIVE -> this == AUTO_RENEWABLE || this == GRACE_PERIOD
                 STATUS_EXPIRING -> this == NOT_AUTO_RENEWABLE
                 STATUS_EXPIRED -> this == EXPIRED || this == INACTIVE
                 else -> false

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/rmf/RMFPProSubscriptionStatusMatchingAttributeTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/rmf/RMFPProSubscriptionStatusMatchingAttributeTest.kt
@@ -98,7 +98,7 @@ class RMFPProSubscriptionStatusMatchingAttributeTest {
 
         assertNotNull(result)
         result?.let {
-            assertTrue(it)
+            assertFalse(it)
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201462763415876/1207718752492279/f

### Description
Previously, we map n`ot-auto-renewable` to `ACTIVE` and `EXPIRING` states. For consistency with other platforms, considering we accept an `array` in `pproSubscriptionStatus` already, we don't need to map `not-auto-renewable` to 2 states anymore.

 To fix this, we are only mapping `not-auto-renewable` to `ACTIVE` state.

### Steps to test this PR
Qa-optional
