### PR TITLE
Add conflict strategy of ignore to stored crash hash keys

### DIFF
--- a/anrs/anrs-store/src/main/java/com/duckduckgo/app/anrs/store/UncaughtExceptionDao.kt
+++ b/anrs/anrs-store/src/main/java/com/duckduckgo/app/anrs/store/UncaughtExceptionDao.kt
@@ -19,13 +19,14 @@ package com.duckduckgo.app.anrs.store
 import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Insert
+import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import kotlinx.coroutines.flow.Flow
 
 @Dao
 abstract class UncaughtExceptionDao {
 
-    @Insert
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
     abstract fun add(exceptionEntity: ExceptionEntity)
 
     @Query("SELECT * FROM uncaught_exception_entity order by timestamp")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1208134428464537/1208151264908063/f 

### Description
Crash data has a computed hash which is used as the primary key in the DB. There are reports of crashes because of duplicate key insertion attempts.

We should ignore subsequents attempts to add the same hash.
