### PR TITLE
Add loading bar performance experiment

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -190,6 +190,7 @@ import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.ENABLED
 import com.duckduckgo.duckplayer.api.DuckPlayer.UserPreferences
 import com.duckduckgo.duckplayer.api.PrivatePlayerMode.AlwaysAsk
 import com.duckduckgo.duckplayer.api.PrivatePlayerMode.Disabled
+import com.duckduckgo.experiments.api.loadingbarexperiment.LoadingBarExperimentManager
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.history.api.HistoryEntry.VisitedPage
@@ -374,6 +375,8 @@ class BrowserTabViewModelTest {
     private val mockAppBuildConfig: AppBuildConfig = mock()
 
     private val mockDuckDuckGoUrlDetector: DuckDuckGoUrlDetector = mock()
+
+    private lateinit var loadingBarExperimentManager: LoadingBarExperimentManager = mock()
 
     private lateinit var remoteMessagingModel: RemoteMessagingModel
 
@@ -613,6 +616,7 @@ class BrowserTabViewModelTest {
             httpErrorPixels = { mockHttpErrorPixels },
             duckPlayer = mockDuckPlayer,
             duckPlayerJSHelper = DuckPlayerJSHelper(mockDuckPlayer, mockAppBuildConfig, mockPixel, mockDuckDuckGoUrlDetector),
+            loadingBarExperimentManager = loadingBarExperimentManager,
         )
 
         testee.loadData("abc", null, false, false)

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -376,7 +376,7 @@ class BrowserTabViewModelTest {
 
     private val mockDuckDuckGoUrlDetector: DuckDuckGoUrlDetector = mock()
 
-    private lateinit var loadingBarExperimentManager: LoadingBarExperimentManager = mock()
+    private var loadingBarExperimentManager: LoadingBarExperimentManager = mock()
 
     private lateinit var remoteMessagingModel: RemoteMessagingModel
 

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -69,6 +69,7 @@ import com.duckduckgo.common.utils.device.DeviceInfo
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.duckplayer.api.DuckPlayer
+import com.duckduckgo.experiments.api.loadingbarexperiment.LoadingBarExperimentManager
 import com.duckduckgo.history.api.NavigationHistory
 import com.duckduckgo.privacy.config.api.AmpLinks
 import com.duckduckgo.subscriptions.api.Subscriptions
@@ -135,6 +136,7 @@ class BrowserWebViewClientTest {
     private val subscriptions: Subscriptions = mock()
     private val mockDuckPlayer: DuckPlayer = mock()
     private val navigationHistory: NavigationHistory = mock()
+    private val loadingBarExperimentManager: LoadingBarExperimentManager = mock()
 
     @UiThreadTest
     @Before
@@ -168,6 +170,7 @@ class BrowserWebViewClientTest {
             mediaPlayback,
             subscriptions,
             mockDuckPlayer,
+            loadingBarExperimentManager,
         )
         testee.webViewClientListener = listener
         whenever(webResourceRequest.url).thenReturn(Uri.EMPTY)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -3799,10 +3799,10 @@ class BrowserTabFragment :
                     cancelTrackersAnimation()
                 }
 
-                if (shouldUpdateOmnibarTextInput(viewState, viewState.omnibarText)) {
-                    if (!viewState.navigationChange) {
-                        omnibar.omnibarTextInput.setText(viewState.omnibarText)
-                    }
+                if (viewState.navigationChange) {
+                    omnibar.appBarLayout.setExpanded(true, true)
+                } else if (shouldUpdateOmnibarTextInput(viewState, viewState.omnibarText)) {
+                    omnibar.omnibarTextInput.setText(viewState.omnibarText)
                     if (viewState.forceExpand) {
                         omnibar.appBarLayout.setExpanded(true, true)
                     }
@@ -4242,7 +4242,7 @@ class BrowserTabFragment :
             viewState: OmnibarViewState,
             omnibarInput: String?,
         ) =
-            (!viewState.isEditing || omnibarInput.isNullOrEmpty()) && omnibar.omnibarTextInput.isDifferent(omnibarInput) || viewState.navigationChange
+            (!viewState.isEditing || omnibarInput.isNullOrEmpty()) && omnibar.omnibarTextInput.isDifferent(omnibarInput)
     }
 
     private fun launchPrint(

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2759,14 +2759,15 @@ class BrowserTabFragment :
                     AppPixelName.BROWSER_PULL_TO_REFRESH.pixelName,
                     mapOf(LOADING_BAR_EXPERIMENT to loadingBarExperimentManager.variant.toBinaryString()),
                 )
+                pixel.fire(
+                    AppPixelName.REFRESH_ACTION_DAILY_PIXEL.pixelName,
+                    mapOf(LOADING_BAR_EXPERIMENT to loadingBarExperimentManager.variant.toBinaryString()),
+                    type = DAILY,
+                )
             } else {
                 pixel.fire(AppPixelName.BROWSER_PULL_TO_REFRESH.pixelName)
+                pixel.fire(AppPixelName.REFRESH_ACTION_DAILY_PIXEL.pixelName, type = DAILY)
             }
-            pixel.fire(
-                AppPixelName.REFRESH_ACTION_DAILY_PIXEL.pixelName,
-                mapOf(LOADING_BAR_EXPERIMENT to loadingBarExperimentManager.variant.toBinaryString()),
-                type = DAILY,
-            )
         }
 
         binding.swipeRefreshContainer.setCanChildScrollUpCallback {
@@ -3609,14 +3610,15 @@ class BrowserTabFragment :
                                 AppPixelName.MENU_ACTION_REFRESH_PRESSED.pixelName,
                                 mapOf(LOADING_BAR_EXPERIMENT to loadingBarExperimentManager.variant.toBinaryString()),
                             )
+                            pixel.fire(
+                                AppPixelName.REFRESH_ACTION_DAILY_PIXEL.pixelName,
+                                mapOf(LOADING_BAR_EXPERIMENT to loadingBarExperimentManager.variant.toBinaryString()),
+                                type = DAILY,
+                            )
                         } else {
                             pixel.fire(AppPixelName.MENU_ACTION_REFRESH_PRESSED.pixelName)
+                            pixel.fire(AppPixelName.REFRESH_ACTION_DAILY_PIXEL.pixelName, type = DAILY)
                         }
-                        pixel.fire(
-                            AppPixelName.REFRESH_ACTION_DAILY_PIXEL.pixelName,
-                            mapOf(LOADING_BAR_EXPERIMENT to loadingBarExperimentManager.variant.toBinaryString()),
-                            type = DAILY,
-                        )
                     }
                 }
                 onMenuItemClicked(menuBinding.newTabMenuItem) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -206,6 +206,7 @@ import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.FIRE_BUTTON_STATE
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.LOADING_BAR_EXPERIMENT
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.DAILY
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.ui.GridViewColumnCalculator
 import com.duckduckgo.app.tabs.ui.TabSwitcherActivity
@@ -2760,6 +2761,7 @@ class BrowserTabFragment :
             } else {
                 pixel.fire(AppPixelName.BROWSER_PULL_TO_REFRESH.pixelName)
             }
+            pixel.fire(AppPixelName.REFRESH_ACTION_DAILY_PIXEL.pixelName, type = DAILY)
         }
 
         binding.swipeRefreshContainer.setCanChildScrollUpCallback {
@@ -3605,6 +3607,7 @@ class BrowserTabFragment :
                         } else {
                             pixel.fire(AppPixelName.MENU_ACTION_REFRESH_PRESSED.pixelName)
                         }
+                        pixel.fire(AppPixelName.REFRESH_ACTION_DAILY_PIXEL.pixelName, type = DAILY)
                     }
                 }
                 onMenuItemClicked(menuBinding.newTabMenuItem) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -207,6 +207,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.FIRE_BUTTON_STATE
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.LOADING_BAR_EXPERIMENT
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.DAILY
+import com.duckduckgo.app.statistics.pixels.toBinaryString
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.ui.GridViewColumnCalculator
 import com.duckduckgo.app.tabs.ui.TabSwitcherActivity
@@ -2756,14 +2757,14 @@ class BrowserTabFragment :
             if (loadingBarExperimentManager.isExperimentEnabled()) {
                 pixel.fire(
                     AppPixelName.BROWSER_PULL_TO_REFRESH.pixelName,
-                    mapOf(LOADING_BAR_EXPERIMENT to loadingBarExperimentManager.variant.toString()),
+                    mapOf(LOADING_BAR_EXPERIMENT to loadingBarExperimentManager.variant.toBinaryString()),
                 )
             } else {
                 pixel.fire(AppPixelName.BROWSER_PULL_TO_REFRESH.pixelName)
             }
             pixel.fire(
                 AppPixelName.REFRESH_ACTION_DAILY_PIXEL.pixelName,
-                mapOf(LOADING_BAR_EXPERIMENT to loadingBarExperimentManager.variant.toString()),
+                mapOf(LOADING_BAR_EXPERIMENT to loadingBarExperimentManager.variant.toBinaryString()),
                 type = DAILY,
             )
         }
