### PR TITLE
Autofill: update dismiss logic to show snackbar

### DIFF
--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillFeature.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillFeature.kt
@@ -82,4 +82,12 @@ interface AutofillFeature {
     @Toggle.DefaultValue(false)
     @InternalAlwaysEnabled
     fun onForExistingUsers(): Toggle
+
+    /**
+     * Remote Flag that enables the old dialog prompt to disable autofill
+     * @return `true` when the remote config has the global "allowToDisableAutofill" autofill sub-feature flag enabled
+     * If the remote feature is not present defaults to `false`
+     */
+    @Toggle.DefaultValue(false)
+    fun showDisableDialogAutofillPrompt(): Toggle
 }

--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillScreens.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillScreens.kt
@@ -58,4 +58,5 @@ enum class AutofillSettingsLaunchSource {
     InternalDevSettings,
     Unknown,
     NewTabShortcut,
+    DisableInSettingsPrompt,
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/SecureStoreBackedAutofillStore.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/SecureStoreBackedAutofillStore.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.autofill.impl.securestorage.SecureStorage
 import com.duckduckgo.autofill.impl.securestorage.WebsiteLoginDetails
 import com.duckduckgo.autofill.impl.securestorage.WebsiteLoginDetailsWithCredentials
 import com.duckduckgo.autofill.impl.store.InternalAutofillStore
+import com.duckduckgo.autofill.impl.ui.credential.saving.declines.AutofillDeclineStore
 import com.duckduckgo.autofill.impl.urlmatcher.AutofillUrlMatcher
 import com.duckduckgo.autofill.store.AutofillPrefsStore
 import com.duckduckgo.autofill.store.LastUpdatedTimeProvider
@@ -44,7 +45,8 @@ import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 @SingleInstanceIn(AppScope::class)
-@ContributesBinding(AppScope::class)
+@ContributesBinding(AppScope::class, AutofillDeclineStore::class)
+@ContributesBinding(AppScope::class, InternalAutofillStore::class)
 class SecureStoreBackedAutofillStore @Inject constructor(
     private val secureStorage: SecureStorage,
     private val lastUpdatedTimeProvider: LastUpdatedTimeProvider,
@@ -53,7 +55,7 @@ class SecureStoreBackedAutofillStore @Inject constructor(
     private val autofillUrlMatcher: AutofillUrlMatcher,
     private val syncCredentialsListener: SyncCredentialsListener,
     passwordStoreEventListenersPlugins: PluginPoint<PasswordStoreEventListener>,
-) : InternalAutofillStore {
+) : InternalAutofillStore, AutofillDeclineStore {
 
     private val passwordStoreEventListeners = passwordStoreEventListenersPlugins.getPlugins()
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
@@ -17,6 +17,8 @@
 package com.duckduckgo.autofill.impl.pixel
 
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_DECLINE_PROMPT_TO_DISABLE_AUTOFILL_SNACKBAR_OPEN_SETTINGS
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_DECLINE_PROMPT_TO_DISABLE_AUTOFILL_SNACKBAR_SHOWN
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENGAGEMENT_ACTIVE_USER
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENGAGEMENT_ENABLED_USER
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENGAGEMENT_ONBOARDED_USER
@@ -83,6 +85,9 @@ enum class AutofillPixelNames(override val pixelName: String) : Pixel.PixelName 
     AUTOFILL_AUTHENTICATION_TO_AUTOFILL_AUTH_SUCCESSFUL("m_autofill_logins_fill_login_inline_authentication_device-auth_authenticated"),
     AUTOFILL_AUTHENTICATION_TO_AUTOFILL_AUTH_FAILURE("m_autofill_logins_fill_login_inline_authentication_device-auth_failed"),
     AUTOFILL_AUTHENTICATION_TO_AUTOFILL_AUTH_CANCELLED("m_autofill_logins_fill_login_inline_authentication_device-auth_cancelled"),
+
+    AUTOFILL_DECLINE_PROMPT_TO_DISABLE_AUTOFILL_SNACKBAR_SHOWN("autofill_logins_save_disable_snackbar_shown"),
+    AUTOFILL_DECLINE_PROMPT_TO_DISABLE_AUTOFILL_SNACKBAR_OPEN_SETTINGS("autofill_logins_save_disable_snackbar_open_settings"),
 
     AUTOFILL_DECLINE_PROMPT_TO_DISABLE_AUTOFILL_SHOWN("m_autofill_logins_save_disable-prompt_shown"),
     AUTOFILL_DECLINE_PROMPT_TO_DISABLE_AUTOFILL_KEEP_USING("m_autofill_logins_save_disable-prompt_autofill-kept"),
@@ -198,6 +203,9 @@ object AutofillPixelsRequiringDataCleaning : PixelParamRemovalPlugin {
             AUTOFILL_ONBOARDING_SAVE_PROMPT_DISMISSED.pixelName to PixelParameter.removeAtb(),
             AUTOFILL_ONBOARDING_SAVE_PROMPT_SAVED.pixelName to PixelParameter.removeAtb(),
             AUTOFILL_ONBOARDING_SAVE_PROMPT_EXCLUDE.pixelName to PixelParameter.removeAtb(),
+
+            AUTOFILL_DECLINE_PROMPT_TO_DISABLE_AUTOFILL_SNACKBAR_SHOWN.pixelName to PixelParameter.removeAtb(),
+            AUTOFILL_DECLINE_PROMPT_TO_DISABLE_AUTOFILL_SNACKBAR_OPEN_SETTINGS.pixelName to PixelParameter.removeAtb(),
         )
     }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/store/InternalAutofillStore.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/store/InternalAutofillStore.kt
@@ -41,18 +41,6 @@ interface InternalAutofillStore : AutofillStore {
     var hasEverBeenPromptedToSaveLogin: Boolean
 
     /**
-     * Whether to monitor autofill decline counts or not
-     * Used to determine whether we should actively detect when a user new to autofill doesn't appear to want it enabled
-     */
-    var monitorDeclineCounts: Boolean
-
-    /**
-     * A count of the number of autofill declines the user has made, persisted across all sessions.
-     * Used to determine whether we should prompt a user new to autofill to disable it if they don't appear to want it enabled
-     */
-    var autofillDeclineCount: Int
-
-    /**
      * Find saved credential for the given id
      * @param id of the saved credential
      */

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillManagementActivity.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillManagementActivity.kt
@@ -249,10 +249,11 @@ class AutofillManagementActivity : DuckDuckGoActivity() {
         resetToolbar()
         val currentUrl = extractSuggestionsUrl()
         val privacyProtectionStatus = extractPrivacyProtectionEnabled()
+        val launchSource = extractLaunchSource()
         Timber.v("showListMode. currentUrl is %s", currentUrl)
 
         supportFragmentManager.commitNow {
-            val fragment = AutofillManagementListMode.instance(currentUrl, privacyProtectionStatus)
+            val fragment = AutofillManagementListMode.instance(currentUrl, privacyProtectionStatus, launchSource)
             replace(R.id.fragment_container_view, fragment, TAG_ALL_CREDENTIALS)
         }
     }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModel.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.autofill.api.AutofillSettingsLaunchSource
 import com.duckduckgo.autofill.api.AutofillSettingsLaunchSource.BrowserOverflow
+import com.duckduckgo.autofill.api.AutofillSettingsLaunchSource.DisableInSettingsPrompt
 import com.duckduckgo.autofill.api.AutofillSettingsLaunchSource.SettingsActivity
 import com.duckduckgo.autofill.api.AutofillSettingsLaunchSource.Sync
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
@@ -537,11 +538,11 @@ class AutofillSettingsViewModel @Inject constructor(
         pixel.fire(AUTOFILL_ENABLE_AUTOFILL_TOGGLE_MANUALLY_ENABLED)
     }
 
-    fun onDisableAutofill() {
+    fun onDisableAutofill(autofillSettingsLaunchSource: AutofillSettingsLaunchSource?) {
         autofillStore.autofillEnabled = false
         _viewState.value = viewState.value.copy(autofillEnabled = false)
 
-        pixel.fire(AUTOFILL_ENABLE_AUTOFILL_TOGGLE_MANUALLY_DISABLED)
+        pixel.fire(AUTOFILL_ENABLE_AUTOFILL_TOGGLE_MANUALLY_DISABLED, mapOf("source" to autofillSettingsLaunchSource?.asString().orEmpty()))
     }
 
     fun onSearchQueryChanged(searchText: String) {
@@ -646,12 +647,7 @@ class AutofillSettingsViewModel @Inject constructor(
     fun sendLaunchPixel(launchSource: AutofillSettingsLaunchSource) {
         Timber.v("Opened autofill management screen from from %s", launchSource)
 
-        val source = when (launchSource) {
-            SettingsActivity -> "settings"
-            BrowserOverflow -> "overflow_menu"
-            Sync -> "sync"
-            else -> null
-        }
+        val source = launchSource.asString()
 
         if (source != null) {
             pixel.fire(AUTOFILL_MANAGEMENT_SCREEN_OPENED, mapOf("source" to source))
@@ -758,6 +754,16 @@ class AutofillSettingsViewModel @Inject constructor(
 
     fun userCancelledSendBreakageReport() {
         pixel.fire(AUTOFILL_SITE_BREAKAGE_REPORT_CONFIRMATION_DISMISSED)
+    }
+
+    private fun AutofillSettingsLaunchSource.asString(): String? {
+        return when (this) {
+            SettingsActivity -> "settings"
+            BrowserOverflow -> "overflow_menu"
+            Sync -> "sync"
+            DisableInSettingsPrompt -> "disable_prompt"
+            else -> null
+        }
     }
 
     data class ViewState(

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementListMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementListMode.kt
@@ -36,6 +36,7 @@ import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.BrowserNav
+import com.duckduckgo.autofill.api.AutofillSettingsLaunchSource
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.impl.R
 import com.duckduckgo.autofill.impl.databinding.FragmentAutofillManagementListModeBinding
@@ -133,7 +134,7 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
 
     private val globalAutofillToggleListener = CompoundButton.OnCheckedChangeListener { _, isChecked ->
         if (!lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) return@OnCheckedChangeListener
-        if (isChecked) viewModel.onEnableAutofill() else viewModel.onDisableAutofill()
+        if (isChecked) viewModel.onEnableAutofill() else viewModel.onDisableAutofill(getAutofillSettingsLaunchSource())
     }
 
     private fun configureToggle() {
@@ -246,6 +247,8 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
 
     private fun getCurrentSiteUrl() = arguments?.getString(ARG_CURRENT_URL, null)
     private fun getPrivacyProtectionEnabled() = arguments?.getBoolean(ARG_PRIVACY_PROTECTION_STATUS)
+    private fun getAutofillSettingsLaunchSource(): AutofillSettingsLaunchSource? =
+        arguments?.getSerializable(ARG_AUTOFILL_SETTINGS_LAUNCH_SOURCE) as AutofillSettingsLaunchSource?
 
     private fun parentBinding() = parentActivity()?.binding
     private fun parentActivity() = (activity as AutofillManagementActivity?)
@@ -553,7 +556,7 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
     }
 
     companion object {
-        fun instance(currentUrl: String? = null, privacyProtectionEnabled: Boolean?) =
+        fun instance(currentUrl: String? = null, privacyProtectionEnabled: Boolean?, source: AutofillSettingsLaunchSource? = null) =
             AutofillManagementListMode().apply {
                 arguments = Bundle().apply {
                     putString(ARG_CURRENT_URL, currentUrl)
@@ -561,11 +564,16 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
                     if (privacyProtectionEnabled != null) {
                         putBoolean(ARG_PRIVACY_PROTECTION_STATUS, privacyProtectionEnabled)
                     }
+
+                    if (source != null) {
+                        putSerializable(ARG_AUTOFILL_SETTINGS_LAUNCH_SOURCE, source)
+                    }
                 }
             }
 
         private const val ARG_CURRENT_URL = "ARG_CURRENT_URL"
         private const val ARG_PRIVACY_PROTECTION_STATUS = "ARG_PRIVACY_PROTECTION_STATUS"
+        private const val ARG_AUTOFILL_SETTINGS_LAUNCH_SOURCE = "ARG_AUTOFILL_SETTINGS_LAUNCH_SOURCE"
     }
 }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/saving/AutofillSavingCredentialsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/saving/AutofillSavingCredentialsViewModel.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.autofill.impl.email.incontext.EmailProtectionInContextSignupViewModel.ViewState
 import com.duckduckgo.autofill.impl.store.InternalAutofillStore
 import com.duckduckgo.autofill.impl.store.NeverSavedSiteRepository
+import com.duckduckgo.autofill.impl.ui.credential.saving.declines.AutofillDeclineCounter
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.FragmentScope
 import javax.inject.Inject
@@ -36,13 +37,14 @@ class AutofillSavingCredentialsViewModel @Inject constructor(
     private val dispatchers: DispatcherProvider,
     private val neverSavedSiteRepository: NeverSavedSiteRepository,
     private val autofillStore: InternalAutofillStore,
+    private val autofillDeclineCounter: AutofillDeclineCounter,
 ) : ViewModel() {
 
     private val _viewState = MutableStateFlow(ViewState())
 
     init {
         viewModelScope.launch(dispatchers.io()) {
-            val shouldShowExpandedView = autofillStore.autofillDeclineCount < 2 && autofillStore.monitorDeclineCounts
+            val shouldShowExpandedView = autofillDeclineCounter.declineCount() < 2 && autofillDeclineCounter.isDeclineCounterActive()
             _viewState.value = ViewState(shouldShowExpandedView)
             Timber.d("Autofill: AutofillSavingCredentialsViewModel initialized")
         }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/saving/ResultHandlerPromptToDisableCredentialSaving.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/saving/ResultHandlerPromptToDisableCredentialSaving.kt
@@ -18,20 +18,28 @@ package com.duckduckgo.autofill.impl.ui.credential.saving
 
 import android.content.Context
 import android.os.Bundle
+import android.view.View
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog.Builder
 import androidx.fragment.app.Fragment
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.autofill.api.AutofillEventListener
+import com.duckduckgo.autofill.api.AutofillFeature
 import com.duckduckgo.autofill.api.AutofillFragmentResultsPlugin
+import com.duckduckgo.autofill.api.AutofillScreens.AutofillSettingsScreen
+import com.duckduckgo.autofill.api.AutofillSettingsLaunchSource
 import com.duckduckgo.autofill.api.CredentialSavePickerDialog
 import com.duckduckgo.autofill.impl.AutofillFireproofDialogSuppressor
+import com.duckduckgo.autofill.impl.R
 import com.duckduckgo.autofill.impl.R.string
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames
 import com.duckduckgo.autofill.impl.store.InternalAutofillStore
 import com.duckduckgo.autofill.impl.ui.credential.saving.declines.AutofillDeclineCounter
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.navigation.api.GlobalActivityStarter
+import com.google.android.material.snackbar.Snackbar
+import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
@@ -42,11 +50,7 @@ import timber.log.Timber
 @ContributesMultibinding(AppScope::class)
 class ResultHandlerPromptToDisableCredentialSaving @Inject constructor(
     private val autofillFireproofDialogSuppressor: AutofillFireproofDialogSuppressor,
-    private val pixel: Pixel,
-    private val dispatchers: DispatcherProvider,
-    private val declineCounter: AutofillDeclineCounter,
-    private val autofillStore: InternalAutofillStore,
-    @com.duckduckgo.app.di.AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val behavior: DisableAutofillPromptBehaviorFactory,
 ) : AutofillFragmentResultsPlugin {
 
     override fun processResult(
@@ -60,19 +64,88 @@ class ResultHandlerPromptToDisableCredentialSaving @Inject constructor(
 
         autofillFireproofDialogSuppressor.autofillSaveOrUpdateDialogVisibilityChanged(visible = false)
 
+        behavior.createBehavior(context, fragment, autofillCallback)?.showPrompt()
+    }
+
+    override fun resultKey(tabId: String): String {
+        return CredentialSavePickerDialog.resultKeyShouldPromptToDisableAutofill(tabId)
+    }
+}
+
+interface DisableAutofillPromptBehaviorFactory {
+    fun createBehavior(
+        context: Context,
+        fragment: Fragment,
+        autofillCallback: AutofillEventListener,
+    ): DisableAutofillPromptBehavior?
+}
+
+@ContributesBinding(AppScope::class)
+class BehaviorFactory @Inject constructor(
+    private val pixel: Pixel,
+    private val autofillFeature: AutofillFeature,
+    private val dispatchers: DispatcherProvider,
+    private val declineCounter: AutofillDeclineCounter,
+    private val autofillStore: InternalAutofillStore,
+    @com.duckduckgo.app.di.AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val globalActivityStarter: GlobalActivityStarter,
+) : DisableAutofillPromptBehaviorFactory {
+    override fun createBehavior(
+        context: Context,
+        fragment: Fragment,
+        autofillCallback: AutofillEventListener,
+    ): DisableAutofillPromptBehavior? {
+        return if (autofillFeature.showDisableDialogAutofillPrompt().isEnabled()) {
+            AskToDisableDialog(context, pixel, dispatchers, declineCounter, autofillStore, autofillCallback, appCoroutineScope)
+        } else {
+            val view: View = fragment.view ?: return null
+            DisableInSettingsSnackbar(context, pixel, view, globalActivityStarter)
+        }
+    }
+}
+
+interface DisableAutofillPromptBehavior {
+    fun showPrompt()
+}
+
+class DisableInSettingsSnackbar(
+    private val context: Context,
+    private val pixel: Pixel,
+    private val view: View,
+    private val globalActivityStarter: GlobalActivityStarter,
+) : DisableAutofillPromptBehavior {
+    override fun showPrompt() {
+        pixel.fire(AutofillPixelNames.AUTOFILL_DECLINE_PROMPT_TO_DISABLE_AUTOFILL_SNACKBAR_SHOWN)
+        Snackbar.make(view, R.string.autofillDisableInSettingsSnackbarText, Snackbar.LENGTH_LONG)
+            .setAction(R.string.autofillDisableInSettingsSnackbarAction) { _ ->
+                pixel.fire(AutofillPixelNames.AUTOFILL_DECLINE_PROMPT_TO_DISABLE_AUTOFILL_SNACKBAR_OPEN_SETTINGS)
+                globalActivityStarter.start(context, AutofillSettingsScreen(AutofillSettingsLaunchSource.DisableInSettingsPrompt))
+            }.show()
+    }
+}
+
+class AskToDisableDialog(
+    private val context: Context,
+    private val pixel: Pixel,
+    private val dispatchers: DispatcherProvider,
+    private val declineCounter: AutofillDeclineCounter,
+    private val autofillStore: InternalAutofillStore,
+    private val autofillCallback: AutofillEventListener,
+    private val appCoroutineScope: CoroutineScope,
+) : DisableAutofillPromptBehavior {
+
+    override fun showPrompt() {
         pixel.fire(AutofillPixelNames.AUTOFILL_DECLINE_PROMPT_TO_DISABLE_AUTOFILL_SHOWN)
 
-        appCoroutineScope.launch(dispatchers.main()) {
-            Builder(context)
-                .setTitle(context.getString(string.autofillDisableAutofillPromptTitle))
-                .setMessage(context.getString(string.autofillDisableAutofillPromptMessage))
-                .setPositiveButton(context.getString(string.autofillDisableAutofillPromptPositiveButton)) { _, _ -> onKeepUsingAutofill() }
-                .setNegativeButton(context.getString(string.autofillDisableAutofillPromptNegativeButton)) { _, _ ->
-                    onDisableAutofill(autofillCallback)
-                }
-                .setOnCancelListener { onCancelledPromptToDisableAutofill() }
-                .show()
-        }
+        Builder(context)
+            .setTitle(context.getString(string.autofillDisableAutofillPromptTitle))
+            .setMessage(context.getString(string.autofillDisableAutofillPromptMessage))
+            .setPositiveButton(context.getString(string.autofillDisableAutofillPromptPositiveButton)) { _, _ -> onKeepUsingAutofill() }
+            .setNegativeButton(context.getString(string.autofillDisableAutofillPromptNegativeButton)) { _, _ ->
+                onDisableAutofill(autofillCallback)
+            }
+            .setOnCancelListener { onCancelledPromptToDisableAutofill() }
+            .show()
     }
 
     private fun onCancelledPromptToDisableAutofill() {
@@ -101,9 +174,5 @@ class ResultHandlerPromptToDisableCredentialSaving @Inject constructor(
             Timber.i("Autofill disabled at user request")
         }
         pixel.fire(AutofillPixelNames.AUTOFILL_DECLINE_PROMPT_TO_DISABLE_AUTOFILL_DISABLE)
-    }
-
-    override fun resultKey(tabId: String): String {
-        return CredentialSavePickerDialog.resultKeyShouldPromptToDisableAutofill(tabId)
     }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/saving/declines/AutofillDeclineStore.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/saving/declines/AutofillDeclineStore.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.ui.credential.saving.declines
+
+interface AutofillDeclineStore {
+    /**
+     * Whether to monitor autofill decline counts or not
+     * Used to determine whether we should actively detect when a user new to autofill doesn't appear to want it enabled
+     */
+    var monitorDeclineCounts: Boolean
+
+    /**
+     * A count of the number of autofill declines the user has made, persisted across all sessions.
+     * Used to determine whether we should prompt a user new to autofill to disable it if they don't appear to want it enabled
+     */
+    var autofillDeclineCount: Int
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/saving/declines/DisablePromptCredentialsObserver.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/saving/declines/DisablePromptCredentialsObserver.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.ui.credential.saving.declines
+
+import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.autofill.impl.store.InternalAutofillStore
+import com.duckduckgo.common.utils.ConflatedJob
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = MainProcessLifecycleObserver::class,
+)
+class DisablePromptCredentialsObserver @Inject constructor(
+    private val internalAutofillStore: InternalAutofillStore,
+    private val autofillDeclineCounter: AutofillDeclineCounter,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val dispatchers: DispatcherProvider,
+) : MainProcessLifecycleObserver {
+
+    private val observerJob = ConflatedJob()
+
+    override fun onCreate(owner: LifecycleOwner) {
+        appCoroutineScope.launch(dispatchers.io()) {
+            if (autofillDeclineCounter.isDeclineCounterActive()) {
+                observerJob += internalAutofillStore.getCredentialCount().onEach { credentialsCount ->
+                    if (credentialsCount > 0) {
+                        autofillDeclineCounter.disableDeclineCounter()
+                        observerJob.cancel()
+                    }
+                }.flowOn(dispatchers.io()).launchIn(appCoroutineScope)
+            }
+        }
+    }
+}

--- a/autofill/autofill-impl/src/main/res/values/donottranslate.xml
+++ b/autofill/autofill-impl/src/main/res/values/donottranslate.xml
@@ -27,4 +27,6 @@
     <string name="onboardingSaveDialogFeature3Title">Sync between devices</string>
     <string name="onboardingSaveDialogFeature3Subtitle">End-to-end encrypted and easy to set up when you’re ready.</string>
 
+    <string name="autofillDisableInSettingsSnackbarText">You can turn off password saving anytime.</string>
+    <string name="autofillDisableInSettingsSnackbarAction">Open Settings</string>
 </resources>

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModelTest.kt
@@ -22,8 +22,10 @@ import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelName
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
+import com.duckduckgo.autofill.api.AutofillSettingsLaunchSource
 import com.duckduckgo.autofill.api.AutofillSettingsLaunchSource.BrowserOverflow
 import com.duckduckgo.autofill.api.AutofillSettingsLaunchSource.BrowserSnackbar
+import com.duckduckgo.autofill.api.AutofillSettingsLaunchSource.DisableInSettingsPrompt
 import com.duckduckgo.autofill.api.AutofillSettingsLaunchSource.SettingsActivity
 import com.duckduckgo.autofill.api.AutofillSettingsLaunchSource.Sync
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
@@ -166,7 +168,7 @@ class AutofillSettingsViewModelTest {
 
     @Test
     fun whenUserDisablesAutofillThenViewStateUpdatedToReflectChange() = runTest {
-        testee.onDisableAutofill()
+        testee.onDisableAutofill(aAutofillSettingsLaunchSource())
         testee.viewState.test {
             assertFalse(this.awaitItem().autofillEnabled)
             cancelAndIgnoreRemainingEvents()
@@ -181,8 +183,8 @@ class AutofillSettingsViewModelTest {
 
     @Test
     fun whenUserDisablesAutofillThenCorrectPixelFired() {
-        testee.onDisableAutofill()
-        verify(pixel).fire(AUTOFILL_ENABLE_AUTOFILL_TOGGLE_MANUALLY_DISABLED)
+        testee.onDisableAutofill(aAutofillSettingsLaunchSource())
+        verify(pixel).fire(eq(AUTOFILL_ENABLE_AUTOFILL_TOGGLE_MANUALLY_DISABLED), any(), any(), eq(COUNT))
     }
 
     @Test
@@ -709,6 +711,12 @@ class AutofillSettingsViewModelTest {
     }
 
     @Test
+    fun whenScreenLaunchedFromDisablePromptThenCorrectLaunchPixelSent() {
+        testee.sendLaunchPixel(DisableInSettingsPrompt)
+        verify(pixel).fire(eq(AUTOFILL_MANAGEMENT_SCREEN_OPENED), any(), any(), eq(COUNT))
+    }
+
+    @Test
     fun whenScreenLaunchedFromSettingsActivityThenCorrectLaunchPixelSent() {
         testee.sendLaunchPixel(SettingsActivity)
         verify(pixel).fire(eq(AUTOFILL_MANAGEMENT_SCREEN_OPENED), any(), any(), eq(COUNT))
@@ -1003,6 +1011,10 @@ class AutofillSettingsViewModelTest {
 
     private fun Command.assertCommandType(expectedType: KClass<out Command>) {
         assertTrue(String.format("Unexpected command type: %s", this::class.simpleName), this::class == expectedType)
+    }
+
+    private fun aAutofillSettingsLaunchSource(): AutofillSettingsLaunchSource {
+        return AutofillSettingsLaunchSource.entries.random()
     }
 }
 

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/saving/AskToDisableDialogTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/saving/AskToDisableDialogTest.kt
@@ -1,0 +1,66 @@
+package com.duckduckgo.autofill.impl.ui.credential.saving
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.autofill.api.AutofillEventListener
+import com.duckduckgo.autofill.impl.store.InternalAutofillStore
+import com.duckduckgo.autofill.impl.ui.credential.saving.declines.AutofillDeclineCounter
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.DispatcherProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+@RunWith(AndroidJUnit4::class)
+class AskToDisableDialogTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+
+    private val pixel: Pixel = mock()
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+    private val dispatchers: DispatcherProvider = coroutineTestRule.testDispatcherProvider
+    private val declineCounter: AutofillDeclineCounter = mock()
+    private val autofillStore: InternalAutofillStore = mock()
+    private val appCoroutineScope: CoroutineScope = coroutineTestRule.testScope
+    private val callback: AutofillEventListener = mock()
+
+    private val testee = AskToDisableDialog(
+        pixel = pixel,
+        dispatchers = dispatchers,
+        declineCounter = declineCounter,
+        autofillStore = autofillStore,
+        autofillCallback = callback,
+        appCoroutineScope = appCoroutineScope,
+        context = context,
+    )
+
+    @Test
+    fun whenUserChoosesToDisableAutofillThenStoreUpdatedToFalse() {
+        testee.onDisableAutofill(callback)
+        verify(autofillStore).autofillEnabled = false
+    }
+
+    @Test
+    fun whenUserChoosesToDisableAutofillThenDeclineCounterDisabled() = runTest {
+        testee.onDisableAutofill(callback)
+        verify(declineCounter).disableDeclineCounter()
+    }
+
+    @Test
+    fun whenUserChoosesToDisableAutofillThenPageRefreshRequested() = runTest {
+        testee.onDisableAutofill(callback)
+        verify(callback).onAutofillStateChange()
+    }
+
+    @Test
+    fun whenUserChoosesToKeepUsingAutofillThenDeclineCounterDisabled() = runTest {
+        testee.onKeepUsingAutofill()
+        verify(declineCounter).disableDeclineCounter()
+    }
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/saving/AutofillSavingCredentialsViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/saving/AutofillSavingCredentialsViewModelTest.kt
@@ -16,15 +16,20 @@
 
 package com.duckduckgo.autofill.impl.ui.credential.saving
 
+import app.cash.turbine.test
 import com.duckduckgo.autofill.impl.store.InternalAutofillStore
 import com.duckduckgo.autofill.impl.store.NeverSavedSiteRepository
+import com.duckduckgo.autofill.impl.ui.credential.saving.declines.AutofillDeclineCounter
 import com.duckduckgo.common.test.CoroutineTestRule
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 class AutofillSavingCredentialsViewModelTest {
 
@@ -33,22 +38,63 @@ class AutofillSavingCredentialsViewModelTest {
 
     private val mockStore: InternalAutofillStore = mock()
     private val neverSavedSiteRepository: NeverSavedSiteRepository = mock()
-    private val testee = AutofillSavingCredentialsViewModel(
-        neverSavedSiteRepository = neverSavedSiteRepository,
-        dispatchers = coroutineTestRule.testDispatcherProvider,
-        autofillStore = mockStore,
-    )
+    private val autofillDeclineCounter: AutofillDeclineCounter = mock<AutofillDeclineCounter>()
+
+    private lateinit var testee: AutofillSavingCredentialsViewModel
+
+    @Test
+    fun whenUserDeclineCounterActiveAndCounterLessThanTwoThenExpandedDialogShown() = runTest {
+        initialiseWithValues(declineCount = 1, isDeclineCounterActive = true)
+        testee.viewState.test {
+            testee.userPromptedToSaveCredentials()
+            val viewState = awaitItem()
+            assertTrue(viewState.expandedDialog)
+        }
+    }
+
+    @Test
+    fun whenUserDeclineCounterNotActiveThenDoNotShownExpandedVersion() = runTest {
+        initialiseWithValues(declineCount = 1, isDeclineCounterActive = false)
+        testee.viewState.test {
+            testee.userPromptedToSaveCredentials()
+            val viewState = awaitItem()
+            assertFalse(viewState.expandedDialog)
+        }
+    }
+
+    @Test
+    fun whenCounterAboveThresholdThenDoNotShownExpandedVersion() = runTest {
+        initialiseWithValues(declineCount = 3, isDeclineCounterActive = true)
+        testee.viewState.test {
+            testee.userPromptedToSaveCredentials()
+            val viewState = awaitItem()
+            assertFalse(viewState.expandedDialog)
+        }
+    }
 
     @Test
     fun whenUserPromptedToSaveThenFlagSet() = runTest {
+        initialiseWithValues(declineCount = 1, isDeclineCounterActive = true)
         testee.userPromptedToSaveCredentials()
         verify(mockStore).hasEverBeenPromptedToSaveLogin = true
     }
 
     @Test
     fun whenUserSpecifiesNeverToSaveCurrentSiteThenSitePersisted() = runTest {
+        initialiseWithValues(declineCount = 1, isDeclineCounterActive = true)
         val url = "https://example.com"
         testee.addSiteToNeverSaveList(url)
         verify(neverSavedSiteRepository).addToNeverSaveList(eq(url))
+    }
+
+    private suspend fun initialiseWithValues(declineCount: Int, isDeclineCounterActive: Boolean) {
+        whenever(autofillDeclineCounter.declineCount()).thenReturn(declineCount)
+        whenever(autofillDeclineCounter.isDeclineCounterActive()).thenReturn(isDeclineCounterActive)
+        testee = AutofillSavingCredentialsViewModel(
+            neverSavedSiteRepository = neverSavedSiteRepository,
+            dispatchers = coroutineTestRule.testDispatcherProvider,
+            autofillStore = mockStore,
+            autofillDeclineCounter = autofillDeclineCounter,
+        )
     }
 }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/saving/DisableInSettingsSnackbarTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/saving/DisableInSettingsSnackbarTest.kt
@@ -1,0 +1,55 @@
+package com.duckduckgo.autofill.impl.ui.credential.saving
+
+import android.content.Context
+import android.view.View
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.autofill.api.TestActivity
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.navigation.api.GlobalActivityStarter
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+@RunWith(AndroidJUnit4::class)
+class DisableInSettingsSnackbarTest {
+
+    @get:Rule
+    val activityRule = ActivityScenarioRule(TestActivity::class.java)
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+
+    private val pixel: Pixel = mock()
+    private val globalActivityStarter: GlobalActivityStarter = mock()
+
+    private lateinit var context: Context
+    private lateinit var view: View
+    private lateinit var testee: DisableInSettingsSnackbar
+
+    @Before
+    fun setUp() {
+        activityRule.scenario.onActivity { activity ->
+            context = activity
+            view = activity.findViewById(android.R.id.content)
+            testee = DisableInSettingsSnackbar(
+                pixel = pixel,
+                globalActivityStarter = globalActivityStarter,
+                context = context,
+                view = view,
+            )
+        }
+    }
+
+    @Test
+    fun whenShowPromptThenFireShownPixel() {
+        testee.showPrompt()
+        verify(pixel).fire(AutofillPixelNames.AUTOFILL_DECLINE_PROMPT_TO_DISABLE_AUTOFILL_SNACKBAR_SHOWN)
+    }
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/feature/toggles/api/toggle/AutofillTestFeature.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/feature/toggles/api/toggle/AutofillTestFeature.kt
@@ -29,6 +29,7 @@ class AutofillTestFeature : AutofillFeature {
     var onByDefault: Boolean = false
     var canIntegrateWithWebView: Boolean = false
     var onForExistingUsers: Boolean = false
+    var showDisableDialogAutofillPrompt: Boolean = false
 
     override fun self(): Toggle = TestToggle(topLevelFeatureEnabled)
     override fun canInjectCredentials(): Toggle = TestToggle(canInjectCredentials)
@@ -38,6 +39,7 @@ class AutofillTestFeature : AutofillFeature {
     override fun canAccessCredentialManagement(): Toggle = TestToggle(canAccessCredentialManagement)
     override fun onByDefault(): Toggle = TestToggle(onByDefault)
     override fun onForExistingUsers(): Toggle = TestToggle(onForExistingUsers)
+    override fun showDisableDialogAutofillPrompt(): Toggle = TestToggle(showDisableDialogAutofillPrompt)
 }
 
 class AutofillReportBreakageTestFeature : AutofillSiteBreakageReportingFeature {

--- a/autofill/autofill-internal/build.gradle
+++ b/autofill/autofill-internal/build.gradle
@@ -32,6 +32,7 @@ android {
 dependencies {
     implementation project(path: ':autofill-api')
     implementation project(':autofill-impl')
+    implementation project(':autofill-store')
     implementation project(':internal-features-api')
     implementation project(path: ':browser-api')
     implementation project(path: ':navigation-api')

--- a/autofill/autofill-internal/src/main/java/com/duckduckgo/autofill/internal/AutofillInternalSettingsActivity.kt
+++ b/autofill/autofill-internal/src/main/java/com/duckduckgo/autofill/internal/AutofillInternalSettingsActivity.kt
@@ -38,6 +38,7 @@ import com.duckduckgo.autofill.impl.store.InternalAutofillStore
 import com.duckduckgo.autofill.impl.store.NeverSavedSiteRepository
 import com.duckduckgo.autofill.impl.ui.credential.management.survey.AutofillSurveyStore
 import com.duckduckgo.autofill.internal.databinding.ActivityAutofillInternalSettingsBinding
+import com.duckduckgo.autofill.store.AutofillPrefsStore
 import com.duckduckgo.browser.api.UserBrowserProperties
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.view.dialog.RadioListAlertDialogBuilder
@@ -73,6 +74,9 @@ class AutofillInternalSettingsActivity : DuckDuckGoActivity() {
 
     @Inject
     lateinit var autofillStore: InternalAutofillStore
+
+    @Inject
+    lateinit var autofillPrefsStore: AutofillPrefsStore
 
     private val dateFormatter = SimpleDateFormat.getDateTimeInstance(SimpleDateFormat.MEDIUM, SimpleDateFormat.MEDIUM)
 
@@ -161,6 +165,7 @@ class AutofillInternalSettingsActivity : DuckDuckGoActivity() {
         configureSurveyEventHandlers()
         configureEngagementEventHandlers()
         configureReportBreakagesHandlers()
+        configureDeclineCounterHandlers()
     }
 
     private fun configureReportBreakagesHandlers() {
@@ -190,6 +195,15 @@ class AutofillInternalSettingsActivity : DuckDuckGoActivity() {
                 autofillSurveyStore.resetPreviousSurveys()
             }
             Toast.makeText(this, getString(R.string.autofillDevSettingsSurveySectionResetted), Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun configureDeclineCounterHandlers() {
+        binding.autofillDeclineCounterResetButton.setOnClickListener {
+            lifecycleScope.launch(dispatchers.io()) {
+                autofillPrefsStore.resetAllValues()
+            }
+            Toast.makeText(this, getString(R.string.autofillDevSettingsDeclineCounterResetted), Toast.LENGTH_SHORT).show()
         }
     }
 

--- a/autofill/autofill-internal/src/main/res/layout/activity_autofill_internal_settings.xml
+++ b/autofill/autofill-internal/src/main/res/layout/activity_autofill_internal_settings.xml
@@ -272,6 +272,16 @@
             app:primaryText="@string/autofillDevSettingsSurveySectionResetPreviousSurveysTitle"
             app:secondaryText="@string/autofillDevSettingsSurveySectionInstruction" />
 
+        <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+            android:id="@+id/autofillDeclineCounterResetButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:primaryText="@string/autofillDevSettingsDeclineCounterResetTitle"
+            app:secondaryText="@string/autofillDevSettingsDeclineCounterResetInstruction" />
 
     </LinearLayout>
 </androidx.core.widget.NestedScrollView>

--- a/autofill/autofill-internal/src/main/res/values/donottranslate.xml
+++ b/autofill/autofill-internal/src/main/res/values/donottranslate.xml
@@ -78,6 +78,9 @@
 
     <string name="autofillDevSettingsSurveySectionTitle">Autofill Survey</string>
     <string name="autofillDevSettingsSurveySectionResetPreviousSurveysTitle">Previously Seen Surveys</string>
+    <string name="autofillDevSettingsDeclineCounterResetTitle">Decline counters</string>
+    <string name="autofillDevSettingsDeclineCounterResetInstruction">Tap to reset decline counter</string>
     <string name="autofillDevSettingsSurveySectionInstruction">Tap to reset available surveys</string>
     <string name="autofillDevSettingsSurveySectionResetted">Previously seen surveys available again</string>
+    <string name="autofillDevSettingsDeclineCounterResetted">Decline counter is 0 and now active. Restart the app.</string>
 </resources>

--- a/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/AutofillPrefsStore.kt
+++ b/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/AutofillPrefsStore.kt
@@ -27,6 +27,7 @@ interface AutofillPrefsStore {
     var autofillDeclineCount: Int
     var monitorDeclineCounts: Boolean
     var hasEverBeenPromptedToSaveLogin: Boolean
+    val autofillStateSetByUser: Boolean
 
     /**
      * Returns if Autofill was enabled by default.
@@ -35,6 +36,12 @@ interface AutofillPrefsStore {
      * which is separate from its current state.
      */
     fun wasDefaultStateEnabled(): Boolean
+
+    /**
+     * Resets all values to their default state
+     * Only for internal use
+     */
+    fun resetAllValues()
 }
 
 class RealAutofillPrefsStore(
@@ -71,6 +78,9 @@ class RealAutofillPrefsStore(
         get() = prefs.getBoolean(HAS_EVER_BEEN_PROMPTED_TO_SAVE_LOGIN, false)
         set(value) = prefs.edit { putBoolean(HAS_EVER_BEEN_PROMPTED_TO_SAVE_LOGIN, value) }
 
+    override val autofillStateSetByUser: Boolean
+        get() = autofillStateSetByUser()
+
     /**
      * Returns if Autofill was enabled by default. Note, this is not necessarily the same as the current state of Autofill.
      */
@@ -105,6 +115,15 @@ class RealAutofillPrefsStore(
     override var monitorDeclineCounts: Boolean
         get() = prefs.getBoolean(MONITOR_AUTOFILL_DECLINES, true)
         set(value) = prefs.edit { putBoolean(MONITOR_AUTOFILL_DECLINES, value) }
+
+    override fun resetAllValues() {
+        prefs.edit {
+            remove(HAS_EVER_BEEN_PROMPTED_TO_SAVE_LOGIN)
+            remove(AUTOFILL_DECLINE_COUNT)
+            remove(MONITOR_AUTOFILL_DECLINES)
+            remove(ORIGINAL_AUTOFILL_DEFAULT_STATE_ENABLED)
+        }
+    }
 
     companion object {
         const val FILENAME = "com.duckduckgo.autofill.store.autofill_store"

--- a/autofill/autofill-test/src/main/AndroidManifest.xml
+++ b/autofill/autofill-test/src/main/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <activity
+            android:name="com.duckduckgo.autofill.api.TestActivity"
+            android:exported="false"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
+    </application>
+</manifest>

--- a/autofill/autofill-test/src/main/java/com/duckduckgo/autofill/api/TestActivity.kt
+++ b/autofill/autofill-test/src/main/java/com/duckduckgo/autofill/api/TestActivity.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.api
+
+import android.os.Bundle
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+
+class TestActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(View(this)) // Set a simple view as the content
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414730916066338/1207895626594373/f 

### Description
Updates logic to show snackbar instead of Dialog after user dismisses twice our save dialog.

### Steps to test this PR

_Feature 1_
- [ ] install The app
- [ ] Login on 2 different sites
- [ ] Always dismiss the save dialog
- [ ] Ensure on the second site, the snackbar is shown (and `autofill_logins_save_disable_snackbar_shown`)
- [ ] click on Open settings in the snackbar (and `autofill_logins_save_disable_snackbar_open_settings`)
- [ ] ensure it takes you to autofill screen
- [ ] Disable autofill now, and ensure pixel `m_autofill_logins_settings_disabled` includes `disable_prompt` as source

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
