### PR TITLE
Fix autocomplete pixels not being sent

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -3551,6 +3551,7 @@ class BrowserTabFragment :
                 if (viewState.showSuggestions || viewState.showFavorites) {
                     if (viewState.favorites.isNotEmpty() && viewState.showFavorites) {
                         showFocusedView()
+                        viewModel.autoCompleteSuggestionsGone()
                         binding.autoCompleteSuggestionsList.gone()
                     } else {
                         binding.autoCompleteSuggestionsList.show()
@@ -3558,6 +3559,7 @@ class BrowserTabFragment :
                         hideFocusedView()
                     }
                 } else {
+                    viewModel.autoCompleteSuggestionsGone()
                     binding.autoCompleteSuggestionsList.gone()
                     hideFocusedView()
                 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/inbox/1157893581871899/1207984745988817/1207988320986561

### Description
Autocomplete pixels stopped being sent after the NTP refactor. This PR fixes that.

### Steps to test this PR
_Pixels sent_
- [x] Fresh install 
- [x] Start typing on the URL bar so that the autocomplete view appears
- [x] Close it, so that the autocomplete view dissappears
- [x] Verify autocomplete pixels are sent
- [x] 13:52:22.781  V  Pixel sent: m_autocomplete_displayed_website with params: {} {}

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207984745988817