### PR TITLE
Reduce the initial prod rollout percentage from 0.1% to 0.0001%

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -65,7 +65,7 @@ platform :android do
     upload_to_play_store(
       apk: apkPath,
       track: 'production',
-      rollout: '0.001', # ie. 0.1%
+      rollout: '0.000001', # ie. 0.0001%
       skip_upload_screenshots: true,
       skip_upload_images: true,
       validate_only: false


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208270529332156/f 

### Description
Sets the initial rollout percentage to a lower value.

| Before | After |
|--------|--------|
| 0.1% | 0.0001% |

Can't find a definitive answer on what the smallest possible value is that the Play Store will still accept, but anecdotally this should work.  

### Steps to test this PR
QA-optional; will find out next time a release is cut if it works (and can revert if it doesn't)