### PR TITLE
Update content scope scripts to version 6.9.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -775,7 +775,8 @@
         android: [
             ...baseFeatures,
             'webCompat',
-            'clickToLoad'
+            'clickToLoad',
+            'breakageReporting'
         ],
         windows: [
             'cookie',
@@ -12096,6 +12097,29 @@
         }
     }
 
+    /**
+     * @returns array of performance metrics
+     */
+    function getJsPerformanceMetrics () {
+        const paintResources = performance.getEntriesByType('paint');
+        const firstPaint = paintResources.find((entry) => entry.name === 'first-contentful-paint');
+        return firstPaint ? [firstPaint.startTime] : []
+    }
+
+    class BreakageReporting extends ContentFeature {
+        init () {
+            this.messaging.subscribe('getBreakageReportValues', () => {
+                const jsPerformance = getJsPerformanceMetrics();
+                const referrer = document.referrer;
+
+                this.messaging.notify('breakageReportResult', {
+                    jsPerformance,
+                    referrer
+                });
+            });
+        }
+    }
+
     var platformFeatures = {
         ddg_feature_runtimeChecks: RuntimeChecks,
         ddg_feature_fingerprintingAudio: FingerprintingAudio,
@@ -12111,7 +12135,8 @@
         ddg_feature_elementHiding: ElementHiding,
         ddg_feature_exceptionHandler: ExceptionHandler,
         ddg_feature_webCompat: WebCompat,
-        ddg_feature_clickToLoad: ClickToLoad
+        ddg_feature_clickToLoad: ClickToLoad,
+        ddg_feature_breakageReporting: BreakageReporting
     };
 
     /* global false */

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^10.15.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#13.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.8.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.9.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#5.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1721137609"
       },
@@ -62,7 +62,6 @@
       "version": "10.15.0",
       "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-10.15.0.tgz",
       "integrity": "sha512-Jxaogy2IuZEEV1+xPyo3c3PnZJmBO6ima/MapF2VolI/IKxXnL+9yYqyydPhSk0ahx42YINA6uIK6zexlKDIkQ==",
-      "license": "MPL-2.0",
       "dependencies": {
         "tldts-experimental": "^6.1.37"
       }
@@ -72,7 +71,7 @@
       "hasInstallScript": true
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#3d067c19d6d1b286149e2e259ee469ab9e4f45d2",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#47cb47893bfe3c6956ca6788d630fc8f94718982",
       "hasInstallScript": true,
       "workspaces": [
         "packages/special-pages",
@@ -209,12 +208,12 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.3.0.tgz",
-      "integrity": "sha512-nrWpWVaDZuaVc5X84xJ0vNrLvomM205oQyLsRt7OHNZbSHslcWsvgFR7O7hire2ZonjLrWBbedmotmIlJDVd6g==",
+      "version": "22.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.4.1.tgz",
+      "integrity": "sha512-1tbpb9325+gPnKK0dMm+/LMriX0vKxf6RnB0SZUqfyVkQ4fMgUSySqhxE/y8Jvs4NyF1yHzTfG9KlnkIODxPKg==",
       "dev": true,
       "dependencies": {
-        "undici-types": "~6.18.2"
+        "undici-types": "~6.19.2"
       }
     },
     "node_modules/@types/resolve": {
@@ -652,22 +651,22 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.39",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.39.tgz",
-      "integrity": "sha512-+Qib8VaRq6F56UjP4CJXd30PI4s3hFumDywUlsbiEWoA8+lfAaWNTLr3e6/zZOgHzVyon4snHaybeFHd8C0j/A=="
+      "version": "6.1.40",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.40.tgz",
+      "integrity": "sha512-csGlF+5GtK0qDvkqhZHbMflIvvMqs7JS3Y3KMrfBuhDAjI+oqH90p4KYMeiCPVF7akTeNoLgFaQ+aPZcGBc1kg=="
     },
     "node_modules/tldts-experimental": {
-      "version": "6.1.39",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.39.tgz",
-      "integrity": "sha512-BX/rK3bM7EZeDxgnKFJPUYQ2wcA/zXy1HdR9wT6iZFi8JJj4P4I+u3GTR+wkQaSB1xNhgbWrGvNt4krQnKg2rw==",
+      "version": "6.1.40",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.40.tgz",
+      "integrity": "sha512-QVDYijyrKQZFl5Ene+hOsIdbDUkG6QB5cwf7KC7UoVehMN/wlpGniYbVbsBNE0Q1A9VUoMZx4XzqVGQfFn2OFQ==",
       "dependencies": {
-        "tldts-core": "^6.1.39"
+        "tldts-core": "^6.1.40"
       }
     },
     "node_modules/undici-types": {
-      "version": "6.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.18.2.tgz",
-      "integrity": "sha512-5ruQbENj95yDYJNS3TvcaxPMshV7aizdv/hWYjGIKoANWKjhWNBsr2YEuYZKodQulB1b8l7ILOuDQep3afowQQ==",
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true
     },
     "node_modules/xregexp": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^10.15.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#13.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.8.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.9.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#5.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1721137609"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208098000878038/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass