### PR TITLE
Android: Crash in BrowserWebViewClient.shouldOverride

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -270,7 +270,9 @@ class BrowserWebViewClient @Inject constructor(
                 }
             }
         } catch (e: Throwable) {
-            crashLogger.logCrash(CrashLogger.Crash(shortName = "m_webview_should_override", t = e))
+            appCoroutineScope.launch(dispatcherProvider.io()) {
+                crashLogger.logCrash(CrashLogger.Crash(shortName = "m_webview_should_override", t = e))
+            }
             return false
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1200905986587319/1207921881230819/f

### Description
Moved crashLogger.logCrash off the main thread.

### Steps to test this PR
QA-optional.

To test this, you can throw an exception at the beginning of the `try` block in `BrowserWebViewClient.shouldOverride` and see it is caught in the `catch` block. The app crashes as `logCrash` is called on the main thread.

### NO UI changes
