### PR TITLE
Reset cpm state on refresh

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -4402,6 +4402,21 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenOnPageChangeThenAutoconsentReset() {
+        updateUrl("http://www.example.com/", "http://twitter.com/explore", true)
+        testee.onAutoconsentResultReceived(consentManaged = true, optOutFailed = true, selfTestFailed = true, isCosmetic = true)
+        assertTrue(testee.siteLiveData.value?.consentManaged!!)
+        assertTrue(testee.siteLiveData.value?.consentOptOutFailed!!)
+        assertTrue(testee.siteLiveData.value?.consentSelfTestFailed!!)
+        assertTrue(testee.siteLiveData.value?.consentCosmeticHide!!)
+        testee.onWebViewRefreshed()
+        assertFalse(testee.siteLiveData.value?.consentManaged!!)
+        assertFalse(testee.siteLiveData.value?.consentOptOutFailed!!)
+        assertFalse(testee.siteLiveData.value?.consentSelfTestFailed!!)
+        assertFalse(testee.siteLiveData.value?.consentCosmeticHide!!)
+    }
+
+    @Test
     fun whenNotEditingUrlBarAndNotCancelledThenCanAutomaticallyShowAutofillPrompt() {
         configureOmnibarNotEditing()
         assertTrue(testee.canAutofillSelectCredentialsDialogCanAutomaticallyShow())

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1726,6 +1726,13 @@ class BrowserTabViewModel @Inject constructor(
         }
     }
 
+    private fun resetAutoConsent() {
+        site?.consentCosmeticHide = false
+        site?.consentManaged = false
+        site?.consentOptOutFailed = false
+        site?.consentSelfTestFailed = false
+    }
+
     override fun getSite(): Site? = site
 
     override fun onReceivedSslError(
@@ -2827,6 +2834,7 @@ class BrowserTabViewModel @Inject constructor(
 
     fun onWebViewRefreshed() {
         refreshBrowserError()
+        resetAutoConsent()
         accessibilityViewState.value = currentAccessibilityViewState().copy(refreshWebView = false)
         canAutofillSelectCredentialsDialogCanAutomaticallyShow = true
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1125189844152671/1207821290657757/f 

### Description
Reset cpm state when manually refreshing page

### Steps to test this PR

- [x]  Visit https://privacy-test-pages.site/features/autoconsent/
- [x]  Check CPM is working: The reject button should show the text "I was clicked!".
- [x]  Open the dashboard, check "Cookies Managed" is shown, then disable protections for the site.
- [x]  Reload the page. The button is not clicked.
- [x]  Re-open the dashboard - "Cookies Managed" is not shown.

