### PR TITLE
Keep exemptions in case of closing a tab and subsequently undoing the action

### DIFF
--- a/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/di/AdClickModule.kt
+++ b/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/di/AdClickModule.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import androidx.room.Room
 import com.duckduckgo.adclick.impl.AdClickData
 import com.duckduckgo.adclick.impl.DuckDuckGoAdClickData
+import com.duckduckgo.adclick.impl.remoteconfig.AdClickAttributionFeature
 import com.duckduckgo.adclick.impl.remoteconfig.AdClickAttributionRepository
 import com.duckduckgo.adclick.impl.remoteconfig.RealAdClickAttributionRepository
 import com.duckduckgo.adclick.impl.store.AdClickDatabase
@@ -73,8 +74,9 @@ class AdClickModule {
         database: AdClickExemptionsDatabase,
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
         dispatcherProvider: DispatcherProvider,
+        adClickAttributionFeature: AdClickAttributionFeature,
         @IsMainProcess isMainProcess: Boolean,
     ): AdClickData {
-        return DuckDuckGoAdClickData(database, appCoroutineScope, dispatcherProvider, isMainProcess)
+        return DuckDuckGoAdClickData(database, appCoroutineScope, dispatcherProvider, adClickAttributionFeature, isMainProcess)
     }
 }

--- a/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/remoteconfig/AdClickAttributionFeature.kt
+++ b/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/remoteconfig/AdClickAttributionFeature.kt
@@ -35,4 +35,11 @@ interface AdClickAttributionFeature {
      */
     @Toggle.DefaultValue(false)
     fun self(): Toggle
+
+    /**
+     * @return `true` when the remote config has the global "persistExemptions" adClickAttribution sub-feature flag enabled
+     * If the remote feature is not present defaults to `false`
+     */
+    @Toggle.DefaultValue(false)
+    fun persistExemptions(): Toggle
 }

--- a/ad-click/ad-click-impl/src/test/java/com/duckduckgo/adclick/impl/DuckDuckGoAdClickDataTest.kt
+++ b/ad-click/ad-click-impl/src/test/java/com/duckduckgo/adclick/impl/DuckDuckGoAdClickDataTest.kt
@@ -16,9 +16,11 @@
 
 package com.duckduckgo.adclick.impl
 
+import com.duckduckgo.adclick.impl.remoteconfig.AdClickAttributionFeature
 import com.duckduckgo.adclick.impl.store.exemptions.AdClickExemptionsDao
 import com.duckduckgo.adclick.impl.store.exemptions.AdClickExemptionsDatabase
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.Toggle
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.test.TestScope
 import org.junit.Assert.assertEquals
