### PR TITLE
Suppress report autofill breakage prompt after previous submission

### DIFF
--- a/app/src/test/java/com/duckduckgo/app/browser/autofill/RealAutofillFireproofDialogSuppressorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/autofill/RealAutofillFireproofDialogSuppressorTest.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.app.browser.autofill
 
 import com.duckduckgo.autofill.impl.RealAutofillFireproofDialogSuppressor
-import com.duckduckgo.autofill.impl.TimeProvider
+import com.duckduckgo.autofill.impl.time.TimeProvider
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/AutofillFireproofDialogSuppressor.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/AutofillFireproofDialogSuppressor.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.autofill.impl
 
+import com.duckduckgo.autofill.impl.time.TimeProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
@@ -59,13 +60,4 @@ class RealAutofillFireproofDialogSuppressor @Inject constructor(private val time
     companion object {
         private val TIME_PERIOD_TO_SUPPRESS_FIREPROOF_PROMPT = TimeUnit.SECONDS.toMillis(10)
     }
-}
-
-interface TimeProvider {
-    fun currentTimeMillis(): Long
-}
-
-@ContributesBinding(AppScope::class)
-class SystemCurrentTimeProvider @Inject constructor() : TimeProvider {
-    override fun currentTimeMillis(): Long = System.currentTimeMillis()
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/deviceauth/AutofillAuthorizationGracePeriod.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/deviceauth/AutofillAuthorizationGracePeriod.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.autofill.impl.deviceauth
 
+import com.duckduckgo.autofill.impl.time.TimeProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
@@ -79,13 +80,4 @@ class AutofillTimeBasedAuthorizationGracePeriod @Inject constructor(
     companion object {
         private const val AUTH_GRACE_PERIOD_MS = 15_000
     }
-}
-
-interface TimeProvider {
-    fun currentTimeMillis(): Long
-}
-
-@ContributesBinding(AppScope::class)
-class SystemCurrentTimeProvider @Inject constructor() : TimeProvider {
-    override fun currentTimeMillis(): Long = System.currentTimeMillis()
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/reporting/AutofillBreakageReportCanShowRules.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/reporting/AutofillBreakageReportCanShowRules.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.reporting
+
+import com.duckduckgo.autofill.impl.reporting.remoteconfig.AutofillSiteBreakageReportingFeature
+import com.duckduckgo.autofill.impl.time.TimeProvider
+import com.duckduckgo.autofill.impl.urlmatcher.AutofillUrlMatcher
+import com.duckduckgo.autofill.store.reporting.AutofillSiteBreakageReportingFeatureRepository
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import kotlinx.coroutines.withContext
+
+interface AutofillBreakageReportCanShowRules {
+    suspend fun canShowForSite(url: String): Boolean
+}
+
+@ContributesBinding(AppScope::class)
+class AutofillBreakageReportCanShowRulesImpl @Inject constructor(
+    private val reportBreakageFeature: AutofillSiteBreakageReportingFeature,
+    private val exceptionsRepository: AutofillSiteBreakageReportingFeatureRepository,
+    private val dispatchers: DispatcherProvider,
+    private val urlMatcher: AutofillUrlMatcher,
+    private val dataStore: AutofillSiteBreakageReportingDataStore,
+    private val timeProvider: TimeProvider,
+
+) : AutofillBreakageReportCanShowRules {
+
+    override suspend fun canShowForSite(url: String): Boolean {
+        return withContext(dispatchers.io()) {
+            if (!featureEnabledInRemoteConfig()) return@withContext false
+
+            val eTldPlusOne = urlMatcher.extractUrlPartsForAutofill(url).eTldPlus1 ?: return@withContext false
+
+            if (eTldPlusOne.isInExceptionList()) return@withContext false
+            if (eTldPlusOne.siteReportSentRecently()) return@withContext false
+
+            true
+        }
+    }
+
+    private fun String.isInExceptionList() = exceptionsRepository.exceptions.contains(this)
+    private fun featureEnabledInRemoteConfig() = reportBreakageFeature.self().isEnabled()
+    private suspend fun String.siteReportSentRecently(): Boolean {
+        val lastSubmissionForSite = dataStore.getTimestampLastFeedbackSent(this) ?: return false
+        val minDaysBeforeResubmissionAllowed = dataStore.getMinimumNumberOfDaysBeforeReportPromptReshown()
+
+        val timeSinceReportMs = timeProvider.currentTimeMillis() - lastSubmissionForSite
+        return timeSinceReportMs <= TimeUnit.DAYS.toMillis(minDaysBeforeResubmissionAllowed.toLong())
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/reporting/AutofillSiteBreakageReportingDataStore.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/reporting/AutofillSiteBreakageReportingDataStore.kt
@@ -20,7 +20,9 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
 import com.duckduckgo.autofill.impl.reporting.remoteconfig.AutofillSiteBreakageReporting
+import com.duckduckgo.autofill.impl.time.TimeProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
@@ -31,12 +33,15 @@ interface AutofillSiteBreakageReportingDataStore {
 
     suspend fun getMinimumNumberOfDaysBeforeReportPromptReshown(): Int
     suspend fun updateMinimumNumberOfDaysBeforeReportPromptReshown(newValue: Int)
+    suspend fun recordFeedbackSent(eTldPlusOne: String)
+    suspend fun getTimestampLastFeedbackSent(eTldPlusOne: String): Long?
 }
 
 @SingleInstanceIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 class AutofillSiteBreakageReportingDataStoreImpl @Inject constructor(
     @AutofillSiteBreakageReporting private val store: DataStore<Preferences>,
+    private val timeProvider: TimeProvider,
 ) : AutofillSiteBreakageReportingDataStore {
 
     private val daysBeforePromptShownAgainKey = intPreferencesKey("days_before_prompt_shown_again")
@@ -47,9 +52,21 @@ class AutofillSiteBreakageReportingDataStoreImpl @Inject constructor(
         }
     }
 
+    override suspend fun recordFeedbackSent(eTldPlusOne: String) {
+        store.edit {
+            it[timestampLastReportedKey(eTldPlusOne)] = timeProvider.currentTimeMillis()
+        }
+    }
+
+    override suspend fun getTimestampLastFeedbackSent(eTldPlusOne: String): Long? {
+        return store.data.firstOrNull()?.get(timestampLastReportedKey(eTldPlusOne))
+    }
+
     override suspend fun getMinimumNumberOfDaysBeforeReportPromptReshown(): Int {
         return store.data.firstOrNull()?.get(daysBeforePromptShownAgainKey) ?: DEFAULT_NUMBER_OF_DAYS_BEFORE_REPORT_PROMPT_RESHOWN
     }
+
+    private fun timestampLastReportedKey(eTldPlusOne: String) = longPreferencesKey("timestamp_last_reported_$eTldPlusOne")
 
     companion object {
         private const val DEFAULT_NUMBER_OF_DAYS_BEFORE_REPORT_PROMPT_RESHOWN = 42

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/time/TimeProvider.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/time/TimeProvider.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.time
+
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface TimeProvider {
+    fun currentTimeMillis(): Long
+}
+
+@ContributesBinding(AppScope::class)
+class SystemCurrentTimeProvider @Inject constructor() : TimeProvider {
+    override fun currentTimeMillis(): Long = System.currentTimeMillis()
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/deviceauth/AutofillTimeBasedAuthorizationGracePeriodTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/deviceauth/AutofillTimeBasedAuthorizationGracePeriodTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.autofill.impl.deviceauth
 
+import com.duckduckgo.autofill.impl.time.TimeProvider
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/reporting/AutofillBreakageReportCanShowRulesImplTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/reporting/AutofillBreakageReportCanShowRulesImplTest.kt
@@ -1,0 +1,110 @@
+package com.duckduckgo.autofill.impl.reporting
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.autofill.impl.encoding.UrlUnicodeNormalizerImpl
+import com.duckduckgo.autofill.impl.time.TimeProvider
+import com.duckduckgo.autofill.impl.urlmatcher.AutofillDomainNameUrlMatcher
+import com.duckduckgo.autofill.store.reporting.AutofillSiteBreakageReportingFeatureRepository
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.toggle.AutofillReportBreakageTestFeature
+import java.util.concurrent.TimeUnit.DAYS
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class AutofillBreakageReportCanShowRulesImplTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+
+    private val urlMatcher = AutofillDomainNameUrlMatcher(UrlUnicodeNormalizerImpl())
+    private val dataStore: AutofillSiteBreakageReportingDataStore = mock()
+    private val remoteFeature = AutofillReportBreakageTestFeature()
+    private val exceptionsRepository: AutofillSiteBreakageReportingFeatureRepository = mock()
+    private val timeProvider: TimeProvider = mock()
+
+    private val testee = AutofillBreakageReportCanShowRulesImpl(
+        reportBreakageFeature = remoteFeature,
+        dispatchers = coroutineTestRule.testDispatcherProvider,
+        urlMatcher = urlMatcher,
+        dataStore = dataStore,
+        exceptionsRepository = exceptionsRepository,
+        timeProvider = timeProvider,
+    )
+
+    @Before
+    fun setup() = runTest {
+        remoteFeature.topLevelFeatureEnabled = true
+        whenever(exceptionsRepository.exceptions).thenReturn(emptyList())
+        whenever(dataStore.getMinimumNumberOfDaysBeforeReportPromptReshown()).thenReturn(10)
+        whenever(timeProvider.currentTimeMillis()).thenReturn(System.currentTimeMillis())
+    }
+
+    @Test
+    fun whenFeatureIsDisabledThenCannotShowPrompt() = runTest {
+        remoteFeature.topLevelFeatureEnabled = false
+        assertFalse(testee.canShowForSite(aSite()))
+    }
+
+    @Test
+    fun whenETldPlusOneNotExtractableThenCannotShowPrompt() = runTest {
+        assertFalse(testee.canShowForSite(""))
+    }
+
+    @Test
+    fun whenSiteInExceptionsListThenCannotShowPrompt() = runTest {
+        whenever(exceptionsRepository.exceptions).thenReturn(listOf("example.com"))
+        assertFalse(testee.canShowForSite("example.com"))
+    }
+
+    @Test
+    fun whenSiteWasRecentlySubmittedAlreadyThenCannotShowPrompt() = runTest {
+        whenever(dataStore.getTimestampLastFeedbackSent(any())).thenReturn(10L)
+        whenever(timeProvider.currentTimeMillis()).thenReturn(20L)
+        assertFalse(testee.canShowForSite("example.com"))
+    }
+
+    @Test
+    fun whenSiteWasSubmittedAtThresholdThenCannotShowPrompt() = runTest {
+        whenever(dataStore.getTimestampLastFeedbackSent(any())).thenReturn(0L)
+        whenever(dataStore.getMinimumNumberOfDaysBeforeReportPromptReshown()).thenReturn(42)
+        whenever(timeProvider.currentTimeMillis()).thenReturn(DAYS.toMillis(42))
+        assertFalse(testee.canShowForSite("example.com"))
+    }
+
+    @Test
+    fun whenSiteWasSubmittedAtOneMsBeyondThresholdThenCanShowPrompt() = runTest {
+        whenever(dataStore.getTimestampLastFeedbackSent(any())).thenReturn(0L)
+        whenever(dataStore.getMinimumNumberOfDaysBeforeReportPromptReshown()).thenReturn(42)
+        whenever(timeProvider.currentTimeMillis()).thenReturn(DAYS.toMillis(42) + 1)
+        assertTrue(testee.canShowForSite("example.com"))
+    }
+
+    @Test
+    fun whenAnotherSiteWasRecentlySubmittedThenCanShowPrompt() = runTest {
+        whenever(dataStore.getTimestampLastFeedbackSent("foo.com")).thenReturn(10L)
+        whenever(timeProvider.currentTimeMillis()).thenReturn(20L)
+        assertTrue(testee.canShowForSite("example.com"))
+    }
+
+    @Test
+    fun whenSiteWasSubmittedBeforeButNotRecentlyThenCanShowPrompt() = runTest {
+        whenever(dataStore.getTimestampLastFeedbackSent(any())).thenReturn(0L)
+        assertTrue(testee.canShowForSite("example.com"))
+    }
+
+    @Test
+    fun whenNoGoodReasonNotToThenCanShowPrompt() = runTest {
+        assertTrue(testee.canShowForSite("example.com"))
+    }
+
+    private fun aSite(): String = "example.com"
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/reporting/AutofillSiteBreakageReportingDataStoreImplTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/reporting/AutofillSiteBreakageReportingDataStoreImplTest.kt
@@ -1,0 +1,93 @@
+package com.duckduckgo.autofill.impl.reporting
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.autofill.impl.time.TimeProvider
+import com.duckduckgo.common.test.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class AutofillSiteBreakageReportingDataStoreImplTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+
+    private val temporaryFolder = TemporaryFolder.builder().assureDeletion().build().also { it.create() }
+
+    private val testDataStore: DataStore<Preferences> =
+        PreferenceDataStoreFactory.create(
+            scope = coroutineTestRule.testScope,
+            produceFile = { temporaryFolder.newFile("temp.preferences_pb") },
+        )
+
+    private val fakeTimeProvider: TimeProvider = mock()
+
+    private val testee = AutofillSiteBreakageReportingDataStoreImpl(
+        store = testDataStore,
+        timeProvider = fakeTimeProvider,
+    )
+
+    @Test
+    fun whenNotUpdatedThenDefaultNumberOfDaysIsCorrect() = runTest {
+        assertEquals(42, testee.getMinimumNumberOfDaysBeforeReportPromptReshown())
+    }
+
+    @Test
+    fun whenUpdatedThenNumberOfDaysMatchesWhatWasSet() = runTest {
+        testee.updateMinimumNumberOfDaysBeforeReportPromptReshown(10)
+        assertEquals(10, testee.getMinimumNumberOfDaysBeforeReportPromptReshown())
+    }
+
+    @Test
+    fun whenSiteNeverRecordedBeforeThenNoTimestampReturned() = runTest {
+        assertNull(testee.getTimestampLastFeedbackSent("example.com"))
+    }
+
+    @Test
+    fun whenSiteRecordedBeforeThenTimestampReturned() = runTest {
+        testee.recordFeedbackSent("example.com")
+        assertNotNull(testee.getTimestampLastFeedbackSent("example.com"))
+    }
+
+    @Test
+    fun whenMultipleSitesRecordedThenCorrectTimestampReturned() = runTest {
+        0L.setAsCurrentTime()
+        testee.recordFeedbackSent("example.com")
+
+        1L.setAsCurrentTime()
+        testee.recordFeedbackSent("example.net")
+
+        2L.setAsCurrentTime()
+        testee.recordFeedbackSent("example.org")
+
+        assertEquals(1L, testee.getTimestampLastFeedbackSent("example.net"))
+    }
+
+    @Test
+    fun whenSiteRecordedAgainThenLastTimestampReturned() = runTest {
+        val site = "example.com"
+
+        0L.setAsCurrentTime()
+        testee.recordFeedbackSent(site)
+
+        1L.setAsCurrentTime()
+        testee.recordFeedbackSent(site)
+
+        assertEquals(1L, testee.getTimestampLastFeedbackSent(site))
+    }
+
+    private fun Long.setAsCurrentTime() {
+        whenever(fakeTimeProvider.currentTimeMillis()).thenReturn(this)
+    }
+}

--- a/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/reporting/AutofillSiteBreakageReportingFeatureRepository.kt
+++ b/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/reporting/AutofillSiteBreakageReportingFeatureRepository.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.launch
 
 interface AutofillSiteBreakageReportingFeatureRepository {
     fun updateAllExceptions(exceptions: List<AutofillSiteBreakageReportingEntity>)
-    val exceptions: CopyOnWriteArrayList<String>
+    val exceptions: List<String>
 }
 
 class AutofillSiteBreakageReportingFeatureRepositoryImpl(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207767049586678/f 

### Description
After submitting an autofill breakage report for a site, the user won't be prompted to send another report for the next _n_ days, where _n_ is a value from remote config (defaulting to `42`).

### Steps to test this PR

ℹ️  Local hack to enable feature: In `AutofillSiteBreakageReportingFeature`, set default value to `true`

---

- [ ] Manually add a password for fill.dev
- [ ] Visit https://fill.dev
- [ ] Tap on overflow->Passwords
- [ ] Tap on `Report a problem with autofill` and choose to `Send Report`
- [ ] Verify you no longer see the "report a problem with autofill" view

**Verifying you don't see the prompt again for the exact same site**
- [ ] Return to browser
- [ ] Tap on overflow->Passwords again.
- [ ] Verify you **don't** see the "report a problem with autofill" view
- [ ] **[Optional]** set your device date to 2 months into the future then repeat; you should see the report autofill problem view

**Verifying another page on same website isn't shown prompt**
- [ ] Visit another page on the fill.dev site (e.g., https://fill.dev/form/login-simple)
- [ ] Tap on overflow->Passwords again.
- [ ] Verify you **don't** see the "report a problem with autofill" view

**Verifying on a totally different website you do see the prompt again**
- [ ] Visit example.com
- [ ] Tap on overflow->Passwords again.
- [ ] Verify you **do** see the "report a problem with autofill" view