### PR TITLE
Fix for search/site suggestions not working after skipping typing animation

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -496,7 +496,9 @@ sealed class DaxBubbleCta(
                 )
                 optionsViews.forEachIndexed { index, buttonView ->
                     it[index].setOptionView(buttonView)
-                    buttonView.animate().alpha(1f).setDuration(500L).startDelay = 2800L
+                    buttonView.animate().alpha(1f).setDuration(500L).setStartDelay(2800L).withEndAction {
+                        onTypingAnimationFinished()
+                    }
                 }
             }
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201807753394693/1208330088276454/f

### Description
set onClickListener for search/site suggestions when typing animation is finished

### Steps to test this PR

- [ ] Fresh install
- [ ] Go to browser
- [ ] When search Dax dialog appears skip typing animation tapping on description
- [ ] When typing animation is finished and options appear, tap on an option
- [ ] Check suggestions work and you navigate to the correct search page
- [ ] Open a new tab
- [ ] Check site suggestions work as expected when typing animation is skipped too

### No UI changes
