### PR TITLE
Use Timber instead of Log in DragLinearLayout

### DIFF
--- a/new-tab-page/new-tab-page-impl/build.gradle
+++ b/new-tab-page/new-tab-page-impl/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     implementation AndroidX.core.ktx
     implementation Google.dagger
     implementation "com.squareup.logcat:logcat:_"
+    implementation JakeWharton.timber
 
     testImplementation Testing.junit4
     testImplementation "org.mockito.kotlin:mockito-kotlin:_"

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/settings/DragLinearLayout.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/settings/DragLinearLayout.kt
@@ -25,7 +25,6 @@ import android.graphics.Canvas
 import android.graphics.Rect
 import android.graphics.drawable.BitmapDrawable
 import android.util.AttributeSet
-import android.util.Log
 import android.util.SparseArray
 import android.view.MotionEvent
 import android.view.View
@@ -35,6 +34,7 @@ import android.widget.LinearLayout
 import androidx.core.view.MotionEventCompat
 import kotlin.math.abs
 import kotlin.math.roundToInt
+import timber.log.Timber
 
 class DragLinearLayout @JvmOverloads constructor(
     context: Context?,
@@ -97,7 +97,7 @@ class DragLinearLayout @JvmOverloads constructor(
             dragHandle!!.setOnLongClickListener(mLongClickDragListener)
             mDraggableChildren.put(indexOfChild(child), DraggableChild())
         } else {
-            Log.e(TAG, "$child is not a child, cannot make draggable.")
+            Timber.e(TAG, "$child is not a child, cannot make draggable.")
         }
     }
 
@@ -256,7 +256,7 @@ class DragLinearLayout @JvmOverloads constructor(
                             observer.removeOnPreDrawListener(this)
                             mDragItem.updateTargetLocation()
                             if (mDragItem.settling()) {
-                                Log.d(TAG, "Updating settle animation")
+                                Timber.d(TAG, "Updating settle animation")
                                 mDragItem.mSettleAnimation!!.removeAllListeners()
                                 mDragItem.mSettleAnimation!!.cancel()
                                 onDragStop()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1200204095367872/1208202859730178/f

### Description
Adds the Timber dependency to the `new-tab-page-impl` module and replaces `Log` usages in `DragLinearLayout`.

### Steps to test this PR
- [ ] Code review
