### PR TITLE
Fix blob download for parent frames when they have child frames

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2529,7 +2529,6 @@ class BrowserTabFragment :
                         ) {
                             if (message.data?.startsWith("data:") == true) {
                                 requestFileDownload(message.data!!, null, "", true)
-                                return
                             } else if (message.data?.startsWith("Ping:") == true) {
                                 val locationRef = message.data.toString().encode().md5().toString()
                                 viewModel.saveReplyProxyForBlobDownload(sourceOrigin.toString(), replyProxy, locationRef)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -334,6 +334,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import okio.ByteString.Companion.encode
 import org.json.JSONObject
 import timber.log.Timber
 
@@ -2529,8 +2530,10 @@ class BrowserTabFragment :
                             if (message.data?.startsWith("data:") == true) {
                                 requestFileDownload(message.data!!, null, "", true)
                                 return
+                            } else if (message.data?.startsWith("Ping:") == true) {
+                                val locationRef = message.data.toString().encode().md5().toString()
+                                viewModel.saveReplyProxyForBlobDownload(sourceOrigin.toString(), replyProxy, locationRef)
                             }
-                            viewModel.saveReplyProxyForBlobDownload(sourceOrigin.toString(), replyProxy)
                         }
                     },
                 )
@@ -2576,7 +2579,8 @@ class BrowserTabFragment :
                 });
             }
         
-            ddgBlobDownloadObj.postMessage('Ping')
+            const pingMessage = 'Ping:' + window.location.href
+            ddgBlobDownloadObj.postMessage(pingMessage)
                     
             ddgBlobDownloadObj.onmessage = function(event) {
                 if (event.data.startsWith('blob:')) {

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -19,7 +19,6 @@ package com.duckduckgo.app.pixels.remoteconfig
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
-import com.duckduckgo.feature.toggles.api.Toggle.InternalAlwaysEnabled
 
 /**
  * This is the class that represents the browser feature flags
@@ -76,6 +75,5 @@ interface AndroidBrowserConfigFeature {
      * @return `true` when the remote feature is enabled.
      */
     @Toggle.DefaultValue(true)
-    @InternalAlwaysEnabled
     fun fixBlobDownloadWithIframes(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.pixels.remoteconfig
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.InternalAlwaysEnabled
 
 /**
  * This is the class that represents the browser feature flags
@@ -67,4 +68,14 @@ interface AndroidBrowserConfigFeature {
      */
     @Toggle.DefaultValue(false)
     fun optimizeTrackerEvaluationV2(): Toggle
+
+    /**
+     * This feature flag guards a fix for blob downloads
+     *
+     * @return always returns `true` for internal builds
+     * @return `true` when the remote feature is enabled.
+     */
+    @Toggle.DefaultValue(true)
+    @InternalAlwaysEnabled
+    fun fixBlobDownloadWithIframes(): Toggle
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208310633343752/f

### Description
Fix blob download when the page contains both parent and child frames

### Steps to test this PR

_Test 1_
- [x] test the use case defined in the Asana task and verify download works

_Test2_
- [x] Verify https://app.asana.com/0/1202552961248957/1206811138963758/f works
- [x] Verify https://app.asana.com/0/1202552961248957/1205697340542591/f works
- [x] Verify https://app.asana.com/0/0/1207170034333645/f works