### PR TITLE
Remove params from user segment pixel

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/api/PixelParamRemovalInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/PixelParamRemovalInterceptor.kt
@@ -20,7 +20,6 @@ import com.duckduckgo.app.browser.WebViewPixelName
 import com.duckduckgo.app.browser.httperrors.HttpErrorPixelName
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.StatisticsPixelName
 import com.duckduckgo.common.utils.AppUrl
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.common.utils.plugins.pixel.PixelInterceptorPlugin
@@ -81,7 +80,6 @@ object PixelInterceptorPixelsRequiringDataCleaning : PixelParamRemovalPlugin {
     override fun names(): List<Pair<String, Set<PixelParameter>>> {
         return listOf(
             AppPixelName.EMAIL_COPIED_TO_CLIPBOARD.pixelName to PixelParameter.removeAll(),
-            StatisticsPixelName.BROWSER_DAILY_ACTIVE_FEATURE_STATE.pixelName to PixelParameter.removeAll(),
             WebViewPixelName.WEB_PAGE_LOADED.pixelName to PixelParameter.removeAll(),
             WebViewPixelName.WEB_PAGE_PAINTED.pixelName to PixelParameter.removeAll(),
             AppPixelName.REFERRAL_INSTALL_UTM_CAMPAIGN.pixelName to PixelParameter.removeAtb(),

--- a/app/src/test/java/com/duckduckgo/app/statistics/pixels/PixelNameTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/statistics/pixels/PixelNameTest.kt
@@ -33,7 +33,7 @@ class PixelNameTest {
                 fail("Duplicate pixel name in AppPixelName: ${it.pixelName}")
             }
         }
-        Pixel.StatisticsPixelName.values().forEach {
+        StatisticsPixelName.values().forEach {
             if (!existingNames.add(it.pixelName)) {
                 fail("Duplicate pixel name in StatisticsPixelName: ${it.pixelName}")
             }

--- a/statistics/statistics-api/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/statistics/statistics-api/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -25,11 +25,6 @@ interface Pixel {
         val pixelName: String
     }
 
-    enum class StatisticsPixelName(override val pixelName: String) : PixelName {
-        BROWSER_DAILY_ACTIVE_FEATURE_STATE("m_browser_feature_daily_active_user_d"),
-        RETENTION_SEGMENTS("m_retention_segments"),
-    }
-
     object PixelParameter {
         const val APP_VERSION = "appVersion"
         const val URL = "url"

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/pixels/FeatureRetentionPixelSender.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/pixels/FeatureRetentionPixelSender.kt
@@ -23,7 +23,6 @@ import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.statistics.api.AtbLifecyclePlugin
 import com.duckduckgo.app.statistics.api.BrowserFeatureStateReporterPlugin
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.LOCALE
-import com.duckduckgo.app.statistics.pixels.Pixel.StatisticsPixelName
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.extensions.toSanitizedLanguageTag

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/pixels/StatisticsPixelName.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/pixels/StatisticsPixelName.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.statistics.pixels
+
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelName
+
+internal enum class StatisticsPixelName(override val pixelName: String) : PixelName {
+    BROWSER_DAILY_ACTIVE_FEATURE_STATE("m_browser_feature_daily_active_user_d"),
+    RETENTION_SEGMENTS("m_retention_segments"),
+}

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/pixels/StatisticsPixelName.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/pixels/StatisticsPixelName.kt
@@ -16,9 +16,12 @@
 
 package com.duckduckgo.app.statistics.pixels
 
+import androidx.annotation.VisibleForTesting
+import androidx.annotation.VisibleForTesting.Companion.PACKAGE_PRIVATE
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelName
 
-internal enum class StatisticsPixelName(override val pixelName: String) : PixelName {
+@VisibleForTesting(otherwise = PACKAGE_PRIVATE)
+enum class StatisticsPixelName(override val pixelName: String) : PixelName {
     BROWSER_DAILY_ACTIVE_FEATURE_STATE("m_browser_feature_daily_active_user_d"),
     RETENTION_SEGMENTS("m_retention_segments"),
 }

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/pixels/StatisticsPixelParamsRemovalPlugin.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/pixels/StatisticsPixelParamsRemovalPlugin.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.statistics.pixels
+
+import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin
+import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin.PixelParameter
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = PixelParamRemovalPlugin::class,
+)
+object StatisticsPixelParamsRemovalPlugin : PixelParamRemovalPlugin {
+    override fun names(): List<Pair<String, Set<PixelParameter>>> {
+        return listOf(
+            StatisticsPixelName.BROWSER_DAILY_ACTIVE_FEATURE_STATE.pixelName to PixelParameter.removeAll(),
+            StatisticsPixelName.RETENTION_SEGMENTS.pixelName to PixelParameter.removeAll(),
+        )
+    }
+}

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/user_segments/UserSegmentsPixelSender.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/user_segments/UserSegmentsPixelSender.kt
@@ -20,7 +20,7 @@ import com.duckduckgo.anrs.api.CrashLogger
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.statistics.api.AtbLifecyclePlugin
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.StatisticsPixelName
+import com.duckduckgo.app.statistics.pixels.StatisticsPixelName
 import com.duckduckgo.app.statistics.user_segments.SegmentCalculation.ActivityType
 import com.duckduckgo.app.statistics.user_segments.SegmentCalculation.ActivityType.APP_USE
 import com.duckduckgo.app.statistics.user_segments.SegmentCalculation.ActivityType.SEARCH


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208217925635108/f

### Description
Remove all default pixel params from user segment pixel.

Incidentally I have also moved all statistics pixels from the `statistics-api` module to the `-impl` module, as there's no reason for them to be public API

### Steps to test this PR
Just moving code around, there's no behavior change

- [x] all tests shall pass

