### PR TITLE
Show on App Launch: Add persistence

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -418,11 +418,10 @@
             android:exported="false"
             android:label="@string/generalSettingsActivityTitle"
             android:parentActivityName="com.duckduckgo.app.settings.SettingsActivity" />
-        <!--TODO add translated copy for label-->
         <activity
             android:name="com.duckduckgo.app.generalsettings.showonapplaunch.ShowOnAppLaunchActivity"
             android:exported="false"
-            android:label="Show on App Launch"
+            android:label="@string/showOnAppLaunchOptionTitle"
             android:parentActivityName="com.duckduckgo.app.generalsettings.GeneralSettingsActivity" />
         <activity
             android:name="com.duckduckgo.app.webtrackingprotection.WebTrackingProtectionActivity"

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -364,6 +364,8 @@ open class BrowserActivity : DuckDuckGoActivity() {
                 return
             }
         }
+
+        viewModel.handleShowOnAppLaunchOption()
     }
 
     private fun configureObservers() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -20,11 +20,16 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
 import com.duckduckgo.app.browser.omnibar.OmnibarEntryConverter
 import com.duckduckgo.app.fire.DataClearer
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.LastOpenedTab
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.NewTabPage
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.SpecificPage
+import com.duckduckgo.app.generalsettings.showonapplaunch.store.ShowOnAppLaunchOptionDataStore
 import com.duckduckgo.app.global.ApplicationClearDataState
 import com.duckduckgo.app.global.rating.AppEnjoymentPromptEmitter
 import com.duckduckgo.app.global.rating.AppEnjoymentPromptOptions
