### PR TITLE
Pixels for reporting autofill breakage UI

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
@@ -33,6 +33,10 @@ import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_PAS
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_PASSWORDS_USER_JOURNEY_UNSUCCESSFUL
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_PASSWORDS_USER_TOOK_NO_ACTION
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SITE_BREAKAGE_REPORT
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SITE_BREAKAGE_REPORT_AVAILABLE
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SITE_BREAKAGE_REPORT_CONFIRMATION_CONFIRMED
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SITE_BREAKAGE_REPORT_CONFIRMATION_DISMISSED
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SITE_BREAKAGE_REPORT_CONFIRMATION_DISPLAYED
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.EMAIL_TOOLTIP_DISMISSED
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.EMAIL_USE_ADDRESS
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.EMAIL_USE_ALIAS
@@ -137,6 +141,10 @@ enum class AutofillPixelNames(override val pixelName: String) : Pixel.PixelName 
     AUTOFILL_IMPORT_PASSWORDS_USER_JOURNEY_RESTARTED("m_autofill_logins_import_user_journey_restarted"),
 
     AUTOFILL_SITE_BREAKAGE_REPORT("autofill_logins_report_failure"),
+    AUTOFILL_SITE_BREAKAGE_REPORT_AVAILABLE("autofill_logins_report_available"),
+    AUTOFILL_SITE_BREAKAGE_REPORT_CONFIRMATION_DISPLAYED("autofill_logins_report_confirmation_displayed"),
+    AUTOFILL_SITE_BREAKAGE_REPORT_CONFIRMATION_DISMISSED("autofill_logins_report_confirmation_dismissed"),
+    AUTOFILL_SITE_BREAKAGE_REPORT_CONFIRMATION_CONFIRMED("autofill_logins_report_confirmation_confirmed"),
 }
 
 @ContributesMultibinding(
@@ -168,6 +176,14 @@ object AutofillPixelsRequiringDataCleaning : PixelParamRemovalPlugin {
             AUTOFILL_IMPORT_PASSWORDS_USER_JOURNEY_RESTARTED.pixelName to PixelParameter.removeAtb(),
 
             AUTOFILL_SITE_BREAKAGE_REPORT.pixelName to PixelParameter.removeAtb(),
+            AUTOFILL_SITE_BREAKAGE_REPORT.pixelName to PixelParameter.removeAtb(),
+            AUTOFILL_SITE_BREAKAGE_REPORT.pixelName to PixelParameter.removeAtb(),
+            AUTOFILL_SITE_BREAKAGE_REPORT.pixelName to PixelParameter.removeAtb(),
+            AUTOFILL_SITE_BREAKAGE_REPORT.pixelName to PixelParameter.removeAtb(),
+            AUTOFILL_SITE_BREAKAGE_REPORT_AVAILABLE.pixelName to PixelParameter.removeAtb(),
+            AUTOFILL_SITE_BREAKAGE_REPORT_CONFIRMATION_DISPLAYED.pixelName to PixelParameter.removeAtb(),
+            AUTOFILL_SITE_BREAKAGE_REPORT_CONFIRMATION_DISMISSED.pixelName to PixelParameter.removeAtb(),
+            AUTOFILL_SITE_BREAKAGE_REPORT_CONFIRMATION_CONFIRMED.pixelName to PixelParameter.removeAtb(),
         )
     }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModel.kt
@@ -40,6 +40,9 @@ import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_MANUALLY_S
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_NEVER_SAVE_FOR_THIS_SITE_CONFIRMATION_PROMPT_CONFIRMED
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_NEVER_SAVE_FOR_THIS_SITE_CONFIRMATION_PROMPT_DISMISSED
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_NEVER_SAVE_FOR_THIS_SITE_CONFIRMATION_PROMPT_DISPLAYED
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SITE_BREAKAGE_REPORT_AVAILABLE
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SITE_BREAKAGE_REPORT_CONFIRMATION_CONFIRMED
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SITE_BREAKAGE_REPORT_CONFIRMATION_DISMISSED
 import com.duckduckgo.autofill.impl.reporting.AutofillBreakageReportCanShowRules
 import com.duckduckgo.autofill.impl.reporting.AutofillBreakageReportSender
 import com.duckduckgo.autofill.impl.reporting.AutofillSiteBreakageReportingDataStore
@@ -709,6 +712,7 @@ class AutofillSettingsViewModel @Inject constructor(
         val currentUrl = _viewState.value.reportBreakageState.currentUrl
         val eTldPlusOne = urlMatcher.extractUrlPartsForAutofill(currentUrl).eTldPlus1
         if (eTldPlusOne != null) {
+            pixel.fire(AutofillPixelNames.AUTOFILL_SITE_BREAKAGE_REPORT_CONFIRMATION_DISPLAYED)
             addCommand(LaunchReportAutofillBreakageConfirmation(eTldPlusOne))
         }
     }
