### PR TITLE
Fix Tab manager crash

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -374,13 +374,11 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
     }
 
     override fun onTabMoved(from: Int, to: Int) {
-        launch {
-            val tabCount = viewModel.tabs.value?.size ?: 0
-            val canSwap = from in 0..< tabCount && to in 0..< tabCount
-            if (canSwap) {
-                tabsAdapter.onTabMoved(from, to)
-                viewModel.onTabMoved(from, to)
-            }
+        val tabCount = viewModel.tabs.value?.size ?: 0
+        val canSwap = from in 0..< tabCount && to in 0..< tabCount
+        if (canSwap) {
+            tabsAdapter.onTabMoved(from, to)
+            viewModel.onTabMoved(from, to)
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://github.com/duckduckgo/Android/pull/4878

### Description
`onTabMoved` is scheduled to be run, so the `to` and/or `from` may be invalid by the time they are actually run. This PR removes that scheduling, so `onTabMoved` is called immediately in response to the tab being moved, and there is no time between scheduling and running this for the repository to emit and change the data by the time we handle this touch event.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207990892540430