### PR TITLE
NTP: Ensure NTP is available to internal users whilst experiment is running

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/FocusedViewProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/FocusedViewProvider.kt
@@ -20,6 +20,8 @@ import android.content.Context
 import android.view.View
 import com.duckduckgo.anvil.annotations.ContributesActivePlugin
 import com.duckduckgo.anvil.annotations.ContributesActivePluginPoint
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.appbuildconfig.api.isInternalBuild
 import com.duckduckgo.common.utils.plugins.ActivePluginPoint
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.newtabpage.api.FocusedViewPlugin
@@ -39,9 +41,14 @@ interface FocusedViewProvider {
 )
 class RealFocusedViewProvider @Inject constructor(
     private val focusedViewVersions: ActivePluginPoint<FocusedViewPlugin>,
+    private val appBuildConfig: AppBuildConfig,
 ) : FocusedViewProvider {
     override fun provideFocusedViewVersion(): Flow<FocusedViewPlugin> = flow {
-        val focusedView = focusedViewVersions.getPlugins().firstOrNull() ?: FocusedLegacyPage()
+        val focusedView = if (appBuildConfig.isInternalBuild()) {
+            FocusedPage()
+        } else {
+            focusedViewVersions.getPlugins().firstOrNull() ?: FocusedLegacyPage()
+        }
         emit(focusedView)
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabPageProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabPageProvider.kt
@@ -20,11 +20,14 @@ import android.content.Context
 import android.view.View
 import com.duckduckgo.anvil.annotations.ContributesActivePlugin
 import com.duckduckgo.anvil.annotations.ContributesActivePluginPoint
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.appbuildconfig.api.isInternalBuild
 import com.duckduckgo.common.utils.plugins.ActivePluginPoint
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.newtabpage.api.NewTabPagePlugin
 import com.duckduckgo.newtabpage.api.NewTabPageVersion
+import com.duckduckgo.newtabpage.impl.NewTabPage
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
@@ -38,9 +41,14 @@ interface NewTabPageProvider {
 @ContributesBinding(scope = ActivityScope::class)
 class RealNewTabPageProvider @Inject constructor(
     private val newTabPageVersions: ActivePluginPoint<NewTabPagePlugin>,
+    private val appBuildConfig: AppBuildConfig,
 ) : NewTabPageProvider {
     override fun provideNewTabPageVersion(): Flow<NewTabPagePlugin> = flow {
-        val newTabPage = newTabPageVersions.getPlugins().firstOrNull() ?: NewTabLegacyPage()
+        val newTabPage = if (appBuildConfig.isInternalBuild()) {
+            NewTabPage()
+        } else {
+            newTabPageVersions.getPlugins().firstOrNull() ?: NewTabLegacyPage()
+        }
         emit(newTabPage)
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/newtab/NewTabPageProviderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/newtab/NewTabPageProviderTest.kt
@@ -19,20 +19,55 @@ package com.duckduckgo.app.browser.newtab
 import android.content.Context
 import android.view.View
 import app.cash.turbine.test
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.appbuildconfig.api.BuildFlavor
 import com.duckduckgo.common.utils.plugins.ActivePluginPoint
 import com.duckduckgo.newtabpage.api.NewTabPagePlugin
 import com.duckduckgo.newtabpage.api.NewTabPageVersion
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
 
 class NewTabPageProviderTest {
 
     private lateinit var testee: NewTabPageProvider
+    private val appBuildConfig: AppBuildConfig = mock()
+
+    @Before
+    fun setup() {
+        whenever(appBuildConfig.flavor).thenReturn(BuildFlavor.PLAY)
+    }
+
+    @Test
+    fun whenInternalBuildAndNoPluginsEnabledThenNewViewProvided() = runTest {
+        testee = RealNewTabPageProvider(noPluginsEnabled, appBuildConfig)
+        whenever(appBuildConfig.flavor).thenReturn(BuildFlavor.INTERNAL)
+
+        testee.provideNewTabPageVersion().test {
+            expectMostRecentItem().also {
+                assertTrue(it.name == NewTabPageVersion.NEW.name)
+            }
+        }
+    }
+
+    @Test
+    fun whenInternalBuildAndAllPluginsEnabledThenNewViewProvided() = runTest {
+        testee = RealNewTabPageProvider(allPluginsEnabled, appBuildConfig)
+        whenever(appBuildConfig.flavor).thenReturn(BuildFlavor.INTERNAL)
+
+        testee.provideNewTabPageVersion().test {
+            expectMostRecentItem().also {
+                assertTrue(it.name == NewTabPageVersion.NEW.name)
+            }
+        }
+    }
 
     @Test
     fun whenLegacyPluginEnabledThenLegacyViewProvided() = runTest {
-        testee = RealNewTabPageProvider(legacyPluginEnabled)
+        testee = RealNewTabPageProvider(legacyPluginEnabled, appBuildConfig)
 
         testee.provideNewTabPageVersion().test {
             expectMostRecentItem().also {
@@ -43,7 +78,7 @@ class NewTabPageProviderTest {
 
     @Test
     fun whenNewPluginEnabledThenNewViewProvided() = runTest {
-        testee = RealNewTabPageProvider(newPluginEnabled)
+        testee = RealNewTabPageProvider(newPluginEnabled, appBuildConfig)
 
         testee.provideNewTabPageVersion().test {
             expectMostRecentItem().also {
@@ -54,7 +89,7 @@ class NewTabPageProviderTest {
 
     @Test
     fun whenAllPluginsEnabledThenLegacyViewProvided() = runTest {
-        testee = RealNewTabPageProvider(allPluginsEnabled)
+        testee = RealNewTabPageProvider(allPluginsEnabled, appBuildConfig)
 
         testee.provideNewTabPageVersion().test {
             expectMostRecentItem().also {
@@ -65,7 +100,7 @@ class NewTabPageProviderTest {
 
     @Test
     fun whenNoPluginsEnabledThenLegacyViewProvided() = runTest {
-        testee = RealNewTabPageProvider(noPluginsEnabled)
+        testee = RealNewTabPageProvider(noPluginsEnabled, appBuildConfig)
 
         testee.provideNewTabPageVersion().test {
             expectMostRecentItem().also {

--- a/app/src/test/java/com/duckduckgo/app/browser/newtab/RealFocusedViewProviderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/newtab/RealFocusedViewProviderTest.kt
@@ -1,0 +1,144 @@
+package com.duckduckgo.app.browser.newtab
+
+import android.content.Context
+import android.view.View
+import app.cash.turbine.test
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.appbuildconfig.api.BuildFlavor
+import com.duckduckgo.common.utils.plugins.ActivePluginPoint
+import com.duckduckgo.newtabpage.api.FocusedViewPlugin
+import com.duckduckgo.newtabpage.api.FocusedViewVersion
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
+
+class RealFocusedViewProviderTest {
+
+    private lateinit var testee: FocusedViewProvider
+    private val appBuildConfig: AppBuildConfig = mock()
+
+    @Before
+    fun setup() {
+        whenever(appBuildConfig.flavor).thenReturn(BuildFlavor.PLAY)
+    }
+
+    @Test
+    fun whenInternalBuildAndNoPluginsEnabledThenNewViewProvided() = runTest {
+        testee = RealFocusedViewProvider(noPluginsEnabled, appBuildConfig)
+        whenever(appBuildConfig.flavor).thenReturn(BuildFlavor.INTERNAL)
+
+        testee.provideFocusedViewVersion().test {
+            expectMostRecentItem().also {
+                assertTrue(it.name == FocusedViewVersion.NEW.name)
+            }
+        }
+    }
+
+    @Test
+    fun whenInternalBuildAndAllPluginsEnabledThenNewViewProvided() = runTest {
+        testee = RealFocusedViewProvider(allPluginsEnabled, appBuildConfig)
+        whenever(appBuildConfig.flavor).thenReturn(BuildFlavor.INTERNAL)
+
+        testee.provideFocusedViewVersion().test {
+            expectMostRecentItem().also {
+                assertTrue(it.name == FocusedViewVersion.NEW.name)
+            }
+        }
+    }
+
+    @Test
+    fun whenLegacyPluginEnabledThenLegacyViewProvided() = runTest {
+        testee = RealFocusedViewProvider(legacyPluginEnabled, appBuildConfig)
+
+        testee.provideFocusedViewVersion().test {
+            expectMostRecentItem().also {
+                assertTrue(it.name == FocusedViewVersion.LEGACY.name)
+            }
+        }
+    }
+
+    @Test
+    fun whenNewPluginEnabledThenNewViewProvided() = runTest {
+        testee = RealFocusedViewProvider(newPluginEnabled, appBuildConfig)
+
+        testee.provideFocusedViewVersion().test {
+            expectMostRecentItem().also {
+                assertTrue(it.name == FocusedViewVersion.NEW.name)
+            }
+        }
+    }
+
+    @Test
+    fun whenAllPluginsEnabledThenLegacyViewProvided() = runTest {
+        testee = RealFocusedViewProvider(allPluginsEnabled, appBuildConfig)
+
+        testee.provideFocusedViewVersion().test {
+            expectMostRecentItem().also {
+                assertTrue(it.name == FocusedViewVersion.LEGACY.name)
+            }
+        }
+    }
+
+    @Test
+    fun whenNoPluginsEnabledThenLegacyViewProvided() = runTest {
+        testee = RealFocusedViewProvider(noPluginsEnabled, appBuildConfig)
+
+        testee.provideFocusedViewVersion().test {
+            expectMostRecentItem().also {
+                assertTrue(it.name == FocusedViewVersion.LEGACY.name)
+            }
+        }
+    }
+
+    private val noPluginsEnabled = object : ActivePluginPoint<FocusedViewPlugin> {
+        override suspend fun getPlugins(): Collection<FocusedViewPlugin> {
+            return emptyList()
+        }
+    }
+
+    private val allPluginsEnabled = object : ActivePluginPoint<FocusedViewPlugin> {
+        override suspend fun getPlugins(): Collection<FocusedViewPlugin> {
+            return listOf(
+                LegacyNewTabPlugin(),
+                NewNewTabPlugin(),
+            )
+        }
+    }
+
+    private val legacyPluginEnabled = object : ActivePluginPoint<FocusedViewPlugin> {
+        override suspend fun getPlugins(): Collection<FocusedViewPlugin> {
+            return listOf(
+                LegacyNewTabPlugin(),
+            )
+        }
+    }
+
+    private val newPluginEnabled = object : ActivePluginPoint<FocusedViewPlugin> {
+        override suspend fun getPlugins(): Collection<FocusedViewPlugin> {
+            return listOf(
+                NewNewTabPlugin(),
+            )
+        }
+    }
+
+    class LegacyNewTabPlugin : FocusedViewPlugin {
+        override val name: String
+            get() = FocusedViewVersion.LEGACY.name
+
+        override fun getView(context: Context): View {
+            return View(context)
+        }
+    }
+
+    class NewNewTabPlugin() : FocusedViewPlugin {
+        override val name: String
+            get() = FocusedViewVersion.NEW.name
+
+        override fun getView(context: Context): View {
+            return View(context)
+        }
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414730916066338/1207940115612759/f

### Description
Enable NTP for internal users once the Experiment is enabled

### Steps to test this PR

Remote Config URL -> http://www.jsonblob.com/api/1268216621771382784

_Internal build_
- [ ] Fresh install
- [ ] Complete Onboarding
- [ ] Verify new NTP is visible

_Play build_
- [ ] Fresh install
- [ ] Keep trying until you get mq variant (control group)
- [ ] Complete Onboarding
- [ ] Verify old NTP is visible

_Play build_
- [ ] Fresh install
- [ ] Keep trying until you get mr variant (experiment variant)
- [ ] Complete Onboarding
- [ ] Verify new NTP is visible