### PR TITLE
Fix CompositeException

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
@@ -227,7 +227,8 @@ class AutoCompleteApi @Inject constructor(
             .toObservable()
             .onErrorResumeNext { throwable: Throwable ->
                 if (throwable is InterruptedIOException) {
-                    // When interrupted, return an empty observable to avoid showing the default state
+                    // If the query text is deleted quickly, the request may be cancelled, resulting in an InterruptedIOException.
+                    // Return an empty observable to avoid showing the default state.
                     Observable.empty()
                 } else {
                     Observable.just(emptyList<AutoCompleteSearchSuggestion>())

--- a/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
@@ -224,10 +224,14 @@ class AutoCompleteApi @Inject constructor(
                 AutoCompleteSearchSuggestion(phrase = it.phrase, isUrl = (it.isNav ?: UriString.isWebUrl(it.phrase)))
             }
             .toList()
-            .onErrorReturn {
-                if (it is InterruptedIOException) throw it else emptyList<AutoCompleteSearchSuggestion>()
-            }
             .toObservable()
+            .onErrorResumeNext { throwable: Throwable ->
+                if (throwable is InterruptedIOException) {
+                    Observable.empty()
+                } else {
+                    Observable.just(emptyList<AutoCompleteSearchSuggestion>())
+                }
+            }
 
     private fun getAutoCompleteBookmarkResults(query: String): Observable<MutableList<RankedSuggestion<AutoCompleteBookmarkSuggestion>>> =
         savedSitesRepository.getBookmarksObservable()

--- a/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
@@ -227,6 +227,7 @@ class AutoCompleteApi @Inject constructor(
             .toObservable()
             .onErrorResumeNext { throwable: Throwable ->
                 if (throwable is InterruptedIOException) {
+                    // When interrupted, return an empty observable to avoid showing the default state
                     Observable.empty()
                 } else {
                     Observable.just(emptyList<AutoCompleteSearchSuggestion>())


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208160020676247/f

### Description
 - This fixes a `CompositeException` that is caused when an exception is thrown in `onError`.
 - To fix this, instead of throwing an exception, we return an empty observable instead.

### Steps to test this PR

- [x] Type and delete text in the omnibar.
- [x] Verify that the autocomplete results update as expected.
