### PR TITLE
Fix bookmarks from NTP

### DIFF
--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/BookmarksShortcut.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/BookmarksShortcut.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.savedsites.impl.newtab
 
 import android.content.Context
+import android.content.Intent
 import com.duckduckgo.anvil.annotations.ContributesActivePlugin
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.browser.api.ui.BrowserScreens.BookmarksScreenNoParams
@@ -49,7 +50,11 @@ class BookmarksNewTabShortcutPlugin @Inject constructor(
     }
 
     override fun onClick(context: Context) {
-        globalActivityStarter.start(context, BookmarksScreenNoParams)
+        val intent = globalActivityStarter.startIntent(context, BookmarksScreenNoParams)?.apply {
+            action = Intent.ACTION_VIEW
+        }
+
+        intent?.let { context.startActivity(intent) }
     }
 
     override suspend fun isUserEnabled(): Boolean {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202552961248957/1208094509610766/f 

### Description
Fixes a bug where clicking on a bookmark after coming from the NTP takes you nowhere

### Steps to test this PR

- [x] Install from internal
- [x] Add a bookmark
- [x] From the NTP tap on the bookmarks icon
- [x] On the bookmarks screen, tap on the bookmark
- [x] You should be taken to the bookmark URL

