### PR TITLE
Update outdated actions used in out workflows

### DIFF
--- a/.github/workflows/action-issue-opened.yaml
+++ b/.github/workflows/action-issue-opened.yaml
@@ -20,7 +20,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Render template
         id: render_template

--- a/.github/workflows/ads-end-to-end.yml
+++ b/.github/workflows/ads-end-to-end.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/ads-end-to-end.yml
+++ b/.github/workflows/ads-end-to-end.yml
@@ -45,7 +45,7 @@ jobs:
           destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
 
       - name: Assemble release APK
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: assembleInternalRelease -Pforce-default-variant
 

--- a/.github/workflows/ads-end-to-end.yml
+++ b/.github/workflows/ads-end-to-end.yml
@@ -44,10 +44,11 @@ jobs:
           fileName: android
           destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
 
-      - name: Assemble release APK
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: assembleInternalRelease -Pforce-default-variant
+
+      - name: Assemble the project
+        run: ./gradlew assembleInternalRelease -Pforce-default-variant
 
       - name: Move APK to new folder
         if: always()

--- a/.github/workflows/ads-end-to-end.yml
+++ b/.github/workflows/ads-end-to-end.yml
@@ -21,7 +21,7 @@ jobs:
           submodules: recursive
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'

--- a/.github/workflows/build-debug-apk.yaml
+++ b/.github/workflows/build-debug-apk.yaml
@@ -35,7 +35,7 @@ jobs:
           go-version: '1.18.3'
 
       - name: Build
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: assembleInternalDebug -Pforce-default-variant
 

--- a/.github/workflows/build-debug-apk.yaml
+++ b/.github/workflows/build-debug-apk.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/build-debug-apk.yaml
+++ b/.github/workflows/build-debug-apk.yaml
@@ -34,10 +34,11 @@ jobs:
         with:
           go-version: '1.18.3'
 
-      - name: Build
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: assembleInternalDebug -Pforce-default-variant
+
+      - name: Assemble the project
+        run: ./gradlew assembleInternalDebug -Pforce-default-variant
 
       - name: Obtain debug apk
         if: always()

--- a/.github/workflows/build-debug-apk.yaml
+++ b/.github/workflows/build-debug-apk.yaml
@@ -30,7 +30,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: '1.18.3'
 

--- a/.github/workflows/build-debug-apk.yaml
+++ b/.github/workflows/build-debug-apk.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Upload debug apk
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pr-ddg-debug
           path: pr-ddg-debug.apk

--- a/.github/workflows/build-debug-apk.yaml
+++ b/.github/workflows/build-debug-apk.yaml
@@ -24,7 +24,7 @@ jobs:
           submodules: recursive
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: '1.18.3'
 
@@ -130,7 +130,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: '1.18.3'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -77,7 +77,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -114,7 +114,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           submodules: recursive
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'
@@ -50,7 +50,7 @@ jobs:
           submodules: recursive
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'
@@ -82,7 +82,7 @@ jobs:
           submodules: recursive
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'
@@ -124,7 +124,7 @@ jobs:
           force: true
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,11 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
 
-      - name: Run Code Formatting Checks
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: code_format_checks
+
+      - name: Run Code Formatting Checks
+        run: ./gradlew code_format_checks
 
   unit_tests:
     name: Unit tests
@@ -55,10 +56,11 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
 
-      - name: JVM tests
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: jvm_tests
+
+      - name: JVM tests
+        run: ./gradlew jvm_tests
 
       - name: Bundle the JVM checks report
         if: always()
@@ -92,10 +94,11 @@ jobs:
         with:
           go-version: '1.18.3'
 
-      - name: Lint
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: lint
+
+      - name: Lint
+        run: ./gradlew lint
 
       - name: Bundle the lint report
         if: always()
@@ -139,15 +142,14 @@ jobs:
           FLANK: ${{ secrets.FLANK }}
         run: echo $FLANK > flank.json
 
-      - name: Build
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: androidTestsBuild
+
+      - name: Build
+        run: ./gradlew androidTestsBuild
 
       - name: Run Android Tests
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: runFlankAndroidTests
+        run: ./gradlew runFlankAndroidTests
 
       - name: Bundle the Android CI tests report
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Run Code Formatting Checks
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: code_format_checks
 
@@ -56,7 +56,7 @@ jobs:
           distribution: 'adopt'
 
       - name: JVM tests
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: jvm_tests
 
@@ -93,7 +93,7 @@ jobs:
           go-version: '1.18.3'
 
       - name: Lint
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: lint
 
@@ -140,12 +140,12 @@ jobs:
         run: echo $FLANK > flank.json
 
       - name: Build
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: androidTestsBuild
 
       - name: Run Android Tests
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: runFlankAndroidTests
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Upload the JVM checks report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: unit-tests-report
           path: unit-tests-report.zip