@@ -3606,14 +3607,14 @@ class BrowserTabFragment :
                         if (loadingBarExperimentManager.isExperimentEnabled()) {
                             pixel.fire(
                                 AppPixelName.MENU_ACTION_REFRESH_PRESSED.pixelName,
-                                mapOf(LOADING_BAR_EXPERIMENT to loadingBarExperimentManager.variant.toString()),
+                                mapOf(LOADING_BAR_EXPERIMENT to loadingBarExperimentManager.variant.toBinaryString()),
                             )
                         } else {
                             pixel.fire(AppPixelName.MENU_ACTION_REFRESH_PRESSED.pixelName)
                         }
                         pixel.fire(
                             AppPixelName.REFRESH_ACTION_DAILY_PIXEL.pixelName,
-                            mapOf(LOADING_BAR_EXPERIMENT to loadingBarExperimentManager.variant.toString()),
+                            mapOf(LOADING_BAR_EXPERIMENT to loadingBarExperimentManager.variant.toBinaryString()),
                             type = DAILY,
                         )
                     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -3786,7 +3786,9 @@ class BrowserTabFragment :
                 }
 
                 if (shouldUpdateOmnibarTextInput(viewState, viewState.omnibarText)) {
-                    omnibar.omnibarTextInput.setText(viewState.omnibarText)
+                    if (!viewState.navigationChange) {
+                        omnibar.omnibarTextInput.setText(viewState.omnibarText)
+                    }
                     if (viewState.forceExpand) {
                         omnibar.appBarLayout.setExpanded(true, true)
                     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2761,7 +2761,11 @@ class BrowserTabFragment :
             } else {
                 pixel.fire(AppPixelName.BROWSER_PULL_TO_REFRESH.pixelName)
             }
-            pixel.fire(AppPixelName.REFRESH_ACTION_DAILY_PIXEL.pixelName, type = DAILY)
+            pixel.fire(
+                AppPixelName.REFRESH_ACTION_DAILY_PIXEL.pixelName,
+                mapOf(LOADING_BAR_EXPERIMENT to loadingBarExperimentManager.variant.toString()),
+                type = DAILY,
+            )
         }
 
         binding.swipeRefreshContainer.setCanChildScrollUpCallback {
@@ -3607,7 +3611,11 @@ class BrowserTabFragment :
                         } else {
                             pixel.fire(AppPixelName.MENU_ACTION_REFRESH_PRESSED.pixelName)
                         }
