### PR TITLE
Add dev settings for clearing breakage reports for easier testing

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/reporting/AutofillSiteBreakageReportingDataStore.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/reporting/AutofillSiteBreakageReportingDataStore.kt
@@ -35,6 +35,7 @@ interface AutofillSiteBreakageReportingDataStore {
     suspend fun updateMinimumNumberOfDaysBeforeReportPromptReshown(newValue: Int)
     suspend fun recordFeedbackSent(eTldPlusOne: String)
     suspend fun getTimestampLastFeedbackSent(eTldPlusOne: String): Long?
+    suspend fun clearAllReports()
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -60,6 +61,10 @@ class AutofillSiteBreakageReportingDataStoreImpl @Inject constructor(
 
     override suspend fun getTimestampLastFeedbackSent(eTldPlusOne: String): Long? {
         return store.data.firstOrNull()?.get(timestampLastReportedKey(eTldPlusOne))
+    }
+
+    override suspend fun clearAllReports() {
+        store.edit { it.clear() }
     }
 
     override suspend fun getMinimumNumberOfDaysBeforeReportPromptReshown(): Int {

--- a/autofill/autofill-internal/src/main/java/com/duckduckgo/autofill/internal/AutofillInternalSettingsActivity.kt
+++ b/autofill/autofill-internal/src/main/java/com/duckduckgo/autofill/internal/AutofillInternalSettingsActivity.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.autofill.api.email.EmailManager
 import com.duckduckgo.autofill.impl.configuration.AutofillJavascriptEnvironmentConfiguration
 import com.duckduckgo.autofill.impl.email.incontext.store.EmailProtectionInContextDataStore
 import com.duckduckgo.autofill.impl.engagement.store.AutofillEngagementRepository
+import com.duckduckgo.autofill.impl.reporting.AutofillSiteBreakageReportingDataStore
 import com.duckduckgo.autofill.impl.store.InternalAutofillStore
 import com.duckduckgo.autofill.impl.store.NeverSavedSiteRepository
 import com.duckduckgo.autofill.impl.ui.credential.management.survey.AutofillSurveyStore
@@ -92,6 +93,9 @@ class AutofillInternalSettingsActivity : DuckDuckGoActivity() {
 
     @Inject
     lateinit var engagementRepository: AutofillEngagementRepository
+
+    @Inject
+    lateinit var reportBreakageDataStore: AutofillSiteBreakageReportingDataStore
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -154,6 +158,16 @@ class AutofillInternalSettingsActivity : DuckDuckGoActivity() {
         configureAutofillJsConfigEventHandlers()
         configureSurveyEventHandlers()
         configureEngagementEventHandlers()
+        configureReportBreakagesHandlers()
+    }
+
+    private fun configureReportBreakagesHandlers() {
+        binding.reportBreakageClearButton.setOnClickListener {
+            lifecycleScope.launch(dispatchers.io()) {
+                reportBreakageDataStore.clearAllReports()
+            }
+            Toast.makeText(this@AutofillInternalSettingsActivity, R.string.autofillDevSettingsReportBreakageHistoryCleared, Toast.LENGTH_SHORT).show()
+        }
     }
 
     private fun configureEngagementEventHandlers() {

--- a/autofill/autofill-internal/src/main/res/layout/activity_autofill_internal_settings.xml
+++ b/autofill/autofill-internal/src/main/res/layout/activity_autofill_internal_settings.xml
@@ -90,6 +90,22 @@
             android:layout_height="wrap_content" />
 
         <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+            android:layout_width="match_parent"
+            android:layout_marginTop="20dp"
+            android:layout_height="wrap_content"
+            app:primaryText="@string/autofillDevSettingsReportBreakageTitle" />
+
+        <com.duckduckgo.common.ui.view.listitem.OneLineListItem
+            android:id="@+id/reportBreakageClearButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:primaryText="@string/autofillDevSettingsReportBreakageClearHistory" />
+
+        <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
             android:id="@+id/engagementSectionTitle"
             android:layout_width="match_parent"
             android:layout_marginTop="20dp"

--- a/autofill/autofill-internal/src/main/res/values/donottranslate.xml
+++ b/autofill/autofill-internal/src/main/res/values/donottranslate.xml
@@ -21,6 +21,9 @@
     <string name="autofillDevSettingsSubtitle">Autofill and Email Protection dev options</string>
     <string name="autofillDevSettingsClearNeverAskAgainSettingButton">Clear \'never ask again\' setting</string>
     <string name="autofillDevSettingsEmailProtectionSignOutButton">Sign out</string>
+    <string name="autofillDevSettingsReportBreakageTitle">Autofill Breakage Reporting</string>
+    <string name="autofillDevSettingsReportBreakageClearHistory">Clear Reporting History</string>
+    <string name="autofillDevSettingsReportBreakageHistoryCleared">Breakage reporting history cleared</string>
     <string name="autofillDevSettingsEngagementTitle">Engagement KPIs</string>
     <string name="autofillDevSettingsEngagementClearHistory">Clear Engagement History</string>
     <string name="autofillDevSettingsEngagementHistoryCleared">Cleared All Engagement History</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/608920331025315/1207855335711810/f 

### Description
Adds a new developer setting for clearing previous reports. This makes it easier to test since you won't have to wait for the timeout period to expire before you can submit again for the same site.

### Steps to test this PR
QA-optional. If you want to test it out manually:

- [ ] Send an autofill breakage report
- [ ] Visit autofill dev settings and tap `Clear Reporting History`
- [ ] Verify that if you relaunch the password management screen you can see the "report breakage" view again


![Screenshot_20240719_152353](https://github.com/user-attachments/assets/6add969a-c280-4c43-80f4-dfd4c7a54d96)