@@ -103,7 +103,7 @@ jobs:
 
       - name: Upload the JVM lint report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: lint-report
           path: lint-report.zip
@@ -164,7 +164,7 @@ jobs:
 
       - name: Upload the Android CI tests report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: android-tests-report
           path: android-tests-report.zip

--- a/.github/workflows/custom-tabs-nightly.yml
+++ b/.github/workflows/custom-tabs-nightly.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/custom-tabs-nightly.yml
+++ b/.github/workflows/custom-tabs-nightly.yml
@@ -21,7 +21,7 @@ jobs:
           submodules: recursive
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'

--- a/.github/workflows/custom-tabs-nightly.yml
+++ b/.github/workflows/custom-tabs-nightly.yml
@@ -45,7 +45,7 @@ jobs:
           destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
 
       - name: Assemble internal release APK
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: assembleInternalRelease -Pforce-default-variant -x lint
 

--- a/.github/workflows/custom-tabs-nightly.yml
+++ b/.github/workflows/custom-tabs-nightly.yml
@@ -44,10 +44,11 @@ jobs:
           fileName: android
           destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
 
-      - name: Assemble internal release APK
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: assembleInternalRelease -Pforce-default-variant -x lint
+
+      - name: Assemble internal release APK
+        run: ./gradlew assembleInternalRelease -Pforce-default-variant -x lint
 
       - name: Move APK to new folder
         if: always()

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
           submodules: recursive
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Execute Gradle build
         run: ./gradlew dokkaHtmlMultiModule

--- a/.github/workflows/e2e-nightly-autofill.yml
+++ b/.github/workflows/e2e-nightly-autofill.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/e2e-nightly-autofill.yml
+++ b/.github/workflows/e2e-nightly-autofill.yml
@@ -44,10 +44,11 @@ jobs:
           fileName: android
           destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
 
-      - name: Assemble APK which does not require auth to use Autofill
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: assemblePlayRelease -Pautofill-disable-auth-requirement -Pforce-default-variant -x lint
+
+      - name: Assemble APK which does not require auth to use Autofill
+        run: ./gradlew assemblePlayRelease -Pautofill-disable-auth-requirement -Pforce-default-variant -x lint
 
       - name: Move APK to new folder
         if: always()

--- a/.github/workflows/e2e-nightly-autofill.yml
+++ b/.github/workflows/e2e-nightly-autofill.yml
@@ -45,7 +45,7 @@ jobs:
           destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
 
       - name: Assemble APK which does not require auth to use Autofill
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: assemblePlayRelease -Pautofill-disable-auth-requirement -Pforce-default-variant -x lint
 

--- a/.github/workflows/e2e-nightly-autofill.yml
+++ b/.github/workflows/e2e-nightly-autofill.yml
@@ -21,7 +21,7 @@ jobs:
           submodules: recursive
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -45,7 +45,7 @@ jobs:
           destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
 
       - name: Assemble release APK
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: assemblePlayRelease -Pforce-default-variant
 

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -21,7 +21,7 @@ jobs:
           submodules: recursive
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -44,10 +44,11 @@ jobs:
           fileName: android
           destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
 
-      - name: Assemble release APK
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: assemblePlayRelease -Pforce-default-variant
+
+      - name: Assemble release APK
+        run: ./gradlew assemblePlayRelease -Pforce-default-variant
 
       - name: Move APK to new folder
         if: always()

--- a/.github/workflows/external-css-tests.yml
+++ b/.github/workflows/external-css-tests.yml
@@ -52,12 +52,12 @@ jobs:
         run: echo $FLANK > flank.json
 
       - name: Build
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: androidTestsBuild
 
       - name: Run Android Tests
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: runFlankPrivacyTests
 

--- a/.github/workflows/external-css-tests.yml
+++ b/.github/workflows/external-css-tests.yml
@@ -51,15 +51,14 @@ jobs:
           FLANK: ${{ secrets.FLANK }}
         run: echo $FLANK > flank.json
 
-      - name: Build
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: androidTestsBuild
+
+      - name: Build
+        run: ./gradlew androidTestsBuild
 
       - name: Run Android Tests
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: runFlankPrivacyTests
+        run: ./gradlew runFlankPrivacyTests
 
       - name: Bundle the Android CI tests report
         if: always()

--- a/.github/workflows/external-css-tests.yml
+++ b/.github/workflows/external-css-tests.yml
@@ -41,7 +41,7 @@ jobs:
         run: npm run build
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'

--- a/.github/workflows/external-css-tests.yml
+++ b/.github/workflows/external-css-tests.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Upload the Android CI tests report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: android-tests-report
           path: android-tests-report.zip

--- a/.github/workflows/external-css-tests.yml
+++ b/.github/workflows/external-css-tests.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/external-ref-tests.yml
+++ b/.github/workflows/external-ref-tests.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/external-ref-tests.yml
+++ b/.github/workflows/external-ref-tests.yml
@@ -39,10 +39,11 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
 
-      - name: JVM tests
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: jvm_tests
+
+      - name: JVM tests
+        run: ./gradlew jvm_tests
 
       - name: Bundle the JVM checks report
         if: always()
@@ -90,15 +91,14 @@ jobs:
           FLANK: ${{ secrets.FLANK }}
         run: echo $FLANK > flank.json
 
-      - name: Build
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: androidTestsBuild
+
+      - name: Build
+        run: ./gradlew androidTestsBuild
 
       - name: Run Android Tests
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: runFlankAndroidTests
+        run: ./gradlew runFlankAndroidTests
 
       - name: Bundle the Android CI tests report
         if: always()

--- a/.github/workflows/external-ref-tests.yml
+++ b/.github/workflows/external-ref-tests.yml
@@ -40,7 +40,7 @@ jobs:
           distribution: 'adopt'
 
       - name: JVM tests
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: jvm_tests
 
@@ -91,12 +91,12 @@ jobs:
         run: echo $FLANK > flank.json
 
       - name: Build
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: androidTestsBuild
 
       - name: Run Android Tests
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: runFlankAndroidTests
 

--- a/.github/workflows/external-ref-tests.yml
+++ b/.github/workflows/external-ref-tests.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Upload the JVM checks report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: unit-tests-report
           path: unit-tests-report.zip
@@ -115,7 +115,7 @@ jobs:
 
       - name: Upload the Android CI tests report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: android-tests-report
           path: android-tests-report.zip

--- a/.github/workflows/external-ref-tests.yml
+++ b/.github/workflows/external-ref-tests.yml
@@ -34,7 +34,7 @@ jobs:
         run: copy-files-from-to
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'
@@ -80,7 +80,7 @@ jobs:
         run: copy-files-from-to
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,7 +27,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Run Code Formatting Checks
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: code_format_checks
 
@@ -48,7 +48,7 @@ jobs:
           distribution: 'adopt'
 
       - name: JVM tests
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: jvm_tests
 
@@ -85,7 +85,7 @@ jobs:
           go-version: '1.18.3'
 
       - name: Lint
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: lint
 
@@ -132,12 +132,12 @@ jobs:
         run: echo $FLANK > flank.json
 
       - name: Build
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: androidTestsBuild
 
       - name: Run Android Tests
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: runFlankAndroidTests
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload the JVM checks report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: unit-tests-report
           path: unit-tests-report.zip
@@ -95,7 +95,7 @@ jobs:
 
       - name: Upload the JVM lint report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: lint-report
           path: lint-report.zip
@@ -156,7 +156,7 @@ jobs:
 
       - name: Upload the Android CI tests report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: android-tests-report
           path: android-tests-report.zip

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -80,7 +80,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: '1.18.3'
 
@@ -122,7 +122,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: '1.18.3'
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,10 +26,11 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
 
-      - name: Run Code Formatting Checks
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: code_format_checks
+
+      - name: Run Code Formatting Checks
+        run: ./gradlew code_format_checks
 
   unit_tests:
     name: Unit tests
@@ -47,10 +48,11 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
 
-      - name: JVM tests
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: jvm_tests
+
+      - name: JVM tests
+        run: ./gradlew jvm_tests
 
       - name: Bundle the JVM checks report
         if: always()
@@ -84,10 +86,11 @@ jobs:
         with:
           go-version: '1.18.3'
 
-      - name: Lint
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: lint
+
+      - name: Lint
+        run: ./gradlew lint
 
       - name: Bundle the lint report
         if: always()
@@ -131,15 +134,14 @@ jobs:
           FLANK: ${{ secrets.FLANK }}
         run: echo $FLANK > flank.json
 
-      - name: Build
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: androidTestsBuild
+
+      - name: Build
+        run: ./gradlew androidTestsBuild
 
       - name: Run Android Tests
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: runFlankAndroidTests
+        run: ./gradlew runFlankAndroidTests
 
       - name: Bundle the Android CI tests report
         if: always()

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,7 +21,7 @@ jobs:
           submodules: recursive
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'
@@ -42,7 +42,7 @@ jobs:
           submodules: recursive
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'
@@ -74,7 +74,7 @@ jobs:
           submodules: recursive
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'
@@ -116,7 +116,7 @@ jobs:
           force: true
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -69,7 +69,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -106,7 +106,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/privacy-dashboard-end-to-end.yml
+++ b/.github/workflows/privacy-dashboard-end-to-end.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/privacy-dashboard-end-to-end.yml
+++ b/.github/workflows/privacy-dashboard-end-to-end.yml
@@ -48,7 +48,7 @@ jobs:
           destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
 
       - name: Assemble release APK
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: assemblePlayRelease -Pforce-default-variant
 

