### PR TITLE
Tab manager scrolling fix

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -56,6 +56,7 @@ import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.CloseAllTabsReque
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.view.gone
+import com.duckduckgo.common.ui.view.hide
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
@@ -234,7 +235,10 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
     }
 
     private fun updateLayoutType(layoutType: LayoutType) {
+        tabsRecycler.hide()
+
         val middleVisibleItem = getMiddleVisibleItem()
+
         this.layoutType = layoutType
         when (layoutType) {
             LayoutType.GRID -> {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -62,12 +62,12 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
+import javax.inject.Inject
+import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
-import javax.inject.Inject
-import kotlin.coroutines.CoroutineContext
 
 @InjectWith(ActivityScope::class)
 class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, CoroutineScope {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -130,6 +130,9 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_tab_switcher)
+
+        firstTimeLoadingTabsList = savedInstanceState?.getBoolean(KEY_FIRST_TIME_LOADING) ?: true
+
         extractIntentExtras()
         configureViewReferences()
         setupToolbar(toolbar)
@@ -137,6 +140,12 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
         configureObservers()
         configureOnBackPressedListener()
         configureAnnouncementBanner()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+
+        outState.putBoolean(KEY_FIRST_TIME_LOADING, firstTimeLoadingTabsList)
     }
 
     private fun configureAnnouncementBanner() {
@@ -522,5 +531,6 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
 
         private const val TAB_GRID_COLUMN_WIDTH_DP = 180
         private const val TAB_GRID_MAX_COLUMN_COUNT = 4
+        private const val KEY_FIRST_TIME_LOADING = "FIRST_TIME_LOADING"
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208062551083727/f

### Description

This PR fixes the initial scroll position after a tab manager is opened. The position should now be centered to the current tab.  

The problem was that the call to scroll to the selected tab was in the `render()` function, which would not always happen before the `LayoutManager` was initialized because the `LiveData` observers were called in different/inconsistent order. This was causing the tabs to sometimes show the first tab when initially opening the tab manager.

The PR also improves the scroll position when switching between the list mode and grid mode, which should now be pretty much centered around the same middle item.

### Steps to test this PR

I was able to reproduce this only when I had a lot of tabs open. If you don’t have many, you can add this to the `TabSwitcherViewModel`:

```kotlin
    init {
        viewModelScope.launch(dispatcherProvider.io()) {
            if (tabRepository.flowTabs.first().size < 100) {
                repeat(100) {
                    tabRepository.add("cnn.com")
                }
            }
        }
    }
``` 

_Initial position_
- [x] Go to tab manager
- [x] Select a tab somewhere in the middle
- [x] Leave the tab manager
- [x] Go back
- [x] Notice the scroll position is centered on the selected tab

_Configuration change_
- [x] Go to tab manager
- [x] Select the first tab
- [x] Go back to the tab manager
- [x] Scroll away from the selected tab
- [x] Rotate the device
- [x] Notice the scroll position has not changed

_Switching view mode_
- [x] Go to tab manager
- [x] Scroll somewhere where you can identify the item in the middle
- [x] Change the view mode
- [x] Notice the previous item is still roughly in the middle
- [x] Switch the view mode again
- [x] Notice the position is roughly the same again
