### PR TITLE
Update Kotlin to 1.9.24 + Anvil to 2.5.0-beta11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,10 @@
 buildscript {
 
     ext {
-        kotlin_version = '1.9.22'
+        kotlin_version = '1.9.24'
         spotless = '6.1.2'
-        anvil_version = '2.5.0-beta09'
-        ksp_version = '1.9.22-1.0.17'
+        anvil_version = '2.5.0-beta11'
+        ksp_version = '1.9.24-1.0.20'
         gradle_plugin = '8.2.0'
         min_sdk = 26
         target_sdk = 34

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version "1.9.22"
+    id 'org.jetbrains.kotlin.jvm' version "1.9.24"
 }
 
 repositories {

--- a/versions.properties
+++ b/versions.properties
@@ -85,7 +85,7 @@ version.jakewharton.rxrelay2=2.0.0
 
 version.jakewharton.timber=5.0.1
 
-version.kotlin=1.9.22
+version.kotlin=1.9.24
 
 version.kotlinx.coroutines=1.7.3
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207912454820662/f

### Description
- Updates Anvil `2.5.0-beta09` → `2.5.0-beta11`.
- Anvil `2.5.0-beta10+` uses Kotlin `1.9.24`, so this also bumps Kotlin `1.9.22` → `1.9.24`.

### Steps to test this PR
- [ ] Smoke test.
