### PR TITLE
Add fastlane lane for updating GitHub release notes (using `gh`)

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -117,6 +117,27 @@ platform :android do
 
     end
 
+   desc "Update GitHub release notes"
+       lane :update_release_notes_github do |options|
+
+         options_release_number = options[:release_number]
+         options_release_notes = options[:release_notes]
+         options_notes_type = options[:notes_type]
+
+         newVersion = determine_version_number(
+             release_number: options_release_number
+         )
+         releaseNotes = determine_release_notes(
+             release_notes: options_release_notes,
+             notes_type: options_notes_type
+         )
+
+         formatted = "## What's new:\n\n#{releaseNotes}"
+         UI.message("\n#{formatted} for release #{newVersion}")
+
+        sh "gh release edit #{newVersion} -n \"#{formatted}\""
+   end
+
 
   desc "Annotate release"
   private_lane :annotate_release do

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -31,6 +31,14 @@ Upload APK to Play Store, in production track with a very small rollout percenta
 
 Update Play Store release notes
 
+### android update_release_notes_github
+
+```sh
+[bundle exec] fastlane android update_release_notes_github
+```
+
+Update GitHub release notes
+
 ### android deploy_dogfood
 
 ```sh


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/608920331025315/1207811052233538/f 

### Description
Adds fastlane lane for updating GitHub release notes

Lane: `update_release_notes_github`
Params: 

- `release_number`
- `release_notes`

Both params above are optional; if you don't provide them via the command line you'll be prompted to enter them interactively.

Example of calling the command with the params on the command line:

- `fastlane update_release_notes_github release_number:5.205.0 release_notes:"Bug fixes and other improvements"`

### Steps to test this PR

QA-optional