### PR TITLE
Omnibar position: Settings and store

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/appearance/AppearanceActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/appearance/AppearanceActivity.kt
@@ -25,8 +25,8 @@ import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.appearance.AppearanceViewModel.Command
-import com.duckduckgo.app.appearance.AppearanceViewModel.Command.LaunchOmnibarPositionSettings
 import com.duckduckgo.app.appearance.AppearanceViewModel.Command.LaunchAppIcon
+import com.duckduckgo.app.appearance.AppearanceViewModel.Command.LaunchOmnibarPositionSettings
 import com.duckduckgo.app.appearance.AppearanceViewModel.Command.LaunchThemeSettings
 import com.duckduckgo.app.appearance.AppearanceViewModel.Command.UpdateTheme
 import com.duckduckgo.app.browser.R

--- a/app/src/main/java/com/duckduckgo/app/appearance/AppearanceActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/appearance/AppearanceActivity.kt
@@ -25,8 +25,13 @@ import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.appearance.AppearanceViewModel.Command
+import com.duckduckgo.app.appearance.AppearanceViewModel.Command.LaunchOmnibarPositionSettings
+import com.duckduckgo.app.appearance.AppearanceViewModel.Command.LaunchAppIcon
+import com.duckduckgo.app.appearance.AppearanceViewModel.Command.LaunchThemeSettings
+import com.duckduckgo.app.appearance.AppearanceViewModel.Command.UpdateTheme
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.ActivityAppearanceBinding
+import com.duckduckgo.app.browser.omnibar.model.OmnibarPosition
 import com.duckduckgo.app.fire.FireActivity
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.DuckDuckGoTheme
@@ -99,6 +104,7 @@ class AppearanceActivity : DuckDuckGoActivity() {
                     binding.experimentalNightMode.quietlySetIsChecked(viewState.forceDarkModeEnabled, forceDarkModeToggleListener)
                     binding.experimentalNightMode.isEnabled = viewState.canForceDarkMode
                     binding.experimentalNightMode.isVisible = viewState.supportsForceDarkMode
+                    updateSelectedOmnibarPosition(it.omnibarPosition)
                 }
             }.launchIn(lifecycleScope)
 
@@ -119,11 +125,22 @@ class AppearanceActivity : DuckDuckGoActivity() {
         binding.selectedThemeSetting.setSecondaryText(subtitle)
     }
 
+    private fun updateSelectedOmnibarPosition(position: OmnibarPosition) {
+        val subtitle = getString(
+            when (position) {
+                OmnibarPosition.TOP -> R.string.settingsAddressBarPositionTop
+                OmnibarPosition.BOTTOM -> R.string.settingsAddressBarPositionBottom
+            },
+        )
+        binding.addressBarPositionSetting.setSecondaryText(subtitle)
+    }
+
     private fun processCommand(it: Command) {
         when (it) {
-            is Command.LaunchAppIcon -> launchAppIconChange()
-            is Command.UpdateTheme -> sendThemeChangedBroadcast()
-            is Command.LaunchThemeSettings -> launchThemeSelector(it.theme)
+            is LaunchAppIcon -> launchAppIconChange()
+            is UpdateTheme -> sendThemeChangedBroadcast()
+            is LaunchThemeSettings -> launchThemeSelector(it.theme)
+            is LaunchOmnibarPositionSettings -> launchOmnibarPositionSelector(it.position)
         }
     }
 
@@ -154,6 +171,29 @@ class AppearanceActivity : DuckDuckGoActivity() {
                             else -> DuckDuckGoTheme.SYSTEM_DEFAULT
                         }
                         viewModel.onThemeSelected(selectedTheme)
+                    }
+                },
+            )
+            .show()
+    }
+
+    private fun launchOmnibarPositionSelector(position: OmnibarPosition) {
+        RadioListAlertDialogBuilder(this)
+            .setTitle(R.string.settingsAddressBarPositionTitle)
+            .setOptions(
+                listOf(
+                    R.string.settingsAddressBarPositionTop,
+                    R.string.settingsAddressBarPositionBottom,
+                ),
+                OmnibarPosition.entries.indexOf(position) + 1,
+            )
+            .setPositiveButton(R.string.dialogSave)
+            .setNegativeButton(R.string.cancel)
+            .addEventListener(
+                object : RadioListAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked(selectedItem: Int) {
+                        val newPosition = OmnibarPosition.entries[selectedItem - 1]
+                        viewModel.onOmnibarPositionUpdated(newPosition)
                     }
                 },
             )

