### PR TITLE
Android: Track HTTP errors

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -83,6 +83,8 @@ import com.duckduckgo.app.browser.customtabs.CustomTabPixelNames
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.browser.favicon.FaviconSource
 import com.duckduckgo.app.browser.history.NavigationHistoryEntry
+import com.duckduckgo.app.browser.httperrors.HttpErrorPixelName
+import com.duckduckgo.app.browser.httperrors.HttpErrorPixels
 import com.duckduckgo.app.browser.logindetection.FireproofDialogsEventHandler
 import com.duckduckgo.app.browser.logindetection.LoginDetected
 import com.duckduckgo.app.browser.logindetection.NavigationAwareLoginDetector
@@ -310,6 +312,9 @@ class BrowserTabViewModelTest {
 
     @Mock
     private lateinit var mockNewTabPixels: NewTabPixels
+
+    @Mock
+    private lateinit var mockHttpErrorPixels: HttpErrorPixels
 
     @Mock
     private lateinit var mockOnboardingStore: OnboardingStore
@@ -620,6 +625,7 @@ class BrowserTabViewModelTest {
             userBrowserProperties = mockUserBrowserProperties,
             history = mockNavigationHistory,
             newTabPixels = { mockNewTabPixels },
+            httpErrorPixels = { mockHttpErrorPixels },
         )
 
         testee.loadData("abc", null, false, false)
@@ -4931,6 +4937,28 @@ class BrowserTabViewModelTest {
             httpErrorCodes = listOf(404),
             hasBrowserError = false,
         )
+    }
+
+    @Test
+    fun whenPageIsChangedWithHttpError400ThenUpdateCountPixelCalledForWebViewReceivedHttpError400Daily() = runTest {
+        testee.recordHttpErrorCode(statusCode = 400, url = "example2.com")
+
+        verify(mockHttpErrorPixels).updateCountPixel(HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_400_DAILY)
+    }
+
+    @Test
+    fun whenPageIsChangedWithHttpError4XXThenUpdateCountPixelCalledForWebViewReceivedHttpError4XXDaily() = runTest {
+        testee.recordHttpErrorCode(statusCode = 403, url = "example2.com")
+
+        verify(mockHttpErrorPixels).updateCountPixel(HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_4XX_DAILY)
+        verify(mockHttpErrorPixels, never()).updateCountPixel(HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_400_DAILY)
+    }
+
+    @Test
+    fun whenPageIsChangedWithHttpError5XXThenUpdateCountPixelCalledForWebViewReceivedHttpError5XXDaily() = runTest {
+        testee.recordHttpErrorCode(statusCode = 504, url = "example2.com")
+
+        verify(mockHttpErrorPixels).updateCountPixel(HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_5XX_DAILY)
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/browser/httperrors/HttpErrorDailyReportingWorker.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/httperrors/HttpErrorDailyReportingWorker.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.httperrors
+
+import android.content.Context
+import androidx.lifecycle.LifecycleOwner
+import androidx.work.BackoffPolicy
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.duckduckgo.anvil.annotations.ContributesWorker
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+
+@ContributesWorker(AppScope::class)
+class HttpErrorDailyReportingWorker(context: Context, workerParameters: WorkerParameters) :
+    CoroutineWorker(context, workerParameters) {
+
+    @Inject
+    lateinit var httpErrorPixels: HttpErrorPixels
+
+    @Inject
+    lateinit var dispatchers: DispatcherProvider
+
+    override suspend fun doWork(): Result {
+        return withContext(dispatchers.io()) {
+            httpErrorPixels.fireCountPixel(HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_400_DAILY)
+            httpErrorPixels.fireCountPixel(HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_4XX_DAILY)
+            httpErrorPixels.fireCountPixel(HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_5XX_DAILY)
+            return@withContext Result.success()
+        }
+    }
+}
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = MainProcessLifecycleObserver::class,
+)
+class HttpErrorDailyReportingWorkerScheduler @Inject constructor(
+    private val workManager: WorkManager,
+) : MainProcessLifecycleObserver {
+
+    override fun onCreate(owner: LifecycleOwner) {
+        super.onCreate(owner)
+        Timber.v("Scheduling http error daily reporting worker")
+        val workerRequest = PeriodicWorkRequestBuilder<HttpErrorDailyReportingWorker>(24, TimeUnit.HOURS)
+            .addTag(DAILY_REPORTING_HTTP_ERROR_WORKER_TAG)
+            .setBackoffCriteria(BackoffPolicy.LINEAR, 10, TimeUnit.MINUTES)
+            .build()
+        workManager.enqueueUniquePeriodicWork(DAILY_REPORTING_HTTP_ERROR_WORKER_TAG, ExistingPeriodicWorkPolicy.UPDATE, workerRequest)
+    }
+
+    companion object {
+        private const val DAILY_REPORTING_HTTP_ERROR_WORKER_TAG = "DAILY_REPORTING_HTTP_ERROR_WORKER_TAG"
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/httperrors/HttpErrorPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/httperrors/HttpErrorPixelName.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.httperrors
+
+import com.duckduckgo.app.statistics.pixels.Pixel
+
+enum class HttpErrorPixelName(override val pixelName: String) : Pixel.PixelName {
+    WEBVIEW_RECEIVED_HTTP_ERROR_400_DAILY("m_webview_received_http_error_400_daily"),
+    WEBVIEW_RECEIVED_HTTP_ERROR_4XX_DAILY("m_webview_received_http_error_4xx_daily"),
+    WEBVIEW_RECEIVED_HTTP_ERROR_5XX_DAILY("m_webview_received_http_error_5xx_daily"),
+}
+
+object HttpErrorPixelParameters {
+    const val HTTP_ERROR_CODE_COUNT = "count"
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/httperrors/HttpErrorPixels.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/httperrors/HttpErrorPixels.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.httperrors
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+interface HttpErrorPixels {
+    fun updateCountPixel(httpErrorPixelName: HttpErrorPixelName)
+    fun fireCountPixel(httpErrorPixelName: HttpErrorPixelName)
+}
+
+@ContributesBinding(AppScope::class)
+class RealHttpErrorPixels @Inject constructor(
+    private val pixel: Pixel,
+    private val context: Context,
+) : HttpErrorPixels {
+
+    private val preferences: SharedPreferences by lazy { context.getSharedPreferences(FILENAME, Context.MODE_PRIVATE) }
+
+    override fun updateCountPixel(httpErrorPixelName: HttpErrorPixelName) {
+        val count = preferences.getInt(httpErrorPixelName.appendCountSuffix(), 0)
+        preferences.edit { putInt(httpErrorPixelName.appendCountSuffix(), count + 1) }
+    }
+
+    override fun fireCountPixel(httpErrorPixelName: HttpErrorPixelName) {
+        val now = Instant.now().toEpochMilli()
+
+        val count = preferences.getInt(httpErrorPixelName.appendCountSuffix(), 0)
+        if (count == 0) {
+            return
+        }
+
+        val timestamp = preferences.getLong(httpErrorPixelName.appendTimestampSuffix(), 0L)
+        if (timestamp == 0L || now >= timestamp) {
+            pixel.fire(httpErrorPixelName, mapOf(HttpErrorPixelParameters.HTTP_ERROR_CODE_COUNT to count.toString()))
+                .also {
+                    preferences.edit {
+                        putLong(httpErrorPixelName.appendTimestampSuffix(), now.plus(TimeUnit.HOURS.toMillis(WINDOW_INTERVAL_HOURS)))
+                        putInt(httpErrorPixelName.appendCountSuffix(), 0)
+                    }
+                }
+        }
+    }
+
+    private fun HttpErrorPixelName.appendTimestampSuffix(): String {
+        return "${this.pixelName}_timestamp"
+    }
+
+    private fun HttpErrorPixelName.appendCountSuffix(): String {
+        return "${this.pixelName}_count"
+    }
+
+    companion object {
+        private const val FILENAME = "com.duckduckgo.app.browser.httperrors"
+        private const val WINDOW_INTERVAL_HOURS = 24L
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/global/api/PixelParamRemovalInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/PixelParamRemovalInterceptor.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.global.api
 
 import com.duckduckgo.app.browser.WebViewPixelName
+import com.duckduckgo.app.browser.httperrors.HttpErrorPixelName
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.StatisticsPixelName
@@ -84,6 +85,9 @@ object PixelInterceptorPixelsRequiringDataCleaning : PixelParamRemovalPlugin {
             WebViewPixelName.WEB_PAGE_LOADED.pixelName to PixelParameter.removeAll(),
             WebViewPixelName.WEB_PAGE_PAINTED.pixelName to PixelParameter.removeAll(),
             AppPixelName.REFERRAL_INSTALL_UTM_CAMPAIGN.pixelName to PixelParameter.removeAtb(),
+            HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_400_DAILY.pixelName to PixelParameter.removeAtb(),
+            HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_4XX_DAILY.pixelName to PixelParameter.removeAtb(),
+            HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_5XX_DAILY.pixelName to PixelParameter.removeAtb(),
         )
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/httperrors/HttpErrorDailyReportingWorkerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/httperrors/HttpErrorDailyReportingWorkerTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.httperrors
+
+import android.content.Context
+import androidx.work.ListenableWorker
+import androidx.work.testing.TestListenableWorkerBuilder
+import com.duckduckgo.common.test.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+internal class HttpErrorDailyReportingWorkerTest {
+
+    @get:Rule
+    var coroutineRule = CoroutineTestRule()
+
+    private val mockHttpErrorPixels: HttpErrorPixels = mock()
+
+    private lateinit var context: Context
+
+    @Before
+    fun setup() {
+        context = mock()
+    }
+
+    @Test
+    fun whenDoWorkThenCallFireCountPixelWithCorrectParamNameAndReturnSuccess() =
+        runTest {
+            val worker = TestListenableWorkerBuilder<HttpErrorDailyReportingWorker>(context = context).build()
+            worker.httpErrorPixels = mockHttpErrorPixels
+            worker.dispatchers = coroutineRule.testDispatcherProvider
+
+            val result = worker.doWork()
+
+            verify(mockHttpErrorPixels).fireCountPixel(HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_400_DAILY)
+            verify(mockHttpErrorPixels).fireCountPixel(HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_4XX_DAILY)
+            verify(mockHttpErrorPixels).fireCountPixel(HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_5XX_DAILY)
+            assertEquals(result, ListenableWorker.Result.success())
+        }
+}

--- a/app/src/test/java/com/duckduckgo/app/browser/httperrors/RealHttpErrorPixelsTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/httperrors/RealHttpErrorPixelsTest.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.httperrors
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
+import com.duckduckgo.common.test.api.InMemorySharedPreferences
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class RealHttpErrorPixelsTest {
+
+    private lateinit var testee: HttpErrorPixels
+    private lateinit var prefs: SharedPreferences
+
+    private val mockPixel: Pixel = mock()
+    private val mockContext: Context = mock()
+
+    @Before
+    fun setup() {
+        prefs = InMemorySharedPreferences()
+        whenever(mockContext.getSharedPreferences("com.duckduckgo.app.browser.httperrors", 0)).thenReturn(prefs)
+        testee = RealHttpErrorPixels(mockPixel, mockContext)
+    }
+
+    @Test
+    fun whenUpdateCountPixelCalledThenSharedPrefUpdated() {
+        val key = "${HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_400_DAILY.pixelName}_count"
+        assertEquals(0, prefs.getInt(key, 0))
+
+        testee.updateCountPixel(HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_400_DAILY)
+        testee.updateCountPixel(HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_400_DAILY)
+
+        assertEquals(2, prefs.getInt(key, 0))
+    }
+
+    @Test
+    fun whenFireCountPixelCalledForZeroCountThenPixelNotSent() {
+        val key = "${HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_400_DAILY.pixelName}_count"
+        assertEquals(0, prefs.getInt(key, 0))
+
+        testee.fireCountPixel(HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_400_DAILY)
+
+        verify(mockPixel, never()).fire(
+            pixel = eq(HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_400_DAILY),
+            parameters = any(),
+            encodedParameters = any(),
+            type = eq(COUNT),
+        )
+    }
+
+    @Test
+    fun whenFireCountPixelCalledForNonZeroCountAndCurrentTimeNotSetThenPixelSent() {
+        val key = "${HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_400_DAILY.pixelName}_count"
+        testee.updateCountPixel(HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_400_DAILY)
+        assertEquals(1, prefs.getInt(key, 0))
+
+        testee.fireCountPixel(HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_400_DAILY)
+
+        verify(mockPixel).fire(
+            pixel = eq(HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_400_DAILY),
+            parameters = eq(mapOf(HttpErrorPixelParameters.HTTP_ERROR_CODE_COUNT to "1")),
+            encodedParameters = any(),
+            type = eq(COUNT),
+        )
+    }
+
+    @Test
+    fun whenFireCountPixelCalledForNonZeroCountAndCurrentTimeBeforeTimestampThenPixelNotSent() {
+        val key = "${HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_400_DAILY.pixelName}_count"
+        val timestampKey = "${HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_400_DAILY.pixelName}_timestamp"
+        val now = Instant.now().toEpochMilli()
+        testee.updateCountPixel(HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_400_DAILY)
+        assertEquals(1, prefs.getInt(key, 0))
+        prefs.edit { putLong(timestampKey, now.plus(TimeUnit.HOURS.toMillis(1))) }
+
+        testee.fireCountPixel(HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_400_DAILY)
+
+        verify(mockPixel, never()).fire(
+            pixel = eq(HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_400_DAILY),
+            parameters = any(),
+            encodedParameters = any(),
+            type = eq(COUNT),
+        )
+    }
+
+    @Test
+    fun whenFireCountPixelCalledForNonZeroCountAndCurrentTimeAfterTimestampThenPixelSent() {
+        val key = "${HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_400_DAILY.pixelName}_count"
+        val timestampKey = "${HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_400_DAILY.pixelName}_timestamp"
+        val now = Instant.now().toEpochMilli()
+        testee.updateCountPixel(HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_400_DAILY)
+        assertEquals(1, prefs.getInt(key, 0))
+        prefs.edit { putLong(timestampKey, now.minus(TimeUnit.HOURS.toMillis(1))) }
+
+        testee.fireCountPixel(HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_400_DAILY)
+
+        verify(mockPixel).fire(
+            pixel = eq(HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_400_DAILY),
+            parameters = eq(mapOf(HttpErrorPixelParameters.HTTP_ERROR_CODE_COUNT to "1")),
+            encodedParameters = any(),
+            type = eq(COUNT),
+        )
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1200581511062568/1208001712805221/f

### Description
Added daily pixels to count 400, 4xx, 5xx http errors. 

### Steps to test this PR

- [x] Install from this branch.
- [x] Navigate to https://httpstat.us/
- [x] Tap on `400`, go back and tap again on 400, go back
- [x] Tap on `403`, go back 
- [x] Tap on `502`, go back and tap again on 502, go back tap again on 502, go back
- [x] Advance time 1 day on the device and filter Logcat by `pixel m_webview_received_http_error` and you should see:
`Pixel sent: m_webview_received_http_error_400_daily with params: {count=2} {}`
`Pixel sent: m_webview_received_http_error_4xx_daily with params: {count=1} {}`
`Pixel sent: m_webview_received_http_error_5xx_daily with params: {count=3} {}`
Notice  the actual pixel url request does not have atb.

### NO UI changes

