### PR TITLE
Fix keyboard crashes in BrowserFragment

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -268,7 +268,9 @@ import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.FragmentViewModelFactory
 import com.duckduckgo.common.utils.KeyboardVisibilityUtil
+import com.duckduckgo.common.utils.extensions.hideKeyboard
 import com.duckduckgo.common.utils.extensions.html
+import com.duckduckgo.common.utils.extensions.showKeyboard
 import com.duckduckgo.common.utils.extensions.toBinaryString
 import com.duckduckgo.common.utils.extensions.websiteFromGeoLocationsApiOrigin
 import com.duckduckgo.common.utils.extractDomain
@@ -3080,7 +3082,7 @@ class BrowserTabFragment :
     private fun hideKeyboard() {
         if (!isHidden) {
             Timber.v("Keyboard now hiding")
-            binding.legacyOmnibar.omnibarTextInput.postDelayed(KEYBOARD_DELAY) { binding.legacyOmnibar.omnibarTextInput?.hideKeyboard() }
+            hideKeyboard(binding.legacyOmnibar.omnibarTextInput)
             binding.focusDummy.requestFocus()
             binding.legacyOmnibar.omniBarContainer.isPressed = false
         }
@@ -3096,8 +3098,10 @@ class BrowserTabFragment :
     private fun showKeyboard() {
         if (!isHidden) {
             Timber.v("Keyboard now showing")
-            binding.legacyOmnibar.omnibarTextInput.postDelayed(KEYBOARD_DELAY) { binding.legacyOmnibar.omnibarTextInput?.showKeyboard() }
-            binding.legacyOmnibar.omniBarContainer.isPressed = true
+            with(binding.legacyOmnibar.omnibarTextInput) {
+                showKeyboard(this)
+                isPressed = true
+            }
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -3098,10 +3098,8 @@ class BrowserTabFragment :
     private fun showKeyboard() {
         if (!isHidden) {
             Timber.v("Keyboard now showing")
-            with(binding.legacyOmnibar.omnibarTextInput) {
-                showKeyboard(this)
-                isPressed = true
-            }
+            showKeyboard(binding.legacyOmnibar.omnibarTextInput)
+            binding.legacyOmnibar.omniBarContainer.isPressed = true
         }
     }
 

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/ViewExtension.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/ViewExtension.kt
@@ -58,6 +58,10 @@ fun View.gone(): View {
 }
 
 /** Extension method to show a keyboard for View. */
+@Deprecated(
+    "This may be unreliable. Use the showKeyboard() extension function from an Activity or Fragment instead.",
+    ReplaceWith("Activity.showKeyboard(editText)"),
+)
 fun View.showKeyboard() {
     val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
     this.requestFocus()
@@ -68,6 +72,10 @@ fun View.showKeyboard() {
  * Try to hide the keyboard and returns whether it worked
  * https://stackoverflow.com/questions/1109022/close-hide-the-android-soft-keyboard
  */
+@Deprecated(
+    "This may be unreliable. Use the hideKeyboard() extension function from an Activity or Fragment instead.",
+    ReplaceWith("Activity.hideKeyboard(editText)"),
+)
 fun View.hideKeyboard(): Boolean {
     try {
         val inputMethodManager =

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/extensions/ActivityExtensions.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/extensions/ActivityExtensions.kt
@@ -17,10 +17,14 @@
 package com.duckduckgo.common.utils.extensions
 
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.content.Intent
 import android.net.Uri
 import android.provider.Settings
+import android.widget.EditText
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 
 /**
  * Deep links to the application App Info settings
@@ -70,4 +74,14 @@ fun AppCompatActivity.launchIgnoreBatteryOptimizationSettings(): Boolean {
     }
 
     return true
+}
+
+fun Activity.showKeyboard(editText: EditText) {
+    editText.requestFocus()
+    WindowInsetsControllerCompat(window, editText).show(WindowInsetsCompat.Type.ime())
+}
+
+fun Activity.hideKeyboard(editText: EditText) {
+    editText.requestFocus()
+    WindowInsetsControllerCompat(window, editText).hide(WindowInsetsCompat.Type.ime())
 }

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/extensions/FragmentExtensions.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/extensions/FragmentExtensions.kt
@@ -21,4 +21,4 @@ import androidx.fragment.app.Fragment
 
 fun Fragment.showKeyboard(editText: EditText) = requireActivity().showKeyboard(editText)
 
-fun Fragment.hideKeyboard(editText: EditText) = requireActivity().showKeyboard(editText)
+fun Fragment.hideKeyboard(editText: EditText) = requireActivity().hideKeyboard(editText)

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/extensions/FragmentExtensions.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/extensions/FragmentExtensions.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.utils.extensions
+
+import android.widget.EditText
+import androidx.fragment.app.Fragment
+
+fun Fragment.showKeyboard(editText: EditText) = requireActivity().showKeyboard(editText)
+
+fun Fragment.hideKeyboard(editText: EditText) = requireActivity().showKeyboard(editText)

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/extensions/FragmentExtensions.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/extensions/FragmentExtensions.kt
@@ -19,6 +19,6 @@ package com.duckduckgo.common.utils.extensions
 import android.widget.EditText
 import androidx.fragment.app.Fragment
 
-fun Fragment.showKeyboard(editText: EditText) = requireActivity().showKeyboard(editText)
+fun Fragment.showKeyboard(editText: EditText) = activity?.showKeyboard(editText)
 
-fun Fragment.hideKeyboard(editText: EditText) = requireActivity().hideKeyboard(editText)
+fun Fragment.hideKeyboard(editText: EditText) = activity?.hideKeyboard(editText)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414730916066338/1208339084893367/f 

### Description

We saw some keyboard crashes due to some recent refactoring of the Omnibar.

The Omnibar was previously solely bound in onActivityCreated.

It was never nulled out in `onDestroyView` so the Fragment held on to it, and when the delay concluded it would happily try to call show/hideKeyboard using the Omnibar without issue.

Now, we’re using the FragmentViewBindingDelegate for the Omnibar, which gets nulled out in onDestroy, so when the delay concluded we tried calling show/hideKeyboard on a null object. 

To fix this we’re introducing new extension functions that follow the [recommended way](https://developer.android.com/develop/ui/views/touch-and-input/keyboard-input/visibility#kotlin) to show and hide the keyboard. 

### Steps to test this PR

_Run the following tests locally they should all pass_
- [x] `whenProtectionsAreDisabledRequestAreNotBlocked`
- [x] `whenProtectionsAreDisabledSurrogatesAreNotLoaded`
- [x] `whenProtectionsAreEnabledHttpsUpgradedCorrectly`
- [x] `whenProtectionsAreEnabledRequestBlockedCorrectly`
- [x] `whenProtectionsAreEnabledSurrogatesAreLoaded`
- [x] `whenProtectionsAreFingerprintProtected`

_Omnibar Keyboard_
- [x] Ensure keyboard shows when opening app with New Tab Page
- [x] Generally play around with the Omnibar EditText and ensure keyboard is shown and hidden where appropriate

### UI changes

N/A