--- a/.github/workflows/privacy-dashboard-end-to-end.yml
+++ b/.github/workflows/privacy-dashboard-end-to-end.yml
@@ -47,10 +47,11 @@ jobs:
           fileName: android
           destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
 
-      - name: Assemble release APK
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: assemblePlayRelease -Pforce-default-variant
+
+      - name: Assemble the project
+        run: ./gradlew assemblePlayRelease -Pforce-default-variant
 
       - name: Move APK to new folder
         if: always()

--- a/.github/workflows/privacy-dashboard-end-to-end.yml
+++ b/.github/workflows/privacy-dashboard-end-to-end.yml
@@ -24,7 +24,7 @@ jobs:
           submodules: recursive
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'

--- a/.github/workflows/privacy.yml
+++ b/.github/workflows/privacy.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/privacy.yml
+++ b/.github/workflows/privacy.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Upload the Android CI tests report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: android-tests-report
           path: android-tests-report.zip

--- a/.github/workflows/privacy.yml
+++ b/.github/workflows/privacy.yml
@@ -45,12 +45,12 @@ jobs:
         run: echo $FLANK > flank.json
 
       - name: Build
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: androidTestsBuild
 
       - name: Run Android Tests
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: runFlankPrivacyTests
 

--- a/.github/workflows/privacy.yml
+++ b/.github/workflows/privacy.yml
@@ -29,7 +29,7 @@ jobs:
           force: true
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'

--- a/.github/workflows/privacy.yml
+++ b/.github/workflows/privacy.yml
@@ -44,15 +44,14 @@ jobs:
           FLANK: ${{ secrets.FLANK }}
         run: echo $FLANK > flank.json
 
-      - name: Build
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: androidTestsBuild
+
+      - name: Build
+        run: ./gradlew androidTestsBuild
 
       - name: Run Android Tests
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: runFlankPrivacyTests
+        run: ./gradlew runFlankPrivacyTests
 
       - name: Bundle the Android CI tests report
         if: always()

--- a/.github/workflows/privacy.yml
+++ b/.github/workflows/privacy.yml
@@ -35,7 +35,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: '1.18.3'
 

--- a/.github/workflows/sync-critical-path.yml
+++ b/.github/workflows/sync-critical-path.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/sync-critical-path.yml
+++ b/.github/workflows/sync-critical-path.yml
@@ -21,7 +21,7 @@ jobs:
           submodules: recursive
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'

--- a/.github/workflows/sync-critical-path.yml
+++ b/.github/workflows/sync-critical-path.yml
@@ -51,10 +51,11 @@ jobs:
           fileName: android
           destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
 
-      - name: Assemble internal release APK
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: assembleInternalRelease -Pforce-default-variant -Psync-disable-auth-requirement -x lint
+
+      - name: Assemble internal release APK
+        run: ./gradlew assembleInternalRelease -Pforce-default-variant -Psync-disable-auth-requirement -x lint
 
       - name: Move APK to new folder
         if: always()

--- a/.github/workflows/sync-critical-path.yml
+++ b/.github/workflows/sync-critical-path.yml
@@ -52,7 +52,7 @@ jobs:
           destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
 
       - name: Assemble internal release APK
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
         with:
           arguments: assembleInternalRelease -Pforce-default-variant -Psync-disable-auth-requirement -x lint
 

--- a/.github/workflows/update-content-scope.yml
+++ b/.github/workflows/update-content-scope.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/update-ref-tests.yml
+++ b/.github/workflows/update-ref-tests.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207965178064690/f

### Description
Update the following to latest versions:
- `actions/checkout` to `v4`
-  `actions/setup-java` to `v4`
- `gradle/gradle-build-action@v2 `to `gradle/actions/setup-gradle@v3`
- `actions/setup-go@v2` to` actions/setup-go@v5`
- `actions/upload-artifact@v3` to `actions/upload-artifact@v4`

### Steps to test this PR
The following actions pass:
- Build debug apk: https://github.com/duckduckgo/Android/actions/runs/10244411392
- ADS e2e https://github.com/duckduckgo/Android/actions/runs/10244396942
- Custom tabs nightly https://github.com/duckduckgo/Android/actions/runs/10244422913
- E2e https://github.com/duckduckgo/Android/actions/runs/10244447653
- NIghtly https://github.com/duckduckgo/Android/actions/runs/10244475866
- CI Tests: https://github.com/duckduckgo/Android/actions/runs/10244879495/job/28338738932

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207965178064690