### PR TITLE
Update content scope scripts to version 6.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^10.10.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#12.0.1",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.25.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.0.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#3.5.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1708702034"
       },
@@ -60,16 +60,16 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "10.10.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-10.10.0.tgz",
-      "integrity": "sha512-ewY0Rrpp/FiFS8tf7qO4+iuAM5h/nSo8jdBQbpOQ1hI7aCP5pIdrZehJWIO7mkiNboVKAaP3p1WBhydIjfQDFA=="
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-10.11.0.tgz",
+      "integrity": "sha512-JybvVNw3vTf/pL7n/hvqPP1Gu3EKN4MoP0Tvse6WvgzWxNSWCWA6+SE+vMc1xPuByG7sIwFs80SIi77ndrZXZQ=="
     },
     "node_modules/@duckduckgo/autofill": {
       "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#2b81745565db09eee8c1cd44d38eefa1011a9f0a",
       "hasInstallScript": true
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#7ac68ae3bc052fa59adbc1ba8fd5cb5849a6bc99",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#9c65477457126ab7ad963a32b7f85ce08e6bd1a7",
       "hasInstallScript": true,
       "workspaces": [
         "packages/special-pages",
@@ -266,9 +266,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.14.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
-      "integrity": "sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==",
+      "version": "20.14.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
+      "integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -284,9 +284,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.0.tgz",
-      "integrity": "sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw==",
+      "version": "8.12.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
+      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^10.10.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#12.0.1",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#5.25.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.0.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#3.5.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1708702034"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207763697290294/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [x] All tests must pass