### PR TITLE
Update content scope scripts to version 6.10.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -8416,7 +8416,12 @@
                 forcedValues['maximum-scale'] = 10;
             }
 
-            if (!viewportTag || this.desktopModeEnabled) {
+            if (this.getFeatureSettingEnabled('plainTextViewPort') && document.contentType === 'text/plain') {
+                // text should span the full screen width
+                forcedValues.width = 'device-width';
+                // keep default scale to prevent text from appearing too small
+                forcedValues['initial-scale'] = 1;
+            } else if (!viewportTag || this.desktopModeEnabled) {
                 // force wide viewport width
                 forcedValues.width = screen.width >= 1280 ? 1280 : 980;
                 forcedValues['initial-scale'] = (screen.width / forcedValues.width).toFixed(3);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^10.15.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#13.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.9.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.10.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#5.1.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1724449523"
       },
@@ -71,7 +71,7 @@
       "hasInstallScript": true
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#47cb47893bfe3c6956ca6788d630fc8f94718982",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#f25bfc9785c65838c9dadb9ff0392285b4b196d5",
       "hasInstallScript": true,
       "workspaces": [
         "packages/special-pages",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^10.15.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#13.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.9.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.10.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#5.1.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1724449523"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass