### PR TITLE
Fix IllegalArgumentException - savedSiteAdded

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2752,7 +2752,11 @@ class BrowserTabFragment :
     private fun savedSiteAdded(savedSiteChangedViewState: SavedSiteChangedViewState) {
         val dismissHandler = Handler(Looper.getMainLooper())
         val dismissRunnable = Runnable {
-            bookmarksBottomSheetDialog?.dialog?.dismiss()
+            bookmarksBottomSheetDialog?.dialog?.let { dialog ->
+                if (dialog.isShowing) {
+                    dialog.dismiss()
+                }
+            }
         }
         val title = getBookmarksBottomSheetTitle(savedSiteChangedViewState.bookmarkFolder)
 
@@ -2785,6 +2789,11 @@ class BrowserTabFragment :
                             )
                             dismissHandler.removeCallbacks(dismissRunnable)
                         }
+                    }
+
+                    override fun onBottomSheetDismissed() {
+                        super.onBottomSheetDismissed()
+                        dismissHandler.removeCallbacks(dismissRunnable)
                     }
                 },
             )


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208046461855770/f

### Description
Fixes a crash when the “Add Bookmarks” `BottomSheetDialog` is dismissed when it isn't showing. 

### Steps to test this PR

_Add bookmark_
- [x] Go to a site
- [x] Tap the overflow and “Add Bookmark"
- [x] Verify that the `BottomSheetDialog` dismisses automatically

_Add bookmark (Manual dismissal)_
- [x] Go to another site
- [x] Tap the overflow and “Add Bookmark"
- [x] Tap outside of the `BottomSheetDialog`
- [x] Verify that the `BottomSheetDialog` is dismissed
