### PR TITLE
Update content scope scripts to version 6.14.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^10.15.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#13.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.14.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.14.1",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#5.1.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1724449523"
       },
@@ -71,7 +71,7 @@
       "hasInstallScript": true
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#1164f9579d226cf16c0c1c79c0928f28a4f3c421",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#b8c858a33cfe665ddfe177df4dbd63d12f6777a6",
       "hasInstallScript": true,
       "workspaces": [
         "packages/special-pages",
@@ -208,9 +208,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.5.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.3.tgz",
-      "integrity": "sha512-njripolh85IA9SQGTAqbmnNZTdxv7X/4OYGPz8tgy5JDr8MP+uDBa921GpYEoDDnwm0Hmn5ZPeJgiiSTPoOzkQ==",
+      "version": "22.5.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.4.tgz",
+      "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
       "dev": true,
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -651,16 +651,16 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.41",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.41.tgz",
-      "integrity": "sha512-SkwZgo1ZzMp2ziMBwci5VBnLR9VywCi02jSgMX5TO5kf9fdaBsxZkblLff3NlJNTcH0vfvEsgw2B7jVR556Vgw=="
+      "version": "6.1.42",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.42.tgz",
+      "integrity": "sha512-MJKxTFpAyUNxST7IrONoeQcFXuF3tQvnVuJ8IRBlA9rzlsAt1speUZSQxai3jrWwxMJ29FWrdpUWBW2pN99Ftw=="
     },
     "node_modules/tldts-experimental": {
-      "version": "6.1.41",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.41.tgz",
-      "integrity": "sha512-sHpzKl2XpmoByBEZvEyTcq/58YPSdA4LDXN2yFQDm7P+i8z8FTDH9IAGkz/GKdgHtP2Doc50BvoHrgm1y/hqmg==",
+      "version": "6.1.42",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.42.tgz",
+      "integrity": "sha512-FAClS//rR4811xTFbSz5X9OpzT1V0s7N3Yoo9zHVV+DixzFE1c1inVAlEmmMun6+x8u1pJFSYzzIKOCiTLjThA==",
       "dependencies": {
-        "tldts-core": "^6.1.41"
+        "tldts-core": "^6.1.42"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^10.15.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#13.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.14.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.14.1",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#5.1.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1724449523"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208241984651435/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass