### PR TITLE
Rearranging tabs: Pixels

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -146,6 +146,7 @@ import com.duckduckgo.app.statistics.api.StatisticsUpdater
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.DAILY
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.UNIQUE
 import com.duckduckgo.app.surrogates.SurrogateResponse
 import com.duckduckgo.app.survey.notification.SurveyNotificationScheduler
@@ -5326,6 +5327,7 @@ class BrowserTabViewModelTest {
 
         assertCommandIssued<Command.LaunchTabSwitcher>()
         verify(mockPixel).fire(AppPixelName.TAB_MANAGER_CLICKED)
+        verify(mockPixel).fire(AppPixelName.TAB_MANAGER_CLICKED_DAILY, emptyMap(), emptyMap(), DAILY)
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -142,6 +142,7 @@ import com.duckduckgo.app.statistics.api.StatisticsUpdater
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.DAILY
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.UNIQUE
 import com.duckduckgo.app.surrogates.SurrogateResponse
 import com.duckduckgo.app.survey.notification.SurveyNotificationScheduler
@@ -2617,6 +2618,7 @@ class BrowserTabViewModel @Inject constructor(
     fun userLaunchingTabSwitcher() {
         command.value = LaunchTabSwitcher
         pixel.fire(AppPixelName.TAB_MANAGER_CLICKED)
+        pixel.fire(AppPixelName.TAB_MANAGER_CLICKED_DAILY, emptyMap(), emptyMap(), DAILY)
     }
 
     private fun isFireproofWebsite(domain: String? = site?.domain): Boolean {

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -319,6 +319,7 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     KEYBOARD_GO_SERP_CLICKED("m_keyboard_go_click_serp"),
 
     TAB_MANAGER_CLICKED("m_tab_manager_clicked"),
+    TAB_MANAGER_CLICKED_DAILY("m_tab_manager_clicked_daily"),
     TAB_MANAGER_NEW_TAB_CLICKED("m_tab_manager_new_tab_click"),
     TAB_MANAGER_SWITCH_TABS("m_tab_manager_switch_tabs"),
     TAB_MANAGER_CLOSE_TAB_CLICKED("m_tab_manager_close_tab_click"),
@@ -332,6 +333,8 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     TAB_MANAGER_MENU_CLOSE_ALL_TABS_CONFIRMED("m_tab_manager_menu_close_all_tabs_confirm"),
     TAB_MANAGER_MENU_DOWNLOADS_PRESSED("m_tab_manager_menu_downloads"),
     TAB_MANAGER_MENU_SETTINGS_PRESSED("m_tab_manager_menu_settings"),
+    TAB_MANAGER_REARRANGE_TABS("m_tab_manager_rearrange_tabs"),
+    TAB_MANAGER_REARRANGE_TABS_DAILY("m_tab_manager_rearrange_tabs_daily"),
 
     ADD_BOOKMARK_CONFIRM_EDITED("m_add_bookmark_confirm_edit"),
 }

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -335,6 +335,9 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     TAB_MANAGER_MENU_SETTINGS_PRESSED("m_tab_manager_menu_settings"),
     TAB_MANAGER_REARRANGE_TABS("m_tab_manager_rearrange_tabs"),
     TAB_MANAGER_REARRANGE_TABS_DAILY("m_tab_manager_rearrange_tabs_daily"),
+    TAB_MANAGER_REARRANGE_BANNER_MANUAL_CLOSED("m_tab_manager_rearrange_banner_manual_closed"),
+    TAB_MANAGER_REARRANGE_BANNER_AUTODISMISSED("m_tab_manager_rearrange_banner_autodismissed"),
+    TAB_MANAGER_REARRANGE_BANNER_DISPLAYED("m_tab_manager_rearrange_banner_displayed"),
 
     ADD_BOOKMARK_CONFIRM_EDITED("m_add_bookmark_confirm_edit"),
 }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -130,7 +130,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
 
     private fun configureAnnouncementBanner() {
         announcementCloseButton.setOnClickListener {
-            hideAnnouncement()
+            viewModel.onFeatureAnnouncementCloseButtonTapped()
         }
     }
 
@@ -212,10 +212,6 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
 
             scrollToShowCurrentTab()
         }
