### PR TITLE
Improve password list view performance, more work done away from main thread

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillManagementRecyclerAdapter.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillManagementRecyclerAdapter.kt
@@ -51,6 +51,7 @@ import com.duckduckgo.autofill.impl.ui.credential.management.viewing.extractTitl
 import com.duckduckgo.common.ui.menu.PopupMenu
 import com.duckduckgo.common.utils.DispatcherProvider
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class AutofillManagementRecyclerAdapter(
     private val lifecycleOwner: LifecycleOwner,
@@ -218,7 +219,7 @@ class AutofillManagementRecyclerAdapter(
     }
 
     @SuppressLint("NotifyDataSetChanged")
-    fun updateLogins(
+    suspend fun updateLogins(
         unsortedCredentials: List<LoginCredentials>,
         unsortedDirectSuggestions: List<LoginCredentials>,
         unsortedSharableSuggestions: List<LoginCredentials>,
@@ -226,14 +227,19 @@ class AutofillManagementRecyclerAdapter(
     ) {
         val newList = mutableListOf<ListItem>()
 
-        val directSuggestionsListItems = suggestionListBuilder.build(unsortedDirectSuggestions, unsortedSharableSuggestions, allowBreakageReporting)
-        newList.addAll(directSuggestionsListItems)
+        withContext(dispatchers.io()) {
+            val directSuggestionsListItems =
+                suggestionListBuilder.build(unsortedDirectSuggestions, unsortedSharableSuggestions, allowBreakageReporting)
+            newList.addAll(directSuggestionsListItems)
 
-        val groupedCredentials = grouper.group(unsortedCredentials)
-        newList.addAll(groupedCredentials)
+            val groupedCredentials = grouper.group(unsortedCredentials)
+            newList.addAll(groupedCredentials)
+        }
 
-        listItems = newList
-        notifyDataSetChanged()
+        withContext(dispatchers.main()) {
+            listItems = newList
+            notifyDataSetChanged()
+        }
     }
 
     @SuppressLint("NotifyDataSetChanged")

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementListMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementListMode.kt
@@ -415,15 +415,17 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
         binding.emptyStateLayout.emptyStateContainer.gone()
         binding.logins.show()
 
-        val currentUrl = getCurrentSiteUrl()
-        val directSuggestions = suggestionMatcher.getDirectSuggestions(currentUrl, credentials)
-        val shareableCredentials = suggestionMatcher.getShareableSuggestions(currentUrl)
+        withContext(dispatchers.io()) {
+            val currentUrl = getCurrentSiteUrl()
+            val directSuggestions = suggestionMatcher.getDirectSuggestions(currentUrl, credentials)
+            val shareableCredentials = suggestionMatcher.getShareableSuggestions(currentUrl)
 
-        adapter.updateLogins(credentials, directSuggestions, shareableCredentials, allowBreakageReporting)
+            adapter.updateLogins(credentials, directSuggestions, shareableCredentials, allowBreakageReporting)
 
-        val hasSuggestions = directSuggestions.isNotEmpty() || shareableCredentials.isNotEmpty()
-        if (allowBreakageReporting && hasSuggestions) {
-            viewModel.onReportBreakageShown()
+            val hasSuggestions = directSuggestions.isNotEmpty() || shareableCredentials.isNotEmpty()
+            if (allowBreakageReporting && hasSuggestions) {
+                viewModel.onReportBreakageShown()
+            }
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/608920331025315/1207876502054844/f 

### Description
Moves some of the heavier work in grouping and sorting passwords off of the main thread.

### Steps to test this PR
- [ ] Access password management screen, add some passwords and make sure it doesn't crash