### PR TITLE
Break build if active plugins are not in app scope

### DIFF
--- a/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesActivePluginPointCodeGenerator.kt
+++ b/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesActivePluginPointCodeGenerator.kt
@@ -135,6 +135,12 @@ class ContributesActivePluginPointCodeGenerator : CodeGenerator {
                 element = vmClass.clazz.identifyingElement,
             )
         }
+        if (scope.fqName != appScopeFqName) {
+            throw AnvilCompilationException(
+                "${vmClass.fqName}: Active plugins can only be used in 'AppScope'.",
+                element = vmClass.clazz.identifyingElement,
+            )
+        }
 
         val content = FileSpec.buildFile(generatedPackage, pluginPointClassFileName) {
             // This is the normal plugin point
@@ -329,6 +335,12 @@ class ContributesActivePluginPointCodeGenerator : CodeGenerator {
         if (existingFeature != null) {
             throw AnvilCompilationException(
                 "${vmClass.fqName} plugin name is duplicated, previous found in $existingFeature",
+                element = vmClass.clazz.identifyingElement,
+            )
+        }
+        if (scope.fqName != appScopeFqName) {
+            throw AnvilCompilationException(
+                "${vmClass.fqName}: Active plugins can only be used in 'AppScope'.",
                 element = vmClass.clazz.identifyingElement,
             )
         }
@@ -626,5 +638,6 @@ class ContributesActivePluginPointCodeGenerator : CodeGenerator {
         private val appCoroutineScopeFqName = FqName("com.duckduckgo.app.di.AppCoroutineScope")
         private val sharedPreferencesFqName = FqName("android.content.SharedPreferences")
         private val jsonAdapterFqName = FqName("com.squareup.moshi.JsonAdapter")
+        private val appScopeFqName = FqName("com.duckduckgo.di.scopes.AppScope")
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/FocusedViewProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/FocusedViewProvider.kt
@@ -19,9 +19,8 @@ package com.duckduckgo.app.browser.newtab
 import android.content.Context
 import android.view.View
 import com.duckduckgo.anvil.annotations.ContributesActivePlugin
-import com.duckduckgo.anvil.annotations.ContributesActivePluginPoint
 import com.duckduckgo.common.utils.plugins.ActivePluginPoint
-import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.newtabpage.api.FocusedViewPlugin
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
@@ -34,7 +33,7 @@ interface FocusedViewProvider {
 }
 
 @ContributesBinding(
-    scope = ActivityScope::class,
+    scope = AppScope::class,
 )
 class RealFocusedViewProvider @Inject constructor(
     private val focusedViewVersions: ActivePluginPoint<FocusedViewPlugin>,
@@ -46,7 +45,7 @@ class RealFocusedViewProvider @Inject constructor(
 }
 
 @ContributesActivePlugin(
-    scope = ActivityScope::class,
+    scope = AppScope::class,
     boundType = FocusedViewPlugin::class,
     priority = FocusedViewPlugin.PRIORITY_LEGACY_FOCUSED_PAGE,
     supportExperiments = true,
@@ -59,7 +58,7 @@ class FocusedLegacyPage @Inject constructor() : FocusedViewPlugin {
 }
 
 @ContributesActivePlugin(
-    scope = ActivityScope::class,
+    scope = AppScope::class,
     boundType = FocusedViewPlugin::class,
     priority = FocusedViewPlugin.PRIORITY_NEW_FOCUSED_PAGE,
     defaultActiveValue = false,
@@ -72,9 +71,3 @@ class FocusedPage @Inject constructor() : FocusedViewPlugin {
         return FocusedView(context)
     }
 }
-
-@ContributesActivePluginPoint(
-    scope = ActivityScope::class,
-    boundType = FocusedViewPlugin::class,
-)
-private interface FocusedViewPluginPointTrigger

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/FocusedViewPluginPointTrigger.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/FocusedViewPluginPointTrigger.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.newtabpage.impl
+
+import com.duckduckgo.anvil.annotations.ContributesActivePluginPoint
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.newtabpage.api.FocusedViewPlugin
+
+@ContributesActivePluginPoint(
+    scope = AppScope::class,
+    boundType = FocusedViewPlugin::class,
+)
+private interface FocusedViewPluginPointTrigger


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1198194956794324/1208197444733454/f

### Description
Active plugins can only be used in AppScope. Break the build if they're wrongly scoped.

### Steps to test this PR
_Test_
* Change the scope of an already existing plugin (eg. `AutofillNewTabShortcutPlugin`)
* clean build
[ ] verify build fails with proper message
