### PR TITLE
Autofill: update logic to decide if user is onboarded

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/SecureStoreBackedAutofillStore.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/SecureStoreBackedAutofillStore.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.autofill.impl.securestorage.SecureStorage
 import com.duckduckgo.autofill.impl.securestorage.WebsiteLoginDetails
 import com.duckduckgo.autofill.impl.securestorage.WebsiteLoginDetailsWithCredentials
 import com.duckduckgo.autofill.impl.store.InternalAutofillStore
+import com.duckduckgo.autofill.impl.ui.credential.saving.declines.AutofillDeclineStore
 import com.duckduckgo.autofill.impl.urlmatcher.AutofillUrlMatcher
 import com.duckduckgo.autofill.store.AutofillPrefsStore
 import com.duckduckgo.autofill.store.LastUpdatedTimeProvider
@@ -44,7 +45,8 @@ import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 @SingleInstanceIn(AppScope::class)
-@ContributesBinding(AppScope::class)
+@ContributesBinding(AppScope::class, AutofillDeclineStore::class)
+@ContributesBinding(AppScope::class, InternalAutofillStore::class)
 class SecureStoreBackedAutofillStore @Inject constructor(
     private val secureStorage: SecureStorage,
     private val lastUpdatedTimeProvider: LastUpdatedTimeProvider,
@@ -53,7 +55,7 @@ class SecureStoreBackedAutofillStore @Inject constructor(
     private val autofillUrlMatcher: AutofillUrlMatcher,
     private val syncCredentialsListener: SyncCredentialsListener,
     passwordStoreEventListenersPlugins: PluginPoint<PasswordStoreEventListener>,
-) : InternalAutofillStore {
+) : InternalAutofillStore, AutofillDeclineStore {
 
     private val passwordStoreEventListeners = passwordStoreEventListenersPlugins.getPlugins()
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/store/InternalAutofillStore.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/store/InternalAutofillStore.kt
@@ -41,18 +41,6 @@ interface InternalAutofillStore : AutofillStore {
     var hasEverBeenPromptedToSaveLogin: Boolean
 
     /**
-     * Whether to monitor autofill decline counts or not
-     * Used to determine whether we should actively detect when a user new to autofill doesn't appear to want it enabled
-     */
-    var monitorDeclineCounts: Boolean
-
-    /**
-     * A count of the number of autofill declines the user has made, persisted across all sessions.
-     * Used to determine whether we should prompt a user new to autofill to disable it if they don't appear to want it enabled
-     */
-    var autofillDeclineCount: Int
-
-    /**
      * Find saved credential for the given id
      * @param id of the saved credential
      */

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/saving/AutofillSavingCredentialsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/saving/AutofillSavingCredentialsViewModel.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.autofill.impl.email.incontext.EmailProtectionInContextSignupViewModel.ViewState
 import com.duckduckgo.autofill.impl.store.InternalAutofillStore
 import com.duckduckgo.autofill.impl.store.NeverSavedSiteRepository
+import com.duckduckgo.autofill.impl.ui.credential.saving.declines.AutofillDeclineCounter
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.FragmentScope
 import javax.inject.Inject
@@ -36,13 +37,14 @@ class AutofillSavingCredentialsViewModel @Inject constructor(
     private val dispatchers: DispatcherProvider,
     private val neverSavedSiteRepository: NeverSavedSiteRepository,
     private val autofillStore: InternalAutofillStore,
+    private val autofillDeclineCounter: AutofillDeclineCounter,
 ) : ViewModel() {
 
     private val _viewState = MutableStateFlow(ViewState())
 
     init {
         viewModelScope.launch(dispatchers.io()) {
-            val shouldShowExpandedView = autofillStore.autofillDeclineCount < 2 && autofillStore.monitorDeclineCounts
+            val shouldShowExpandedView = autofillDeclineCounter.declineCount() < 2 && autofillDeclineCounter.isDeclineCounterActive()
             _viewState.value = ViewState(shouldShowExpandedView)
             Timber.d("Autofill: AutofillSavingCredentialsViewModel initialized")
         }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/saving/declines/AutofillDeclineStore.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/saving/declines/AutofillDeclineStore.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.ui.credential.saving.declines
+
+interface AutofillDeclineStore {
+    /**
+     * Whether to monitor autofill decline counts or not
+     * Used to determine whether we should actively detect when a user new to autofill doesn't appear to want it enabled
+     */
+    var monitorDeclineCounts: Boolean
+
+    /**
+     * A count of the number of autofill declines the user has made, persisted across all sessions.
+     * Used to determine whether we should prompt a user new to autofill to disable it if they don't appear to want it enabled
+     */
+    var autofillDeclineCount: Int
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/saving/declines/DisablePromptCredentialsObserver.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/saving/declines/DisablePromptCredentialsObserver.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.ui.credential.saving.declines
+
+import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.autofill.impl.store.InternalAutofillStore
+import com.duckduckgo.common.utils.ConflatedJob
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = MainProcessLifecycleObserver::class,
+)
+class DisablePromptCredentialsObserver @Inject constructor(
+    private val internalAutofillStore: InternalAutofillStore,
+    private val autofillDeclineCounter: AutofillDeclineCounter,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val dispatchers: DispatcherProvider,
+) : MainProcessLifecycleObserver {
+
+    private val observerJob = ConflatedJob()
+
+    override fun onCreate(owner: LifecycleOwner) {
+        appCoroutineScope.launch(dispatchers.io()) {
+            if (autofillDeclineCounter.isDeclineCounterActive()) {
+                observerJob += internalAutofillStore.getCredentialCount().onEach { credentialsCount ->
+                    if (credentialsCount > 0) {
+                        autofillDeclineCounter.disableDeclineCounter()
+                        observerJob.cancel()
+                    }
+                }.flowOn(dispatchers.io()).launchIn(appCoroutineScope)
+            }
+        }
+    }
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/saving/AutofillSavingCredentialsViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/saving/AutofillSavingCredentialsViewModelTest.kt
@@ -16,15 +16,20 @@
 
 package com.duckduckgo.autofill.impl.ui.credential.saving
 
+import app.cash.turbine.test
 import com.duckduckgo.autofill.impl.store.InternalAutofillStore
 import com.duckduckgo.autofill.impl.store.NeverSavedSiteRepository
+import com.duckduckgo.autofill.impl.ui.credential.saving.declines.AutofillDeclineCounter
 import com.duckduckgo.common.test.CoroutineTestRule
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 class AutofillSavingCredentialsViewModelTest {
 
@@ -33,22 +38,63 @@ class AutofillSavingCredentialsViewModelTest {
 
     private val mockStore: InternalAutofillStore = mock()
     private val neverSavedSiteRepository: NeverSavedSiteRepository = mock()
-    private val testee = AutofillSavingCredentialsViewModel(
-        neverSavedSiteRepository = neverSavedSiteRepository,
-        dispatchers = coroutineTestRule.testDispatcherProvider,
-        autofillStore = mockStore,
-    )
+    private val autofillDeclineCounter: AutofillDeclineCounter = mock<AutofillDeclineCounter>()
+
+    private lateinit var testee: AutofillSavingCredentialsViewModel
+
+    @Test
+    fun whenUserDeclineCounterActiveAndCounterLessThanTwoThenExpandedDialogShown() = runTest {
+        initialiseWithValues(declineCount = 1, isDeclineCounterActive = true)
+        testee.viewState.test {
+            testee.userPromptedToSaveCredentials()
+            val viewState = awaitItem()
+            assertTrue(viewState.expandedDialog)
+        }
+    }
+
+    @Test
+    fun whenUserDeclineCounterNotActiveThenDoNotShownExpandedVersion() = runTest {
+        initialiseWithValues(declineCount = 1, isDeclineCounterActive = false)
+        testee.viewState.test {
+            testee.userPromptedToSaveCredentials()
+            val viewState = awaitItem()
+            assertFalse(viewState.expandedDialog)
+        }
+    }
+
+    @Test
+    fun whenCounterAboveThresholdThenDoNotShownExpandedVersion() = runTest {
+        initialiseWithValues(declineCount = 3, isDeclineCounterActive = true)
+        testee.viewState.test {
+            testee.userPromptedToSaveCredentials()
+            val viewState = awaitItem()
+            assertFalse(viewState.expandedDialog)
+        }
+    }
 
     @Test
     fun whenUserPromptedToSaveThenFlagSet() = runTest {
+        initialiseWithValues(declineCount = 1, isDeclineCounterActive = true)
         testee.userPromptedToSaveCredentials()
         verify(mockStore).hasEverBeenPromptedToSaveLogin = true
     }
 
     @Test
     fun whenUserSpecifiesNeverToSaveCurrentSiteThenSitePersisted() = runTest {
+        initialiseWithValues(declineCount = 1, isDeclineCounterActive = true)
         val url = "https://example.com"
         testee.addSiteToNeverSaveList(url)
         verify(neverSavedSiteRepository).addToNeverSaveList(eq(url))
+    }
+
+    private suspend fun initialiseWithValues(declineCount: Int, isDeclineCounterActive: Boolean) {
+        whenever(autofillDeclineCounter.declineCount()).thenReturn(declineCount)
+        whenever(autofillDeclineCounter.isDeclineCounterActive()).thenReturn(isDeclineCounterActive)
+        testee = AutofillSavingCredentialsViewModel(
+            neverSavedSiteRepository = neverSavedSiteRepository,
+            dispatchers = coroutineTestRule.testDispatcherProvider,
+            autofillStore = mockStore,
+            autofillDeclineCounter = autofillDeclineCounter,
+        )
     }
 }

--- a/autofill/autofill-internal/build.gradle
+++ b/autofill/autofill-internal/build.gradle
@@ -32,6 +32,7 @@ android {
 dependencies {
     implementation project(path: ':autofill-api')
     implementation project(':autofill-impl')
+    implementation project(':autofill-store')
     implementation project(':internal-features-api')
     implementation project(path: ':browser-api')
     implementation project(path: ':navigation-api')

--- a/autofill/autofill-internal/src/main/java/com/duckduckgo/autofill/internal/AutofillInternalSettingsActivity.kt
+++ b/autofill/autofill-internal/src/main/java/com/duckduckgo/autofill/internal/AutofillInternalSettingsActivity.kt
@@ -38,6 +38,7 @@ import com.duckduckgo.autofill.impl.store.InternalAutofillStore
 import com.duckduckgo.autofill.impl.store.NeverSavedSiteRepository
 import com.duckduckgo.autofill.impl.ui.credential.management.survey.AutofillSurveyStore
 import com.duckduckgo.autofill.internal.databinding.ActivityAutofillInternalSettingsBinding
+import com.duckduckgo.autofill.store.AutofillPrefsStore
 import com.duckduckgo.browser.api.UserBrowserProperties
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.view.dialog.RadioListAlertDialogBuilder
@@ -73,6 +74,9 @@ class AutofillInternalSettingsActivity : DuckDuckGoActivity() {
 
     @Inject
     lateinit var autofillStore: InternalAutofillStore
+
+    @Inject
+    lateinit var autofillPrefsStore: AutofillPrefsStore
 
     private val dateFormatter = SimpleDateFormat.getDateTimeInstance(SimpleDateFormat.MEDIUM, SimpleDateFormat.MEDIUM)
 
@@ -161,6 +165,7 @@ class AutofillInternalSettingsActivity : DuckDuckGoActivity() {
         configureSurveyEventHandlers()
         configureEngagementEventHandlers()
         configureReportBreakagesHandlers()
+        configureDeclineCounterHandlers()
     }
 
     private fun configureReportBreakagesHandlers() {
@@ -190,6 +195,15 @@ class AutofillInternalSettingsActivity : DuckDuckGoActivity() {
                 autofillSurveyStore.resetPreviousSurveys()
             }
             Toast.makeText(this, getString(R.string.autofillDevSettingsSurveySectionResetted), Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun configureDeclineCounterHandlers() {
+        binding.autofillDeclineCounterResetButton.setOnClickListener {
+            lifecycleScope.launch(dispatchers.io()) {
+                autofillPrefsStore.resetAllValues()
+            }
+            Toast.makeText(this, getString(R.string.autofillDevSettingsDeclineCounterResetted), Toast.LENGTH_SHORT).show()
         }
     }
 

--- a/autofill/autofill-internal/src/main/res/layout/activity_autofill_internal_settings.xml
+++ b/autofill/autofill-internal/src/main/res/layout/activity_autofill_internal_settings.xml
@@ -272,6 +272,16 @@
             app:primaryText="@string/autofillDevSettingsSurveySectionResetPreviousSurveysTitle"
             app:secondaryText="@string/autofillDevSettingsSurveySectionInstruction" />
 
+        <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+            android:id="@+id/autofillDeclineCounterResetButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:primaryText="@string/autofillDevSettingsDeclineCounterResetTitle"
+            app:secondaryText="@string/autofillDevSettingsDeclineCounterResetInstruction" />
 
     </LinearLayout>
 </androidx.core.widget.NestedScrollView>

--- a/autofill/autofill-internal/src/main/res/values/donottranslate.xml
+++ b/autofill/autofill-internal/src/main/res/values/donottranslate.xml
@@ -78,6 +78,9 @@
 
     <string name="autofillDevSettingsSurveySectionTitle">Autofill Survey</string>
     <string name="autofillDevSettingsSurveySectionResetPreviousSurveysTitle">Previously Seen Surveys</string>
+    <string name="autofillDevSettingsDeclineCounterResetTitle">Decline counters</string>
+    <string name="autofillDevSettingsDeclineCounterResetInstruction">Tap to reset decline counter</string>
     <string name="autofillDevSettingsSurveySectionInstruction">Tap to reset available surveys</string>
     <string name="autofillDevSettingsSurveySectionResetted">Previously seen surveys available again</string>
+    <string name="autofillDevSettingsDeclineCounterResetted">Decline counter is 0 and now active. Restart the app.</string>
 </resources>

--- a/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/AutofillPrefsStore.kt
+++ b/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/AutofillPrefsStore.kt
@@ -27,6 +27,7 @@ interface AutofillPrefsStore {
     var autofillDeclineCount: Int
     var monitorDeclineCounts: Boolean
     var hasEverBeenPromptedToSaveLogin: Boolean
+    val autofillStateSetByUser: Boolean
 
     /**
      * Returns if Autofill was enabled by default.
@@ -70,6 +71,9 @@ class RealAutofillPrefsStore(
     override var hasEverBeenPromptedToSaveLogin: Boolean
         get() = prefs.getBoolean(HAS_EVER_BEEN_PROMPTED_TO_SAVE_LOGIN, false)
         set(value) = prefs.edit { putBoolean(HAS_EVER_BEEN_PROMPTED_TO_SAVE_LOGIN, value) }
+
+    override val autofillStateSetByUser: Boolean
+        get() = autofillStateSetByUser()
 
     /**
      * Returns if Autofill was enabled by default. Note, this is not necessarily the same as the current state of Autofill.

--- a/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/AutofillPrefsStore.kt
+++ b/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/AutofillPrefsStore.kt
@@ -36,6 +36,12 @@ interface AutofillPrefsStore {
      * which is separate from its current state.
      */
     fun wasDefaultStateEnabled(): Boolean
+
+    /**
+     * Resets all values to their default state
+     * Only for internal use
+     */
+    fun resetAllValues()
 }
 
 class RealAutofillPrefsStore(
@@ -109,6 +115,15 @@ class RealAutofillPrefsStore(
     override var monitorDeclineCounts: Boolean
         get() = prefs.getBoolean(MONITOR_AUTOFILL_DECLINES, true)
         set(value) = prefs.edit { putBoolean(MONITOR_AUTOFILL_DECLINES, value) }
+
+    override fun resetAllValues() {
+        prefs.edit {
+            remove(HAS_EVER_BEEN_PROMPTED_TO_SAVE_LOGIN)
+            remove(AUTOFILL_DECLINE_COUNT)
+            remove(MONITOR_AUTOFILL_DECLINES)
+            remove(ORIGINAL_AUTOFILL_DEFAULT_STATE_ENABLED)
+        }
+    }
 
     companion object {
         const val FILENAME = "com.duckduckgo.autofill.store.autofill_store"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414730916066338/1207943705873936/f 

### Description
Aligns logic with other platforms around when don't ask users about disabling autofill:
- if a password has been stored or user manually enabled autofill, then don't ask.

### Steps to test this PR

_Feature 1_
- [ ] Fresh install
- [ ] Perform any of the following actions (saving a password manually, enabling sync with another device with passwords, clicking on save on Save dialog when asked)
- [ ] ensure onboarding dialog is completed
- [ ] ensure dismissing twice the dialog prompt never asks user to disable autofill

_Feature 2_
- [ ] Fresh install
- [ ] Go into passwords and disable autofill, then enable it again
- [ ] Go to a site an login
- [ ] ensure save dialog shown but no onboarding
- [ ] ensure dismissing twice the dialog prompt never asks user to disable autofill

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