-                        pixel.fire(AppPixelName.REFRESH_ACTION_DAILY_PIXEL.pixelName, type = DAILY)
+                        pixel.fire(
+                            AppPixelName.REFRESH_ACTION_DAILY_PIXEL.pixelName,
+                            mapOf(LOADING_BAR_EXPERIMENT to loadingBarExperimentManager.variant.toString()),
+                            type = DAILY,
+                        )
                     }
                 }
                 onMenuItemClicked(menuBinding.newTabMenuItem) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -3458,11 +3458,9 @@ class BrowserTabViewModel @Inject constructor(
     private fun showOmniBar() {
         omnibarViewState.value = currentOmnibarViewState().copy(
             navigationChange = true,
-            forceExpand = true,
         )
         omnibarViewState.value = currentOmnibarViewState().copy(
             navigationChange = false,
-            forceExpand = false,
         )
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -176,6 +176,7 @@ import com.duckduckgo.downloads.api.FileDownloader
 import com.duckduckgo.downloads.api.FileDownloader.PendingFileDownload
 import com.duckduckgo.duckplayer.api.DuckPlayer
 import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.ENABLED
+import com.duckduckgo.experiments.api.loadingbarexperiment.LoadingBarExperimentManager
 import com.duckduckgo.history.api.NavigationHistory
 import com.duckduckgo.js.messaging.api.JsCallbackData
 import com.duckduckgo.newtabpage.impl.pixels.NewTabPixels
@@ -279,6 +280,7 @@ class BrowserTabViewModel @Inject constructor(
     private val httpErrorPixels: Lazy<HttpErrorPixels>,
     private val duckPlayer: DuckPlayer,
     private val duckPlayerJSHelper: DuckPlayerJSHelper,
+    private val loadingBarExperimentManager: LoadingBarExperimentManager,
 ) : WebViewClientListener,
     EditSavedSiteListener,
     DeleteBookmarkListener,
@@ -1153,6 +1155,10 @@ class BrowserTabViewModel @Inject constructor(
         webNavigationState = newWebNavigationState
 
         if (!currentBrowserViewState().browserShowing) return
+
+        if (loadingBarExperimentManager.isExperimentEnabled()) {
+            showOmniBar()
+        }
 
         canAutofillSelectCredentialsDialogCanAutomaticallyShow = true
 
@@ -3447,6 +3453,17 @@ class BrowserTabViewModel @Inject constructor(
         if (cta is OnboardingDaxDialogCta) {
             onDismissOnboardingDaxDialog(cta)
         }
+    }
+
+    private fun showOmniBar() {
+        omnibarViewState.value = currentOmnibarViewState().copy(
+            navigationChange = true,
+            forceExpand = true,
+        )
+        omnibarViewState.value = currentOmnibarViewState().copy(
+            navigationChange = false,
+            forceExpand = false,
+        )
     }
 
     fun onUserDismissedAutoCompleteInAppMessage() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -62,6 +62,7 @@ import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.LOADING_BAR_EXPERIMENT
+import com.duckduckgo.app.statistics.pixels.toBinaryString
 import com.duckduckgo.autoconsent.api.Autoconsent
 import com.duckduckgo.autofill.api.BrowserAutofill
 import com.duckduckgo.autofill.api.InternalTestUserChecker
@@ -409,7 +410,7 @@ class BrowserWebViewClient @Inject constructor(
             if (loadingBarExperimentManager.isExperimentEnabled()) {
                 pixel.fire(
                     AppPixelName.URI_LOADED.pixelName,
-                    mapOf(LOADING_BAR_EXPERIMENT to loadingBarExperimentManager.variant.toString()),
+                    mapOf(LOADING_BAR_EXPERIMENT to loadingBarExperimentManager.variant.toBinaryString()),
                 )
             } else {
                 pixel.fire(AppPixelName.URI_LOADED)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -59,7 +59,9 @@ import com.duckduckgo.app.browser.pageloadpixel.PageLoadedHandler
 import com.duckduckgo.app.browser.pageloadpixel.firstpaint.PagePaintedHandler
 import com.duckduckgo.app.browser.print.PrintInjector
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.LOADING_BAR_EXPERIMENT
 import com.duckduckgo.autoconsent.api.Autoconsent
 import com.duckduckgo.autofill.api.BrowserAutofill
 import com.duckduckgo.autofill.api.InternalTestUserChecker
@@ -70,6 +72,7 @@ import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.duckplayer.api.DuckPlayer
 import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.ENABLED
+import com.duckduckgo.experiments.api.loadingbarexperiment.LoadingBarExperimentManager
 import com.duckduckgo.history.api.NavigationHistory
 import com.duckduckgo.privacy.config.api.AmpLinks
 import com.duckduckgo.subscriptions.api.Subscriptions
@@ -109,6 +112,7 @@ class BrowserWebViewClient @Inject constructor(
     private val mediaPlayback: MediaPlayback,
     private val subscriptions: Subscriptions,
     private val duckPlayer: DuckPlayer,
+    private val loadingBarExperimentManager: LoadingBarExperimentManager,
 ) : WebViewClient() {
 
     var webViewClientListener: WebViewClientListener? = null
@@ -401,6 +405,14 @@ class BrowserWebViewClient @Inject constructor(
                         start = null
                     }
                 }
+            }
+            if (loadingBarExperimentManager.isExperimentEnabled()) {
+                pixel.fire(
+                    AppPixelName.URI_LOADED.pixelName,
+                    mapOf(LOADING_BAR_EXPERIMENT to loadingBarExperimentManager.variant.toString()),
+                )
+            } else {
+                pixel.fire(AppPixelName.URI_LOADED)
             }
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/di/NetworkModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/NetworkModule.kt
@@ -31,6 +31,7 @@ import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.common.utils.plugins.pixel.PixelInterceptorPlugin
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.experiments.api.VariantManager
+import com.duckduckgo.experiments.api.loadingbarexperiment.LoadingBarExperimentManager
 import com.duckduckgo.user.agent.api.UserAgentProvider
 import com.squareup.moshi.Moshi
 import dagger.Lazy
@@ -171,6 +172,7 @@ class NetworkModule {
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
         appBuildConfig: AppBuildConfig,
         dispatcherProvider: DispatcherProvider,
+        loadingBarExperimentManager: LoadingBarExperimentManager,
     ): FeedbackSubmitter =
         FireAndForgetFeedbackSubmitter(
             feedbackService,
@@ -181,6 +183,7 @@ class NetworkModule {
             appCoroutineScope,
             appBuildConfig,
             dispatcherProvider,
+            loadingBarExperimentManager,
         )
 
     companion object {

--- a/app/src/main/java/com/duckduckgo/app/feedback/api/FeedbackService.kt
+++ b/app/src/main/java/com/duckduckgo/app/feedback/api/FeedbackService.kt
@@ -40,6 +40,7 @@ interface FeedbackService {
         @Field("manufacturer") manufacturer: String,
         @Field("model") model: String,
         @Field("atb") atb: String,
+        @Field("loading_bar_exp") loadingBarExperiment: String?,
     )
 
     companion object {

--- a/app/src/main/java/com/duckduckgo/app/feedback/api/FeedbackSubmitter.kt
+++ b/app/src/main/java/com/duckduckgo/app/feedback/api/FeedbackSubmitter.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.pixels.AppPixelName.FEEDBACK_NEGATIVE_SUBMISSION
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.LOADING_BAR_EXPERIMENT
+import com.duckduckgo.app.statistics.pixels.toBinaryString
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.utils.DispatcherProvider
@@ -143,7 +144,7 @@ class FireAndForgetFeedbackSubmitter(
         if (loadingBarExperimentManager.isExperimentEnabled()) {
             pixel.fire(
                 pixelName,
-                mapOf(LOADING_BAR_EXPERIMENT to loadingBarExperimentManager.variant.toString()),
+                mapOf(LOADING_BAR_EXPERIMENT to loadingBarExperimentManager.variant.toBinaryString()),
             )
         } else {
             pixel.fire(pixelName)
@@ -170,7 +171,11 @@ class FireAndForgetFeedbackSubmitter(
             model = Build.MODEL,
             api = appBuildConfig.sdkInt,
             atb = atbWithVariant(),
-            loadingBarExperiment = if (loadingBarExperimentManager.isExperimentEnabled()) loadingBarExperimentManager.variant.toString() else null,
+            loadingBarExperiment = if (loadingBarExperimentManager.isExperimentEnabled()) {
+                loadingBarExperimentManager.variant.toBinaryString()
+            } else {
+                null
+            },
         )
     }
 

--- a/app/src/main/java/com/duckduckgo/app/feedback/api/FeedbackSubmitter.kt
+++ b/app/src/main/java/com/duckduckgo/app/feedback/api/FeedbackSubmitter.kt
@@ -28,10 +28,12 @@ import com.duckduckgo.app.feedback.ui.negative.FeedbackType.SubReason
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.pixels.AppPixelName.FEEDBACK_NEGATIVE_SUBMISSION
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.LOADING_BAR_EXPERIMENT
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.experiments.api.VariantManager
+import com.duckduckgo.experiments.api.loadingbarexperiment.LoadingBarExperimentManager
 import java.util.Locale
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -63,6 +65,7 @@ class FireAndForgetFeedbackSubmitter(
     private val appCoroutineScope: CoroutineScope,
     private val appBuildConfig: AppBuildConfig,
     private val dispatcherProvider: DispatcherProvider,
+    private val loadingBarExperimentManager: LoadingBarExperimentManager,
 ) : FeedbackSubmitter {
     override suspend fun sendNegativeFeedback(
         mainReason: MainReason,
@@ -135,7 +138,16 @@ class FireAndForgetFeedbackSubmitter(
 
     private fun sendPixel(pixelName: String) {
         Timber.d("Firing feedback pixel: $pixelName")
-        pixel.fire(pixelName)
+
+        // Loading Bar Experiment
+        if (loadingBarExperimentManager.isExperimentEnabled()) {
+            pixel.fire(
+                pixelName,
+                mapOf(LOADING_BAR_EXPERIMENT to loadingBarExperimentManager.variant.toString()),
+            )
+        } else {
+            pixel.fire(pixelName)
+        }
     }
 
     private suspend fun submitFeedback(

--- a/app/src/main/java/com/duckduckgo/app/feedback/api/FeedbackSubmitter.kt
+++ b/app/src/main/java/com/duckduckgo/app/feedback/api/FeedbackSubmitter.kt
@@ -170,6 +170,7 @@ class FireAndForgetFeedbackSubmitter(
             model = Build.MODEL,
             api = appBuildConfig.sdkInt,
             atb = atbWithVariant(),
+            loadingBarExperiment = if (loadingBarExperimentManager.isExperimentEnabled()) loadingBarExperimentManager.variant.toString() else null,
         )
     }
 

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -360,4 +360,6 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
 
     INDONESIA_MESSAGE_SHOWN("m_indonesia_message_shown_d"),
     INDONESIA_MESSAGE_DISMISSED("m_indonesia_message_dismissed"),
+
+    REFRESH_ACTION_DAILY_PIXEL("m_refresh_action_daily"),
 }

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -362,4 +362,5 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     INDONESIA_MESSAGE_DISMISSED("m_indonesia_message_dismissed"),
 
     REFRESH_ACTION_DAILY_PIXEL("m_refresh_action_daily"),
+    URI_LOADED("m_uri_loaded"),
 }

--- a/app/src/main/java/com/duckduckgo/app/survey/ui/SurveyViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/survey/ui/SurveyViewModel.kt
@@ -31,6 +31,7 @@ import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.SingleLiveEvent
 import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.experiments.api.loadingbarexperiment.LoadingBarExperimentManager
 import javax.inject.Inject
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
@@ -44,6 +45,7 @@ class SurveyViewModel @Inject constructor(
     private val dispatchers: DispatcherProvider,
     private val appDaysUsedRepository: AppDaysUsedRepository,
     private val surveyRepository: SurveyRepository,
+    private val loadingBarExperimentManager: LoadingBarExperimentManager,
 ) : ViewModel() {
 
     sealed class Command {
@@ -84,6 +86,11 @@ class SurveyViewModel @Inject constructor(
             .appendQueryParameter(SurveyParams.MODEL, appBuildConfig.model)
             .appendQueryParameter(SurveyParams.SOURCE, source.name.lowercase())
             .appendQueryParameter(SurveyParams.LAST_ACTIVE_DATE, lastActiveDay)
+
+        // Loading Bar Experiment
+        if (loadingBarExperimentManager.isExperimentEnabled()) {
+            urlBuilder.appendQueryParameter(SurveyParams.COHORT, loadingBarExperimentManager.variant.toString())
+        }
 
         return urlBuilder.build().toString()
     }
@@ -126,5 +133,6 @@ class SurveyViewModel @Inject constructor(
         const val MODEL = "mo"
         const val LAST_ACTIVE_DATE = "da"
         const val SOURCE = "src"
+        const val COHORT = "loading_bar_exp"
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/survey/ui/SurveyViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/survey/ui/SurveyViewModelTest.kt
@@ -176,6 +176,33 @@ class SurveyViewModelTest {
         assertEquals("name", loadedUri.getQueryParameter("ddgv"))
         assertEquals("pixel", loadedUri.getQueryParameter("man"))
         assertEquals("XL", loadedUri.getQueryParameter("mo"))
+        assertEquals(null, loadedUri.getQueryParameter("loading_bar_exp"))
+    }
+
+    @Test
+    fun givenLoadingBarExperimentWhenSurveyStartedThenExtraParametersAddedToUrl() {
+        whenever(mockStatisticsStore.atb).thenReturn(Atb("123"))
+        whenever(mockStatisticsStore.variant).thenReturn("abc")
+        whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(2))
+        whenever(mockAppBuildConfig.sdkInt).thenReturn(16)
+        whenever(mockAppBuildConfig.manufacturer).thenReturn("pixel")
+        whenever(mockLoadingBarExperimentManager.isExperimentEnabled()).thenReturn(true)
+        whenever(mockLoadingBarExperimentManager.variant).thenReturn(true)
+
+        val captor = argumentCaptor<Command.LoadSurvey>()
+        testee.start(Survey("", "https://survey.com", null, SCHEDULED), testSource)
+        verify(mockCommandObserver).onChanged(captor.capture())
+        val loadedUri = captor.lastValue.url.toUri()
+
+        assertEquals("123", loadedUri.getQueryParameter("atb"))
+        assertEquals("abc", loadedUri.getQueryParameter("var"))
+        assertEquals("2", loadedUri.getQueryParameter("delta"))
+        assertEquals("16", loadedUri.getQueryParameter("av"))
+        assertEquals("name", loadedUri.getQueryParameter("ddgv"))
+        assertEquals("pixel", loadedUri.getQueryParameter("man"))
+        assertEquals("in_app", loadedUri.getQueryParameter("src"))
+        assertEquals("today", loadedUri.getQueryParameter("da"))
+        assertEquals("true", loadedUri.getQueryParameter("loading_bar_exp"))
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/survey/ui/SurveyViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/survey/ui/SurveyViewModelTest.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.app.survey.ui.SurveyViewModel.Command
 import com.duckduckgo.app.usage.app.AppDaysUsedRepository
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.experiments.api.loadingbarexperiment.LoadingBarExperimentManager
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
@@ -67,6 +68,8 @@ class SurveyViewModelTest {
 
     private val mockSurveyRepository: SurveyRepository = mock()
 
+    private val mockLoadingBarExperimentManager: LoadingBarExperimentManager = mock()
+
     private lateinit var testee: SurveyViewModel
     private val testSource = SurveySource.IN_APP
 
@@ -84,6 +87,7 @@ class SurveyViewModelTest {
                 coroutineTestRule.testDispatcherProvider,
                 mockAppDaysUsedRepository,
                 mockSurveyRepository,
+                mockLoadingBarExperimentManager,
             )
             testee.command.observeForever(mockCommandObserver)
         }

--- a/experiments/experiments-api/src/main/java/com/duckduckgo/experiments/api/loadingbarexperiment/LoadingBarExperimentManager.kt
+++ b/experiments/experiments-api/src/main/java/com/duckduckgo/experiments/api/loadingbarexperiment/LoadingBarExperimentManager.kt
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.app.browser.viewstate
+package com.duckduckgo.experiments.api.loadingbarexperiment
 
-data class OmnibarViewState(
-    val omnibarText: String = "",
-    val isEditing: Boolean = false,
-    val shouldMoveCaretToEnd: Boolean = false,
-    val navigationChange: Boolean = false,
-    val forceExpand: Boolean = true,
-)
+interface LoadingBarExperimentManager {
+    fun isExperimentEnabled(): Boolean
+    val variant: Boolean
+}

--- a/experiments/experiments-api/src/main/java/com/duckduckgo/experiments/api/loadingbarexperiment/LoadingBarExperimentManager.kt
+++ b/experiments/experiments-api/src/main/java/com/duckduckgo/experiments/api/loadingbarexperiment/LoadingBarExperimentManager.kt
@@ -18,5 +18,6 @@ package com.duckduckgo.experiments.api.loadingbarexperiment
 
 interface LoadingBarExperimentManager {
     fun isExperimentEnabled(): Boolean
+    suspend fun update()
     val variant: Boolean
 }

--- a/experiments/experiments-impl/build.gradle
+++ b/experiments/experiments-impl/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation project(path: ':app-build-config-api')
     implementation project(path: ':experiments-api')
     implementation project(path: ':subscriptions-api')
+    implementation project(path: ':data-store-api')
 
     // Room
     implementation AndroidX.room.runtime

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/loadingbarexperiment/DuckDuckGoLoadingBarExperimentManager.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/loadingbarexperiment/DuckDuckGoLoadingBarExperimentManager.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.experiments.api.loadingbarexperiment.LoadingBarExperimentM
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
 import javax.inject.Inject
+import timber.log.Timber
 
 @ContributesBinding(AppScope::class)
 @SingleInstanceIn(AppScope::class)
@@ -33,6 +34,7 @@ class DuckDuckGoLoadingBarExperimentManager @Inject constructor(
     private var enabled: Boolean? = null
 
     override fun isExperimentEnabled(): Boolean {
+        Timber.d("Loading bar experiment: Retrieving experiment status")
         if (hasVariant == null) {
             hasVariant = loadingBarExperimentDataStore.hasVariant
         }
@@ -42,6 +44,12 @@ class DuckDuckGoLoadingBarExperimentManager @Inject constructor(
         }
 
         return hasVariant == true && enabled == true
+    }
+
+    override suspend fun update() {
+        Timber.d("Loading bar experiment: Experimental variables updated")
+        hasVariant = loadingBarExperimentDataStore.hasVariant
+        enabled = loadingBarExperimentFeature.self().isEnabled()
     }
 
     override val variant: Boolean

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/loadingbarexperiment/DuckDuckGoLoadingBarExperimentManager.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/loadingbarexperiment/DuckDuckGoLoadingBarExperimentManager.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.experiments.impl.loadingbarexperiment
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.experiments.api.loadingbarexperiment.LoadingBarExperimentManager
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+@ContributesBinding(AppScope::class)
+@SingleInstanceIn(AppScope::class)
+class DuckDuckGoLoadingBarExperimentManager @Inject constructor(
+    private val loadingBarExperimentDataStore: LoadingBarExperimentDataStore,
+    private val loadingBarExperimentFeature: LoadingBarExperimentFeature,
+) : LoadingBarExperimentManager {
+
+    private var hasVariant: Boolean? = null
+    private var enabled: Boolean? = null
+
+    override fun isExperimentEnabled(): Boolean {
+        if (hasVariant == null) {
+            hasVariant = loadingBarExperimentDataStore.hasVariant
+        }
+
+        if (enabled == null) {
+            enabled = loadingBarExperimentFeature.self().isEnabled()
+        }
+
+        return hasVariant == true && enabled == true
+    }
+
+    override val variant: Boolean
+        get() = loadingBarExperimentDataStore.variant
+}

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/loadingbarexperiment/LoadingBarExperimentDataStore.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/loadingbarexperiment/LoadingBarExperimentDataStore.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.experiments.impl.loadingbarexperiment
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface LoadingBarExperimentDataStore {
+    var variant: Boolean
+    val hasVariant: Boolean
+}
+
+@ContributesBinding(AppScope::class)
+class LoadingBarExperimentSharedPreferences @Inject constructor(private val context: Context) :
+    LoadingBarExperimentDataStore {
+
+    override var variant: Boolean
+        get() = preferences.getBoolean(KEY_VARIANT, false)
+        set(value) = preferences.edit { putBoolean(KEY_VARIANT, value) }
+
+    override val hasVariant: Boolean
+        get() = preferences.contains(KEY_VARIANT)
+
+    private val preferences: SharedPreferences by lazy { context.getSharedPreferences(FILENAME, Context.MODE_PRIVATE) }
+
+    companion object {
+        private const val FILENAME = "com.duckduckgo.app.loadingbarexperiment"
+        private const val KEY_VARIANT = "com.duckduckgo.app.loadingbarexperiment.variant"
+    }
+}

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/loadingbarexperiment/LoadingBarExperimentDataStore.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/loadingbarexperiment/LoadingBarExperimentDataStore.kt
@@ -16,9 +16,9 @@
 
 package com.duckduckgo.experiments.impl.loadingbarexperiment
 
-import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
@@ -29,8 +29,9 @@ interface LoadingBarExperimentDataStore {
 }
 
 @ContributesBinding(AppScope::class)
-class LoadingBarExperimentSharedPreferences @Inject constructor(private val context: Context) :
-    LoadingBarExperimentDataStore {
+class LoadingBarExperimentSharedPreferences @Inject constructor(
+    private val sharedPreferencesProvider: SharedPreferencesProvider,
+) : LoadingBarExperimentDataStore {
 
     override var variant: Boolean
         get() = preferences.getBoolean(KEY_VARIANT, false)
@@ -39,7 +40,7 @@ class LoadingBarExperimentSharedPreferences @Inject constructor(private val cont
     override val hasVariant: Boolean
         get() = preferences.contains(KEY_VARIANT)
 
-    private val preferences: SharedPreferences by lazy { context.getSharedPreferences(FILENAME, Context.MODE_PRIVATE) }
+    private val preferences: SharedPreferences by lazy { sharedPreferencesProvider.getSharedPreferences(FILENAME) }
 
     companion object {
         private const val FILENAME = "com.duckduckgo.app.loadingbarexperiment"

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/loadingbarexperiment/LoadingBarExperimentFeature.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/loadingbarexperiment/LoadingBarExperimentFeature.kt
@@ -19,7 +19,6 @@ package com.duckduckgo.experiments.impl.loadingbarexperiment
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
-import com.duckduckgo.feature.toggles.api.Toggle.InternalAlwaysEnabled
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
@@ -27,10 +26,8 @@ import com.duckduckgo.feature.toggles.api.Toggle.InternalAlwaysEnabled
 )
 interface LoadingBarExperimentFeature {
     @Toggle.DefaultValue(false)
-    @InternalAlwaysEnabled
     fun self(): Toggle
 
     @Toggle.DefaultValue(false)
-    @InternalAlwaysEnabled
     fun allocateVariants(): Toggle
 }

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/loadingbarexperiment/LoadingBarExperimentFeature.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/loadingbarexperiment/LoadingBarExperimentFeature.kt
@@ -14,12 +14,23 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.app.browser.viewstate
+package com.duckduckgo.experiments.impl.loadingbarexperiment
 
-data class OmnibarViewState(
-    val omnibarText: String = "",
-    val isEditing: Boolean = false,
-    val shouldMoveCaretToEnd: Boolean = false,
-    val navigationChange: Boolean = false,
-    val forceExpand: Boolean = true,
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.InternalAlwaysEnabled
+
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "loadingBarExp",
 )
+interface LoadingBarExperimentFeature {
+    @Toggle.DefaultValue(false)
+    @InternalAlwaysEnabled
+    fun self(): Toggle
+
+    @Toggle.DefaultValue(false)
+    @InternalAlwaysEnabled
+    fun allocateVariants(): Toggle
+}

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/loadingbarexperiment/LoadingBarExperimentPixels.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/loadingbarexperiment/LoadingBarExperimentPixels.kt
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.app.browser.viewstate
+package com.duckduckgo.experiments.impl.loadingbarexperiment
 
-data class OmnibarViewState(
-    val omnibarText: String = "",
-    val isEditing: Boolean = false,
-    val shouldMoveCaretToEnd: Boolean = false,
-    val navigationChange: Boolean = false,
-    val forceExpand: Boolean = true,
-)
+import com.duckduckgo.app.statistics.pixels.Pixel
+
+enum class LoadingBarExperimentPixels(override val pixelName: String) : Pixel.PixelName {
+    LOADING_BAR_EXPERIMENT_ENROLLMENT_TEST("m_loading_bar_exp_enrollment_test"),
+    LOADING_BAR_EXPERIMENT_ENROLLMENT_CONTROL("m_loading_bar_exp_enrollment_control"),
+}

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/loadingbarexperiment/LoadingBarExperimentVariantInitializer.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/loadingbarexperiment/LoadingBarExperimentVariantInitializer.kt
@@ -17,9 +17,7 @@
 package com.duckduckgo.experiments.impl.loadingbarexperiment
 
 import androidx.annotation.VisibleForTesting
-import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.di.AppCoroutineScope
-import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
@@ -36,10 +34,6 @@ import org.apache.commons.math3.distribution.EnumeratedIntegerDistribution
 
 @ContributesMultibinding(
     scope = AppScope::class,
-    boundType = MainProcessLifecycleObserver::class,
-)
-@ContributesMultibinding(
-    scope = AppScope::class,
     boundType = PrivacyConfigCallbackPlugin::class,
 )
 @SingleInstanceIn(AppScope::class)
@@ -50,11 +44,7 @@ class LoadingBarExperimentVariantInitializer @Inject constructor(
     private val pixel: Pixel,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
-) : MainProcessLifecycleObserver, PrivacyConfigCallbackPlugin {
-
-    override fun onResume(owner: LifecycleOwner) {
-        appCoroutineScope.launch(dispatcherProvider.io()) { initialize() }
-    }
+) : PrivacyConfigCallbackPlugin {
 
     @VisibleForTesting
     fun initialize() {

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/loadingbarexperiment/LoadingBarExperimentVariantInitializer.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/loadingbarexperiment/LoadingBarExperimentVariantInitializer.kt
@@ -46,8 +46,7 @@ class LoadingBarExperimentVariantInitializer @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
 ) : PrivacyConfigCallbackPlugin {
 
-    @VisibleForTesting
-    fun initialize() {
+    private fun initialize() {
         if (!loadingBarExperimentDataStore.hasVariant &&
             loadingBarExperimentFeature.self().isEnabled() &&
             loadingBarExperimentFeature.allocateVariants().isEnabled()
@@ -62,7 +61,8 @@ class LoadingBarExperimentVariantInitializer @Inject constructor(
     }
 
     // Test variant = true, Control variant = false
-    private fun generateRandomBoolean(): Boolean {
+    @VisibleForTesting
+    fun generateRandomBoolean(): Boolean {
         val values = intArrayOf(0, 1)
         val probabilities = doubleArrayOf(1.0, 1.0)
         val distribution = EnumeratedIntegerDistribution(values, probabilities)

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/loadingbarexperiment/LoadingBarExperimentVariantInitializer.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/loadingbarexperiment/LoadingBarExperimentVariantInitializer.kt
@@ -67,7 +67,7 @@ class LoadingBarExperimentVariantInitializer @Inject constructor(
     // Test variant = true, Control variant = false
     private fun generateRandomBoolean(): Boolean {
         val values = intArrayOf(0, 1)
-        val probabilities = doubleArrayOf(0.5, 0.5)
+        val probabilities = doubleArrayOf(1.0, 1.0)
         val distribution = EnumeratedIntegerDistribution(values, probabilities)
         return distribution.sample() == 1
     }

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/loadingbarexperiment/LoadingBarExperimentVariantInitializer.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/loadingbarexperiment/LoadingBarExperimentVariantInitializer.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.experiments.impl.loadingbarexperiment
+
+import androidx.annotation.VisibleForTesting
+import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.experiments.impl.loadingbarexperiment.LoadingBarExperimentPixels.LOADING_BAR_EXPERIMENT_ENROLLMENT_CONTROL
+import com.duckduckgo.experiments.impl.loadingbarexperiment.LoadingBarExperimentPixels.LOADING_BAR_EXPERIMENT_ENROLLMENT_TEST
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import org.apache.commons.math3.distribution.EnumeratedIntegerDistribution
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = MainProcessLifecycleObserver::class,
+)
+@SingleInstanceIn(AppScope::class)
+class LoadingBarExperimentVariantInitializer @Inject constructor(
+    private val loadingBarExperimentDataStore: LoadingBarExperimentDataStore,
+    private val loadingBarExperimentFeature: LoadingBarExperimentFeature,
+    private val pixel: Pixel,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val dispatcherProvider: DispatcherProvider,
+) : MainProcessLifecycleObserver {
+
+    override fun onResume(owner: LifecycleOwner) {
+        appCoroutineScope.launch(dispatcherProvider.io()) { initialize() }
+    }
+
+    @VisibleForTesting
+    suspend fun initialize() {
+        if (!loadingBarExperimentDataStore.hasVariant &&
+            loadingBarExperimentFeature.self().isEnabled() &&
+            loadingBarExperimentFeature.allocateVariants().isEnabled()
+        ) {
+            loadingBarExperimentDataStore.variant = generateRandomBoolean()
+            if (loadingBarExperimentDataStore.variant) {
+                pixel.fire(LOADING_BAR_EXPERIMENT_ENROLLMENT_TEST)
+            } else {
+                pixel.fire(LOADING_BAR_EXPERIMENT_ENROLLMENT_CONTROL)
+            }
+        }
+    }
+
+    // Test variant = true, Control variant = false
+    private fun generateRandomBoolean(): Boolean {
+        val values = intArrayOf(0, 1)
+        val probabilities = doubleArrayOf(0.5, 0.5)
+        val distribution = EnumeratedIntegerDistribution(values, probabilities)
+        return distribution.sample() == 1
+    }
+}

--- a/experiments/experiments-impl/src/test/java/com/duckduckgo/experiments/impl/loadingbarexperiment/DuckDuckGoLoadingBarExperimentManagerTest.kt
+++ b/experiments/experiments-impl/src/test/java/com/duckduckgo/experiments/impl/loadingbarexperiment/DuckDuckGoLoadingBarExperimentManagerTest.kt
@@ -40,7 +40,7 @@ class DuckDuckGoLoadingBarExperimentManagerTest {
     }
 
     @Test
-    fun whenHasVariantAndIsEnabledThenIsExperimentEnabledReturnsTrue() {
+    fun whenHasVariantAndIsEnabledThenIsExperimentEnabledReturnTrue() {
         whenever(mockLoadingBarExperimentDataStore.hasVariant).thenReturn(true)
         whenever(mockToggle.isEnabled()).thenReturn(true)
 
@@ -51,7 +51,7 @@ class DuckDuckGoLoadingBarExperimentManagerTest {
     }
 
     @Test
-    fun whenHasNoVariantThenIsExperimentEnabledReturnsFalse() {
+    fun whenHasNoVariantThenIsExperimentEnabledReturnFalse() {
         whenever(mockLoadingBarExperimentDataStore.hasVariant).thenReturn(false)
         whenever(mockToggle.isEnabled()).thenReturn(true)
 
@@ -62,7 +62,7 @@ class DuckDuckGoLoadingBarExperimentManagerTest {
     }
 
     @Test
-    fun whenIsNotEnabledThenIsExperimentEnabledReturnsFalse() {
+    fun whenIsNotEnabledThenIsExperimentEnabledReturnFalse() {
         whenever(mockLoadingBarExperimentDataStore.hasVariant).thenReturn(true)
         whenever(mockToggle.isEnabled()).thenReturn(false)
 
@@ -73,7 +73,7 @@ class DuckDuckGoLoadingBarExperimentManagerTest {
     }
 
     @Test
-    fun whenHasNoVariantAndIsNotEnabledThenIsExperimentEnabledReturnsFalse() {
+    fun whenHasNoVariantAndIsNotEnabledThenIsExperimentEnabledReturnFalse() {
         whenever(mockLoadingBarExperimentDataStore.hasVariant).thenReturn(false)
         whenever(mockToggle.isEnabled()).thenReturn(false)
 

--- a/experiments/experiments-impl/src/test/java/com/duckduckgo/experiments/impl/loadingbarexperiment/DuckDuckGoLoadingBarExperimentManagerTest.kt
+++ b/experiments/experiments-impl/src/test/java/com/duckduckgo/experiments/impl/loadingbarexperiment/DuckDuckGoLoadingBarExperimentManagerTest.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.duckduckgo.experiments.impl.loadingbarexperiment.DuckDuckGoLoadingBarExperimentManager
+import com.duckduckgo.experiments.impl.loadingbarexperiment.LoadingBarExperimentDataStore
+import com.duckduckgo.experiments.impl.loadingbarexperiment.LoadingBarExperimentFeature
+import com.duckduckgo.feature.toggles.api.Toggle
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.*
+
+class DuckDuckGoLoadingBarExperimentManagerTest {
+
+    private lateinit var testee: DuckDuckGoLoadingBarExperimentManager
+
+    private val mockLoadingBarExperimentDataStore: LoadingBarExperimentDataStore = mock()
+    private val mockLoadingBarExperimentFeature: LoadingBarExperimentFeature = mock()
+    private val mockToggle: Toggle = mock()
+
+    @Before
+    fun setup() {
+        testee = DuckDuckGoLoadingBarExperimentManager(mockLoadingBarExperimentDataStore, mockLoadingBarExperimentFeature)
+        whenever(mockLoadingBarExperimentFeature.self()).thenReturn(mockToggle)
+    }
+
+    @Test
+    fun whenHasVariantAndIsEnabledThenIsExperimentEnabledReturnsTrue() {
+        whenever(mockLoadingBarExperimentDataStore.hasVariant).thenReturn(true)
+        whenever(mockToggle.isEnabled()).thenReturn(true)
+
+        assertTrue(testee.isExperimentEnabled())
+
+        verify(mockLoadingBarExperimentDataStore).hasVariant
+        verify(mockLoadingBarExperimentFeature.self()).isEnabled()
+    }
+
+    @Test
+    fun whenHasNoVariantThenIsExperimentEnabledReturnsFalse() {
+        whenever(mockLoadingBarExperimentDataStore.hasVariant).thenReturn(false)
+        whenever(mockToggle.isEnabled()).thenReturn(true)
+
+        assertFalse(testee.isExperimentEnabled())
+
+        verify(mockLoadingBarExperimentDataStore).hasVariant
+        verify(mockLoadingBarExperimentFeature.self()).isEnabled()
+    }
+
+    @Test
+    fun whenIsNotEnabledThenIsExperimentEnabledReturnsFalse() {
+        whenever(mockLoadingBarExperimentDataStore.hasVariant).thenReturn(true)
+        whenever(mockToggle.isEnabled()).thenReturn(false)
+
+        assertFalse(testee.isExperimentEnabled())
+
+        verify(mockLoadingBarExperimentDataStore).hasVariant
+        verify(mockLoadingBarExperimentFeature.self()).isEnabled()
+    }
+
+    @Test
+    fun whenHasNoVariantAndIsNotEnabledThenIsExperimentEnabledReturnsFalse() {
+        whenever(mockLoadingBarExperimentDataStore.hasVariant).thenReturn(false)
+        whenever(mockToggle.isEnabled()).thenReturn(false)
+
+        assertFalse(testee.isExperimentEnabled())
+
+        verify(mockLoadingBarExperimentDataStore).hasVariant
+        verify(mockLoadingBarExperimentFeature.self()).isEnabled()
+    }
+
+    @Test
+    fun whenUpdateCalledThenVariablesAreUpdated() = runTest {
+        whenever(mockLoadingBarExperimentDataStore.hasVariant).thenReturn(false)
+        whenever(mockToggle.isEnabled()).thenReturn(true)
+
+        testee.update()
+
+        assertFalse(testee.isExperimentEnabled())
+
+        whenever(mockLoadingBarExperimentDataStore.hasVariant).thenReturn(false)
+        whenever(mockToggle.isEnabled()).thenReturn(false)
+
+        testee.update()
+
+        assertFalse(testee.isExperimentEnabled())
+
+        whenever(mockLoadingBarExperimentDataStore.hasVariant).thenReturn(true)
+        whenever(mockToggle.isEnabled()).thenReturn(false)
+
+        testee.update()
+
+        assertFalse(testee.isExperimentEnabled())
+
+        whenever(mockLoadingBarExperimentDataStore.hasVariant).thenReturn(true)
+        whenever(mockToggle.isEnabled()).thenReturn(true)
+
+        testee.update()
+
+        assertTrue(testee.isExperimentEnabled())
+    }
+
+    @Test
+    fun whenGetVariantThenVariantIsReturned() {
+        whenever(mockLoadingBarExperimentDataStore.variant).thenReturn(true)
+
+        assertTrue(testee.variant)
+
+        verify(mockLoadingBarExperimentDataStore).variant
+    }
+}

--- a/experiments/experiments-impl/src/test/java/com/duckduckgo/experiments/impl/loadingbarexperiment/DuckDuckGoLoadingBarExperimentManagerTest.kt
+++ b/experiments/experiments-impl/src/test/java/com/duckduckgo/experiments/impl/loadingbarexperiment/DuckDuckGoLoadingBarExperimentManagerTest.kt
@@ -40,7 +40,7 @@ class DuckDuckGoLoadingBarExperimentManagerTest {
     }
 
     @Test
-    fun whenHasVariantAndIsEnabledThenIsExperimentEnabledReturnTrue() {
+    fun whenHasVariantAndIsEnabledThenIsExperimentEnabledReturnsTrue() {
         whenever(mockLoadingBarExperimentDataStore.hasVariant).thenReturn(true)
         whenever(mockToggle.isEnabled()).thenReturn(true)
 
@@ -51,7 +51,7 @@ class DuckDuckGoLoadingBarExperimentManagerTest {
     }
 
     @Test
-    fun whenHasNoVariantThenIsExperimentEnabledReturnFalse() {
+    fun whenHasNoVariantThenIsExperimentEnabledReturnsFalse() {
         whenever(mockLoadingBarExperimentDataStore.hasVariant).thenReturn(false)
         whenever(mockToggle.isEnabled()).thenReturn(true)
 
@@ -62,7 +62,7 @@ class DuckDuckGoLoadingBarExperimentManagerTest {
     }
 
     @Test
-    fun whenIsNotEnabledThenIsExperimentEnabledReturnFalse() {
+    fun whenIsNotEnabledThenIsExperimentEnabledReturnsFalse() {
         whenever(mockLoadingBarExperimentDataStore.hasVariant).thenReturn(true)
         whenever(mockToggle.isEnabled()).thenReturn(false)
 
@@ -73,7 +73,7 @@ class DuckDuckGoLoadingBarExperimentManagerTest {
     }
 
     @Test
-    fun whenHasNoVariantAndIsNotEnabledThenIsExperimentEnabledReturnFalse() {
+    fun whenHasNoVariantAndIsNotEnabledThenIsExperimentEnabledReturnsFalse() {
         whenever(mockLoadingBarExperimentDataStore.hasVariant).thenReturn(false)
         whenever(mockToggle.isEnabled()).thenReturn(false)
 

--- a/experiments/experiments-impl/src/test/java/com/duckduckgo/experiments/impl/loadingbarexperiment/DuckDuckGoLoadingBarExperimentManagerTest.kt
+++ b/experiments/experiments-impl/src/test/java/com/duckduckgo/experiments/impl/loadingbarexperiment/DuckDuckGoLoadingBarExperimentManagerTest.kt
@@ -84,13 +84,15 @@ class DuckDuckGoLoadingBarExperimentManagerTest {
     }
 
     @Test
-    fun whenUpdateCalledThenVariablesAreUpdated() = runTest {
+    fun whenUpdateCalledThenCachedVariablesAreUpdated() = runTest {
         whenever(mockLoadingBarExperimentDataStore.hasVariant).thenReturn(false)
         whenever(mockToggle.isEnabled()).thenReturn(true)
 
         testee.update()
 
         assertFalse(testee.isExperimentEnabled())
+        verify(mockLoadingBarExperimentDataStore, times(1)).hasVariant
+        verify(mockToggle, times(1)).isEnabled()
 
         whenever(mockLoadingBarExperimentDataStore.hasVariant).thenReturn(false)
         whenever(mockToggle.isEnabled()).thenReturn(false)
@@ -98,6 +100,8 @@ class DuckDuckGoLoadingBarExperimentManagerTest {
         testee.update()
 
         assertFalse(testee.isExperimentEnabled())
+        verify(mockLoadingBarExperimentDataStore, times(2)).hasVariant
+        verify(mockToggle, times(2)).isEnabled()
 
         whenever(mockLoadingBarExperimentDataStore.hasVariant).thenReturn(true)
         whenever(mockToggle.isEnabled()).thenReturn(false)
@@ -105,6 +109,8 @@ class DuckDuckGoLoadingBarExperimentManagerTest {
         testee.update()
 
         assertFalse(testee.isExperimentEnabled())
+        verify(mockLoadingBarExperimentDataStore, times(3)).hasVariant
+        verify(mockToggle, times(3)).isEnabled()
 
         whenever(mockLoadingBarExperimentDataStore.hasVariant).thenReturn(true)
         whenever(mockToggle.isEnabled()).thenReturn(true)
@@ -112,6 +118,8 @@ class DuckDuckGoLoadingBarExperimentManagerTest {
         testee.update()
 
         assertTrue(testee.isExperimentEnabled())
+        verify(mockLoadingBarExperimentDataStore, times(4)).hasVariant
+        verify(mockToggle, times(4)).isEnabled()
     }
 
     @Test

--- a/experiments/experiments-impl/src/test/java/com/duckduckgo/experiments/impl/loadingbarexperiment/LoadingBarExperimentSharedPreferencesTest.kt
+++ b/experiments/experiments-impl/src/test/java/com/duckduckgo/experiments/impl/loadingbarexperiment/LoadingBarExperimentSharedPreferencesTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.experiments.impl.loadingbarexperiment
+
+import android.content.SharedPreferences
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.*
+import org.mockito.kotlin.whenever
+
+class LoadingBarExperimentSharedPreferencesTest {
+
+    private lateinit var testee: LoadingBarExperimentSharedPreferences
+
+    private val sharedPreferencesProvider: SharedPreferencesProvider = mock()
+    private val sharedPreferences: SharedPreferences = mock()
+
+    @Before
+    fun setUp() {
+        whenever(sharedPreferencesProvider.getSharedPreferences("com.duckduckgo.app.loadingbarexperiment")).thenReturn(sharedPreferences)
+
+        testee = LoadingBarExperimentSharedPreferences(sharedPreferencesProvider)
+    }
+
+    @Test
+    fun whenVariantIsSetToTrueThenReturnTrue() {
+        whenever(sharedPreferences.getBoolean("com.duckduckgo.app.loadingbarexperiment.variant", false)).thenReturn(true)
+
+        assertTrue(testee.variant)
+    }
+
+    @Test
+    fun whenVariantIsSetToFalseThenReturnFalse() {
+        whenever(sharedPreferences.getBoolean("com.duckduckgo.app.loadingbarexperiment.variant", false)).thenReturn(false)
+
+        assertFalse(testee.variant)
+    }
+
+    @Test
+    fun whenVariantIsNotSetThenHasVariantReturnFalse() {
+        whenever(sharedPreferences.contains("com.duckduckgo.app.loadingbarexperiment.variant")).thenReturn(false)
+
+        assertFalse(testee.hasVariant)
+    }
+
+    @Test
+    fun whenVariantIsSetThenHasVariantReturnTrue() {
+        whenever(sharedPreferences.contains("com.duckduckgo.app.loadingbarexperiment.variant")).thenReturn(true)
+
+        assertTrue(testee.hasVariant)
+    }
+}

--- a/experiments/experiments-impl/src/test/java/com/duckduckgo/experiments/impl/loadingbarexperiment/LoadingBarExperimentVariantInitializerTest.kt
+++ b/experiments/experiments-impl/src/test/java/com/duckduckgo/experiments/impl/loadingbarexperiment/LoadingBarExperimentVariantInitializerTest.kt
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.experiments.impl.loadingbarexperiment
+
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.experiments.api.loadingbarexperiment.LoadingBarExperimentManager
+import com.duckduckgo.experiments.impl.loadingbarexperiment.LoadingBarExperimentPixels.LOADING_BAR_EXPERIMENT_ENROLLMENT_CONTROL
+import com.duckduckgo.experiments.impl.loadingbarexperiment.LoadingBarExperimentPixels.LOADING_BAR_EXPERIMENT_ENROLLMENT_TEST
+import com.duckduckgo.feature.toggles.api.Toggle
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.*
+
+class LoadingBarExperimentVariantInitializerTest {
+
+    @get:Rule
+    var coroutineRule = CoroutineTestRule()
+
+    private lateinit var testee: LoadingBarExperimentVariantInitializer
+
+    private val mockLoadingBarExperimentManager: LoadingBarExperimentManager = mock()
+    private val mockLoadingBarExperimentDataStore: LoadingBarExperimentDataStore = mock()
+    private val mockLoadingBarExperimentFeature: LoadingBarExperimentFeature = mock()
+    private val mockPixel: Pixel = mock()
+    private val mockToggle: Toggle = mock()
+    private val mockAllocationToggle: Toggle = mock()
+
+    @Before
+    fun setup() {
+        testee = spy(
+            LoadingBarExperimentVariantInitializer(
+                mockLoadingBarExperimentManager,
+                mockLoadingBarExperimentDataStore,
+                mockLoadingBarExperimentFeature,
+                mockPixel,
+                coroutineRule.testScope,
+                coroutineRule.testDispatcherProvider,
+            ),
+        )
+        whenever(mockLoadingBarExperimentFeature.self()).thenReturn(mockToggle)
+        whenever(mockLoadingBarExperimentFeature.allocateVariants()).thenReturn(mockAllocationToggle)
+    }
+
+    @Test
+    fun whenPrivacyConfigDownloadedAndGeneratedBooleanIsTrueThenVariantSetToTrueAndTestPixelFired() = runTest {
+        whenever(mockLoadingBarExperimentDataStore.hasVariant).thenReturn(false)
+        whenever(mockToggle.isEnabled()).thenReturn(true)
+        whenever(mockAllocationToggle.isEnabled()).thenReturn(true)
+        whenever(mockLoadingBarExperimentDataStore.variant).thenReturn(true)
+        whenever(testee.generateRandomBoolean()).thenReturn(true)
+
+        testee.onPrivacyConfigDownloaded()
+
+        verify(mockLoadingBarExperimentDataStore).variant = true
+        verify(mockPixel).fire(LOADING_BAR_EXPERIMENT_ENROLLMENT_TEST)
+    }
+
+    @Test
+    fun whenPrivacyConfigDownloadedAndGeneratedBooleanIsFalseThenVariantSetToFalseAndControlPixelFired() = runTest {
+        whenever(mockLoadingBarExperimentDataStore.hasVariant).thenReturn(false)
+        whenever(mockToggle.isEnabled()).thenReturn(true)
+        whenever(mockAllocationToggle.isEnabled()).thenReturn(true)
+        whenever(mockLoadingBarExperimentDataStore.variant).thenReturn(false)
+        whenever(testee.generateRandomBoolean()).thenReturn(false)
+
+        testee.onPrivacyConfigDownloaded()
+
+        verify(mockLoadingBarExperimentDataStore).variant = false
+        verify(mockPixel).fire(LOADING_BAR_EXPERIMENT_ENROLLMENT_CONTROL)
+    }
+
+    @Test
+    fun whenPrivacyConfigDownloadedAndVariantAlreadySetThenNoVariantChangesAndNoPixelsFired() = runTest {
+        whenever(mockLoadingBarExperimentDataStore.hasVariant).thenReturn(true)
+
+        testee.onPrivacyConfigDownloaded()
+
+        verify(mockLoadingBarExperimentDataStore, never()).variant = any()
+        verify(mockPixel, never()).fire(LOADING_BAR_EXPERIMENT_ENROLLMENT_TEST)
+        verify(mockPixel, never()).fire(LOADING_BAR_EXPERIMENT_ENROLLMENT_CONTROL)
+    }
+
+    @Test
+    fun whenPrivacyConfigDownloadedAndFeatureToggleDisabledThenNoVariantChangesAndNoPixelsFired() = runTest {
+        whenever(mockLoadingBarExperimentDataStore.hasVariant).thenReturn(false)
+        whenever(mockToggle.isEnabled()).thenReturn(false)
+
+        testee.onPrivacyConfigDownloaded()
+
+        verify(mockLoadingBarExperimentDataStore, never()).variant = any()
+        verify(mockPixel, never()).fire(LOADING_BAR_EXPERIMENT_ENROLLMENT_TEST)
+        verify(mockPixel, never()).fire(LOADING_BAR_EXPERIMENT_ENROLLMENT_CONTROL)
+    }
+
+    @Test
+    fun whenPrivacyConfigDownloadedAndAllocationToggleDisabledThenNoVariantChangesAndNoPixelsFired() = runTest {
+        whenever(mockLoadingBarExperimentDataStore.hasVariant).thenReturn(false)
+        whenever(mockToggle.isEnabled()).thenReturn(true)
+        whenever(mockAllocationToggle.isEnabled()).thenReturn(false)
+
+        testee.onPrivacyConfigDownloaded()
+
+        verify(mockLoadingBarExperimentDataStore, never()).variant = any()
+        verify(mockPixel, never()).fire(LOADING_BAR_EXPERIMENT_ENROLLMENT_TEST)
+        verify(mockPixel, never()).fire(LOADING_BAR_EXPERIMENT_ENROLLMENT_CONTROL)
+    }
+
+    @Test
+    fun whenPrivacyConfigDownloadedAndBothTogglesDisabledThenNoVariantChangesAndNoPixelsFired() = runTest {
+        whenever(mockLoadingBarExperimentDataStore.hasVariant).thenReturn(false)
+        whenever(mockToggle.isEnabled()).thenReturn(false)
+        whenever(mockAllocationToggle.isEnabled()).thenReturn(false)
+
+        testee.onPrivacyConfigDownloaded()
+
+        verify(mockLoadingBarExperimentDataStore, never()).variant = any()
+        verify(mockPixel, never()).fire(LOADING_BAR_EXPERIMENT_ENROLLMENT_TEST)
+        verify(mockPixel, never()).fire(LOADING_BAR_EXPERIMENT_ENROLLMENT_CONTROL)
+    }
+
+    @Test
+    fun whenPrivacyConfigDownloadedThenLoadingBarExperimentManagerUpdated() = runTest {
+        testee.onPrivacyConfigDownloaded()
+
+        verify(mockLoadingBarExperimentManager).update()
+    }
+}

--- a/statistics/statistics-api/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/statistics/statistics-api/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -57,6 +57,9 @@ interface Pixel {
         const val VOICE_SEARCH = "voice_search"
         const val LOCALE = "locale"
         const val FROM_ONBOARDING = "from_onboarding"
+
+        // Loading Bar Experiment
+        const val LOADING_BAR_EXPERIMENT = "loading_bar_exp"
     }
 
     object PixelValues {

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/pixels/FeatureRetentionPixelSender.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/pixels/FeatureRetentionPixelSender.kt
@@ -22,12 +22,14 @@ import androidx.core.content.edit
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.statistics.api.AtbLifecyclePlugin
 import com.duckduckgo.app.statistics.api.BrowserFeatureStateReporterPlugin
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.LOADING_BAR_EXPERIMENT
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.LOCALE
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.extensions.toSanitizedLanguageTag
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.experiments.api.loadingbarexperiment.LoadingBarExperimentManager
 import com.squareup.anvil.annotations.ContributesMultibinding
 import java.time.Instant
 import java.time.ZoneOffset
@@ -38,6 +40,7 @@ import kotlinx.coroutines.launch
 
 @ContributesMultibinding(AppScope::class)
 class FeatureRetentionPixelSender @Inject constructor(
+    private val loadingBarExperimentManager: LoadingBarExperimentManager,
     private val context: Context,
     private val pixel: Pixel,
     @AppCoroutineScope private val coroutineScope: CoroutineScope,
@@ -73,6 +76,10 @@ class FeatureRetentionPixelSender @Inject constructor(
         }
 
         parameters[LOCALE] = getLocale()
+
+        if (loadingBarExperimentManager.isExperimentEnabled()) {
+            parameters[LOADING_BAR_EXPERIMENT] = loadingBarExperimentManager.variant.toString()
+        }
 
         // check if pixel was already sent in the current day
         if (timestamp == null || now > timestamp) {

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/pixels/FeatureRetentionPixelSender.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/pixels/FeatureRetentionPixelSender.kt
@@ -78,7 +78,7 @@ class FeatureRetentionPixelSender @Inject constructor(
         parameters[LOCALE] = getLocale()
 
         if (loadingBarExperimentManager.isExperimentEnabled()) {
-            parameters[LOADING_BAR_EXPERIMENT] = loadingBarExperimentManager.variant.toString()
+            parameters[LOADING_BAR_EXPERIMENT] = loadingBarExperimentManager.variant.toBinaryString()
         }
 
         // check if pixel was already sent in the current day


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208210291365732/f

### Description

- Adds a custom experiment to measure the perceived performance of the loading bar on existing users.
- The experiment randomly assigns a variant on-update, with percentage roll-out controlled by the loadingBarExp feature toggle.

### Steps to test this PR
_Point at the config linked in the task_

-------
_In `LoadingBarExperimentVariantInitializer` set `val probabilities = doubleArrayOf(0.0, 1.0)`_

_Enrolment_
- [x] Fresh install from this branch
- [x] Verify that `m_loading_bar_exp_enrollment_test` is sent

_Daily_
- [x] Verify that `m_browser_feature_daily_active_user_d` is sent with param `loading_bar_exp=1`

_URI loaded_
- [x] Load a site (eg. example.com)
- [x] Verify that `m_uri_loaded` is sent with param `loading_bar_exp=1`

_Pull to refresh_
- [x] Pull to refresh the page
- [x] Verify that `m_browser_pull_to_refresh` is sent with param `loading_bar_exp=1`
 
_Refresh_
- [x] Refresh the page from the menu
- [x] Verify that `m_nav_r_p` is sent with param `loading_bar_exp=1`

_Refresh action daily_
- [x] Verify that only one `m_refresh_action_daily` is sent with param `loading_bar_exp=1`

_Loading bar_
- [x] Search for something on SERP
- [x] Scroll to hide the loading bar
- [x] Click a link
- [x] Verify that the loading bar shows immediately

_Feedback_
- [x] Go to “Settings” > “About” > “Share Feedback"
- [x] Share positive feedback
- [x] Verify that `mfbs_positive_submit` is sent with param `loading_bar_exp=1`
- [x] Share negative feedback
- [x] Verify that `mfbs_negative_submit` is sent with param `loading_bar_exp=1`

-------
_In `LoadingBarExperimentVariantInitializer` set `val probabilities = doubleArrayOf(1.0, 0.0)`_

_Enrolment_
- [x] Fresh install from this branch
- [x] Verify that `m_loading_bar_exp_enrollment_control` is sent

_Daily_
- [x] Verify that `m_browser_feature_daily_active_user_d` is sent with param `loading_bar_exp=0`

_URI loaded_
- [x] Load a site (eg. example.com)
- [x] Verify that `m_uri_loaded` is sent with param `loading_bar_exp=0`

_Pull to refresh_
- [x] Pull to refresh the page
- [x] Verify that `m_browser_pull_to_refresh` is sent with param `loading_bar_exp=0`
 
_Refresh_
- [x] Refresh the page from the menu
- [x] Verify that `m_nav_r_p` is sent with param `loading_bar_exp=0`

_Refresh action daily_
- [x] Verify that only one `m_refresh_action_daily` is sent with param `loading_bar_exp=0`

_Loading bar_
- [x] Search for something on SERP
- [x] Scroll to hide the loading bar
- [x] Click a link
- [x] Verify that there is a delay when showing the loading bar

_Feedback_
- [x] Go to “Settings” > “About” > “Share Feedback"
- [x] Share positive feedback
- [x] Verify that `mfbs_positive_submit` is sent with param `loading_bar_exp=0`
- [x] Share negative feedback
- [x] Verify that `mfbs_negative_submit` is sent with param `loading_bar_exp=0`

-------
_In the config, disable `allocateVariants`_

_Enrolment_
- [x] Fresh install from this branch
- [x] Verify that `m_loading_bar_exp_enrollment` pixel is **not** sent

_Daily_
- [x] Verify that `m_browser_feature_daily_active_user_d` is sent **without** param `loading_bar_exp`

_URI loaded_
- [x] Load a site (eg. example.com)
- [x] Verify that `m_uri_loaded` is sent **without** param `loading_bar_exp`

_Pull to refresh_
- [x] Pull to refresh the page
- [x] Verify that `m_browser_pull_to_refresh` is sent **without** param `loading_bar_exp`
 
_Refresh_
- [x] Refresh the page from the menu
- [x] Verify that `m_nav_r_p` is sent **without** param `loading_bar_exp`

_Refresh action daily_
- [x] Verify that only one `m_refresh_action_daily` is sent **without** param `loading_bar_exp`

_Feedback_
- [x] Go to “Settings” > “About” > “Share Feedback"
- [x] Share positive feedback
- [x] Verify that `mfbs_positive_submit` is sent *without* param `loading_bar_exp`
- [x] Share negative feedback
- [x] Verify that `mfbs_negative_submit` is sent *without* param `loading_bar_exp`

-------
_In the config, re-enable `allocateVariants`_

- [x] Fresh install from this branch
- [x] Load a site (eg. example.com)
- [x] Verify that `m_uri_loaded` is sent with param `loading_bar_exp=0`

_In the config, disable the `loadingBarExp` feature_

- [x] Reload the config
- [x] Load a site (eg. example.com)
- [x] Verify that `m_uri_loaded` is sent **without** param `loading_bar_exp`

### UI changes (Before/After)
https://github.com/user-attachments/assets/3ec616ed-4006-435c-86fd-fa55db2f1271


