### PR TITLE
Move priorities inside plugin APIs to make them more discoverable

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/newtab/AppTrackingProtectionStateView.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/newtab/AppTrackingProtectionStateView.kt
@@ -189,7 +189,7 @@ class AppTrackingProtectionStateView @JvmOverloads constructor(
 @ContributesActivePlugin(
     AppScope::class,
     boundType = NewTabPageSectionPlugin::class,
-    priority = 2,
+    priority = NewTabPageSectionPlugin.PRIORITY_APP_TP,
 )
 class AppTrackingProtectionNewTabPageSectionPlugin @Inject constructor(
     private val vpnStore: VpnStore,

--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/FocusedViewProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/FocusedViewProvider.kt
@@ -23,7 +23,6 @@ import com.duckduckgo.anvil.annotations.ContributesActivePluginPoint
 import com.duckduckgo.common.utils.plugins.ActivePluginPoint
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.newtabpage.api.FocusedViewPlugin
-import com.duckduckgo.newtabpage.api.FocusedViewVersion
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
@@ -54,8 +53,6 @@ class RealFocusedViewProvider @Inject constructor(
 )
 class FocusedLegacyPage @Inject constructor() : FocusedViewPlugin {
 
-    override val name: String = FocusedViewVersion.LEGACY.name
-
     override fun getView(context: Context): View {
         return FocusedLegacyView(context)
     }
@@ -71,7 +68,6 @@ class FocusedLegacyPage @Inject constructor() : FocusedViewPlugin {
 )
 class FocusedPage @Inject constructor() : FocusedViewPlugin {
 
-    override val name: String = FocusedViewVersion.NEW.name
     override fun getView(context: Context): View {
         return FocusedView(context)
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/FocusedViewProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/FocusedViewProvider.kt
@@ -49,7 +49,7 @@ class RealFocusedViewProvider @Inject constructor(
 @ContributesActivePlugin(
     scope = ActivityScope::class,
     boundType = FocusedViewPlugin::class,
-    priority = 100,
+    priority = FocusedViewPlugin.PRIORITY_LEGACY_FOCUSED_PAGE,
     supportExperiments = true,
 )
 class FocusedLegacyPage @Inject constructor() : FocusedViewPlugin {
@@ -64,7 +64,7 @@ class FocusedLegacyPage @Inject constructor() : FocusedViewPlugin {
 @ContributesActivePlugin(
     scope = ActivityScope::class,
     boundType = FocusedViewPlugin::class,
-    priority = 0,
+    priority = FocusedViewPlugin.PRIORITY_NEW_FOCUSED_PAGE,
     defaultActiveValue = false,
     supportExperiments = true,
     internalAlwaysEnabled = true,

--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabPageProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabPageProvider.kt
@@ -24,7 +24,6 @@ import com.duckduckgo.common.utils.plugins.ActivePluginPoint
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.newtabpage.api.NewTabPagePlugin
-import com.duckduckgo.newtabpage.api.NewTabPageVersion
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
@@ -51,8 +50,6 @@ class RealNewTabPageProvider @Inject constructor(
     priority = NewTabPagePlugin.PRIORITY_NTP,
 )
 class NewTabLegacyPage @Inject constructor() : NewTabPagePlugin {
-
-    override val name: String = NewTabPageVersion.LEGACY.name
 
     override fun getView(context: Context): View {
         return NewTabLegacyPageView(context)

--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabPageProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabPageProvider.kt
@@ -48,7 +48,7 @@ class RealNewTabPageProvider @Inject constructor(
 @ContributesActivePlugin(
     scope = AppScope::class,
     boundType = NewTabPagePlugin::class,
-    priority = 100,
+    priority = NewTabPagePlugin.PRIORITY_NTP,
 )
 class NewTabLegacyPage @Inject constructor() : NewTabPagePlugin {
 

--- a/app/src/main/java/com/duckduckgo/app/downloads/DownloadsNewTabShortcutPlugin.kt
+++ b/app/src/main/java/com/duckduckgo/app/downloads/DownloadsNewTabShortcutPlugin.kt
@@ -31,7 +31,7 @@ import javax.inject.Inject
 @ContributesActivePlugin(
     AppScope::class,
     boundType = NewTabPageShortcutPlugin::class,
-    priority = 3,
+    priority = NewTabPageShortcutPlugin.PRIORITY_DOWNLOADS,
 )
 class DownloadsNewTabShortcutPlugin @Inject constructor(
     private val globalActivityStarter: GlobalActivityStarter,

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsNewTabShortcutPlugin.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsNewTabShortcutPlugin.kt
@@ -31,7 +31,7 @@ import javax.inject.Inject
 @ContributesActivePlugin(
     AppScope::class,
     boundType = NewTabPageShortcutPlugin::class,
-    priority = 4,
+    priority = NewTabPageShortcutPlugin.PRIORITY_SETTINGS,
 )
 class SettingsNewTabShortcutPlugin @Inject constructor(
     private val globalActivityStarter: GlobalActivityStarter,

--- a/app/src/test/java/com/duckduckgo/app/browser/newtab/NewTabPageProviderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/newtab/NewTabPageProviderTest.kt
@@ -21,7 +21,6 @@ import android.view.View
 import app.cash.turbine.test
 import com.duckduckgo.common.utils.plugins.ActivePluginPoint
 import com.duckduckgo.newtabpage.api.NewTabPagePlugin
-import com.duckduckgo.newtabpage.api.NewTabPageVersion
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -36,7 +35,7 @@ class NewTabPageProviderTest {
 
         testee.provideNewTabPageVersion().test {
             expectMostRecentItem().also {
-                assertTrue(it.name == NewTabPageVersion.LEGACY.name)
+                assertTrue(it is LegacyNewTabPlugin)
             }
         }
     }
@@ -47,7 +46,7 @@ class NewTabPageProviderTest {
 
         testee.provideNewTabPageVersion().test {
             expectMostRecentItem().also {
-                assertTrue(it.name == NewTabPageVersion.NEW.name)
+                assertTrue(it is NewNewTabPlugin)
             }
         }
     }
@@ -58,7 +57,7 @@ class NewTabPageProviderTest {
 
         testee.provideNewTabPageVersion().test {
             expectMostRecentItem().also {
-                assertTrue(it.name == NewTabPageVersion.NEW.name)
+                assertTrue(it is NewNewTabPlugin)
             }
         }
     }
@@ -69,7 +68,7 @@ class NewTabPageProviderTest {
 
         testee.provideNewTabPageVersion().test {
             expectMostRecentItem().also {
-                assertTrue(it.name == NewTabPageVersion.LEGACY.name)
+                assertTrue(it is LegacyNewTabPlugin)
             }
         }
     }
@@ -80,7 +79,7 @@ class NewTabPageProviderTest {
 
         testee.provideNewTabPageVersion().test {
             expectMostRecentItem().also {
-                assertTrue(it.name == NewTabPageVersion.LEGACY.name)
+                assertTrue(it is NewTabLegacyPage)
             }
         }
     }
@@ -126,18 +125,12 @@ class NewTabPageProviderTest {
     }
 
     class LegacyNewTabPlugin : NewTabPagePlugin {
-        override val name: String
-            get() = NewTabPageVersion.LEGACY.name
-
         override fun getView(context: Context): View {
             return View(context)
         }
     }
 
     class NewNewTabPlugin() : NewTabPagePlugin {
-        override val name: String
-            get() = NewTabPageVersion.NEW.name
-
         override fun getView(context: Context): View {
             return View(context)
         }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/newtab/AutofillNewTabShortcut.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/newtab/AutofillNewTabShortcut.kt
@@ -32,7 +32,7 @@ import javax.inject.Inject
 @ContributesActivePlugin(
     AppScope::class,
     boundType = NewTabPageShortcutPlugin::class,
-    priority = 2,
+    priority = NewTabPageShortcutPlugin.PRIORITY_AUTOFILL,
 )
 class AutofillNewTabShortcutPlugin @Inject constructor(
     private val globalActivityStarter: GlobalActivityStarter,

--- a/new-tab-page/new-tab-page-api/src/main/java/com/duckduckgo/newtabpage/api/FocusedViewPlugin.kt
+++ b/new-tab-page/new-tab-page-api/src/main/java/com/duckduckgo/newtabpage/api/FocusedViewPlugin.kt
@@ -35,6 +35,11 @@ interface FocusedViewPlugin : ActivePlugin {
      * @return [View]
      */
     fun getView(context: Context): View
+
+    companion object {
+        const val PRIORITY_NEW_FOCUSED_PAGE = 0
+        const val PRIORITY_LEGACY_FOCUSED_PAGE = 100
+    }
 }
 
 enum class FocusedViewVersion {

--- a/new-tab-page/new-tab-page-api/src/main/java/com/duckduckgo/newtabpage/api/FocusedViewPlugin.kt
+++ b/new-tab-page/new-tab-page-api/src/main/java/com/duckduckgo/newtabpage/api/FocusedViewPlugin.kt
@@ -27,9 +27,6 @@ import com.duckduckgo.common.utils.plugins.ActivePlugin
  */
 interface FocusedViewPlugin : ActivePlugin {
 
-    /** Name of the focused view version */
-    val name: String
-
     /**
      * This method returns a [View] that will be used as the Focused View content
      * @return [View]
@@ -40,9 +37,4 @@ interface FocusedViewPlugin : ActivePlugin {
         const val PRIORITY_NEW_FOCUSED_PAGE = 0
         const val PRIORITY_LEGACY_FOCUSED_PAGE = 100
     }
-}
-
-enum class FocusedViewVersion {
-    LEGACY,
-    NEW,
 }

--- a/new-tab-page/new-tab-page-api/src/main/java/com/duckduckgo/newtabpage/api/NewTabPagePlugin.kt
+++ b/new-tab-page/new-tab-page-api/src/main/java/com/duckduckgo/newtabpage/api/NewTabPagePlugin.kt
@@ -35,6 +35,11 @@ interface NewTabPagePlugin : ActivePlugin {
      * @return [View]
      */
     fun getView(context: Context): View
+
+    companion object {
+        const val PRIORITY_LEGACY_NTP = 0
+        const val PRIORITY_NTP = 100
+    }
 }
 
 enum class NewTabPageVersion {

--- a/new-tab-page/new-tab-page-api/src/main/java/com/duckduckgo/newtabpage/api/NewTabPagePlugin.kt
+++ b/new-tab-page/new-tab-page-api/src/main/java/com/duckduckgo/newtabpage/api/NewTabPagePlugin.kt
@@ -27,9 +27,6 @@ import com.duckduckgo.common.utils.plugins.ActivePlugin
  */
 interface NewTabPagePlugin : ActivePlugin {
 
-    /** Name of the focused view version */
-    val name: String
-
     /**
      * This method returns a [View] that will be used as the NewTabPage content
      * @return [View]
@@ -40,9 +37,4 @@ interface NewTabPagePlugin : ActivePlugin {
         const val PRIORITY_LEGACY_NTP = 0
         const val PRIORITY_NTP = 100
     }
-}
-
-enum class NewTabPageVersion {
-    LEGACY,
-    NEW,
 }

--- a/new-tab-page/new-tab-page-api/src/main/java/com/duckduckgo/newtabpage/api/NewTabPageSectionPlugin.kt
+++ b/new-tab-page/new-tab-page-api/src/main/java/com/duckduckgo/newtabpage/api/NewTabPageSectionPlugin.kt
@@ -40,6 +40,13 @@ interface NewTabPageSectionPlugin : ActivePlugin {
      * @return [Boolean]
      */
     suspend fun isUserEnabled(): Boolean
+
+    companion object {
+        const val PRIORITY_REMOTE_MESSAGE = 10
+        const val PRIORITY_APP_TP = 20
+        const val PRIORITY_FAVOURITES = 33
+        const val PRIORITY_SHORTCUTS = 40
+    }
 }
 
 enum class NewTabPageSection {

--- a/new-tab-page/new-tab-page-api/src/main/java/com/duckduckgo/newtabpage/api/NewTabPageShortcutPlugin.kt
+++ b/new-tab-page/new-tab-page-api/src/main/java/com/duckduckgo/newtabpage/api/NewTabPageShortcutPlugin.kt
@@ -44,6 +44,14 @@ interface NewTabPageShortcutPlugin : ActivePlugin {
      * Used from the New Tab Settings screen
      */
     suspend fun setUserEnabled(enabled: Boolean)
+
+    companion object {
+        const val PRIORITY_BOOKMARKS = 10
+        const val PRIORITY_AUTOFILL = 20
+        const val PRIORITY_DOWNLOADS = 30
+        const val PRIORITY_SETTINGS = 40
+        const val PRIORITY_AI_CHAT = 50
+    }
 }
 
 interface NewTabShortcut {

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/NewTabPage.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/NewTabPage.kt
@@ -21,7 +21,6 @@ import android.view.View
 import com.duckduckgo.anvil.annotations.ContributesActivePlugin
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.newtabpage.api.NewTabPagePlugin
-import com.duckduckgo.newtabpage.api.NewTabPageVersion
 import com.duckduckgo.newtabpage.impl.view.NewTabPageView
 import javax.inject.Inject
 
@@ -35,7 +34,6 @@ import javax.inject.Inject
 )
 class NewTabPage @Inject constructor() : NewTabPagePlugin {
 
-    override val name: String = NewTabPageVersion.NEW.name
     override fun getView(context: Context): View {
         return NewTabPageView(context)
     }

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/NewTabPage.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/NewTabPage.kt
@@ -28,7 +28,7 @@ import javax.inject.Inject
 @ContributesActivePlugin(
     scope = AppScope::class,
     boundType = NewTabPagePlugin::class,
-    priority = 0, // lower to come first in the list of plugins,
+    priority = NewTabPagePlugin.PRIORITY_LEGACY_NTP,
     defaultActiveValue = false,
     supportExperiments = true,
     internalAlwaysEnabled = true,

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/shortcuts/NewTabShortcuts.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/shortcuts/NewTabShortcuts.kt
@@ -30,7 +30,7 @@ import javax.inject.Inject
 @ContributesActivePlugin(
     AppScope::class,
     boundType = NewTabPageShortcutPlugin::class,
-    priority = 5,
+    priority = NewTabPageShortcutPlugin.PRIORITY_AI_CHAT,
 )
 class AIChatNewTabShortcutPlugin @Inject constructor(
     private val browserNav: BrowserNav,

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/shortcuts/ShortcutsNewTabSectionView.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/shortcuts/ShortcutsNewTabSectionView.kt
@@ -156,7 +156,7 @@ class ShortcutsNewTabSectionView @JvmOverloads constructor(
 @ContributesActivePlugin(
     AppScope::class,
     boundType = NewTabPageSectionPlugin::class,
-    priority = 4,
+    priority = NewTabPageSectionPlugin.PRIORITY_SHORTCUTS,
 )
 
 class ShortcutsNewTabSectionPlugin @Inject constructor(

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/newtab/RemoteMessageView.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/newtab/RemoteMessageView.kt
@@ -212,7 +212,7 @@ class RemoteMessageView @JvmOverloads constructor(
 @ContributesActivePlugin(
     AppScope::class,
     boundType = NewTabPageSectionPlugin::class,
-    priority = 1,
+    priority = NewTabPageSectionPlugin.PRIORITY_REMOTE_MESSAGE,
 )
 class RemoteMessageNewTabSectionPlugin @Inject constructor(
     private val remoteMessageModel: RemoteMessageModel,

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/BookmarksShortcut.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/BookmarksShortcut.kt
@@ -32,7 +32,7 @@ import javax.inject.Inject
 @ContributesActivePlugin(
     AppScope::class,
     boundType = NewTabPageShortcutPlugin::class,
-    priority = 1,
+    priority = NewTabPageShortcutPlugin.PRIORITY_BOOKMARKS,
 )
 class BookmarksNewTabShortcutPlugin @Inject constructor(
     private val globalActivityStarter: GlobalActivityStarter,

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionView.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionView.kt
@@ -419,7 +419,7 @@ class FavouritesNewTabSectionView @JvmOverloads constructor(
 @ContributesActivePlugin(
     AppScope::class,
     boundType = NewTabPageSectionPlugin::class,
-    priority = 3,
+    priority = NewTabPageSectionPlugin.PRIORITY_FAVOURITES,
 )
 class FavouritesNewTabSectionPlugin @Inject constructor(
     private val setting: NewTabFavouritesSectionSetting,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1198194956794324/1208113353562028/f

### Description
Move plugin priorities to the priority interface for discoverability.

I have also convert priorities 1, 2, 3 etc to 10, 20, 30 subsequently so that it's simpler to insert plugins in the future

Incidentally, the second commit removes the `name` property from couple plugins as it's not used.

### Steps to test this PR
Code review to double check priorities/order remain the same.
Smoke test NTP