--- a/app/src/main/java/com/duckduckgo/app/appearance/AppearanceActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/appearance/AppearanceActivity.kt
@@ -92,6 +92,7 @@ class AppearanceActivity : DuckDuckGoActivity() {
     private fun configureUiEventHandlers() {
         binding.selectedThemeSetting.setClickListener { viewModel.userRequestedToChangeTheme() }
         binding.changeAppIconSetting.setOnClickListener { viewModel.userRequestedToChangeIcon() }
+        binding.addressBarPositionSetting.setOnClickListener { viewModel.userRequestedToChangeAddressBarPosition() }
     }
 
     private fun observeViewModel() {

--- a/app/src/main/java/com/duckduckgo/app/appearance/AppearanceViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/appearance/AppearanceViewModel.kt
@@ -70,7 +70,7 @@ class AppearanceViewModel @Inject constructor(
 
     fun viewState(): Flow<ViewState> = viewState.onStart {
         viewModelScope.launch {
-            viewState.emit(
+            viewState.update {
                 currentViewState().copy(
                     theme = themingDataStore.theme,
                     appIcon = settingsDataStore.appIcon,
@@ -78,8 +78,8 @@ class AppearanceViewModel @Inject constructor(
                     canForceDarkMode = canForceDarkMode(),
                     supportsForceDarkMode = WebViewFeature.isFeatureSupported(WebViewFeature.ALGORITHMIC_DARKENING),
                     omnibarPosition = settingsDataStore.omnibarPosition,
-                ),
-            )
+                )
+            }
         }
     }
 
@@ -115,7 +115,7 @@ class AppearanceViewModel @Inject constructor(
         viewModelScope.launch(dispatcherProvider.io()) {
             themingDataStore.theme = selectedTheme
             withContext(dispatcherProvider.main()) {
-                viewState.emit(currentViewState().copy(theme = selectedTheme, forceDarkModeEnabled = canForceDarkMode()))
+                viewState.update { currentViewState().copy(theme = selectedTheme, forceDarkModeEnabled = canForceDarkMode()) }
                 command.send(Command.UpdateTheme)
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/appearance/AppearanceViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/appearance/AppearanceViewModel.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
@@ -131,7 +132,7 @@ class AppearanceViewModel @Inject constructor(
     fun onOmnibarPositionUpdated(position: OmnibarPosition) {
         viewModelScope.launch(dispatcherProvider.io()) {
             settingsDataStore.omnibarPosition = position
-            viewState.update {currentViewState().copy(omnibarPosition = position) }
+            viewState.update { currentViewState().copy(omnibarPosition = position) }
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/appearance/AppearanceViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/appearance/AppearanceViewModel.kt
@@ -131,7 +131,7 @@ class AppearanceViewModel @Inject constructor(
     fun onOmnibarPositionUpdated(position: OmnibarPosition) {
         viewModelScope.launch(dispatcherProvider.io()) {
             settingsDataStore.omnibarPosition = position
-            viewState.emit(currentViewState().copy(omnibarPosition = position))
+            viewState.update {currentViewState().copy(omnibarPosition = position) }
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -122,6 +122,7 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     SETTINGS_PERMISSIONS_PRESSED("ms_permissions_setting_pressed"),
     SETTINGS_APPEARANCE_PRESSED("ms_appearance_setting_pressed"),
     SETTINGS_APP_ICON_PRESSED("ms_app_icon_setting_pressed"),
+    SETTINGS_ADDRESS_BAR_POSITION_PRESSED("ms_address_bar_position_setting_pressed"),
     SETTINGS_MAC_APP_PRESSED("ms_mac_app_setting_pressed"),
     SETTINGS_WINDOWS_APP_PRESSED("ms_windows_app_setting_pressed"),
     SETTINGS_EMAIL_PROTECTION_PRESSED("ms_email_protection_setting_pressed"),

--- a/app/src/main/java/com/duckduckgo/app/settings/db/SettingsDataStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/db/SettingsDataStore.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.settings.db
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
+import com.duckduckgo.app.browser.omnibar.model.OmnibarPosition
 import com.duckduckgo.app.fire.fireproofwebsite.ui.AutomaticFireproofSetting
 import com.duckduckgo.app.fire.fireproofwebsite.ui.AutomaticFireproofSetting.ASK_EVERY_TIME
 import com.duckduckgo.app.fire.fireproofwebsite.ui.AutomaticFireproofSetting.NEVER
@@ -52,6 +53,7 @@ interface SettingsDataStore {
     var appLinksEnabled: Boolean
     var showAppLinksPrompt: Boolean
     var showAutomaticFireproofDialog: Boolean
+    var omnibarPosition: OmnibarPosition
 
     /**
      * This will be checked upon app startup and used to decide whether it should perform a clear or not.
@@ -176,6 +178,10 @@ class SettingsSharedPreferences @Inject constructor(
         get() = preferences.getBoolean(SHOW_AUTOMATIC_FIREPROOF_DIALOG, true)
         set(enabled) = preferences.edit { putBoolean(SHOW_AUTOMATIC_FIREPROOF_DIALOG, enabled) }
 
+    override var omnibarPosition: OmnibarPosition
+        get() = OmnibarPosition.valueOf(preferences.getString(KEY_OMNIBAR_POSITION, OmnibarPosition.TOP.name) ?: OmnibarPosition.TOP.name)
+        set(value) = preferences.edit { putString(KEY_OMNIBAR_POSITION, value.name) }
+
     override fun hasBackgroundTimestampRecorded(): Boolean = preferences.contains(KEY_APP_BACKGROUNDED_TIMESTAMP)
     override fun clearAppBackgroundTimestamp() = preferences.edit { remove(KEY_APP_BACKGROUNDED_TIMESTAMP) }
 
@@ -248,6 +254,7 @@ class SettingsSharedPreferences @Inject constructor(
         const val SHOW_AUTOMATIC_FIREPROOF_DIALOG = "SHOW_AUTOMATIC_FIREPROOF_DIALOG"
         const val KEY_NOTIFY_ME_IN_DOWNLOADS_DISMISSED = "KEY_NOTIFY_ME_IN_DOWNLOADS_DISMISSED"
         const val KEY_EXPERIMENTAL_SITE_DARK_MODE = "KEY_EXPERIMENTAL_SITE_DARK_MODE"
+        const val KEY_OMNIBAR_POSITION = "KEY_OMNIBAR_POSITION"
     }
 
     private class FireAnimationPrefsMapper {

--- a/app/src/main/res/layout/activity_appearance.xml
+++ b/app/src/main/res/layout/activity_appearance.xml
@@ -87,6 +87,19 @@
 
             </LinearLayout>
 
+            <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingBottom="0dp" />
+
+            <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+                android:id="@+id/addressBarPositionSetting"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="@string/settingsAddressBarPositionTitle"
+                app:primaryTextTruncated="false"
+                app:secondaryText="@string/settingsAddressBarPositionTop" />
+
         </LinearLayout>
     </ScrollView>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -57,4 +57,8 @@
     <!-- New Tab -->
     <string name="newTabPageShortcutDownloads">Downloads</string>
     <string name="newTabPageShortcutSettings">Settings</string>
+
+    <string name="settingsAddressBarPositionTitle">Address Bar</string>
+    <string name="settingsAddressBarPositionTop">Top</string>
+    <string name="settingsAddressBarPositionBottom">Bottom</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -158,9 +158,6 @@
     <string name="settingsPermissionsSetting">Permissions</string>
     <string name="settingsSyncSetting">Sync &amp; Backup</string>
     <string name="settingsFireButton">Fire Button</string>
-    <string name="settingsAddressBarPositionTitle">Address Bar</string>
-    <string name="settingsAddressBarPositionTop">Top</string>
-    <string name="settingsAddressBarPositionBottom">Bottom</string>
 
     <!-- Private Search -->
     <string name="privateSearchActivityTitle">Private Search</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -158,6 +158,9 @@
     <string name="settingsPermissionsSetting">Permissions</string>
     <string name="settingsSyncSetting">Sync &amp; Backup</string>
     <string name="settingsFireButton">Fire Button</string>
+    <string name="settingsAddressBarPositionTitle">Address Bar</string>
+    <string name="settingsAddressBarPositionTop">Top</string>
+    <string name="settingsAddressBarPositionBottom">Bottom</string>
 
     <!-- Private Search -->
     <string name="privateSearchActivityTitle">Private Search</string>

--- a/app/src/test/java/com/duckduckgo/app/Fakes.kt
+++ b/app/src/test/java/com/duckduckgo/app/Fakes.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.app
 
+import com.duckduckgo.app.browser.omnibar.model.OmnibarPosition
 import com.duckduckgo.app.fire.fireproofwebsite.ui.AutomaticFireproofSetting
 import com.duckduckgo.app.fire.fireproofwebsite.ui.AutomaticFireproofSetting.ASK_EVERY_TIME
 import com.duckduckgo.app.icon.api.AppIcon
@@ -107,6 +108,10 @@ class FakeSettingsDataStore : SettingsDataStore {
     override var showAutomaticFireproofDialog: Boolean
         get() = store["showAutomaticFireproofDialog"] as Boolean? ?: true
         set(value) { store["showAutomaticFireproofDialog"] = value }
+
+    override var omnibarPosition: OmnibarPosition
+        get() = OmnibarPosition.valueOf(store["omnibarPosition"] as String)
+        set(value) { store["omnibarPosition"] = value.name }
 
     override var notifyMeInDownloadsDismissed: Boolean
         get() = store["notifyMeInDownloadsDismissed"] as Boolean? ?: false

--- a/app/src/test/java/com/duckduckgo/app/appearance/AppearanceViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/appearance/AppearanceViewModelTest.kt
@@ -19,6 +19,8 @@ package com.duckduckgo.app.appearance
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import app.cash.turbine.test
 import com.duckduckgo.app.appearance.AppearanceViewModel.Command
+import com.duckduckgo.app.browser.omnibar.model.OmnibarPosition.BOTTOM
+import com.duckduckgo.app.browser.omnibar.model.OmnibarPosition.TOP
 import com.duckduckgo.app.icon.api.AppIcon
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.settings.clear.FireAnimation
@@ -68,6 +70,7 @@ internal class AppearanceViewModelTest {
         whenever(mockAppSettingsDataStore.appIcon).thenReturn(AppIcon.DEFAULT)
         whenever(mockThemeSettingsDataStore.theme).thenReturn(DuckDuckGoTheme.SYSTEM_DEFAULT)
         whenever(mockAppSettingsDataStore.selectedFireAnimation).thenReturn(FireAnimation.HeroFire)
+        whenever(mockAppSettingsDataStore.omnibarPosition).thenReturn(TOP)
 
         testee = AppearanceViewModel(
             mockThemeSettingsDataStore,
@@ -180,6 +183,18 @@ internal class AppearanceViewModelTest {
         testee.onForceDarkModeSettingChanged(false)
         verify(mockAppSettingsDataStore).experimentalWebsiteDarkMode = false
         verify(mockPixel).fire(AppPixelName.FORCE_DARK_MODE_DISABLED)
+    }
+
+    @Test
+    fun whenOmnibarPositionUpdatedToBottom() = runTest {
+        testee.onOmnibarPositionUpdated(BOTTOM)
+        verify(mockAppSettingsDataStore).omnibarPosition = BOTTOM
+    }
+
+    @Test
+    fun whenOmnibarPositionUpdatedToTop() = runTest {
+        testee.onOmnibarPositionUpdated(TOP)
+        verify(mockAppSettingsDataStore).omnibarPosition = TOP
     }
 
     @Test

--- a/browser-api/src/main/java/com/duckduckgo/app/browser/omnibar/model/OmnibarPosition.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/browser/omnibar/model/OmnibarPosition.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.omnibar.model
+
+enum class OmnibarPosition {
+    TOP, BOTTOM
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207418217763355/1206100017017597/f
Figma link: https://www.figma.com/design/Z4TFKpzzc02naMpqYO9ehv/Bottom-URL-bar-(Android)?node-id=1-2&t=oeftk6SHYD0A2iwr-1

### Description

This PR adds a new Settings option to change the position of the browser address bar. The selected value is saved in the user preferences.

### Steps to test this PR

- [x] Go to Settings
- [x] Tap on Appearance
- [x] Notice a new Address Bar option
- [x] Tap on it and notice a dialog shows up
- [x] Change the section and Save
- [x] Notice the new selection is reflected in the setting description
- [x] Leave the Settings
- [x] Navigate back to Appearance settings
- [x] Notice the selection was preserved

### UI changes

https://github.com/user-attachments/assets/f2fb8635-6e96-4439-a130-dea91e7b11de