### PR TITLE
Tab manager crash fix

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/tabpreview/TabEntityDiffCallback.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabpreview/TabEntityDiffCallback.kt
@@ -20,10 +20,11 @@ import android.os.Bundle
 import androidx.recyclerview.widget.DiffUtil
 import com.duckduckgo.app.tabs.model.TabEntity
 
-class TabEntityDiffCallback(
-    private val oldList: List<TabEntity>,
-    private val newList: List<TabEntity>,
-) : DiffUtil.Callback() {
+class TabEntityDiffCallback(old: List<TabEntity>, new: List<TabEntity>) : DiffUtil.Callback() {
+
+    // keep a local copy of the lists to avoid any changes to the lists during the diffing process
+    private val oldList = old.toList()
+    private val newList = new.toList()
 
     private fun areItemsTheSame(
         oldItem: TabEntity,

--- a/app/src/main/java/com/duckduckgo/app/browser/tabpreview/TabEntityDiffCallback.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabpreview/TabEntityDiffCallback.kt
@@ -77,15 +77,27 @@ class TabEntityDiffCallback(old: List<TabEntity>, new: List<TabEntity>) : DiffUt
     }
 
     override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-        return areItemsTheSame(oldList[oldItemPosition], newList[newItemPosition])
+        return if (oldItemPosition in oldList.indices && newItemPosition in newList.indices) {
+            areItemsTheSame(oldList[oldItemPosition], newList[newItemPosition])
+        } else {
+            false
+        }
     }
 
     override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-        return areContentsTheSame(oldList[oldItemPosition], newList[newItemPosition])
+        return if (oldItemPosition in oldList.indices && newItemPosition in newList.indices) {
+            areContentsTheSame(oldList[oldItemPosition], newList[newItemPosition])
+        } else {
+            false
+        }
     }
 
     override fun getChangePayload(oldItemPosition: Int, newItemPosition: Int): Any {
-        return getChangePayload(oldList[oldItemPosition], newList[newItemPosition])
+        return if (oldItemPosition in oldList.indices && newItemPosition in newList.indices) {
+            getChangePayload(oldList[oldItemPosition], newList[newItemPosition])
+        } else {
+            Bundle()
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
@@ -261,13 +261,7 @@ class TabSwitcherAdapter(
         }
     }
 
-    fun updateData(data: List<TabEntity>?) {
-        if (data != null) {
-            submitList(data)
-        }
-    }
-
-    private fun submitList(updatedList: List<TabEntity>) {
+    fun updateData(updatedList: List<TabEntity>) {
         val diffResult = DiffUtil.calculateDiff(TabEntityDiffCallback(list, updatedList))
 
         list.clear()
@@ -292,9 +286,7 @@ class TabSwitcherAdapter(
 
     fun onTabMoved(from: Int, to: Int) {
         val swapped = list.swap(from, to)
-        list.clear()
-        list.addAll(swapped)
-        notifyItemMoved(from, to)
+        updateData(swapped)
     }
 
     @SuppressLint("NotifyDataSetChanged")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207418217763355/1208000508832396/f

### Description

This is the 2nd attempt at fixing the crash. I wasn’t able to reproduce it, but the theory is that the adapter list gets modified while it’s being diffed, which results in an inconsistency and `IndexOutOfBoundsException` being thrown.

The fix for this is to create a local copy of the diffed lists, which should resolve race condition issue. I also added index range checks to be extra careful even though they *should* be redundant. 

### Steps to test this PR

I wasn’t able to reproduce the crash. Smoke-testing the drag & drop feature should be enough.
