### PR TITLE
Add ATB initialized callback to ATB plugin, and rename for clarity

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldRetentionPixelSender.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldRetentionPixelSender.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.mobile.android.vpn.pixels
 
 import com.duckduckgo.app.di.AppCoroutineScope
-import com.duckduckgo.app.statistics.api.RefreshRetentionAtbPlugin
+import com.duckduckgo.app.statistics.api.AtbLifecyclePlugin
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.mobile.android.vpn.AppTpVpnFeature
@@ -33,7 +33,7 @@ class DeviceShieldRetentionPixelSender @Inject constructor(
     private val vpnFeaturesRegistry: VpnFeaturesRegistry,
     @AppCoroutineScope private val coroutineScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
-) : RefreshRetentionAtbPlugin {
+) : AtbLifecyclePlugin {
 
     override fun onSearchRetentionAtbRefreshed() {
         coroutineScope.launch(dispatcherProvider.io()) {

--- a/app/src/androidTest/java/com/duckduckgo/app/integration/AtbIntegrationTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/integration/AtbIntegrationTest.kt
@@ -19,7 +19,7 @@ package com.duckduckgo.app.integration
 import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.getDaggerComponent
-import com.duckduckgo.app.statistics.api.RefreshRetentionAtbPlugin
+import com.duckduckgo.app.statistics.api.AtbLifecyclePlugin
 import com.duckduckgo.app.statistics.api.StatisticsRequester
 import com.duckduckgo.app.statistics.api.StatisticsService
 import com.duckduckgo.app.statistics.model.Atb
@@ -68,8 +68,8 @@ class AtbIntegrationTest {
         whenever(mockVariantManager.getVariantKey()).thenReturn("ma")
         service = getDaggerComponent().retrofit().create(StatisticsService::class.java)
 
-        val plugins = object : PluginPoint<RefreshRetentionAtbPlugin> {
-            override fun getPlugins(): Collection<RefreshRetentionAtbPlugin> {
+        val plugins = object : PluginPoint<AtbLifecyclePlugin> {
+            override fun getPlugins(): Collection<AtbLifecyclePlugin> {
                 return listOf()
             }
         }

--- a/app/src/androidTest/java/com/duckduckgo/app/statistics/api/StatisticsRequesterJsonTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/statistics/api/StatisticsRequesterJsonTest.kt
@@ -74,8 +74,8 @@ class StatisticsRequesterJsonTest {
         statisticsStore = StatisticsSharedPreferences(InstrumentationRegistry.getInstrumentation().targetContext)
         statisticsStore.clearAtb()
 
-        val plugins = object : PluginPoint<RefreshRetentionAtbPlugin> {
-            override fun getPlugins(): Collection<RefreshRetentionAtbPlugin> {
+        val plugins = object : PluginPoint<AtbLifecyclePlugin> {
+            override fun getPlugins(): Collection<AtbLifecyclePlugin> {
                 return listOf()
             }
         }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/engagement/AutofillRefreshRetentionListener.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/engagement/AutofillRefreshRetentionListener.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.autofill.impl.engagement
 
 import com.duckduckgo.app.di.AppCoroutineScope
-import com.duckduckgo.app.statistics.api.RefreshRetentionAtbPlugin
+import com.duckduckgo.app.statistics.api.AtbLifecyclePlugin
 import com.duckduckgo.autofill.impl.engagement.store.AutofillEngagementRepository
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
@@ -31,7 +31,7 @@ class AutofillRefreshRetentionListener @Inject constructor(
     private val engagementRepository: AutofillEngagementRepository,
     @AppCoroutineScope private val coroutineScope: CoroutineScope,
     private val dispatchers: DispatcherProvider,
-) : RefreshRetentionAtbPlugin {
+) : AtbLifecyclePlugin {
 
     override fun onSearchRetentionAtbRefreshed() {
         coroutineScope.launch(dispatchers.io()) {

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/pixels/NetworkProtectionRetentionPixelSender.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/pixels/NetworkProtectionRetentionPixelSender.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.networkprotection.impl.pixels
 
 import com.duckduckgo.app.di.AppCoroutineScope
-import com.duckduckgo.app.statistics.api.RefreshRetentionAtbPlugin
+import com.duckduckgo.app.statistics.api.AtbLifecyclePlugin
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.networkprotection.api.NetworkProtectionState
@@ -32,7 +32,7 @@ class NetworkProtectionRetentionPixelSender @Inject constructor(
     private val networkProtectionPixels: NetworkProtectionPixels,
     @AppCoroutineScope private val coroutineScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
-) : RefreshRetentionAtbPlugin {
+) : AtbLifecyclePlugin {
 
     override fun onSearchRetentionAtbRefreshed() {
         coroutineScope.launch(dispatcherProvider.io()) {

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/api/AtbLifecyclePlugin.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/api/AtbLifecyclePlugin.kt
@@ -20,14 +20,25 @@ import com.duckduckgo.anvil.annotations.ContributesPluginPoint
 import com.duckduckgo.di.scopes.AppScope
 
 @ContributesPluginPoint(AppScope::class)
-interface RefreshRetentionAtbPlugin {
+interface AtbLifecyclePlugin {
     /**
      * Will be called right after we have refreshed the ATB retention on search
      */
-    fun onSearchRetentionAtbRefreshed()
+    fun onSearchRetentionAtbRefreshed() {
+        // default is no-op
+    }
 
     /**
      * Will be called right after we have refreshed the ATB retention on search
      */
-    fun onAppRetentionAtbRefreshed()
+    fun onAppRetentionAtbRefreshed() {
+        // default is no-op
+    }
+
+    /**
+     * Will be called right after the ATB is first initialized and successfully sent via exti call
+     */
+    fun onAppAtbInitialized() {
+        // default is no-op
+    }
 }

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/api/StatisticsRequester.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/api/StatisticsRequester.kt
@@ -43,7 +43,7 @@ class StatisticsRequester @Inject constructor(
     private val store: StatisticsDataStore,
     private val service: StatisticsService,
     private val variantManager: VariantManager,
-    private val plugins: PluginPoint<RefreshRetentionAtbPlugin>,
+    private val plugins: PluginPoint<AtbLifecyclePlugin>,
     private val emailManager: EmailManager,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val dispatchers: DispatcherProvider,
@@ -86,7 +86,10 @@ class StatisticsRequester @Inject constructor(
                 service.exti(atbWithVariant)
             }
             .subscribe(
-                { Timber.d("Atb initialization succeeded") },
+                {
+                    Timber.d("Atb initialization succeeded")
+                    plugins.getPlugins().forEach { it.onAppAtbInitialized() }
+                },
                 {
                     store.clearAtb()
                     Timber.w("Atb initialization failed ${it.localizedMessage}")

--- a/statistics/src/main/java/com/duckduckgo/app/statistics/pixels/FeatureRetentionPixelSender.kt
+++ b/statistics/src/main/java/com/duckduckgo/app/statistics/pixels/FeatureRetentionPixelSender.kt
@@ -20,8 +20,8 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.statistics.api.AtbLifecyclePlugin
 import com.duckduckgo.app.statistics.api.BrowserFeatureStateReporterPlugin
-import com.duckduckgo.app.statistics.api.RefreshRetentionAtbPlugin
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.LOCALE
 import com.duckduckgo.app.statistics.pixels.Pixel.StatisticsPixelName
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
@@ -45,7 +45,7 @@ class FeatureRetentionPixelSender @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
     private val plugins: PluginPoint<BrowserFeatureStateReporterPlugin>,
     private val appBuildConfig: AppBuildConfig,
-) : RefreshRetentionAtbPlugin {
+) : AtbLifecyclePlugin {
 
     private val preferences: SharedPreferences by lazy { context.getSharedPreferences(PIXELS_PREF_FILE, Context.MODE_PRIVATE) }
 

--- a/statistics/src/test/java/com/duckduckgo/app/statistics/api/StatisticsRequesterTest.kt
+++ b/statistics/src/test/java/com/duckduckgo/app/statistics/api/StatisticsRequesterTest.kt
@@ -44,8 +44,8 @@ class StatisticsRequesterTest {
     private var mockVariantManager: VariantManager = mock()
     private val mockEmailManager: EmailManager = mock()
 
-    private val plugins = object : PluginPoint<RefreshRetentionAtbPlugin> {
-        override fun getPlugins(): Collection<RefreshRetentionAtbPlugin> {
+    private val plugins = object : PluginPoint<AtbLifecyclePlugin> {
+        override fun getPlugins(): Collection<AtbLifecyclePlugin> {
             return listOf()
         }
     }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionRefreshRetentionAtbPlugin.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionRefreshRetentionAtbPlugin.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.subscriptions.impl.pixels
 
 import com.duckduckgo.app.di.AppCoroutineScope
-import com.duckduckgo.app.statistics.api.RefreshRetentionAtbPlugin
+import com.duckduckgo.app.statistics.api.AtbLifecyclePlugin
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.subscriptions.impl.SubscriptionsManager
 import com.duckduckgo.subscriptions.impl.repository.isActive
@@ -31,7 +31,7 @@ class SubscriptionRefreshRetentionAtbPlugin @Inject constructor(
     @AppCoroutineScope private val coroutineScope: CoroutineScope,
     private val subscriptionsManager: SubscriptionsManager,
     private val pixelSender: SubscriptionPixelSender,
-) : RefreshRetentionAtbPlugin {
+) : AtbLifecyclePlugin {
 
     override fun onSearchRetentionAtbRefreshed() = Unit // no-op
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1207965428441026/f 

### Description
- Renames `RefreshRetentionAtbPlugin` ➡️ `AtbLifecyclePlugin`
- Adds atb initialized callback
- Makes default implementation of the callbacks no-ops

No other changes in this PR.

### Steps to test this PR
- [ ] QA-optional