### PR TITLE
Fix Bookmarks not opening when opened via Shortcut access

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/shortcut/AppShortcutCreator.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/shortcut/AppShortcutCreator.kt
@@ -111,9 +111,12 @@ class AppShortcutCreator @Inject constructor(
     }
 
     private fun buildBookmarksShortcut(context: Context): ShortcutInfo {
+        val browserActivity = BrowserActivity.intent(context).also { it.action = Intent.ACTION_VIEW }
         val bookmarksActivity = BookmarksActivity.intent(context).also { it.action = Intent.ACTION_VIEW }
 
-        val stackBuilder = TaskStackBuilder.create(context).addNextIntentWithParentStack(bookmarksActivity)
+        val stackBuilder = TaskStackBuilder.create(context)
+            .addNextIntent(browserActivity)
+            .addNextIntent(bookmarksActivity)
 
         return ShortcutInfoCompat.Builder(context, SHORTCUT_ID_SHOW_BOOKMARKS)
             .setShortLabel(context.getString(com.duckduckgo.saved.sites.impl.R.string.bookmarksActivityTitle))

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksActivity.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksActivity.kt
@@ -371,7 +371,7 @@ class BookmarksActivity : DuckDuckGoActivity() {
 
     private fun openSavedSite(url: String) {
         if (intent.action == Intent.ACTION_VIEW) {
-            browserNav.openInNewTab(this, url)
+            startActivity(browserNav.openInNewTab(this, url))
         } else {
             val resultValue = Intent()
             resultValue.putExtra(SAVED_SITE_URL_EXTRA, url)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207908166761516/1208043907427492/f

### Description

Clicking a bookmarked site from the list when accessed via the “Bookmarks” app shortcut would **not** open the bookmarked site in the app, instead the app would close. 

This fixes that by putting back an activity launch when clicking the bookmark, specifically after it’s been launched with an intent to `VIEW` which was removed when BookmarksActivity was moved to the `savedsites` module.

I took the opportunity to tie up the loose end where the app would close when pressing the back or up button after accessing it via the “Bookmarks” shortcut by stacking the `BrowserActivity` first before launching the `Bookmarks ` my suspicion this stopped working because of the module move as well, as we’re now missing a ParentActivity in the Manifest for the `BookmarksActivity`

### Steps to test this PR

#### Opening a bookmarked site while in the app

- [x] Launch app
- [x] Ensure you have a bookmarked site
- [x] Click the bookmarked site
- [x] The site should open

#### Opening a bookmarked via the “Bookmarks” shortcut

- [x] Ensure the app is accessible on the device home screen
- [x] Click and hold the app icon
- [x] Click the bookmarks shortcut
- [x] Click a bookmarked site
- [x] The site should open

#### Pressing the up button opens the browser screen

- [x] Click and hold the app icon
- [x] Click the bookmarks shortcut
- [x] Press the up button in the toolbar
- [x] The app should open on the browser screen

#### Pressing the back button opens the browser screen

- [x] Click and hold the app icon
- [x] Click the bookmarks shortcut
- [x] Press the back button/swipe back 
- [x] The app should open on the browser screen

### Demo

https://github.com/user-attachments/assets/38f0c09f-eb40-4254-a19d-04271030f622