### PR TITLE
Update content scope scripts to version 6.16.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -12192,9 +12192,7 @@
                         overlayInteracted: false,
                         privatePlayerMode: { alwaysAsk: {} }
                     },
-                    ui: {
-                        overlayCopy: this.environment.getOverlayCopyOverride() || 'default'
-                    }
+                    ui: {}
                 })
             }
             return this.messaging.request(MSG_NAME_INITIAL_SETUP)
@@ -12678,15 +12676,6 @@
     };
 
     /**
-     * Converts occurrences of {newline} in a string to <br> tags
-     * @param {string} text
-     */
-    function nl2br (text) {
-        return html`${text.split('{newline}')
-        .map((line, i) => i === 0 ? line : html`<br>${line}`)}`
-    }
-
-    /**
      * @typedef {ReturnType<html>} Template
      */
 
@@ -12700,25 +12689,11 @@
      */
 
     /**
-     *  @type {Record<import('../duck-player').UISettings['overlayCopy'], OverlayCopyTranslation>}
+     *  @type {Record<'default', OverlayCopyTranslation>}
      */
     const overlayCopyVariants = {
         default: {
-            title: i18n.t('videoOverlayTitle'),
-            subtitle: html`<b>${i18n.t('playText')}</b> ${i18n.t('videoOverlaySubtitle')}`,
-            buttonOptOut: i18n.t('videoButtonOptOut'),
-            buttonOpen: i18n.t('videoButtonOpen'),
-            rememberLabel: i18n.t('rememberLabel')
-        },
-        a1: {
             title: i18n.t('videoOverlayTitle2'),
-            subtitle: i18n.t('videoOverlaySubtitle2'),
-            buttonOptOut: i18n.t('videoButtonOptOut2'),
-            buttonOpen: i18n.t('videoButtonOpen2'),
-            rememberLabel: i18n.t('rememberLabel')
-        },
-        b1: {
-            title: nl2br(i18n.t('videoOverlayTitle3')),
             subtitle: i18n.t('videoOverlaySubtitle2'),
             buttonOptOut: i18n.t('videoButtonOptOut2'),
             buttonOpen: i18n.t('videoButtonOpen2'),
@@ -13374,7 +13349,7 @@
          * @returns {HTMLDivElement}
          */
         createOverlay () {
-            const overlayCopy = overlayCopyVariants[this.ui?.overlayCopy || 'default'];
+            const overlayCopy = overlayCopyVariants.default;
             const overlayElement = document.createElement('div');
             overlayElement.classList.add('ddg-video-player-overlay');
             const svgIcon = trustedUnsafe(dax);
@@ -14280,22 +14255,6 @@
             return false
         }
 
-        /**
-         * @returns {import("../duck-player.js").UISettings['overlayCopy'] | null}
-         */
-        getOverlayCopyOverride () {
-            if (this.isIntegrationMode()) {
-                const allowedOverlayCopyOverrides = ['default', 'a1', 'b1'];
-
-                const url = new URLSearchParams(window.location.href);
-                const override = url.get('overlayCopy');
-                if (override && allowedOverlayCopyOverrides.includes(override)) {
-                    return /** @type {import("../duck-player.js").UISettings['overlayCopy']} */ (override)
-                }
-            }
-            return null
-        }
-
         isIntegrationMode () {
             return this.debug === true && this.injectName === 'integration'
         }
@@ -14378,7 +14337,6 @@
 
     /**
      * @typedef UISettings - UI-specific settings
-     * @property {'default'|'a1'|'b1'} overlayCopy - Overlay copy experiment variant
      * @property {boolean} [allowFirstVideo] - should the first video be allowed to load/play?
      * @property {boolean} [playInDuckPlayer] - Forces next video to be played in Duck Player regardless of user setting
      */

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^10.15.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#13.1.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.15.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.16.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#5.1.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1724449523"
       },
@@ -68,11 +68,10 @@
     },
     "node_modules/@duckduckgo/autofill": {
       "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#1fee787458d13f8ed07f9fe81aecd6e59609339e",
-      "hasInstallScript": true,
-      "license": "Apache-2.0"
+      "hasInstallScript": true
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#9f3717b3913a12956f1386fe7b657f68545fba83",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#4f0d109f13beec7e8beaf0bd5c0e2c1d528677f8",
       "hasInstallScript": true,
       "workspaces": [
         "packages/special-pages",
@@ -209,9 +208,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.5.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.4.tgz",
-      "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
+      "version": "22.5.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.5.tgz",
+      "integrity": "sha512-Xjs4y5UPO/CLdzpgR6GirZJx36yScjh73+2NlLlkFRSoQN8B0DpfXPdZGnvVmLRLOsqDpOfTNv7D9trgGhmOIA==",
       "dev": true,
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -634,9 +633,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.32.0.tgz",
-      "integrity": "sha512-v3Gtw3IzpBJ0ugkxEX8U0W6+TnPKRRCWGh1jC/iM/e3Ki5+qvO1L1EAZ56bZasc64aXHwRHNIQEzm6//i5cemQ==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.33.0.tgz",
+      "integrity": "sha512-JuPVaB7s1gdFKPKTelwUyRq5Sid2A3Gko2S0PncwdBq7kN9Ti9HPWDQ06MPsEDGsZeVESjKEnyGy68quBk1w6g==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -652,16 +651,16 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.43",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.43.tgz",
-      "integrity": "sha512-iO1G3F2NqtmJUYlTfcH2liSdaqDnjpYn6iGftbLRNx8DF6IRIjbknVt+q0ijwZ2KGZX3J8zeYGFoiI+ZtHT5MQ=="
+      "version": "6.1.46",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.46.tgz",
+      "integrity": "sha512-zA3ai/j4aFcmbqTvTONkSBuWs0Q4X4tJxa0gV9sp6kDbq5dAhQDSg0WUkReEm0fBAKAGNj+wPKCCsR8MYOYmwA=="
     },
     "node_modules/tldts-experimental": {
-      "version": "6.1.43",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.43.tgz",
-      "integrity": "sha512-sziyPA9lOF4QQ1lB51HYVvPfoGmwWEuMrpJ9PleIRLWf1RU3O5JWqEDF07EiuuqilBOPfoeZvnJhOVYksTMtoA==",
+      "version": "6.1.46",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.46.tgz",
+      "integrity": "sha512-u99EeyzhUNRwJep1M1CXBGmQ6OWncv0bi98/9CBv+AX6ep0B3HOkl0iS+C2OisWWoMBXdNkdNQa85aLkyrWwlA==",
       "dependencies": {
-        "tldts-core": "^6.1.43"
+        "tldts-core": "^6.1.46"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^10.15.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#13.1.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.15.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.16.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#5.1.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1724449523"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass