### PR TITLE
Bump create-pull-request GH action to 6.1.0

### DIFF
--- a/.github/workflows/update-content-scope.yml
+++ b/.github/workflows/update-content-scope.yml
@@ -57,7 +57,7 @@ jobs:
         env:
           RELEASE_VERSION: ${{ steps.extract-release-version.outputs._1}}
         id: create-pr
-        uses: peter-evans/create-pull-request@v5.0.2
+        uses: peter-evans/create-pull-request@v6.1.0
         with:
           base: "develop"
           title: Update content scope scripts to version ${{ steps.extract-release-version.outputs._1}}

--- a/.github/workflows/update-ref-tests.yml
+++ b/.github/workflows/update-ref-tests.yml
@@ -64,7 +64,7 @@ jobs:
         env:
           RELEASE_VERSION: ${{ steps.extract-release-version.outputs._1}}
         id: create-pr
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6.1.0
         with:
           base: "develop"
           title: Update reference tests to version ${{ steps.extract-release-version.outputs._1}}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205648422731273/1207923237973390/f

### Description

This PR updates the peter-evans/create-pull-request action to the latest version. It fixes a bug, which causes workflow failures whenever there is an existing PR to update.

### Steps to test this PR

QA-optional

### No UI changes
