### PR TITLE
Delay adding FocusedView until it's necessary

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -830,7 +830,6 @@ class BrowserTabFragment :
         configureOmnibarTextInput()
         configureFindInPage()
         configureAutoComplete()
-        configureFocusedView()
         configureNewTab()
         initPrivacyProtectionsPopup()
 
@@ -2126,18 +2125,6 @@ class BrowserTabFragment :
             },
         )
         binding.autoCompleteSuggestionsList.adapter = autoCompleteSuggestionsAdapter
-    }
-
-    private fun configureFocusedView() {
-        focusedViewProvider.provideFocusedViewVersion().onEach { focusedView ->
-            binding.focusedViewContainerLayout.addView(
-                focusedView.getView(requireContext()),
-                LayoutParams(
-                    LayoutParams.MATCH_PARENT,
-                    LayoutParams.MATCH_PARENT,
-                ),
-            )
-        }.launchIn(lifecycleScope)
     }
 
     private fun configureNewTab() {
@@ -3563,18 +3550,37 @@ class BrowserTabFragment :
                 // viewState.showFavourites needs to be moved to FocusedViewModel
                 if (viewState.showSuggestions || viewState.showFavorites) {
                     if (viewState.favorites.isNotEmpty() && viewState.showFavorites) {
+                        showFocusedView()
                         binding.autoCompleteSuggestionsList.gone()
-                        binding.focusedViewContainerLayout.show()
                     } else {
                         binding.autoCompleteSuggestionsList.show()
-                        binding.focusedViewContainerLayout.gone()
                         autoCompleteSuggestionsAdapter.updateData(viewState.searchResults.query, viewState.searchResults.suggestions)
+                        hideFocusedView()
                     }
                 } else {
                     binding.autoCompleteSuggestionsList.gone()
-                    binding.focusedViewContainerLayout.gone()
+                    hideFocusedView()
                 }
             }
+        }
+
+        private fun showFocusedView() {
+            binding.focusedViewContainerLayout.show()
+            if (binding.focusedViewContainerLayout.childCount == 0) {
+                focusedViewProvider.provideFocusedViewVersion().onEach { focusedView ->
+                    binding.focusedViewContainerLayout.addView(
+                        focusedView.getView(requireContext()),
+                        LayoutParams(
+                            LayoutParams.MATCH_PARENT,
+                            LayoutParams.MATCH_PARENT,
+                        ),
+                    )
+                }.launchIn(lifecycleScope)
+            }
+        }
+
+        private fun hideFocusedView() {
+            binding.focusedViewContainerLayout.gone()
         }
 
         fun renderOmnibar(viewState: OmnibarViewState) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -3566,6 +3566,10 @@ class BrowserTabFragment :
 
         private fun showFocusedView() {
             binding.focusedViewContainerLayout.show()
+            configureFocusedView()
+        }
+
+        private fun configureFocusedView() {
             if (binding.focusedViewContainerLayout.childCount == 0) {
                 focusedViewProvider.provideFocusedViewVersion().onEach { focusedView ->
                     binding.focusedViewContainerLayout.addView(

--- a/app/src/main/res/layout/fragment_browser_tab.xml
+++ b/app/src/main/res/layout/fragment_browser_tab.xml
@@ -51,6 +51,7 @@
         android:id="@+id/focusedViewContainerLayout"
         android:clipToPadding="false"
         android:elevation="4dp"
+        android:background="?attr/daxColorSurface"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior" />


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1157893581871903/1207816154536989/f

### Description
Delay the addition of the FocusedView until it’s necessary

### Steps to test this PR

_Enable FocusedView_
- [x] Fresh install, add some favourites
- [x] Visit a site so it’s setup for the next time the app opens
- [x] Force close and open it up again
- [x] Tap on the omnibar
- [x] Verify that FocusedView is visible
- [x] Open New Tab
- [x] Visit a site
- [x] Tap on the omnibar
- [x] Verify FocusedView is visible