### PR TITLE
Fix ANR due race accessing DAO in NTP

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -614,7 +614,7 @@ class BrowserTabViewModelTest {
             bypassedSSLCertificatesRepository = mockBypassedSSLCertificatesRepository,
             userBrowserProperties = mockUserBrowserProperties,
             history = mockNavigationHistory,
-            newTabPixels = mockNewTabPixels,
+            newTabPixels = { mockNewTabPixels },
         )
 
         testee.loadData("abc", null, false)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -193,6 +193,7 @@ import com.duckduckgo.sync.api.favicons.FaviconsFetchingPrompt
 import com.duckduckgo.voice.api.VoiceSearchAvailability
 import com.duckduckgo.voice.api.VoiceSearchAvailabilityPixelLogger
 import com.jakewharton.rxrelay2.PublishRelay
+import dagger.Lazy
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
 import io.reactivex.schedulers.Schedulers
@@ -265,7 +266,7 @@ class BrowserTabViewModel @Inject constructor(
     private val bypassedSSLCertificatesRepository: BypassedSSLCertificatesRepository,
     private val userBrowserProperties: UserBrowserProperties,
     private val history: NavigationHistory,
-    private val newTabPixels: NewTabPixels,
+    private val newTabPixels: Lazy<NewTabPixels>, // Lazy to construct the instance and deps only when actually sending the pixel
 ) : WebViewClientListener,
     EditSavedSiteListener,
     DeleteBookmarkListener,
@@ -3337,7 +3338,7 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     fun onNewTabShown() {
-        newTabPixels.fireNewTabDisplayed()
+        newTabPixels.get().fireNewTabDisplayed()
     }
 
     companion object {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202552961248957/1207980975183570/f

### Description
Ensure only NTP constructs the new tab pixel avoding a race and eventual ANR

### Steps to test this PR

_Test_
- [x] install internal build and launch app
- [x] open a new tab
- [x] verify the `m_new_tab_page_displayed` is sent
- [x] verify NTP works normally
