### PR TITLE
Fix dark status bar icon colours in dark mode in onboarding 

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePage.kt
@@ -288,7 +288,6 @@ class WelcomePage : OnboardingPageFragment(R.layout.content_onboarding_welcome_p
         activity?.window?.apply {
             clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS)
             addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
-            decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
             decorView.systemUiVisibility += View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
             statusBarColor = Color.TRANSPARENT
             navigationBarColor = Color.BLACK

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePage.kt
@@ -30,6 +30,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.ViewPropertyAnimatorCompat
+import androidx.core.view.WindowCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.flowWithLifecycle
@@ -286,9 +287,8 @@ class WelcomePage : OnboardingPageFragment(R.layout.content_onboarding_welcome_p
 
     private fun applyFullScreenFlags() {
         activity?.window?.apply {
-            clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS)
             addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
-            decorView.systemUiVisibility += View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+            WindowCompat.setDecorFitsSystemWindows(this, false)
             statusBarColor = Color.TRANSPARENT
             navigationBarColor = Color.BLACK
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208019450206551/f
		
### Description

The status bars icons were dark in dark mode in onboarding. We were explicitly setting the status bar icon colours to dark regardless of light/dark mode. We can just let the default handle this for us based on mode.

While doing the changes I noticed we were using some deprecated functions/settings so I removed and updated them where appropriate.

### Steps to test this PR

- [ ] Ensure you’ve not launched the app previously (clear and wipe data)
- [ ] Set device to dark mode
- [ ] Launch app
- [ ] The status bar icons should be light
- [ ] Switch to light mode
- [ ] The status bar icons should be dark 

### UI changes

| Before                                                                                                     | After                                                                                                      |
|------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------|
| <figure> <img src="https://github.com/user-attachments/assets/8dd13d9e-c964-4529-9d25-c85b8208cc5e" alt="Pixel 5 API 26 (Emulator)" width="400px" /> <figcaption>Pixel 5 API 26 (Emulator)</figcaption> </figure> | <figure> <img src="https://github.com/user-attachments/assets/18ef22b1-1b37-4eb6-9745-b6a2a079efd6" alt="Pixel 5 API 26 (Emulator)" width="400px" /> <figcaption>Pixel 5 API 26 (Emulator)</figcaption> </figure> |
| <figure> <img src="https://github.com/user-attachments/assets/0f5014dc-74d0-45c9-aa91-3364eafcd0f0" alt="OnePlus 6 API 30 (Device)" width="400px" /> <figcaption>OnePlus 6 API 30 (Device)</figcaption> </figure> | <figure> <img src="https://github.com/user-attachments/assets/4a7fe738-ca50-47cc-bc30-24dff91b4d6b" alt="OnePlus 6 API 30 (Device)" width="400px" /> <figcaption>OnePlus 6 API 30 (Device)</figcaption> </figure> |
| <figure> <img src="https://github.com/user-attachments/assets/4511c21a-72c8-4e10-8984-521d9fe957ee" alt="OnePlus 6 API 30 (Device)" width="400px" /> <figcaption>OnePlus 6 API 30 (Device)</figcaption> </figure> | <figure> <img src="https://github.com/user-attachments/assets/b827ed6b-b5e9-4b29-af44-89637d6ba4da" alt="OnePlus 6 API 30 (Device)" width="400px" /> <figcaption>OnePlus 6 API 30 (Device)</figcaption> </figure> |
| <figure> <img src="https://github.com/user-attachments/assets/d1327fc1-4cac-460d-9939-8d2c3d4c0d18" alt="Pixel 4a API 33 (Device)" width="400px" /> <figcaption>Pixel 4a API 33 (Device)</figcaption> </figure> | <figure> <img src="https://github.com/user-attachments/assets/8abe135c-de3e-45cb-8654-dbf1c4f00b21" alt="Pixel 4a API 33 (Device)" width="400px" /> <figcaption>Pixel 4a API 33 (Device)</figcaption> </figure> |
| <figure> <img src="https://github.com/user-attachments/assets/fa86ed37-87c1-4c70-b8cb-bdec0e22dadd" alt="Pixel 4a API 33 (Device)" width="400px" /> <figcaption>Pixel 4a API 33 (Device)</figcaption> </figure> | <figure> <img src="https://github.com/user-attachments/assets/6739adec-c084-4916-a2c8-4d45d13cc2c3" alt="Pixel 4a API 33 (Device)" width="400px" /> <figcaption>Pixel 4a API 33 (Device)</figcaption> </figure> |

