### PR TITLE
Skip additional Trackers dialogs during onboarding

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -239,7 +239,7 @@ class CtaViewModel @Inject constructor(
             return null
         }
 
-        nonNullSite.let {
+        nonNullSite.let { it ->
             if (duckDuckGoUrlDetector.isDuckDuckGoEmailUrl(it.url)) {
                 return null
             }
@@ -258,9 +258,9 @@ class CtaViewModel @Inject constructor(
             // Is major network
             if (it.entity != null) {
                 it.entity?.let { entity ->
-                    if (!daxDialogNetworkShown() && !daxDialogTrackersFoundShown() && OnboardingDaxDialogCta.mainTrackerNetworks.contains(
-                            entity.displayName,
-                        )
+                    if (!daxDialogNetworkShown() && !daxDialogTrackersFoundShown() && OnboardingDaxDialogCta.mainTrackerNetworks.any { mainNetwork ->
+                        entity.displayName.contains(mainNetwork)
+                    }
                     ) {
                         return OnboardingDaxDialogCta.DaxMainNetworkCta(onboardingStore, appInstallStore, entity.displayName, host)
                     }

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -258,7 +258,10 @@ class CtaViewModel @Inject constructor(
             // Is major network
             if (it.entity != null) {
                 it.entity?.let { entity ->
-                    if (!daxDialogNetworkShown() && OnboardingDaxDialogCta.mainTrackerNetworks.contains(entity.displayName)) {
+                    if (!daxDialogNetworkShown() && !daxDialogTrackersFoundShown() && OnboardingDaxDialogCta.mainTrackerNetworks.contains(
+                            entity.displayName,
+                        )
+                    ) {
                         return OnboardingDaxDialogCta.DaxMainNetworkCta(onboardingStore, appInstallStore, entity.displayName, host)
                     }
                 }

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -239,7 +239,7 @@ class CtaViewModel @Inject constructor(
             return null
         }
 
-        nonNullSite.let { it ->
+        nonNullSite.let {
             if (duckDuckGoUrlDetector.isDuckDuckGoEmailUrl(it.url)) {
                 return null
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1176956903599313/1208030810715640/f

### Description
Skip displaying major network onboarding dialog if other trackers dialog has been shown
Fix a bug where we weren't showing major network dialog in websites like instagram or youtube.

### Steps to test this PR

_Skip additional major network dialog display_
- [ ] Fresh install
- [ ] Go to a website with trackers (e.g. bbc.co.uk)
- [ ] Dismiss trackers dialog tapping dialog's button
- [ ] Navigate to facebook.com
- [ ] Check major network dialog is not showing


_Bug fix_
- [ ] Fresh install
- [ ] Go to instagram.com or youtube.com
- [ ] Check major network onboarding dialog is displayed


### No UI changes