@@ -55,6 +60,7 @@ import com.duckduckgo.feature.toggles.api.Toggle
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -69,6 +75,7 @@ class BrowserViewModel @Inject constructor(
     private val dispatchers: DispatcherProvider,
     private val pixel: Pixel,
     private val skipUrlConversionOnNewTabFeature: SkipUrlConversionOnNewTabFeature,
+    private val showOnAppLaunchOptionDataStore: ShowOnAppLaunchOptionDataStore,
 ) : ViewModel(),
     CoroutineScope {
 
@@ -283,6 +290,21 @@ class BrowserViewModel @Inject constructor(
 
     fun onBookmarksActivityResult(url: String) {
         command.value = Command.OpenSavedSite(url)
+    }
+
+    fun handleShowOnAppLaunchOption() {
+        viewModelScope.launch {
+            when (val option = showOnAppLaunchOptionDataStore.optionFlow.first()) {
+                LastOpenedTab -> Unit
+                NewTabPage -> onNewTabRequested()
+                is SpecificPage -> {
+                    val liveSelectedTabUrl = tabRepository.getSelectedTab()?.url
+                    if (liveSelectedTabUrl != option.url) {
+                        onOpenInNewTabRequested(option.url)
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/GeneralSettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/GeneralSettingsActivity.kt
@@ -25,10 +25,15 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
 import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.ActivityGeneralSettingsBinding
 import com.duckduckgo.app.generalsettings.GeneralSettingsViewModel.Command
 import com.duckduckgo.app.generalsettings.GeneralSettingsViewModel.Command.LaunchShowOnAppLaunchScreen
 import com.duckduckgo.app.generalsettings.showonapplaunch.ShowOnAppLaunchScreenNoParams
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.LastOpenedTab
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.NewTabPage
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.SpecificPage
 import com.duckduckgo.app.global.view.fadeTransitionConfig
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
@@ -104,7 +109,7 @@ class GeneralSettingsActivity : DuckDuckGoActivity() {
                         binding.voiceSearchToggle.isVisible = true
                         binding.voiceSearchToggle.quietlySetIsChecked(viewState.voiceSearchEnabled, voiceSearchChangeListener)
                     }
-                    binding.showOnAppLaunchButton.setSecondaryText(viewState.showOnAppLaunchSelectedOptionText)
+                    setShowOnAppLaunchOptionSecondaryText(viewState.showOnAppLaunchSelectedOption)
                 }
             }.launchIn(lifecycleScope)
 
@@ -112,6 +117,15 @@ class GeneralSettingsActivity : DuckDuckGoActivity() {
             .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
             .onEach { processCommand(it) }
             .launchIn(lifecycleScope)
+    }
+
+    private fun setShowOnAppLaunchOptionSecondaryText(showOnAppLaunchOption: ShowOnAppLaunchOption) {
+        val optionString = when (showOnAppLaunchOption) {
+            is LastOpenedTab -> getString(R.string.showOnAppLaunchOptionLastOpenedTab)
+            is NewTabPage -> getString(R.string.showOnAppLaunchOptionNewTabPage)
+            is SpecificPage -> showOnAppLaunchOption.url
+        }
+        binding.showOnAppLaunchButton.setSecondaryText(optionString)
     }
 
     private fun processCommand(command: Command) {

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/GeneralSettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/GeneralSettingsViewModel.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption
 import com.duckduckgo.app.generalsettings.showonapplaunch.store.ShowOnAppLaunchOptionDataStore
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.pixels.AppPixelName.AUTOCOMPLETE_GENERAL_SETTINGS_TOGGLED_OFF
 import com.duckduckgo.app.pixels.AppPixelName.AUTOCOMPLETE_GENERAL_SETTINGS_TOGGLED_ON
 import com.duckduckgo.app.pixels.AppPixelName.AUTOCOMPLETE_RECENT_SITES_GENERAL_SETTINGS_TOGGLED_OFF
@@ -143,6 +144,7 @@ class GeneralSettingsViewModel @Inject constructor(
 
     fun onShowOnAppLaunchButtonClick() {
         sendCommand(Command.LaunchShowOnAppLaunchScreen)
+        pixel.fire(AppPixelName.SETTINGS_GENERAL_APP_LAUNCH_PRESSED)
     }
 
     private fun observeShowOnAppLaunchOption() {

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/GeneralSettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/GeneralSettingsViewModel.kt
@@ -19,6 +19,8 @@ package com.duckduckgo.app.generalsettings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption
+import com.duckduckgo.app.generalsettings.showonapplaunch.store.ShowOnAppLaunchOptionDataStore
 import com.duckduckgo.app.pixels.AppPixelName.AUTOCOMPLETE_GENERAL_SETTINGS_TOGGLED_OFF
 import com.duckduckgo.app.pixels.AppPixelName.AUTOCOMPLETE_GENERAL_SETTINGS_TOGGLED_ON
 import com.duckduckgo.app.pixels.AppPixelName.AUTOCOMPLETE_RECENT_SITES_GENERAL_SETTINGS_TOGGLED_OFF
@@ -37,7 +39,11 @@ import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -49,6 +55,7 @@ class GeneralSettingsViewModel @Inject constructor(
     private val voiceSearchAvailability: VoiceSearchAvailability,
     private val voiceSearchRepository: VoiceSearchRepository,
     private val dispatcherProvider: DispatcherProvider,
+    private val showOnAppLaunchOptionDataStore: ShowOnAppLaunchOptionDataStore,
 ) : ViewModel() {
 
     data class ViewState(
@@ -57,7 +64,7 @@ class GeneralSettingsViewModel @Inject constructor(
         val storeHistoryEnabled: Boolean,
         val showVoiceSearch: Boolean,
         val voiceSearchEnabled: Boolean,
-        val showOnAppLaunchSelectedOptionText: String,
+        val showOnAppLaunchSelectedOption: ShowOnAppLaunchOption,
     )
 
     sealed class Command {
@@ -82,10 +89,11 @@ class GeneralSettingsViewModel @Inject constructor(
                 storeHistoryEnabled = history.isHistoryFeatureAvailable(),
                 showVoiceSearch = voiceSearchAvailability.isVoiceSearchSupported,
                 voiceSearchEnabled = voiceSearchAvailability.isVoiceSearchAvailable,
-                // TODO get the actual value from prefs
-                showOnAppLaunchSelectedOptionText = "Last Opened Tab",
+                showOnAppLaunchSelectedOption = showOnAppLaunchOptionDataStore.optionFlow.first(),
             )
         }
+
+        observeShowOnAppLaunchOption()
     }
 
     fun onAutocompleteSettingChanged(enabled: Boolean) {
@@ -135,6 +143,13 @@ class GeneralSettingsViewModel @Inject constructor(
 
     fun onShowOnAppLaunchButtonClick() {
         sendCommand(Command.LaunchShowOnAppLaunchScreen)
+    }
+
+    private fun observeShowOnAppLaunchOption() {
+        showOnAppLaunchOptionDataStore.optionFlow
+            .onEach { showOnAppLaunchOption ->
+                _viewState.update { it!!.copy(showOnAppLaunchSelectedOption = showOnAppLaunchOption) }
+            }.launchIn(viewModelScope)
     }
 
     private fun sendCommand(newCommand: Command) {

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchActivity.kt
@@ -69,15 +69,15 @@ class ShowOnAppLaunchActivity : DuckDuckGoActivity() {
     }
 
     private fun configureUiEventHandlers() {
-        binding.lastOpenedTabCheckListItem.setOnClickListener {
+        binding.lastOpenedTabCheckListItem.setClickListener {
             viewModel.onShowOnAppLaunchOptionChanged(LastOpenedTab)
         }
 
-        binding.newTabCheckListItem.setOnClickListener {
+        binding.newTabCheckListItem.setClickListener {
             viewModel.onShowOnAppLaunchOptionChanged(NewTabPage)
         }
 
-        binding.specificPageCheckListItem.setOnClickListener {
+        binding.specificPageCheckListItem.setClickListener {
             viewModel.onShowOnAppLaunchOptionChanged(SpecificPage(binding.specificPageUrlInput.text))
         }
 

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchActivity.kt
@@ -24,9 +24,9 @@ import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.browser.databinding.ActivityShowOnAppLaunchSettingBinding
-import com.duckduckgo.app.generalsettings.showonapplaunch.ShowOnAppLaunchViewModel.ShowOnAppLaunchOption.LastOpenedTab
-import com.duckduckgo.app.generalsettings.showonapplaunch.ShowOnAppLaunchViewModel.ShowOnAppLaunchOption.NewTabPage
-import com.duckduckgo.app.generalsettings.showonapplaunch.ShowOnAppLaunchViewModel.ShowOnAppLaunchOption.SpecificPage
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.LastOpenedTab
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.NewTabPage
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.SpecificPage
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.view.showKeyboard
 import com.duckduckgo.common.ui.viewbinding.viewBinding

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchActivity.kt
@@ -46,6 +46,8 @@ class ShowOnAppLaunchActivity : DuckDuckGoActivity() {
         setContentView(binding.root)
         setupToolbar(binding.includeToolbar.toolbar)
 
+        binding.specificPageUrlInput.setSelectAllOnFocus(true)
+
         configureUiEventHandlers()
         observeViewModel()
     }
@@ -78,6 +80,14 @@ class ShowOnAppLaunchActivity : DuckDuckGoActivity() {
         binding.specificPageCheckListItem.setOnClickListener {
             viewModel.onShowOnAppLaunchOptionChanged(SpecificPage(binding.specificPageUrlInput.text))
         }
+
+        binding.specificPageUrlInput.addFocusChangedListener { _, hasFocus ->
+            if (hasFocus) {
+                viewModel.onShowOnAppLaunchOptionChanged(
+                    SpecificPage(binding.specificPageUrlInput.text),
+                )
+            }
+        }
     }
 
     private fun observeViewModel() {
@@ -99,14 +109,12 @@ class ShowOnAppLaunchActivity : DuckDuckGoActivity() {
                         uncheckLastOpenedTabCheckListItem()
                         uncheckNewTabCheckListItem()
                         binding.specificPageCheckListItem.setChecked(true)
-                        with(binding.specificPageUrlInput) {
-                            isEditable = true
-                            setSelectAllOnFocus(true)
-                        }
                     }
                 }
 
-                binding.specificPageUrlInput.text = viewState.specificPageUrl
+                if (binding.specificPageUrlInput.text != viewState.specificPageUrl) {
+                    binding.specificPageUrlInput.text = viewState.specificPageUrl
+                }
             }
             .launchIn(lifecycleScope)
     }
@@ -122,5 +130,6 @@ class ShowOnAppLaunchActivity : DuckDuckGoActivity() {
     private fun uncheckSpecificPageCheckListItem() {
         binding.specificPageCheckListItem.setChecked(false)
         binding.specificPageUrlInput.isEditable = false
+        binding.specificPageUrlInput.isEditable = true
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchActivity.kt
@@ -28,7 +28,6 @@ import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchO
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.NewTabPage
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.SpecificPage
 import com.duckduckgo.common.ui.DuckDuckGoActivity
-import com.duckduckgo.common.ui.view.showKeyboard
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.ActivityScope
 import kotlinx.coroutines.flow.launchIn
@@ -49,6 +48,11 @@ class ShowOnAppLaunchActivity : DuckDuckGoActivity() {
 
         configureUiEventHandlers()
         observeViewModel()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        viewModel.setSpecificPageUrl(binding.specificPageUrlInput.text)
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -96,13 +100,13 @@ class ShowOnAppLaunchActivity : DuckDuckGoActivity() {
                         uncheckNewTabCheckListItem()
                         binding.specificPageCheckListItem.setChecked(true)
                         with(binding.specificPageUrlInput) {
-                            text = viewState.selectedOption.url
                             isEditable = true
                             setSelectAllOnFocus(true)
-                            showKeyboard()
                         }
                     }
                 }
+
+                binding.specificPageUrlInput.text = viewState.specificPageUrl
             }
             .launchIn(lifecycleScope)
     }

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchActivity.kt
@@ -52,8 +52,8 @@ class ShowOnAppLaunchActivity : DuckDuckGoActivity() {
         observeViewModel()
     }
 
-    override fun onStop() {
-        super.onStop()
+    override fun onPause() {
+        super.onPause()
         viewModel.setSpecificPageUrl(binding.specificPageUrlInput.text)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchActivity.kt
@@ -80,16 +80,20 @@ class ShowOnAppLaunchActivity : DuckDuckGoActivity() {
         viewModel.viewState
             .flowWithLifecycle(lifecycle, Lifecycle.State.RESUMED)
             .onEach { viewState ->
-                clearSelections()
-
                 when (viewState.selectedOption) {
                     LastOpenedTab -> {
+                        uncheckNewTabCheckListItem()
+                        uncheckSpecificPageCheckListItem()
                         binding.lastOpenedTabCheckListItem.setChecked(true)
                     }
                     NewTabPage -> {
+                        uncheckLastOpenedTabCheckListItem()
+                        uncheckSpecificPageCheckListItem()
                         binding.newTabCheckListItem.setChecked(true)
                     }
                     is SpecificPage -> {
+                        uncheckLastOpenedTabCheckListItem()
+                        uncheckNewTabCheckListItem()
                         binding.specificPageCheckListItem.setChecked(true)
                         with(binding.specificPageUrlInput) {
                             text = viewState.selectedOption.url
@@ -103,9 +107,15 @@ class ShowOnAppLaunchActivity : DuckDuckGoActivity() {
             .launchIn(lifecycleScope)
     }
 
-    private fun clearSelections() {
+    private fun uncheckLastOpenedTabCheckListItem() {
         binding.lastOpenedTabCheckListItem.setChecked(false)
+    }
+
+    private fun uncheckNewTabCheckListItem() {
         binding.newTabCheckListItem.setChecked(false)
+    }
+
+    private fun uncheckSpecificPageCheckListItem() {
         binding.specificPageCheckListItem.setChecked(false)
         binding.specificPageUrlInput.isEditable = false
     }

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchActivity.kt
@@ -92,7 +92,7 @@ class ShowOnAppLaunchActivity : DuckDuckGoActivity() {
 
     private fun observeViewModel() {
         viewModel.viewState
-            .flowWithLifecycle(lifecycle, Lifecycle.State.RESUMED)
+            .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
             .onEach { viewState ->
                 when (viewState.selectedOption) {
                     LastOpenedTab -> {

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchStateReporterPlugin.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchStateReporterPlugin.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.generalsettings.showonapplaunch
+
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption
+import com.duckduckgo.app.generalsettings.showonapplaunch.store.ShowOnAppLaunchOptionDataStore
+import com.duckduckgo.app.statistics.api.BrowserFeatureStateReporterPlugin
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+
+interface ShowOnAppLaunchReporterPlugin
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = BrowserFeatureStateReporterPlugin::class,
+)
+@ContributesBinding(scope = AppScope::class, boundType = ShowOnAppLaunchReporterPlugin::class)
+class ShowOnAppLaunchStateReporterPlugin
+@Inject
+constructor(
+    private val dispatcherProvider: DispatcherProvider,
+    private val showOnAppLaunchOptionDataStore: ShowOnAppLaunchOptionDataStore,
+) : ShowOnAppLaunchReporterPlugin, BrowserFeatureStateReporterPlugin {
+
+    override fun featureStateParams(): Map<String, String> {
+        val option =
+            runBlocking(dispatcherProvider.io()) {
+                showOnAppLaunchOptionDataStore.optionFlow.first()
+            }
+        val dailyPixelValue = ShowOnAppLaunchOption.getDailyPixelValue(option)
+        return mapOf(PixelParameter.LAUNCH_SCREEN to dailyPixelValue)
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchUrlConverterImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchUrlConverterImpl.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.generalsettings.showonapplaunch
+
+import android.net.Uri
+import com.duckduckgo.app.generalsettings.showonapplaunch.store.ShowOnAppLaunchOptionDataStore
+
+class ShowOnAppLaunchUrlConverterImpl : UrlConverter {
+
+    override fun convertUrl(url: String?): String {
+        if (url.isNullOrBlank()) return ShowOnAppLaunchOptionDataStore.DEFAULT_SPECIFIC_PAGE_URL
+
+        val uri = Uri.parse(url.trim())
+
+        val convertedUri = if (uri.scheme == null) {
+            Uri.Builder().scheme("http").authority(uri.path?.lowercase())
+        } else {
+            uri.buildUpon()
+                .scheme(uri.scheme?.lowercase())
+                .authority(uri.authority?.lowercase())
+        }
+            .apply {
+                query(uri.query)
+                fragment(uri.fragment)
+            }
+            .build()
+            .toString()
+
+        return Uri.decode(convertedUri)
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModel.kt
@@ -19,13 +19,11 @@ package com.duckduckgo.app.generalsettings.showonapplaunch
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
-import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption
 import com.duckduckgo.app.generalsettings.showonapplaunch.store.ShowOnAppLaunchOptionDataStore
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import javax.inject.Inject
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModel.kt
@@ -37,7 +37,6 @@ import timber.log.Timber
 
 @ContributesViewModel(ActivityScope::class)
 class ShowOnAppLaunchViewModel @Inject constructor(
-    @AppCoroutineScope private val appScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
     private val showOnAppLaunchOptionDataStore: ShowOnAppLaunchOptionDataStore,
 ) : ViewModel() {
@@ -66,14 +65,14 @@ class ShowOnAppLaunchViewModel @Inject constructor(
 
     fun onShowOnAppLaunchOptionChanged(option: ShowOnAppLaunchOption) {
         Timber.i("User changed show on app launch option to $option")
-        viewModelScope.launch {
+        viewModelScope.launch(dispatcherProvider.io()) {
             showOnAppLaunchOptionDataStore.setShowOnAppLaunchOption(option)
         }
     }
 
     fun setSpecificPageUrl(url: String) {
         Timber.i("Setting specific page url to $url")
-        appScope.launch {
+        viewModelScope.launch(dispatcherProvider.io()) {
             showOnAppLaunchOptionDataStore.setSpecificPageUrl(url)
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModel.kt
@@ -19,40 +19,47 @@ package com.duckduckgo.app.generalsettings.showonapplaunch
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption
 import com.duckduckgo.app.generalsettings.showonapplaunch.store.ShowOnAppLaunchOptionDataStore
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
 @ContributesViewModel(ActivityScope::class)
 class ShowOnAppLaunchViewModel @Inject constructor(
-    dispatcherProvider: DispatcherProvider,
+    @AppCoroutineScope private val appScope: CoroutineScope,
+    private val dispatcherProvider: DispatcherProvider,
     private val showOnAppLaunchOptionDataStore: ShowOnAppLaunchOptionDataStore,
 ) : ViewModel() {
 
     data class ViewState(
         val selectedOption: ShowOnAppLaunchOption,
+        val specificPageUrl: String,
     )
 
     private val _viewState = MutableStateFlow<ViewState?>(null)
     val viewState = _viewState.asStateFlow().filterNotNull()
 
     init {
-        observeShowOnAppLaunchOptionChanges(dispatcherProvider)
+        observeShowOnAppLaunchOptionChanges()
     }
 
-    private fun observeShowOnAppLaunchOptionChanges(dispatcherProvider: DispatcherProvider) {
-        showOnAppLaunchOptionDataStore.optionFlow.onEach { option ->
-            _viewState.value = ViewState(option)
+    private fun observeShowOnAppLaunchOptionChanges() {
+        combine(
+            showOnAppLaunchOptionDataStore.optionFlow,
+            showOnAppLaunchOptionDataStore.specificPageUrlFlow,
+        ) { option, specificPageUrl ->
+            _viewState.value = ViewState(option, specificPageUrl)
         }.flowOn(dispatcherProvider.io())
             .launchIn(viewModelScope)
     }
@@ -61,6 +68,13 @@ class ShowOnAppLaunchViewModel @Inject constructor(
         Timber.i("User changed show on app launch option to $option")
         viewModelScope.launch {
             showOnAppLaunchOptionDataStore.setShowOnAppLaunchOption(option)
+        }
+    }
+
+    fun setSpecificPageUrl(url: String) {
+        Timber.i("Setting specific page url to $url")
+        appScope.launch {
+            showOnAppLaunchOptionDataStore.setSpecificPageUrl(url)
         }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModel.kt
@@ -19,9 +19,7 @@ package com.duckduckgo.app.generalsettings.showonapplaunch
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
-import com.duckduckgo.app.generalsettings.showonapplaunch.ShowOnAppLaunchViewModel.ShowOnAppLaunchOption.LastOpenedTab
-import com.duckduckgo.app.generalsettings.showonapplaunch.ShowOnAppLaunchViewModel.ShowOnAppLaunchOption.NewTabPage
-import com.duckduckgo.app.generalsettings.showonapplaunch.ShowOnAppLaunchViewModel.ShowOnAppLaunchOption.SpecificPage
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import javax.inject.Inject
@@ -36,13 +34,6 @@ import timber.log.Timber
 class ShowOnAppLaunchViewModel @Inject constructor(
     dispatcherProvider: DispatcherProvider,
 ) : ViewModel() {
-
-    sealed class ShowOnAppLaunchOption {
-
-        data object LastOpenedTab : ShowOnAppLaunchOption()
-        data object NewTabPage : ShowOnAppLaunchOption()
-        data class SpecificPage(val url: String) : ShowOnAppLaunchOption()
-    }
 
     data class ViewState(
         val selectedOption: ShowOnAppLaunchOption,

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/UrlConverter.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/UrlConverter.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.generalsettings.showonapplaunch
+
+interface UrlConverter {
+
+    fun convertUrl(url: String?): String
+}

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/model/ShowOnAppLaunchOption.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/model/ShowOnAppLaunchOption.kt
@@ -16,6 +16,10 @@
 
 package com.duckduckgo.app.generalsettings.showonapplaunch.model
 
+import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_GENERAL_APP_LAUNCH_LAST_OPENED_TAB_SELECTED
+import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_GENERAL_APP_LAUNCH_NEW_TAB_PAGE_SELECTED
+import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_GENERAL_APP_LAUNCH_SPECIFIC_PAGE_SELECTED
+
 sealed class ShowOnAppLaunchOption(val id: Int) {
 
     data object LastOpenedTab : ShowOnAppLaunchOption(1)
@@ -29,6 +33,18 @@ sealed class ShowOnAppLaunchOption(val id: Int) {
             2 -> NewTabPage
             3 -> SpecificPage("")
             else -> throw IllegalArgumentException("Unknown id: $id")
+        }
+
+        fun getPixelName(option: ShowOnAppLaunchOption) = when (option) {
+            LastOpenedTab -> SETTINGS_GENERAL_APP_LAUNCH_LAST_OPENED_TAB_SELECTED
+            NewTabPage -> SETTINGS_GENERAL_APP_LAUNCH_NEW_TAB_PAGE_SELECTED
+            is SpecificPage -> SETTINGS_GENERAL_APP_LAUNCH_SPECIFIC_PAGE_SELECTED
+        }
+
+        fun getDailyPixelValue(option: ShowOnAppLaunchOption) = when (option) {
+            LastOpenedTab -> "last_opened_tab"
+            NewTabPage -> "new_tab_page"
+            is SpecificPage -> "specific_page"
         }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/model/ShowOnAppLaunchOption.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/model/ShowOnAppLaunchOption.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.generalsettings.showonapplaunch.model
+
+sealed class ShowOnAppLaunchOption(val id: Int) {
+
+    data object LastOpenedTab : ShowOnAppLaunchOption(1)
+    data object NewTabPage : ShowOnAppLaunchOption(2)
+    data class SpecificPage(val url: String) : ShowOnAppLaunchOption(3)
+
+    companion object {
+
+        fun mapToOption(id: Int): ShowOnAppLaunchOption = when (id) {
+            1 -> LastOpenedTab
+            2 -> NewTabPage
+            3 -> SpecificPage("")
+            else -> throw IllegalArgumentException("Unknown id: $id")
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/store/ShowOnAppLaunchDataStoreModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/store/ShowOnAppLaunchDataStoreModule.kt
@@ -20,6 +20,8 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
+import com.duckduckgo.app.generalsettings.showonapplaunch.ShowOnAppLaunchUrlConverterImpl
+import com.duckduckgo.app.generalsettings.showonapplaunch.UrlConverter
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
@@ -37,6 +39,9 @@ object ShowOnAppLaunchDataStoreModule {
     @Provides
     @ShowOnAppLaunch
     fun showOnAppLaunchDataStore(context: Context): DataStore<Preferences> = context.showOnAppLaunchDataStore
+
+    @Provides
+    fun showOnAppLaunchUrlConverter(): UrlConverter = ShowOnAppLaunchUrlConverterImpl()
 }
 
 @Qualifier

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/store/ShowOnAppLaunchDataStoreModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/store/ShowOnAppLaunchDataStoreModule.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.generalsettings.showonapplaunch.store
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesTo
+import dagger.Module
+import dagger.Provides
+import javax.inject.Qualifier
+
+@ContributesTo(AppScope::class)
+@Module
+object ShowOnAppLaunchDataStoreModule {
+
+    private val Context.showOnAppLaunchDataStore: DataStore<Preferences> by preferencesDataStore(
+        name = "show_on_app_launch",
+    )
+
+    @Provides
+    @ShowOnAppLaunch
+    fun showOnAppLaunchDataStore(context: Context): DataStore<Preferences> = context.showOnAppLaunchDataStore
+}
+
+@Qualifier
+annotation class ShowOnAppLaunch

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/store/ShowOnAppLaunchOptionDataStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/store/ShowOnAppLaunchOptionDataStore.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.generalsettings.showonapplaunch.store
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.LastOpenedTab
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.NewTabPage
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.SpecificPage
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+interface ShowOnAppLaunchOptionDataStore {
+    val optionFlow: Flow<ShowOnAppLaunchOption>
+
+    suspend fun setShowOnAppLaunchOption(showOnAppLaunchOption: ShowOnAppLaunchOption)
+}
+
+@ContributesBinding(AppScope::class)
+class ShowOnAppLaunchOptionPrefsDataStore @Inject constructor(
+    @ShowOnAppLaunch private val store: DataStore<Preferences>,
+) : ShowOnAppLaunchOptionDataStore {
+
+    override val optionFlow: Flow<ShowOnAppLaunchOption> = store.data.map { preferences ->
+        preferences[intPreferencesKey(KEY_SHOW_ON_APP_LAUNCH_OPTION)]?.let { optionId ->
+            when (val option = ShowOnAppLaunchOption.mapToOption(optionId)) {
+                LastOpenedTab,
+                NewTabPage,
+                -> option
+                is SpecificPage -> {
+                    val url = preferences[stringPreferencesKey(KEY_SHOW_ON_APP_LAUNCH_SPECIFIC_PAGE_URL)]!!
+                    SpecificPage(url)
+                }
+            }
+        } ?: LastOpenedTab
+    }
+
+    override suspend fun setShowOnAppLaunchOption(showOnAppLaunchOption: ShowOnAppLaunchOption) {
+        store.edit { preferences ->
+            preferences[intPreferencesKey(KEY_SHOW_ON_APP_LAUNCH_OPTION)] = showOnAppLaunchOption.id
+
+            if (showOnAppLaunchOption is SpecificPage) {
+                preferences[stringPreferencesKey(KEY_SHOW_ON_APP_LAUNCH_SPECIFIC_PAGE_URL)] = showOnAppLaunchOption.url.ifBlank {
+                    DEFAULT_SPECIFIC_PAGE_URL
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val DEFAULT_SPECIFIC_PAGE_URL = "duckduckgo.com"
+        private const val KEY_SHOW_ON_APP_LAUNCH_OPTION = "SHOW_ON_APP_LAUNCH_OPTION"
+        private const val KEY_SHOW_ON_APP_LAUNCH_SPECIFIC_PAGE_URL = "SHOW_ON_APP_LAUNCH_SPECIFIC_PAGE_URL"
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/store/ShowOnAppLaunchOptionDataStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/store/ShowOnAppLaunchOptionDataStore.kt
@@ -33,8 +33,10 @@ import kotlinx.coroutines.flow.map
 
 interface ShowOnAppLaunchOptionDataStore {
     val optionFlow: Flow<ShowOnAppLaunchOption>
+    val specificPageUrlFlow: Flow<String>
 
     suspend fun setShowOnAppLaunchOption(showOnAppLaunchOption: ShowOnAppLaunchOption)
+    suspend fun setSpecificPageUrl(url: String)
 }
 
 @ContributesBinding(AppScope::class)
@@ -56,15 +58,23 @@ class ShowOnAppLaunchOptionPrefsDataStore @Inject constructor(
         } ?: LastOpenedTab
     }
 
+    override val specificPageUrlFlow: Flow<String> = store.data.map { preferences ->
+        preferences[stringPreferencesKey(KEY_SHOW_ON_APP_LAUNCH_SPECIFIC_PAGE_URL)] ?: DEFAULT_SPECIFIC_PAGE_URL
+    }
+
     override suspend fun setShowOnAppLaunchOption(showOnAppLaunchOption: ShowOnAppLaunchOption) {
         store.edit { preferences ->
             preferences[intPreferencesKey(KEY_SHOW_ON_APP_LAUNCH_OPTION)] = showOnAppLaunchOption.id
 
             if (showOnAppLaunchOption is SpecificPage) {
-                preferences[stringPreferencesKey(KEY_SHOW_ON_APP_LAUNCH_SPECIFIC_PAGE_URL)] = showOnAppLaunchOption.url.ifBlank {
-                    DEFAULT_SPECIFIC_PAGE_URL
-                }
+                preferences[stringPreferencesKey(KEY_SHOW_ON_APP_LAUNCH_SPECIFIC_PAGE_URL)]
             }
+        }
+    }
+
+    override suspend fun setSpecificPageUrl(url: String) {
+        store.edit { preferences ->
+            preferences[stringPreferencesKey(KEY_SHOW_ON_APP_LAUNCH_SPECIFIC_PAGE_URL)] = url
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/store/ShowOnAppLaunchOptionDataStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/store/ShowOnAppLaunchOptionDataStore.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.generalsettings.showonapplaunch.store
 
 import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
@@ -25,6 +26,7 @@ import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchO
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.LastOpenedTab
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.NewTabPage
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.SpecificPage
+import com.duckduckgo.app.generalsettings.showonapplaunch.store.ShowOnAppLaunchOptionDataStore.Companion.DEFAULT_SPECIFIC_PAGE_URL
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
@@ -37,6 +39,10 @@ interface ShowOnAppLaunchOptionDataStore {
 
     suspend fun setShowOnAppLaunchOption(showOnAppLaunchOption: ShowOnAppLaunchOption)
     suspend fun setSpecificPageUrl(url: String)
+
+    companion object {
+        const val DEFAULT_SPECIFIC_PAGE_URL = "https://duckduckgo.com/"
+    }
 }
 
 @ContributesBinding(AppScope::class)
@@ -67,19 +73,22 @@ class ShowOnAppLaunchOptionPrefsDataStore @Inject constructor(
             preferences[intPreferencesKey(KEY_SHOW_ON_APP_LAUNCH_OPTION)] = showOnAppLaunchOption.id
 
             if (showOnAppLaunchOption is SpecificPage) {
-                preferences[stringPreferencesKey(KEY_SHOW_ON_APP_LAUNCH_SPECIFIC_PAGE_URL)]
+                preferences.setShowOnAppLaunch(showOnAppLaunchOption.url)
             }
         }
     }
 
     override suspend fun setSpecificPageUrl(url: String) {
         store.edit { preferences ->
-            preferences[stringPreferencesKey(KEY_SHOW_ON_APP_LAUNCH_SPECIFIC_PAGE_URL)] = url
+            preferences.setShowOnAppLaunch(url)
         }
     }
 
+    private fun MutablePreferences.setShowOnAppLaunch(url: String) {
+        set(stringPreferencesKey(KEY_SHOW_ON_APP_LAUNCH_SPECIFIC_PAGE_URL), url)
+    }
+
     companion object {
-        private const val DEFAULT_SPECIFIC_PAGE_URL = "duckduckgo.com"
         private const val KEY_SHOW_ON_APP_LAUNCH_OPTION = "SHOW_ON_APP_LAUNCH_OPTION"
         private const val KEY_SHOW_ON_APP_LAUNCH_SPECIFIC_PAGE_URL = "SHOW_ON_APP_LAUNCH_SPECIFIC_PAGE_URL"
     }

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -139,6 +139,10 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     SETTINGS_PRIVATE_SEARCH_MORE_SEARCH_SETTINGS_PRESSED("ms_private_search_more_search_settings_pressed"),
     SETTINGS_COOKIE_POPUP_PROTECTION_PRESSED("ms_cookie_popup_protection_setting_pressed"),
     SETTINGS_FIRE_BUTTON_PRESSED("ms_fire_button_setting_pressed"),
+    SETTINGS_GENERAL_APP_LAUNCH_PRESSED("m_settings_general_app_launch_pressed"),
+    SETTINGS_GENERAL_APP_LAUNCH_LAST_OPENED_TAB_SELECTED("m_settings_general_app_launch_last_opened_tab_selected"),
+    SETTINGS_GENERAL_APP_LAUNCH_NEW_TAB_PAGE_SELECTED("m_settings_general_app_launch_new_tab_page_selected"),
+    SETTINGS_GENERAL_APP_LAUNCH_SPECIFIC_PAGE_SELECTED("m_settings_general_app_launch_specific_page_selected"),
 
     SURVEY_CTA_SHOWN(pixelName = "mus_cs"),
     SURVEY_CTA_DISMISSED(pixelName = "mus_cd"),

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
@@ -298,6 +298,9 @@ class TabDataRepository @Inject constructor(
         siteData.clear()
     }
 
+    override suspend fun getSelectedTab(): TabEntity? =
+        withContext(dispatchers.io()) { tabsDao.selectedTab() }
+
     override suspend fun select(tabId: String) {
         databaseExecutor().scheduleDirect {
             val selection = TabSelectionEntity(tabId = tabId)

--- a/app/src/main/res/layout/activity_general_settings.xml
+++ b/app/src/main/res/layout/activity_general_settings.xml
@@ -77,7 +77,7 @@
                 android:id="@+id/showOnAppLaunchButton"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:primaryText="Show on App Launch"
+                app:primaryText="@string/showOnAppLaunchOptionTitle"
                 tools:secondaryText="Last Opened Tab" />
 
         </LinearLayout>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -804,4 +804,10 @@
     <string name="onboardingFireButtonDaxDialogOkButton">Изпробвайте го</string>
     <string name="onboardingFireButtonDaxDialogCancelButton">Пропускане</string>
 
+    <!-- Show on App Launch Option -->
+    <string name="showOnAppLaunchOptionTitle">Показване при стартиране на приложението</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Последно отворен раздел</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Страница с нов раздел</string>
+    <string name="showOnAppLaunchOptionSpecificPage">Конкретна страница</string>
+
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -808,4 +808,10 @@
     <string name="onboardingFireButtonDaxDialogOkButton">Vyzkoušejte ho</string>
     <string name="onboardingFireButtonDaxDialogCancelButton">Přeskočit</string>
 
+    <!-- Show on App Launch Option -->
+    <string name="showOnAppLaunchOptionTitle">Zobrazit při spuštění aplikace</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Naposledy otevřená karta</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Stránka Nová karta</string>
+    <string name="showOnAppLaunchOptionSpecificPage">Konkrétní stránka</string>
+
 </resources>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -804,4 +804,10 @@
     <string name="onboardingFireButtonDaxDialogOkButton">Prøv det</string>
     <string name="onboardingFireButtonDaxDialogCancelButton">Spring over</string>
 
+    <!-- Show on App Launch Option -->
+    <string name="showOnAppLaunchOptionTitle">Vis ved app-start</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Sidst åbnede fane</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Ny faneside</string>
+    <string name="showOnAppLaunchOptionSpecificPage">Specifik side</string>
+
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -804,4 +804,10 @@
     <string name="onboardingFireButtonDaxDialogOkButton">Ausprobieren</string>
     <string name="onboardingFireButtonDaxDialogCancelButton">Überspringen</string>
 
+    <!-- Show on App Launch Option -->
+    <string name="showOnAppLaunchOptionTitle">Beim App-Start anzeigen</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Zuletzt geöffneter Tab</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Neue Tab-Seite</string>
+    <string name="showOnAppLaunchOptionSpecificPage">Bestimmte Seite</string>
+
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -804,4 +804,10 @@
     <string name="onboardingFireButtonDaxDialogOkButton">Δοκιμάστε το</string>
     <string name="onboardingFireButtonDaxDialogCancelButton">Παράλειψη</string>
 
+    <!-- Show on App Launch Option -->
+    <string name="showOnAppLaunchOptionTitle">Εμφάνιση στην Εκκίνηση εφαρμογής</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Τελευταία καρτέλα που άνοιξε</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Σελίδα νέας καρτέλας</string>
+    <string name="showOnAppLaunchOptionSpecificPage">Συγκεκριμένη σελίδα</string>
+
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -804,4 +804,10 @@
     <string name="onboardingFireButtonDaxDialogOkButton">Pruébalo</string>
     <string name="onboardingFireButtonDaxDialogCancelButton">Omitir</string>
 
+    <!-- Show on App Launch Option -->
+    <string name="showOnAppLaunchOptionTitle">Mostrar al abrir la aplicación</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Última pestaña abierta</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Página de nueva pestaña</string>
+    <string name="showOnAppLaunchOptionSpecificPage">Página específica</string>
+
 </resources>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -804,4 +804,10 @@
     <string name="onboardingFireButtonDaxDialogOkButton">Proovi seda</string>
     <string name="onboardingFireButtonDaxDialogCancelButton">Jäta vahele</string>
 
+    <!-- Show on App Launch Option -->
+    <string name="showOnAppLaunchOptionTitle">Kuva rakenduse käivitamisel</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Viimati avatud vahekaart</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Uue vahekaardi leht</string>
+    <string name="showOnAppLaunchOptionSpecificPage">Konkreetne lehekülg</string>
+
 </resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -804,4 +804,10 @@
     <string name="onboardingFireButtonDaxDialogOkButton">Kokeile sitä</string>
     <string name="onboardingFireButtonDaxDialogCancelButton">Ohita</string>
 
+    <!-- Show on App Launch Option -->
+    <string name="showOnAppLaunchOptionTitle">Näytä sovelluksen käynnistyksen yhteydessä</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Viimeksi avattu -välilehti</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Uusi välilehti -sivu</string>
+    <string name="showOnAppLaunchOptionSpecificPage">Tietty sivu</string>
+
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -804,4 +804,10 @@
     <string name="onboardingFireButtonDaxDialogOkButton">Essayez</string>
     <string name="onboardingFireButtonDaxDialogCancelButton">Ignorer</string>
 
+    <!-- Show on App Launch Option -->
+    <string name="showOnAppLaunchOptionTitle">Afficher au lancement de l\'application</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Dernier onglet ouvert</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Nouvelle page d\'onglet</string>
+    <string name="showOnAppLaunchOptionSpecificPage">Page spécifique</string>
+
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -808,4 +808,10 @@
     <string name="onboardingFireButtonDaxDialogOkButton">Isprobaj ga</string>
     <string name="onboardingFireButtonDaxDialogCancelButton">Preskoči</string>
 
+    <!-- Show on App Launch Option -->
+    <string name="showOnAppLaunchOptionTitle">Prikaži pri pokretanju aplikacije</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Posljednja otvorena kartica</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Nova stranica kartice</string>
+    <string name="showOnAppLaunchOptionSpecificPage">Specifična stranica</string>
+
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -804,4 +804,10 @@
     <string name="onboardingFireButtonDaxDialogOkButton">Kipróbálom</string>
     <string name="onboardingFireButtonDaxDialogCancelButton">Kihagyás</string>
 
+    <!-- Show on App Launch Option -->
+    <string name="showOnAppLaunchOptionTitle">Megjelenítés az alkalmazás indításakor</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Utoljára megnyitott lap</string>
+    <string name="showOnAppLaunchOptionNewTabPage">„Új lap” oldal</string>
+    <string name="showOnAppLaunchOptionSpecificPage">Speciális oldal</string>
+
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -804,4 +804,10 @@
     <string name="onboardingFireButtonDaxDialogOkButton">Provalo</string>
     <string name="onboardingFireButtonDaxDialogCancelButton">Salta</string>
 
+    <!-- Show on App Launch Option -->
+    <string name="showOnAppLaunchOptionTitle">Mostra all\'avvio dell\'app</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Ultima scheda aperta</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Pagina Nuova scheda</string>
+    <string name="showOnAppLaunchOptionSpecificPage">Pagina specifica</string>
+
 </resources>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -808,4 +808,10 @@
     <string name="onboardingFireButtonDaxDialogOkButton">Išbandykite</string>
     <string name="onboardingFireButtonDaxDialogCancelButton">Praleisti</string>
 
+    <!-- Show on App Launch Option -->
+    <string name="showOnAppLaunchOptionTitle">Rodyti paleidus programą</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Paskutinį kartą atidarytas skirtukas</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Naujas skirtuko puslapis</string>
+    <string name="showOnAppLaunchOptionSpecificPage">Konkretus puslapis</string>
+
 </resources>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -806,4 +806,10 @@
     <string name="onboardingFireButtonDaxDialogOkButton">Izmēģini</string>
     <string name="onboardingFireButtonDaxDialogCancelButton">Izlaist</string>
 
+    <!-- Show on App Launch Option -->
+    <string name="showOnAppLaunchOptionTitle">Rādīt lietotnes palaišanas laikā</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Pēdējā atvērtā cilne</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Jaunas cilnes lapa</string>
+    <string name="showOnAppLaunchOptionSpecificPage">Konkrēta lapa</string>
+
 </resources>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -804,4 +804,10 @@
     <string name="onboardingFireButtonDaxDialogOkButton">Prøv det</string>
     <string name="onboardingFireButtonDaxDialogCancelButton">Hopp over</string>
 
+    <!-- Show on App Launch Option -->
+    <string name="showOnAppLaunchOptionTitle">Vis ved lansering av appen</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Sist åpnet fane</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Ny faneside</string>
+    <string name="showOnAppLaunchOptionSpecificPage">Spesifikk side</string>
+
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -804,4 +804,10 @@
     <string name="onboardingFireButtonDaxDialogOkButton">Probeer het zelf</string>
     <string name="onboardingFireButtonDaxDialogCancelButton">Overslaan</string>
 
+    <!-- Show on App Launch Option -->
+    <string name="showOnAppLaunchOptionTitle">Weergeven bij het starten van de app</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Laatst geopende tabblad</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Nieuwe tabbladpagina</string>
+    <string name="showOnAppLaunchOptionSpecificPage">Specifieke pagina</string>
+
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -808,4 +808,10 @@
     <string name="onboardingFireButtonDaxDialogOkButton">Wypróbuj</string>
     <string name="onboardingFireButtonDaxDialogCancelButton">Pomiń</string>
 
+    <!-- Show on App Launch Option -->
+    <string name="showOnAppLaunchOptionTitle">Pokaż przy uruchomieniu aplikacji</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Ostatnio otwarta karta</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Strona nowej karty</string>
+    <string name="showOnAppLaunchOptionSpecificPage">Określona strona</string>
+
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -804,4 +804,10 @@
     <string name="onboardingFireButtonDaxDialogOkButton">Experimenta-o</string>
     <string name="onboardingFireButtonDaxDialogCancelButton">Ignorar</string>
 
+    <!-- Show on App Launch Option -->
+    <string name="showOnAppLaunchOptionTitle">Mostrar ao abrir a aplicação</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Último separador aberto</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Nova página de separador</string>
+    <string name="showOnAppLaunchOptionSpecificPage">Página específica</string>
+
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -806,4 +806,10 @@
     <string name="onboardingFireButtonDaxDialogOkButton">Încearcă-l</string>
     <string name="onboardingFireButtonDaxDialogCancelButton">Ignorare</string>
 
+    <!-- Show on App Launch Option -->
+    <string name="showOnAppLaunchOptionTitle">Afișează la lansarea aplicației</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Ultima filă deschisă</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Filă nouă</string>
+    <string name="showOnAppLaunchOptionSpecificPage">Pagină specifică</string>
+
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -808,4 +808,10 @@
     <string name="onboardingFireButtonDaxDialogOkButton">Попробовать</string>
     <string name="onboardingFireButtonDaxDialogCancelButton">Пропустить</string>
 
+    <!-- Show on App Launch Option -->
+    <string name="showOnAppLaunchOptionTitle">Показывать при запуске приложения</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Последняя открытая вкладка</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Страница новой вкладки</string>
+    <string name="showOnAppLaunchOptionSpecificPage">Конкретная страница</string>
+
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -808,4 +808,10 @@
     <string name="onboardingFireButtonDaxDialogOkButton">Vyskúšajte to</string>
     <string name="onboardingFireButtonDaxDialogCancelButton">Preskočiť</string>
 
+    <!-- Show on App Launch Option -->
+    <string name="showOnAppLaunchOptionTitle">Zobraziť pri spustení aplikácie</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Naposledy otvorená karta</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Stránka na novej karte</string>
+    <string name="showOnAppLaunchOptionSpecificPage">Špecifická stránka</string>
+
 </resources>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -808,4 +808,10 @@
     <string name="onboardingFireButtonDaxDialogOkButton">Preizkusite</string>
     <string name="onboardingFireButtonDaxDialogCancelButton">Preskoči</string>
 
+    <!-- Show on App Launch Option -->
+    <string name="showOnAppLaunchOptionTitle">Pokaži ob zagonu aplikacije</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Zadnji odprt zavihek</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Stran z novim zavihkom</string>
+    <string name="showOnAppLaunchOptionSpecificPage">Določena stran</string>
+
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -804,4 +804,10 @@
     <string name="onboardingFireButtonDaxDialogOkButton">Prova</string>
     <string name="onboardingFireButtonDaxDialogCancelButton">Hoppa över</string>
 
+    <!-- Show on App Launch Option -->
+    <string name="showOnAppLaunchOptionTitle">Visa vid app-start</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Senast öppnade flik</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Ny fliksida</string>
+    <string name="showOnAppLaunchOptionSpecificPage">Specifik sida</string>
+
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -804,4 +804,10 @@
     <string name="onboardingFireButtonDaxDialogOkButton">Deneyin</string>
     <string name="onboardingFireButtonDaxDialogCancelButton">Atla</string>
 
+    <!-- Show on App Launch Option -->
+    <string name="showOnAppLaunchOptionTitle">Uygulama Başlatıldığında Göster</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Son Açılan Sekme</string>
+    <string name="showOnAppLaunchOptionNewTabPage">Yeni Sekme Sayfası</string>
+    <string name="showOnAppLaunchOptionSpecificPage">Belirli Bir Sayfa</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -803,4 +803,11 @@
     <string name="onboardingFireButtonDaxDialogOkButton">Try it</string>
     <string name="onboardingFireButtonDaxDialogCancelButton">Skip</string>
 
+    <!-- Show on App Launch Option -->
+    <!-- TODO add translated copy -->
+    <string name="showOnAppLaunchOptionTitle" tools:ignore="MissingTranslation">Show on App Launch</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab" tools:ignore="MissingTranslation">Last Opened Tab</string>
+    <string name="showOnAppLaunchOptionNewTabPage" tools:ignore="MissingTranslation">New Tab Page</string>
+    <string name="showOnAppLaunchOptionSpecificPage" tools:ignore="MissingTranslation">Specific Page</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -804,10 +804,9 @@
     <string name="onboardingFireButtonDaxDialogCancelButton">Skip</string>
 
     <!-- Show on App Launch Option -->
-    <!-- TODO add translated copy -->
-    <string name="showOnAppLaunchOptionTitle" tools:ignore="MissingTranslation">Show on App Launch</string>
-    <string name="showOnAppLaunchOptionLastOpenedTab" tools:ignore="MissingTranslation">Last Opened Tab</string>
-    <string name="showOnAppLaunchOptionNewTabPage" tools:ignore="MissingTranslation">New Tab Page</string>
-    <string name="showOnAppLaunchOptionSpecificPage" tools:ignore="MissingTranslation">Specific Page</string>
+    <string name="showOnAppLaunchOptionTitle">Show on App Launch</string>
+    <string name="showOnAppLaunchOptionLastOpenedTab">Last Opened Tab</string>
+    <string name="showOnAppLaunchOptionNewTabPage">New Tab Page</string>
+    <string name="showOnAppLaunchOptionSpecificPage">Specific Page</string>
 
 </resources>

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
@@ -23,6 +23,8 @@ import com.duckduckgo.app.browser.BrowserViewModel.Command
 import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
 import com.duckduckgo.app.browser.omnibar.OmnibarEntryConverter
 import com.duckduckgo.app.fire.DataClearer
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption
+import com.duckduckgo.app.generalsettings.showonapplaunch.store.ShowOnAppLaunchOptionDataStore
 import com.duckduckgo.app.global.rating.AppEnjoymentPromptEmitter
 import com.duckduckgo.app.global.rating.AppEnjoymentPromptOptions
 import com.duckduckgo.app.global.rating.AppEnjoymentUserEventRecorder
@@ -35,6 +37,7 @@ import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -52,34 +55,27 @@ class BrowserViewModelTest {
     @Suppress("unused")
     var instantTaskExecutorRule = InstantTaskExecutorRule()
 
-    @get:Rule
-    var coroutinesTestRule = CoroutineTestRule()
+    @get:Rule var coroutinesTestRule = CoroutineTestRule()
 
-    @Mock
-    private lateinit var mockCommandObserver: Observer<Command>
+    @Mock private lateinit var mockCommandObserver: Observer<Command>
 
     private val commandCaptor = argumentCaptor<Command>()
 
-    @Mock
-    private lateinit var mockTabRepository: TabRepository
+    @Mock private lateinit var mockTabRepository: TabRepository
 
-    @Mock
-    private lateinit var mockOmnibarEntryConverter: OmnibarEntryConverter
+    @Mock private lateinit var mockOmnibarEntryConverter: OmnibarEntryConverter
 
-    @Mock
-    private lateinit var mockAutomaticDataClearer: DataClearer
+    @Mock private lateinit var mockAutomaticDataClearer: DataClearer
 
-    @Mock
-    private lateinit var mockAppEnjoymentUserEventRecorder: AppEnjoymentUserEventRecorder
+    @Mock private lateinit var mockAppEnjoymentUserEventRecorder: AppEnjoymentUserEventRecorder
 
-    @Mock
-    private lateinit var mockAppEnjoymentPromptEmitter: AppEnjoymentPromptEmitter
+    @Mock private lateinit var mockAppEnjoymentPromptEmitter: AppEnjoymentPromptEmitter
 
-    @Mock
-    private lateinit var mockPixel: Pixel
+    @Mock private lateinit var mockPixel: Pixel
 
-    @Mock
-    private lateinit var mockDefaultBrowserDetector: DefaultBrowserDetector
+    @Mock private lateinit var mockDefaultBrowserDetector: DefaultBrowserDetector
+
+    @Mock private lateinit var showOnAppLaunchOptionDataStore: ShowOnAppLaunchOptionDataStore
 
     private lateinit var testee: BrowserViewModel
 
@@ -93,17 +89,7 @@ class BrowserViewModelTest {
 
         configureSkipUrlConversionInNewTabState(enabled = true)
 
-        testee = BrowserViewModel(
-            tabRepository = mockTabRepository,
-            queryUrlConverter = mockOmnibarEntryConverter,
-            dataClearer = mockAutomaticDataClearer,
-            appEnjoymentPromptEmitter = mockAppEnjoymentPromptEmitter,
-            appEnjoymentUserEventRecorder = mockAppEnjoymentUserEventRecorder,
-            defaultBrowserDetector = mockDefaultBrowserDetector,
-            dispatchers = coroutinesTestRule.testDispatcherProvider,
-            pixel = mockPixel,
-            skipUrlConversionOnNewTabFeature = skipUrlConversionOnNewTabFeature,
-        )
+        initTestee()
 
         testee.command.observeForever(mockCommandObserver)
 
@@ -265,6 +251,57 @@ class BrowserViewModelTest {
         configureSkipUrlConversionInNewTabState(enabled = false)
         testee.onOpenInNewTabRequested(query = "query")
         verify(mockOmnibarEntryConverter).convertQueryToUrl("query")
+    }
+
+    @Test
+    fun whenAppOpenAndLastOpenedTabSetThenNoTabsAdded() = runTest {
+        whenever(showOnAppLaunchOptionDataStore.optionFlow)
+            .thenReturn(flowOf(ShowOnAppLaunchOption.LastOpenedTab))
+
+        testee.handleShowOnAppLaunchOption()
+
+        verify(mockTabRepository, never()).add(url = any(), skipHome = any())
+        verify(mockTabRepository, never()).addFromSourceTab(url = any(), skipHome = any(), sourceTabId = any())
+        verify(mockTabRepository, never()).addDefaultTab()
+    }
+
+    @Test
+    fun whenAppOpenAndNewTabPageSetThenNewTabAdded() = runTest {
+        whenever(showOnAppLaunchOptionDataStore.optionFlow)
+            .thenReturn(flowOf(ShowOnAppLaunchOption.NewTabPage))
+
+        testee.handleShowOnAppLaunchOption()
+
+        verify(mockTabRepository, atMost(1)).add()
+        verify(mockTabRepository, never()).addFromSourceTab(url = any(), skipHome = any(), sourceTabId = any())
+        verify(mockTabRepository, never()).addDefaultTab()
+    }
+
+    @Test
+    fun whenAppOpenAndSpecificPageSetThenNewTabAddedWithUrl() = runTest {
+        whenever(showOnAppLaunchOptionDataStore.optionFlow)
+            .thenReturn(flowOf(ShowOnAppLaunchOption.SpecificPage("example.com")))
+
+        testee.handleShowOnAppLaunchOption()
+
+        verify(mockTabRepository, atMost(1)).add(url = "example.com", skipHome = false)
+        verify(mockTabRepository, never()).addFromSourceTab(url = any(), skipHome = any(), sourceTabId = any())
+        verify(mockTabRepository, never()).addDefaultTab()
+    }
+
+    private fun initTestee() {
+        testee = BrowserViewModel(
+            tabRepository = mockTabRepository,
+            queryUrlConverter = mockOmnibarEntryConverter,
+            dataClearer = mockAutomaticDataClearer,
+            appEnjoymentPromptEmitter = mockAppEnjoymentPromptEmitter,
+            appEnjoymentUserEventRecorder = mockAppEnjoymentUserEventRecorder,
+            defaultBrowserDetector = mockDefaultBrowserDetector,
+            dispatchers = coroutinesTestRule.testDispatcherProvider,
+            pixel = mockPixel,
+            skipUrlConversionOnNewTabFeature = skipUrlConversionOnNewTabFeature,
+            showOnAppLaunchOptionDataStore = showOnAppLaunchOptionDataStore,
+        )
     }
 
     private fun configureSkipUrlConversionInNewTabState(enabled: Boolean) {

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/GeneralSettingsViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/GeneralSettingsViewModelTest.kt
@@ -20,6 +20,10 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import app.cash.turbine.test
 import com.duckduckgo.app.FakeSettingsDataStore
 import com.duckduckgo.app.generalsettings.GeneralSettingsViewModel.Command.LaunchShowOnAppLaunchScreen
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.LastOpenedTab
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.NewTabPage
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.SpecificPage
+import com.duckduckgo.app.generalsettings.showonapplaunch.store.FakeShowOnAppLaunchOptionDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.history.api.NavigationHistory
@@ -50,6 +54,8 @@ internal class GeneralSettingsViewModelTest {
 
     private lateinit var fakeAppSettingsDataStore: FakeSettingsDataStore
 
+    private lateinit var fakeShowOnAppLaunchOptionDataStore: FakeShowOnAppLaunchOptionDataStore
+
     @Mock
     private lateinit var mockPixel: Pixel
 
@@ -76,6 +82,8 @@ internal class GeneralSettingsViewModelTest {
 
             fakeAppSettingsDataStore = FakeSettingsDataStore()
 
+            fakeShowOnAppLaunchOptionDataStore = FakeShowOnAppLaunchOptionDataStore()
+
             testee = GeneralSettingsViewModel(
                 fakeAppSettingsDataStore,
                 mockPixel,
@@ -83,6 +91,7 @@ internal class GeneralSettingsViewModelTest {
                 mockVoiceSearchAvailability,
                 mockVoiceSearchRepository,
                 dispatcherProvider,
+                fakeShowOnAppLaunchOptionDataStore,
             )
         }
     }
@@ -133,6 +142,7 @@ internal class GeneralSettingsViewModelTest {
     @Test
     fun whenVoiceSearchEnabledThenViewStateEmitted() = runTest {
         fakeAppSettingsDataStore.autoCompleteSuggestionsEnabled = true
+        fakeShowOnAppLaunchOptionDataStore.setShowOnAppLaunchOption(LastOpenedTab)
         whenever(mockVoiceSearchAvailability.isVoiceSearchAvailable).thenReturn(true)
 
         val viewState = defaultViewState()
@@ -178,12 +188,54 @@ internal class GeneralSettingsViewModelTest {
         }
     }
 
+    @Test
+    fun whenShowOnAppLaunchSetToLastOpenedTabThenShowOnAppLaunchOptionIsLastOpenedTab() = runTest {
+        fakeShowOnAppLaunchOptionDataStore.setShowOnAppLaunchOption(LastOpenedTab)
+
+        testee.viewState.test {
+            assertEquals(LastOpenedTab, awaitItem()?.showOnAppLaunchSelectedOption)
+        }
+    }
+
+    @Test
+    fun whenShowOnAppLaunchSetToNewTabPageThenShowOnAppLaunchOptionIsNewTabPage() = runTest {
+        fakeShowOnAppLaunchOptionDataStore.setShowOnAppLaunchOption(NewTabPage)
+
+        testee.viewState.test {
+            assertEquals(NewTabPage, awaitItem()?.showOnAppLaunchSelectedOption)
+        }
+    }
+
+    @Test
+    fun whenShowOnAppLaunchSetToSpecificPageThenShowOnAppLaunchOptionIsSpecificPage() = runTest {
+        val specificPage = SpecificPage("example.com")
+
+        fakeShowOnAppLaunchOptionDataStore.setShowOnAppLaunchOption(specificPage)
+
+        testee.viewState.test {
+            assertEquals(specificPage, awaitItem()?.showOnAppLaunchSelectedOption)
+        }
+    }
+
+    @Test
+    fun whenShowOnAppLaunchUpdatedThenViewStateIsUpdated() = runTest {
+        fakeShowOnAppLaunchOptionDataStore.setShowOnAppLaunchOption(LastOpenedTab)
+
+        testee.viewState.test {
+            awaitItem()
+
+            fakeShowOnAppLaunchOptionDataStore.setShowOnAppLaunchOption(NewTabPage)
+
+            assertEquals(NewTabPage, awaitItem()?.showOnAppLaunchSelectedOption)
+        }
+    }
+
     private fun defaultViewState() = GeneralSettingsViewModel.ViewState(
         autoCompleteSuggestionsEnabled = true,
         autoCompleteRecentlyVisitedSitesSuggestionsUserEnabled = true,
         storeHistoryEnabled = false,
         showVoiceSearch = false,
         voiceSearchEnabled = false,
-        showOnAppLaunchSelectedOptionText = "Last Opened Tab",
+        showOnAppLaunchSelectedOption = LastOpenedTab,
     )
 }

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/GeneralSettingsViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/GeneralSettingsViewModelTest.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchO
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.NewTabPage
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.SpecificPage
 import com.duckduckgo.app.generalsettings.showonapplaunch.store.FakeShowOnAppLaunchOptionDataStore
+import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_GENERAL_APP_LAUNCH_PRESSED
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.history.api.NavigationHistory
@@ -228,6 +229,13 @@ internal class GeneralSettingsViewModelTest {
 
             assertEquals(NewTabPage, awaitItem()?.showOnAppLaunchSelectedOption)
         }
+    }
+
+    @Test
+    fun whenShowOnAppLaunchClickedThenPixelFiredEmitted() = runTest {
+        testee.onShowOnAppLaunchButtonClick()
+
+        verify(mockPixel).fire(SETTINGS_GENERAL_APP_LAUNCH_PRESSED)
     }
 
     private fun defaultViewState() = GeneralSettingsViewModel.ViewState(

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchStateReporterPluginTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchStateReporterPluginTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.generalsettings.showonapplaunch
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption
+import com.duckduckgo.app.generalsettings.showonapplaunch.store.FakeShowOnAppLaunchOptionDataStore
+import com.duckduckgo.app.generalsettings.showonapplaunch.store.ShowOnAppLaunchOptionDataStore
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.DispatcherProvider
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ShowOnAppLaunchReporterPluginTest {
+
+    @get:Rule val coroutineTestRule = CoroutineTestRule()
+
+    private val dispatcherProvider: DispatcherProvider = coroutineTestRule.testDispatcherProvider
+    private lateinit var testee: ShowOnAppLaunchStateReporterPlugin
+    private lateinit var fakeDataStore: ShowOnAppLaunchOptionDataStore
+
+    @Before
+    fun setup() {
+        fakeDataStore = FakeShowOnAppLaunchOptionDataStore(ShowOnAppLaunchOption.LastOpenedTab)
+
+        testee = ShowOnAppLaunchStateReporterPlugin(dispatcherProvider, fakeDataStore)
+    }
+
+    @Test
+    fun whenOptionIsSetToLastOpenedPageThenShouldReturnDailyPixelValue() = runTest {
+        fakeDataStore.setShowOnAppLaunchOption(ShowOnAppLaunchOption.LastOpenedTab)
+        val result = testee.featureStateParams()
+        assertEquals("last_opened_tab", result[PixelParameter.LAUNCH_SCREEN])
+    }
+
+    @Test
+    fun whenOptionIsSetToNewTabPageThenShouldReturnDailyPixelValue() = runTest {
+        fakeDataStore.setShowOnAppLaunchOption(ShowOnAppLaunchOption.NewTabPage)
+        val result = testee.featureStateParams()
+        assertEquals("new_tab_page", result[PixelParameter.LAUNCH_SCREEN])
+    }
+
+    @Test
+    fun whenOptionIsSetToSpecificPageThenShouldReturnDailyPixelValue() = runTest {
+        val specificPage = ShowOnAppLaunchOption.SpecificPage("example.com")
+        fakeDataStore.setShowOnAppLaunchOption(specificPage)
+        val result = testee.featureStateParams()
+        assertEquals("specific_page", result[PixelParameter.LAUNCH_SCREEN])
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchUrlConverterImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchUrlConverterImplTest.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.generalsettings.showonapplaunch
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.generalsettings.showonapplaunch.store.ShowOnAppLaunchOptionDataStore.Companion.DEFAULT_SPECIFIC_PAGE_URL
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ShowOnAppLaunchUrlConverterImplTest {
+
+    private val urlConverter = ShowOnAppLaunchUrlConverterImpl()
+
+    @Test
+    fun whenUrlIsNullThenShouldReturnDefaultUrl() {
+        val result = urlConverter.convertUrl(null)
+        assertEquals(DEFAULT_SPECIFIC_PAGE_URL, result)
+    }
+
+    @Test
+    fun whenUrlIsEmptyThenShouldReturnDefaultUrl() {
+        val result = urlConverter.convertUrl("")
+        assertEquals(DEFAULT_SPECIFIC_PAGE_URL, result)
+    }
+
+    @Test
+    fun whenUrlIsBlankThenShouldReturnDefaultUrl() {
+        val result = urlConverter.convertUrl(" ")
+        assertEquals(DEFAULT_SPECIFIC_PAGE_URL, result)
+    }
+
+    @Test
+    fun whenUrlHasNoSchemeThenHttpSchemeIsAdded() {
+        val result = urlConverter.convertUrl("www.example.com")
+        assertEquals("http://www.example.com", result)
+    }
+
+    @Test
+    fun whenUrlHasNoSchemeAndSubdomainThenHttpSchemeIsAdded() {
+        val result = urlConverter.convertUrl("example.com")
+        assertEquals("http://example.com", result)
+    }
+
+    @Test
+    fun whenUrlHasASchemeThenShouldReturnTheSameUrl() {
+        val result = urlConverter.convertUrl("https://www.example.com")
+        assertEquals("https://www.example.com", result)
+    }
+
+    @Test
+    fun whenUrlHasDifferentSchemeThenShouldReturnTheSameUrl() {
+        val result = urlConverter.convertUrl("ftp://www.example.com")
+        assertEquals("ftp://www.example.com", result)
+    }
+
+    @Test
+    fun whenUrlHasSpecialCharactersThenShouldReturnTheSameUrl() {
+        val result = urlConverter.convertUrl("https://www.example.com/path?query=param&another=param")
+        assertEquals("https://www.example.com/path?query=param&another=param", result)
+    }
+
+    @Test
+    fun whenUrlHasPortThenShouldReturnTheSameUrl() {
+        val result = urlConverter.convertUrl("https://www.example.com:8080")
+        assertEquals("https://www.example.com:8080", result)
+    }
+
+    @Test
+    fun whenUrlHasPathAndQueryParametersThenShouldReturnTheSameUrl() {
+        val result = urlConverter.convertUrl("https://www.example.com/path/to/resource?query=param")
+        assertEquals("https://www.example.com/path/to/resource?query=param", result)
+    }
+
+    @Test
+    fun whenUrlHasUppercaseProtocolThenShouldLowercaseProtocol() {
+        val result = urlConverter.convertUrl("HTTPS://www.example.com")
+        assertEquals("https://www.example.com", result)
+    }
+
+    @Test
+    fun whenUrlHasUppercaseSubdomainThenShouldLowercaseSubdomain() {
+        val result = urlConverter.convertUrl("https://WWW.example.com")
+        assertEquals("https://www.example.com", result)
+    }
+
+    @Test
+    fun whenUrlHasUppercaseDomainThenShouldLowercaseDomain() {
+        val result = urlConverter.convertUrl("https://www.EXAMPLE.com")
+        assertEquals("https://www.example.com", result)
+    }
+
+    @Test
+    fun whenUrlHasUppercaseTopLevelDomainThenShouldLowercaseTopLevelDomain() {
+        val result = urlConverter.convertUrl("https://www.example.COM")
+        assertEquals("https://www.example.com", result)
+    }
+
+    @Test
+    fun whenUrlHasMixedCaseThenOnlyProtocolSubdomainDomainAndTldAreLowercased() {
+        val result = urlConverter.convertUrl("HTTPS://WWW.EXAMPLE.COM/Path?Query=Param#Fragment")
+        assertEquals("https://www.example.com/Path?Query=Param#Fragment", result)
+    }
+
+    @Test
+    fun whenUrlIsNotAValidUrlReturnsInvalidUrlWithHttpScheme() {
+        val result = urlConverter.convertUrl("example")
+        assertEquals("http://example", result)
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModelTest.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.generalsettings.showonapplaunch
+
+import app.cash.turbine.test
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.LastOpenedTab
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.NewTabPage
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.SpecificPage
+import com.duckduckgo.app.generalsettings.showonapplaunch.store.FakeShowOnAppLaunchOptionDataStore
+import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_GENERAL_APP_LAUNCH_LAST_OPENED_TAB_SELECTED
+import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_GENERAL_APP_LAUNCH_NEW_TAB_PAGE_SELECTED
+import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_GENERAL_APP_LAUNCH_SPECIFIC_PAGE_SELECTED
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.fakes.FakePixel
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class ShowOnAppLaunchViewModelTest {
+
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule()
+
+    private lateinit var testee: ShowOnAppLaunchViewModel
+    private lateinit var fakeDataStore: FakeShowOnAppLaunchOptionDataStore
+    private lateinit var fakePixel: FakePixel
+    private val dispatcherProvider: DispatcherProvider = coroutineTestRule.testDispatcherProvider
+
+    @Before
+    fun setup() {
+        fakeDataStore = FakeShowOnAppLaunchOptionDataStore(LastOpenedTab)
+        fakePixel = FakePixel()
+        testee = ShowOnAppLaunchViewModel(dispatcherProvider, fakeDataStore, FakeUrlConverter(), fakePixel)
+    }
+
+    @Test
+    fun whenViewModelInitializedThenInitialStateIsCorrect() = runTest {
+        testee.viewState.test {
+            val initialState = awaitItem()
+            assertEquals(LastOpenedTab, initialState.selectedOption)
+            assertEquals("https://duckduckgo.com", initialState.specificPageUrl)
+        }
+    }
+
+    @Test
+    fun whenShowOnAppLaunchOptionChangedThenStateIsUpdated() = runTest {
+        testee.onShowOnAppLaunchOptionChanged(NewTabPage)
+        testee.viewState.test {
+            val updatedState = awaitItem()
+            assertEquals(NewTabPage, updatedState.selectedOption)
+        }
+    }
+
+    @Test
+    fun whenSpecificPageUrlSetThenStateIsUpdated() = runTest {
+        val newUrl = "https://example.com"
+
+        testee.setSpecificPageUrl(newUrl)
+        testee.viewState.test {
+            val updatedState = awaitItem()
+            assertEquals(newUrl, updatedState.specificPageUrl)
+        }
+    }
+
+    @Test
+    fun whenMultipleOptionsChangedThenStateIsUpdatedCorrectly() = runTest {
+        testee.onShowOnAppLaunchOptionChanged(NewTabPage)
+        testee.onShowOnAppLaunchOptionChanged(LastOpenedTab)
+        testee.viewState.test {
+            val updatedState = awaitItem()
+            assertEquals(LastOpenedTab, updatedState.selectedOption)
+        }
+    }
+
+    @Test
+    fun whenOptionChangedToLastOpenedPageThenLastOpenedPageIsFired() = runTest {
+        testee.onShowOnAppLaunchOptionChanged(NewTabPage)
+        testee.onShowOnAppLaunchOptionChanged(LastOpenedTab)
+        assertEquals(2, fakePixel.firedPixels.size)
+        assertEquals(SETTINGS_GENERAL_APP_LAUNCH_LAST_OPENED_TAB_SELECTED.pixelName, fakePixel.firedPixels.last())
+    }
+
+    @Test
+    fun whenOptionChangedToNewTabPageThenNewTabPagePixelIsFired() = runTest {
+        testee.onShowOnAppLaunchOptionChanged(NewTabPage)
+        assertEquals(1, fakePixel.firedPixels.size)
+        assertEquals(SETTINGS_GENERAL_APP_LAUNCH_NEW_TAB_PAGE_SELECTED.pixelName, fakePixel.firedPixels[0])
+    }
+
+    @Test
+    fun whenOptionChangedToSpecificPageThenSpecificPixelIsFired() = runTest {
+        testee.onShowOnAppLaunchOptionChanged(SpecificPage("https://example.com"))
+        assertEquals(1, fakePixel.firedPixels.size)
+        assertEquals(SETTINGS_GENERAL_APP_LAUNCH_SPECIFIC_PAGE_SELECTED.pixelName, fakePixel.firedPixels[0])
+    }
+
+    private class FakeUrlConverter : UrlConverter {
+
+        override fun convertUrl(url: String?): String {
+            return url ?: "https://duckduckgo.com"
+        }
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/store/FakeShowOnAppLaunchOptionDataStore.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/store/FakeShowOnAppLaunchOptionDataStore.kt
@@ -22,11 +22,11 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.filterNotNull
 
-class FakeShowOnAppLaunchOptionDataStore : ShowOnAppLaunchOptionDataStore {
+class FakeShowOnAppLaunchOptionDataStore(defaultOption: ShowOnAppLaunchOption? = null) : ShowOnAppLaunchOptionDataStore {
 
-    private var currentOptionStateFlow = MutableStateFlow<ShowOnAppLaunchOption?>(null)
+    private var currentOptionStateFlow = MutableStateFlow(defaultOption)
 
-    private var currentSpecificPageUrl = MutableStateFlow("duckduckgo.com")
+    private var currentSpecificPageUrl = MutableStateFlow("https://duckduckgo.com")
 
     override val optionFlow: Flow<ShowOnAppLaunchOption> = currentOptionStateFlow.asStateFlow().filterNotNull()
 

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/store/FakeShowOnAppLaunchOptionDataStore.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/store/FakeShowOnAppLaunchOptionDataStore.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.generalsettings.showonapplaunch.store
+
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.filterNotNull
+
+class FakeShowOnAppLaunchOptionDataStore : ShowOnAppLaunchOptionDataStore {
+
+    private var currentOptionStateFlow = MutableStateFlow<ShowOnAppLaunchOption?>(null)
+
+    override val optionFlow: Flow<ShowOnAppLaunchOption> = currentOptionStateFlow.asStateFlow().filterNotNull()
+
+    override suspend fun setShowOnAppLaunchOption(showOnAppLaunchOption: ShowOnAppLaunchOption) {
+        currentOptionStateFlow.value = showOnAppLaunchOption
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/store/FakeShowOnAppLaunchOptionDataStore.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/store/FakeShowOnAppLaunchOptionDataStore.kt
@@ -26,9 +26,17 @@ class FakeShowOnAppLaunchOptionDataStore : ShowOnAppLaunchOptionDataStore {
 
     private var currentOptionStateFlow = MutableStateFlow<ShowOnAppLaunchOption?>(null)
 
+    private var currentSpecificPageUrl = MutableStateFlow("duckduckgo.com")
+
     override val optionFlow: Flow<ShowOnAppLaunchOption> = currentOptionStateFlow.asStateFlow().filterNotNull()
+
+    override val specificPageUrlFlow: Flow<String> = currentSpecificPageUrl.asStateFlow()
 
     override suspend fun setShowOnAppLaunchOption(showOnAppLaunchOption: ShowOnAppLaunchOption) {
         currentOptionStateFlow.value = showOnAppLaunchOption
+    }
+
+    override suspend fun setSpecificPageUrl(url: String) {
+        currentSpecificPageUrl.value = url
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/store/ShowOnAppLaunchPrefsDataStoreTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/store/ShowOnAppLaunchPrefsDataStoreTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.generalsettings.showonapplaunch.store
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStoreFile
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.cash.turbine.test
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.LastOpenedTab
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.NewTabPage
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.SpecificPage
+import com.duckduckgo.common.test.CoroutineTestRule
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ShowOnAppLaunchPrefsDataStoreTest {
+
+    @get:Rule val coroutineRule = CoroutineTestRule()
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private val dataStoreFile = context.preferencesDataStoreFile("show_on_app_launch")
+
+    private val testDataStore: DataStore<Preferences> =
+        PreferenceDataStoreFactory.create(
+            scope = coroutineRule.testScope,
+            produceFile = { dataStoreFile },
+        )
+
+    private val testee: ShowOnAppLaunchOptionDataStore =
+        ShowOnAppLaunchOptionPrefsDataStore(testDataStore)
+
+    @After
+    fun after() {
+        dataStoreFile.delete()
+    }
+
+    @Test
+    fun whenOptionIsNullThenShouldReturnLastOpenedPage() = runTest {
+        assertEquals(LastOpenedTab, testee.optionFlow.first())
+    }
+
+    @Test
+    fun whenOptionIsSetToLastOpenedPageThenShouldReturnLastOpenedPage() = runTest {
+        testee.setShowOnAppLaunchOption(LastOpenedTab)
+        assertEquals(LastOpenedTab, testee.optionFlow.first())
+    }
+
+    @Test
+    fun whenOptionIsSetToNewTabPageThenShouldReturnNewTabPage() = runTest {
+        testee.setShowOnAppLaunchOption(NewTabPage)
+        assertEquals(NewTabPage, testee.optionFlow.first())
+    }
+
+    @Test
+    fun whenOptionIsSetToSpecificPageThenShouldReturnSpecificPage() = runTest {
+        val specificPage = SpecificPage("example.com")
+
+        testee.setShowOnAppLaunchOption(specificPage)
+        assertEquals(specificPage, testee.optionFlow.first())
+    }
+
+    @Test
+    fun whenSpecificPageIsNullThenShouldReturnDefaultUrl() = runTest {
+        assertEquals("https://duckduckgo.com/", testee.specificPageUrlFlow.first())
+    }
+
+    @Test
+    fun whenSpecificPageUrlIsSetThenShouldReturnSpecificPageUrl() = runTest {
+        testee.setSpecificPageUrl("example.com")
+        assertEquals("example.com", testee.specificPageUrlFlow.first())
+    }
+
+    @Test
+    fun whenOptionIsChangedThenNewOptionEmitted() = runTest {
+        testee.optionFlow.test {
+            val defaultOption = awaitItem()
+
+            assertEquals(LastOpenedTab, defaultOption)
+
+            testee.setShowOnAppLaunchOption(NewTabPage)
+
+            assertEquals(NewTabPage, awaitItem())
+
+            testee.setShowOnAppLaunchOption(SpecificPage("example.com"))
+
+            assertEquals(SpecificPage("example.com"), awaitItem())
+        }
+    }
+}

--- a/app/src/test/java/com/duckduckgo/fakes/FakePixel.kt
+++ b/app/src/test/java/com/duckduckgo/fakes/FakePixel.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.fakes
+
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelName
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType
+
+internal class FakePixel : Pixel {
+
+    val firedPixels = mutableListOf<String>()
+
+    override fun fire(
+        pixel: PixelName,
+        parameters: Map<String, String>,
+        encodedParameters: Map<String, String>,
+        type: PixelType,
+    ) {
+        firedPixels.add(pixel.pixelName)
+    }
+
+    override fun fire(
+        pixelName: String,
+        parameters: Map<String, String>,
+        encodedParameters: Map<String, String>,
+        type: PixelType,
+    ) {
+        firedPixels.add(pixelName)
+    }
+
+    override fun enqueueFire(
+        pixel: PixelName,
+        parameters: Map<String, String>,
+        encodedParameters: Map<String, String>,
+    ) {
+        firedPixels.add(pixel.pixelName)
+    }
+
+    override fun enqueueFire(
+        pixelName: String,
+        parameters: Map<String, String>,
+        encodedParameters: Map<String, String>,
+    ) {
+        firedPixels.add(pixelName)
+    }
+}

--- a/browser-api/src/main/java/com/duckduckgo/app/tabs/model/TabRepository.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/tabs/model/TabRepository.kt
@@ -93,6 +93,8 @@ interface TabRepository {
 
     suspend fun deleteAll()
 
+    suspend fun getSelectedTab(): TabEntity?
+
     suspend fun select(tabId: String)
 
     fun updateTabPreviewImage(

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/listitem/RadioListItem.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/listitem/RadioListItem.kt
@@ -98,6 +98,7 @@ class RadioListItem @JvmOverloads constructor(
     }
 
     fun setClickListener(onClick: () -> Unit) {
+        binding.radioButton.setOnClickListener { onClick() }
         binding.itemContainer.setOnClickListener { onClick() }
     }
 

--- a/statistics/statistics-api/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/statistics/statistics-api/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -60,6 +60,7 @@ interface Pixel {
 
         // Loading Bar Experiment
         const val LOADING_BAR_EXPERIMENT = "loading_bar_exp"
+        const val LAUNCH_SCREEN = "launch_screen"
     }
 
     object PixelValues {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207908166761516/1208156273709085/f

### Description

Adds persistence via datastore and observes the changes in the General settings screen and the ShowOnAppLaunch settings screen

### Steps to test this PR

- [x] Open General settings
- [x] Check current value of “Show on App Launch” secondary text
- [x] Open “Show on App Launch”
- [x] Change option
- [x] Go back to General settings
- [x] Check the updated secondary matches your option. In the case of “Specific Page” it will be the url 

**Note**: There’s no validation and storage of an updated “Specific Page” in this PR. That will be in a future PR.  

### UI changes

[persistence_demo.webm](https://github.com/user-attachments/assets/236ed58d-81af-4838-9749-b19af98b006c)
