### PR TITLE
Fix buttons cut off in Dialog single choice landscape

### DIFF
--- a/common/common-ui/src/main/res/layout/dialog_single_choice_alert.xml
+++ b/common/common-ui/src/main/res/layout/dialog_single_choice_alert.xml
@@ -54,7 +54,9 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHeight_max="@dimen/dialogRadioGroupHeightMax"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/radioListDialogMessage">
+        app:layout_constraintTop_toBottomOf="@id/radioListDialogMessage"
+        app:layout_constraintBottom_toTopOf="@id/radioListDialogPositiveButton"
+        android:layout_marginBottom="@dimen/keyline_4">
 
         <RadioGroup
             android:id="@+id/radioListDialogRadioGroup"
@@ -67,42 +69,34 @@
         android:id="@+id/radioListDialogPositiveButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/keyline_4"
         android:text="Positive"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/radioListDialogContent"/>
+        app:layout_constraintEnd_toEndOf="parent"/>
 
     <com.duckduckgo.common.ui.view.button.DaxButtonDestructive
         android:id="@+id/radioListDialogDestructivePositiveButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/keyline_4"
         android:text="Positive"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/radioListDialogContent"/>
+        app:layout_constraintEnd_toEndOf="parent"/>
 
     <com.duckduckgo.common.ui.view.button.DaxButtonGhost
         android:id="@+id/radioListDialogNegativeButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/keyline_4"
         android:layout_marginEnd="@dimen/keyline_2"
         android:text="Cancel"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/radioListDialogPositiveButton"
-        app:layout_constraintTop_toBottomOf="@+id/radioListDialogContent"/>
+        app:layout_constraintEnd_toStartOf="@+id/radioListDialogPositiveButton"/>
 
     <com.duckduckgo.common.ui.view.button.DaxButtonGhost
         android:id="@+id/radioListDestructiveDialogNegativeButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/keyline_4"
         android:layout_marginEnd="@dimen/keyline_2"
         android:text="Cancel"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/radioListDialogDestructivePositiveButton"
-        app:layout_constraintTop_toBottomOf="@+id/radioListDialogContent"/>
+        app:layout_constraintEnd_toStartOf="@+id/radioListDialogDestructivePositiveButton"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205008441501016/1207953456660783/f 

### Description
Fix buttons cut off in Dialog single choice landscape. This was particularly noticeable in Duck Player, where the settings dialog had title and subtitle

### Steps to test this PR

_Feature 1_
- [ ] Smoke test single choice dialogs across the app

### UI changes
![dp_dialog](https://github.com/user-attachments/assets/cc9f3b6d-5127-412c-90e3-9b541739c7c7)
![fire](https://github.com/user-attachments/assets/09149642-aedd-41f9-aafc-3f4957a325ce)
