### PR TITLE
New Tab: Pixels

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
@@ -226,5 +226,8 @@ enum class DeviceShieldPixelNames(override val pixelName: String, val enqueue: B
     VPN_START_ATTEMPT("m_vpn_ev_start_attempt_c", enqueue = true),
     VPN_START_ATTEMPT_SUCCESS("m_vpn_ev_start_attempt_success_c", enqueue = true),
     VPN_START_ATTEMPT_FAILURE("m_vpn_ev_start_attempt_failure_c", enqueue = true),
+
+    NEW_TAB_SECTION_TOGGLED_OFF("m_new_tab_page_customize_section_off_appTP"),
+    NEW_TAB_SECTION_TOGGLED_ON("m_new_tab_page_customize_section_on_appTP"),
     ;
 }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
@@ -363,6 +363,9 @@ interface DeviceShieldPixels {
     fun reportVpnStartAttempt()
 
     fun reportVpnStartAttemptSuccess()
+
+    // New Tab Engagement pixels https://app.asana.com/0/72649045549333/1207667088727866/f
+    fun reportNewTabSectionToggled(enabled: Boolean)
 }
 
 @ContributesBinding(AppScope::class)
@@ -825,6 +828,14 @@ class RealDeviceShieldPixels @Inject constructor(
 
     override fun reportTLSParsingError(errorCode: Int) {
         tryToFireDailyPixel(String.format(Locale.US, DeviceShieldPixelNames.REPORT_TLS_PARSING_ERROR_CODE_DAILY.pixelName, errorCode))
+    }
+
+    override fun reportNewTabSectionToggled(enabled: Boolean) {
+        if (enabled) {
+            firePixel(DeviceShieldPixelNames.NEW_TAB_SECTION_TOGGLED_ON)
+        } else {
+            firePixel(DeviceShieldPixelNames.NEW_TAB_SECTION_TOGGLED_OFF)
+        }
     }
 
     private fun firePixel(

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/newtab/AppTrackingProtectionNewTabSettingsViewModel.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/newtab/AppTrackingProtectionNewTabSettingsViewModel.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixels
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -37,6 +38,7 @@ import kotlinx.coroutines.withContext
 class AppTrackingProtectionNewTabSettingsViewModel @Inject constructor(
     private val dispatchers: DispatcherProvider,
     private val setting: NewTabAppTrackingProtectionSectionSetting,
+    private val pixel: DeviceShieldPixels,
 ) : ViewModel(), DefaultLifecycleObserver {
 
     private val _viewState = MutableStateFlow(ViewState(true))
@@ -57,5 +59,6 @@ class AppTrackingProtectionNewTabSettingsViewModel @Inject constructor(
 
     fun onSettingEnabled(enabled: Boolean) {
         setting.self().setEnabled(State(enabled))
+        pixel.reportNewTabSectionToggled(enabled)
     }
 }

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNamesTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNamesTest.kt
@@ -22,8 +22,10 @@ import org.junit.Test
 class DeviceShieldPixelNamesTest {
     @Test
     fun allAppTrackingProtectionPixelsShallBePrefixed() {
-        DeviceShieldPixelNames.values().map { it.pixelName }.forEach { pixel ->
-            assertTrue(pixel.startsWith("m_atp") || pixel.startsWith("m_vpn"))
-        }
+        DeviceShieldPixelNames.values()
+            .map { it.pixelName }
+            .forEach { pixel ->
+                assertTrue(pixel.startsWith("m_atp") || pixel.startsWith("m_vpn") || pixel.startsWith("m_new_tab_page"))
+            }
     }
 }

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/newtab/AppTrackingProtectionNewTabSettingsViewModelTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/newtab/AppTrackingProtectionNewTabSettingsViewModelTest.kt
@@ -21,6 +21,7 @@ import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixels
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -28,6 +29,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 class AppTrackingProtectionNewTabSettingsViewModelTest {
@@ -38,12 +40,14 @@ class AppTrackingProtectionNewTabSettingsViewModelTest {
     private lateinit var testee: AppTrackingProtectionNewTabSettingsViewModel
     private val setting: NewTabAppTrackingProtectionSectionSetting = mock()
     private val lifecycleOwner: LifecycleOwner = mock()
+    private val pixels: DeviceShieldPixels = mock()
 
     @Before
     fun setup() {
         testee = AppTrackingProtectionNewTabSettingsViewModel(
             coroutinesTestRule.testDispatcherProvider,
             setting,
+            pixels,
         )
     }
 
@@ -93,5 +97,45 @@ class AppTrackingProtectionNewTabSettingsViewModelTest {
                 assertFalse(it.enabled)
             }
         }
+    }
+
+    @Test
+    fun whenSettingEnabledThenPixelFired() = runTest {
+        whenever(setting.self()).thenReturn(
+            object : Toggle {
+                override fun isEnabled(): Boolean {
+                    return false
+                }
+
+                override fun setEnabled(state: State) {
+                }
+
+                override fun getRawStoredState(): State {
+                    return State()
+                }
+            },
+        )
+        testee.onSettingEnabled(true)
+        verify(pixels).reportNewTabSectionToggled(true)
+    }
+
+    @Test
+    fun whenSettingDisabledThenPixelFired() = runTest {
+        whenever(setting.self()).thenReturn(
+            object : Toggle {
+                override fun isEnabled(): Boolean {
+                    return false
+                }
+
+                override fun setEnabled(state: State) {
+                }
+
+                override fun getRawStoredState(): State {
+                    return State()
+                }
+            },
+        )
+        testee.onSettingEnabled(false)
+        verify(pixels).reportNewTabSectionToggled(false)
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -94,7 +94,6 @@ import com.duckduckgo.app.browser.model.LongPressTarget
 import com.duckduckgo.app.browser.newtab.FavoritesQuickAccessAdapter
 import com.duckduckgo.app.browser.newtab.FavoritesQuickAccessAdapter.QuickAccessFavorite
 import com.duckduckgo.app.browser.omnibar.OmnibarEntryConverter
-import com.duckduckgo.app.browser.remotemessage.CommandActionMapper
 import com.duckduckgo.app.browser.remotemessage.RemoteMessagingModel
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.browser.viewstate.BrowserViewState
@@ -148,7 +147,6 @@ import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.UNIQUE
 import com.duckduckgo.app.surrogates.SurrogateResponse
-import com.duckduckgo.app.survey.notification.SurveyNotificationScheduler
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.trackerdetection.EntityLookup
@@ -174,6 +172,7 @@ import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.history.api.HistoryEntry.VisitedPage
 import com.duckduckgo.history.api.NavigationHistory
+import com.duckduckgo.newtabpage.impl.pixels.NewTabPixels
 import com.duckduckgo.privacy.config.api.*
 import com.duckduckgo.privacy.config.impl.features.gpc.RealGpc
 import com.duckduckgo.privacy.config.impl.features.gpc.RealGpc.Companion.GPC_HEADER
@@ -195,8 +194,6 @@ import com.duckduckgo.site.permissions.api.SitePermissionsManager
 import com.duckduckgo.site.permissions.api.SitePermissionsManager.SitePermissionQueryResponse
 import com.duckduckgo.site.permissions.api.SitePermissionsManager.SitePermissions
 import com.duckduckgo.subscriptions.api.Subscriptions
-import com.duckduckgo.sync.api.engine.SyncEngine
-import com.duckduckgo.sync.api.engine.SyncEngine.SyncTrigger.FEATURE_READ
 import com.duckduckgo.sync.api.favicons.FaviconsFetchingPrompt
 import com.duckduckgo.voice.api.VoiceSearchAvailability
 import com.duckduckgo.voice.api.VoiceSearchAvailabilityPixelLogger
@@ -308,6 +305,9 @@ class BrowserTabViewModelTest {
     private lateinit var mockPixel: Pixel
 
     @Mock
+    private lateinit var mockNewTabPixels: NewTabPixels
+
+    @Mock
     private lateinit var mockOnboardingStore: OnboardingStore
 
     @Mock
@@ -386,9 +386,6 @@ class BrowserTabViewModelTest {
     private lateinit var mockUserAllowListRepository: UserAllowListRepository
 
     @Mock
-    private lateinit var mockSurveyNotificationScheduler: SurveyNotificationScheduler
-
-    @Mock
     private lateinit var mockFileChooserCallback: ValueCallback<Array<Uri>>
 
     private lateinit var remoteMessagingModel: RemoteMessagingModel
@@ -447,8 +444,6 @@ class BrowserTabViewModelTest {
 
     private val mockSitePermissionsManager: SitePermissionsManager = mock()
 
-    private val mockSyncEngine: SyncEngine = mock()
-
     private val cameraHardwareChecker: CameraHardwareChecker = mock()
 
     private val androidBrowserConfig: AndroidBrowserConfigFeature = mock()
@@ -471,7 +466,6 @@ class BrowserTabViewModelTest {
     private val mockExtendedOnboardingFeatureToggles: ExtendedOnboardingFeatureToggles = mock()
     private val mockUserBrowserProperties: UserBrowserProperties = mock()
     private val mockAutoCompleteRepository: AutoCompleteRepository = mock()
-    private val commandActionMapper: CommandActionMapper = mock()
 
     @Before
     fun before() {
@@ -602,8 +596,6 @@ class BrowserTabViewModelTest {
             autofillCapabilityChecker = autofillCapabilityChecker,
             autofillFireproofDialogSuppressor = autofillFireproofDialogSuppressor,
             automaticSavedLoginsMonitor = automaticSavedLoginsMonitor,
-            surveyNotificationScheduler = mockSurveyNotificationScheduler,
-            syncEngine = mockSyncEngine,
             device = mockDeviceInfo,
             sitePermissionsManager = mockSitePermissionsManager,
             cameraHardwareChecker = cameraHardwareChecker,
@@ -617,7 +609,7 @@ class BrowserTabViewModelTest {
             bypassedSSLCertificatesRepository = mockBypassedSSLCertificatesRepository,
             userBrowserProperties = mockUserBrowserProperties,
             history = mockNavigationHistory,
-            commandActionMapper = commandActionMapper,
+            newTabPixels = mockNewTabPixels,
         )
 
         testee.loadData("abc", null, false)
@@ -4662,17 +4654,6 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenNewTabOpenedAndFavouritesPresentThenSyncTriggered() = runTest {
-        val favoriteSite = Favorite(id = UUID.randomUUID().toString(), title = "", url = "www.example.com", position = 0, lastModified = "timestamp")
-        favoriteListFlow.send(listOf(favoriteSite))
-        loadUrl("www.example.com", isBrowserShowing = true)
-
-        testee.onNewTabFavouritesShown()
-
-        verify(mockSyncEngine).triggerSync(FEATURE_READ)
-    }
-
-    @Test
     fun whenOnShowFileChooserWithImageWildcardedTypeThenImageOrCameraChooserCommandSent() {
         val params = buildFileChooserParams(arrayOf("image/*"))
         testee.showFileChooser(mockFileChooserCallback, params)
@@ -5430,6 +5411,13 @@ class BrowserTabViewModelTest {
         testee.sendPixelsOnEnterKeyPressed()
 
         verify(mockPixel).fire(AppPixelName.KEYBOARD_GO_SERP_CLICKED)
+    }
+
+    @Test
+    fun whenNewTabShownThenPixelIsFired() {
+        testee.onNewTabShown()
+
+        verify(mockNewTabPixels).fireNewTabDisplayed()
     }
 
     private fun aCredential(): LoginCredentials {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -335,11 +335,11 @@ open class BrowserActivity : DuckDuckGoActivity() {
                 lifecycleScope.launch { viewModel.onOpenFavoriteFromWidget(query = sharedText) }
                 return
             } else if (intent.getBooleanExtra(OPEN_IN_CURRENT_TAB_EXTRA, false)) {
-                Timber.w("New Tab: open in current tab requested")
+                Timber.w("open in current tab requested")
                 if (currentTab != null) {
                     currentTab?.submitQuery(sharedText)
                 } else {
-                    Timber.w("New Tab: can't use current tab, opening in new tab instead")
+                    Timber.w("can't use current tab, opening in new tab instead")
                     lifecycleScope.launch { viewModel.onOpenInNewTabRequested(query = sharedText, skipHome = true) }
                 }
                 return

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -198,8 +198,6 @@ open class BrowserActivity : DuckDuckGoActivity() {
             Timber.i("Automatic data clearer not yet finished, so deferring processing of intent")
             lastIntent = intent
         }
-
-        viewModel.launchFromThirdParty()
     }
 
     private fun initializeServiceWorker() {
@@ -350,7 +348,9 @@ open class BrowserActivity : DuckDuckGoActivity() {
                 val selectedText = intent.getBooleanExtra(SELECTED_TEXT_EXTRA, false)
                 val sourceTabId = if (selectedText) currentTab?.tabId else null
                 val skipHome = !selectedText
+                viewModel.launchFromThirdParty()
                 lifecycleScope.launch { viewModel.onOpenInNewTabRequested(sourceTabId = sourceTabId, query = sharedText, skipHome = skipHome) }
+
                 return
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1147,7 +1147,6 @@ class BrowserTabFragment :
     }
 
     private fun showHome() {
-        Timber.d("New Tab: showHome")
         viewModel.onHomeShown()
         dismissAppLinkSnackBar()
         errorSnackbar.dismiss()
@@ -1163,7 +1162,6 @@ class BrowserTabFragment :
     }
 
     private fun showBrowser() {
-        Timber.d("New Tab: showBrowser")
         newBrowserTab.newTabLayout.gone()
         newBrowserTab.newTabContainerLayout.gone()
         binding.browserLayout.show()
@@ -1178,7 +1176,6 @@ class BrowserTabFragment :
         errorType: WebViewErrorResponse,
         url: String?,
     ) {
-        Timber.d("New Tab: showError")
         webViewContainer.gone()
         newBrowserTab.newTabLayout.gone()
         newBrowserTab.newTabContainerLayout.gone()
@@ -2866,7 +2863,6 @@ class BrowserTabFragment :
     }
 
     private fun hideKeyboard() {
-        Timber.d("New Tab: hideKeyboard")
         if (!isHidden) {
             Timber.v("Keyboard now hiding")
             omnibar.omnibarTextInput.postDelayed(KEYBOARD_DELAY) { omnibar.omnibarTextInput?.hideKeyboard() }
@@ -2876,7 +2872,6 @@ class BrowserTabFragment :
     }
 
     private fun showKeyboard() {
-        Timber.d("New Tab: showKeyboard")
         if (!isHidden) {
             Timber.v("Keyboard now showing")
             omnibar.omnibarTextInput.postDelayed(KEYBOARD_DELAY) { omnibar.omnibarTextInput?.showKeyboard() }
@@ -3823,7 +3818,6 @@ class BrowserTabFragment :
         }
 
         fun renderCtaViewState(viewState: CtaViewState) {
-            Timber.d("New Tab: render $viewState")
             if (isHidden || isActiveCustomTab()) {
                 return
             }
@@ -3946,10 +3940,8 @@ class BrowserTabFragment :
         }
 
         private fun showNewTab() {
-            Timber.d("New Tab: showNewTab")
             newTabPageProvider.provideNewTabPageVersion().onEach { newTabPage ->
                 if (newBrowserTab.newTabContainerLayout.childCount == 0) {
-                    Timber.d("New Tab: adding $newTabPage")
                     newBrowserTab.newTabContainerLayout.addView(
                         newTabPage.getView(requireContext()),
                         LayoutParams(
@@ -3966,7 +3958,6 @@ class BrowserTabFragment :
         }
 
         private fun hideNewTab() {
-            Timber.d("New Tab: hideNewTab")
             newBrowserTab.newTabContainerLayout.gone()
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -3962,6 +3962,7 @@ class BrowserTabFragment :
                 .launchIn(lifecycleScope)
             newBrowserTab.newTabContainerLayout.show()
             newBrowserTab.newTabLayout.show()
+            viewModel.onNewTabShown()
         }
 
         private fun hideNewTab() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2428,7 +2428,6 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     suspend fun refreshCta(): Cta? {
-        Timber.d("New Tab: refreshCTA")
         if (currentGlobalLayoutState() is Browser) {
             val isBrowserShowing = currentBrowserViewState().browserShowing
             if (hasCtaBeenShownForCurrentPage.get() && isBrowserShowing) return null
@@ -2442,7 +2441,6 @@ class BrowserTabViewModel @Inject constructor(
             val isOnboardingComplete = withContext(dispatchers.io()) {
                 ctaViewModel.daxDialogEndShown()
             }
-            Timber.d("New Tab: refreshCTA $cta")
             if (isBrowserShowing && cta != null) hasCtaBeenShownForCurrentPage.set(true)
             ctaViewState.value = currentCtaViewState().copy(
                 cta = cta,

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -141,6 +141,7 @@ import com.duckduckgo.app.statistics.api.StatisticsUpdater
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.DAILY
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.UNIQUE
 import com.duckduckgo.app.surrogates.SurrogateResponse
 import com.duckduckgo.app.tabs.model.TabEntity
@@ -1925,6 +1926,7 @@ class BrowserTabViewModel @Inject constructor(
                 onDeleteFavoriteRequested(favorite)
             } else {
                 pixel.fire(AppPixelName.MENU_ACTION_ADD_FAVORITE_PRESSED.pixelName)
+                pixel.fire(SavedSitesPixelName.MENU_ACTION_ADD_FAVORITE_PRESSED_DAILY.pixelName, type = DAILY)
                 saveFavoriteSite(url, title ?: "")
             }
         }
@@ -2075,6 +2077,7 @@ class BrowserTabViewModel @Inject constructor(
 
     override fun onFavoriteAdded() {
         pixel.fire(SavedSitesPixelName.EDIT_BOOKMARK_ADD_FAVORITE_TOGGLED)
+        pixel.fire(SavedSitesPixelName.EDIT_BOOKMARK_ADD_FAVORITE_TOGGLED_DAILY)
     }
 
     override fun onFavoriteRemoved() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -90,7 +90,6 @@ import com.duckduckgo.app.browser.newtab.FavoritesQuickAccessAdapter
 import com.duckduckgo.app.browser.omnibar.OmnibarEntryConverter
 import com.duckduckgo.app.browser.omnibar.QueryOrigin
 import com.duckduckgo.app.browser.omnibar.QueryOrigin.FromAutocomplete
-import com.duckduckgo.app.browser.remotemessage.CommandActionMapper
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.browser.urlextraction.UrlExtractionListener
 import com.duckduckgo.app.browser.viewstate.AccessibilityViewState
@@ -144,7 +143,6 @@ import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.UNIQUE
 import com.duckduckgo.app.surrogates.SurrogateResponse
-import com.duckduckgo.app.survey.notification.SurveyNotificationScheduler
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.trackerdetection.model.TrackingEvent
@@ -172,6 +170,7 @@ import com.duckduckgo.downloads.api.FileDownloader
 import com.duckduckgo.downloads.api.FileDownloader.PendingFileDownload
 import com.duckduckgo.history.api.NavigationHistory
 import com.duckduckgo.js.messaging.api.JsCallbackData
+import com.duckduckgo.newtabpage.impl.pixels.NewTabPixels
 import com.duckduckgo.privacy.config.api.*
 import com.duckduckgo.privacy.dashboard.impl.pixels.PrivacyDashboardPixels
 import com.duckduckgo.privacyprotectionspopup.api.PrivacyProtectionsPopupExperimentExternalPixels
@@ -190,8 +189,6 @@ import com.duckduckgo.site.permissions.api.SitePermissionsManager
 import com.duckduckgo.site.permissions.api.SitePermissionsManager.SitePermissionQueryResponse
 import com.duckduckgo.site.permissions.api.SitePermissionsManager.SitePermissions
 import com.duckduckgo.subscriptions.api.Subscriptions
-import com.duckduckgo.sync.api.engine.SyncEngine
-import com.duckduckgo.sync.api.engine.SyncEngine.SyncTrigger.FEATURE_READ
 import com.duckduckgo.sync.api.favicons.FaviconsFetchingPrompt
 import com.duckduckgo.voice.api.VoiceSearchAvailability
 import com.duckduckgo.voice.api.VoiceSearchAvailabilityPixelLogger
@@ -255,10 +252,8 @@ class BrowserTabViewModel @Inject constructor(
     private val adClickManager: AdClickManager,
     private val autofillFireproofDialogSuppressor: AutofillFireproofDialogSuppressor,
     private val automaticSavedLoginsMonitor: AutomaticSavedLoginsMonitor,
-    private val surveyNotificationScheduler: SurveyNotificationScheduler,
     private val device: DeviceInfo,
     private val sitePermissionsManager: SitePermissionsManager,
-    private val syncEngine: SyncEngine,
     private val cameraHardwareChecker: CameraHardwareChecker,
     private val androidBrowserConfig: AndroidBrowserConfigFeature,
     private val privacyProtectionsPopupManager: PrivacyProtectionsPopupManager,
@@ -270,7 +265,7 @@ class BrowserTabViewModel @Inject constructor(
     private val bypassedSSLCertificatesRepository: BypassedSSLCertificatesRepository,
     private val userBrowserProperties: UserBrowserProperties,
     private val history: NavigationHistory,
-    private val commandActionMapper: CommandActionMapper,
+    private val newTabPixels: NewTabPixels,
 ) : WebViewClientListener,
     EditSavedSiteListener,
     DeleteBookmarkListener,
@@ -2432,12 +2427,6 @@ class BrowserTabViewModel @Inject constructor(
         }
     }
 
-    fun onNewTabFavouritesShown() {
-        viewModelScope.launch(dispatchers.io()) {
-            syncEngine.triggerSync(FEATURE_READ)
-        }
-    }
-
     suspend fun refreshCta(): Cta? {
         Timber.d("New Tab: refreshCTA")
         if (currentGlobalLayoutState() is Browser) {
@@ -3336,6 +3325,10 @@ class BrowserTabViewModel @Inject constructor(
 
     private fun isUrl(text: String): Boolean {
         return URLUtil.isNetworkUrl(text) || URLUtil.isAssetUrl(text) || URLUtil.isFileUrl(text) || URLUtil.isContentUrl(text)
+    }
+
+    fun onNewTabShown() {
+        newTabPixels.fireNewTabDisplayed()
     }
 
     companion object {

--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/FocusedLegacyViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/FocusedLegacyViewModel.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.app.browser.newtab.FocusedLegacyViewModel.Command.DeleteSa
 import com.duckduckgo.app.browser.newtab.FocusedLegacyViewModel.Command.ShowEditSavedSiteDialog
 import com.duckduckgo.app.browser.viewstate.SavedSiteChangedViewState
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.DAILY
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.savedsites.api.SavedSitesRepository
@@ -210,6 +211,7 @@ class FocusedLegacyViewModel @Inject constructor(
 
     override fun onFavoriteAdded() {
         pixel.fire(SavedSitesPixelName.EDIT_BOOKMARK_ADD_FAVORITE_TOGGLED)
+        pixel.fire(SavedSitesPixelName.EDIT_BOOKMARK_ADD_FAVORITE_TOGGLED_DAILY, type = DAILY)
     }
 
     override fun onFavoriteRemoved() {

--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageView.kt
@@ -219,7 +219,6 @@ class NewTabLegacyPageView @JvmOverloads constructor(
     }
 
     private fun render(viewState: ViewState) {
-        Timber.d("New Tab: render $viewState")
         if (viewState.message == null && viewState.favourites.isEmpty()) {
             homeBackgroundLogo.showLogo()
         } else {
@@ -348,8 +347,6 @@ class NewTabLegacyPageView @JvmOverloads constructor(
         newMessage: Boolean,
     ) {
         val parentVisible = (this.parent as? View)?.isVisible ?: false
-        Timber.d("New Tab: RMF isParentVisible $parentVisible")
-
         val shouldRender = parentVisible && (newMessage || binding.messageCta.isGone)
 
         if (shouldRender) {

--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageViewModel.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.app.browser.viewstate.SavedSiteChangedViewState
 import com.duckduckgo.app.cta.db.DismissedCtaDao
 import com.duckduckgo.app.cta.model.CtaId
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.DAILY
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.playstore.PlayStoreUtils
 import com.duckduckgo.di.scopes.ViewScope
@@ -319,6 +320,7 @@ class NewTabLegacyPageViewModel @Inject constructor(
 
     override fun onFavoriteAdded() {
         pixel.fire(SavedSitesPixelName.EDIT_BOOKMARK_ADD_FAVORITE_TOGGLED)
+        pixel.fire(SavedSitesPixelName.EDIT_BOOKMARK_ADD_FAVORITE_TOGGLED_DAILY, type = DAILY)
     }
 
     override fun onFavoriteRemoved() {

--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageViewModel.kt
@@ -61,7 +61,6 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import timber.log.Timber
 
 @SuppressLint("NoLifecycleObserver") // we don't observe app lifecycle
 @ContributesViewModel(ViewScope::class)
@@ -123,7 +122,6 @@ class NewTabLegacyPageViewModel @Inject constructor(
     override fun onStart(owner: LifecycleOwner) {
         super.onStart(owner)
 
-        Timber.d("New Tab: onStart")
         viewModelScope.launch(dispatchers.io()) {
             savedSitesRepository.getFavorites()
                 .combine(hiddenIds) { favorites, hiddenIds ->
@@ -137,7 +135,6 @@ class NewTabLegacyPageViewModel @Inject constructor(
                 }
                 .flowOn(dispatchers.io())
                 .onEach { snapshot ->
-                    Timber.d("New Tab: $snapshot")
                     val newMessage = snapshot.remoteMessage?.id != lastRemoteMessageSeen?.id
                     if (newMessage) {
                         lastRemoteMessageSeen = snapshot.remoteMessage

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -119,7 +119,6 @@ class CtaViewModel @Inject constructor(
     }
 
     private suspend fun completeStageIfDaxOnboardingCompleted() {
-        Timber.d("New Tab: completeStageIfDaxOnboardingCompleted")
         if (daxOnboardingActive() && allOnboardingCtasShown()) {
             Timber.d("Completing DAX ONBOARDING")
             userStageStore.stageCompleted(AppStage.DAX_ONBOARDING)
@@ -173,10 +172,8 @@ class CtaViewModel @Inject constructor(
     }
 
     private suspend fun getHomeCta(): Cta? {
-        Timber.d("New Tab: getHomeCta")
         return when {
             canShowDaxIntroCta() && extendedOnboardingFeatureToggles.noBrowserCtas().isEnabled() -> {
-                Timber.d("New Tab: getHomeCta insert DAX_END")
                 dismissedCtaDao.insert(DismissedCta(CtaId.DAX_INTRO))
                 dismissedCtaDao.insert(DismissedCta(CtaId.DAX_END))
                 null
@@ -225,7 +222,6 @@ class CtaViewModel @Inject constructor(
         return when {
             !daxOnboardingActive() || hideTips() -> false
             extendedOnboardingFeatureToggles.noBrowserCtas().isEnabled() -> {
-                Timber.d("New Tab: canShowDaxDialogCta insert DAX_END")
                 settingsDataStore.hideTips = true
                 dismissedCtaDao.insert(DismissedCta(CtaId.DAX_END))
                 userStageStore.stageCompleted(AppStage.DAX_ONBOARDING)
@@ -237,7 +233,6 @@ class CtaViewModel @Inject constructor(
 
     @WorkerThread
     private suspend fun getDaxDialogCta(site: Site?): Cta? {
-        Timber.d("New Tab: getDaxDialogCta")
         val nonNullSite = site ?: return null
 
         val host = nonNullSite.domain

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
@@ -31,6 +31,7 @@ import com.duckduckgo.app.onboarding.store.isNewUser
 import com.duckduckgo.app.pixels.AppPixelName.*
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.DAILY
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.UpdateVoiceSearch
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.SingleLiveEvent
@@ -362,6 +363,7 @@ class SystemSearchViewModel @Inject constructor(
 
     override fun onFavoriteAdded() {
         pixel.fire(SavedSitesPixelName.EDIT_BOOKMARK_ADD_FAVORITE_TOGGLED)
+        pixel.fire(SavedSitesPixelName.EDIT_BOOKMARK_ADD_FAVORITE_TOGGLED_DAILY, type = DAILY)
     }
 
     override fun onFavoriteRemoved() {

--- a/new-tab-page/new-tab-page-impl/build.gradle
+++ b/new-tab-page/new-tab-page-impl/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation project(':navigation-api')
     implementation project(':common-ui')
     implementation project(':data-store-api')
+    implementation project(path: ':statistics')
 
     implementation AndroidX.appCompat
     implementation Google.android.material

--- a/new-tab-page/new-tab-page-impl/build.gradle
+++ b/new-tab-page/new-tab-page-impl/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     implementation project(':navigation-api')
     implementation project(':common-ui')
     implementation project(':data-store-api')
-    implementation project(path: ':statistics')
+    implementation project(':statistics')
 
     implementation AndroidX.appCompat
     implementation Google.android.material

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/pixels/NewTabPixelNames.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/pixels/NewTabPixelNames.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.newtabpage.impl.pixels
+
+import com.duckduckgo.app.statistics.pixels.Pixel
+
+enum class NewTabPixelNames(override val pixelName: String) : Pixel.PixelName {
+    WELCOME_MESSAGE_SHOWN("m_new_tab_page_message_displayed"),
+    WELCOME_MESSAGE_DISMISSED("m_new_tab_page_message_dismissed"),
+    FAVOURITES_LIST_EXPANDED("m_new_tab_page_favorites_expanded"),
+    FAVOURITES_LIST_COLLAPSED("m_new_tab_page_favorites_collapsed"),
+    FAVOURITES_TOOLTIP_PRESSED("m_new_tab_page_favorites_info_tooltip"),
+    CUSTOMIZE_PAGE_PRESSED("m_new_tab_page_customize"),
+    SHORTCUT_PRESSED("m_new_tab_page_shortcut_clicked_"),
+    SHORTCUT_REMOVED("m_new_tab_page_customize_shortcut_removed_"),
+    SHORTCUT_ADDED("m_new_tab_page_customize_shortcut_added_"),
+    SHORTCUT_SECTION_TOGGLED_OFF("m_new_tab_page_customize_section_off_shortcuts"),
+    SHORTCUT_SECTION_TOGGLED_ON("m_new_tab_page_customize_section_on_shortcuts"),
+    SECTION_REARRANGED("m_new_tab_page_customize_section_reordered"),
+    NEW_TAB_DISPLAYED("m_new_tab_page_displayed"),
+    NEW_TAB_DISPLAYED_UNIQUE("m_new_tab_page_displayed_unique"),
+}

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/pixels/NewTabPixelNames.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/pixels/NewTabPixelNames.kt
@@ -19,8 +19,6 @@ package com.duckduckgo.newtabpage.impl.pixels
 import com.duckduckgo.app.statistics.pixels.Pixel
 
 enum class NewTabPixelNames(override val pixelName: String) : Pixel.PixelName {
-    WELCOME_MESSAGE_SHOWN("m_new_tab_page_message_displayed"),
-    WELCOME_MESSAGE_DISMISSED("m_new_tab_page_message_dismissed"),
     FAVOURITES_LIST_EXPANDED("m_new_tab_page_favorites_expanded"),
     FAVOURITES_LIST_COLLAPSED("m_new_tab_page_favorites_collapsed"),
     FAVOURITES_TOOLTIP_PRESSED("m_new_tab_page_favorites_info_tooltip"),

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/pixels/NewTabPixelNames.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/pixels/NewTabPixelNames.kt
@@ -19,9 +19,6 @@ package com.duckduckgo.newtabpage.impl.pixels
 import com.duckduckgo.app.statistics.pixels.Pixel
 
 enum class NewTabPixelNames(override val pixelName: String) : Pixel.PixelName {
-    FAVOURITES_LIST_EXPANDED("m_new_tab_page_favorites_expanded"),
-    FAVOURITES_LIST_COLLAPSED("m_new_tab_page_favorites_collapsed"),
-    FAVOURITES_TOOLTIP_PRESSED("m_new_tab_page_favorites_info_tooltip"),
     CUSTOMIZE_PAGE_PRESSED("m_new_tab_page_customize"),
     SHORTCUT_PRESSED("m_new_tab_page_shortcut_clicked_"),
     SHORTCUT_REMOVED("m_new_tab_page_customize_shortcut_removed_"),
@@ -31,4 +28,22 @@ enum class NewTabPixelNames(override val pixelName: String) : Pixel.PixelName {
     SECTION_REARRANGED("m_new_tab_page_customize_section_reordered"),
     NEW_TAB_DISPLAYED("m_new_tab_page_displayed"),
     NEW_TAB_DISPLAYED_UNIQUE("m_new_tab_page_displayed_unique"),
+}
+
+object NewTabPixelParameters {
+    const val SHORTCUTS = "shortcuts"
+    const val FAVORITES = "favorites"
+    const val APP_TRACKING_PROTECTION = "appTP"
+    const val FAVORITES_COUNT = "favoriteCount"
+}
+
+object NewTabPixelValues {
+    const val SECTION_ENABLED = "1"
+    const val SECTION_DISABLED = "0"
+    const val FAVORITES_2_3 = "2_3"
+    const val FAVORITES_4_5 = "4_5"
+    const val FAVORITES_6_10 = "6_10"
+    const val FAVORITES_11_15 = "11_15"
+    const val FAVORITES_16_25 = "16_25"
+    const val FAVORITES_25 = ">25"
 }

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/pixels/NewTabPixels.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/pixels/NewTabPixels.kt
@@ -24,8 +24,6 @@ import javax.inject.Inject
 
 interface NewTabPixels {
     // Engagement pixels https://app.asana.com/0/72649045549333/1207667088727866/f
-    fun fireWelcomeMessageShownPixel()
-    fun fireWelcomeMessageDismissedPixel()
     fun fireCustomizePagePressedPixel()
     fun fireShortcutPressed(shortcutName: String)
     fun fireShortcutAdded(shortcutName: String)
@@ -41,14 +39,6 @@ interface NewTabPixels {
 class RealNewTabPixels @Inject constructor(
     private val pixel: Pixel,
 ) : NewTabPixels {
-    override fun fireWelcomeMessageShownPixel() {
-        pixel.fire(NewTabPixelNames.WELCOME_MESSAGE_SHOWN)
-    }
-
-    override fun fireWelcomeMessageDismissedPixel() {
-        pixel.fire(NewTabPixelNames.WELCOME_MESSAGE_DISMISSED)
-    }
-
     override fun fireCustomizePagePressedPixel() {
         pixel.fire(NewTabPixelNames.CUSTOMIZE_PAGE_PRESSED)
     }

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/pixels/NewTabPixels.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/pixels/NewTabPixels.kt
@@ -49,6 +49,7 @@ class RealNewTabPixels @Inject constructor(
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
 ) : NewTabPixels {
+
     override fun fireCustomizePagePressedPixel() {
         pixel.fire(NewTabPixelNames.CUSTOMIZE_PAGE_PRESSED)
     }
@@ -106,7 +107,7 @@ class RealNewTabPixels @Inject constructor(
         }
     }
 
-    private suspend fun getFavoritesParameterValue(): String {
+    private fun getFavoritesParameterValue(): String {
         val favorites = savedSitesRepository.favoritesCount()
         if (favorites < 2) {
             return favorites.toString()

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/pixels/NewTabPixels.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/pixels/NewTabPixels.kt
@@ -16,11 +16,19 @@
 
 package com.duckduckgo.newtabpage.impl.pixels
 
+import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.DAILY
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.plugins.ActivePluginPoint
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.newtabpage.api.NewTabPageSection
+import com.duckduckgo.newtabpage.api.NewTabPageSectionPlugin
+import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 interface NewTabPixels {
     // Engagement pixels https://app.asana.com/0/72649045549333/1207667088727866/f
@@ -38,21 +46,25 @@ interface NewTabPixels {
 @ContributesBinding(AppScope::class)
 class RealNewTabPixels @Inject constructor(
     private val pixel: Pixel,
+    private val sections: ActivePluginPoint<NewTabPageSectionPlugin>,
+    private val savedSitesRepository: SavedSitesRepository,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val dispatcherProvider: DispatcherProvider,
 ) : NewTabPixels {
     override fun fireCustomizePagePressedPixel() {
         pixel.fire(NewTabPixelNames.CUSTOMIZE_PAGE_PRESSED)
     }
 
     override fun fireShortcutPressed(shortcutName: String) {
-        pixel.fire(NewTabPixelNames.SHORTCUT_PRESSED.name + shortcutName)
+        pixel.fire(NewTabPixelNames.SHORTCUT_PRESSED.pixelName + shortcutName)
     }
 
     override fun fireShortcutAdded(shortcutName: String) {
-        pixel.fire(NewTabPixelNames.SHORTCUT_ADDED.name + shortcutName)
+        pixel.fire(NewTabPixelNames.SHORTCUT_ADDED.pixelName + shortcutName)
     }
 
     override fun fireShortcutRemoved(shortcutName: String) {
-        pixel.fire(NewTabPixelNames.SHORTCUT_REMOVED.name + shortcutName)
+        pixel.fire(NewTabPixelNames.SHORTCUT_REMOVED.pixelName + shortcutName)
     }
 
     override fun fireShortcutSectionToggled(enabled: Boolean) {
@@ -68,7 +80,54 @@ class RealNewTabPixels @Inject constructor(
     }
 
     override fun fireNewTabDisplayed() {
-        pixel.fire(NewTabPixelNames.NEW_TAB_DISPLAYED)
-        pixel.fire(NewTabPixelNames.NEW_TAB_DISPLAYED_UNIQUE, type = DAILY)
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            val paramsMap = mutableMapOf<String, String>().apply {
+                val allSections = sections.getPlugins()
+                val favoriteSection = getSectionParameterValue(allSections.firstOrNull { it.name == NewTabPageSection.FAVOURITES.name })
+                put(NewTabPixelParameters.FAVORITES, favoriteSection)
+                val shortcutsSection = getSectionParameterValue(allSections.firstOrNull { it.name == NewTabPageSection.SHORTCUTS.name })
+                put(NewTabPixelParameters.SHORTCUTS, shortcutsSection)
+                val appTPSection = getSectionParameterValue(allSections.firstOrNull { it.name == NewTabPageSection.APP_TRACKING_PROTECTION.name })
+                put(NewTabPixelParameters.APP_TRACKING_PROTECTION, appTPSection)
+                put(NewTabPixelParameters.FAVORITES_COUNT, getFavoritesParameterValue())
+            }
+            pixel.fire(NewTabPixelNames.NEW_TAB_DISPLAYED)
+            pixel.fire(pixel = NewTabPixelNames.NEW_TAB_DISPLAYED_UNIQUE, type = DAILY, parameters = paramsMap)
+        }
+    }
+
+    private suspend fun getSectionParameterValue(sectionPlugin: NewTabPageSectionPlugin?): String {
+        return if (sectionPlugin != null) {
+            if (sectionPlugin.isUserEnabled()) {
+                NewTabPixelValues.SECTION_ENABLED
+            } else {
+                NewTabPixelValues.SECTION_DISABLED
+            }
+        } else {
+            NewTabPixelValues.SECTION_DISABLED
+        }
+    }
+
+    private suspend fun getFavoritesParameterValue(): String {
+        val favorites = savedSitesRepository.favoritesCount()
+        if (favorites < 2) {
+            return favorites.toString()
+        }
+        if (favorites < 4) {
+            return NewTabPixelValues.FAVORITES_2_3
+        }
+        if (favorites < 6) {
+            return NewTabPixelValues.FAVORITES_4_5
+        }
+        if (favorites < 11) {
+            return NewTabPixelValues.FAVORITES_6_10
+        }
+        if (favorites < 16) {
+            return NewTabPixelValues.FAVORITES_11_15
+        }
+        if (favorites < 26) {
+            return NewTabPixelValues.FAVORITES_16_25
+        }
+        return NewTabPixelValues.FAVORITES_25
     }
 }

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/pixels/NewTabPixels.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/pixels/NewTabPixels.kt
@@ -39,8 +39,6 @@ interface NewTabPixels {
     fun fireShortcutSectionToggled(enabled: Boolean)
     fun fireSectionReordered()
     fun fireNewTabDisplayed()
-
-    // Experiment pixels https://app.asana.com/0/72649045549333/1207667088727867/f
 }
 
 @ContributesBinding(AppScope::class)

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/pixels/NewTabPixels.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/pixels/NewTabPixels.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.newtabpage.impl.pixels
+
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.DAILY
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface NewTabPixels {
+    // Engagement pixels https://app.asana.com/0/72649045549333/1207667088727866/f
+    fun fireWelcomeMessageShownPixel()
+    fun fireWelcomeMessageDismissedPixel()
+    fun fireCustomizePagePressedPixel()
+    fun fireShortcutPressed(shortcutName: String)
+    fun fireShortcutAdded(shortcutName: String)
+    fun fireShortcutRemoved(shortcutName: String)
+    fun fireShortcutSectionToggled(enabled: Boolean)
+    fun fireSectionReordered()
+    fun fireNewTabDisplayed()
+
+    // Experiment pixels https://app.asana.com/0/72649045549333/1207667088727867/f
+}
+
+@ContributesBinding(AppScope::class)
+class RealNewTabPixels @Inject constructor(
+    private val pixel: Pixel,
+) : NewTabPixels {
+    override fun fireWelcomeMessageShownPixel() {
+        pixel.fire(NewTabPixelNames.WELCOME_MESSAGE_SHOWN)
+    }
+
+    override fun fireWelcomeMessageDismissedPixel() {
+        pixel.fire(NewTabPixelNames.WELCOME_MESSAGE_DISMISSED)
+    }
+
+    override fun fireCustomizePagePressedPixel() {
+        pixel.fire(NewTabPixelNames.CUSTOMIZE_PAGE_PRESSED)
+    }
+
+    override fun fireShortcutPressed(shortcutName: String) {
+        pixel.fire(NewTabPixelNames.SHORTCUT_PRESSED.name + shortcutName)
+    }
+
+    override fun fireShortcutAdded(shortcutName: String) {
+        pixel.fire(NewTabPixelNames.SHORTCUT_ADDED.name + shortcutName)
+    }
+
+    override fun fireShortcutRemoved(shortcutName: String) {
+        pixel.fire(NewTabPixelNames.SHORTCUT_REMOVED.name + shortcutName)
+    }
+
+    override fun fireShortcutSectionToggled(enabled: Boolean) {
+        if (enabled) {
+            pixel.fire(NewTabPixelNames.SHORTCUT_SECTION_TOGGLED_ON)
+        } else {
+            pixel.fire(NewTabPixelNames.SHORTCUT_SECTION_TOGGLED_OFF)
+        }
+    }
+
+    override fun fireSectionReordered() {
+        pixel.fire(NewTabPixelNames.SECTION_REARRANGED)
+    }
+
+    override fun fireNewTabDisplayed() {
+        pixel.fire(NewTabPixelNames.NEW_TAB_DISPLAYED)
+        pixel.fire(NewTabPixelNames.NEW_TAB_DISPLAYED_UNIQUE, type = DAILY)
+    }
+}

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/shortcuts/ShortcutsAdapter.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/shortcuts/ShortcutsAdapter.kt
@@ -24,7 +24,6 @@ import android.view.MotionEvent
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
-import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import com.duckduckgo.newtabpage.api.NewTabPageShortcutPlugin
 import com.duckduckgo.newtabpage.impl.databinding.RowShortcutSectionItemBinding
@@ -35,6 +34,7 @@ import com.duckduckgo.newtabpage.impl.shortcuts.ShortcutsAdapter.ShortcutViewHol
 
 class ShortcutsAdapter(
     private val onMoveListener: (ViewHolder) -> Unit,
+    private val onClickListener: (NewTabPageShortcutPlugin) -> Unit,
 ) : ListAdapter<ShortcutItem, ShortcutViewHolder>(NewTabSectionsDiffCallback()) {
 
     var expanded: Boolean = false
@@ -51,6 +51,7 @@ class ShortcutsAdapter(
         return ShortcutViewHolder(
             RowShortcutSectionItemBinding.inflate(LayoutInflater.from(parent.context), parent, false),
             onMoveListener,
+            onClickListener,
         )
     }
 
@@ -63,7 +64,8 @@ class ShortcutsAdapter(
 
     class ShortcutViewHolder(
         private val binding: RowShortcutSectionItemBinding,
-        private val onMoveListener: (RecyclerView.ViewHolder) -> Unit,
+        private val onMoveListener: (ViewHolder) -> Unit,
+        private val onClickListener: (NewTabPageShortcutPlugin) -> Unit,
     ) : ViewHolder(binding.root), DragDropViewHolderListener {
 
         private var itemState: ItemState = Stale
@@ -101,6 +103,7 @@ class ShortcutsAdapter(
                     false
                 }
                 setClickListener {
+                    onClickListener(item.plugin)
                     item.plugin.onClick(context)
                 }
                 configureTouchListener()

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/shortcuts/ShortcutsNewTabSectionView.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/shortcuts/ShortcutsNewTabSectionView.kt
@@ -117,7 +117,9 @@ class ShortcutsNewTabSectionView @JvmOverloads constructor(
     private fun createQuickAccessAdapter(
         onMoveListener: (RecyclerView.ViewHolder) -> Unit,
     ): ShortcutsAdapter {
-        return ShortcutsAdapter(onMoveListener)
+        return ShortcutsAdapter(onMoveListener) { shortcutPlugin ->
+            viewModel.onShortcutPressed(shortcutPlugin)
+        }
     }
 
     private fun configureQuickAccessGridLayout(recyclerView: RecyclerView) {

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/shortcuts/ShortcutsNewTabSettingsViewModel.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/shortcuts/ShortcutsNewTabSettingsViewModel.kt
@@ -24,6 +24,7 @@ import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.newtabpage.impl.pixels.NewTabPixels
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -36,6 +37,7 @@ import kotlinx.coroutines.withContext
 class ShortcutsNewTabSettingsViewModel @Inject constructor(
     private val dispatchers: DispatcherProvider,
     private val dataStore: NewTabShortcutDataStore,
+    private val pixels: NewTabPixels,
 ) : ViewModel(), DefaultLifecycleObserver {
 
     private val _viewState = MutableStateFlow(ViewState(true))
@@ -60,6 +62,7 @@ class ShortcutsNewTabSettingsViewModel @Inject constructor(
             withContext(dispatchers.main()) {
                 _viewState.update { ViewState(enabled) }
             }
+            pixels.fireShortcutSectionToggled(enabled)
         }
     }
 }

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/shortcuts/ShortcutsViewModel.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/shortcuts/ShortcutsViewModel.kt
@@ -34,7 +34,6 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
-import logcat.logcat
 
 @SuppressLint("NoLifecycleObserver") // we don't observe app lifecycle
 @ContributesViewModel(ViewScope::class)
@@ -65,7 +64,6 @@ class ShortcutsViewModel @Inject constructor(
 
     fun onQuickAccessListChanged(newShortcuts: List<String>) {
         newTabSettingsStore.shortcutSettings = newShortcuts
-        logcat { "New Tab: Shortcuts updated to $newShortcuts" }
     }
 
     fun onShortcutPressed(shortcutPlugin: NewTabPageShortcutPlugin) {

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/shortcuts/ShortcutsViewModel.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/shortcuts/ShortcutsViewModel.kt
@@ -24,6 +24,8 @@ import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.newtabpage.api.NewTabPageShortcutPlugin
+import com.duckduckgo.newtabpage.impl.pixels.NewTabPixels
 import com.duckduckgo.newtabpage.impl.settings.NewTabSettingsStore
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -40,7 +42,7 @@ class ShortcutsViewModel @Inject constructor(
     private val dispatchers: DispatcherProvider,
     private val newTabSettingsStore: NewTabSettingsStore,
     private val newTabShortcutsProvider: NewTabShortcutsProvider,
-
+    private val pixels: NewTabPixels,
 ) : ViewModel(), DefaultLifecycleObserver {
 
     data class ViewState(val shortcuts: List<ShortcutItem> = emptyList())
@@ -64,5 +66,9 @@ class ShortcutsViewModel @Inject constructor(
     fun onQuickAccessListChanged(newShortcuts: List<String>) {
         newTabSettingsStore.shortcutSettings = newShortcuts
         logcat { "New Tab: Shortcuts updated to $newShortcuts" }
+    }
+
+    fun onShortcutPressed(shortcutPlugin: NewTabPageShortcutPlugin) {
+        pixels.fireShortcutPressed(shortcutPlugin.getShortcut().name)
     }
 }

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/shortcuts/ShortcutsViewModel.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/shortcuts/ShortcutsViewModel.kt
@@ -69,6 +69,6 @@ class ShortcutsViewModel @Inject constructor(
     }
 
     fun onShortcutPressed(shortcutPlugin: NewTabPageShortcutPlugin) {
-        pixels.fireShortcutPressed(shortcutPlugin.getShortcut().name)
+        pixels.fireShortcutPressed(shortcutPlugin.getShortcut().name())
     }
 }

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/view/NewTabPageView.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/view/NewTabPageView.kt
@@ -158,10 +158,12 @@ class NewTabPageView @JvmOverloads constructor(
 
     private fun setClickListeners() {
         binding.newTabEditScroll.setOnClickListener {
+            viewModel.onCustomisePageClicked()
             globalActivityStarter.start(context, NewTabSettingsScreenNoParams)
         }
 
         binding.newTabEditAnchor.setOnClickListener {
+            viewModel.onCustomisePageClicked()
             globalActivityStarter.start(context, NewTabSettingsScreenNoParams)
         }
     }

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/view/NewTabPageViewModel.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/view/NewTabPageViewModel.kt
@@ -69,4 +69,8 @@ class NewTabPageViewModel @Inject constructor(
             _viewState.update { ViewState() }
         }.flowOn(dispatcherProvider.io()).launchIn(viewModelScope)
     }
+
+    fun onCustomisePageClicked() {
+        newTabPixels.fireCustomizePagePressedPixel()
+    }
 }

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/view/NewTabPageViewModel.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/view/NewTabPageViewModel.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.newtabpage.api.NewTabPageSection.FAVOURITES
 import com.duckduckgo.newtabpage.api.NewTabPageSection.SHORTCUTS
 import com.duckduckgo.newtabpage.api.NewTabPageSectionPlugin
 import com.duckduckgo.newtabpage.api.NewTabPageSectionProvider
+import com.duckduckgo.newtabpage.impl.pixels.NewTabPixels
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -42,6 +43,7 @@ import kotlinx.coroutines.flow.update
 @ContributesViewModel(ViewScope::class)
 class NewTabPageViewModel @Inject constructor(
     private val newTabSectionsProvider: NewTabPageSectionProvider,
+    private val newTabPixels: NewTabPixels,
     private val dispatcherProvider: DispatcherProvider,
 ) : ViewModel(), DefaultLifecycleObserver {
 
@@ -56,6 +58,7 @@ class NewTabPageViewModel @Inject constructor(
 
     override fun onResume(owner: LifecycleOwner) {
         refreshViews()
+        newTabPixels.fireNewTabDisplayed()
     }
 
     private fun refreshViews() {

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/view/NewTabPageViewModel.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/view/NewTabPageViewModel.kt
@@ -58,7 +58,6 @@ class NewTabPageViewModel @Inject constructor(
 
     override fun onResume(owner: LifecycleOwner) {
         refreshViews()
-        newTabPixels.fireNewTabDisplayed()
     }
 
     private fun refreshViews() {

--- a/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/NewTabPageSectionProviderTest.kt
+++ b/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/NewTabPageSectionProviderTest.kt
@@ -142,7 +142,7 @@ class NewTabPageSectionProviderTest {
         )
 
         testee = RealNewTabPageSectionProvider(
-            enabledSectionPlugins,
+            enabledSectionsPlugins,
             activeSectionSettingsPlugins,
             newTabSettingsStore,
         )
@@ -153,76 +153,6 @@ class NewTabPageSectionProviderTest {
                 assertTrue(it[1].name == NewTabPageSection.APP_TRACKING_PROTECTION.name)
                 assertTrue(it[2].name == NewTabPageSection.SHORTCUTS.name)
             }
-        }
-    }
-
-    private val activeSectionSettingsPlugins = object : PluginPoint<NewTabPageSectionSettingsPlugin> {
-        override fun getPlugins(): Collection<NewTabPageSectionSettingsPlugin> {
-            return listOf(
-                FakeActiveSectionSettingPlugin(NewTabPageSection.APP_TRACKING_PROTECTION.name, true),
-                FakeActiveSectionSettingPlugin(NewTabPageSection.FAVOURITES.name, true),
-                FakeActiveSectionSettingPlugin(NewTabPageSection.SHORTCUTS.name, true),
-            )
-        }
-    }
-
-    private val disabledSectionSettingsPlugins = object : PluginPoint<NewTabPageSectionSettingsPlugin> {
-        override fun getPlugins(): Collection<NewTabPageSectionSettingsPlugin> {
-            return listOf(
-                FakeActiveSectionSettingPlugin(NewTabPageSection.REMOTE_MESSAGING_FRAMEWORK.name, false),
-                FakeActiveSectionSettingPlugin(NewTabPageSection.APP_TRACKING_PROTECTION.name, false),
-                FakeActiveSectionSettingPlugin(NewTabPageSection.FAVOURITES.name, false),
-                FakeActiveSectionSettingPlugin(NewTabPageSection.SHORTCUTS.name, false),
-            )
-        }
-    }
-
-    private class FakeActiveSectionSettingPlugin(
-        val section: String,
-        val isEnabled: Boolean,
-    ) : NewTabPageSectionSettingsPlugin {
-        override val name: String
-            get() = section
-
-        override fun getView(context: Context): View? {
-            return null
-        }
-
-        override suspend fun isActive(): Boolean {
-            return isEnabled
-        }
-    }
-
-    private val enabledSectionPlugins = object : ActivePluginPoint<NewTabPageSectionPlugin> {
-        override suspend fun getPlugins(): Collection<NewTabPageSectionPlugin> {
-            return listOf(
-                FakeEnabledSectionPlugin(NewTabPageSection.REMOTE_MESSAGING_FRAMEWORK.name, true),
-                FakeEnabledSectionPlugin(NewTabPageSection.APP_TRACKING_PROTECTION.name, true),
-                FakeEnabledSectionPlugin(NewTabPageSection.FAVOURITES.name, true),
-                FakeEnabledSectionPlugin(NewTabPageSection.SHORTCUTS.name, true),
-            )
-        }
-    }
-
-    private val favoriteDisabledSectionPlugins = object : ActivePluginPoint<NewTabPageSectionPlugin> {
-        override suspend fun getPlugins(): Collection<NewTabPageSectionPlugin> {
-            return listOf(
-                FakeEnabledSectionPlugin(NewTabPageSection.REMOTE_MESSAGING_FRAMEWORK.name, true),
-                FakeEnabledSectionPlugin(NewTabPageSection.APP_TRACKING_PROTECTION.name, true),
-                FakeEnabledSectionPlugin(NewTabPageSection.FAVOURITES.name, false),
-                FakeEnabledSectionPlugin(NewTabPageSection.SHORTCUTS.name, true),
-            )
-        }
-    }
-
-    private val disabledSectionPlugins = object : ActivePluginPoint<NewTabPageSectionPlugin> {
-        override suspend fun getPlugins(): Collection<NewTabPageSectionPlugin> {
-            return listOf(
-                FakeEnabledSectionPlugin(NewTabPageSection.REMOTE_MESSAGING_FRAMEWORK.name, false),
-                FakeEnabledSectionPlugin(NewTabPageSection.APP_TRACKING_PROTECTION.name, false),
-                FakeEnabledSectionPlugin(NewTabPageSection.FAVOURITES.name, false),
-                FakeEnabledSectionPlugin(NewTabPageSection.SHORTCUTS.name, false),
-            )
         }
     }
 }

--- a/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/NewTabPageSectionProviderTest.kt
+++ b/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/NewTabPageSectionProviderTest.kt
@@ -16,15 +16,9 @@
 
 package com.duckduckgo.newtabpage.impl
 
-import android.content.Context
-import android.view.View
 import app.cash.turbine.test
-import com.duckduckgo.common.utils.plugins.ActivePluginPoint
-import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.newtabpage.api.NewTabPageSection
-import com.duckduckgo.newtabpage.api.NewTabPageSectionPlugin
 import com.duckduckgo.newtabpage.api.NewTabPageSectionProvider
-import com.duckduckgo.newtabpage.api.NewTabPageSectionSettingsPlugin
 import com.duckduckgo.newtabpage.impl.settings.NewTabSettingsStore
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertTrue

--- a/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/TestPluginPoints.kt
+++ b/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/TestPluginPoints.kt
@@ -151,6 +151,92 @@ var allShortcutSettings: List<String> = listOf(
     FakeShortcut("settings").name,
 )
 
+val activeSectionSettingsPlugins = object : PluginPoint<NewTabPageSectionSettingsPlugin> {
+    override fun getPlugins(): Collection<NewTabPageSectionSettingsPlugin> {
+        return listOf(
+            FakeActiveSectionSettingPlugin(NewTabPageSection.APP_TRACKING_PROTECTION.name, true),
+            FakeActiveSectionSettingPlugin(NewTabPageSection.FAVOURITES.name, true),
+            FakeActiveSectionSettingPlugin(NewTabPageSection.SHORTCUTS.name, true),
+        )
+    }
+}
+
+val disabledSectionSettingsPlugins = object : PluginPoint<NewTabPageSectionSettingsPlugin> {
+    override fun getPlugins(): Collection<NewTabPageSectionSettingsPlugin> {
+        return listOf(
+            FakeActiveSectionSettingPlugin(NewTabPageSection.REMOTE_MESSAGING_FRAMEWORK.name, false),
+            FakeActiveSectionSettingPlugin(NewTabPageSection.APP_TRACKING_PROTECTION.name, false),
+            FakeActiveSectionSettingPlugin(NewTabPageSection.FAVOURITES.name, false),
+            FakeActiveSectionSettingPlugin(NewTabPageSection.SHORTCUTS.name, false),
+        )
+    }
+}
+
+private class FakeActiveSectionSettingPlugin(
+    val section: String,
+    val isEnabled: Boolean,
+) : NewTabPageSectionSettingsPlugin {
+    override val name: String
+        get() = section
+
+    override fun getView(context: Context): View? {
+        return null
+    }
+
+    override suspend fun isActive(): Boolean {
+        return isEnabled
+    }
+}
+
+val enabledSectionPlugins = object : ActivePluginPoint<NewTabPageSectionPlugin> {
+    override suspend fun getPlugins(): Collection<NewTabPageSectionPlugin> {
+        return listOf(
+            FakeEnabledSectionPlugin(NewTabPageSection.REMOTE_MESSAGING_FRAMEWORK.name, true),
+            FakeEnabledSectionPlugin(NewTabPageSection.APP_TRACKING_PROTECTION.name, true),
+            FakeEnabledSectionPlugin(NewTabPageSection.FAVOURITES.name, true),
+            FakeEnabledSectionPlugin(NewTabPageSection.SHORTCUTS.name, true),
+        )
+    }
+}
+
+val favoriteDisabledSectionPlugins = object : ActivePluginPoint<NewTabPageSectionPlugin> {
+    override suspend fun getPlugins(): Collection<NewTabPageSectionPlugin> {
+        return listOf(
+            FakeEnabledSectionPlugin(NewTabPageSection.REMOTE_MESSAGING_FRAMEWORK.name, true),
+            FakeEnabledSectionPlugin(NewTabPageSection.APP_TRACKING_PROTECTION.name, true),
+            FakeEnabledSectionPlugin(NewTabPageSection.FAVOURITES.name, false),
+            FakeEnabledSectionPlugin(NewTabPageSection.SHORTCUTS.name, true),
+        )
+    }
+}
+
+val disabledSectionPlugins = object : ActivePluginPoint<NewTabPageSectionPlugin> {
+    override suspend fun getPlugins(): Collection<NewTabPageSectionPlugin> {
+        return listOf(
+            FakeEnabledSectionPlugin(NewTabPageSection.REMOTE_MESSAGING_FRAMEWORK.name, false),
+            FakeEnabledSectionPlugin(NewTabPageSection.APP_TRACKING_PROTECTION.name, false),
+            FakeEnabledSectionPlugin(NewTabPageSection.FAVOURITES.name, false),
+            FakeEnabledSectionPlugin(NewTabPageSection.SHORTCUTS.name, false),
+        )
+    }
+}
+
+class FakeEnabledSectionPlugin(
+    val section: String,
+    val isUserEnabled: Boolean,
+) : NewTabPageSectionPlugin {
+    override val name: String
+        get() = section
+
+    override fun getView(context: Context): View? {
+        return null
+    }
+
+    override suspend fun isUserEnabled(): Boolean {
+        return isUserEnabled
+    }
+}
+
 class FakeSettingStore(
     sections: List<String> = allSectionSettings,
     shortcuts: List<String> = allShortcutSettings,

--- a/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/TestPluginPoints.kt
+++ b/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/TestPluginPoints.kt
@@ -221,22 +221,6 @@ val disabledSectionPlugins = object : ActivePluginPoint<NewTabPageSectionPlugin>
     }
 }
 
-class FakeEnabledSectionPlugin(
-    val section: String,
-    val isUserEnabled: Boolean,
-) : NewTabPageSectionPlugin {
-    override val name: String
-        get() = section
-
-    override fun getView(context: Context): View? {
-        return null
-    }
-
-    override suspend fun isUserEnabled(): Boolean {
-        return isUserEnabled
-    }
-}
-
 class FakeSettingStore(
     sections: List<String> = allSectionSettings,
     shortcuts: List<String> = allShortcutSettings,

--- a/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/pixels/RealNewTabPixelsTest.kt
+++ b/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/pixels/RealNewTabPixelsTest.kt
@@ -1,0 +1,238 @@
+package com.duckduckgo.newtabpage.impl.pixels
+
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.DAILY
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.newtabpage.impl.disabledSectionPlugins
+import com.duckduckgo.newtabpage.impl.enabledSectionsPlugins
+import com.duckduckgo.savedsites.api.SavedSitesRepository
+import kotlinx.coroutines.test.TestScope
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class RealNewTabPixelsTest {
+
+    @get:Rule
+    var coroutinesTestRule = CoroutineTestRule()
+
+    private lateinit var testee: RealNewTabPixels
+
+    private val pixel: Pixel = mock()
+    private val savedSitesRepository: SavedSitesRepository = mock()
+
+    @Before
+    fun setup() {
+        testee = RealNewTabPixels(
+            pixel,
+            enabledSectionsPlugins,
+            savedSitesRepository,
+            TestScope(),
+            coroutinesTestRule.testDispatcherProvider,
+        )
+    }
+
+    @Test
+    fun whenFireCustomizePagePressedPixelThenPixelFired() {
+        testee.fireCustomizePagePressedPixel()
+
+        verify(pixel).fire(NewTabPixelNames.CUSTOMIZE_PAGE_PRESSED)
+    }
+
+    @Test
+    fun whenFireShortcutPressedThenPixelFired() {
+        testee.fireShortcutPressed("shortcut")
+
+        verify(pixel).fire(NewTabPixelNames.SHORTCUT_PRESSED.pixelName + "shortcut")
+    }
+
+    @Test
+    fun whenFireShortcutAddedThenPixelFired() {
+        testee.fireShortcutAdded("shortcut")
+
+        verify(pixel).fire(NewTabPixelNames.SHORTCUT_ADDED.pixelName + "shortcut")
+    }
+
+    @Test
+    fun whenFireShortcutRemovedThenPixelFired() {
+        testee.fireShortcutRemoved("shortcut")
+
+        verify(pixel).fire(NewTabPixelNames.SHORTCUT_REMOVED.pixelName + "shortcut")
+    }
+
+    @Test
+    fun whenFireShortcutSectionToggledEnabledThenPixelFired() {
+        testee.fireShortcutSectionToggled(true)
+
+        verify(pixel).fire(NewTabPixelNames.SHORTCUT_SECTION_TOGGLED_ON)
+    }
+
+    @Test
+    fun whenFireShortcutSectionToggledDisabledThenPixelFired() {
+        testee.fireShortcutSectionToggled(false)
+
+        verify(pixel).fire(NewTabPixelNames.SHORTCUT_SECTION_TOGGLED_OFF)
+    }
+
+    @Test
+    fun whenFireSectionReorderedThenPixelFired() {
+        testee.fireSectionReordered()
+
+        verify(pixel).fire(NewTabPixelNames.SECTION_REARRANGED)
+    }
+
+    @Test
+    fun whenNewTabDisplayedAndNoFavoritesThenPixelFired() {
+        whenever(savedSitesRepository.favoritesCount()).thenReturn(0)
+        val paramsMap = mutableMapOf<String, String>().apply {
+            put(NewTabPixelParameters.FAVORITES, "1")
+            put(NewTabPixelParameters.SHORTCUTS, "1")
+            put(NewTabPixelParameters.APP_TRACKING_PROTECTION, "1")
+            put(NewTabPixelParameters.FAVORITES_COUNT, "0")
+        }
+
+        testee.fireNewTabDisplayed()
+
+        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED)
+        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED_UNIQUE, type = DAILY, parameters = paramsMap)
+    }
+
+    @Test
+    fun whenNewTabDisplayedAnd1FavoriteThenPixelFired() {
+        whenever(savedSitesRepository.favoritesCount()).thenReturn(1)
+        val paramsMap = mutableMapOf<String, String>().apply {
+            put(NewTabPixelParameters.FAVORITES, "1")
+            put(NewTabPixelParameters.SHORTCUTS, "1")
+            put(NewTabPixelParameters.APP_TRACKING_PROTECTION, "1")
+            put(NewTabPixelParameters.FAVORITES_COUNT, "1")
+        }
+
+        testee.fireNewTabDisplayed()
+
+        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED)
+        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED_UNIQUE, type = DAILY, parameters = paramsMap)
+    }
+
+    @Test
+    fun whenNewTabDisplayedAnd3FavoritesThenPixelFired() {
+        whenever(savedSitesRepository.favoritesCount()).thenReturn(3)
+        val paramsMap = mutableMapOf<String, String>().apply {
+            put(NewTabPixelParameters.FAVORITES, "1")
+            put(NewTabPixelParameters.SHORTCUTS, "1")
+            put(NewTabPixelParameters.APP_TRACKING_PROTECTION, "1")
+            put(NewTabPixelParameters.FAVORITES_COUNT, NewTabPixelValues.FAVORITES_2_3)
+        }
+
+        testee.fireNewTabDisplayed()
+
+        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED)
+        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED_UNIQUE, type = DAILY, parameters = paramsMap)
+    }
+
+    @Test
+    fun whenNewTabDisplayedAnd5FavoritesThenPixelFired() {
+        whenever(savedSitesRepository.favoritesCount()).thenReturn(5)
+        val paramsMap = mutableMapOf<String, String>().apply {
+            put(NewTabPixelParameters.FAVORITES, "1")
+            put(NewTabPixelParameters.SHORTCUTS, "1")
+            put(NewTabPixelParameters.APP_TRACKING_PROTECTION, "1")
+            put(NewTabPixelParameters.FAVORITES_COUNT, NewTabPixelValues.FAVORITES_4_5)
+        }
+
+        testee.fireNewTabDisplayed()
+
+        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED)
+        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED_UNIQUE, type = DAILY, parameters = paramsMap)
+    }
+
+    @Test
+    fun whenNewTabDisplayedAnd10FavoritesThenPixelFired() {
+        whenever(savedSitesRepository.favoritesCount()).thenReturn(10)
+        val paramsMap = mutableMapOf<String, String>().apply {
+            put(NewTabPixelParameters.FAVORITES, "1")
+            put(NewTabPixelParameters.SHORTCUTS, "1")
+            put(NewTabPixelParameters.APP_TRACKING_PROTECTION, "1")
+            put(NewTabPixelParameters.FAVORITES_COUNT, NewTabPixelValues.FAVORITES_6_10)
+        }
+
+        testee.fireNewTabDisplayed()
+
+        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED)
+        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED_UNIQUE, type = DAILY, parameters = paramsMap)
+    }
+
+    @Test
+    fun whenNewTabDisplayedAnd15FavoritesThenPixelFired() {
+        whenever(savedSitesRepository.favoritesCount()).thenReturn(15)
+        val paramsMap = mutableMapOf<String, String>().apply {
+            put(NewTabPixelParameters.FAVORITES, "1")
+            put(NewTabPixelParameters.SHORTCUTS, "1")
+            put(NewTabPixelParameters.APP_TRACKING_PROTECTION, "1")
+            put(NewTabPixelParameters.FAVORITES_COUNT, NewTabPixelValues.FAVORITES_11_15)
+        }
+
+        testee.fireNewTabDisplayed()
+
+        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED)
+        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED_UNIQUE, type = DAILY, parameters = paramsMap)
+    }
+
+    @Test
+    fun whenNewTabDisplayedAnd20FavoritesThenPixelFired() {
+        whenever(savedSitesRepository.favoritesCount()).thenReturn(20)
+        val paramsMap = mutableMapOf<String, String>().apply {
+            put(NewTabPixelParameters.FAVORITES, "1")
+            put(NewTabPixelParameters.SHORTCUTS, "1")
+            put(NewTabPixelParameters.APP_TRACKING_PROTECTION, "1")
+            put(NewTabPixelParameters.FAVORITES_COUNT, NewTabPixelValues.FAVORITES_16_25)
+        }
+
+        testee.fireNewTabDisplayed()
+
+        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED)
+        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED_UNIQUE, type = DAILY, parameters = paramsMap)
+    }
+
+    @Test
+    fun whenNewTabDisplayedAnd50FavoritesThenPixelFired() {
+        whenever(savedSitesRepository.favoritesCount()).thenReturn(50)
+        val paramsMap = mutableMapOf<String, String>().apply {
+            put(NewTabPixelParameters.FAVORITES, "1")
+            put(NewTabPixelParameters.SHORTCUTS, "1")
+            put(NewTabPixelParameters.APP_TRACKING_PROTECTION, "1")
+            put(NewTabPixelParameters.FAVORITES_COUNT, NewTabPixelValues.FAVORITES_25)
+        }
+
+        testee.fireNewTabDisplayed()
+
+        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED)
+        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED_UNIQUE, type = DAILY, parameters = paramsMap)
+    }
+
+    @Test
+    fun whenNewTabDisplayedAndNoSectionsEnabledThenPixelFired() {
+        testee = RealNewTabPixels(
+            pixel,
+            disabledSectionPlugins,
+            savedSitesRepository,
+            TestScope(),
+            coroutinesTestRule.testDispatcherProvider,
+        )
+
+        whenever(savedSitesRepository.favoritesCount()).thenReturn(50)
+        val paramsMap = mutableMapOf<String, String>().apply {
+            put(NewTabPixelParameters.FAVORITES, "0")
+            put(NewTabPixelParameters.SHORTCUTS, "0")
+            put(NewTabPixelParameters.APP_TRACKING_PROTECTION, "0")
+            put(NewTabPixelParameters.FAVORITES_COUNT, NewTabPixelValues.FAVORITES_25)
+        }
+
+        testee.fireNewTabDisplayed()
+
+        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED)
+        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED_UNIQUE, type = DAILY, parameters = paramsMap)
+    }
+}

--- a/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/settings/NewTabPageViewModelTest.kt
+++ b/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/settings/NewTabPageViewModelTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.newtabpage.impl.settings
 
+import androidx.lifecycle.LifecycleOwner
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.newtabpage.api.NewTabPageSection
@@ -41,6 +42,7 @@ class NewTabPageViewModelTest {
 
     private val sectionProvider: NewTabPageSectionProvider = mock()
     private val pixels: NewTabPixels = mock()
+    private val lifecycleOwner: LifecycleOwner = mock()
 
     private lateinit var testee: NewTabPageViewModel
 
@@ -52,10 +54,11 @@ class NewTabPageViewModelTest {
     @Test
     fun whenViewModelStartsThenCorrectStateEmitted() = runTest {
         whenever(sectionProvider.provideSections()).thenReturn(flowOf(emptyList()))
+        testee.onResume(lifecycleOwner)
         testee.viewState.test {
             expectMostRecentItem().also {
                 assertTrue(it.sections.isEmpty())
-                assertTrue(it.loading)
+                assertFalse(it.loading)
                 assertFalse(it.showDax)
             }
             verify(pixels).fireNewTabDisplayed()
@@ -75,6 +78,8 @@ class NewTabPageViewModelTest {
             ),
         )
 
+        testee.onResume(lifecycleOwner)
+
         testee.viewState.test {
             expectMostRecentItem().also {
                 assertTrue(it.sections.isNotEmpty())
@@ -83,5 +88,12 @@ class NewTabPageViewModelTest {
                 assertFalse(it.showDax)
             }
         }
+    }
+
+    @Test
+    fun whenCustomisePageClickedThenPixelSent() {
+        testee.onCustomisePageClicked()
+
+        verify(pixels).fireCustomizePagePressedPixel()
     }
 }

--- a/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/settings/NewTabPageViewModelTest.kt
+++ b/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/settings/NewTabPageViewModelTest.kt
@@ -61,7 +61,6 @@ class NewTabPageViewModelTest {
                 assertFalse(it.loading)
                 assertTrue(it.showDax)
             }
-            verify(pixels).fireNewTabDisplayed()
         }
     }
 
@@ -83,7 +82,6 @@ class NewTabPageViewModelTest {
                 assertFalse(it.loading)
                 assertFalse(it.showDax)
             }
-            verify(pixels).fireNewTabDisplayed()
         }
     }
 
@@ -105,7 +103,6 @@ class NewTabPageViewModelTest {
                 assertFalse(it.loading)
                 assertFalse(it.showDax)
             }
-            verify(pixels).fireNewTabDisplayed()
         }
     }
 
@@ -126,7 +123,6 @@ class NewTabPageViewModelTest {
                 assertFalse(it.loading)
                 assertTrue(it.showDax)
             }
-            verify(pixels).fireNewTabDisplayed()
         }
     }
 

--- a/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/settings/NewTabPageViewModelTest.kt
+++ b/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/settings/NewTabPageViewModelTest.kt
@@ -59,7 +59,72 @@ class NewTabPageViewModelTest {
             expectMostRecentItem().also {
                 assertTrue(it.sections.isEmpty())
                 assertFalse(it.loading)
+                assertTrue(it.showDax)
+            }
+            verify(pixels).fireNewTabDisplayed()
+        }
+    }
+
+    @Test
+    fun whenFavouritesShownThenDaxNotVisible() = runTest {
+        whenever(sectionProvider.provideSections()).thenReturn(
+            flowOf(
+                listOf(
+                    FakeEnabledSectionPlugin(NewTabPageSection.REMOTE_MESSAGING_FRAMEWORK.name, true),
+                    FakeEnabledSectionPlugin(NewTabPageSection.APP_TRACKING_PROTECTION.name, true),
+                    FakeEnabledSectionPlugin(NewTabPageSection.FAVOURITES.name, true),
+                ),
+            ),
+        )
+        testee.onResume(lifecycleOwner)
+        testee.viewState.test {
+            expectMostRecentItem().also {
+                assertTrue(it.sections.size == 3)
+                assertFalse(it.loading)
                 assertFalse(it.showDax)
+            }
+            verify(pixels).fireNewTabDisplayed()
+        }
+    }
+
+    @Test
+    fun whenShortcutsShownThenDaxNotVisible() = runTest {
+        whenever(sectionProvider.provideSections()).thenReturn(
+            flowOf(
+                listOf(
+                    FakeEnabledSectionPlugin(NewTabPageSection.REMOTE_MESSAGING_FRAMEWORK.name, true),
+                    FakeEnabledSectionPlugin(NewTabPageSection.APP_TRACKING_PROTECTION.name, true),
+                    FakeEnabledSectionPlugin(NewTabPageSection.SHORTCUTS.name, true),
+                ),
+            ),
+        )
+        testee.onResume(lifecycleOwner)
+        testee.viewState.test {
+            expectMostRecentItem().also {
+                assertTrue(it.sections.size == 3)
+                assertFalse(it.loading)
+                assertFalse(it.showDax)
+            }
+            verify(pixels).fireNewTabDisplayed()
+        }
+    }
+
+    @Test
+    fun whenShortcutsOrFavouritesNotShownThenDaxVisible() = runTest {
+        whenever(sectionProvider.provideSections()).thenReturn(
+            flowOf(
+                listOf(
+                    FakeEnabledSectionPlugin(NewTabPageSection.REMOTE_MESSAGING_FRAMEWORK.name, true),
+                    FakeEnabledSectionPlugin(NewTabPageSection.APP_TRACKING_PROTECTION.name, true),
+                ),
+            ),
+        )
+        testee.onResume(lifecycleOwner)
+        testee.viewState.test {
+            expectMostRecentItem().also {
+                assertTrue(it.sections.size == 2)
+                assertFalse(it.loading)
+                assertTrue(it.showDax)
             }
             verify(pixels).fireNewTabDisplayed()
         }

--- a/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/settings/NewTabPageViewModelTest.kt
+++ b/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/settings/NewTabPageViewModelTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.newtabpage.impl.settings
+
+import app.cash.turbine.test
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.newtabpage.api.NewTabPageSection
+import com.duckduckgo.newtabpage.api.NewTabPageSectionProvider
+import com.duckduckgo.newtabpage.impl.FakeEnabledSectionPlugin
+import com.duckduckgo.newtabpage.impl.pixels.NewTabPixels
+import com.duckduckgo.newtabpage.impl.view.NewTabPageViewModel
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class NewTabPageViewModelTest {
+
+    @get:Rule
+    var coroutinesTestRule = CoroutineTestRule()
+
+    private val sectionProvider: NewTabPageSectionProvider = mock()
+    private val pixels: NewTabPixels = mock()
+
+    private lateinit var testee: NewTabPageViewModel
+
+    @Before
+    fun setup() {
+        testee = NewTabPageViewModel(sectionProvider, pixels, coroutinesTestRule.testDispatcherProvider)
+    }
+
+    @Test
+    fun whenViewModelStartsThenCorrectStateEmitted() = runTest {
+        whenever(sectionProvider.provideSections()).thenReturn(flowOf(emptyList()))
+        testee.viewState.test {
+            expectMostRecentItem().also {
+                assertTrue(it.sections.isEmpty())
+                assertTrue(it.loading)
+                assertFalse(it.showDax)
+            }
+            verify(pixels).fireNewTabDisplayed()
+        }
+    }
+
+    @Test
+    fun whenSectionsProvidedThenCorrectStateEmitted() = runTest {
+        whenever(sectionProvider.provideSections()).thenReturn(
+            flowOf(
+                listOf(
+                    FakeEnabledSectionPlugin(NewTabPageSection.REMOTE_MESSAGING_FRAMEWORK.name, true),
+                    FakeEnabledSectionPlugin(NewTabPageSection.APP_TRACKING_PROTECTION.name, true),
+                    FakeEnabledSectionPlugin(NewTabPageSection.FAVOURITES.name, true),
+                    FakeEnabledSectionPlugin(NewTabPageSection.SHORTCUTS.name, true),
+                ),
+            ),
+        )
+
+        testee.viewState.test {
+            expectMostRecentItem().also {
+                assertTrue(it.sections.isNotEmpty())
+                assertTrue(it.sections.size == 4)
+                assertFalse(it.loading)
+                assertFalse(it.showDax)
+            }
+        }
+    }
+}

--- a/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/settings/NewTabSetingsViewModelTest.kt
+++ b/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/settings/NewTabSetingsViewModelTest.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.newtabpage.impl.FakeShortcut
 import com.duckduckgo.newtabpage.impl.FakeShortcutDataStore
 import com.duckduckgo.newtabpage.impl.FakeShortcutPlugin
 import com.duckduckgo.newtabpage.impl.enabledSectionSettingsPlugins
+import com.duckduckgo.newtabpage.impl.pixels.NewTabPixels
 import com.duckduckgo.newtabpage.impl.shortcuts.NewTabShortcutsProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
@@ -43,6 +44,7 @@ class NewTabSetingsViewModelTest {
 
     private val sectionSettingsProvider: NewTabPageSectionSettingsProvider = mock()
     private val shortcutsProvider: NewTabShortcutsProvider = mock()
+    private val pixels: NewTabPixels = mock()
     private val shortcutStore = FakeShortcutDataStore()
     private val settingsStore = FakeSettingStore()
 
@@ -55,6 +57,7 @@ class NewTabSetingsViewModelTest {
             shortcutsProvider,
             shortcutStore,
             settingsStore,
+            pixels,
             coroutinesTestRule.testDispatcherProvider,
         )
     }

--- a/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/shortcuts/ShortcutsNewTabSettingsViewModelTest.kt
+++ b/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/shortcuts/ShortcutsNewTabSettingsViewModelTest.kt
@@ -3,12 +3,14 @@ package com.duckduckgo.newtabpage.impl.shortcuts
 import androidx.lifecycle.LifecycleOwner
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.newtabpage.impl.pixels.NewTabPixels
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 class ShortcutsNewTabSettingsViewModelTest {
@@ -19,12 +21,14 @@ class ShortcutsNewTabSettingsViewModelTest {
     private lateinit var testee: ShortcutsNewTabSettingsViewModel
     private val setting: NewTabShortcutDataStore = mock()
     private val lifecycleOwner: LifecycleOwner = mock()
+    private val pixels: NewTabPixels = mock()
 
     @Before
     fun setup() {
         testee = ShortcutsNewTabSettingsViewModel(
             coroutinesTestRule.testDispatcherProvider,
             setting,
+            pixels,
         )
     }
 
@@ -48,5 +52,17 @@ class ShortcutsNewTabSettingsViewModelTest {
                 assertFalse(it.enabled)
             }
         }
+    }
+
+    @Test
+    fun whenSettingEnabledThenPixelFired() = runTest {
+        testee.onSettingEnabled(true)
+        verify(pixels).fireShortcutSectionToggled(true)
+    }
+
+    @Test
+    fun whenSettingDisabledThenPixelFired() = runTest {
+        testee.onSettingEnabled(false)
+        verify(pixels).fireShortcutSectionToggled(false)
     }
 }

--- a/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/shortcuts/ShortcutsViewModelTest.kt
+++ b/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/shortcuts/ShortcutsViewModelTest.kt
@@ -19,7 +19,10 @@ package com.duckduckgo.newtabpage.impl.shortcuts
 import androidx.lifecycle.LifecycleOwner
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.newtabpage.impl.FakeShortcut
+import com.duckduckgo.newtabpage.impl.FakeShortcutPlugin
 import com.duckduckgo.newtabpage.impl.FakeShortcutPluginPoint
+import com.duckduckgo.newtabpage.impl.pixels.NewTabPixels
 import com.duckduckgo.newtabpage.impl.settings.NewTabSettingsStore
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -28,6 +31,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 class ShortcutsViewModelTest {
@@ -40,6 +44,7 @@ class ShortcutsViewModelTest {
     private var mockLifecycleOwner: LifecycleOwner = mock()
     private val newTabSettingsStore: NewTabSettingsStore = mock()
     private val newTabShortcutsProvider: NewTabShortcutsProvider = mock()
+    private val pixels: NewTabPixels = mock()
     private val shortcutPlugins = FakeShortcutPluginPoint()
 
     @Before
@@ -48,6 +53,7 @@ class ShortcutsViewModelTest {
             coroutineRule.testDispatcherProvider,
             newTabSettingsStore,
             newTabShortcutsProvider,
+            pixels,
         )
     }
 
@@ -71,5 +77,13 @@ class ShortcutsViewModelTest {
                 assertTrue(it.shortcuts.isNotEmpty())
             }
         }
+    }
+
+    @Test
+    fun whenShortcutPressedThenPixelFired() {
+        val shortcut = FakeShortcut("bookmarks")
+        testee.onShortcutPressed(FakeShortcutPlugin(shortcut))
+
+        verify(pixels).fireShortcutPressed(shortcut.name)
     }
 }

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/network/PrivacyConfigService.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/network/PrivacyConfigService.kt
@@ -18,14 +18,13 @@ package com.duckduckgo.privacy.config.impl.network
 
 import com.duckduckgo.anvil.annotations.ContributesServiceApi
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.privacy.config.api.PRIVACY_REMOTE_CONFIG_URL
 import com.duckduckgo.privacy.config.impl.models.JsonPrivacyConfig
 import retrofit2.Response
 import retrofit2.http.GET
 
 @ContributesServiceApi(AppScope::class)
 interface PrivacyConfigService {
-    // @GET(PRIVACY_REMOTE_CONFIG_URL)
-    // onboarding
-    @GET("http://www.jsonblob.com/api/1260881980894863360")
+    @GET(PRIVACY_REMOTE_CONFIG_URL)
     suspend fun privacyConfig(): Response<JsonPrivacyConfig>
 }

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/network/PrivacyConfigService.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/network/PrivacyConfigService.kt
@@ -18,13 +18,14 @@ package com.duckduckgo.privacy.config.impl.network
 
 import com.duckduckgo.anvil.annotations.ContributesServiceApi
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.privacy.config.api.PRIVACY_REMOTE_CONFIG_URL
 import com.duckduckgo.privacy.config.impl.models.JsonPrivacyConfig
 import retrofit2.Response
 import retrofit2.http.GET
 
 @ContributesServiceApi(AppScope::class)
 interface PrivacyConfigService {
-    @GET(PRIVACY_REMOTE_CONFIG_URL)
+    // @GET(PRIVACY_REMOTE_CONFIG_URL)
+    // onboarding
+    @GET("http://www.jsonblob.com/api/1260881980894863360")
     suspend fun privacyConfig(): Response<JsonPrivacyConfig>
 }

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/network/RemoteMessagingService.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/network/RemoteMessagingService.kt
@@ -23,7 +23,6 @@ import retrofit2.http.GET
 
 @ContributesServiceApi(AppScope::class)
 interface RemoteMessagingService {
-    // @GET("https://staticcdn.duckduckgo.com/remotemessaging/config/v1/android-config.json")
-    @GET("http://www.jsonblob.com/api/1235947624862703616")
+    @GET("https://staticcdn.duckduckgo.com/remotemessaging/config/v1/android-config.json")
     suspend fun config(): JsonRemoteMessagingConfig
 }

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/network/RemoteMessagingService.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/network/RemoteMessagingService.kt
@@ -23,6 +23,7 @@ import retrofit2.http.GET
 
 @ContributesServiceApi(AppScope::class)
 interface RemoteMessagingService {
-    @GET("https://staticcdn.duckduckgo.com/remotemessaging/config/v1/android-config.json")
+    // @GET("https://staticcdn.duckduckgo.com/remotemessaging/config/v1/android-config.json")
+    @GET("http://www.jsonblob.com/api/1235947624862703616")
     suspend fun config(): JsonRemoteMessagingConfig
 }

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/SavedSitesPixelName.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/SavedSitesPixelName.kt
@@ -23,6 +23,13 @@ enum class SavedSitesPixelName(override val pixelName: String) : Pixel.PixelName
     BOOKMARK_EXPORT_SUCCESS("m_be_a"),
     BOOKMARK_EXPORT_ERROR("m_be_e"),
 
+    /** New Tab Pixels **/
+    FAVOURITES_LIST_EXPANDED("m_new_tab_page_favorites_expanded"),
+    FAVOURITES_LIST_COLLAPSED("m_new_tab_page_favorites_collapsed"),
+    FAVOURITES_TOOLTIP_PRESSED("m_new_tab_page_favorites_info_tooltip"),
+    FAVOURITES_SECTION_TOGGLED_OFF("m_new_tab_page_customize_section_off_favorites"),
+    FAVOURITES_SECTION_TOGGLED_ON("m_new_tab_page_customize_section_on_favorites"),
+
     FAVORITE_BOOKMARKS_ITEM_PRESSED("m_fav_b"),
 
     BOOKMARK_LAUNCHED("m_bookmark_launched"),

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/SavedSitesPixelName.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/SavedSitesPixelName.kt
@@ -18,10 +18,28 @@ package com.duckduckgo.savedsites.impl
 
 import com.duckduckgo.app.statistics.pixels.Pixel
 enum class SavedSitesPixelName(override val pixelName: String) : Pixel.PixelName {
+    /** Bookmarks Screen **/
     BOOKMARK_IMPORT_SUCCESS("m_bi_s"),
     BOOKMARK_IMPORT_ERROR("m_bi_e"),
     BOOKMARK_EXPORT_SUCCESS("m_be_a"),
     BOOKMARK_EXPORT_ERROR("m_be_e"),
+    FAVORITE_BOOKMARKS_ITEM_PRESSED("m_fav_b"),
+    BOOKMARK_LAUNCHED("m_bookmark_launched"),
+    BOOKMARK_LAUNCHED_DAILY("m_bookmark_launched_daily"),
+
+    /** Edit Bookmark Dialog **/
+    EDIT_BOOKMARK_ADD_FAVORITE_TOGGLED("m_edit_bookmark_add_favorite"),
+    EDIT_BOOKMARK_ADD_FAVORITE_TOGGLED_DAILY("m_edit_bookmark_add_favorite_daily"),
+    EDIT_BOOKMARK_REMOVE_FAVORITE_TOGGLED("m_edit_bookmark_remove_favorite"),
+    EDIT_BOOKMARK_DELETE_BOOKMARK_CLICKED("m_edit_bookmark_delete"),
+    EDIT_BOOKMARK_DELETE_BOOKMARK_CONFIRMED("m_edit_bookmark_delete_confirm"),
+    EDIT_BOOKMARK_DELETE_BOOKMARK_CANCELLED("m_edit_bookmark_delete_cancel"),
+
+    /** Browser Menu **/
+    BOOKMARK_MENU_ADD_FAVORITE_CLICKED("m_bookmark_menu_add_favorite"),
+    BOOKMARK_MENU_EDIT_BOOKMARK_CLICKED("m_bookmark_menu_edit"),
+    BOOKMARK_MENU_REMOVE_FAVORITE_CLICKED("m_bookmark_menu_remove_favorite"),
+    BOOKMARK_MENU_DELETE_BOOKMARK_CLICKED("m_bookmark_menu_delete"),
 
     /** New Tab Pixels **/
     FAVOURITES_LIST_EXPANDED("m_new_tab_page_favorites_expanded"),
@@ -29,19 +47,6 @@ enum class SavedSitesPixelName(override val pixelName: String) : Pixel.PixelName
     FAVOURITES_TOOLTIP_PRESSED("m_new_tab_page_favorites_info_tooltip"),
     FAVOURITES_SECTION_TOGGLED_OFF("m_new_tab_page_customize_section_off_favorites"),
     FAVOURITES_SECTION_TOGGLED_ON("m_new_tab_page_customize_section_on_favorites"),
-
-    FAVORITE_BOOKMARKS_ITEM_PRESSED("m_fav_b"),
-
-    BOOKMARK_LAUNCHED("m_bookmark_launched"),
-
-    EDIT_BOOKMARK_ADD_FAVORITE_TOGGLED("m_edit_bookmark_add_favorite"),
-    EDIT_BOOKMARK_REMOVE_FAVORITE_TOGGLED("m_edit_bookmark_remove_favorite"),
-    EDIT_BOOKMARK_DELETE_BOOKMARK_CLICKED("m_edit_bookmark_delete"),
-    EDIT_BOOKMARK_DELETE_BOOKMARK_CONFIRMED("m_edit_bookmark_delete_confirm"),
-    EDIT_BOOKMARK_DELETE_BOOKMARK_CANCELLED("m_edit_bookmark_delete_cancel"),
-
-    BOOKMARK_MENU_ADD_FAVORITE_CLICKED("m_bookmark_menu_add_favorite"),
-    BOOKMARK_MENU_EDIT_BOOKMARK_CLICKED("m_bookmark_menu_edit"),
-    BOOKMARK_MENU_REMOVE_FAVORITE_CLICKED("m_bookmark_menu_remove_favorite"),
-    BOOKMARK_MENU_DELETE_BOOKMARK_CLICKED("m_bookmark_menu_delete"),
+    FAVOURITE_CLICKED("m_favorite_clicked"),
+    FAVOURITE_CLICKED_DAILY("m_favorite_clicked_daily"),
 }

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/SavedSitesPixelName.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/SavedSitesPixelName.kt
@@ -49,4 +49,5 @@ enum class SavedSitesPixelName(override val pixelName: String) : Pixel.PixelName
     FAVOURITES_SECTION_TOGGLED_ON("m_new_tab_page_customize_section_on_favorites"),
     FAVOURITE_CLICKED("m_favorite_clicked"),
     FAVOURITE_CLICKED_DAILY("m_favorite_clicked_daily"),
+    MENU_ACTION_ADD_FAVORITE_PRESSED_DAILY("m_nav_af_p_daily"),
 }

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksViewModel.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksViewModel.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.DAILY
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.SingleLiveEvent
 import com.duckduckgo.di.scopes.ActivityScope
@@ -133,6 +134,7 @@ class BookmarksViewModel @Inject constructor(
 
     override fun onFavoriteAdded() {
         pixel.fire(SavedSitesPixelName.EDIT_BOOKMARK_ADD_FAVORITE_TOGGLED)
+        pixel.fire(SavedSitesPixelName.EDIT_BOOKMARK_ADD_FAVORITE_TOGGLED_DAILY, type = DAILY)
     }
 
     override fun onFavoriteRemoved() {
@@ -157,6 +159,7 @@ class BookmarksViewModel @Inject constructor(
             pixel.fire(SavedSitesPixelName.FAVORITE_BOOKMARKS_ITEM_PRESSED)
         }
         pixel.fire(SavedSitesPixelName.BOOKMARK_LAUNCHED)
+        pixel.fire(SavedSitesPixelName.BOOKMARK_LAUNCHED_DAILY, type = DAILY)
         command.value = OpenSavedSite(savedSite.url)
     }
 

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionView.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionView.kt
@@ -170,7 +170,6 @@ class FavouritesNewTabSectionView @JvmOverloads constructor(
         binding.quickAccessRecyclerView.disableAnimation()
 
         binding.sectionHeaderOverflowIcon.setOnClickListener {
-            viewModel.onTooltipPressed()
             showNewTabFavouritesPopup(it)
         }
     }
@@ -192,6 +191,7 @@ class FavouritesNewTabSectionView @JvmOverloads constructor(
             LayoutParams.WRAP_CONTENT,
             true,
         ).apply {
+            viewModel.onTooltipPressed()
             showAsDropDown(anchor)
         }
     }

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionView.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionView.kt
@@ -259,6 +259,7 @@ class FavouritesNewTabSectionView @JvmOverloads constructor(
     }
 
     private fun submitUrl(url: String) {
+        viewModel.onFavoriteClicked()
         context.startActivity(browserNav.openInCurrentTab(context, url))
     }
 

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionView.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionView.kt
@@ -170,6 +170,7 @@ class FavouritesNewTabSectionView @JvmOverloads constructor(
         binding.quickAccessRecyclerView.disableAnimation()
 
         binding.sectionHeaderOverflowIcon.setOnClickListener {
+            viewModel.onTooltipPressed()
             showNewTabFavouritesPopup(it)
         }
     }
@@ -298,10 +299,12 @@ class FavouritesNewTabSectionView @JvmOverloads constructor(
                             expandAnimator.reverse()
                             adapter.submitList(viewState.favourites.take(numOfCollapsedItems).map { FavouriteItemFavourite(it) })
                             adapter.expanded = false
+                            viewModel.onListCollapsed()
                         } else {
                             expandAnimator.start()
                             adapter.submitList(viewState.favourites.map { FavouriteItemFavourite(it) })
                             adapter.expanded = true
+                            viewModel.onListExpanded()
                         }
                     }
                 } else {

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionViewModel.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionViewModel.kt
@@ -23,6 +23,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.browser.favicon.FaviconManager
+import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.savedsites.api.SavedSitesRepository
@@ -30,6 +31,7 @@ import com.duckduckgo.savedsites.api.models.BookmarkFolder
 import com.duckduckgo.savedsites.api.models.SavedSite
 import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
 import com.duckduckgo.savedsites.api.models.SavedSite.Favorite
+import com.duckduckgo.savedsites.impl.SavedSitesPixelName
 import com.duckduckgo.savedsites.impl.newtab.FavouritesNewTabSectionViewModel.Command.DeleteFavoriteConfirmation
 import com.duckduckgo.savedsites.impl.newtab.FavouritesNewTabSectionViewModel.Command.DeleteSavedSiteConfirmation
 import com.duckduckgo.savedsites.impl.newtab.FavouritesNewTabSectionViewModel.Command.ShowEditSavedSiteDialog
@@ -54,6 +56,7 @@ import kotlinx.coroutines.withContext
 class FavouritesNewTabSectionViewModel @Inject constructor(
     private val dispatchers: DispatcherProvider,
     private val savedSitesRepository: SavedSitesRepository,
+    private val pixel: Pixel,
     private val faviconManager: FaviconManager,
     private val syncEngine: SyncEngine,
 ) : ViewModel(), DefaultLifecycleObserver {
@@ -215,6 +218,18 @@ class FavouritesNewTabSectionViewModel @Inject constructor(
         viewModelScope.launch(dispatchers.io()) {
             syncEngine.triggerSync(FEATURE_READ)
         }
+    }
+
+    fun onTooltipPressed() {
+        pixel.fire(SavedSitesPixelName.FAVOURITES_TOOLTIP_PRESSED)
+    }
+
+    fun onListExpanded() {
+        pixel.fire(SavedSitesPixelName.FAVOURITES_LIST_EXPANDED)
+    }
+
+    fun onListCollapsed() {
+        pixel.fire(SavedSitesPixelName.FAVOURITES_LIST_COLLAPSED)
     }
 
     fun onFavouriteEdited(favorite: Favorite) {

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionViewModel.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionViewModel.kt
@@ -264,6 +264,6 @@ class FavouritesNewTabSectionViewModel @Inject constructor(
 
     fun onFavoriteClicked() {
         pixel.fire(SavedSitesPixelName.FAVOURITE_CLICKED)
-        pixel.fire(SavedSitesPixelName.FAVOURITE_CLICKED, type = DAILY)
+        pixel.fire(SavedSitesPixelName.FAVOURITE_CLICKED_DAILY, type = DAILY)
     }
 }

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionViewModel.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionViewModel.kt
@@ -24,6 +24,7 @@ import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.DAILY
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.savedsites.api.SavedSitesRepository
@@ -253,10 +254,16 @@ class FavouritesNewTabSectionViewModel @Inject constructor(
     }
 
     fun onFavoriteAdded() {
-        // pixel.fire(SavedSitesPixelName.EDIT_BOOKMARK_ADD_FAVORITE_TOGGLED)
+        pixel.fire(SavedSitesPixelName.EDIT_BOOKMARK_ADD_FAVORITE_TOGGLED)
+        pixel.fire(SavedSitesPixelName.EDIT_BOOKMARK_ADD_FAVORITE_TOGGLED_DAILY, type = DAILY)
     }
 
     fun onFavoriteRemoved() {
-        // pixel.fire(SavedSitesPixelName.EDIT_BOOKMARK_REMOVE_FAVORITE_TOGGLED)
+        pixel.fire(SavedSitesPixelName.EDIT_BOOKMARK_REMOVE_FAVORITE_TOGGLED)
+    }
+
+    fun onFavoriteClicked() {
+        pixel.fire(SavedSitesPixelName.FAVOURITE_CLICKED)
+        pixel.fire(SavedSitesPixelName.FAVOURITE_CLICKED, type = DAILY)
     }
 }

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionsAdapter.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionsAdapter.kt
@@ -43,7 +43,6 @@ import com.duckduckgo.savedsites.impl.newtab.FavouritesNewTabSectionsAdapter.Fav
 import com.duckduckgo.savedsites.impl.newtab.FavouritesNewTabSectionsAdapter.FavouriteViewHolder.ItemState.Stale
 import kotlin.math.absoluteValue
 import kotlinx.coroutines.launch
-import logcat.logcat
 
 class FavouritesNewTabSectionsAdapter(
     private val lifecycleOwner: LifecycleOwner,
@@ -203,7 +202,6 @@ class FavouritesNewTabSectionsAdapter(
 
         private fun configureClickListeners(favorite: Favorite) {
             binding.root.setLongClickListener {
-                logcat { "New Tab: onLongClick" }
                 itemState = LongPress
                 scaleUpFavicon()
                 showOverFlowMenu(binding.root, favorite)

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSettingsViewModel.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSettingsViewModel.kt
@@ -22,9 +22,11 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.savedsites.impl.SavedSitesPixelName
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -37,6 +39,7 @@ import kotlinx.coroutines.withContext
 class FavouritesNewTabSettingsViewModel @Inject constructor(
     private val dispatchers: DispatcherProvider,
     private val setting: NewTabFavouritesSectionSetting,
+    private val pixel: Pixel,
 ) : ViewModel(), DefaultLifecycleObserver {
 
     private val _viewState = MutableStateFlow(ViewState(true))
@@ -57,5 +60,10 @@ class FavouritesNewTabSettingsViewModel @Inject constructor(
 
     fun onSettingEnabled(enabled: Boolean) {
         setting.self().setEnabled(State(enabled))
+        if (enabled) {
+            pixel.fire(SavedSitesPixelName.FAVOURITES_SECTION_TOGGLED_ON)
+        } else {
+            pixel.fire(SavedSitesPixelName.FAVOURITES_SECTION_TOGGLED_OFF)
+        }
     }
 }

--- a/saved-sites/saved-sites-impl/src/test/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionViewModelTests.kt
+++ b/saved-sites/saved-sites-impl/src/test/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionViewModelTests.kt
@@ -19,9 +19,11 @@ package com.duckduckgo.savedsites.impl.newtab
 import androidx.lifecycle.LifecycleOwner
 import app.cash.turbine.test
 import com.duckduckgo.app.browser.favicon.FaviconManager
+import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.savedsites.api.models.SavedSite.Favorite
+import com.duckduckgo.savedsites.impl.SavedSitesPixelName
 import com.duckduckgo.savedsites.impl.newtab.FavouritesNewTabSectionViewModel.Command.DeleteFavoriteConfirmation
 import com.duckduckgo.savedsites.impl.newtab.FavouritesNewTabSectionViewModel.Command.ShowEditSavedSiteDialog
 import com.duckduckgo.sync.api.engine.SyncEngine
@@ -47,6 +49,7 @@ class FavouritesNewTabSectionViewModelTests {
     private val mockSavedSitesRepository: SavedSitesRepository = mock()
     private val faviconManager: FaviconManager = mock()
     private val syncEngine: SyncEngine = mock()
+    private val pixel: Pixel = mock()
 
     private lateinit var testee: FavouritesNewTabSectionViewModel
 
@@ -56,7 +59,13 @@ class FavouritesNewTabSectionViewModelTests {
     @Before
     fun setup() {
         whenever(mockSavedSitesRepository.getFavorites()).thenReturn(flowOf(emptyList()))
-        testee = FavouritesNewTabSectionViewModel(coroutinesTestRule.testDispatcherProvider, mockSavedSitesRepository, faviconManager, syncEngine)
+        testee = FavouritesNewTabSectionViewModel(
+            coroutinesTestRule.testDispatcherProvider,
+            mockSavedSitesRepository,
+            pixel,
+            faviconManager,
+            syncEngine,
+        )
     }
 
     @Test
@@ -127,5 +136,26 @@ class FavouritesNewTabSectionViewModelTests {
         testee.onNewTabFavouritesShown()
 
         verify(syncEngine).triggerSync(FEATURE_READ)
+    }
+
+    @Test
+    fun whenTooltipPressedThenPixelSent() = runTest {
+        testee.onTooltipPressed()
+
+        verify(pixel).fire(SavedSitesPixelName.FAVOURITES_TOOLTIP_PRESSED)
+    }
+
+    @Test
+    fun whenListExpandedThenPixelSent() = runTest {
+        testee.onListExpanded()
+
+        verify(pixel).fire(SavedSitesPixelName.FAVOURITES_LIST_EXPANDED)
+    }
+
+    @Test
+    fun whenListCollapsedThenPixelSent() = runTest {
+        testee.onListCollapsed()
+
+        verify(pixel).fire(SavedSitesPixelName.FAVOURITES_LIST_COLLAPSED)
     }
 }

--- a/saved-sites/saved-sites-impl/src/test/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSettingsViewModelTest.kt
+++ b/saved-sites/saved-sites-impl/src/test/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSettingsViewModelTest.kt
@@ -2,15 +2,18 @@ package com.duckduckgo.savedsites.impl.newtab
 
 import androidx.lifecycle.LifecycleOwner
 import app.cash.turbine.test
+import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.savedsites.impl.SavedSitesPixelName
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 class FavouritesNewTabSettingsViewModelTest {
@@ -21,12 +24,14 @@ class FavouritesNewTabSettingsViewModelTest {
     private lateinit var testee: FavouritesNewTabSettingsViewModel
     private val setting: NewTabFavouritesSectionSetting = mock()
     private val lifecycleOwner: LifecycleOwner = mock()
+    private val pixels: Pixel = mock()
 
     @Before
     fun setup() {
         testee = FavouritesNewTabSettingsViewModel(
             coroutinesTestRule.testDispatcherProvider,
             setting,
+            pixels,
         )
     }
 
@@ -76,5 +81,45 @@ class FavouritesNewTabSettingsViewModelTest {
                 assertFalse(it.enabled)
             }
         }
+    }
+
+    @Test
+    fun whenSettingEnabledThenPixelFired() = runTest {
+        whenever(setting.self()).thenReturn(
+            object : Toggle {
+                override fun isEnabled(): Boolean {
+                    return false
+                }
+
+                override fun setEnabled(state: State) {
+                }
+
+                override fun getRawStoredState(): State {
+                    return State()
+                }
+            },
+        )
+        testee.onSettingEnabled(true)
+        verify(pixels).fire(SavedSitesPixelName.FAVOURITES_SECTION_TOGGLED_ON)
+    }
+
+    @Test
+    fun whenSettingDisabledThenPixelFired() = runTest {
+        whenever(setting.self()).thenReturn(
+            object : Toggle {
+                override fun isEnabled(): Boolean {
+                    return false
+                }
+
+                override fun setEnabled(state: State) {
+                }
+
+                override fun getRawStoredState(): State {
+                    return State()
+                }
+            },
+        )
+        testee.onSettingEnabled(false)
+        verify(pixels).fire(SavedSitesPixelName.FAVOURITES_SECTION_TOGGLED_OFF)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1207131725936040/f

### Description
Adds pixels to the new NTP
Engagement pixels: https://app.asana.com/0/72649045549333/1207667088727866
Experiment pixels: https://app.asana.com/0/72649045549333/1207667088727867/f

### Steps to test this PR

_When New Tab Page is displayed _
- [x] Open New Tab
- [x] Verify pixel sent `m_new_tab_page_displayed`
- [x] Verify daily pixel with parameters 
- [x] see https://app.asana.com/0/72649045549333/1207667088727866 for rules
- [x] Verify pixel sent `m_new_tab_page_displayed_unique with params: {favorites=1, shortcuts=1, appTP=1, favoriteCount=11_15`

_Clicks on the Edit/Customize button_
- [x] Open New Tab
- [x] Tap on Customize page
- [x] Verify pixel sent `m_new_tab_page_customize`

_Clicks on each shortcut_
- [x] Open New Tab
- [x] Tap on a shortcut
- [x] Verify pixel sent `m_new_tab_page_shortcut_clicked_[shortcut name]`

_Clicks on the info icon_
- [x] Open New Tab
- [x] Ensure you don’t have favorites
- [x] Tap on the icon icon next to placholders
- [x] Verify pixel sent `m_new_tab_page_favorites_info_tooltip`

_When user expands Favourites list_
- [x] Open New Tab
- [x] Ensure you have more than 8 favorites
- [x] Expand list of favorites
- [x] Verify pixel sent `m_new_tab_page_favorites_expanded`

_When user collapses Favourites list_
- [x] Open New Tab
- [x] Ensure you have more than 8 favorites
- [x] With the list expanded, collapse it
- [x] Verify pixel sent `m_new_tab_page_favorites_collapsed`

_When each section is toggled OFF or ON_
- [x] Ensure App Tracking Protection is enabled
- [x] Open New Tab
- [x] Open Customise New Tab
- [x] Disable Favourites section
- [x] Verify pixel sent `m_new_tab_page_customize_section_off_favorites`
- [x] Enable Favourites section
- [x] Verify pixel sent `m_new_tab_page_customize_section_on_favorites`
- [x] Disable Shortcuts section
- [x] Verify pixel sent `m_new_tab_page_customize_section_off_shortcuts`
- [x] Enable Shortcuts section
- [x] Verify pixel sent `m_new_tab_page_customize_section_on_shortcuts`
- [x] Disable AppTP section
- [x] Verify pixel sent `m_new_tab_page_customize_section_off_appTP`
- [x] Enable AppTP section
- [x] Verify pixel sent `m_new_tab_page_customize_section_on_appTP`

_When sections are swapped_
- [x] Open New Tab
- [x] Open Customise New Tab
- [x] Reorder any section
- [x] Verify pixel sent `m_new_tab_page_customize_section_reordered`

_When shortcut enabled / disabled_
- [x] Open New Tab
- [x] Open Customise New Tab
- [x] Enable a shortcut (AI Chat)
- [x] Verify pixel sent `m_new_tab_page_customize_shortcut_added_chat`
- [x] Disable a shortcut (AI Chat)
- [x] Verify pixel sent `m_new_tab_page_customize_shortcut_removed_chat`
- [x] Verify same thing happens with other shortcuts, but with its own name

_When user toggles 'Add Favorite' from Add Bookmark confirmation_
- [x] Navigate to a site
- [x] Add it as bookmark, and toggle Favorite
- [x] Verify pixel sent `m_nav_af_p`
- [x] Verify pixel sent `m_nav_af_p_daily` (should only be sent once per day

_When user clicks on a Favorite on NTP_
- [x] Open New Tab
- [x] Tap on a favourite
- [x] Verify pixel sent `m_favorite_clicked`
- [x] Verify pixel sent `m_favorite_clicked_daily` (should only be sent once per day

_When user clicks on a Bookmark in Bookmark list_
- [x] Open Bookmarks
- [x] Tap on a bookmark
- [x] Verify pixel sent `m_bookmark_launched`
- [x] Verify pixel sent `m_bookmark_launched_daily` (should only be sent once per day
