### PR TITLE
Submit autofill feedback report

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1504,7 +1504,7 @@ class BrowserTabFragment :
             is Command.ShowEmailProtectionInContextSignUpPrompt -> showNativeInContextEmailProtectionSignupPrompt()
 
             is Command.CancelIncomingAutofillRequest -> injectAutofillCredentials(it.url, null)
-            is Command.LaunchAutofillSettings -> launchAutofillManagementScreen()
+            is Command.LaunchAutofillSettings -> launchAutofillManagementScreen(it.privacyProtectionEnabled)
             is Command.EditWithSelectedQuery -> {
                 omnibar.omnibarTextInput.setText(it.query)
                 omnibar.omnibarTextInput.setSelection(it.query.length)
@@ -2523,10 +2523,11 @@ class BrowserTabFragment :
         }
     }
 
-    private fun launchAutofillManagementScreen() {
+    private fun launchAutofillManagementScreen(privacyProtectionEnabled: Boolean) {
         val screen = AutofillSettingsScreenShowSuggestionsForSiteParams(
             currentUrl = webView?.url,
             source = AutofillSettingsLaunchSource.BrowserOverflow,
+            privacyProtectionEnabled = privacyProtectionEnabled,
         )
         globalActivityStarter.start(requireContext(), screen)
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2923,7 +2923,7 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     fun onAutofillMenuSelected() {
-        command.value = LaunchAutofillSettings
+        command.value = LaunchAutofillSettings(privacyProtectionEnabled = !currentBrowserViewState().isPrivacyProtectionDisabled)
     }
 
     @VisibleForTesting

--- a/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
@@ -198,7 +198,7 @@ sealed class Command {
     class ShowEmailProtectionChooseEmailPrompt(val address: String) : Command()
     object ShowEmailProtectionInContextSignUpPrompt : Command()
     class CancelIncomingAutofillRequest(val url: String) : Command()
-    object LaunchAutofillSettings : Command()
+    data class LaunchAutofillSettings(val privacyProtectionEnabled: Boolean) : Command()
     class EditWithSelectedQuery(val query: String) : Command()
     class ShowBackNavigationHistory(val history: List<NavigationHistoryEntry>) : Command()
     object EmailSignEvent : Command()

--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillScreens.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillScreens.kt
@@ -31,10 +31,12 @@ sealed interface AutofillScreens {
      * Launch the Autofill management activity, which will show suggestions for the current url and the full list of available credentials
      * @param currentUrl The current URL the user is viewing. This is used to show suggestions for the current site if available.
      * @param source is used to indicate from where in the app Autofill management activity was launched
+     * @param privacyProtectionEnabled whether privacy protection is enabled for the current web site
      */
     data class AutofillSettingsScreenShowSuggestionsForSiteParams(
         val currentUrl: String?,
         val source: AutofillSettingsLaunchSource,
+        val privacyProtectionEnabled: Boolean,
     ) : ActivityParams
 
     /**

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_PAS
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_PASSWORDS_USER_JOURNEY_SUCCESSFUL
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_PASSWORDS_USER_JOURNEY_UNSUCCESSFUL
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_PASSWORDS_USER_TOOK_NO_ACTION
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SITE_BREAKAGE_REPORT
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.EMAIL_TOOLTIP_DISMISSED
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.EMAIL_USE_ADDRESS
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.EMAIL_USE_ALIAS
@@ -134,6 +135,8 @@ enum class AutofillPixelNames(override val pixelName: String) : Pixel.PixelName 
     AUTOFILL_IMPORT_PASSWORDS_USER_JOURNEY_UNSUCCESSFUL("m_autofill_logins_import_failure"),
     AUTOFILL_IMPORT_PASSWORDS_USER_JOURNEY_STARTED("m_autofill_logins_import_user_journey_started"),
     AUTOFILL_IMPORT_PASSWORDS_USER_JOURNEY_RESTARTED("m_autofill_logins_import_user_journey_restarted"),
+
+    AUTOFILL_SITE_BREAKAGE_REPORT("autofill_logins_report_failure"),
 }
 
 @ContributesMultibinding(
@@ -163,6 +166,8 @@ object AutofillPixelsRequiringDataCleaning : PixelParamRemovalPlugin {
             AUTOFILL_IMPORT_PASSWORDS_USER_JOURNEY_UNSUCCESSFUL.pixelName to PixelParameter.removeAtb(),
             AUTOFILL_IMPORT_PASSWORDS_USER_JOURNEY_STARTED.pixelName to PixelParameter.removeAtb(),
             AUTOFILL_IMPORT_PASSWORDS_USER_JOURNEY_RESTARTED.pixelName to PixelParameter.removeAtb(),
+
+            AUTOFILL_SITE_BREAKAGE_REPORT.pixelName to PixelParameter.removeAtb(),
         )
     }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/reporting/AutofillBreakageReportSender.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/reporting/AutofillBreakageReportSender.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.reporting
+
+import android.net.Uri
+import androidx.core.net.toUri
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.autofill.api.email.EmailManager
+import com.duckduckgo.autofill.impl.AutofillGlobalCapabilityChecker
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SITE_BREAKAGE_REPORT
+import com.duckduckgo.autofill.impl.store.NeverSavedSiteRepository
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+interface AutofillBreakageReportSender {
+    fun sendBreakageReport(
+        url: String,
+        privacyProtectionEnabled: Boolean?,
+    )
+}
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class AutofillBreakageReportSenderImpl @Inject constructor(
+    private val appBuildConfig: AppBuildConfig,
+    private val autofillCapabilityChecker: AutofillGlobalCapabilityChecker,
+    private val pixel: Pixel,
+    private val dispatchers: DispatcherProvider,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val emailManager: EmailManager,
+    private val neverSavedSiteRepository: NeverSavedSiteRepository,
+) : AutofillBreakageReportSender {
+
+    /**
+     * website: the URL + path of the website with all query parameters removed (to identify the page with an issue e.g. checkout form vs login page)
+     * language: the app’s language setting (e.g. `en`, `fr`) as autofill issues are frequently language specific
+     * autofill_enabled: whether the user has the autofill feature enabled  (true / false)
+     * privacy_protection : whether privacy protection was enabled for the site (true / false)
+     * email_protection: whether a user has enabled email protection (true / false)
+     * never_prompt: whether a user has decided if they want to be prompted to save logins for this site (true / false)
+     */
+
+    override fun sendBreakageReport(
+        url: String,
+        privacyProtectionEnabled: Boolean?,
+    ) {
+        appCoroutineScope.launch(dispatchers.io()) {
+            val params = mapOf(
+                "website" to formatUrl(url),
+                "language" to formatLanguage(),
+                "autofill_enabled" to formatAutofillEnabledStatus(),
+                "privacy_protection" to formatPrivacyProtectionStatus(privacyProtectionEnabled),
+                "email_protection" to formatEmailProtectionStatus(),
+                "never_prompt" to formatNeverProtectThisSiteStatus(url),
+            )
+            Timber.d("Sending autofill breakage report %s", params)
+
+            pixel.fire(AUTOFILL_SITE_BREAKAGE_REPORT, parameters = params)
+        }
+    }
+
+    private suspend fun formatNeverProtectThisSiteStatus(url: String): String {
+        return neverSavedSiteRepository.isInNeverSaveList(url).toString()
+    }
+
+    private fun formatEmailProtectionStatus(): String {
+        return emailManager.isSignedIn().toString()
+    }
+
+    private fun formatPrivacyProtectionStatus(privacyProtectionEnabled: Boolean?): String {
+        return when (privacyProtectionEnabled) {
+            null -> "unknown"
+            else -> privacyProtectionEnabled.toString()
+        }
+    }
+
+    private suspend fun formatAutofillEnabledStatus(): String {
+        return autofillCapabilityChecker.isAutofillEnabledByUser().toString()
+    }
+
+    private fun formatUrl(url: String): String {
+        val uri = url.toUri()
+        return Uri.Builder()
+            .scheme(uri.scheme)
+            .authority(uri.authority)
+            .path(uri.path)
+            .fragment(uri.fragment)
+            .build()
+            .toString()
+    }
+
+    private fun formatLanguage(): String {
+        return appBuildConfig.deviceLocale.language
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillManagementActivity.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillManagementActivity.kt
@@ -248,10 +248,12 @@ class AutofillManagementActivity : DuckDuckGoActivity() {
     private fun showListMode() {
         resetToolbar()
         val currentUrl = extractSuggestionsUrl()
+        val privacyProtectionStatus = extractPrivacyProtectionEnabled()
         Timber.v("showListMode. currentUrl is %s", currentUrl)
 
         supportFragmentManager.commitNow {
-            replace(R.id.fragment_container_view, AutofillManagementListMode.instance(currentUrl), TAG_ALL_CREDENTIALS)
+            val fragment = AutofillManagementListMode.instance(currentUrl, privacyProtectionStatus)
+            replace(R.id.fragment_container_view, fragment, TAG_ALL_CREDENTIALS)
         }
     }
 
@@ -389,6 +391,12 @@ class AutofillManagementActivity : DuckDuckGoActivity() {
             return viewMode.currentUrl
         }
         return null
+    }
+
+    private fun extractPrivacyProtectionEnabled(): Boolean? {
+        intent.getActivityParams(AutofillSettingsScreenShowSuggestionsForSiteParams::class.java)?.let {
+            return it.privacyProtectionEnabled
+        } ?: return null
     }
 
     companion object {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementListMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementListMode.kt
@@ -149,13 +149,13 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
         configureToggle()
         configureRecyclerView()
         configureImportPasswordsButton()
-        configureCurrentUrlState()
+        configureCurrentSiteState()
         observeViewModel()
         configureToolbar()
     }
 
-    private fun configureCurrentUrlState() {
-        viewModel.updateCurrentUrl(getCurrentUrlForSuggestions())
+    private fun configureCurrentSiteState() {
+        viewModel.updateCurrentSite(getCurrentSiteUrl(), getPrivacyProtectionEnabled())
     }
 
     override fun onStop() {
@@ -245,7 +245,8 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
     private fun showSearchBar() = parentActivity()?.showSearchBar()
     private fun hideSearchBar() = parentActivity()?.hideSearchBar()
 
-    private fun getCurrentUrlForSuggestions() = arguments?.getString(ARG_CURRENT_URL, null)
+    private fun getCurrentSiteUrl() = arguments?.getString(ARG_CURRENT_URL, null)
+    private fun getPrivacyProtectionEnabled() = arguments?.getBoolean(ARG_PRIVACY_PROTECTION_STATUS)
 
     private fun parentBinding() = parentActivity()?.binding
     private fun parentActivity() = (activity as AutofillManagementActivity?)
@@ -365,7 +366,7 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
                             object : TextAlertDialogBuilder.EventListener() {
                                 override fun onPositiveButtonClicked() {
                                     Timber.i("Send breakage report confirmed")
-                                    viewModel.userConfirmedSendBreakageReport(eTldPlusOne)
+                                    viewModel.userConfirmedSendBreakageReport()
                                 }
                             },
                         )
@@ -408,7 +409,7 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
         binding.emptyStateLayout.emptyStateContainer.gone()
         binding.logins.show()
 
-        val currentUrl = getCurrentUrlForSuggestions()
+        val currentUrl = getCurrentSiteUrl()
         val directSuggestions = suggestionMatcher.getDirectSuggestions(currentUrl, credentials)
         val shareableCredentials = suggestionMatcher.getShareableSuggestions(currentUrl)
 
@@ -539,14 +540,19 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
     }
 
     companion object {
-        fun instance(currentUrl: String? = null) =
+        fun instance(currentUrl: String? = null, privacyProtectionEnabled: Boolean?) =
             AutofillManagementListMode().apply {
                 arguments = Bundle().apply {
                     putString(ARG_CURRENT_URL, currentUrl)
+
+                    if (privacyProtectionEnabled != null) {
+                        putBoolean(ARG_PRIVACY_PROTECTION_STATUS, privacyProtectionEnabled)
+                    }
                 }
             }
 
         private const val ARG_CURRENT_URL = "ARG_CURRENT_URL"
+        private const val ARG_PRIVACY_PROTECTION_STATUS = "ARG_PRIVACY_PROTECTION_STATUS"
     }
 }
 

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/reporting/AutofillBreakageReportSenderImplTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/reporting/AutofillBreakageReportSenderImplTest.kt
@@ -1,0 +1,190 @@
+package com.duckduckgo.autofill.impl.reporting
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.autofill.api.email.EmailManager
+import com.duckduckgo.autofill.impl.AutofillGlobalCapabilityChecker
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SITE_BREAKAGE_REPORT
+import com.duckduckgo.autofill.impl.store.NeverSavedSiteRepository
+import com.duckduckgo.common.test.CoroutineTestRule
+import java.util.*
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class AutofillBreakageReportSenderImplTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+
+    private val appBuildConfig: AppBuildConfig = mock()
+    private val autoCapabilityChecker: AutofillGlobalCapabilityChecker = mock()
+    private val emailManager: EmailManager = mock()
+    private val neverSavedSiteRepository: NeverSavedSiteRepository = mock()
+    private val pixel: Pixel = mock()
+    private val paramsCaptor = argumentCaptor<Map<String, String>>()
+
+    private val testee = AutofillBreakageReportSenderImpl(
+        pixel = pixel,
+        neverSavedSiteRepository = neverSavedSiteRepository,
+        emailManager = emailManager,
+        dispatchers = coroutineTestRule.testDispatcherProvider,
+        appCoroutineScope = coroutineTestRule.testScope,
+        autofillCapabilityChecker = autoCapabilityChecker,
+        appBuildConfig = appBuildConfig,
+    )
+
+    @Before
+    fun setup() = runTest {
+        configureDefaults()
+    }
+
+    @Test
+    fun whenReportSentThenPixelFired() = runTest {
+        sendReport()
+        verifyPixelSentHasCorrectNumberOfParameters()
+    }
+
+    @Test
+    fun whenReportSentThenCorrectLanguageIncludedPixelFired() = runTest {
+        whenever(appBuildConfig.deviceLocale).thenReturn(Locale.FRANCE)
+        sendReport()
+        "fr".assertMatchesLanguage()
+    }
+
+    @Test
+    fun whenReportSentWithEmailProtectionEnabledThenCorrectParamIncluded() = runTest {
+        whenever(emailManager.isSignedIn()).thenReturn(true)
+        sendReport()
+        "true".assertMatchesEmailProtection()
+    }
+
+    @Test
+    fun whenReportSentWithEmailProtectionDisabledThenCorrectParamIncluded() = runTest {
+        whenever(emailManager.isSignedIn()).thenReturn(false)
+        sendReport()
+        "false".assertMatchesEmailProtection()
+    }
+
+    @Test
+    fun whenReportSentWithAutofillEnabledThenCorrectParamIncluded() = runTest {
+        whenever(autoCapabilityChecker.isAutofillEnabledByUser()).thenReturn(true)
+        sendReport()
+        "true".assertMatchesAutofillEnabled()
+    }
+
+    @Test
+    fun whenReportSentWithAutofillDisabledThenCorrectParamIncluded() = runTest {
+        whenever(autoCapabilityChecker.isAutofillEnabledByUser()).thenReturn(false)
+        sendReport()
+        "false".assertMatchesAutofillEnabled()
+    }
+
+    @Test
+    fun whenReportSentWithPrivacyProtectionEnabledThenCorrectParamIncluded() = runTest {
+        sendReport(protectionStatus = true)
+        "true".assertMatchesPrivacyProtectionStatus()
+    }
+
+    @Test
+    fun whenReportSentWithPrivacyProtectionDisabledThenCorrectParamIncluded() = runTest {
+        sendReport(protectionStatus = false)
+        "false".assertMatchesPrivacyProtectionStatus()
+    }
+
+    @Test
+    fun whenReportSentWithPrivacyProtectionUnknownThenCorrectParamIncluded() = runTest {
+        sendReport(protectionStatus = null)
+        "unknown".assertMatchesPrivacyProtectionStatus()
+    }
+
+    @Test
+    fun whenReportSentWithNeverSavedSiteTrueThenCorrectParamIncluded() = runTest {
+        whenever(neverSavedSiteRepository.isInNeverSaveList(any())).thenReturn(true)
+        sendReport()
+        "true".assertMatchesNeverSavedSite()
+    }
+
+    @Test
+    fun whenReportSentWithNeverSavedSiteFalseThenCorrectParamIncluded() = runTest {
+        whenever(neverSavedSiteRepository.isInNeverSaveList(any())).thenReturn(false)
+        sendReport()
+        "false".assertMatchesNeverSavedSite()
+    }
+
+    @Test
+    fun whenUrlContainsQueryParamsReportSentWithCorrectUrl() {
+        sendReport(url = "https://example.com?q=hello")
+        "https://example.com".assertMatchesWebsite()
+    }
+
+    @Test
+    fun whenUrlContainsPortSentWithCorrectUrl() {
+        sendReport(url = "https://example.com:8080")
+        "https://example.com%3A8080".assertMatchesWebsite()
+    }
+
+    @Test
+    fun whenUrlContainsPathSentWithCorrectUrl() {
+        sendReport(url = "https://example.com/foo/bar")
+        "https://example.com/foo/bar".assertMatchesWebsite()
+    }
+
+    @Test
+    fun whenUrlContainsFragmentSentWithCorrectUrl() {
+        sendReport(url = "https://example.com/foo#bar")
+        "https://example.com/foo#bar".assertMatchesWebsite()
+    }
+
+    private suspend fun configureDefaults() {
+        whenever(appBuildConfig.deviceLocale).thenReturn(Locale.US)
+        whenever(autoCapabilityChecker.isAutofillEnabledByUser()).thenReturn(true)
+        whenever(emailManager.isSignedIn()).thenReturn(true)
+        whenever(neverSavedSiteRepository.isInNeverSaveList(any())).thenReturn(true)
+    }
+
+    private fun verifyPixelSentHasCorrectNumberOfParameters() {
+        assertEquals(6, paramsCaptor.lastValue.size)
+    }
+
+    private fun sendReport(url: String = "https://example.com", protectionStatus: Boolean? = true) {
+        testee.sendBreakageReport(url, protectionStatus)
+        verify(pixel).fire(eq(AUTOFILL_SITE_BREAKAGE_REPORT), paramsCaptor.capture(), any(), eq(COUNT))
+    }
+
+    private fun String.assertMatchesEmailProtection() {
+        assertEquals(this, paramsCaptor.lastValue["email_protection"])
+    }
+
+    private fun String.assertMatchesAutofillEnabled() {
+        assertEquals(this, paramsCaptor.lastValue["autofill_enabled"])
+    }
+
+    private fun String.assertMatchesPrivacyProtectionStatus() {
+        assertEquals(this, paramsCaptor.lastValue["privacy_protection"])
+    }
+
+    private fun String.assertMatchesLanguage() {
+        assertEquals(this, paramsCaptor.lastValue["language"])
+    }
+
+    private fun String.assertMatchesNeverSavedSite() {
+        assertEquals(this, paramsCaptor.lastValue["never_prompt"])
+    }
+
+    private fun String.assertMatchesWebsite() {
+        assertEquals(this, paramsCaptor.lastValue["website"])
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207769724660967/f 

### Description
Handles the actual submission of the autofill breakage report.

### Steps to test this PR

ℹ️ Local hack to enable feature: In `AutofillSiteBreakageReportingFeature`, set default value to `true`
ℹ️ Logcat filter: `autofill_logins_report_failure` 

---

- [ ] Manually add a password for fill.dev
- [ ] Visit https://fill.dev
- [ ] Tap on overflow->Passwords
- [ ] Tap on `Report a problem with autofill` and choose to `Send Report`
- [ ] Verify logs contain `autofill_logins_report_failure`
- [ ] Verify params match up with your current state. e.g., if signed in to email protection, language code is picked up
