### PR TITLE
Create RMF matchers for duckPlayerOnboarded and duckPlayerEnabled

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/duckplayer/DuckPlayerJSHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/duckplayer/DuckPlayerJSHelper.kt
@@ -109,7 +109,7 @@ class DuckPlayerJSHelper @Inject constructor(
         duckPlayer.setUserPreferences(overlayInteracted, privatePlayerModeObject.keys().next())
     }
 
-    private fun sendDuckPlayerPixel(data: JSONObject) {
+    private suspend fun sendDuckPlayerPixel(data: JSONObject) {
         val pixelName = data.getString("pixelName")
         val paramsMap = data.getJSONObject("params").keys().asSequence().associateWith {
             data.getJSONObject("params").getString(it)

--- a/duckplayer/duckplayer-api/src/main/java/com/duckduckgo/duckplayer/api/DuckPlayer.kt
+++ b/duckplayer/duckplayer-api/src/main/java/com/duckduckgo/duckplayer/api/DuckPlayer.kt
@@ -50,7 +50,7 @@ interface DuckPlayer {
      * @param pixelName The name of the pixel.
      * @param pixelData The data associated with the pixel.
      */
-    fun sendDuckPlayerPixel(pixelName: String, pixelData: Map<String, String>)
+    suspend fun sendDuckPlayerPixel(pixelName: String, pixelData: Map<String, String>)
 
     /**
      * Retrieves the user preferences.

--- a/duckplayer/duckplayer-impl/build.gradle
+++ b/duckplayer/duckplayer-impl/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     implementation project(':app-build-config-api')
     implementation project(':js-messaging-api')
     implementation project(':navigation-api')
+    implementation project(':remote-messaging-api')
     implementation project(':settings-api')
     implementation project(':statistics')
     api AndroidX.dataStore.preferences

--- a/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerEnabledRMFMatchingAttribute.kt
+++ b/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerEnabledRMFMatchingAttribute.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckplayer.impl
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckplayer.api.DuckPlayer
+import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.ENABLED
+import com.duckduckgo.duckplayer.api.PrivatePlayerMode.AlwaysAsk
+import com.duckduckgo.duckplayer.api.PrivatePlayerMode.Enabled
+import com.duckduckgo.remote.messaging.api.AttributeMatcherPlugin
+import com.duckduckgo.remote.messaging.api.JsonMatchingAttribute
+import com.duckduckgo.remote.messaging.api.JsonToMatchingAttributeMapper
+import com.duckduckgo.remote.messaging.api.MatchingAttribute
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = JsonToMatchingAttributeMapper::class,
+)
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = AttributeMatcherPlugin::class,
+)
+@SingleInstanceIn(AppScope::class)
+class DuckPlayerEnabledRMFMatchingAttribute @Inject constructor(
+    private val duckPlayer: DuckPlayer,
+) : JsonToMatchingAttributeMapper, AttributeMatcherPlugin {
+    override suspend fun evaluate(matchingAttribute: MatchingAttribute): Boolean? {
+        val duckPlayerEnabled = duckPlayer.getDuckPlayerState() == ENABLED &&
+            duckPlayer.getUserPreferences().privatePlayerMode.let { it == AlwaysAsk || it == Enabled }
+        return when (matchingAttribute) {
+            is DuckPlayerEnabledMatchingAttribute -> duckPlayerEnabled == matchingAttribute.remoteValue
+            else -> null
+        }
+    }
+
+    override fun map(
+        key: String,
+        jsonMatchingAttribute: JsonMatchingAttribute,
+    ): MatchingAttribute? {
+        return when (key) {
+            DuckPlayerEnabledMatchingAttribute.KEY -> {
+                jsonMatchingAttribute.value?.let {
+                    DuckPlayerEnabledMatchingAttribute(jsonMatchingAttribute.value as Boolean)
+                }
+            }
+            else -> null
+        }
+    }
+}
+
+internal data class DuckPlayerEnabledMatchingAttribute(
+    val remoteValue: Boolean,
+) : MatchingAttribute {
+    companion object {
+        const val KEY = "duckPlayerEnabled"
+    }
+}

--- a/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerFeatureRepository.kt
+++ b/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerFeatureRepository.kt
@@ -63,6 +63,8 @@ interface DuckPlayerFeatureRepository {
     suspend fun getYouTubeWatchPath(): String
     suspend fun getYouTubeUrl(): String
     suspend fun getYouTubeEmbedUrl(): String
+    suspend fun isOnboarded(): Boolean
+    suspend fun setUserOnboarded()
 }
 
 @ContributesBinding(AppScope::class)
@@ -184,5 +186,13 @@ class RealDuckPlayerFeatureRepository @Inject constructor(
 
     override suspend fun getYouTubeEmbedUrl(): String {
         return duckPlayerDataStore.getYoutubeEmbedUrl()
+    }
+
+    override suspend fun isOnboarded(): Boolean {
+        return duckPlayerDataStore.getUserOnboarded()
+    }
+
+    override suspend fun setUserOnboarded() {
+        duckPlayerDataStore.setUserOnboarded()
     }
 }

--- a/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerOnboardedRMFMatchingAttribute.kt
+++ b/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerOnboardedRMFMatchingAttribute.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckplayer.impl
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.remote.messaging.api.AttributeMatcherPlugin
+import com.duckduckgo.remote.messaging.api.JsonMatchingAttribute
+import com.duckduckgo.remote.messaging.api.JsonToMatchingAttributeMapper
+import com.duckduckgo.remote.messaging.api.MatchingAttribute
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = JsonToMatchingAttributeMapper::class,
+)
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = AttributeMatcherPlugin::class,
+)
+@SingleInstanceIn(AppScope::class)
+class DuckPlayerOnboardedRMFMatchingAttribute @Inject constructor(
+    private val duckPlayerFeatureRepository: DuckPlayerFeatureRepository,
+) : JsonToMatchingAttributeMapper, AttributeMatcherPlugin {
+    override suspend fun evaluate(matchingAttribute: MatchingAttribute): Boolean? {
+        return when (matchingAttribute) {
+            is DuckPlayerOnboardedMatchingAttribute -> duckPlayerFeatureRepository.isOnboarded() == matchingAttribute.remoteValue
+            else -> null
+        }
+    }
+
+    override fun map(
+        key: String,
+        jsonMatchingAttribute: JsonMatchingAttribute,
+    ): MatchingAttribute? {
+        return when (key) {
+            DuckPlayerOnboardedMatchingAttribute.KEY -> {
+                jsonMatchingAttribute.value?.let {
+                    DuckPlayerOnboardedMatchingAttribute(jsonMatchingAttribute.value as Boolean)
+                }
+            }
+            else -> null
+        }
+    }
+}
+
+internal data class DuckPlayerOnboardedMatchingAttribute(
+    val remoteValue: Boolean,
+) : MatchingAttribute {
+    companion object {
+        const val KEY = "duckPlayerOnboarded"
+    }
+}

--- a/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/RealDuckPlayer.kt
+++ b/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/RealDuckPlayer.kt
@@ -132,15 +132,22 @@ class RealDuckPlayer @Inject constructor(
         }
     }
 
-    override fun sendDuckPlayerPixel(
+    override suspend fun sendDuckPlayerPixel(
         pixelName: String,
         pixelData: Map<String, String>,
     ) {
-        when (pixelName) {
-            "overlay" -> pixel.fire(DUCK_PLAYER_OVERLAY_YOUTUBE_IMPRESSIONS, parameters = pixelData)
-            "play.use" -> pixel.fire(DUCK_PLAYER_VIEW_FROM_YOUTUBE_MAIN_OVERLAY, parameters = pixelData)
-            "play.do_not_use" -> pixel.fire(DUCK_PLAYER_OVERLAY_YOUTUBE_WATCH_HERE, parameters = pixelData)
-            else -> {}
+        val duckPlayerPixelName = when (pixelName) {
+            "overlay" -> DUCK_PLAYER_OVERLAY_YOUTUBE_IMPRESSIONS
+            "play.use" -> DUCK_PLAYER_VIEW_FROM_YOUTUBE_MAIN_OVERLAY
+            "play.do_not_use" -> DUCK_PLAYER_OVERLAY_YOUTUBE_WATCH_HERE
+            else -> { null }
+        }
+
+        duckPlayerPixelName?.let {
+            pixel.fire(duckPlayerPixelName, parameters = pixelData)
+            if (duckPlayerPixelName == DUCK_PLAYER_OVERLAY_YOUTUBE_IMPRESSIONS) {
+                duckPlayerFeatureRepository.setUserOnboarded()
+            }
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205008441501016/1208088492211812/f 

### Description

### Steps to test this PR

**Pre-requisites**
1. Checkout content-scope-scripts branch `pr-releases/pr-993` 
2. Set PRIVACY_REMOTE_CONFIG_URL to https://www.jsonblob.com/api/1252645298605252608
3. Set RemoteMessagingService#config() URL to https://jsonblob.com/api/1275101402324918272

**Test steps**
- [ ] Fresh install the app. Do the onboarding steps. Do steps 2 and 3 from above.
- [ ] Run the app, check if you see the "`A message for users not onboarded to Duck Player`" message. Dismiss it
- [ ] Open Youtube.com. Search for Iron Maiden. Tap on "Watch in Duck Player"
- [ ] Close the tab, kill the app.
- [ ] Change the version [here](https://jsonblob.com/api/1275101402324918272) from 1 to 2
- [ ] Open the app, check if you see the `A message for Duck Player onboarded users`. Dismiss it
- [ ] Go to settings, Duck Player, change "Open Videos in Duck Player" to "Always"
- [ ]  Kill the app
- [ ] Change the version [here](https://jsonblob.com/api/1275101402324918272) from 2 to 3
- [ ] Open the app, check if you see the `A message for Duck Player enabled users`

### UI changes
![image](https://github.com/user-attachments/assets/79ab4c1f-5cf8-49d9-a8f7-a8c5ea280a7b)
![image](https://github.com/user-attachments/assets/df6c289f-fce7-4e58-9798-f5c9d40ff87f)
![image](https://github.com/user-attachments/assets/d7b62f9d-601b-4735-b0ac-6aa61a80c4fd)