@@ -29,6 +31,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -42,14 +45,18 @@ class DuckDuckGoAdClickDataTest {
 
     private val mockDatabase: AdClickExemptionsDatabase = mock()
     private val mockAdClickExemptionsDao: AdClickExemptionsDao = mock()
+    private val mockAdClickAttributionFeature: AdClickAttributionFeature = mock()
+    private val mockToggle: Toggle = mock()
 
     @Before
     fun before() {
+        whenever(mockAdClickAttributionFeature.persistExemptions()).thenReturn(mockToggle)
         whenever(mockDatabase.adClickExemptionsDao()).thenReturn(mockAdClickExemptionsDao)
         testee = DuckDuckGoAdClickData(
             database = mockDatabase,
             coroutineScope = TestScope(),
             dispatcherProvider = coroutineRule.testDispatcherProvider,
+            adClickAttributionFeature = mockAdClickAttributionFeature,
             isMainProcess = true,
         )
     }
@@ -72,7 +79,20 @@ class DuckDuckGoAdClickDataTest {
     }
 
     @Test
-    fun whenRemoveExemptionForActiveTabCalledThenAllExemptionForTabAreRemoved() {
+    fun whenRemoveExemptionForActiveTabCalledAndPersistExemptionsIsFalseThenAllExemptionForTabAreRemovedFromMemory() {
+        whenever(mockAdClickAttributionFeature.persistExemptions().isEnabled()).thenReturn(false)
+        testee.addExemption(exemptionWithExpiration("host1"))
+        assertTrue(testee.isHostExempted("host1"))
+
+        testee.removeExemption()
+
+        assertFalse(testee.isHostExempted("host1"))
+        verify(mockAdClickExemptionsDao, never()).deleteTabExemption(any())
+    }
+
+    @Test
+    fun whenRemoveExemptionForActiveTabCalledAndPersistExemptionsIsTrueThenAllExemptionForTabAreRemovedFromMemoryAndDb() {
+        whenever(mockAdClickAttributionFeature.persistExemptions().isEnabled()).thenReturn(true)
         testee.addExemption(exemptionWithExpiration("host1"))
         assertTrue(testee.isHostExempted("host1"))
 
@@ -83,7 +103,24 @@ class DuckDuckGoAdClickDataTest {
     }
 
     @Test
-    fun whenAddExemptionForActiveTabCalledForADifferentHostThenOnlyThatSecondHostExemptionExists() {
+    fun whenAddExemptionForActiveTabCalledForADifferentHostAndPersistExemptionsIsFalseThenOnlyThatSecondHostExemptionExistsInMemory() {
+        whenever(mockAdClickAttributionFeature.persistExemptions().isEnabled()).thenReturn(false)
+        val host = "host1"
+        val otherHost = "host2"
+
+        testee.addExemption(exemptionWithExpiration(host))
+        assertEquals(host, testee.getExemption()!!.hostTldPlusOne)
+        verify(mockAdClickExemptionsDao, never()).insertTabExemption(any())
+        reset(mockAdClickExemptionsDao)
+
+        testee.addExemption(exemptionWithExpiration(otherHost))
+        assertEquals(otherHost, testee.getExemption()!!.hostTldPlusOne)
+        verify(mockAdClickExemptionsDao, never()).insertTabExemption(any())
+    }
+
+    @Test
+    fun whenAddExemptionForActiveTabCalledForADifferentHostAndPersistExemptionsIsTrueThenOnlyThatSecondHostExemptionExistsInMemoryAndDb() {
+        whenever(mockAdClickAttributionFeature.persistExemptions().isEnabled()).thenReturn(true)
         val host = "host1"
         val otherHost = "host2"
 
@@ -98,7 +135,25 @@ class DuckDuckGoAdClickDataTest {
     }
 
     @Test
-    fun whenAddExemptionForTabCalledForADifferentHostThenOnlyThatSecondHostExemptionExists() {
+    fun whenAddExemptionForTabCalledForADifferentHostAndPersistExemptionsIsFalseThenOnlyThatSecondHostExemptionExistsInMemory() {
+        whenever(mockAdClickAttributionFeature.persistExemptions().isEnabled()).thenReturn(false)
+        val host = "host1"
+        val otherHost = "host2"
+        val tabId = "tabId"
+
+        testee.addExemption(tabId, exemptionWithExpiration(host))
+        assertEquals(host, testee.getExemption(tabId)!!.hostTldPlusOne)
+        verify(mockAdClickExemptionsDao, never()).insertTabExemption(any())
+        reset(mockAdClickExemptionsDao)
+
+        testee.addExemption(tabId, exemptionWithExpiration(otherHost))
+        assertEquals(otherHost, testee.getExemption(tabId)!!.hostTldPlusOne)
+        verify(mockAdClickExemptionsDao, never()).insertTabExemption(any())
+    }
+
+    @Test
+    fun whenAddExemptionForTabCalledForADifferentHostAndPersistExemptionsIsTrueThenOnlyThatSecondHostExemptionExistsInMemoryAndDb() {
+        whenever(mockAdClickAttributionFeature.persistExemptions().isEnabled()).thenReturn(true)
         val host = "host1"
         val otherHost = "host2"
         val tabId = "tabId"
@@ -114,7 +169,21 @@ class DuckDuckGoAdClickDataTest {
     }
 
     @Test
-    fun whenRemoveCalledForTabIdThenExemptionForTabIdIsRemoved() {
+    fun whenRemoveCalledForTabIdAndPersistExemptionsIsFalseThenNoDbInteractions() {
+        whenever(mockAdClickAttributionFeature.persistExemptions().isEnabled()).thenReturn(false)
+        val host = "host1"
+        val tabId = "tabId"
+        testee.addExemption(tabId, exemptionWithExpiration(host))
+        assertEquals(host, testee.getExemption(tabId)!!.hostTldPlusOne)
+
+        testee.remove(tabId)
+
+        verify(mockAdClickExemptionsDao, never()).deleteTabExemption(tabId)
+    }
+
+    @Test
+    fun whenRemoveCalledForTabIdAndPersistExemptionsIsTrueThenExemptionForTabIdIsRemovedFromDb() {
+        whenever(mockAdClickAttributionFeature.persistExemptions().isEnabled()).thenReturn(true)
         val host = "host1"
         val tabId = "tabId"
         testee.addExemption(tabId, exemptionWithExpiration(host))
@@ -126,7 +195,21 @@ class DuckDuckGoAdClickDataTest {
     }
 
     @Test
-    fun whenRemoveAllCalledThenExemptionsAreRemoved() {
+    fun whenRemoveAllCalledAndPersistExemptionsIsFalseThenNoDbInteractions() {
+        whenever(mockAdClickAttributionFeature.persistExemptions().isEnabled()).thenReturn(false)
+        val host = "host1"
+        val tabId = "tabId"
+        testee.addExemption(tabId, exemptionWithExpiration(host))
+        assertEquals(host, testee.getExemption(tabId)!!.hostTldPlusOne)
+
+        testee.removeAll()
+
+        verify(mockAdClickExemptionsDao, never()).deleteAllTabExemptions()
+    }
+
+    @Test
+    fun whenRemoveAllCalledAndPersistExemptionsIsTrueThenExemptionsAreRemovedFromDb() {
+        whenever(mockAdClickAttributionFeature.persistExemptions().isEnabled()).thenReturn(true)
         val host = "host1"
         val tabId = "tabId"
         testee.addExemption(tabId, exemptionWithExpiration(host))
@@ -138,7 +221,21 @@ class DuckDuckGoAdClickDataTest {
     }
 
     @Test
-    fun whenRemoveAllExpiredCalledThenExpiredExemptionsAreRemoved() {
+    fun whenRemoveAllExpiredCalledAndPersistExemptionsIsFalseThenNoDbInteractions() {
+        whenever(mockAdClickAttributionFeature.persistExemptions().isEnabled()).thenReturn(false)
+        val host = "host1"
+        val tabId = "tabId"
+        testee.addExemption(tabId, exemptionWithExpiration(host))
+        assertEquals(host, testee.getExemption(tabId)!!.hostTldPlusOne)
+
+        testee.removeAllExpired()
+
+        verify(mockAdClickExemptionsDao, never()).deleteAllExpiredTabExemptions(any())
+    }
+
+    @Test
+    fun whenRemoveAllExpiredCalledAndPersistExemptionsIsTrueThenExpiredExemptionsAreRemovedFromDb() {
+        whenever(mockAdClickAttributionFeature.persistExemptions().isEnabled()).thenReturn(true)
         val host = "host1"
         val tabId = "tabId"
         testee.addExemption(tabId, exemptionWithExpiration(host))

--- a/app/src/androidTest/java/com/duckduckgo/app/tabs/db/TabsDaoTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/tabs/db/TabsDaoTest.kt
@@ -265,6 +265,18 @@ class TabsDaoTest {
     }
 
     @Test
+    fun whenGetDeletableTabIdsCalledThenReturnListWithDeletableTabIds() {
+        val firstTabNonDeletable = TabEntity("TAB_ID_1", "http//www.example.com", position = 0, deletable = false)
+        val secondTabDeletable = TabEntity("TAB_ID_2", "http//www.example.com", position = 1, deletable = true)
+        testee.insertTab(firstTabNonDeletable)
+        testee.insertTab(secondTabDeletable)
+
+        val deletableTabIds = testee.getDeletableTabIds()
+
+        assertEquals(listOf("TAB_ID_2"), deletableTabIds)
+    }
+
+    @Test
     fun deleteTabsMarkedAsDeletableDeletesOnlyDeletableTabs() {
         testee.insertTab(TabEntity("TAB_ID1", position = 0, deletable = true))
         val tab = TabEntity("TAB_ID2", position = 1)

--- a/app/src/androidTest/java/com/duckduckgo/app/tabs/model/TabDataRepositoryTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/tabs/model/TabDataRepositoryTest.kt
@@ -276,6 +276,20 @@ class TabDataRepositoryTest {
     }
 
     @Test
+    fun whenGetDeletableTabIdsCalledThenReturnsAListWithDeletableTabIds() = runTest {
+        val db = createDatabase()
+        val dao = db.tabsDao()
+        dao.insertTab(TabEntity(tabId = "id_1", url = "http://www.example.com", skipHome = false, viewed = true, position = 0, deletable = true))
+        dao.insertTab(TabEntity(tabId = "id_2", url = "http://www.example.com", skipHome = false, viewed = true, position = 1, deletable = false))
+        dao.insertTab(TabEntity(tabId = "id_3", url = "http://www.example.com", skipHome = false, viewed = true, position = 2, deletable = true))
+        val testee = tabDataRepository(dao)
+
+        val deletableTabIds = testee.getDeletableTabIds()
+
+        assertEquals(listOf("id_1", "id_3"), deletableTabIds)
+    }
+
+    @Test
     fun whenDeleteTabAndSelectSourceLiveSelectedTabReturnsToSourceTab() = runTest {
         val db = createDatabase()
         val dao = db.tabsDao()

--- a/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDao.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDao.kt
@@ -68,6 +68,9 @@ abstract class TabsDao {
     @Query("delete from tabs where deletable is 1")
     abstract fun deleteTabsMarkedAsDeletable()
 
+    @Query("select tabId from tabs where deletable is 1")
+    abstract fun getDeletableTabIds(): List<String>
+
     @Transaction
     open fun markTabAsDeletable(tab: TabEntity) {
         // requirement: only one tab can be marked as deletable

--- a/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDbSanitizer.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDbSanitizer.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.tabs.db
 
 import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.adclick.api.AdClickManager
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.tabs.model.TabRepository
@@ -31,11 +32,15 @@ import kotlinx.coroutines.launch
 class TabsDbSanitizer @Inject constructor(
     private val tabRepository: TabRepository,
     private val dispatchers: DispatcherProvider,
+    private val adClickManager: AdClickManager,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
 ) : MainProcessLifecycleObserver {
 
     override fun onStart(owner: LifecycleOwner) {
         appCoroutineScope.launch(dispatchers.main()) {
+            tabRepository.getDeletableTabIds().forEach {
+                adClickManager.clearTabId(it)
+            }
             tabRepository.purgeDeletableTabs()
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
@@ -273,6 +273,10 @@ class TabDataRepository @Inject constructor(
         purgeDeletableTabsJob.join()
     }
 
+    override suspend fun getDeletableTabIds(): List<String> = withContext(dispatchers.io()) {
+        return@withContext tabsDao.getDeletableTabIds()
+    }
+
     override suspend fun deleteTabAndSelectSource(tabId: String) {
         databaseExecutor().scheduleDirect {
             val tabToDelete = tabsDao.tab(tabId) ?: return@scheduleDirect

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -43,6 +43,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 @ContributesViewModel(ActivityScope::class)
 class TabSwitcherViewModel @Inject constructor(
@@ -113,7 +114,6 @@ class TabSwitcherViewModel @Inject constructor(
 
     suspend fun onMarkTabAsDeletable(tab: TabEntity, swipeGestureUsed: Boolean) {
         tabRepository.markDeletable(tab)
-        adClickManager.clearTabId(tab.tabId)
         if (swipeGestureUsed) {
             pixel.fire(AppPixelName.TAB_MANAGER_CLOSE_TAB_SWIPED)
         } else {
@@ -126,6 +126,10 @@ class TabSwitcherViewModel @Inject constructor(
     }
 
     suspend fun purgeDeletableTabs() {
+        Timber.d("TAG_ANA Purging deletable tabs")
+        tabRepository.getDeletableTabIds().forEach {
+            adClickManager.clearTabId(it)
+        }
         tabRepository.purgeDeletableTabs()
     }
 
@@ -139,6 +143,8 @@ class TabSwitcherViewModel @Inject constructor(
             tabs.value?.forEach {
                 onTabDeleted(it)
             }
+            // Make sure all exemptions are removed as all tabs are deleted.
+            adClickManager.clearAll()
             pixel.fire(AppPixelName.TAB_MANAGER_MENU_CLOSE_ALL_TABS_CONFIRMED)
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -43,7 +43,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 @ContributesViewModel(ActivityScope::class)
 class TabSwitcherViewModel @Inject constructor(
@@ -126,7 +125,6 @@ class TabSwitcherViewModel @Inject constructor(
     }
 
     suspend fun purgeDeletableTabs() {
-        Timber.d("TAG_ANA Purging deletable tabs")
         tabRepository.getDeletableTabIds().forEach {
             adClickManager.clearTabId(it)
         }

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -57,6 +57,7 @@ import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -175,7 +176,7 @@ class TabSwitcherViewModelTest {
         testee.onMarkTabAsDeletable(entity, swipeGestureUsed)
 
         verify(mockTabRepository).markDeletable(entity)
-        verify(mockAdClickManager).clearTabId(entity.tabId)
+        verify(mockAdClickManager, never()).clearTabId(entity.tabId)
         verify(mockPixel).fire(AppPixelName.TAB_MANAGER_CLOSE_TAB_SWIPED)
     }
 
@@ -187,7 +188,7 @@ class TabSwitcherViewModelTest {
         testee.onMarkTabAsDeletable(entity, swipeGestureUsed)
 
         verify(mockTabRepository).markDeletable(entity)
-        verify(mockAdClickManager).clearTabId(entity.tabId)
+        verify(mockAdClickManager, never()).clearTabId(entity.tabId)
         verify(mockPixel).fire(AppPixelName.TAB_MANAGER_CLOSE_TAB_CLICKED)
     }
 
@@ -201,8 +202,13 @@ class TabSwitcherViewModelTest {
 
     @Test
     fun whenPurgeDeletableTabsThenCallRepositoryPurgeDeletableTabs() = runTest {
+        whenever(mockTabRepository.getDeletableTabIds()).thenReturn(listOf("id_1", "id_2"))
+
         testee.purgeDeletableTabs()
 
+        verify(mockTabRepository).getDeletableTabIds()
+        verify(mockAdClickManager).clearTabId("id_1")
+        verify(mockAdClickManager).clearTabId("id_2")
         verify(mockTabRepository).purgeDeletableTabs()
     }
 

--- a/browser-api/src/main/java/com/duckduckgo/app/tabs/model/TabRepository.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/tabs/model/TabRepository.kt
@@ -87,6 +87,8 @@ interface TabRepository {
      */
     suspend fun purgeDeletableTabs()
 
+    suspend fun getDeletableTabIds(): List<String>
+
     suspend fun deleteTabAndSelectSource(tabId: String)
 
     suspend fun deleteAll()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1207991167374138/f

### Description
Updated the code to make sure the exemption is kept after undoing a tab close action.

### Steps to test this PR
See the **Tests** section in the description of https://app.asana.com/0/488551667048375/1207991167374138/f

### NO UI changes
