### PR TITLE
Github Issue: [Bug] App hides itself when minimizing and sometimes even close

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -236,7 +236,6 @@
         <activity
             android:name="com.duckduckgo.app.dispatchers.IntentDispatcherActivity"
             android:theme="@style/Theme.AppCompat.Transparent.NoActionBar"
-            android:excludeFromRecents="true"
             android:exported="true">
 
             <!-- Allows app to become default browser -->


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1200581511062568/1207877791850324/f

### Description
Removed `excludeFromRecents` flag associated with `IntentDispatcherActivity`.

### Steps to test this PR
- [ ] Install from this branch.
- [ ] Open the app and make it the default browser.
- [ ] Open Google Discover and tap on a link.
- [ ] Tap on the overflow menu and choose to open in DuckDuckGo browser.
- [ ] Once you see the DuckDuckGo browser, tap on the Android Home button. The app should hide now.
- [ ] Tap on the Android Recent Apps button. Notice the DuckDuckGo app is there.

### NO UI changes
