### PR TITLE
Fix survey's store declaration

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/survey/AutofillSurveyFeature.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/survey/AutofillSurveyFeature.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.autofill.impl.ui.credential.management.survey
 
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.app.di.AppCoroutineScope
-import com.duckduckgo.autofill.impl.reporting.remoteconfig.AutofillSiteBreakageReportingRemoteSettingsPersister
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.FeatureSettings
@@ -34,7 +33,7 @@ import kotlinx.coroutines.launch
     scope = AppScope::class,
     boundType = AutofillSurveysFeature::class,
     featureName = "autofillSurveys",
-    settingsStore = AutofillSiteBreakageReportingRemoteSettingsPersister::class,
+    settingsStore = AutofillSurveyFeatureSettingsStore::class,
 )
 /**
  * This is the class that represents the feature flag for showing autofill user-surveys.


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/608920331025315/1208317909207871/f 

### Description
To support saving the feature's settings for autofill surveys, we added a `AutofillSurveyFeatureSettingsStore`. However, the config of the autofill feature wrongly stated which settings store to use: 
- specified: `AutofillSiteBreakageReportingRemoteSettingsPersister`
- should have been: `AutofillSurveyFeatureSettingsStore`

This doesn't matter in terms of functionality. i.e., it works as expected (hence why it wasn't caught in testing), but still good to tidy up.

### Steps to test this PR
- QA optional