### PR TITLE
Fixing internal flaky test round 2

### DIFF
--- a/anrs/anrs-internal/src/test/java/com/duckduckgo/app/anr/internal/store/DatabaseCleanupObserverTest.kt
+++ b/anrs/anrs-internal/src/test/java/com/duckduckgo/app/anr/internal/store/DatabaseCleanupObserverTest.kt
@@ -37,7 +37,7 @@ class DatabaseCleanupObserverTest {
     @Test
     fun whenAppCreatedThenOldAnrsAreRemoved() = runTest {
         db.anrDao().insertAnr(aAnrEntity("1", LocalDateTime.now()))
-        db.anrDao().insertAnr(aAnrEntity("2", LocalDateTime.now().minusDays(31)))
+        db.anrDao().insertAnr(aAnrEntity("2", LocalDateTime.now().minusDays(35)))
 
         testee.onCreate(mockLifecycleOwner)
 
@@ -49,7 +49,7 @@ class DatabaseCleanupObserverTest {
     @Test
     fun whenAppCreatedThenOldCrashesAreRemoved() = runTest {
         db.crashDao().insertCrash(aCrashEntity("1", LocalDateTime.now()))
-        db.crashDao().insertCrash(aCrashEntity("2", LocalDateTime.now().minusDays(31)))
+        db.crashDao().insertCrash(aCrashEntity("2", LocalDateTime.now().minusDays(35)))
 
         testee.onCreate(mockLifecycleOwner)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414730916066338/1207773361177582/f

### Description
Tries to fix flaky test by using different timestamp for old entity objects

### Steps to test this PR

_Feature 1_
- [ ] ci is green
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
