### PR TITLE
Tab manager crash fix

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/tabpreview/TabEntityDiffCallback.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabpreview/TabEntityDiffCallback.kt
@@ -22,7 +22,7 @@ import com.duckduckgo.app.tabs.model.TabEntity
 
 class TabEntityDiffCallback(
     private val oldList: List<TabEntity>,
-    var newList: List<TabEntity>,
+    private val newList: List<TabEntity>,
 ) : DiffUtil.Callback() {
 
     private fun areItemsTheSame(

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabGridItemDecorator.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabGridItemDecorator.kt
@@ -53,14 +53,10 @@ class TabGridItemDecorator(
             val child = recyclerView.getChildAt(i)
 
             val positionInAdapter = recyclerView.getChildAdapterPosition(child)
-            if (positionInAdapter < 0) {
-                continue
-            }
-
-            val tab = adapter.getTab(positionInAdapter)
-
-            if (tab.tabId == selectedTabId) {
-                drawSelectedTabDecoration(child, canvas)
+            adapter.getTab(positionInAdapter)?.let { tab ->
+                if (tab.tabId == selectedTabId) {
+                    drawSelectedTabDecoration(child, canvas)
+                }
             }
         }
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -220,7 +220,9 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
 
     private fun scrollToShowCurrentTab() {
         val index = tabsAdapter.adapterPositionForTab(selectedTabId)
-        tabsRecycler.post { tabsRecycler.scrollToPosition(index) }
+        if (index != -1) {
+            tabsRecycler.post { tabsRecycler.scrollToPosition(index) }
+        }
     }
 
     private fun processCommand(command: Command) {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -297,8 +297,10 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
     }
 
     override fun onTabDeleted(position: Int, deletedBySwipe: Boolean) {
-        val tab = tabsAdapter.getTab(position)
-        launch { viewModel.onMarkTabAsDeletable(tab, deletedBySwipe) }
+        if (position >= 0 && position < tabsAdapter.itemCount) {
+            val tab = tabsAdapter.getTab(position)
+            launch { viewModel.onMarkTabAsDeletable(tab, deletedBySwipe) }
+        }
     }
 
     override fun onTabMoved(from: Int, to: Int) {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -299,8 +299,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
     }
 
     override fun onTabDeleted(position: Int, deletedBySwipe: Boolean) {
-        if (position >= 0 && position < tabsAdapter.itemCount) {
-            val tab = tabsAdapter.getTab(position)
+        tabsAdapter.getTab(position)?.let { tab ->
             launch { viewModel.onMarkTabAsDeletable(tab, deletedBySwipe) }
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
@@ -54,7 +54,6 @@ class TabSwitcherAdapter(
 ) : Adapter<TabViewHolder>() {
 
     private val list = mutableListOf<TabEntity>()
-    private val diffCallback = TabEntityDiffCallback(list, listOf())
 
     private var isDragging: Boolean = false
 
@@ -201,8 +200,7 @@ class TabSwitcherAdapter(
     }
 
     private fun submitList(updatedList: List<TabEntity>) {
-        diffCallback.newList = updatedList
-        val diffResult = DiffUtil.calculateDiff(diffCallback)
+        val diffResult = DiffUtil.calculateDiff(TabEntityDiffCallback(list, updatedList))
 
         list.clear()
         list.addAll(updatedList)

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
@@ -207,7 +207,7 @@ class TabSwitcherAdapter(
         diffResult.dispatchUpdatesTo(this)
     }
 
-    fun getTab(position: Int): TabEntity = list[position]
+    fun getTab(position: Int): TabEntity? = list.getOrNull(position)
 
     fun adapterPositionForTab(tabId: String?): Int {
         if (tabId == null) return -1

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -55,9 +55,9 @@ class TabSwitcherViewModel @Inject constructor(
         const val REINSTALL_VARIANT = "ru"
     }
 
-    var tabs: LiveData<List<TabEntity>> = tabRepository.liveTabs
+    val tabs: LiveData<List<TabEntity>> = tabRepository.liveTabs
     val activeTab = tabRepository.liveSelectedTab
-    var deletableTabs: LiveData<List<TabEntity>> = tabRepository.flowDeletableTabs.asLiveData(
+    val deletableTabs: LiveData<List<TabEntity>> = tabRepository.flowDeletableTabs.asLiveData(
         context = viewModelScope.coroutineContext,
     )
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202552961248957/1207981775109546/f
Possibly also: https://app.asana.com/0/1202552961248957/1207981775109549

### Description

This PR adds bounds checks for the tab getter in the RecyclerView adapter. The first crash is caused by a rapid double tap on the tab close button, which results in an invalid index being returned.

The second crash is possibly a different manifestation of the same problem but due to a race condition it happens elsewhere. It should be resolved by [8bfcfbd](https://github.com/duckduckgo/Android/commit/8bfcfbddca920ce5e8250e6987179f992c8c82f1).

### Steps to test this PR

_Duble tap_
- [x] Go to the tab manager 
- [x] Add a few tabs
- [x] Tap on a tab close button very quickly
- [x] Notice the app doesn’t crash

