### PR TITLE
Add support for specifying a custom debug signing certificate

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -73,6 +73,20 @@ android {
         arg("room.generateKotlin", "true")
     }
     signingConfigs {
+        debug {
+            def localPropertiesFile = project.rootProject.file('local.properties')
+            if (localPropertiesFile.exists()) {
+                def properties = new Properties()
+                localPropertiesFile.withInputStream { properties.load(it) }
+
+                if (properties.getProperty("useCustomDebugCert")?.toBoolean()) {
+                    storeFile = file(properties['customDebugCertPath']?.toString())
+                    storePassword = properties['customDebugCertStorePassword']?.toString()
+                    keyAlias = properties['customDebugCertAlias']?.toString()
+                    keyPassword properties['customDebugCertKeyPassword']?.toString()
+                }
+            }
+        }
         release
     }
     buildTypes {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202552961248957/1207182540886158/f 

### Description
Enables a custom signing certificate to be specified for `debug` builds. 

By default, behavior is the same as it's always been. To override the default and specify a custom debug signing cert:
- create a signing certificate / keystore and store it somewhere
- in `local.properties` in the project, add the following values:

```
useCustomDebugCert=true
customDebugCertPath=<path_to_keystore>
customDebugCertAlias=<alias>
customDebugCertStorePassword=<store_password>
customDebugCertKeyPassword=<key_password>
```

### Steps to test this PR

- [x] QA optional, make sure your debug builds work as normal without you needing to configure anything
- [x] If you want, create a new keystore / signing key and get it to be used by specifying the values in your `local.properties` as above. tip: can add a log statement when the app starts up which calls `SigningCertificateHashExtractor.sha256Hash()` to verify which cert is in use