### PR TITLE
New Tab: Fix RMF Pixels

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -105,6 +105,7 @@ import com.duckduckgo.app.browser.viewstate.LoadingViewState
 import com.duckduckgo.app.browser.webview.SslWarningLayout.Action
 import com.duckduckgo.app.cta.db.DismissedCtaDao
 import com.duckduckgo.app.cta.model.CtaId
+import com.duckduckgo.app.cta.model.CtaId.DAX_END
 import com.duckduckgo.app.cta.model.DismissedCta
 import com.duckduckgo.app.cta.ui.Cta
 import com.duckduckgo.app.cta.ui.CtaViewModel
@@ -2355,6 +2356,16 @@ class BrowserTabViewModelTest {
         whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(false)
         testee.refreshCta()
         assertNull(testee.ctaViewState.value!!.cta)
+    }
+
+    @Test
+    fun whenCtaRefreshedAndOnboardingCompleteThenViewStateUpdated() = runTest {
+        whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(false)
+        whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(DAX_END)).thenReturn(true)
+        testee.refreshCta()
+        assertNull(testee.ctaViewState.value!!.cta)
+        assertTrue(testee.ctaViewState.value!!.daxOnboardingComplete)
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2123,7 +2123,6 @@ class BrowserTabFragment :
 
     private fun configureFocusedView() {
         focusedViewProvider.provideFocusedViewVersion().onEach { focusedView ->
-            Timber.d("New Tab: Focused View $focusedView")
             binding.focusedViewContainerLayout.addView(
                 focusedView.getView(requireContext()),
                 LayoutParams(
@@ -3797,7 +3796,6 @@ class BrowserTabFragment :
         }
 
         fun renderCtaViewState(viewState: CtaViewState) {
-            Timber.d("New Tab: ctaViewState $viewState")
             if (isHidden || isActiveCustomTab()) {
                 return
             }
@@ -3818,7 +3816,6 @@ class BrowserTabFragment :
         }
 
         private fun showCta(configuration: Cta) {
-            Timber.d("New Tab: CTA to show $configuration")
             when (configuration) {
                 is HomePanelCta -> showHomeCta(configuration)
                 is DaxBubbleCta -> showDaxOnboardingBubbleCta(configuration)
@@ -3918,7 +3915,6 @@ class BrowserTabFragment :
 
         private fun showNewTab() {
             newTabPageProvider.provideNewTabPageVersion().onEach { newTabPage ->
-                Timber.d("New Tab: Provide Page $newTabPage")
                 newBrowserTab.newTabContainerLayout.addView(
                     newTabPage.getView(requireContext()),
                     LayoutParams(
@@ -3932,7 +3928,6 @@ class BrowserTabFragment :
         }
 
         private fun hideNewTab() {
-            Timber.d("New Tab: hideNewTab")
             newBrowserTab.newTabContainerLayout.gone()
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -3810,8 +3810,7 @@ class BrowserTabFragment :
                         showCta(viewState.cta)
                     }
 
-                    else -> {
-                        hideDaxCta()
+                    viewState.daxOnboardingComplete -> {
                         showNewTab()
                     }
                 }
@@ -3918,20 +3917,17 @@ class BrowserTabFragment :
         }
 
         private fun showNewTab() {
-            Timber.d("New Tab: showNewTab child count ${newBrowserTab.newTabContainerLayout.childCount}")
-            if (newBrowserTab.newTabContainerLayout.childCount == 0) {
-                newTabPageProvider.provideNewTabPageVersion().onEach { newTabPage ->
-                    Timber.d("New Tab: Provide Page $newTabPage")
-                    newBrowserTab.newTabContainerLayout.addView(
-                        newTabPage.getView(requireContext()),
-                        LayoutParams(
-                            LayoutParams.MATCH_PARENT,
-                            LayoutParams.MATCH_PARENT,
-                        ),
-                    )
-                }
-                    .launchIn(lifecycleScope)
+            newTabPageProvider.provideNewTabPageVersion().onEach { newTabPage ->
+                Timber.d("New Tab: Provide Page $newTabPage")
+                newBrowserTab.newTabContainerLayout.addView(
+                    newTabPage.getView(requireContext()),
+                    LayoutParams(
+                        LayoutParams.MATCH_PARENT,
+                        LayoutParams.MATCH_PARENT,
+                    ),
+                )
             }
+                .launchIn(lifecycleScope)
             newBrowserTab.newTabContainerLayout.show()
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -3797,6 +3797,7 @@ class BrowserTabFragment :
         }
 
         fun renderCtaViewState(viewState: CtaViewState) {
+            Timber.d("New Tab: ctaViewState $viewState")
             if (isHidden || isActiveCustomTab()) {
                 return
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -3805,6 +3805,7 @@ class BrowserTabFragment :
                 lastSeenCtaViewState = viewState
                 when {
                     viewState.cta != null -> {
+                        hideNewTab()
                         showCta(viewState.cta)
                     }
 
@@ -3912,8 +3913,6 @@ class BrowserTabFragment :
                     ctaBottomSheet.show()
                 }
             }
-
-            showNewTab()
             viewModel.onCtaShown()
         }
 
@@ -3936,6 +3935,7 @@ class BrowserTabFragment :
         }
 
         private fun hideNewTab() {
+            Timber.d("New Tab: hideNewTab")
             newBrowserTab.newTabContainerLayout.gone()
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2142,18 +2142,6 @@ class BrowserTabFragment :
                 omnibar.omniBarContainer.isPressed = false
             }
         }
-
-        newTabPageProvider.provideNewTabPageVersion().onEach { newTabPage ->
-            Timber.d("New Tab: Page $newTabPage")
-            newBrowserTab.newTabContainerLayout.addView(
-                newTabPage.getView(requireContext()),
-                LayoutParams(
-                    LayoutParams.MATCH_PARENT,
-                    LayoutParams.MATCH_PARENT,
-                ),
-            )
-        }
-            .launchIn(lifecycleScope)
     }
 
     private fun configurePrivacyShield() {
@@ -3930,6 +3918,20 @@ class BrowserTabFragment :
         }
 
         private fun showNewTab() {
+            Timber.d("New Tab: showNewTab child count ${newBrowserTab.newTabContainerLayout.childCount}")
+            if (newBrowserTab.newTabContainerLayout.childCount == 0) {
+                newTabPageProvider.provideNewTabPageVersion().onEach { newTabPage ->
+                    Timber.d("New Tab: Provide Page $newTabPage")
+                    newBrowserTab.newTabContainerLayout.addView(
+                        newTabPage.getView(requireContext()),
+                        LayoutParams(
+                            LayoutParams.MATCH_PARENT,
+                            LayoutParams.MATCH_PARENT,
+                        ),
+                    )
+                }
+                    .launchIn(lifecycleScope)
+            }
             newBrowserTab.newTabContainerLayout.show()
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2427,8 +2427,11 @@ class BrowserTabViewModel @Inject constructor(
                     siteLiveData.value,
                 )
             }
+            val isOnboardingComplete = withContext(dispatchers.io()) {
+                ctaViewModel.daxDialogEndShown()
+            }
             if (isBrowserShowing && cta != null) hasCtaBeenShownForCurrentPage.set(true)
-            ctaViewState.value = currentCtaViewState().copy(cta = cta)
+            ctaViewState.value = currentCtaViewState().copy(cta = cta, daxOnboardingComplete = isOnboardingComplete)
             ctaChangedTicker.emit(System.currentTimeMillis().toString())
             return cta
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageView.kt
@@ -21,11 +21,13 @@ import android.app.PendingIntent
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
+import android.graphics.Rect
 import android.text.Spanned
 import android.util.AttributeSet
 import android.widget.LinearLayout
 import androidx.core.text.toSpannable
 import androidx.core.view.isGone
+import androidx.core.view.isVisible
 import androidx.fragment.app.findFragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.findViewTreeLifecycleOwner
@@ -344,10 +346,18 @@ class NewTabLegacyPageView @JvmOverloads constructor(
         message: RemoteMessage,
         newMessage: Boolean,
     ) {
-        val shouldRender = newMessage || binding.messageCta.isGone
+        val globalVisibilityRectangle = Rect()
+        val isVisibleToUser = getGlobalVisibleRect(globalVisibilityRectangle)
+        Timber.d("New Tab: isVisibleToUser $isVisibleToUser")
+        Timber.d("New Tab: isVisibleToUser height  ${globalVisibilityRectangle.height()}")
+        Timber.d("New Tab: isVisibleToUser width  ${globalVisibilityRectangle.width()}")
+
+        val shouldRender = isVisibleToUser && (newMessage || binding.messageCta.isGone)
 
         if (shouldRender) {
             binding.messageCta.show()
+            binding.messageCta.isVisible
+            parent
             viewModel.onMessageShown()
             binding.messageCta.setMessage(message.asMessage())
             binding.messageCta.onCloseButtonClicked {

--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageView.kt
@@ -217,7 +217,6 @@ class NewTabLegacyPageView @JvmOverloads constructor(
     }
 
     private fun render(viewState: ViewState) {
-        Timber.d("New Tab: render $viewState")
         if (viewState.message == null && viewState.favourites.isEmpty()) {
             homeBackgroundLogo.showLogo()
         } else {

--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageView.kt
@@ -21,7 +21,6 @@ import android.app.PendingIntent
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
-import android.graphics.Rect
 import android.text.Spanned
 import android.util.AttributeSet
 import android.widget.LinearLayout
@@ -218,12 +217,13 @@ class NewTabLegacyPageView @JvmOverloads constructor(
     }
 
     private fun render(viewState: ViewState) {
+        Timber.d("New Tab: render $viewState")
         if (viewState.message == null && viewState.favourites.isEmpty()) {
             homeBackgroundLogo.showLogo()
         } else {
             homeBackgroundLogo.hideLogo()
         }
-        if (viewState.message != null) {
+        if (viewState.message != null && viewState.onboardingComplete) {
             showRemoteMessage(viewState.message, viewState.newMessage)
         } else {
             binding.messageCta.gone()
@@ -345,11 +345,7 @@ class NewTabLegacyPageView @JvmOverloads constructor(
         message: RemoteMessage,
         newMessage: Boolean,
     ) {
-        val globalVisibilityRectangle = Rect()
-        val isVisibleToUser = getGlobalVisibleRect(globalVisibilityRectangle)
-        Timber.d("New Tab: isVisibleToUser $isVisibleToUser")
-
-        val shouldRender = isVisibleToUser && (newMessage || binding.messageCta.isGone)
+        val shouldRender = newMessage || binding.messageCta.isGone
 
         if (shouldRender) {
             binding.messageCta.setMessage(message.asMessage())

--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageView.kt
@@ -27,7 +27,6 @@ import android.util.AttributeSet
 import android.widget.LinearLayout
 import androidx.core.text.toSpannable
 import androidx.core.view.isGone
-import androidx.core.view.isVisible
 import androidx.fragment.app.findFragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.findViewTreeLifecycleOwner
@@ -349,16 +348,10 @@ class NewTabLegacyPageView @JvmOverloads constructor(
         val globalVisibilityRectangle = Rect()
         val isVisibleToUser = getGlobalVisibleRect(globalVisibilityRectangle)
         Timber.d("New Tab: isVisibleToUser $isVisibleToUser")
-        Timber.d("New Tab: isVisibleToUser height  ${globalVisibilityRectangle.height()}")
-        Timber.d("New Tab: isVisibleToUser width  ${globalVisibilityRectangle.width()}")
 
         val shouldRender = isVisibleToUser && (newMessage || binding.messageCta.isGone)
 
         if (shouldRender) {
-            binding.messageCta.show()
-            binding.messageCta.isVisible
-            parent
-            viewModel.onMessageShown()
             binding.messageCta.setMessage(message.asMessage())
             binding.messageCta.onCloseButtonClicked {
                 viewModel.onMessageCloseButtonClicked()
@@ -372,6 +365,8 @@ class NewTabLegacyPageView @JvmOverloads constructor(
             binding.messageCta.onPromoActionClicked {
                 viewModel.onMessageActionButtonClicked()
             }
+            binding.messageCta.show()
+            viewModel.onMessageShown()
         }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageViewModel.kt
@@ -134,13 +134,12 @@ class NewTabLegacyPageViewModel @Inject constructor(
                     }
 
                     withContext(dispatchers.io()) {
-                        val onboardingComplete = dismissedCtaDao.exists(CtaId.DAX_END)
                         _viewState.emit(
                             viewState.value.copy(
                                 message = snapshot.remoteMessage,
                                 newMessage = newMessage,
                                 favourites = snapshot.favourites,
-                                onboardingComplete = onboardingComplete,
+                                onboardingComplete = isHomeOnboardingComplete(),
                             ),
                         )
                     }
@@ -148,6 +147,12 @@ class NewTabLegacyPageViewModel @Inject constructor(
                 .flowOn(dispatchers.main())
                 .launchIn(viewModelScope)
         }
+    }
+
+    // We only want to show New Tab when the Home CTAs from Onboarding has finished
+    // https://app.asana.com/0/1157893581871903/1207769731595075/f
+    private fun isHomeOnboardingComplete(): Boolean {
+        return dismissedCtaDao.exists(CtaId.DAX_END)
     }
 
     fun onMessageShown() {

--- a/app/src/main/java/com/duckduckgo/app/browser/viewstate/CtaViewState.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/viewstate/CtaViewState.kt
@@ -20,4 +20,5 @@ import com.duckduckgo.app.cta.ui.Cta
 
 data class CtaViewState(
     val cta: Cta? = null,
+    val daxOnboardingComplete: Boolean = false,
 )

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -284,7 +284,7 @@ class CtaViewModel @Inject constructor(
 
     private fun daxDialogIntroShown(): Boolean = dismissedCtaDao.exists(CtaId.DAX_INTRO)
 
-    private fun daxDialogEndShown(): Boolean = dismissedCtaDao.exists(CtaId.DAX_END)
+    fun daxDialogEndShown(): Boolean = dismissedCtaDao.exists(CtaId.DAX_END)
 
     private fun daxDialogSerpShown(): Boolean = dismissedCtaDao.exists(CtaId.DAX_DIALOG_SERP)
 

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -175,6 +175,7 @@ class CtaViewModel @Inject constructor(
         return when {
             canShowDaxIntroCta() && extendedOnboardingFeatureToggles.noBrowserCtas().isEnabled() -> {
                 dismissedCtaDao.insert(DismissedCta(CtaId.DAX_INTRO))
+                dismissedCtaDao.insert(DismissedCta(CtaId.DAX_END))
                 null
             }
             canShowDaxIntroCta() && !extendedOnboardingFeatureToggles.noBrowserCtas().isEnabled() -> {
@@ -222,6 +223,7 @@ class CtaViewModel @Inject constructor(
             !daxOnboardingActive() || hideTips() -> false
             extendedOnboardingFeatureToggles.noBrowserCtas().isEnabled() -> {
                 settingsDataStore.hideTips = true
+                dismissedCtaDao.insert(DismissedCta(CtaId.DAX_END))
                 userStageStore.stageCompleted(AppStage.DAX_ONBOARDING)
                 false
             }
@@ -284,6 +286,8 @@ class CtaViewModel @Inject constructor(
 
     private fun daxDialogIntroShown(): Boolean = dismissedCtaDao.exists(CtaId.DAX_INTRO)
 
+    // We only want to show New Tab when the Home CTAs from Onboarding has finished
+    // https://app.asana.com/0/1157893581871903/1207769731595075/f
     fun daxDialogEndShown(): Boolean = dismissedCtaDao.exists(CtaId.DAX_END)
 
     private fun daxDialogSerpShown(): Boolean = dismissedCtaDao.exists(CtaId.DAX_DIALOG_SERP)

--- a/app/src/main/res/layout/view_new_tab_legacy.xml
+++ b/app/src/main/res/layout/view_new_tab_legacy.xml
@@ -51,7 +51,7 @@
         <com.duckduckgo.common.ui.view.MessageCta
             android:id="@+id/messageCta"
             android:layout_width="0dp"
-            tools:visibility="gone"
+            android:visibility="gone"
             android:layout_height="wrap_content"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/network/RemoteMessagingService.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/network/RemoteMessagingService.kt
@@ -23,6 +23,7 @@ import retrofit2.http.GET
 
 @ContributesServiceApi(AppScope::class)
 interface RemoteMessagingService {
-    @GET("https://staticcdn.duckduckgo.com/remotemessaging/config/v1/android-config.json")
+    // @GET("https://staticcdn.duckduckgo.com/remotemessaging/config/v1/android-config.json")
+    @GET(" https://www.jsonblob.com/api/1260259880362434560")
     suspend fun config(): JsonRemoteMessagingConfig
 }

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/network/RemoteMessagingService.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/network/RemoteMessagingService.kt
@@ -23,7 +23,6 @@ import retrofit2.http.GET
 
 @ContributesServiceApi(AppScope::class)
 interface RemoteMessagingService {
-    // @GET("https://staticcdn.duckduckgo.com/remotemessaging/config/v1/android-config.json")
-    @GET(" https://www.jsonblob.com/api/1260259880362434560")
+    @GET("https://staticcdn.duckduckgo.com/remotemessaging/config/v1/android-config.json")
     suspend fun config(): JsonRemoteMessagingConfig
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1157893581871903/1207769731595075/f

### Description
This PR ensures that RMF and New Tab are only visible if onboarding has finished

### Steps to test this PR

_RMF Pixels_
- [ ] Change RMF endpoint to https://www.jsonblob.com/api/1260259880362434560
- [ ] Fresh install
- [ ] Reach first onboarding screen (ensure you are in the exp variant that has onboarding)
- [ ] See logs filtering by message~:"RMF|m_remote_message”
- [ ] Verify ‘m_remote_message_shown’ is not sent
- [ ] Complete onboarding (Continue until you see the End dialog"
- [ ] Open New Tab
- [ ] Verify RMF is visible (Bottom Sheet will also be visible)
- [ ] Verify ‘m_remote_message_shown’ is sent

_New Tab_
- [ ] Revert RMF endpoint
- [ ] Fresh install
- [ ] Reach first onboarding screen (ensure you are in the exp variant that has onboarding)
- [ ] Open New Tab
- [ ] Verify Onboarding is visible, not New Tab
- [ ] Complete onboarding (Continue until you see the End dialog"
- [ ] Open New Tab
- [ ] Verify New Tab is visible alongside the Widget Bottom Sheet