### PR TITLE
Fix flaky campaign test

### DIFF
--- a/app/src/test/java/com/duckduckgo/app/pixels/campaign/params/RealAdditionalPixelParamsGeneratorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/pixels/campaign/params/RealAdditionalPixelParamsGeneratorTest.kt
@@ -19,7 +19,6 @@ package com.duckduckgo.app.pixels.campaign.params
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -40,7 +39,7 @@ class RealAdditionalPixelParamsGeneratorTest {
     }
 
     @Test
-    fun whenPluginsAreAvailableThenGeneraterdParamsShouldBeRandomAndCorrectSize() = runTest {
+    fun whenPluginsAreAvailableThenGeneratedParamsShouldBeCorrectSize() = runTest {
         val plugins = MockPluginPoint(
             listOf(
                 object : AdditionalPixelParamPlugin {
@@ -73,11 +72,6 @@ class RealAdditionalPixelParamsGeneratorTest {
             ),
         )
         val generator = RealAdditionalPixelParamsGenerator(plugins)
-        val generatedValue1 = generator.generateAdditionalParams()
-        val generatedValue2 = generator.generateAdditionalParams()
-
-        assertEquals(6, generatedValue1.size)
-        assertEquals(6, generatedValue2.size)
-        assertNotEquals(generatedValue1, generatedValue2)
+        assertEquals(6, generator.generateAdditionalParams().size)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201462763415876/1207948877341495/f

### Description
The test before can fail at random since we can't guarantee that the 2 generated values will never be the same. We attempt to randomize but it is not worth investing in more complex logic to ensure randomness.

### Steps to test this PR
Unit tests pass
