### PR TITLE
Update onboarding site suggestions

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboarding/store/OnboardingStoreImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/store/OnboardingStoreImpl.kt
@@ -98,15 +98,15 @@ class OnboardingStoreImpl @Inject constructor(private val context: Context) : On
             }
 
             "DE" -> {
-                site1 = "kicker.de"
+                site1 = "bundesliga.de"
                 site2 = "tagesschau.de"
-                site3 = "ebay.com"
-                site4Query = "duden.de/rechtschreibung/Ente"
+                site3 = "galeria.de"
+                site4Query = "dict.leo.org/german-english/Ente"
             }
 
             "CA" -> {
                 site1 = "tsn.ca"
-                site2 = "cbc.ca"
+                site2 = "ctvnews.ca"
                 site3 = "canadiantire.ca"
                 site4Query = "britannica.com/animal/duck"
             }
@@ -120,7 +120,7 @@ class OnboardingStoreImpl @Inject constructor(private val context: Context) : On
 
             "AU" -> {
                 site1 = "afl.com.au"
-                site2 = "abc.net.au"
+                site2 = "yahoo.com"
                 site3 = "ebay.com"
                 site4Query = "britannica.com/animal/duck"
             }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/store/OnboardingStoreImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/store/OnboardingStoreImpl.kt
@@ -101,12 +101,12 @@ class OnboardingStoreImpl @Inject constructor(private val context: Context) : On
                 site1 = "bundesliga.de"
                 site2 = "tagesschau.de"
                 site3 = "galeria.de"
-                site4Query = "dict.leo.org/german-english/Ente"
+                site4Query = "britannica.com/animal/duck"
             }
 
             "CA" -> {
                 site1 = "tsn.ca"
-                site2 = "ctvnews.ca"
+                site2 = "yahoo.com"
                 site3 = "canadiantire.ca"
                 site4Query = "britannica.com/animal/duck"
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1207863588162441/f

### Description
Update onboarding site suggestions for some countries

### Steps to test this PR

_Germany_
- Set your device language to German (Germany)
- Fresh install
- Perform a search
- SERP dialog will appear, tap on 'Got it!' button
- New sites in-context dialog will appear
- [ ] Check option 1 is `bundesliga.com`
- [x] Check option 3 is `galeria.de`
- [x] Tap on option 4 and check it navigates to `dict.leo.org/german-english/Ente`

_Canada_
- Set your device language to English (Canada)
- Fresh install
- Perform a search
- SERP dialog will appear, tap on 'Got it!' button
- Open new tap
- [x] Check option 2 is `ctvnews.ca`
- [x] Tap on option 2 and check it navigates to `ctvnews.ca`

_Australia_
- Set your device language to English (Australia)
- Fresh install
- Perform a search
- SERP dialog will appear, tap on 'Got it!' button
- Open new tap
- [x] Check option 2 is `yahoo.com`
- [x] Tap on option 2 and check it navigates to `yahoo.com`

### No UI changes