-    }
-
-    private fun hideAnnouncement() {
-        viewModel.onTabFeatureAnnouncementDismissed()
     }
 
     private fun scrollToShowCurrentTab() {
@@ -312,7 +308,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
     }
 
     private fun onTabDraggingStarted() {
-        hideAnnouncement()
+        viewModel.onTabDraggingStarted()
         tabsAdapter.onDraggingStarted()
 
         // remove the tab selection border while dragging because it doesn't scale well

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -160,14 +160,20 @@ class TabSwitcherViewModel @Inject constructor(
             val data = tabRepository.tabSwitcherData.first()
             tabRepository.setAnnouncementDisplayCount(data.announcementDisplayCount + 1)
         }
+
+        pixel.fire(AppPixelName.TAB_MANAGER_REARRANGE_BANNER_DISPLAYED)
     }
 
     fun onFeatureAnnouncementCloseButtonTapped() {
         dismissFeatureAnnouncementBanner()
+
+        pixel.fire(AppPixelName.TAB_MANAGER_REARRANGE_BANNER_MANUAL_CLOSED)
     }
 
     fun onTabDraggingStarted() {
         dismissFeatureAnnouncementBanner()
+
+        pixel.fire(AppPixelName.TAB_MANAGER_REARRANGE_BANNER_AUTODISMISSED)
 
         viewModelScope.launch(dispatcherProvider.io()) {
             val params = mapOf("userState" to tabRepository.tabSwitcherData.first().userState.name)

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.DAILY
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.tabs.model.TabSwitcherData.UserState.EXISTING
@@ -161,7 +162,21 @@ class TabSwitcherViewModel @Inject constructor(
         }
     }
 
-    fun onTabFeatureAnnouncementDismissed() {
+    fun onFeatureAnnouncementCloseButtonTapped() {
+        dismissFeatureAnnouncementBanner()
+    }
+
+    fun onTabDraggingStarted() {
+        dismissFeatureAnnouncementBanner()
+
+        viewModelScope.launch(dispatcherProvider.io()) {
+            val params = mapOf("userState" to tabRepository.tabSwitcherData.first().userState.name)
+            pixel.fire(AppPixelName.TAB_MANAGER_REARRANGE_TABS, params)
+            pixel.fire(AppPixelName.TAB_MANAGER_REARRANGE_TABS_DAILY, parameters = params, encodedParameters = emptyMap(), DAILY)
+        }
+    }
+
+    private fun dismissFeatureAnnouncementBanner() {
         viewModelScope.launch(dispatcherProvider.io()) {
             tabRepository.setWasAnnouncementDismissed(true)
         }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -182,9 +182,11 @@ class TabSwitcherViewModel @Inject constructor(
     }
 
     fun onTabDraggingStarted() {
-        dismissFeatureAnnouncementBanner()
+        if (isBannerAlreadyVisible) {
+            dismissFeatureAnnouncementBanner()
 
-        pixel.fire(AppPixelName.TAB_MANAGER_REARRANGE_BANNER_AUTODISMISSED)
+            pixel.fire(AppPixelName.TAB_MANAGER_REARRANGE_BANNER_AUTODISMISSED)
+        }
 
         viewModelScope.launch(dispatcherProvider.io()) {
             val params = mapOf("userState" to tabRepository.tabSwitcherData.first().userState.name)

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -34,7 +34,6 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.SingleLiveEvent
 import com.duckduckgo.di.scopes.ActivityScope
 import javax.inject.Inject
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
@@ -53,7 +52,6 @@ class TabSwitcherViewModel @Inject constructor(
 ) : ViewModel() {
     companion object {
         const val MAX_ANNOUNCEMENT_DISPLAY_COUNT = 3
-        const val BANNER_UPDATE_DELAY = 200L
         const val REINSTALL_VARIANT = "ru"
     }
 
@@ -72,8 +70,6 @@ class TabSwitcherViewModel @Inject constructor(
                 (data.userState == EXISTING || statisticsDataStore.variant == REINSTALL_VARIANT) &&
                 (tabs.size > 1 || isBannerAlreadyVisible)
         isBannerAlreadyVisible = isVisible
-
-        delay(BANNER_UPDATE_DELAY) // delay to improve the UX when opening new tabs
         isVisible
     }
         .onStart { announcementDisplayCount = tabRepository.tabSwitcherData.first().announcementDisplayCount }

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -21,6 +21,7 @@ package com.duckduckgo.app.tabs.ui
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
+import app.cash.turbine.test
 import com.duckduckgo.adclick.api.AdClickManager
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.pixels.AppPixelName
@@ -36,19 +37,26 @@ import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command
 import com.duckduckgo.common.test.CoroutineTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
-import org.mockito.kotlin.*
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 class TabSwitcherViewModelTest {
 
@@ -84,34 +92,37 @@ class TabSwitcherViewModelTest {
     private val repoDeletableTabs = Channel<List<TabEntity>>()
     private val tabs = MutableLiveData<List<TabEntity>>()
 
+    private val tabSwitcherData = TabSwitcherData(NEW, false, 0)
+    private val flowTabs = flowOf(listOf(TabEntity("1", position = 1), TabEntity("2", position = 2)))
+
     @Before
     fun before() {
         MockitoAnnotations.openMocks(this)
+
+        whenever(mockTabRepository.flowDeletableTabs)
+            .thenReturn(repoDeletableTabs.consumeAsFlow())
+        whenever(mockTabRepository.liveTabs)
+            .thenReturn(tabs)
         runBlocking {
-            whenever(mockTabRepository.flowDeletableTabs)
-                .thenReturn(repoDeletableTabs.consumeAsFlow())
-            whenever(mockTabRepository.liveTabs)
-                .thenReturn(tabs)
             whenever(mockTabRepository.add()).thenReturn("TAB_ID")
-            whenever(mockTabRepository.tabSwitcherData).thenReturn(
-                flowOf(
-                    TabSwitcherData(
-                        userState = NEW,
-                        wasAnnouncementDismissed = false,
-                        announcementDisplayCount = 0,
-                    ),
-                ),
-            )
-            testee = TabSwitcherViewModel(
-                mockTabRepository,
-                mockWebViewSessionStorage,
-                mockAdClickManager,
-                coroutinesTestRule.testDispatcherProvider,
-                mockPixel,
-                statisticsDataStore,
-            )
-            testee.command.observeForever(mockCommandObserver)
         }
+        whenever(mockTabRepository.tabSwitcherData).thenReturn(flowOf(tabSwitcherData))
+        whenever(mockTabRepository.flowTabs).thenReturn(flowTabs)
+        whenever(statisticsDataStore.variant).thenReturn("")
+
+        initializeViewModel()
+    }
+
+    private fun initializeViewModel() {
+        testee = TabSwitcherViewModel(
+            mockTabRepository,
+            mockWebViewSessionStorage,
+            mockAdClickManager,
+            coroutinesTestRule.testDispatcherProvider,
+            mockPixel,
+            statisticsDataStore,
+        )
+        testee.command.observeForever(mockCommandObserver)
     }
 
     @After
@@ -280,9 +291,40 @@ class TabSwitcherViewModelTest {
         verify(mockPixel).fire(AppPixelName.TAB_MANAGER_MENU_SETTINGS_PRESSED)
     }
 
+    @Test
+    fun whenOnDraggingStartedAnnouncementDismissedAndThePixelSent() = runTest {
+        whenever(mockTabRepository.tabSwitcherData).thenReturn(flowOf(TabSwitcherData(TabSwitcherData.UserState.EXISTING, false, 2)))
+
+        // we need to use the new stubbing here
+        initializeViewModel()
+
+        coroutinesTestRule.testScope.launch {
+            testee.isFeatureAnnouncementVisible.collect()
+        }
+
+        testee.onTabDraggingStarted()
+
+        verify(mockTabRepository).setWasAnnouncementDismissed(true)
+        verify(mockPixel).fire(AppPixelName.TAB_MANAGER_REARRANGE_BANNER_AUTODISMISSED)
+    }
+
+    @Test
+    fun whenAnnouncementDisplayedThePixelSent() = runTest {
+        testee.onTabFeatureAnnouncementDisplayed()
+
+        verify(mockPixel).fire(AppPixelName.TAB_MANAGER_REARRANGE_BANNER_DISPLAYED)
+    }
+
+    @Test
+    fun whenAnnouncementDismissedThePixelIsSent() = runTest {
+        testee.onFeatureAnnouncementCloseButtonTapped()
+
+        verify(mockPixel).fire(AppPixelName.TAB_MANAGER_REARRANGE_BANNER_MANUAL_CLOSED)
+    }
+
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun whenOnDraggingStartedThePixelSent() = runTest {
+    fun whenOnDraggingStartedThePixelsSent() = runTest {
         testee.onTabDraggingStarted()
 
         advanceUntilIdle()
@@ -290,5 +332,89 @@ class TabSwitcherViewModelTest {
         val params = mapOf("userState" to NEW.name)
         verify(mockPixel).fire(AppPixelName.TAB_MANAGER_REARRANGE_TABS, params, emptyMap(), COUNT)
         verify(mockPixel).fire(AppPixelName.TAB_MANAGER_REARRANGE_TABS_DAILY, params, emptyMap(), DAILY)
+    }
+
+    @Test
+    fun whenOnTabFeatureAnnouncementDisplayedAnnouncementCountIncremented() = runTest {
+        val initialCount = 0
+        val expectedCount = initialCount + 1
+
+        testee.onTabFeatureAnnouncementDisplayed()
+
+        verify(mockTabRepository).setAnnouncementDisplayCount(expectedCount)
+    }
+
+    @Test
+    fun onFeatureAnnouncementCloseButtonTapped_announcementIsMarkedAsDismissed() = runTest {
+        testee.onFeatureAnnouncementCloseButtonTapped()
+
+        verify(mockTabRepository).setWasAnnouncementDismissed(true)
+    }
+
+    @Test
+    fun whenOnTabMovedRepositoryUpdatesTabPosition() = runTest {
+        val fromIndex = 0
+        val toIndex = 2
+
+        testee.onTabMoved(fromIndex, toIndex)
+
+        verify(mockTabRepository).updateTabPosition(fromIndex, toIndex)
+    }
+
+    @Test
+    fun isFeatureAnnouncementVisible_ExistingUser_NotDismissed_BelowMaxCount_MultipleTabs() = runTest {
+        whenever(mockTabRepository.tabSwitcherData).thenReturn(flowOf(TabSwitcherData(TabSwitcherData.UserState.EXISTING, false, 2)))
+
+        // we need to use the new stubbing here
+        initializeViewModel()
+
+        testee.isFeatureAnnouncementVisible.test {
+            assertTrue(awaitItem())
+        }
+    }
+
+    @Test
+    fun isFeatureAnnouncementVisible_ReturningUser_NotDismissed_BelowMaxCount_MultipleTabs() = runTest {
+        whenever(statisticsDataStore.variant).thenReturn("ru")
+
+        // we need to use the new stubbing here
+        initializeViewModel()
+
+        testee.isFeatureAnnouncementVisible.test {
+            assertTrue(awaitItem())
+        }
+    }
+
+    @Test
+    fun isFeatureAnnouncementVisible_NewUser() = runTest {
+        val isVisible = testee.isFeatureAnnouncementVisible.value
+        assertFalse(isVisible)
+    }
+
+    @Test
+    fun isFeatureAnnouncementVisible_Dismissed() = runTest {
+        whenever(mockTabRepository.tabSwitcherData).thenReturn(flowOf(TabSwitcherData(TabSwitcherData.UserState.EXISTING, true, 0)))
+
+        val isVisible = testee.isFeatureAnnouncementVisible.value
+        assertFalse(isVisible)
+    }
+
+    @Test
+    fun isFeatureAnnouncementVisible_AboveMaxDisplayCount() = runTest {
+        whenever(mockTabRepository.tabSwitcherData).thenReturn(flowOf(TabSwitcherData(TabSwitcherData.UserState.EXISTING, false, 4)))
+
+        val isVisible = testee.isFeatureAnnouncementVisible.value
+        assertFalse(isVisible)
+    }
+
+    @Test
+    fun isFeatureAnnouncementVisible_SingleTab() = runTest {
+        val data = TabSwitcherData(TabSwitcherData.UserState.EXISTING, false, 0)
+
+        whenever(mockTabRepository.tabSwitcherData).thenReturn(flowOf(data))
+        whenever(mockTabRepository.flowTabs).thenReturn(flowOf(listOf(TabEntity("1", position = 1))))
+
+        val isVisible = testee.isFeatureAnnouncementVisible.value
+        assertFalse(isVisible)
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/userstate/UserStateReporterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/userstate/UserStateReporterTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.userstate
+
+import android.content.Context
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.duckduckgo.app.tabs.model.TabDataRepository
+import com.duckduckgo.common.test.CoroutineTestRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExperimentalCoroutinesApi
+class UserStateReporterTest {
+    @get:Rule
+    @Suppress("unused")
+    var instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @get:Rule
+    var coroutinesTestRule = CoroutineTestRule()
+
+    private val dispatcherProvider = coroutinesTestRule.testDispatcherProvider
+    private val repository = mock<TabDataRepository>()
+    private val context = mock<Context>()
+    private val packageManager = mock<PackageManager>()
+
+    @Before
+    fun setUp() {
+        whenever(context.packageManager).thenReturn(packageManager)
+    }
+
+    @Test
+    fun verifyUserIsNewWhenFirstInstallTimeEqualsLastInstallTime() = runTest {
+        val packageInfo = PackageInfo().apply {
+            firstInstallTime = 1000L
+            lastUpdateTime = 1000L
+        }
+        initializeSut(packageInfo)
+
+        verify(repository).setIsUserNew(true)
+    }
+
+    @Test
+    fun verifyUserExistingWhenFirstInstallTimeDoesNotEqualLastInstallTime() = runTest {
+        val packageInfo = PackageInfo().apply {
+            firstInstallTime = 1000L
+            lastUpdateTime = 2000L
+        }
+        initializeSut(packageInfo)
+
+        verify(repository).setIsUserNew(false)
+    }
+
+    private fun initializeSut(packageInfo: PackageInfo) {
+        whenever(packageManager.getPackageInfo(context.packageName, 0)).thenReturn(packageInfo)
+
+        val userStateReporter = UserStateReporter(dispatcherProvider, repository, context, TestScope())
+
+        userStateReporter.onCreate(mock())
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207418217763355/1207689147487669/f

### Description

This PR adds the following pixels:

- `m_tab_manager_rearrange_tabs`: When a user long-presses and drags a tab to rearrange the order
- `m_tab_manager_rearrange_tabs_daily`: When a user long-presses and drags a tab to rearrange the order (fired only once per day per user who takes this action)
- `m_tab_manager_clicked_daily`: When a user opens the tab manager screen (fired only once per day per user who takes this action)

### Steps to test this PR

_Opening the tab manager_
- [x] Start the app
- [x] Navigate to the tab manager
- [x] Verify that `m_tab_manager_clicked_daily` pixel is fired
- [x] Leave the tab manager and come back
- [x] Verify the pixel is not fired

_Rearranging the tabs_
- [x] Start the app
- [x] Navigate to the tab manager
- [x] Long-tap on a tab
- [x] Verify that `m_tab_manager_rearrange_tabs` pixel is fired
- [x] Verify that `m_tab_manager_rearrange_tabs_daily` pixel is fired
- [x] Leave the tab manager and come back
- [x] Verify that only `m_tab_manager_rearrange_tabs` pixel is fired
