### PR TITLE
Fix onFireDialogVisibilityChanged crash

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -4077,6 +4077,8 @@ class BrowserTabFragment :
     }
 
     fun onFireDialogVisibilityChanged(isVisible: Boolean) {
+        if (!isAdded) return
+
         if (isVisible) {
             viewModel.ctaViewState.removeObserver(ctaViewStateObserver)
         } else {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1206222240301795/f

### Description
Fixes an `UninitializedPropertyAccessException` when `onFireDialogVisibilityChanged` is called.

### Steps to test this PR
- [ ] Code review.
