### PR TITLE
UI for autofill breakage reports

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/suggestion/SuggestionListBuilder.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/suggestion/SuggestionListBuilder.kt
@@ -34,6 +34,7 @@ class SuggestionListBuilder @Inject constructor(
     fun build(
         unsortedDirectSuggestions: List<LoginCredentials>,
         unsortedSharableSuggestions: List<LoginCredentials>,
+        allowBreakageReporting: Boolean,
     ): List<ListItem> {
         val list = mutableListOf<ListItem>()
 
@@ -45,6 +46,10 @@ class SuggestionListBuilder @Inject constructor(
 
             val allSuggestions = sortedDirectSuggestions + sortedSharableSuggestions
             list.addAll(allSuggestions.map { SuggestedCredential(it) })
+
+            if (allowBreakageReporting) {
+                list.add(ListItem.ReportAutofillBreakage)
+            }
 
             list.add(Divider)
         }

--- a/autofill/autofill-impl/src/main/res/drawable/autofill_rounded_report_breakage_icon_background.xml
+++ b/autofill/autofill-impl/src/main/res/drawable/autofill_rounded_report_breakage_icon_background.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2024 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid
+        android:color="?attr/daxColorContainer"/>
+</shape>

--- a/autofill/autofill-impl/src/main/res/drawable/ic_alert_24.xml
+++ b/autofill/autofill-impl/src/main/res/drawable/ic_alert_24.xml
@@ -1,0 +1,35 @@
+<!--
+  ~ Copyright (c) 2024 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M11.96,13.636C11.478,13.636 11.05,13.302 10.997,12.873L10.354,7.907C10.301,7.43 10.729,7 11.318,7H12.656C13.191,7 13.672,7.43 13.619,7.907L12.976,12.873C12.87,13.302 12.441,13.636 11.96,13.636Z"
+        android:fillColor="?attr/daxColorPrimaryIcon"
+        android:fillAlpha="0.84" />
+    <path
+        android:pathData="M13.5,16.5C13.5,17.328 12.828,18 12,18C11.172,18 10.5,17.328 10.5,16.5C10.5,15.672 11.172,15 12,15C12.828,15 13.5,15.672 13.5,16.5Z"
+        android:fillColor="?attr/daxColorPrimaryIcon"
+        android:fillAlpha="0.84" />
+    <path
+        android:pathData="M8.987,3.802C10.296,1.399 13.704,1.399 15.013,3.802L21.566,15.829C22.833,18.152 21.174,21 18.553,21H5.447C2.826,21 1.167,18.152 2.433,15.829L8.987,3.802ZM10.743,4.759C11.294,3.747 12.706,3.747 13.257,4.759L19.81,16.786C20.371,17.815 19.612,19 18.553,19H5.447C4.388,19 3.629,17.815 4.19,16.786L10.743,4.759Z"
+        android:fillColor="?attr/daxColorPrimaryIcon"
+        android:fillAlpha="0.84"
+        android:fillType="evenOdd" />
+</vector>

--- a/autofill/autofill-impl/src/main/res/layout/item_row_autofill_report_breakage_management_screen.xml
+++ b/autofill/autofill-impl/src/main/res/layout/item_row_autofill_report_breakage_management_screen.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2022 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:paddingStart="10dp"
+    android:paddingEnd="0dp"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="@dimen/twoLineItemHeight"
+    android:layout_margin="4dp">
+
+    <ImageView
+        android:id="@+id/icon"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:padding="8dp"
+        android:background="@drawable/autofill_rounded_report_breakage_icon_background"
+        app:srcCompat="@drawable/ic_alert_24"
+        android:importantForAccessibility="no"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+        android:id="@+id/title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        tools:text="duckduckgo.com"
+        app:primaryText="@string/autofillManagementReportBreakagePromptTitle"
+        app:secondaryText="@string/autofillManagementReportBreakagePromptSubtitle"
+        app:layout_constraintStart_toEndOf="@id/icon"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="@id/icon"
+        app:layout_constraintTop_toTopOf="@id/icon" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/autofill/autofill-impl/src/main/res/values/donottranslate.xml
+++ b/autofill/autofill-impl/src/main/res/values/donottranslate.xml
@@ -17,4 +17,12 @@
 <resources>
     <!-- New Tab -->
     <string name="newTabPageShortcutPasswords">Passwords</string>
+
+    <string name="autofillManagementReportBreakagePromptTitle">Report a problem with autofill</string>
+    <string name="autofillManagementReportBreakagePromptSubtitle">Anonymously report autofill not working on this site. Passwords are never shared.</string>
+    <string name="autofillManagementReportBreakageDialogTitle" instruction="Placeholder is a website URL">Report autofill not working on %1$s?</string>
+    <string name="autofillManagementReportBreakageDialogMessage">Reports sent to DuckDuckGo are anonymous and do not include your username, password, or any other personally identifiable information.\n\nThe report only includes the website url and the status of some autofill settings.</string>
+    <string name="autofillManagementReportBreakageDialogPositiveButton">Send Report</string>
+    <string name="autofillManagementReportBreakageDialogNegativeButton">Cancel</string>
+    <string name="autofillManagementReportBreakageSuccessMessage">Thank you! Your report will help us make DuckDuckGo better for everyone.</string>
 </resources>

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModelTest.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.autofill.api.AutofillSettingsLaunchSource.Sync
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.api.email.EmailManager
 import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator
+import com.duckduckgo.autofill.impl.encoding.UrlUnicodeNormalizerImpl
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_COPY_PASSWORD
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_COPY_USERNAME
@@ -63,7 +64,10 @@ import com.duckduckgo.autofill.impl.ui.credential.management.survey.SurveyDetail
 import com.duckduckgo.autofill.impl.ui.credential.management.viewing.duckaddress.DuckAddressIdentifier
 import com.duckduckgo.autofill.impl.ui.credential.management.viewing.duckaddress.RealDuckAddressIdentifier
 import com.duckduckgo.autofill.impl.ui.credential.repository.DuckAddressStatusRepository
+import com.duckduckgo.autofill.impl.urlmatcher.AutofillDomainNameUrlMatcher
+import com.duckduckgo.autofill.store.reporting.AutofillSiteBreakageReportingFeatureRepository
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.toggle.AutofillReportBreakageTestFeature
 import kotlin.reflect.KClass
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
@@ -101,6 +105,9 @@ class AutofillSettingsViewModelTest {
     private val duckAddressIdentifier: DuckAddressIdentifier = RealDuckAddressIdentifier()
     private val neverSavedSiteRepository: NeverSavedSiteRepository = mock()
     private val autofillSurvey: AutofillSurvey = mock()
+    private val reportBreakageFeature = AutofillReportBreakageTestFeature()
+    private val reportBreakageFeatureExceptions: AutofillSiteBreakageReportingFeatureRepository = mock()
+    private val urlMatcher = AutofillDomainNameUrlMatcher(UrlUnicodeNormalizerImpl())
     private val testee = AutofillSettingsViewModel(
         autofillStore = mockStore,
         clipboardInteractor = clipboardInteractor,
@@ -116,6 +123,9 @@ class AutofillSettingsViewModelTest {
         syncEngine = mock(),
         neverSavedSiteRepository = neverSavedSiteRepository,
         autofillSurvey = autofillSurvey,
+        reportBreakageFeature = reportBreakageFeature,
+        reportBreakageFeatureExceptions = reportBreakageFeatureExceptions,
+        urlMatcher = urlMatcher,
     )
 
     @Before

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/suggestion/SuggestionListBuilderTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/suggestion/SuggestionListBuilderTest.kt
@@ -39,62 +39,62 @@ class SuggestionListBuilderTest {
 
     @Test
     fun whenNoSuggestionThenEmptyListReturned() {
-        assertTrue(testee.build(emptyList(), emptyList()).isEmpty())
+        assertTrue(testee.build(emptyList(), emptyList(), allowBreakageReporting = false).isEmpty())
     }
 
     @Test
     fun whenOneDirectSuggestionThenDividerAddedLast() {
         val suggestions = buildSuggestions(1)
-        val list = testee.build(suggestions, emptyList())
+        val list = testee.build(suggestions, emptyList(), allowBreakageReporting = false)
         assertTrue(list.last() is ListItem.Divider)
     }
 
     @Test
     fun whenTwoDirectSuggestionsThenDividerAddedLast() {
         val suggestions = buildSuggestions(2)
-        val list = testee.build(suggestions, emptyList())
+        val list = testee.build(suggestions, emptyList(), allowBreakageReporting = false)
         assertTrue(list.last() is ListItem.Divider)
     }
 
     @Test
     fun whenOneDirectSuggestionThenCorrectNumberOfListItemsReturned() {
         val suggestions = buildSuggestions(1)
-        val list = testee.build(suggestions, emptyList())
+        val list = testee.build(suggestions, emptyList(), allowBreakageReporting = false)
         assertEquals(NUM_SUGGESTION_HEADERS + NUM_DIVIDERS + suggestions.size, list.size)
     }
 
     @Test
     fun whenTwoDirectSuggestionsThenCorrectNumberOfListItemsReturned() {
         val suggestions = buildSuggestions(2)
-        val list = testee.build(suggestions, emptyList())
+        val list = testee.build(suggestions, emptyList(), allowBreakageReporting = false)
         assertEquals(NUM_SUGGESTION_HEADERS + NUM_DIVIDERS + suggestions.size, list.size)
     }
 
     @Test
     fun whenTenDirectSuggestionsThenThirteenListItemsReturned() {
         val suggestions = buildSuggestions(10)
-        val list = testee.build(suggestions, emptyList())
+        val list = testee.build(suggestions, emptyList(), allowBreakageReporting = false)
         assertEquals(NUM_SUGGESTION_HEADERS + NUM_DIVIDERS + suggestions.size, list.size)
     }
 
     @Test
     fun whenDirectSuggestionAddedThenGroupNameIsCorrect() {
         val suggestions = buildSuggestions(1)
-        val heading = testee.build(suggestions, emptyList()).first()
+        val heading = testee.build(suggestions, emptyList(), allowBreakageReporting = false).first()
         assertTrue(heading is ListItem.GroupHeading)
     }
 
     @Test
     fun whenNoDirectSuggestionsButOneShareableThenCorrectNumberOfListItemsReturned() {
         val suggestions = buildSuggestions(1)
-        val list = testee.build(emptyList(), suggestions)
+        val list = testee.build(emptyList(), suggestions, allowBreakageReporting = false)
         assertEquals(NUM_SUGGESTION_HEADERS + NUM_DIVIDERS + suggestions.size, list.size)
     }
 
     @Test
     fun whenNoDirectSuggestionsButMultipleShareableThenCorrectNumberOfListItemsReturned() {
         val suggestions = buildSuggestions(10)
-        val list = testee.build(emptyList(), suggestions)
+        val list = testee.build(emptyList(), suggestions, allowBreakageReporting = false)
         assertEquals(NUM_SUGGESTION_HEADERS + NUM_DIVIDERS + suggestions.size, list.size)
     }
 
@@ -102,7 +102,7 @@ class SuggestionListBuilderTest {
     fun whenOneDirectAndOneShareableThenDirectSuggestionsAppearFirst() {
         val directSuggestions = buildSuggestions(1)
         val sharableSuggestions = buildSuggestions(1, startingIndex = directSuggestions.size)
-        val list = testee.build(directSuggestions, sharableSuggestions)
+        val list = testee.build(directSuggestions, sharableSuggestions, allowBreakageReporting = false)
         assertEquals(NUM_SUGGESTION_HEADERS + NUM_DIVIDERS + directSuggestions.size + sharableSuggestions.size, list.size)
         assertTrue(list[0] is ListItem.GroupHeading)
         assertEquals(0L, (list[1] as SuggestedCredential).credentials.id)
@@ -113,7 +113,7 @@ class SuggestionListBuilderTest {
     fun whenMultipleDirectAndSomeShareableThenDirectSuggestionsAppearFirst() {
         val directSuggestions = buildSuggestions(10, isShareable = false)
         val sharableSuggestions = buildSuggestions(1, isShareable = true, startingIndex = directSuggestions.size)
-        val list = testee.build(directSuggestions, sharableSuggestions)
+        val list = testee.build(directSuggestions, sharableSuggestions, allowBreakageReporting = false)
         assertEquals(NUM_SUGGESTION_HEADERS + NUM_DIVIDERS + directSuggestions.size + sharableSuggestions.size, list.size)
         assertTrue(list[0] is ListItem.GroupHeading)
         assertEquals("direct", (list[1] as SuggestedCredential).credentials.username)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/608920331025315/1207767049586685/f 

### Description
Adds the UI for showing the option to send an autofill breakage report.

Note, this branch doesn't actually submit the report or suppress the prompt from showing again.

### Steps to test this PR

ℹ️  Local hack to enable feature: In `AutofillSiteBreakageReportingFeature`, set default value to `true`

---

**Verifying it doesn't show unexpectedly**
- [ ] Fresh install
- [ ] Tap on overflow->Passwords; verify you do **not** see the "report a problem" view
- [ ] Manually add a password for `fill.dev`, and press back after saving. verify you do **not** see the "report a problem" view
- [ ] Return to browser and visit a different site, e.g., `example.com`
- [ ] Tap on overflow->Passwords; verify you do **not** see the "report a problem" view
- [ ] Visit `fill.dev`. This time, access passwords from `Settings` (not directly from the overflow.) verify you do **not** see the "report a problem" view

**Verifying it does show when it should**
- [ ] With a password saved for `fill.dev` already, visit `fill.dev`
- [ ] Tap on overflow->Passwords; verify you **do** see the "report a problem" view

**Verifying it behaves when tapped on**
- [ ] Tap on "Report a problem with autofill"
- [ ] Verify prompt looks good against designs
- [ ] Tap `Send Report` and verify confirmation snackbar looks good

**Verifying feature flag works**
- [ ] Remove your local hack so that the feature defaults to `false` (and remote config isn't yet set up for it anyway)
- [ ] With a password saved for `fill.dev` already, visit `fill.dev`
- [ ] Tap on overflow->Passwords; verify you do **not** see the "report a problem" view


![output](https://github.com/user-attachments/assets/6ae3326b-81dc-4f61-a762-7f57ddaaca32)