@@ -719,6 +723,15 @@ class AutofillSettingsViewModel @Inject constructor(
             privacyProtectionEnabled = privacyProtectionEnabled,
         )
         _viewState.value = _viewState.value.copy(reportBreakageState = updatedReportBreakageState)
+    }
+
+    fun onReportBreakageShown() {
+        if (!_viewState.value.reportBreakageState.onReportBreakageShown) {
+            val updatedReportBreakageState = _viewState.value.reportBreakageState.copy(onReportBreakageShown = true)
+            _viewState.value = _viewState.value.copy(reportBreakageState = updatedReportBreakageState)
+
+            pixel.fire(AUTOFILL_SITE_BREAKAGE_REPORT_AVAILABLE)
+        }
     }
 
     fun userConfirmedSendBreakageReport() {
@@ -739,6 +752,12 @@ class AutofillSettingsViewModel @Inject constructor(
         _viewState.value = _viewState.value.copy(reportBreakageState = updatedReportBreakageState)
 
         addCommand(ListModeCommand.ShowUserReportSentMessage)
+
+        pixel.fire(AUTOFILL_SITE_BREAKAGE_REPORT_CONFIRMATION_CONFIRMED)
+    }
+
+    fun userCancelledSendBreakageReport() {
+        pixel.fire(AUTOFILL_SITE_BREAKAGE_REPORT_CONFIRMATION_DISMISSED)
     }
 
     data class ViewState(
@@ -755,6 +774,7 @@ class AutofillSettingsViewModel @Inject constructor(
         val currentUrl: String? = null,
         val allowBreakageReporting: Boolean = false,
         val privacyProtectionEnabled: Boolean? = null,
+        val onReportBreakageShown: Boolean = false,
     )
 
     /**

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementListMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementListMode.kt
@@ -79,7 +79,6 @@ import com.google.android.material.snackbar.Snackbar
 import javax.inject.Inject
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import timber.log.Timber
 
 @InjectWith(FragmentScope::class)
 class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill_management_list_mode) {
@@ -365,8 +364,15 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
                         .addEventListener(
                             object : TextAlertDialogBuilder.EventListener() {
                                 override fun onPositiveButtonClicked() {
-                                    Timber.i("Send breakage report confirmed")
                                     viewModel.userConfirmedSendBreakageReport()
+                                }
+
+                                override fun onNegativeButtonClicked() {
+                                    viewModel.userCancelledSendBreakageReport()
+                                }
+
+                                override fun onDialogCancelled() {
+                                    viewModel.userCancelledSendBreakageReport()
                                 }
                             },
                         )
@@ -414,6 +420,11 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
         val shareableCredentials = suggestionMatcher.getShareableSuggestions(currentUrl)
 
         adapter.updateLogins(credentials, directSuggestions, shareableCredentials, allowBreakageReporting)
+
+        val hasSuggestions = directSuggestions.isNotEmpty() || shareableCredentials.isNotEmpty()
+        if (allowBreakageReporting && hasSuggestions) {
+            viewModel.onReportBreakageShown()
+        }
     }
 
     private fun configureRecyclerView() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207772527673440/f 

### Description
General pixels around reporting autofill breakage dialog

### Steps to test this PR

ℹ️ Local hack to enable feature: In `AutofillSiteBreakageReportingFeature`, set default value to `true`
ℹ️ Logcat filter: `message~:"Pixel sent:.*autofill_logins_report"`

---



- [ ] Manually add a password for fill.dev
- [ ] visit https://fill.dev
- [ ] Open `Overflow->Passwords` and authenticate (note, important to go through overflow here)
- [ ] Verify `autofill_logins_report_available` in logs

**Verifying cancellations**
- [ ] Tap on `Report a problem with autofill`; verify `autofill_logins_report_confirmation_displayed` in logs
- [ ] Tap `Cancel` button; verify `autofill_logins_report_confirmation_dismissed` in logs
- [ ] Tap on `Report a problem with autofill` again
- [ ] This time, tap outside of the dialog; verify `autofill_logins_report_confirmation_dismissed` in logs
- [ ] Tap on `Report a problem with autofill` again
- [ ] This time, tap back button; verify `autofill_logins_report_confirmation_dismissed` in logs

**Verifying acceptance**
- [ ] Tap on `Report a problem with autofill` again
- [ ] Tap on `Send Report` button; verify `autofill_logins_report_confirmation_displayed` in logs