### PR TITLE
Update content scope scripts to version 6.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^10.13.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#13.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.6.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.7.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#5.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1721137609"
       },
@@ -59,20 +59,19 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "10.13.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-10.13.0.tgz",
-      "integrity": "sha512-tR2XpSjA0Y4IC+Ql0J1e9B29Bz3qMEQW/+6gxJ6DRmvu0D8MsKvw0pST2rD/Q3+Mp9rL/FCklB/2X73hLK17LA==",
+      "version": "10.14.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-10.14.0.tgz",
+      "integrity": "sha512-FMuPv2k4Dv7s7qF8ffe5aA3eNlCP3PaYI+qiFGUxcCFG7iNpaDgcOM3Cu1lQc9Kq4wAlzqbIAb4e4miV4gg2wA==",
       "dependencies": {
         "tldts-experimental": "^6.1.37"
       }
     },
     "node_modules/@duckduckgo/autofill": {
       "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#1f12b78d9bac4a1d9b6bad18dc2ef0593bed34a3",
-      "hasInstallScript": true,
-      "license": "Apache-2.0"
+      "hasInstallScript": true
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#13ee45e6785f5d15bd909438a8e73c55b81a26b6",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#f97053d24c21ea301d4067adbbe0899ff940526a",
       "hasInstallScript": true,
       "workspaces": [
         "packages/special-pages",
@@ -209,9 +208,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.1.0.tgz",
-      "integrity": "sha512-AOmuRF0R2/5j1knA3c6G3HOk523Ga+l+ZXltX8SF1+5oqcXijjfTd8fY3XRZqSihEu9XhtQnKYLmkFaoxgsJHw==",
+      "version": "22.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.2.0.tgz",
+      "integrity": "sha512-bm6EG6/pCpkxDf/0gDNDdtDILMOHgaQBVOJGdwsqClnxA3xL6jtMv76rLBc006RVMWbmaf0xbmom4Z/5o2nRkQ==",
       "dev": true,
       "dependencies": {
         "undici-types": "~6.13.0"
@@ -634,9 +633,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.31.3",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.3.tgz",
-      "integrity": "sha512-pAfYn3NIZLyZpa83ZKigvj6Rn9c/vd5KfYGX7cN1mnzqgDcxWvrU5ZtAfIKhEXz9nRecw4z3LXkjaq96/qZqAA==",
+      "version": "5.31.6",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.6.tgz",
+      "integrity": "sha512-PQ4DAriWzKj+qgehQ7LK5bQqCFNMmlhjR2PFFLuqGCpuCAauxemVBWwWOxo3UIwWQx8+Pr61Df++r76wDmkQBg==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -652,16 +651,16 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.38",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.38.tgz",
-      "integrity": "sha512-TKmqyzXCha5k3WFSIW0ofB7W8BkUe1euZ1z9rZLckai5JxqndBt8CuWfusU9EB1qS5ycS+k9zf6Zs0bucKRDkg=="
+      "version": "6.1.39",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.39.tgz",
+      "integrity": "sha512-+Qib8VaRq6F56UjP4CJXd30PI4s3hFumDywUlsbiEWoA8+lfAaWNTLr3e6/zZOgHzVyon4snHaybeFHd8C0j/A=="
     },
     "node_modules/tldts-experimental": {
-      "version": "6.1.38",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.38.tgz",
-      "integrity": "sha512-s7uRPCo4W/VmBgR7CpA8WjTb7Hgh73tCfv69E+Mbl5m+oeNkAonuKWBx/RiY7PtZi0DAJ7Rb+5Ieiw5O6SI8HA==",
+      "version": "6.1.39",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.39.tgz",
+      "integrity": "sha512-BX/rK3bM7EZeDxgnKFJPUYQ2wcA/zXy1HdR9wT6iZFi8JJj4P4I+u3GTR+wkQaSB1xNhgbWrGvNt4krQnKg2rw==",
       "dependencies": {
-        "tldts-core": "^6.1.38"
+        "tldts-core": "^6.1.39"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^10.13.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#13.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.6.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.7.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#5.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1721137609"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass