### PR TITLE
Move plugins to RefreshVersions

### DIFF
--- a/ad-click/ad-click-impl/build.gradle
+++ b/ad-click/ad-click-impl/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'com.squareup.anvil'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/anrs/anrs-internal/build.gradle
+++ b/anrs/anrs-internal/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'com.squareup.anvil'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/anrs/anrs-store/build.gradle
+++ b/anrs/anrs-store/build.gradle
@@ -17,7 +17,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/anvil/anvil-compiler/build.gradle
+++ b/anvil/anvil-compiler/build.gradle
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import static de.fayard.refreshVersions.core.Versions.versionFor
 
 plugins {
     id 'java-library'
@@ -34,8 +35,9 @@ kotlin {
 dependencies {
     implementation project(path: ':anvil-annotations')
 
-    api "com.squareup.anvil:compiler-api:${anvil_version}"
-    implementation("com.squareup.anvil:compiler-utils:${anvil_version}")
+    def anvil_version = versionFor(project, "plugin.com.squareup.anvil")
+    api "com.squareup.anvil:compiler-api:$anvil_version"
+    implementation("com.squareup.anvil:compiler-utils:$anvil_version")
     implementation("com.squareup:kotlinpoet:1.11.0")
     implementation Google.dagger
     implementation project(":feature-toggles-api")

--- a/anvil/anvil-compiler/build.gradle
+++ b/anvil/anvil-compiler/build.gradle
@@ -18,7 +18,7 @@ import static de.fayard.refreshVersions.core.Versions.versionFor
 plugins {
     id 'java-library'
     id 'kotlin'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/code-formatting.gradle"

--- a/app-store/build.gradle
+++ b/app-store/build.gradle
@@ -17,7 +17,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/app-tracking-protection/vpn-store/build.gradle
+++ b/app-tracking-protection/vpn-store/build.gradle
@@ -17,7 +17,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,7 +3,7 @@ plugins {
 
     id 'kotlin-android'
     id 'kotlin-kapt'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
     id 'com.squareup.anvil'
 }
 apply from: '../versioning.gradle'
@@ -448,6 +448,9 @@ dependencies {
     // Flipper
     internalImplementation "com.facebook.flipper:flipper:_"
     internalImplementation "com.facebook.soloader:soloader:_"
+
+    internalImplementation "com.github.YarikSOffice.Venom:venom:_"
+    playImplementation "com.github.YarikSOffice.Venom:venom-no-op:_"
 
     // Testing dependencies
     androidTestUtil AndroidX.test.orchestrator

--- a/autoconsent/autoconsent-impl/build.gradle
+++ b/autoconsent/autoconsent-impl/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'com.squareup.anvil'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/autofill/autofill-store/build.gradle
+++ b/autofill/autofill-store/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/breakage-reporting/breakage-reporting-impl/build.gradle
+++ b/breakage-reporting/breakage-reporting-impl/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'com.squareup.anvil'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/broken-site/broken-site-store/build.gradle
+++ b/broken-site/broken-site-store/build.gradle
@@ -17,7 +17,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -1,23 +1,18 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+import static de.fayard.refreshVersions.core.Versions.versionFor
 
 buildscript {
 
     ext {
-        kotlin_version = '1.9.24'
-        spotless = '6.1.2'
-        anvil_version = '2.5.0-beta11'
         ksp_version = '1.9.24-1.0.20'
-        gradle_plugin = '8.5.1'
         min_sdk = 26
         target_sdk = 34
         compile_sdk = 34
-        fladle_version = '0.17.4'
-        kotlinter_version = '3.12.0'
-        dokka_version = '1.8.20'
 
         // Calculate lint_version (must always be gradle_plugin + 23)
-        def components = gradle_plugin.split('\\.')
-        lint_version = gradle_plugin.replaceFirst(components[0], (components[0].toInteger() + 23).toString())
+        def gradle_plugin_version = versionFor(project, Android.tools.build.gradlePlugin)
+        def components = gradle_plugin_version.split('\\.')
+        lint_version = gradle_plugin_version.replaceFirst(components[0], (components[0].toInteger() + 23).toString())
     }
 
     repositories {
@@ -26,10 +21,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:$gradle_plugin"
-        classpath "com.diffplug.spotless:spotless-plugin-gradle:$spotless"
-        classpath "com.squareup.anvil:gradle-plugin:$anvil_version"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath(Android.tools.build.gradlePlugin)
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -37,15 +29,19 @@ buildscript {
 }
 
 plugins {
-    id 'org.jetbrains.dokka' version "$dokka_version"
-    id 'com.osacky.fulladle' version "$fladle_version"
-    id 'org.jmailen.kotlinter' version "$kotlinter_version" apply false
+    id 'com.squareup.anvil' apply false
+    id 'org.jetbrains.dokka'
+    id 'com.osacky.fulladle'
+    id 'org.jetbrains.kotlin.android' apply false
+    id 'org.jmailen.kotlinter' apply false
+    id 'com.diffplug.spotless' apply false
 }
 
 allprojects {
     repositories {
         google()
         mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
     configurations.all {
         resolutionStrategy.force 'org.objenesis:objenesis:2.6'

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ import static de.fayard.refreshVersions.core.Versions.versionFor
 buildscript {
 
     ext {
-        ksp_version = '1.9.24-1.0.20'
         min_sdk = 26
         target_sdk = 34
         compile_sdk = 34
@@ -34,6 +33,7 @@ plugins {
     id 'com.osacky.fulladle'
     id 'org.jetbrains.kotlin.android' apply false
     id 'org.jmailen.kotlinter' apply false
+    id 'com.google.devtools.ksp' apply false
     id 'com.diffplug.spotless' apply false
 }
 

--- a/common/common-utils/build.gradle
+++ b/common/common-utils/build.gradle
@@ -17,7 +17,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
     id 'com.squareup.anvil'
 }
 

--- a/cookies/cookies-store/build.gradle
+++ b/cookies/cookies-store/build.gradle
@@ -17,7 +17,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/custom-tabs/custom-tabs-impl/build.gradle
+++ b/custom-tabs/custom-tabs-impl/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'com.squareup.anvil'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/data-store/data-store-impl/build.gradle
+++ b/data-store/data-store-impl/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'com.squareup.anvil'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/downloads/downloads-store/build.gradle
+++ b/downloads/downloads-store/build.gradle
@@ -17,7 +17,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/duckplayer/duckplayer-impl/build.gradle
+++ b/duckplayer/duckplayer-impl/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'com.squareup.anvil'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/element-hiding/element-hiding-store/build.gradle
+++ b/element-hiding/element-hiding-store/build.gradle
@@ -17,7 +17,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/example-feature/example-feature-impl/build.gradle
+++ b/example-feature/example-feature-impl/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'com.squareup.anvil'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/example-feature/example-feature-internal/build.gradle
+++ b/example-feature/example-feature-internal/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'com.squareup.anvil'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/experiments/experiments-impl/build.gradle
+++ b/experiments/experiments-impl/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'com.squareup.anvil'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/feature-toggles/feature-toggles-internal/build.gradle
+++ b/feature-toggles/feature-toggles-internal/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'com.squareup.anvil'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/fingerprint-protection/fingerprint-protection-store/build.gradle
+++ b/fingerprint-protection/fingerprint-protection-store/build.gradle
@@ -17,7 +17,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/history/history-impl/build.gradle
+++ b/history/history-impl/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'com.squareup.anvil'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/httpsupgrade/httpsupgrade-store/build.gradle
+++ b/httpsupgrade/httpsupgrade-store/build.gradle
@@ -17,7 +17,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/network-protection/network-protection-store/build.gradle
+++ b/network-protection/network-protection-store/build.gradle
@@ -17,7 +17,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/new-tab-page/new-tab-page-impl/build.gradle
+++ b/new-tab-page/new-tab-page-impl/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'com.squareup.anvil'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/privacy-config/privacy-config-store/build.gradle
+++ b/privacy-config/privacy-config-store/build.gradle
@@ -17,7 +17,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/privacy-protections-popup/privacy-protections-popup-impl/build.gradle
+++ b/privacy-protections-popup/privacy-protections-popup-impl/build.gradle
@@ -17,7 +17,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
     id 'com.squareup.anvil'
 }
 

--- a/remote-messaging/remote-messaging-internal/build.gradle
+++ b/remote-messaging/remote-messaging-internal/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'com.squareup.anvil'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/remote-messaging/remote-messaging-store/build.gradle
+++ b/remote-messaging/remote-messaging-store/build.gradle
@@ -17,7 +17,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/request-filterer/request-filterer-store/build.gradle
+++ b/request-filterer/request-filterer-store/build.gradle
@@ -17,7 +17,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/runtime-checks/runtime-checks-store/build.gradle
+++ b/runtime-checks/runtime-checks-store/build.gradle
@@ -17,7 +17,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/saved-sites/saved-sites-impl/build.gradle
+++ b/saved-sites/saved-sites-impl/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'com.squareup.anvil'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/saved-sites/saved-sites-store/build.gradle
+++ b/saved-sites/saved-sites-store/build.gradle
@@ -17,7 +17,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/site-permissions/site-permissions-store/build.gradle
+++ b/site-permissions/site-permissions-store/build.gradle
@@ -17,7 +17,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/statistics/statistics-impl/build.gradle
+++ b/statistics/statistics-impl/build.gradle
@@ -17,7 +17,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
     id 'com.squareup.anvil'
 }
 

--- a/sync/sync-settings-impl/build.gradle
+++ b/sync/sync-settings-impl/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'com.squareup.anvil'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/sync/sync-store/build.gradle
+++ b/sync/sync-store/build.gradle
@@ -17,7 +17,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/user-agent/user-agent-impl/build.gradle
+++ b/user-agent/user-agent-impl/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'com.squareup.anvil'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/user-agent/user-agent-store/build.gradle
+++ b/user-agent/user-agent-store/build.gradle
@@ -17,7 +17,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/verified-installation/verified-installation-impl/build.gradle
+++ b/verified-installation/verified-installation-impl/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'com.squareup.anvil'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/versions.properties
+++ b/versions.properties
@@ -19,6 +19,8 @@ plugin.org.jetbrains.kotlin=1.9.24
 
 plugin.org.jmailen.kotlinter=3.12.0
 
+plugin.com.google.devtools.ksp=1.9.24-1.0.20
+
 plugin.com.diffplug.spotless=6.1.2
 
 version.android.billingclient=6.0.1
@@ -84,6 +86,10 @@ version.com.frybits.harmony..harmony=1.2.6
 version.com.frybits.harmony..harmony-crypto=1.2.6
 
 version.com.getkeepsafe.relinker..relinker=1.4.5
+
+version.com.github.YarikSOffice.Venom..venom=0.7.1
+
+version.com.github.YarikSOffice.Venom..venom-no-op=0.7.1
 
 version.com.github.bumptech.glide..ksp=4.16.0
 

--- a/versions.properties
+++ b/versions.properties
@@ -7,6 +7,20 @@
 #### suppress inspection "SpellCheckingInspection" for whole file
 #### suppress inspection "UnusedProperty" for whole file
 
+plugin.android=8.5.1
+
+plugin.com.squareup.anvil=2.5.0-beta11
+
+plugin.org.jetbrains.dokka=1.8.20
+
+plugin.com.osacky.fulladle=0.17.4
+
+plugin.org.jetbrains.kotlin=1.9.24
+
+plugin.org.jmailen.kotlinter=3.12.0
+
+plugin.com.diffplug.spotless=6.1.2
+
 version.android.billingclient=6.0.1
 
 version.androidx.appcompat=1.7.0

--- a/voice-search/voice-search-store/build.gradle
+++ b/voice-search/voice-search-store/build.gradle
@@ -17,7 +17,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"

--- a/web-compat/web-compat-store/build.gradle
+++ b/web-compat/web-compat-store/build.gradle
@@ -17,7 +17,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'com.google.devtools.ksp' version "$ksp_version"
+    id 'com.google.devtools.ksp'
 }
 
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207908166761516/1208315099637999/f 

### Description

Moves our plugins to refreshVersions so that they will be updated when the `refreshVersions` task is run.

As part of this moved all but the AGP plugin to the plugins block. Not quite sure why that one didn’t want to work but don’t want to spend too much time on it, it’s still part of RefreshVersions. 

I did not update the plugins as part of this PR.

### Steps to test this PR

_Feature 1_
- [ ] Check the plugin versions in `versions.properties` match the previous versions
- [ ] Run `./gradlew refreshVersions` and check the plugins get update comments (if they have an update of course) 
- [ ] Sync, build & run should be successful

### UI changes
 
N/A

### Screenshot of the changes working

<img width="702" alt="Screenshot 2024-09-17 at 11 19 50" src="https://github.com/user-attachments/assets/9bde859d-95d0-4cc4-a368-caec1960cd70">
