### PR TITLE
Support autocomplete recent item removal

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -48,7 +48,9 @@ import com.duckduckgo.app.accessibility.data.AccessibilitySettingsSharedPreferen
 import com.duckduckgo.app.autocomplete.api.AutoComplete
 import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteResult
 import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteSuggestion.AutoCompleteBookmarkSuggestion
+import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteSuggestion.AutoCompleteDefaultSuggestion
 import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteSuggestion.AutoCompleteHistoryRelatedSuggestion.AutoCompleteHistorySearchSuggestion
+import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteSuggestion.AutoCompleteHistoryRelatedSuggestion.AutoCompleteHistorySuggestion
 import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteSuggestion.AutoCompleteSearchSuggestion
 import com.duckduckgo.app.autocomplete.api.AutoCompleteApi
 import com.duckduckgo.app.autocomplete.api.AutoCompleteScorer
@@ -204,6 +206,7 @@ import com.duckduckgo.voice.api.VoiceSearchAvailabilityPixelLogger
 import dagger.Lazy
 import io.reactivex.Observable
 import io.reactivex.Single
+import io.reactivex.observers.TestObserver
 import java.io.File
 import java.math.BigInteger
 import java.security.cert.X509Certificate
@@ -5465,6 +5468,69 @@ class BrowserTabViewModelTest {
         testee.onNewTabShown()
 
         verify(mockNewTabPixels).fireNewTabDisplayed()
+    }
+
+    @Test
+    fun whenUserLongPressedOnHistorySuggestionThenShowRemoveSearchSuggestionDialogCommandIssued() {
+        val suggestion = AutoCompleteHistorySuggestion(phrase = "phrase", title = "title", url = "url", isAllowedInTopHits = false)
+
+        testee.userLongPressedAutocomplete(suggestion)
+
+        verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
+        val issuedCommand = commandCaptor.allValues.find { it is Command.ShowRemoveSearchSuggestionDialog }
+        assertEquals(suggestion, (issuedCommand as Command.ShowRemoveSearchSuggestionDialog).suggestion)
+    }
+
+    @Test
+    fun whenUserLongPressedOnHistorySearchSuggestionThenShowRemoveSearchSuggestionDialogCommandIssued() {
+        val suggestion = AutoCompleteHistorySearchSuggestion(phrase = "phrase", isAllowedInTopHits = false)
+
+        testee.userLongPressedAutocomplete(suggestion)
+
+        verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
+        val issuedCommand = commandCaptor.allValues.find { it is Command.ShowRemoveSearchSuggestionDialog }
+        assertEquals(suggestion, (issuedCommand as Command.ShowRemoveSearchSuggestionDialog).suggestion)
+    }
+
+    @Test
+    fun whenUserLongPressedOnOtherSuggestionThenDoNothing() {
+        val suggestion = AutoCompleteDefaultSuggestion(phrase = "phrase")
+
+        testee.userLongPressedAutocomplete(suggestion)
+
+        assertCommandNotIssued<Command.ShowRemoveSearchSuggestionDialog>()
+    }
+
+    @Test
+    fun whenOnRemoveSearchSuggestionConfirmedForHistorySuggestionThenPixelFiredAndHistoryEntryRemoved() = runBlocking {
+        val suggestion = AutoCompleteHistorySuggestion(phrase = "phrase", title = "title", url = "url", isAllowedInTopHits = false)
+        val omnibarText = "foo"
+
+        val testObserver = TestObserver.create<String>()
+        testee.autoCompletePublishSubject.subscribe(testObserver)
+
+        testee.onRemoveSearchSuggestionConfirmed(suggestion, omnibarText)
+
+        verify(mockPixel).fire(AppPixelName.AUTOCOMPLETE_RESULT_DELETED)
+        verify(mockNavigationHistory).removeHistoryEntryByUrl(suggestion.url)
+        testObserver.assertValue(omnibarText)
+        assertCommandIssued<Command.AutocompleteItemRemoved>()
+    }
+
+    @Test
+    fun whenOnRemoveSearchSuggestionConfirmedForHistorySearchSuggestionThenPixelFiredAndHistoryEntryRemoved() = runBlocking {
+        val suggestion = AutoCompleteHistorySearchSuggestion(phrase = "phrase", isAllowedInTopHits = false)
+        val omnibarText = "foo"
+
+        val testObserver = TestObserver.create<String>()
+        testee.autoCompletePublishSubject.subscribe(testObserver)
+
+        testee.onRemoveSearchSuggestionConfirmed(suggestion, omnibarText)
+
+        verify(mockPixel).fire(AppPixelName.AUTOCOMPLETE_RESULT_DELETED)
+        verify(mockNavigationHistory).removeHistoryEntryByQuery(suggestion.phrase)
+        testObserver.assertValue(omnibarText)
+        assertCommandIssued<Command.AutocompleteItemRemoved>()
     }
 
     private fun aCredential(): LoginCredentials {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1608,7 +1608,7 @@ class BrowserTabFragment :
 
     private fun scrollToPositionWithOffset(position: Int, offset: Int) {
         val layoutManager = binding.autoCompleteSuggestionsList.layoutManager as LinearLayoutManager
-        layoutManager.scrollToPositionWithOffset(position, offset - 6.toPx())
+        layoutManager.scrollToPositionWithOffset(position, offset - AUTOCOMPLETE_PADDING_DP.toPx())
     }
 
     private fun launchScreen(
@@ -3354,7 +3354,7 @@ class BrowserTabFragment :
 
         private const val BOOKMARKS_BOTTOM_SHEET_DURATION = 3500L
 
-        private const val WEB_MESSAGE_LISTENER_WEBVIEW_VERSION = "126.0.6478.40"
+        private const val AUTOCOMPLETE_PADDING_DP = 6
 
         fun newInstance(
             tabId: String,

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -94,7 +94,6 @@ import com.duckduckgo.app.browser.WebViewErrorResponse.OMITTED
 import com.duckduckgo.app.browser.applinks.AppLinksLauncher
 import com.duckduckgo.app.browser.applinks.AppLinksSnackBarConfigurator
 import com.duckduckgo.app.browser.autocomplete.BrowserAutoCompleteSuggestionsAdapter
-import com.duckduckgo.common.utils.KeyboardVisibilityUtil
 import com.duckduckgo.app.browser.commands.Command
 import com.duckduckgo.app.browser.commands.Command.ShowBackNavigationHistory
 import com.duckduckgo.app.browser.commands.NavigationCommand
@@ -239,6 +238,7 @@ import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.FragmentViewModelFactory
+import com.duckduckgo.common.utils.KeyboardVisibilityUtil
 import com.duckduckgo.common.utils.extensions.html
 import com.duckduckgo.common.utils.extensions.websiteFromGeoLocationsApiOrigin
 import com.duckduckgo.common.utils.extractDomain

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -94,7 +94,7 @@ import com.duckduckgo.app.browser.WebViewErrorResponse.OMITTED
 import com.duckduckgo.app.browser.applinks.AppLinksLauncher
 import com.duckduckgo.app.browser.applinks.AppLinksSnackBarConfigurator
 import com.duckduckgo.app.browser.autocomplete.BrowserAutoCompleteSuggestionsAdapter
-import com.duckduckgo.app.browser.autocomplete.KeyboardVisibilityUtil
+import com.duckduckgo.common.utils.KeyboardVisibilityUtil
 import com.duckduckgo.app.browser.commands.Command
 import com.duckduckgo.app.browser.commands.Command.ShowBackNavigationHistory
 import com.duckduckgo.app.browser.commands.NavigationCommand

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -739,21 +739,21 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     fun onRemoveSearchSuggestionConfirmed(suggestion: AutoCompleteSuggestion, omnibarText: String) {
-        appCoroutineScope.launch(dispatchers.main()) {
-            withContext(dispatchers.io()) {
-                pixel.fire(AUTOCOMPLETE_RESULT_DELETED)
-                when (suggestion) {
-                    is AutoCompleteHistorySuggestion -> {
-                        history.removeHistoryEntryByUrl(suggestion.url)
-                    }
-                    is AutoCompleteHistorySearchSuggestion -> {
-                        history.removeHistoryEntryByQuery(suggestion.phrase)
-                    }
-                    else -> {}
+        appCoroutineScope.launch(dispatchers.io()) {
+            pixel.fire(AUTOCOMPLETE_RESULT_DELETED)
+            when (suggestion) {
+                is AutoCompleteHistorySuggestion -> {
+                    history.removeHistoryEntryByUrl(suggestion.url)
                 }
+                is AutoCompleteHistorySearchSuggestion -> {
+                    history.removeHistoryEntryByQuery(suggestion.phrase)
+                }
+                else -> {}
             }
-            autoCompletePublishSubject.accept(omnibarText)
-            command.value = AutocompleteItemRemoved
+            withContext(dispatchers.main()) {
+                autoCompletePublishSubject.accept(omnibarText)
+                command.value = AutocompleteItemRemoved
+            }
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -735,7 +735,9 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     private fun showRemoveSearchSuggestionDialog(suggestion: AutoCompleteSuggestion) {
-        command.value = ShowRemoveSearchSuggestionDialog(suggestion)
+        appCoroutineScope.launch(dispatchers.main()) {
+            command.value = ShowRemoveSearchSuggestionDialog(suggestion)
+        }
     }
 
     fun onRemoveSearchSuggestionConfirmed(suggestion: AutoCompleteSuggestion, omnibarText: String) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -754,6 +754,7 @@ class BrowserTabViewModel @Inject constructor(
                 }
             }
             autoCompletePublishSubject.accept(omnibarText)
+            command.value = AutocompleteItemRemoved
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -729,8 +729,7 @@ class BrowserTabViewModel @Inject constructor(
 
     fun userLongPressedAutocomplete(suggestion: AutoCompleteSuggestion) {
         when (suggestion) {
-            is AutoCompleteHistorySuggestion -> showRemoveSearchSuggestionDialog(suggestion)
-            is AutoCompleteHistorySearchSuggestion -> showRemoveSearchSuggestionDialog(suggestion)
+            is AutoCompleteHistorySuggestion, is AutoCompleteHistorySearchSuggestion -> showRemoveSearchSuggestionDialog(suggestion)
             else -> return
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/autocomplete/BrowserAutoCompleteSuggestionsAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/autocomplete/BrowserAutoCompleteSuggestionsAdapter.kt
@@ -39,6 +39,7 @@ class BrowserAutoCompleteSuggestionsAdapter(
     private val editableSearchClickListener: (AutoCompleteSuggestion) -> Unit,
     private val autoCompleteInAppMessageDismissedListener: () -> Unit,
     private val autoCompleteOpenSettingsClickListener: () -> Unit,
+    private val autoCompleteLongPressClickListener: (AutoCompleteSuggestion) -> Unit,
 ) : RecyclerView.Adapter<AutoCompleteViewHolder>() {
 
     private val deleteClickListener: (AutoCompleteSuggestion) -> Unit = {
@@ -92,6 +93,7 @@ class BrowserAutoCompleteSuggestionsAdapter(
                 editableSearchClickListener,
                 deleteClickListener,
                 autoCompleteOpenSettingsClickListener,
+                autoCompleteLongPressClickListener,
             )
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/autocomplete/KeyboardVisibilityUtil.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/autocomplete/KeyboardVisibilityUtil.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.autocomplete
+
+import android.graphics.Rect
+import android.view.View
+import android.view.ViewTreeObserver
+
+class KeyboardVisibilityUtil(private val rootView: View) {
+
+    fun addKeyboardVisibilityListener(onKeyboardVisible: () -> Unit) {
+        rootView.viewTreeObserver.addOnGlobalLayoutListener(object : ViewTreeObserver.OnGlobalLayoutListener {
+            override fun onGlobalLayout() {
+                if (isKeyboardVisible()) {
+                    rootView.viewTreeObserver.removeOnGlobalLayoutListener(this)
+                    onKeyboardVisible()
+                }
+            }
+        },
+        )
+    }
+
+    private fun isKeyboardVisible(): Boolean {
+        val rect = Rect()
+        rootView.getWindowVisibleDisplayFrame(rect)
+        val screenHeight = rootView.height
+        val keypadHeight = screenHeight - rect.bottom
+        return keypadHeight > screenHeight * 0.15
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/autocomplete/KeyboardVisibilityUtil.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/autocomplete/KeyboardVisibilityUtil.kt
@@ -23,14 +23,15 @@ import android.view.ViewTreeObserver
 class KeyboardVisibilityUtil(private val rootView: View) {
 
     fun addKeyboardVisibilityListener(onKeyboardVisible: () -> Unit) {
-        rootView.viewTreeObserver.addOnGlobalLayoutListener(object : ViewTreeObserver.OnGlobalLayoutListener {
-            override fun onGlobalLayout() {
-                if (isKeyboardVisible()) {
-                    rootView.viewTreeObserver.removeOnGlobalLayoutListener(this)
-                    onKeyboardVisible()
+        rootView.viewTreeObserver.addOnGlobalLayoutListener(
+            object : ViewTreeObserver.OnGlobalLayoutListener {
+                override fun onGlobalLayout() {
+                    if (isKeyboardVisible()) {
+                        rootView.viewTreeObserver.removeOnGlobalLayoutListener(this)
+                        onKeyboardVisible()
+                    }
                 }
-            }
-        },
+            },
         )
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/autocomplete/SuggestionViewHolderFactory.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/autocomplete/SuggestionViewHolderFactory.kt
@@ -46,6 +46,7 @@ interface SuggestionViewHolderFactory {
         editableSearchClickListener: (AutoCompleteSuggestion) -> Unit,
         deleteClickListener: (AutoCompleteSuggestion) -> Unit = {},
         openSettingsClickListener: () -> Unit = {},
+        longPressClickListener: (AutoCompleteSuggestion) -> Unit = {},
     )
 }
 
@@ -64,6 +65,7 @@ class SearchSuggestionViewHolderFactory : SuggestionViewHolderFactory {
         editableSearchClickListener: (AutoCompleteSuggestion) -> Unit,
         deleteClickListener: (AutoCompleteSuggestion) -> Unit,
         openSettingsClickListener: () -> Unit,
+        longPressClickListener: (AutoCompleteSuggestion) -> Unit,
     ) {
         val searchSuggestionViewHolder = holder as AutoCompleteViewHolder.SearchSuggestionViewHolder
         searchSuggestionViewHolder.bind(suggestion as AutoCompleteSearchSuggestion, immediateSearchClickListener, editableSearchClickListener)
@@ -85,9 +87,15 @@ class HistorySuggestionViewHolderFactory : SuggestionViewHolderFactory {
         editableSearchClickListener: (AutoCompleteSuggestion) -> Unit,
         deleteClickListener: (AutoCompleteSuggestion) -> Unit,
         openSettingsClickListener: () -> Unit,
+        longPressClickListener: (AutoCompleteSuggestion) -> Unit,
     ) {
         val searchSuggestionViewHolder = holder as AutoCompleteViewHolder.HistorySuggestionViewHolder
-        searchSuggestionViewHolder.bind(suggestion as AutoCompleteHistorySuggestion, immediateSearchClickListener, editableSearchClickListener)
+        searchSuggestionViewHolder.bind(
+            suggestion as AutoCompleteHistorySuggestion,
+            immediateSearchClickListener,
+            editableSearchClickListener,
+            longPressClickListener,
+        )
     }
 }
 
@@ -106,12 +114,14 @@ class HistorySearchSuggestionViewHolderFactory : SuggestionViewHolderFactory {
         editableSearchClickListener: (AutoCompleteSuggestion) -> Unit,
         deleteClickListener: (AutoCompleteSuggestion) -> Unit,
         openSettingsClickListener: () -> Unit,
+        longPressClickListener: (AutoCompleteSuggestion) -> Unit,
     ) {
         val historySearchSuggestionViewHolder = holder as AutoCompleteViewHolder.HistorySearchSuggestionViewHolder
         historySearchSuggestionViewHolder.bind(
             suggestion as AutoCompleteHistorySearchSuggestion,
             immediateSearchClickListener,
             editableSearchClickListener,
+            longPressClickListener,
         )
     }
 }
@@ -131,6 +141,7 @@ class BookmarkSuggestionViewHolderFactory : SuggestionViewHolderFactory {
         editableSearchClickListener: (AutoCompleteSuggestion) -> Unit,
         deleteClickListener: (AutoCompleteSuggestion) -> Unit,
         openSettingsClickListener: () -> Unit,
+        longPressClickListener: (AutoCompleteSuggestion) -> Unit,
     ) {
         val bookmarkSuggestionViewHolder = holder as AutoCompleteViewHolder.BookmarkSuggestionViewHolder
         bookmarkSuggestionViewHolder.bind(suggestion as AutoCompleteBookmarkSuggestion, immediateSearchClickListener, editableSearchClickListener)
@@ -155,6 +166,7 @@ class EmptySuggestionViewHolderFactory : SuggestionViewHolderFactory {
         editableSearchClickListener: (AutoCompleteSuggestion) -> Unit,
         deleteClickListener: (AutoCompleteSuggestion) -> Unit,
         openSettingsClickListener: () -> Unit,
+        longPressClickListener: (AutoCompleteSuggestion) -> Unit,
     ) {
         // do nothing
     }
@@ -174,6 +186,7 @@ class DefaultSuggestionViewHolderFactory : SuggestionViewHolderFactory {
         editableSearchClickListener: (AutoCompleteSuggestion) -> Unit,
         deleteClickListener: (AutoCompleteSuggestion) -> Unit,
         openSettingsClickListener: () -> Unit,
+        longPressClickListener: (AutoCompleteSuggestion) -> Unit,
     ) {
         val viewholder = holder as AutoCompleteViewHolder.DefaultSuggestionViewHolder
         viewholder.bind(suggestion as AutoCompleteDefaultSuggestion, immediateSearchClickListener)
@@ -193,6 +206,7 @@ class InAppMessageViewHolderFactory : SuggestionViewHolderFactory {
         editableSearchClickListener: (AutoCompleteSuggestion) -> Unit,
         deleteClickListener: (AutoCompleteSuggestion) -> Unit,
         openSettingsClickListener: () -> Unit,
+        longPressClickListener: (AutoCompleteSuggestion) -> Unit,
     ) {
         val viewHolder = holder as InAppMessageViewHolder
         viewHolder.bind(suggestion, deleteClickListener, openSettingsClickListener)
@@ -222,6 +236,7 @@ sealed class AutoCompleteViewHolder(itemView: View) : RecyclerView.ViewHolder(it
             item: AutoCompleteHistorySearchSuggestion,
             immediateSearchListener: (AutoCompleteSuggestion) -> Unit,
             editableSearchClickListener: (AutoCompleteSuggestion) -> Unit,
+            longPressClickListener: (AutoCompleteSuggestion) -> Unit,
         ) = with(binding) {
             phrase.text = item.phrase
 
@@ -229,6 +244,10 @@ sealed class AutoCompleteViewHolder(itemView: View) : RecyclerView.ViewHolder(it
 
             editQueryImage.setOnClickListener { editableSearchClickListener(item) }
             root.setOnClickListener { immediateSearchListener(item) }
+            root.setOnLongClickListener {
+                longPressClickListener(item)
+                true
+            }
         }
     }
 
@@ -252,12 +271,17 @@ sealed class AutoCompleteViewHolder(itemView: View) : RecyclerView.ViewHolder(it
             item: AutoCompleteHistorySuggestion,
             immediateSearchListener: (AutoCompleteSuggestion) -> Unit,
             editableSearchClickListener: (AutoCompleteSuggestion) -> Unit,
+            longPressClickListener: (AutoCompleteSuggestion) -> Unit,
         ) = with(binding) {
             title.text = item.title
             url.text = item.phrase
 
             goToSuggestionImage.setOnClickListener { editableSearchClickListener(item) }
             root.setOnClickListener { immediateSearchListener(item) }
+            root.setOnLongClickListener {
+                longPressClickListener(item)
+                true
+            }
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
@@ -24,6 +24,7 @@ import android.view.View
 import android.webkit.PermissionRequest
 import android.webkit.SslErrorHandler
 import android.webkit.ValueCallback
+import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteSuggestion
 import com.duckduckgo.app.browser.BrowserTabViewModel.FileChooserRequestedParams
 import com.duckduckgo.app.browser.BrowserTabViewModel.LocationPermission
 import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType.AppLink
@@ -230,4 +231,5 @@ sealed class Command {
         val payload: String,
     ) : Command()
     data class HideOnboardingDaxDialog(val onboardingCta: OnboardingDaxDialogCta) : Command()
+    data class ShowRemoveSearchSuggestionDialog(val suggestion: AutoCompleteSuggestion) : Command()
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
@@ -232,4 +232,5 @@ sealed class Command {
     ) : Command()
     data class HideOnboardingDaxDialog(val onboardingCta: OnboardingDaxDialogCta) : Command()
     data class ShowRemoveSearchSuggestionDialog(val suggestion: AutoCompleteSuggestion) : Command()
+    data object AutocompleteItemRemoved : Command()
 }

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -213,6 +213,8 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     AUTOCOMPLETE_DISPLAYED_LOCAL_HISTORY("m_autocomplete_displayed_history_site"),
     AUTOCOMPLETE_DISPLAYED_LOCAL_HISTORY_SEARCH("m_autocomplete_displayed_history_search"),
 
+    AUTOCOMPLETE_RESULT_DELETED("m_autocomplete_result_deleted"),
+
     SERP_REQUERY("rq_%s"),
 
     CHANGE_APP_ICON_OPENED("m_ic"),

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
@@ -41,7 +41,7 @@ import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.R.string
 import com.duckduckgo.app.browser.autocomplete.BrowserAutoCompleteSuggestionsAdapter
-import com.duckduckgo.app.browser.autocomplete.KeyboardVisibilityUtil
+import com.duckduckgo.common.utils.KeyboardVisibilityUtil
 import com.duckduckgo.app.browser.databinding.ActivitySystemSearchBinding
 import com.duckduckgo.app.browser.databinding.IncludeQuickAccessItemsBinding
 import com.duckduckgo.app.browser.favicon.FaviconManager

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
@@ -41,7 +41,6 @@ import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.R.string
 import com.duckduckgo.app.browser.autocomplete.BrowserAutoCompleteSuggestionsAdapter
-import com.duckduckgo.common.utils.KeyboardVisibilityUtil
 import com.duckduckgo.app.browser.databinding.ActivitySystemSearchBinding
 import com.duckduckgo.app.browser.databinding.IncludeQuickAccessItemsBinding
 import com.duckduckgo.app.browser.favicon.FaviconManager
@@ -62,6 +61,7 @@ import com.duckduckgo.common.ui.view.hideKeyboard
 import com.duckduckgo.common.ui.view.showKeyboard
 import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.KeyboardVisibilityUtil
 import com.duckduckgo.common.utils.extensions.html
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.mobile.android.R as CommonR

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
@@ -302,8 +302,7 @@ class SystemSearchViewModel @Inject constructor(
 
     fun userLongPressedAutocomplete(suggestion: AutoCompleteSuggestion) {
         when (suggestion) {
-            is AutoCompleteHistorySuggestion -> showRemoveSearchSuggestionDialog(suggestion)
-            is AutoCompleteHistorySearchSuggestion -> showRemoveSearchSuggestionDialog(suggestion)
+            is AutoCompleteHistorySuggestion, is AutoCompleteHistorySearchSuggestion -> showRemoveSearchSuggestionDialog(suggestion)
             else -> return
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
@@ -109,6 +109,7 @@ class SystemSearchViewModel @Inject constructor(
         data class EditQuery(val query: String) : Command()
         object UpdateVoiceSearch : Command()
         data class ShowRemoveSearchSuggestionDialog(val suggestion: AutoCompleteSuggestion) : Command()
+        data object AutocompleteItemRemoved : Command()
     }
 
     val onboardingViewState: MutableLiveData<OnboardingViewState> = MutableLiveData()
@@ -324,6 +325,7 @@ class SystemSearchViewModel @Inject constructor(
                 }
             }
             resultsPublishSubject.accept(omnibarText)
+            command.value = Command.AutocompleteItemRemoved
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
@@ -312,21 +312,21 @@ class SystemSearchViewModel @Inject constructor(
     }
 
     fun onRemoveSearchSuggestionConfirmed(suggestion: AutoCompleteSuggestion, omnibarText: String) {
-        appCoroutineScope.launch(dispatchers.main()) {
-            withContext(dispatchers.io()) {
-                pixel.fire(AUTOCOMPLETE_RESULT_DELETED)
-                when (suggestion) {
-                    is AutoCompleteHistorySuggestion -> {
-                        history.removeHistoryEntryByUrl(suggestion.url)
-                    }
-                    is AutoCompleteHistorySearchSuggestion -> {
-                        history.removeHistoryEntryByQuery(suggestion.phrase)
-                    }
-                    else -> {}
+        appCoroutineScope.launch(dispatchers.io()) {
+            pixel.fire(AUTOCOMPLETE_RESULT_DELETED)
+            when (suggestion) {
+                is AutoCompleteHistorySuggestion -> {
+                    history.removeHistoryEntryByUrl(suggestion.url)
                 }
+                is AutoCompleteHistorySearchSuggestion -> {
+                    history.removeHistoryEntryByQuery(suggestion.phrase)
+                }
+                else -> {}
             }
-            resultsPublishSubject.accept(omnibarText)
-            command.value = Command.AutocompleteItemRemoved
+            withContext(dispatchers.main()) {
+                resultsPublishSubject.accept(omnibarText)
+                command.value = Command.AutocompleteItemRemoved
+            }
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
@@ -308,7 +308,9 @@ class SystemSearchViewModel @Inject constructor(
     }
 
     private fun showRemoveSearchSuggestionDialog(suggestion: AutoCompleteSuggestion) {
-        command.value = Command.ShowRemoveSearchSuggestionDialog(suggestion)
+        appCoroutineScope.launch(dispatchers.main()) {
+            command.value = Command.ShowRemoveSearchSuggestionDialog(suggestion)
+        }
     }
 
     fun onRemoveSearchSuggestionConfirmed(suggestion: AutoCompleteSuggestion, omnibarText: String) {

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.app.systemsearch
 
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -116,7 +117,8 @@ class SystemSearchViewModel @Inject constructor(
     val resultsViewState: MutableLiveData<Suggestions> = MutableLiveData()
     val command: SingleLiveEvent<Command> = SingleLiveEvent()
 
-    private val resultsPublishSubject = PublishRelay.create<String>()
+    @VisibleForTesting
+    val resultsPublishSubject = PublishRelay.create<String>()
     private var results = SystemSearchResult(AutoCompleteResult("", emptyList()), emptyList())
     private var resultsDisposable: Disposable? = null
     private var latestQuickAccessItems: Suggestions.QuickAccessItems = Suggestions.QuickAccessItems(emptyList())

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -86,6 +86,9 @@
     <!-- AutoComplete Suggestions -->
     <string name="editQueryBeforeSubmitting">Редактиране на заявка преди търсене</string>
     <string name="settingsAutocompleteEnabled">Показване на предложенията за автоматично довършване</string>
+    <string name="autocompleteRemoveItemTitle">Премахване на предложение за търсене?</string>
+    <string name="autocompleteRemoveItemCancel">Отмени</string>
+    <string name="autocompleteRemoveItemRemove">Премахване</string>
 
     <!-- Opening external apps -->
     <string name="openExternalApp">Отваряне на външно приложение</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -86,6 +86,9 @@
     <!-- AutoComplete Suggestions -->
     <string name="editQueryBeforeSubmitting">Upravit dotaz před vyhledáváním</string>
     <string name="settingsAutocompleteEnabled">Zobrazit návrhy automatického doplňování</string>
+    <string name="autocompleteRemoveItemTitle">Odebrat návrh vyhledávání?</string>
+    <string name="autocompleteRemoveItemCancel">Zrušit</string>
+    <string name="autocompleteRemoveItemRemove">Odstranit</string>
 
     <!-- Opening external apps -->
     <string name="openExternalApp">Otevřít externí aplikaci</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -86,6 +86,9 @@
     <!-- AutoComplete Suggestions -->
     <string name="editQueryBeforeSubmitting">Redigér forespørgsel før søgning</string>
     <string name="settingsAutocompleteEnabled">Vis forslag til Autoudfyld</string>
+    <string name="autocompleteRemoveItemTitle">Fjern søgeforslag?</string>
+    <string name="autocompleteRemoveItemCancel">Annuller</string>
+    <string name="autocompleteRemoveItemRemove">Fjern</string>
 
     <!-- Opening external apps -->
     <string name="openExternalApp">Åbn ekstern app</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -86,6 +86,9 @@
     <!-- AutoComplete Suggestions -->
     <string name="editQueryBeforeSubmitting">Anfrage vor der Suche bearbeiten</string>
     <string name="settingsAutocompleteEnabled">Vorschläge für die Autovervollständigung</string>
+    <string name="autocompleteRemoveItemTitle">Suchvorschlag entfernen?</string>
+    <string name="autocompleteRemoveItemCancel">Abbrechen</string>
+    <string name="autocompleteRemoveItemRemove">Entfernen</string>
 
     <!-- Opening external apps -->
     <string name="openExternalApp">Externe App öffnen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -86,6 +86,9 @@
     <!-- AutoComplete Suggestions -->
     <string name="editQueryBeforeSubmitting">Επεξεργασία ερωτήματος πριν την αναζήτηση</string>
     <string name="settingsAutocompleteEnabled">Εμφάνιση προτάσεων αυτόματης συμπλήρωσης</string>
+    <string name="autocompleteRemoveItemTitle">Αφαίρεση πρότασης αναζήτησης;</string>
+    <string name="autocompleteRemoveItemCancel">Ακύρωση</string>
+    <string name="autocompleteRemoveItemRemove">Αφαίρεση</string>
 
     <!-- Opening external apps -->
     <string name="openExternalApp">Άνοιγμα εξωτερικής εφαρμογής</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -86,6 +86,9 @@
     <!-- AutoComplete Suggestions -->
     <string name="editQueryBeforeSubmitting">Editar consulta antes de buscar</string>
     <string name="settingsAutocompleteEnabled">Sugerencias de autocompletado</string>
+    <string name="autocompleteRemoveItemTitle">¿Eliminar sugerencia de búsqueda?</string>
+    <string name="autocompleteRemoveItemCancel">Cancelar</string>
+    <string name="autocompleteRemoveItemRemove">Eliminar</string>
 
     <!-- Opening external apps -->
     <string name="openExternalApp">Abrir aplicación externa</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -86,6 +86,9 @@
     <!-- AutoComplete Suggestions -->
     <string name="editQueryBeforeSubmitting">Enne otsimist muutke päringut</string>
     <string name="settingsAutocompleteEnabled">Automaatselt täidetavad ettepanekud</string>
+    <string name="autocompleteRemoveItemTitle">Kas eemaldada otsingusoovitus?</string>
+    <string name="autocompleteRemoveItemCancel">Loobu</string>
+    <string name="autocompleteRemoveItemRemove">Eemaldage</string>
 
     <!-- Opening external apps -->
     <string name="openExternalApp">Ava väline rakendus</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -86,6 +86,9 @@
     <!-- AutoComplete Suggestions -->
     <string name="editQueryBeforeSubmitting">Muokkaa kyselyä ennen hakua</string>
     <string name="settingsAutocompleteEnabled">Näytä automaattisen täydennyksen ehdotukset</string>
+    <string name="autocompleteRemoveItemTitle">Poistetaanko hakuehdotus?</string>
+    <string name="autocompleteRemoveItemCancel">Peruuta</string>
+    <string name="autocompleteRemoveItemRemove">Poista</string>
 
     <!-- Opening external apps -->
     <string name="openExternalApp">Avaa ulkoinen sovellus</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -86,6 +86,9 @@
     <!-- AutoComplete Suggestions -->
     <string name="editQueryBeforeSubmitting">Modifier la requête avant la recherche</string>
     <string name="settingsAutocompleteEnabled">Afficher les suggestions de saisie semi-automatique</string>
+    <string name="autocompleteRemoveItemTitle">Supprimer la suggestion de recherche ?</string>
+    <string name="autocompleteRemoveItemCancel">Annuler</string>
+    <string name="autocompleteRemoveItemRemove">Supprimer</string>
 
     <!-- Opening external apps -->
     <string name="openExternalApp">Ouvrir une application externe</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -86,6 +86,9 @@
     <!-- AutoComplete Suggestions -->
     <string name="editQueryBeforeSubmitting">Uredi upit prije pretraživanja</string>
     <string name="settingsAutocompleteEnabled">Prijedlozi za automatsko ispunjavanje</string>
+    <string name="autocompleteRemoveItemTitle">Ukloni prijedlog za pretraživanje?</string>
+    <string name="autocompleteRemoveItemCancel">Odustani</string>
+    <string name="autocompleteRemoveItemRemove">Ukloni</string>
 
     <!-- Opening external apps -->
     <string name="openExternalApp">Otvori vanjsku aplikaciju</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -86,6 +86,9 @@
     <!-- AutoComplete Suggestions -->
     <string name="editQueryBeforeSubmitting">Lekérdezés szerkesztése keresés előtt</string>
     <string name="settingsAutocompleteEnabled">Automatikus kiegészítési javaslatok megjelenítése</string>
+    <string name="autocompleteRemoveItemTitle">Eltávolítod a keresési javaslatot?</string>
+    <string name="autocompleteRemoveItemCancel">Mégsem</string>
+    <string name="autocompleteRemoveItemRemove">Eltávolítás</string>
 
     <!-- Opening external apps -->
     <string name="openExternalApp">Külső alkalmazás megnyitása</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -86,6 +86,9 @@
     <!-- AutoComplete Suggestions -->
     <string name="editQueryBeforeSubmitting">Modifica query prima di iniziare la ricerca</string>
     <string name="settingsAutocompleteEnabled">Mostra suggerimenti di completamento automatico</string>
+    <string name="autocompleteRemoveItemTitle">Rimuovere il suggerimento di ricerca?</string>
+    <string name="autocompleteRemoveItemCancel">Annulla</string>
+    <string name="autocompleteRemoveItemRemove">Rimuovi</string>
 
     <!-- Opening external apps -->
     <string name="openExternalApp">Apri l\'app esterna</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -86,6 +86,9 @@
     <!-- AutoComplete Suggestions -->
     <string name="editQueryBeforeSubmitting">Redaguoti užklausą prieš ieškant</string>
     <string name="settingsAutocompleteEnabled">Rodyti automatinio užbaigimo pasiūlymus</string>
+    <string name="autocompleteRemoveItemTitle">Pašalinti paieškos pasiūlymą?</string>
+    <string name="autocompleteRemoveItemCancel">Atšaukti</string>
+    <string name="autocompleteRemoveItemRemove">Pašalinti</string>
 
     <!-- Opening external apps -->
     <string name="openExternalApp">Atidaryti išorinę programą</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -86,6 +86,9 @@
     <!-- AutoComplete Suggestions -->
     <string name="editQueryBeforeSubmitting">Rediģēt vaicājumu pirms meklēšanas</string>
     <string name="settingsAutocompleteEnabled">Automātiski pabeigt ieteikumus</string>
+    <string name="autocompleteRemoveItemTitle">Vai noņemt meklēšanas ieteikumu?</string>
+    <string name="autocompleteRemoveItemCancel">Atcelt</string>
+    <string name="autocompleteRemoveItemRemove">Noņemt</string>
 
     <!-- Opening external apps -->
     <string name="openExternalApp">Atvērt ārējo lietotni</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -86,6 +86,9 @@
     <!-- AutoComplete Suggestions -->
     <string name="editQueryBeforeSubmitting">Rediger spørringen før du søker</string>
     <string name="settingsAutocompleteEnabled">Vis forslag fra autofullføring</string>
+    <string name="autocompleteRemoveItemTitle">Vil du fjerne søkeforslaget?</string>
+    <string name="autocompleteRemoveItemCancel">Avbryt</string>
+    <string name="autocompleteRemoveItemRemove">Fjern</string>
 
     <!-- Opening external apps -->
     <string name="openExternalApp">Åpne ekstern app</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -86,6 +86,9 @@
     <!-- AutoComplete Suggestions -->
     <string name="editQueryBeforeSubmitting">Bewerk query alvorens te zoeken</string>
     <string name="settingsAutocompleteEnabled">Suggesties voor automatisch aanvullen weergeven</string>
+    <string name="autocompleteRemoveItemTitle">Zoeksuggestie verwijderen?</string>
+    <string name="autocompleteRemoveItemCancel">Annuleren</string>
+    <string name="autocompleteRemoveItemRemove">Verwijderen</string>
 
     <!-- Opening external apps -->
     <string name="openExternalApp">Externe app openen</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -86,6 +86,9 @@
     <!-- AutoComplete Suggestions -->
     <string name="editQueryBeforeSubmitting">Edytuj zapytanie przed wyszukiwaniem</string>
     <string name="settingsAutocompleteEnabled">Pokaż sugestie autouzupełniania</string>
+    <string name="autocompleteRemoveItemTitle">Usunąć sugestię wyszukiwania?</string>
+    <string name="autocompleteRemoveItemCancel">Anuluj</string>
+    <string name="autocompleteRemoveItemRemove">Usuń</string>
 
     <!-- Opening external apps -->
     <string name="openExternalApp">Otwórz zewnętrzną aplikację</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -86,6 +86,9 @@
     <!-- AutoComplete Suggestions -->
     <string name="editQueryBeforeSubmitting">Editar consulta antes de pesquisar</string>
     <string name="settingsAutocompleteEnabled">Mostrar sugestões de preenchimento automático</string>
+    <string name="autocompleteRemoveItemTitle">Remover sugestão de pesquisa?</string>
+    <string name="autocompleteRemoveItemCancel">Cancelar</string>
+    <string name="autocompleteRemoveItemRemove">Remover</string>
 
     <!-- Opening external apps -->
     <string name="openExternalApp">Abrir aplicação externa</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -86,6 +86,9 @@
     <!-- AutoComplete Suggestions -->
     <string name="editQueryBeforeSubmitting">Editare interogare înainte de căutare</string>
     <string name="settingsAutocompleteEnabled">Afișează sugestiile de completare automată</string>
+    <string name="autocompleteRemoveItemTitle">Dorești să elimini sugestia de căutare?</string>
+    <string name="autocompleteRemoveItemCancel">Anulare</string>
+    <string name="autocompleteRemoveItemRemove">Elimină</string>
 
     <!-- Opening external apps -->
     <string name="openExternalApp">Deschide aplicația externă</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -86,6 +86,9 @@
     <!-- AutoComplete Suggestions -->
     <string name="editQueryBeforeSubmitting">Редактировать запрос перед поиском</string>
     <string name="settingsAutocompleteEnabled">Показать предложения автозаполнения</string>
+    <string name="autocompleteRemoveItemTitle">Удалить поисковую рекомендацию?</string>
+    <string name="autocompleteRemoveItemCancel">Отменить</string>
+    <string name="autocompleteRemoveItemRemove">Удалить</string>
 
     <!-- Opening external apps -->
     <string name="openExternalApp">Открыть внешнее приложение</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -86,6 +86,9 @@
     <!-- AutoComplete Suggestions -->
     <string name="editQueryBeforeSubmitting">Upraviť otázku pred vyhľadávaním</string>
     <string name="settingsAutocompleteEnabled">Zobraziť návrhy automatického dopĺňania</string>
+    <string name="autocompleteRemoveItemTitle">Odstrániť návrh vyhľadávania?</string>
+    <string name="autocompleteRemoveItemCancel">Zrušiť</string>
+    <string name="autocompleteRemoveItemRemove">Odstrániť</string>
 
     <!-- Opening external apps -->
     <string name="openExternalApp">Otvoriť externú aplikáciu</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -86,6 +86,9 @@
     <!-- AutoComplete Suggestions -->
     <string name="editQueryBeforeSubmitting">Uredi poizvedbo pred iskanjem</string>
     <string name="settingsAutocompleteEnabled">Pokaži predloge za samodokončanje</string>
+    <string name="autocompleteRemoveItemTitle">Želite odstraniti predlog iskanja?</string>
+    <string name="autocompleteRemoveItemCancel">Prekliči</string>
+    <string name="autocompleteRemoveItemRemove">Odstrani</string>
 
     <!-- Opening external apps -->
     <string name="openExternalApp">Odpri zunanjo aplikacijo</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -86,6 +86,9 @@
     <!-- AutoComplete Suggestions -->
     <string name="editQueryBeforeSubmitting">Redigera förfrågan innan sökning</string>
     <string name="settingsAutocompleteEnabled">Visa Autoslutför förslag</string>
+    <string name="autocompleteRemoveItemTitle">Ta bort sökförslag?</string>
+    <string name="autocompleteRemoveItemCancel">Avbryt</string>
+    <string name="autocompleteRemoveItemRemove">Ta bort</string>
 
     <!-- Opening external apps -->
     <string name="openExternalApp">Öppna extern app</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -86,6 +86,9 @@
     <!-- AutoComplete Suggestions -->
     <string name="editQueryBeforeSubmitting">Aramadan önce sorguyu düzenle</string>
     <string name="settingsAutocompleteEnabled">Otomatik Tamamlama Önerileri</string>
+    <string name="autocompleteRemoveItemTitle">Arama önerisi kaldırılsın mı?</string>
+    <string name="autocompleteRemoveItemCancel">Vazgeç</string>
+    <string name="autocompleteRemoveItemRemove">Kaldır</string>
 
     <!-- Opening external apps -->
     <string name="openExternalApp">Haricî Uygulamayı Aç</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,8 +86,8 @@
     <string name="editQueryBeforeSubmitting">Edit query before searching</string>
     <string name="settingsAutocompleteEnabled">Autocomplete Suggestions</string>
     <string name="autocompleteRemoveItemTitle">Remove search suggestion?</string>
-    <string name="autocompleteRemoveItemRemove">Remove</string>
     <string name="autocompleteRemoveItemCancel">Cancel</string>
+    <string name="autocompleteRemoveItemRemove">Remove</string>
 
     <!-- Opening external apps -->
     <string name="openExternalApp">Open External App</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,6 +85,9 @@
     <!-- AutoComplete Suggestions -->
     <string name="editQueryBeforeSubmitting">Edit query before searching</string>
     <string name="settingsAutocompleteEnabled">Autocomplete Suggestions</string>
+    <string name="autocompleteRemoveItemTitle">Remove search suggestion?</string>
+    <string name="autocompleteRemoveItemRemove">Remove</string>
+    <string name="autocompleteRemoveItemCancel">Cancel</string>
 
     <!-- Opening external apps -->
     <string name="openExternalApp">Open External App</string>

--- a/app/src/test/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
@@ -34,6 +34,7 @@ import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Suggestions.QuickAc
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Suggestions.SystemSearchResultsViewState
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.test.InstantSchedulersRule
+import com.duckduckgo.history.api.NavigationHistory
 import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.savedsites.api.models.SavedSite.Favorite
 import com.duckduckgo.savedsites.impl.SavedSitesPixelName
@@ -65,6 +66,7 @@ class SystemSearchViewModelTest {
     private val mocksavedSitesRepository: SavedSitesRepository = mock()
     private val mockPixel: Pixel = mock()
     private val mockSettingsStore: SettingsDataStore = mock()
+    private val mockHistory: NavigationHistory = mock()
 
     private val commandObserver: Observer<Command> = mock()
     private val commandCaptor = argumentCaptor<Command>()
@@ -86,6 +88,7 @@ class SystemSearchViewModelTest {
             mockPixel,
             mocksavedSitesRepository,
             mockSettingsStore,
+            mockHistory,
             coroutineRule.testDispatcherProvider,
             coroutineRule.testScope,
         )
@@ -361,6 +364,7 @@ class SystemSearchViewModelTest {
             mockPixel,
             mocksavedSitesRepository,
             mockSettingsStore,
+            mockHistory,
             coroutineRule.testDispatcherProvider,
             coroutineRule.testScope,
         )
@@ -385,6 +389,7 @@ class SystemSearchViewModelTest {
             mockPixel,
             mocksavedSitesRepository,
             mockSettingsStore,
+            mockHistory,
             coroutineRule.testDispatcherProvider,
             coroutineRule.testScope,
         )
@@ -436,6 +441,7 @@ class SystemSearchViewModelTest {
             mockPixel,
             mocksavedSitesRepository,
             mockSettingsStore,
+            mockHistory,
             coroutineRule.testDispatcherProvider,
             coroutineRule.testScope,
         )

--- a/app/src/test/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/systemsearch/SystemSearchViewModelTest.kt
@@ -21,6 +21,9 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.Observer
 import com.duckduckgo.app.autocomplete.api.AutoComplete
 import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteResult
+import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteSuggestion.AutoCompleteDefaultSuggestion
+import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteSuggestion.AutoCompleteHistoryRelatedSuggestion.AutoCompleteHistorySearchSuggestion
+import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteSuggestion.AutoCompleteHistoryRelatedSuggestion.AutoCompleteHistorySuggestion
 import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteSuggestion.AutoCompleteSearchSuggestion
 import com.duckduckgo.app.browser.newtab.FavoritesQuickAccessAdapter.QuickAccessFavorite
 import com.duckduckgo.app.onboarding.store.*
@@ -28,7 +31,9 @@ import com.duckduckgo.app.pixels.AppPixelName.*
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command
+import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.AutocompleteItemRemoved
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.LaunchDuckDuckGo
+import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.ShowRemoveSearchSuggestionDialog
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.UpdateVoiceSearch
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Suggestions.QuickAccessItems
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Suggestions.SystemSearchResultsViewState
@@ -39,16 +44,16 @@ import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.savedsites.api.models.SavedSite.Favorite
 import com.duckduckgo.savedsites.impl.SavedSitesPixelName
 import io.reactivex.Observable
-import kotlinx.coroutines.ExperimentalCoroutinesApi
+import io.reactivex.observers.TestObserver
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.*
 import org.junit.*
 import org.junit.Assert.*
 import org.mockito.Mockito.verify
+import org.mockito.internal.util.DefaultMockingDetails
 import org.mockito.kotlin.*
 
-@OptIn(ExperimentalCoroutinesApi::class)
-@Suppress("EXPERIMENTAL_API_USAGE")
 class SystemSearchViewModelTest {
 
     @get:Rule
@@ -473,17 +478,88 @@ class SystemSearchViewModelTest {
         verify(mockPixel).fire(SavedSitesPixelName.EDIT_BOOKMARK_REMOVE_FAVORITE_TOGGLED)
     }
 
+    @Test
+    fun whenUserLongPressedOnHistorySuggestionThenShowRemoveSearchSuggestionDialogCommandIssued() {
+        val suggestion = AutoCompleteHistorySuggestion(phrase = "phrase", title = "title", url = "url", isAllowedInTopHits = false)
+
+        testee.userLongPressedAutocomplete(suggestion)
+
+        verify(commandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
+        val issuedCommand = commandCaptor.allValues.find { it is ShowRemoveSearchSuggestionDialog }
+        assertEquals(suggestion, (issuedCommand as ShowRemoveSearchSuggestionDialog).suggestion)
+    }
+
+    @Test
+    fun whenUserLongPressedOnHistorySearchSuggestionThenShowRemoveSearchSuggestionDialogCommandIssued() {
+        val suggestion = AutoCompleteHistorySearchSuggestion(phrase = "phrase", isAllowedInTopHits = false)
+
+        testee.userLongPressedAutocomplete(suggestion)
+
+        verify(commandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
+        val issuedCommand = commandCaptor.allValues.find { it is ShowRemoveSearchSuggestionDialog }
+        assertEquals(suggestion, (issuedCommand as ShowRemoveSearchSuggestionDialog).suggestion)
+    }
+
+    @Test
+    fun whenUserLongPressedOnOtherSuggestionThenDoNothing() {
+        val suggestion = AutoCompleteDefaultSuggestion(phrase = "phrase")
+
+        testee.userLongPressedAutocomplete(suggestion)
+
+        assertCommandNotIssued<ShowRemoveSearchSuggestionDialog>()
+    }
+
+    @Test
+    fun whenOnRemoveSearchSuggestionConfirmedForHistorySuggestionThenPixelFiredAndHistoryEntryRemoved() = runBlocking {
+        val suggestion = AutoCompleteHistorySuggestion(phrase = "phrase", title = "title", url = "url", isAllowedInTopHits = false)
+        val omnibarText = "foo"
+
+        val testObserver = TestObserver.create<String>()
+        testee.resultsPublishSubject.subscribe(testObserver)
+
+        testee.onRemoveSearchSuggestionConfirmed(suggestion, omnibarText)
+
+        verify(mockPixel).fire(AUTOCOMPLETE_RESULT_DELETED)
+        verify(mockHistory).removeHistoryEntryByUrl(suggestion.url)
+        testObserver.assertValue(omnibarText)
+        assertCommandIssued<AutocompleteItemRemoved>()
+    }
+
+    @Test
+    fun whenOnRemoveSearchSuggestionConfirmedForHistorySearchSuggestionThenPixelFiredAndHistoryEntryRemoved() = runBlocking {
+        val suggestion = AutoCompleteHistorySearchSuggestion(phrase = "phrase", isAllowedInTopHits = false)
+        val omnibarText = "foo"
+
+        val testObserver = TestObserver.create<String>()
+        testee.resultsPublishSubject.subscribe(testObserver)
+
+        testee.onRemoveSearchSuggestionConfirmed(suggestion, omnibarText)
+
+        verify(mockPixel).fire(AUTOCOMPLETE_RESULT_DELETED)
+        verify(mockHistory).removeHistoryEntryByQuery(suggestion.phrase)
+        testObserver.assertValue(omnibarText)
+        assertCommandIssued<AutocompleteItemRemoved>()
+    }
+
     private suspend fun whenOnboardingShowing() {
         whenever(mockUserStageStore.getUserAppStage()).thenReturn(AppStage.NEW)
         testee.resetViewState()
     }
 
-    private fun givenEmptyUserStageStore(): UserStageStore {
-        val emptyUserStageDao = object : UserStageDao {
-            override suspend fun currentUserAppStage() = UserStage(appStage = AppStage.NEW)
-            override fun insert(userStage: UserStage) {}
+    private inline fun <reified T : Command> assertCommandIssued(instanceAssertions: T.() -> Unit = {}) {
+        verify(commandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
+        val issuedCommand = commandCaptor.allValues.find { it is T }
+        assertNotNull(issuedCommand)
+        (issuedCommand as T).apply { instanceAssertions() }
+    }
+
+    private inline fun <reified T : Command> assertCommandNotIssued() {
+        val defaultMockingDetails = DefaultMockingDetails(commandObserver)
+        if (defaultMockingDetails.invocations.isNotEmpty()) {
+            verify(commandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
+            val issuedCommand = commandCaptor.allValues.find { it is T }
+            assertNull(issuedCommand)
         }
-        return AppUserStageStore(emptyUserStageDao, coroutineRule.testDispatcherProvider)
     }
 
     companion object {

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/KeyboardVisibilityUtil.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/KeyboardVisibilityUtil.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.app.browser.autocomplete
+package com.duckduckgo.common.utils
 
 import android.graphics.Rect
 import android.view.View
@@ -35,11 +35,16 @@ class KeyboardVisibilityUtil(private val rootView: View) {
         )
     }
 
+    // Logic taken from NewTabPageView
     private fun isKeyboardVisible(): Boolean {
         val rect = Rect()
         rootView.getWindowVisibleDisplayFrame(rect)
         val screenHeight = rootView.height
         val keypadHeight = screenHeight - rect.bottom
-        return keypadHeight > screenHeight * 0.15
+        return keypadHeight > screenHeight * KEYBOARD_VISIBILITY_THRESHOLD
+    }
+
+    companion object {
+        private const val KEYBOARD_VISIBILITY_THRESHOLD = 0.15
     }
 }

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/KeyboardVisibilityUtil.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/KeyboardVisibilityUtil.kt
@@ -35,7 +35,6 @@ class KeyboardVisibilityUtil(private val rootView: View) {
         )
     }
 
-    // Logic taken from NewTabPageView
     private fun isKeyboardVisible(): Boolean {
         val rect = Rect()
         rootView.getWindowVisibleDisplayFrame(rect)

--- a/history/history-api/src/main/java/com/duckduckgo/history/api/NavigationHistory.kt
+++ b/history/history-api/src/main/java/com/duckduckgo/history/api/NavigationHistory.kt
@@ -41,6 +41,16 @@ interface NavigationHistory {
     suspend fun clearHistory()
 
     /**
+     * Removes a history entry by URL.
+     */
+    suspend fun removeHistoryEntryByUrl(url: String)
+
+    /**
+     * Removes a history entry by query.
+     */
+    suspend fun removeHistoryEntryByQuery(query: String)
+
+    /**
      * Returns whether the history is enabled by the user.
      */
     suspend fun isHistoryUserEnabled(): Boolean

--- a/history/history-impl/src/main/java/com/duckduckgo/history/impl/HistoryRepository.kt
+++ b/history/history-impl/src/main/java/com/duckduckgo/history/impl/HistoryRepository.kt
@@ -38,6 +38,10 @@ interface HistoryRepository {
 
     suspend fun clearHistory()
 
+    suspend fun removeHistoryEntryByUrl(url: String)
+
+    suspend fun removeHistoryEntryByQuery(query: String)
+
     suspend fun isHistoryUserEnabled(default: Boolean): Boolean
 
     suspend fun setHistoryUserEnabled(value: Boolean)
@@ -95,6 +99,26 @@ class RealHistoryRepository(
             cachedHistoryEntries = null
             historyDao.deleteAll()
             fetchAndCacheHistoryEntries()
+        }
+    }
+
+    override suspend fun removeHistoryEntryByUrl(url: String) {
+        withContext(dispatcherProvider.io()) {
+            historyDao.getHistoryEntryByUrl(url)?.let {
+                cachedHistoryEntries = null
+                historyDao.delete(it)
+                fetchAndCacheHistoryEntries()
+            }
+        }
+    }
+
+    override suspend fun removeHistoryEntryByQuery(query: String) {
+        withContext(dispatcherProvider.io()) {
+            historyDao.getHistoryEntryByQuery(query)?.let {
+                cachedHistoryEntries = null
+                historyDao.delete(it)
+                fetchAndCacheHistoryEntries()
+            }
         }
     }
 

--- a/history/history-impl/src/main/java/com/duckduckgo/history/impl/HistoryRepository.kt
+++ b/history/history-impl/src/main/java/com/duckduckgo/history/impl/HistoryRepository.kt
@@ -104,21 +104,17 @@ class RealHistoryRepository(
 
     override suspend fun removeHistoryEntryByUrl(url: String) {
         withContext(dispatcherProvider.io()) {
-            historyDao.getHistoryEntryByUrl(url)?.let {
-                cachedHistoryEntries = null
-                historyDao.delete(it)
-                fetchAndCacheHistoryEntries()
-            }
+            cachedHistoryEntries = null
+            historyDao.deleteEntriesByUrl(url)
+            fetchAndCacheHistoryEntries()
         }
     }
 
     override suspend fun removeHistoryEntryByQuery(query: String) {
         withContext(dispatcherProvider.io()) {
-            historyDao.getHistoryEntriesByQuery(query)?.let {
-                cachedHistoryEntries = null
-                historyDao.delete(it)
-                fetchAndCacheHistoryEntries()
-            }
+            cachedHistoryEntries = null
+            historyDao.deleteEntriesByQuery(query)
+            fetchAndCacheHistoryEntries()
         }
     }
 

--- a/history/history-impl/src/main/java/com/duckduckgo/history/impl/HistoryRepository.kt
+++ b/history/history-impl/src/main/java/com/duckduckgo/history/impl/HistoryRepository.kt
@@ -114,7 +114,7 @@ class RealHistoryRepository(
 
     override suspend fun removeHistoryEntryByQuery(query: String) {
         withContext(dispatcherProvider.io()) {
-            historyDao.getHistoryEntryByQuery(query)?.let {
+            historyDao.getHistoryEntriesByQuery(query)?.let {
                 cachedHistoryEntries = null
                 historyDao.delete(it)
                 fetchAndCacheHistoryEntries()

--- a/history/history-impl/src/main/java/com/duckduckgo/history/impl/RealNavigationHistory.kt
+++ b/history/history-impl/src/main/java/com/duckduckgo/history/impl/RealNavigationHistory.kt
@@ -63,6 +63,14 @@ class RealNavigationHistory @Inject constructor(
         historyRepository.clearHistory()
     }
 
+    override suspend fun removeHistoryEntryByUrl(url: String) {
+        historyRepository.removeHistoryEntryByUrl(url)
+    }
+
+    override suspend fun removeHistoryEntryByQuery(query: String) {
+        historyRepository.removeHistoryEntryByQuery(query)
+    }
+
     override suspend fun clearOldEntries() {
         historyRepository.clearEntriesOlderThan(currentTimeProvider.localDateTimeNow().minusDays(30))
     }

--- a/history/history-impl/src/main/java/com/duckduckgo/history/impl/store/HistoryDao.kt
+++ b/history/history-impl/src/main/java/com/duckduckgo/history/impl/store/HistoryDao.kt
@@ -56,6 +56,9 @@ interface HistoryDao {
     @Query("SELECT * FROM history_entries WHERE url = :url LIMIT 1")
     suspend fun getHistoryEntryByUrl(url: String): HistoryEntryEntity?
 
+    @Query("SELECT * FROM history_entries WHERE `query` = :query LIMIT 1")
+    suspend fun getHistoryEntryByQuery(query: String?): HistoryEntryEntity?
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertHistoryEntry(historyEntry: HistoryEntryEntity): Long
 

--- a/history/history-impl/src/main/java/com/duckduckgo/history/impl/store/HistoryDao.kt
+++ b/history/history-impl/src/main/java/com/duckduckgo/history/impl/store/HistoryDao.kt
@@ -56,9 +56,6 @@ interface HistoryDao {
     @Query("SELECT * FROM history_entries WHERE url = :url LIMIT 1")
     suspend fun getHistoryEntryByUrl(url: String): HistoryEntryEntity?
 
-    @Query("SELECT * FROM history_entries WHERE `query` = :query")
-    suspend fun getHistoryEntriesByQuery(query: String?): List<HistoryEntryEntity>?
-
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertHistoryEntry(historyEntry: HistoryEntryEntity): Long
 
@@ -82,6 +79,12 @@ interface HistoryDao {
 
     @Delete
     suspend fun delete(entities: List<HistoryEntryEntity>)
+
+    @Query("DELETE FROM history_entries WHERE `query` = :query")
+    suspend fun deleteEntriesByQuery(query: String)
+
+    @Query("DELETE FROM history_entries WHERE `url` = :url")
+    suspend fun deleteEntriesByUrl(url: String)
 
     @Query("DELETE FROM visits_list WHERE timestamp < :timestamp")
     suspend fun deleteOldVisitsByTimestamp(timestamp: String)

--- a/history/history-impl/src/main/java/com/duckduckgo/history/impl/store/HistoryDao.kt
+++ b/history/history-impl/src/main/java/com/duckduckgo/history/impl/store/HistoryDao.kt
@@ -56,8 +56,8 @@ interface HistoryDao {
     @Query("SELECT * FROM history_entries WHERE url = :url LIMIT 1")
     suspend fun getHistoryEntryByUrl(url: String): HistoryEntryEntity?
 
-    @Query("SELECT * FROM history_entries WHERE `query` = :query LIMIT 1")
-    suspend fun getHistoryEntryByQuery(query: String?): HistoryEntryEntity?
+    @Query("SELECT * FROM history_entries WHERE `query` = :query")
+    suspend fun getHistoryEntriesByQuery(query: String?): List<HistoryEntryEntity>?
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertHistoryEntry(historyEntry: HistoryEntryEntity): Long

--- a/history/history-impl/src/test/java/com/duckduckgo/history/impl/HistoryTest.kt
+++ b/history/history-impl/src/test/java/com/duckduckgo/history/impl/HistoryTest.kt
@@ -115,4 +115,22 @@ class HistoryTest {
             verify(mockHistoryRepository, never()).saveToHistory(any(), any(), any(), any())
         }
     }
+
+    @Test
+    fun whenRemoveHistoryEntryByUrlThenRemoveHistoryEntryByUrlCalled() = runTest {
+        val url = "https://example.com"
+
+        testee.removeHistoryEntryByUrl(url)
+
+        verify(mockHistoryRepository).removeHistoryEntryByUrl(eq(url))
+    }
+
+    @Test
+    fun whenRemoveHistoryEntryByQueryThenRemoveHistoryEntryByQueryCalled() = runTest {
+        val query = "query"
+
+        testee.removeHistoryEntryByQuery(query)
+
+        verify(mockHistoryRepository).removeHistoryEntryByQuery(eq(query))
+    }
 }

--- a/history/history-impl/src/test/java/com/duckduckgo/history/impl/store/HistoryDaoTest.kt
+++ b/history/history-impl/src/test/java/com/duckduckgo/history/impl/store/HistoryDaoTest.kt
@@ -132,4 +132,42 @@ class HistoryDaoTest {
             Assert.assertEquals(1, historyEntriesWithVisits.first().visits.count())
         }
     }
+
+    @Test
+    fun whenDeleteEntriesByQueryThenCorrectEntriesDeleted() {
+        runTest {
+            val insertDate = LocalDateTime.of(2000, JANUARY, 1, 0, 0)
+            historyDao.updateOrInsertVisit("url1", "title1", "query1", false, insertDate)
+            historyDao.updateOrInsertVisit("url2", "title2", "query2", false, insertDate)
+            historyDao.updateOrInsertVisit("url3", "title3", "query1", false, insertDate)
+
+            historyDao.deleteEntriesByQuery("query1")
+
+            val historyEntriesWithVisits = historyDao.getHistoryEntriesWithVisits()
+
+            Assert.assertEquals(1, historyEntriesWithVisits.count())
+            Assert.assertNull(historyEntriesWithVisits.find { it.historyEntry.query == "query1" })
+            Assert.assertNotNull(historyEntriesWithVisits.find { it.historyEntry.query == "query2" })
+        }
+    }
+
+    @Test
+    fun whenDeleteEntriesByUrlThenCorrectEntryDeleted() {
+        runTest {
+            val insertDate = LocalDateTime.of(2000, JANUARY, 1, 0, 0)
+            historyDao.updateOrInsertVisit("url1", "title1", null, false, insertDate)
+            historyDao.updateOrInsertVisit("url2", "title2", null, false, insertDate)
+            historyDao.updateOrInsertVisit("url3", "title3", null, false, insertDate)
+            historyDao.updateOrInsertVisit("url2", "title4", null, false, insertDate)
+
+            historyDao.deleteEntriesByUrl("url2")
+
+            val historyEntriesWithVisits = historyDao.getHistoryEntriesWithVisits()
+
+            Assert.assertEquals(2, historyEntriesWithVisits.count())
+            Assert.assertNull(historyEntriesWithVisits.find { it.historyEntry.url == "url2" })
+            Assert.assertNotNull(historyEntriesWithVisits.find { it.historyEntry.url == "url1" })
+            Assert.assertNotNull(historyEntriesWithVisits.find { it.historyEntry.url == "url3" })
+        }
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207977618326502/f

### Description
Adds the ability to delete recent items from the autocomplete list.

### Steps to test this PR

_Remove query_
- [x] Search for something (eg. “dogs”)
- [x] Clear the search and type the first few letters
- [x] Long press the recent item
- [x] Verify that the keyboard is hidden and the dialog is shown
- [x] Press “Remove"
- [x] Verify that the `m_autocomplete_result_deleted` pixel is sent
- [x] Verify that the item is deleted
- [x] Verify that the keyboard is shown

_Remove URL_
- [x] Visit a URL (eg. “dog.com”)
- [x] Clear the search and type the first few letters
- [x] Long press the recent item
- [x] Verify that the keyboard is hidden and the dialog is shown
- [x] Press “Remove"
- [x] Verify that the `m_autocomplete_result_deleted` pixel is sent
- [x] Verify that the item is deleted
- [x] Verify that the keyboard is shown

_Cancel_
- [x] Do the same thing and press “Cancel" or tap outside the dialog
- [x] Verify that the item is not deleted

_Widget_
- [x] Add the widget
- [x] Follow the same steps as _Remove query_, _Remove URL_ and _Cancel_

### UI changes
| Browser  | Widget |
| ------ | ----- |
![remove_history](https://github.com/user-attachments/assets/b3479df8-8e39-4389-aac1-6e3d5ae93527)|![remove_history_widget](https://github.com/user-attachments/assets/f7c5630f-e11b-4e5f-afea-005cf517e39e)


