### PR TITLE
Enforce legacy UX for new tab and focussed view

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/FocusedViewProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/FocusedViewProvider.kt
@@ -49,6 +49,7 @@ class RealFocusedViewProvider @Inject constructor(
 @ContributesActivePlugin(
     scope = ActivityScope::class,
     boundType = FocusedViewPlugin::class,
+    priority = 0,
 )
 class FocusedLegacyPage @Inject constructor() : FocusedViewPlugin {
 
@@ -62,6 +63,8 @@ class FocusedLegacyPage @Inject constructor() : FocusedViewPlugin {
 @ContributesActivePlugin(
     scope = ActivityScope::class,
     boundType = FocusedViewPlugin::class,
+    priority = 100,
+    defaultActiveValue = false,
 )
 class FocusedPage @Inject constructor() : FocusedViewPlugin {
 

--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabPageProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabPageProvider.kt
@@ -48,6 +48,7 @@ class RealNewTabPageProvider @Inject constructor(
 @ContributesActivePlugin(
     scope = AppScope::class,
     boundType = NewTabPagePlugin::class,
+    priority = 0,
 )
 class NewTabLegacyPage @Inject constructor() : NewTabPagePlugin {
 

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/NewTabPage.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/NewTabPage.kt
@@ -28,7 +28,8 @@ import javax.inject.Inject
 @ContributesActivePlugin(
     scope = AppScope::class,
     boundType = NewTabPagePlugin::class,
-    priority = 100, // higher to come last in the list of plugins
+    priority = 100, // higher to come last in the list of plugins,
+    defaultActiveValue = false,
 )
 class NewTabPage @Inject constructor() : NewTabPagePlugin {
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/608920331025315/1207866714282844/f 

### Description
Enforces legacy UX for new tab and focussed views. 

We will probably have to revisit this in future to give the _new_ UX for internal users because this PR will enforce legacy experience regardless.

### Steps to test this PR

- [ ] Clean install
- [ ] Complete onboarding
- [ ] Add a favorite
- [ ] Open a new tab; verify you see the _old_  UX for new tab screen