### PR TITLE
Ensure snackbar shows only once that informs users they can configure autofill

### DIFF
--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/saving/ResultHandlerPromptToDisableCredentialSavingTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/saving/ResultHandlerPromptToDisableCredentialSavingTest.kt
@@ -6,6 +6,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import com.duckduckgo.autofill.api.AutofillEventListener
 import com.duckduckgo.autofill.impl.AutofillFireproofDialogSuppressor
+import com.duckduckgo.autofill.store.AutofillPrefsStore
 import com.duckduckgo.common.test.CoroutineTestRule
 import org.junit.Rule
 import org.junit.Test
@@ -23,6 +24,7 @@ class ResultHandlerPromptToDisableCredentialSavingTest {
     private val autofillFireproofDialogSuppressor: AutofillFireproofDialogSuppressor = mock()
     private val context = getInstrumentation().targetContext
     private val disableAutofillPromptBehavior: DisableAutofillPromptBehavior = mock()
+    private val autofillPrefsStore: AutofillPrefsStore = mock()
     private val disablePromptBehaviorFactory: DisableAutofillPromptBehaviorFactory = mock<DisableAutofillPromptBehaviorFactory>().also {
         whenever(it.createBehavior(any(), any(), any())).thenReturn(disableAutofillPromptBehavior)
     }
@@ -31,6 +33,9 @@ class ResultHandlerPromptToDisableCredentialSavingTest {
     private val testee = ResultHandlerPromptToDisableCredentialSaving(
         autofillFireproofDialogSuppressor = autofillFireproofDialogSuppressor,
         behavior = disablePromptBehaviorFactory,
+        autofillPrefsStore = autofillPrefsStore,
+        appCoroutineScope = coroutineTestRule.testScope,
+        dispatchers = coroutineTestRule.testDispatcherProvider,
     )
 
     @Test
@@ -47,6 +52,7 @@ class ResultHandlerPromptToDisableCredentialSavingTest {
         testee.processResult(result, context, "tab-id-123", fragment, callback)
         verify(disablePromptBehaviorFactory).createBehavior(context, fragment, callback)
         verify(disableAutofillPromptBehavior).showPrompt()
+        verify(autofillPrefsStore).timestampUserLastPromptedToDisableAutofill = any()
     }
 
     private fun bundleForAutofillDisablePrompt(): Bundle = Bundle()

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/saving/declines/AutofillDisablingDeclineCounterTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/saving/declines/AutofillDisablingDeclineCounterTest.kt
@@ -123,11 +123,21 @@ class AutofillDisablingDeclineCounterTest {
     }
 
     @Test
-    fun whenDeclineIncreasesTotalCountAtThresholdThenShouldOfferToDisable() = runTest {
+    fun whenDeclineIncreasesTotalCountAtThresholdAndNotPromptedBeforeThenShouldOfferToDisable() = runTest {
         initialiseDeclineCounter()
+        configureNeverPromptedToDisableBefore()
         configureGlobalDeclineCountAtThreshold()
         testee.userDeclinedToSaveCredentials("a.com")
         assertShouldPromptToDisableAutofill()
+    }
+
+    @Test
+    fun whenDeclineIncreasesTotalCountAtThresholdAndPromptedBeforeThenShouldNotOfferToDisable() = runTest {
+        initialiseDeclineCounter()
+        configurePromptedToDisableBefore()
+        configureGlobalDeclineCountAtThreshold()
+        testee.userDeclinedToSaveCredentials("a.com")
+        assertShouldNotPromptToDisableAutofill()
     }
 
     private fun configureGlobalDeclineCountAtThreshold() {
@@ -157,5 +167,13 @@ class AutofillDisablingDeclineCounterTest {
             appCoroutineScope = this,
             dispatchers = coroutineTestRule.testDispatcherProvider,
         )
+    }
+
+    private fun configureNeverPromptedToDisableBefore() {
+        whenever(autofillPrefsStore.timestampUserLastPromptedToDisableAutofill).thenReturn(null)
+    }
+
+    private fun configurePromptedToDisableBefore() {
+        whenever(autofillPrefsStore.timestampUserLastPromptedToDisableAutofill).thenReturn(100)
     }
 }

--- a/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/AutofillPrefsStore.kt
+++ b/autofill/autofill-store/src/main/java/com/duckduckgo/autofill/store/AutofillPrefsStore.kt
@@ -28,6 +28,7 @@ interface AutofillPrefsStore {
     var monitorDeclineCounts: Boolean
     var hasEverBeenPromptedToSaveLogin: Boolean
     val autofillStateSetByUser: Boolean
+    var timestampUserLastPromptedToDisableAutofill: Long?
 
     /**
      * Returns if Autofill was enabled by default.
@@ -81,6 +82,16 @@ class RealAutofillPrefsStore(
     override val autofillStateSetByUser: Boolean
         get() = autofillStateSetByUser()
 
+    override var timestampUserLastPromptedToDisableAutofill: Long?
+        get() {
+            val timestamp = prefs.getLong(TIMESTAMP_WHEN_USER_LAST_PROMPTED_TO_DISABLE_AUTOFILL, -1)
+            if (timestamp == -1L) {
+                return null
+            }
+            return timestamp
+        }
+        set(value) = prefs.edit { putLong(TIMESTAMP_WHEN_USER_LAST_PROMPTED_TO_DISABLE_AUTOFILL, value ?: -1) }
+
     /**
      * Returns if Autofill was enabled by default. Note, this is not necessarily the same as the current state of Autofill.
      */
@@ -129,6 +140,7 @@ class RealAutofillPrefsStore(
         const val FILENAME = "com.duckduckgo.autofill.store.autofill_store"
         const val AUTOFILL_ENABLED = "autofill_enabled"
         const val HAS_EVER_BEEN_PROMPTED_TO_SAVE_LOGIN = "autofill_has_ever_been_prompted_to_save_login"
+        const val TIMESTAMP_WHEN_USER_LAST_PROMPTED_TO_DISABLE_AUTOFILL = "timestamp_when_user_last_prompted_to_disable_autofill"
         const val AUTOFILL_DECLINE_COUNT = "autofill_decline_count"
         const val MONITOR_AUTOFILL_DECLINES = "monitor_autofill_declines"
         const val ORIGINAL_AUTOFILL_DEFAULT_STATE_ENABLED = "original_autofill_default_state_enabled"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1207978333418692/f 

### Description
Adds an additional check that the snackbar informing users they can configure autofill in settings will be shown only once.

This fixes a bug whereby it would show repeatedly if you kept declining a login for the same site
- same site meaning the decline counter wouldn't keep increasing, and therefore the condition to show the snackbar was continually being met
- this PR adds in a timestamp for when user was last given the option, and is checked before offering to do it again (timestamp rather than a boolean to give us more flexibility in future if we need to show it again).

### Steps to test this PR

- [ ] Clean install
- [ ] Visit a login form (e.g., https://fill.dev/form/login-simple)
- [ ] Add a username and password (>= 4 characters) and tap **Login** button
- [ ] Decline the prompt to save the password (doesn't matter if using ✖️  button, tapping outside dialog or android's back button)
- [ ] Visit another login form (e.g., https://privacy-test-pages.glitch.me/autofill/form-submission.html)
- [ ] Add username and password in first form and tap **Sign in** button
- [ ] Decline the prompt to save the password when prompted by any means
- [ ] Verify you **do** see the snackbar informing users about configuring autofill
- [ ] Repeat the login attempt, and again decline when prompted to save the password
- [ ] This time, verify you do **not** see the snackbar again