### PR TITLE
New privacyProEligible filter for experiments

### DIFF
--- a/experiments/experiments-api/src/main/java/com/duckduckgo/experiments/api/VariantConfig.kt
+++ b/experiments/experiments-api/src/main/java/com/duckduckgo/experiments/api/VariantConfig.kt
@@ -25,4 +25,5 @@ data class VariantConfig(
 data class VariantFilters(
     val locale: List<String> = emptyList(),
     val androidVersion: List<String> = emptyList(),
+    val privacyProEligible: Boolean? = null,
 )

--- a/experiments/experiments-impl/build.gradle
+++ b/experiments/experiments-impl/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation project(path: ':common-utils')
     implementation project(path: ':statistics-api')
     implementation project(path: ':app-build-config-api')
+    implementation project(path: ':experiments-api')
     implementation project(path: ':subscriptions-api')
 
     // Room

--- a/experiments/experiments-impl/build.gradle
+++ b/experiments/experiments-impl/build.gradle
@@ -29,10 +29,9 @@ dependencies {
 
     implementation project(path: ':di')
     implementation project(path: ':common-utils')
-    implementation project(path: ':experiments-api')
     implementation project(path: ':statistics-api')
     implementation project(path: ':app-build-config-api')
-    implementation project(path: ':browser-api')
+    implementation project(path: ':subscriptions-api')
 
     // Room
     implementation AndroidX.room.runtime

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/ExperimentFiltersManager.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/ExperimentFiltersManager.kt
@@ -59,9 +59,8 @@ class ExperimentFiltersManagerImpl @Inject constructor(
             filters[ANDROID_VERSION] = entity.filters!!.androidVersion.contains(userAndroidVersion)
         }
         if (entity.filters?.privacyProEligible != null) {
-            runBlocking(dispatcherProvider.io()) {
-                filters[PRIVACY_PRO_ELIGIBLE] = entity.filters?.privacyProEligible == subscriptions.isEligible()
-            }
+            val privacyProEligible = runBlocking(dispatcherProvider.io()) { subscriptions.isEligible() }
+            filters[PRIVACY_PRO_ELIGIBLE] = entity.filters?.privacyProEligible == privacyProEligible
         }
 
         return { filters.filter { !it.value }.isEmpty() }

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/ExperimentFiltersManager.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/ExperimentFiltersManager.kt
@@ -17,13 +17,17 @@
 package com.duckduckgo.experiments.impl
 
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.experiments.api.VariantConfig
 import com.duckduckgo.experiments.impl.ExperimentFiltersManagerImpl.ExperimentFilterType.ANDROID_VERSION
 import com.duckduckgo.experiments.impl.ExperimentFiltersManagerImpl.ExperimentFilterType.LOCALE
+import com.duckduckgo.experiments.impl.ExperimentFiltersManagerImpl.ExperimentFilterType.PRIVACY_PRO_ELIGIBLE
+import com.duckduckgo.subscriptions.api.Subscriptions
 import com.squareup.anvil.annotations.ContributesBinding
 import java.util.Locale
 import javax.inject.Inject
+import kotlinx.coroutines.runBlocking
 
 interface ExperimentFiltersManager {
     fun addFilters(entity: VariantConfig): (AppBuildConfig) -> Boolean
@@ -32,6 +36,8 @@ interface ExperimentFiltersManager {
 @ContributesBinding(AppScope::class)
 class ExperimentFiltersManagerImpl @Inject constructor(
     private val appBuildConfig: AppBuildConfig,
+    private val subscriptions: Subscriptions,
+    private val dispatcherProvider: DispatcherProvider,
 ) : ExperimentFiltersManager {
     override fun addFilters(entity: VariantConfig): (AppBuildConfig) -> Boolean {
         if (entity.variantKey == "sc" || entity.variantKey == "se") {
@@ -41,6 +47,7 @@ class ExperimentFiltersManagerImpl @Inject constructor(
         val filters: MutableMap<ExperimentFilterType, Boolean> = mutableMapOf(
             LOCALE to true,
             ANDROID_VERSION to true,
+            PRIVACY_PRO_ELIGIBLE to true,
         )
 
         if (!entity.filters?.locale.isNullOrEmpty()) {
@@ -50,6 +57,11 @@ class ExperimentFiltersManagerImpl @Inject constructor(
         if (!entity.filters?.androidVersion.isNullOrEmpty()) {
             val userAndroidVersion = appBuildConfig.sdkInt.toString()
             filters[ANDROID_VERSION] = entity.filters!!.androidVersion.contains(userAndroidVersion)
+        }
+        if (entity.filters?.privacyProEligible != null) {
+            runBlocking(dispatcherProvider.io()) {
+                filters[PRIVACY_PRO_ELIGIBLE] = entity.filters?.privacyProEligible == subscriptions.isEligible()
+            }
         }
 
         return { filters.filter { !it.value }.isEmpty() }
@@ -79,5 +91,6 @@ class ExperimentFiltersManagerImpl @Inject constructor(
     enum class ExperimentFilterType {
         LOCALE,
         ANDROID_VERSION,
+        PRIVACY_PRO_ELIGIBLE,
     }
 }

--- a/statistics/statistics-impl/build.gradle
+++ b/statistics/statistics-impl/build.gradle
@@ -34,7 +34,6 @@ dependencies {
     implementation project(path: ':app-build-config-api')
     implementation project(path: ':browser-api')
     implementation project(path: ':autofill-api')
-    implementation project(path: ':experiments-api')
     implementation project(path: ':privacy-config-api')
     implementation project(path: ':data-store-api')
     implementation project(path: ':anrs-api')

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/api/RxPixelSender.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/api/RxPixelSender.kt
@@ -26,7 +26,6 @@ import com.duckduckgo.app.statistics.store.PixelFiredRepository
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.common.utils.device.DeviceInfo
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.experiments.api.VariantManager
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
@@ -51,7 +50,6 @@ class RxPixelSender @Inject constructor(
     private val api: PixelService,
     private val pendingPixelDao: PendingPixelDao,
     private val statisticsDataStore: StatisticsDataStore,
-    private val variantManager: VariantManager,
     private val deviceInfo: DeviceInfo,
     private val statisticsLibraryConfig: StatisticsLibraryConfig?,
     private val pixelFiredRepository: PixelFiredRepository,
@@ -159,7 +157,7 @@ class RxPixelSender @Inject constructor(
         return defaultParameters.plus(parameters)
     }
 
-    private fun getAtbInfo() = statisticsDataStore.atb?.formatWithVariant(variantManager.getVariantKey()) ?: ""
+    private fun getAtbInfo() = statisticsDataStore.atb?.formatWithVariant(statisticsDataStore.variant) ?: ""
 
     private fun getDeviceFactor() = deviceInfo.formFactor().description
 

--- a/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/api/RxPixelSenderTest.kt
+++ b/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/api/RxPixelSenderTest.kt
@@ -41,7 +41,6 @@ import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.test.InstantSchedulersRule
 import com.duckduckgo.common.utils.device.DeviceInfo
-import com.duckduckgo.experiments.api.VariantManager
 import io.reactivex.Completable
 import java.util.concurrent.TimeoutException
 import kotlinx.coroutines.test.runTest
@@ -75,9 +74,6 @@ class RxPixelSenderTest {
     val mockStatisticsDataStore: StatisticsDataStore = mock()
 
     @Mock
-    val mockVariantManager: VariantManager = mock()
-
-    @Mock
     val mockDeviceInfo: DeviceInfo = mock()
 
     private lateinit var db: TestAppDatabase
@@ -97,7 +93,6 @@ class RxPixelSenderTest {
             api,
             pendingPixelDao,
             mockStatisticsDataStore,
-            mockVariantManager,
             mockDeviceInfo,
             object : StatisticsLibraryConfig {
                 override fun shouldFirePixelsAsDev() = true
@@ -397,7 +392,7 @@ class RxPixelSenderTest {
     }
 
     private fun givenVariant(variantKey: String) {
-        whenever(mockVariantManager.getVariantKey()).thenReturn(variantKey)
+        whenever(mockStatisticsDataStore.variant).thenReturn(variantKey)
     }
 
     private fun givenAtbVariant(atb: Atb) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201807753394693/1208158029105828/f

### Description
Add new filter `privacyProEligible` to remote experiment framework

### Steps to test this PR
_Pre steps_
- [x] Change privacy-config URL for `PRIVACY_REMOTE_CONFIG_URL = "https://jsonblob.com/api/1279046082855034880"`
- [x] Make sure you remove DuckDuckGo folder under Downloads directory

_privacyProEligible filter disabled_
- [x] In the JsonBlob, under `experimentalVariants` set `privacyProEligible` to false for `mq` and `mr` variants
>         "filters": {
>           "privacyProEligible": false
>         }
- [x] Fresh install
- [x] Filter by 'variant' in Logcat
- [x] If you are **not** eligible for privacyPro, then `mq` or `mr` **should** be assigned
- [x] If you **are** eligible, then **no** variant should be assigned

_privacyProEligible filter enabled_
- [ ] In the JsonBlob, under `experimentalVariants` set `privacyProEligible` to true for `mq` and `mr` variants
>         "filters": {
>           "privacyProEligible": true
>         }
- [ ] Fresh install
- [ ] Filter by 'variant' in Logcat
- [ ] If you are **not eligible** for privacyPro, then `mq` or `mr` **should not** be assigned
- [ ] If you **are** eligible, then a variant **should** be assigned

### No UI changes
