### PR TITLE
NTP legacy view should respect orientation changes

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageView.kt
@@ -21,6 +21,7 @@ import android.app.PendingIntent
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
+import android.content.res.Configuration
 import android.text.Spanned
 import android.util.AttributeSet
 import android.view.View
@@ -126,6 +127,12 @@ class NewTabLegacyPageView @JvmOverloads constructor(
 
     private val viewModel: NewTabLegacyPageViewModel by lazy {
         ViewModelProvider(findViewTreeViewModelStoreOwner()!!, viewModelFactory)[NewTabLegacyPageViewModel::class.java]
+    }
+
+    // BrowserTabFragment overrides onConfigurationChange, so we have to do this too
+    override fun onConfigurationChanged(newConfig: Configuration?) {
+        super.onConfigurationChanged(newConfig)
+        configureQuickAccessGridLayout(binding.quickAccessRecyclerView)
     }
 
     override fun onAttachedToWindow() {

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/network/PrivacyConfigService.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/network/PrivacyConfigService.kt
@@ -18,13 +18,13 @@ package com.duckduckgo.privacy.config.impl.network
 
 import com.duckduckgo.anvil.annotations.ContributesServiceApi
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.privacy.config.api.PRIVACY_REMOTE_CONFIG_URL
 import com.duckduckgo.privacy.config.impl.models.JsonPrivacyConfig
 import retrofit2.Response
 import retrofit2.http.GET
 
 @ContributesServiceApi(AppScope::class)
 interface PrivacyConfigService {
-    @GET(PRIVACY_REMOTE_CONFIG_URL)
+    // @GET(PRIVACY_REMOTE_CONFIG_URL)
+    @GET("https://jsonblob.com/api/jsonBlob/1268216621771382784")
     suspend fun privacyConfig(): Response<JsonPrivacyConfig>
 }

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/network/PrivacyConfigService.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/network/PrivacyConfigService.kt
@@ -18,13 +18,13 @@ package com.duckduckgo.privacy.config.impl.network
 
 import com.duckduckgo.anvil.annotations.ContributesServiceApi
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.privacy.config.api.PRIVACY_REMOTE_CONFIG_URL
 import com.duckduckgo.privacy.config.impl.models.JsonPrivacyConfig
 import retrofit2.Response
 import retrofit2.http.GET
 
 @ContributesServiceApi(AppScope::class)
 interface PrivacyConfigService {
-    // @GET(PRIVACY_REMOTE_CONFIG_URL)
-    @GET("https://jsonblob.com/api/jsonBlob/1268216621771382784")
+    @GET(PRIVACY_REMOTE_CONFIG_URL)
     suspend fun privacyConfig(): Response<JsonPrivacyConfig>
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1114857721287938/1207910885306190

### Description
Fixes issue when navigating from landscape to portrait in the NTP legacy view

### Steps to test this PR

_From develop _
- [x] Start app in landscape, open New Tab
- [x] List shows 6 items per row
- [x] Rotate to portrait
- [x] List looks all over the place and icons can’t be read

_From this branch_
- [x] Start app in landscape, open New Tab
- [x] List shows 6 items per row
- [x] Rotate to portrait
- [x] List shows 4 items per row and looks right