### PR TITLE
Ensure InstallSource extraction logic runs after privacy config downloaded

### DIFF
--- a/installation/installation-impl/src/main/java/com/duckduckgo/installation/impl/installer/InstallSourcePrivacyConfigObserver.kt
+++ b/installation/installation-impl/src/main/java/com/duckduckgo/installation/impl/installer/InstallSourcePrivacyConfigObserver.kt
@@ -16,17 +16,17 @@
 
 package com.duckduckgo.installation.impl.installer
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.edit
-import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.di.AppCoroutineScope
-import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.installation.impl.installer.InstallationPixelName.APP_INSTALLER_PACKAGE_NAME
+import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
 import javax.inject.Inject
@@ -34,26 +34,25 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
+@SuppressLint("DenyListedApi")
 @ContributesMultibinding(
     scope = AppScope::class,
-    boundType = MainProcessLifecycleObserver::class,
+    boundType = PrivacyConfigCallbackPlugin::class,
 )
 @SingleInstanceIn(AppScope::class)
-class InstallSourceLifecycleObserver @Inject constructor(
+class InstallSourcePrivacyConfigObserver @Inject constructor(
     private val installSourceExtractor: InstallSourceExtractor,
     private val context: Context,
     private val pixel: Pixel,
     private val dispatchers: DispatcherProvider,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
-) : MainProcessLifecycleObserver {
+) : PrivacyConfigCallbackPlugin {
 
     private val sharedPreferences: SharedPreferences by lazy {
         context.getSharedPreferences(SHARED_PREFERENCES_FILENAME, Context.MODE_PRIVATE)
     }
 
-    override fun onCreate(owner: LifecycleOwner) {
-        super.onCreate(owner)
-
+    override fun onPrivacyConfigDownloaded() {
         appCoroutineScope.launch(dispatchers.io()) {
             if (!hasAlreadyProcessed()) {
                 val installationSource = installSourceExtractor.extract()

--- a/installation/installation-impl/src/test/java/InstallSourcePrivacyConfigObserverTest.kt
+++ b/installation/installation-impl/src/test/java/InstallSourcePrivacyConfigObserverTest.kt
@@ -16,7 +16,6 @@
 
 package com.duckduckgo.installation.impl.installer
 
-import androidx.lifecycle.LifecycleOwner
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
@@ -34,17 +33,16 @@ import org.mockito.kotlin.verify
 import org.robolectric.RuntimeEnvironment
 
 @RunWith(AndroidJUnit4::class)
-class InstallSourceLifecycleObserverTest {
+class InstallSourcePrivacyConfigObserverTest {
 
     @get:Rule
     val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
 
-    private val mockLifecycleOwner = mock<LifecycleOwner>()
     private val mockPixel = mock<Pixel>()
     private val context = RuntimeEnvironment.getApplication()
     private val mockInstallSourceExtractor = mock<InstallSourceExtractor>()
 
-    private val testee = InstallSourceLifecycleObserver(
+    private val testee = InstallSourcePrivacyConfigObserver(
         context = context,
         pixel = mockPixel,
         dispatchers = coroutineTestRule.testDispatcherProvider,
@@ -54,14 +52,14 @@ class InstallSourceLifecycleObserverTest {
 
     @Test
     fun whenNotPreviouslyProcessedThenPixelSent() = runTest {
-        testee.onCreate(mockLifecycleOwner)
+        testee.onPrivacyConfigDownloaded()
         verify(mockPixel).fire(eq(APP_INSTALLER_PACKAGE_NAME), any(), any(), eq(Count))
     }
 
     @Test
     fun whenPreviouslyProcessedThenPixelNotSent() = runTest {
         testee.recordInstallSourceProcessed()
-        testee.onCreate(mockLifecycleOwner)
+        testee.onPrivacyConfigDownloaded()
         verify(mockPixel, never()).fire(eq(APP_INSTALLER_PACKAGE_NAME), any(), any(), eq(Count))
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/608920331025315/1208315780180365/f 

### Description
Ensures install source extraction logic runs after privacy config has been downloaded. 
- This is needed by a higher level branch on the stack where remote config is read and used in the install source extraction. 
- This PR just lays the groundwork to support that use case

### Steps to test this PR

- [x] Fresh install
- [x] Run the app, and wait for privacy config to finish downloading
- [x] Verify you see `Installation source extracted` in the logs
- [x] Kill the app and re-open it, and wait for privacy config to finish
- [x] Verify you see `Already processed` in the logs