### PR TITLE
Handle print exception onWrite

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/print/PrintDocumentAdapterFactory.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/print/PrintDocumentAdapterFactory.kt
@@ -22,6 +22,7 @@ import android.os.ParcelFileDescriptor
 import android.print.PageRange
 import android.print.PrintAttributes
 import android.print.PrintDocumentAdapter
+import timber.log.Timber
 
 class PrintDocumentAdapterFactory {
     companion object {
@@ -52,7 +53,12 @@ class PrintDocumentAdapterFactory {
                     cancellationSignal: CancellationSignal?,
                     callback: WriteResultCallback?,
                 ) {
-                    printDocumentAdapter.onWrite(pages, destination, cancellationSignal, callback)
+                    runCatching {
+                        printDocumentAdapter.onWrite(pages, destination, cancellationSignal, callback)
+                    }.onFailure { exception ->
+                        Timber.e(exception, "Failed to write document")
+                        callback?.onWriteCancelled()
+                    }
                 }
 
                 override fun onFinish() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207831722240169/f

### Description
Handles the case where a print job has not been cleaned up before starting a new one.

### Steps to test this PR
- [x] Search for “dog"
- [x] Tap “More results” a few times so that the page is quite long
- [x] Tap “Print Page” and quickly tap back before the preview is shown
- [x] Quickly tap “Print Page” again
- [x] Verify that the retry screen is shown
- [x] Tap “Retry” (You may need to wait a little while if the document is large)
- [x] Verify that the preview is shown

### UI changes
| API 27  | API 34 | Video |
| ------ | ----- | ----- |
![retry_api27](https://github.com/user-attachments/assets/d634c7c0-877c-4037-b4ed-0ca2790c9519)|![retry](https://github.com/user-attachments/assets/ac88d923-ca9b-4b8c-ad20-d64240462a30)|![video](https://github.com/user-attachments/assets/91c5d0f5-4c9a-4ec3-a82b-c5120103001e)


