### PR TITLE
Tab manager crash fix

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
@@ -174,7 +174,6 @@ class TabSwitcherAdapter(
         }
 
         glide.load(cachedWebViewPreview)
-            .placeholder(holder.tabPreview.drawable)
             .transition(DrawableTransitionOptions.withCrossFade())
             .into(holder.tabPreview)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202552961248957/1207940772480311/f

### Description

This PR removes the call to add a placeholder with the existing image drawable, which was causing a crash when scrolling.

### Steps to test this PR

- [ ] Go to tab manager
- [ ] Open 30-40 tabs
- [ ] Scroll up and down
- [ ] Notice that the app doesn’t crash anymore

