### PR TITLE
Autofill: adds internal setting to reset decline counter

### DIFF
--- a/autofill/autofill-internal/build.gradle
+++ b/autofill/autofill-internal/build.gradle
@@ -32,6 +32,7 @@ android {
 dependencies {
     implementation project(path: ':autofill-api')
     implementation project(':autofill-impl')
+    implementation project(':autofill-store')
     implementation project(':internal-features-api')
     implementation project(path: ':browser-api')
     implementation project(path: ':navigation-api')

--- a/autofill/autofill-internal/src/main/java/com/duckduckgo/autofill/internal/AutofillInternalSettingsActivity.kt
+++ b/autofill/autofill-internal/src/main/java/com/duckduckgo/autofill/internal/AutofillInternalSettingsActivity.kt
@@ -38,6 +38,7 @@ import com.duckduckgo.autofill.impl.store.InternalAutofillStore
 import com.duckduckgo.autofill.impl.store.NeverSavedSiteRepository
 import com.duckduckgo.autofill.impl.ui.credential.management.survey.AutofillSurveyStore
 import com.duckduckgo.autofill.internal.databinding.ActivityAutofillInternalSettingsBinding
+import com.duckduckgo.autofill.store.AutofillPrefsStore
 import com.duckduckgo.browser.api.UserBrowserProperties
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.view.dialog.RadioListAlertDialogBuilder
@@ -73,6 +74,9 @@ class AutofillInternalSettingsActivity : DuckDuckGoActivity() {
 
     @Inject
     lateinit var autofillStore: InternalAutofillStore
+
+    @Inject
+    lateinit var autofillPrefsStore: AutofillPrefsStore
 
     private val dateFormatter = SimpleDateFormat.getDateTimeInstance(SimpleDateFormat.MEDIUM, SimpleDateFormat.MEDIUM)
 
@@ -161,6 +165,7 @@ class AutofillInternalSettingsActivity : DuckDuckGoActivity() {
         configureSurveyEventHandlers()
         configureEngagementEventHandlers()
         configureReportBreakagesHandlers()
+        configureDeclineCounterHandlers()
     }
 
     private fun configureReportBreakagesHandlers() {
@@ -190,6 +195,15 @@ class AutofillInternalSettingsActivity : DuckDuckGoActivity() {
                 autofillSurveyStore.resetPreviousSurveys()
             }
             Toast.makeText(this, getString(R.string.autofillDevSettingsSurveySectionResetted), Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun configureDeclineCounterHandlers() {
+        binding.autofillDeclineCounterResetButton.setOnClickListener {
+            lifecycleScope.launch(dispatchers.io()) {
+                autofillPrefsStore.resetAllValues()
+            }
+            Toast.makeText(this, getString(R.string.autofillDevSettingsDeclineCounterResetted), Toast.LENGTH_SHORT).show()
         }
     }
 

--- a/autofill/autofill-internal/src/main/res/layout/activity_autofill_internal_settings.xml
+++ b/autofill/autofill-internal/src/main/res/layout/activity_autofill_internal_settings.xml
@@ -272,6 +272,16 @@
             app:primaryText="@string/autofillDevSettingsSurveySectionResetPreviousSurveysTitle"
             app:secondaryText="@string/autofillDevSettingsSurveySectionInstruction" />
 
+        <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+            android:id="@+id/autofillDeclineCounterResetButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:primaryText="@string/autofillDevSettingsDeclineCounterResetTitle"
+            app:secondaryText="@string/autofillDevSettingsDeclineCounterResetInstruction" />
 
     </LinearLayout>
 </androidx.core.widget.NestedScrollView>

--- a/autofill/autofill-internal/src/main/res/values/donottranslate.xml
+++ b/autofill/autofill-internal/src/main/res/values/donottranslate.xml
@@ -78,6 +78,9 @@
 
     <string name="autofillDevSettingsSurveySectionTitle">Autofill Survey</string>
     <string name="autofillDevSettingsSurveySectionResetPreviousSurveysTitle">Previously Seen Surveys</string>
+    <string name="autofillDevSettingsDeclineCounterResetTitle">Decline counters</string>
+    <string name="autofillDevSettingsDeclineCounterResetInstruction">Tap to reset decline counter</string>
     <string name="autofillDevSettingsSurveySectionInstruction">Tap to reset available surveys</string>
     <string name="autofillDevSettingsSurveySectionResetted">Previously seen surveys available again</string>
+    <string name="autofillDevSettingsDeclineCounterResetted">Decline counter is 0 and now active. Restart the app.</string>
 </resources>

--- a/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/AutofillPrefsStore.kt
+++ b/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/AutofillPrefsStore.kt
@@ -36,6 +36,12 @@ interface AutofillPrefsStore {
      * which is separate from its current state.
      */
     fun wasDefaultStateEnabled(): Boolean
+
+    /**
+     * Resets all values to their default state
+     * Only for internal use
+     */
+    fun resetAllValues()
 }
 
 class RealAutofillPrefsStore(
@@ -109,6 +115,15 @@ class RealAutofillPrefsStore(
     override var monitorDeclineCounts: Boolean
         get() = prefs.getBoolean(MONITOR_AUTOFILL_DECLINES, true)
         set(value) = prefs.edit { putBoolean(MONITOR_AUTOFILL_DECLINES, value) }
+
+    override fun resetAllValues() {
+        prefs.edit {
+            remove(HAS_EVER_BEEN_PROMPTED_TO_SAVE_LOGIN)
+            remove(AUTOFILL_DECLINE_COUNT)
+            remove(MONITOR_AUTOFILL_DECLINES)
+            remove(ORIGINAL_AUTOFILL_DEFAULT_STATE_ENABLED)
+        }
+    }
 
     companion object {
         const val FILENAME = "com.duckduckgo.autofill.store.autofill_store"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1207954526931535/f 

### Description
Adds an internal setting to reset values used by counter decliner logic

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
