### PR TITLE
Tests for onboarding steps

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -453,6 +453,8 @@ class BrowserTabViewModelTest {
 
     private val mockEnabledToggle: Toggle = mock { on { it.isEnabled() } doReturn true }
 
+    private val mockDisabledToggle: Toggle = mock { on { it.isEnabled() } doReturn false }
+
     private val mockPrivacyProtectionsPopupManager: PrivacyProtectionsPopupManager = mock()
 
     private val mockPrivacyProtectionsToggleUsageListener: PrivacyProtectionsToggleUsageListener = mock()
@@ -667,6 +669,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenViewBecomesVisibleAndHomeShowingThenKeyboardShown() = runTest {
+        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
         whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(true)
 
         setBrowserShowing(false)
@@ -688,6 +691,7 @@ class BrowserTabViewModelTest {
     fun whenViewBecomesVisibleAndHomeShowingThenRefreshCtaIsCalled() {
         runTest {
             setBrowserShowing(false)
+            whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
             val observer = ValueCaptorObserver<CtaViewState>()
             testee.ctaViewState.observeForever(observer)
 
@@ -2349,6 +2353,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenCtaRefreshedAndOnlyStandardAddSupportedAndWidgetAlreadyInstalledThenCtaIsNull() = runTest {
+        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(false)
         whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(true)
         testee.refreshCta()
@@ -2358,6 +2363,7 @@ class BrowserTabViewModelTest {
     @Test
     fun whenCtaRefreshedAndIsNewTabIsFalseThenReturnNull() = runTest {
         setBrowserShowing(true)
+        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
         whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(false)
         testee.refreshCta()
@@ -2366,6 +2372,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenCtaRefreshedAndOnboardingCompleteThenViewStateUpdated() = runTest {
+        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(false)
         whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(true)
         whenever(mockDismissedCtaDao.exists(DAX_END)).thenReturn(true)
@@ -2379,6 +2386,7 @@ class BrowserTabViewModelTest {
     @Test
     fun whenCtaRefreshedAndBrowserShowingThenViewStateUpdated() = runTest {
         setBrowserShowing(true)
+        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
         whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(false)
         whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(true)
         whenever(mockDismissedCtaDao.exists(DAX_END)).thenReturn(true)

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -287,9 +287,10 @@ class CtaViewModel @Inject constructor(
 
     // We only want to show New Tab when the Home CTAs from Onboarding has finished
     // https://app.asana.com/0/1157893581871903/1207769731595075/f
-    fun areBubbleDaxDialogsCompleted(): Boolean {
+    suspend fun areBubbleDaxDialogsCompleted(): Boolean {
+        val noBrowserCtaExperiment = extendedOnboardingFeatureToggles.noBrowserCtas().isEnabled()
         val bubbleCtasShown = daxDialogEndShown() && (daxDialogNetworkShown() || daxDialogOtherShown() || daxDialogTrackersFoundShown())
-        return bubbleCtasShown || hideTips()
+        return noBrowserCtaExperiment || bubbleCtasShown || hideTips() || !userStageStore.daxOnboardingActive()
     }
 
     private fun daxDialogSerpShown(): Boolean = dismissedCtaDao.exists(CtaId.DAX_DIALOG_SERP)

--- a/app/src/test/java/com/duckduckgo/app/browser/newtab/NewTabPageProviderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/newtab/NewTabPageProviderTest.kt
@@ -93,8 +93,8 @@ class NewTabPageProviderTest {
     private val allPluginsEnabled = object : ActivePluginPoint<NewTabPagePlugin> {
         override suspend fun getPlugins(): Collection<NewTabPagePlugin> {
             return listOf(
-                LegacyNewTabPlugin(),
                 NewNewTabPlugin(),
+                LegacyNewTabPlugin(),
             )
         }
     }

--- a/app/src/test/java/com/duckduckgo/app/browser/newtab/NewTabPageProviderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/newtab/NewTabPageProviderTest.kt
@@ -53,6 +53,17 @@ class NewTabPageProviderTest {
     }
 
     @Test
+    fun whenNTPFirstPluginFirstEnabledThenLegacyViewProvided() = runTest {
+        testee = RealNewTabPageProvider(ntpFirstPluginsEnabled)
+
+        testee.provideNewTabPageVersion().test {
+            expectMostRecentItem().also {
+                assertTrue(it.name == NewTabPageVersion.NEW.name)
+            }
+        }
+    }
+
+    @Test
     fun whenAllPluginsEnabledThenLegacyViewProvided() = runTest {
         testee = RealNewTabPageProvider(allPluginsEnabled)
 
@@ -91,6 +102,15 @@ class NewTabPageProviderTest {
     }
 
     private val allPluginsEnabled = object : ActivePluginPoint<NewTabPagePlugin> {
+        override suspend fun getPlugins(): Collection<NewTabPagePlugin> {
+            return listOf(
+                LegacyNewTabPlugin(),
+                NewNewTabPlugin(),
+            )
+        }
+    }
+
+    private val ntpFirstPluginsEnabled = object : ActivePluginPoint<NewTabPagePlugin> {
         override suspend fun getPlugins(): Collection<NewTabPagePlugin> {
             return listOf(
                 NewNewTabPlugin(),

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/OnboardingDaxDialogTests.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/OnboardingDaxDialogTests.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.cta.ui
+
+import com.duckduckgo.app.browser.DuckDuckGoUrlDetector
+import com.duckduckgo.app.cta.db.DismissedCtaDao
+import com.duckduckgo.app.cta.model.CtaId.DAX_DIALOG_NETWORK
+import com.duckduckgo.app.cta.model.CtaId.DAX_DIALOG_OTHER
+import com.duckduckgo.app.cta.model.CtaId.DAX_DIALOG_TRACKERS_FOUND
+import com.duckduckgo.app.cta.model.CtaId.DAX_END
+import com.duckduckgo.app.global.install.AppInstallStore
+import com.duckduckgo.app.onboarding.store.OnboardingStore
+import com.duckduckgo.app.onboarding.store.UserStageStore
+import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.ExtendedOnboardingFeatureToggles
+import com.duckduckgo.app.privacy.db.UserAllowListRepository
+import com.duckduckgo.app.settings.db.SettingsDataStore
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.app.widget.ui.WidgetCapabilities
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.DispatcherProvider
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
+
+class OnboardingDaxDialogTests {
+
+    private lateinit var testee: CtaViewModel
+
+    @get:Rule
+    @Suppress("unused")
+    val coroutineRule = CoroutineTestRule()
+
+    private val appInstallStore: AppInstallStore = mock()
+    private val pixel: Pixel = mock()
+    private val widgetCapabilities: WidgetCapabilities = mock()
+    private val dismissedCtaDao: DismissedCtaDao = mock()
+    private val userAllowListRepository: UserAllowListRepository = mock()
+    private val settingsDataStore: SettingsDataStore = mock()
+    private val onboardingStore: OnboardingStore = mock()
+    private val userStageStore: UserStageStore = mock()
+    private val tabRepository: TabRepository = mock()
+    private val dispatchers: DispatcherProvider = mock()
+    private val duckDuckGoUrlDetector: DuckDuckGoUrlDetector = mock()
+    private val extendedOnboardingFeatureToggles: ExtendedOnboardingFeatureToggles = mock()
+
+    @Before
+    fun before() {
+        testee = CtaViewModel(
+            appInstallStore,
+            pixel,
+            widgetCapabilities,
+            dismissedCtaDao,
+            userAllowListRepository,
+            settingsDataStore, onboardingStore, userStageStore, tabRepository, dispatchers, duckDuckGoUrlDetector, extendedOnboardingFeatureToggles,
+        )
+    }
+
+    @Test
+    fun whenDaxDialogEndAndDaxDialogNetworkShownThenOnboardingComplete() = runTest {
+        whenever(settingsDataStore.hideTips).thenReturn(false)
+        whenever(dismissedCtaDao.exists(DAX_END)).thenReturn(true)
+        whenever(dismissedCtaDao.exists(DAX_DIALOG_NETWORK)).thenReturn(true)
+
+        val onboardingComplete = testee.areBubbleDaxDialogsCompleted()
+        assertTrue(onboardingComplete)
+    }
+
+    @Test
+    fun whenDaxDialogEndAndDaxDialogTrackersFoundThenOnboardingComplete() = runTest {
+        whenever(settingsDataStore.hideTips).thenReturn(false)
+        whenever(dismissedCtaDao.exists(DAX_END)).thenReturn(true)
+        whenever(dismissedCtaDao.exists(DAX_DIALOG_TRACKERS_FOUND)).thenReturn(true)
+
+        val onboardingComplete = testee.areBubbleDaxDialogsCompleted()
+        assertTrue(onboardingComplete)
+    }
+
+    @Test
+    fun whenDaxDialogEndAndDaxDialogOtherFoundThenOnboardingComplete() = runTest {
+        whenever(settingsDataStore.hideTips).thenReturn(false)
+        whenever(dismissedCtaDao.exists(DAX_END)).thenReturn(true)
+        whenever(dismissedCtaDao.exists(DAX_DIALOG_OTHER)).thenReturn(true)
+
+        val onboardingComplete = testee.areBubbleDaxDialogsCompleted()
+        assertTrue(onboardingComplete)
+    }
+
+    @Test
+    fun whenDaxDialogEndNotShownThenOnboardingNotComplete() = runTest {
+        whenever(settingsDataStore.hideTips).thenReturn(false)
+        whenever(dismissedCtaDao.exists(DAX_END)).thenReturn(false)
+
+        val onboardingComplete = testee.areBubbleDaxDialogsCompleted()
+        assertFalse(onboardingComplete)
+    }
+
+    @Test
+    fun whenHideTipsThenOnboardingComplete() = runTest {
+        whenever(settingsDataStore.hideTips).thenReturn(true)
+
+        val onboardingComplete = testee.areBubbleDaxDialogsCompleted()
+        assertTrue(onboardingComplete)
+    }
+
+    @Test
+    fun whenDaxDialogEndShownButOtherDialogsNotShownThenOnboardingNotComplete() = runTest {
+        whenever(settingsDataStore.hideTips).thenReturn(false)
+        whenever(dismissedCtaDao.exists(DAX_END)).thenReturn(true)
+        whenever(dismissedCtaDao.exists(DAX_DIALOG_OTHER)).thenReturn(false)
+        whenever(dismissedCtaDao.exists(DAX_DIALOG_TRACKERS_FOUND)).thenReturn(false)
+        whenever(dismissedCtaDao.exists(DAX_DIALOG_NETWORK)).thenReturn(false)
+
+        val onboardingComplete = testee.areBubbleDaxDialogsCompleted()
+        assertFalse(onboardingComplete)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1157893581871903/1207939900109577/f

### Description
- Improve the check for Onboarding is complete
- Add tests to make the implementation more robust

### Steps to test this PR

On each step, wait for searches and sites to fully load in the browser

_Onboarding not complete_
- [x] Fresh install
- [x] Start onboarding but don’t complete it
- [x] Close app and open it again
- [x] Verify dax onboarding appears and NTP doesn’t.

_Favorites under Onboarding_
- [x] Fresh install
- [x] Perform a search
- [x] Save bookmark → Add favorite
- [x] Visit a site → ⚠️ Don't dismiss the trackers onboarding CTA
- [x] Save bookmark → Add favorite
- [x] Open a new tab
- [x] Perform a search
- [x] Open a new tab
- [x] Check favorites are not displayed underneath Dax dialog
- [x] Tap on a site suggestion
- [x] Check favorites are not displayed  underneath Dax dialog before site is loaded
