### PR TITLE
Show on App Launch: Add pixels

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/generalsettings/GeneralSettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/GeneralSettingsViewModel.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption
 import com.duckduckgo.app.generalsettings.showonapplaunch.store.ShowOnAppLaunchOptionDataStore
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.pixels.AppPixelName.AUTOCOMPLETE_GENERAL_SETTINGS_TOGGLED_OFF
 import com.duckduckgo.app.pixels.AppPixelName.AUTOCOMPLETE_GENERAL_SETTINGS_TOGGLED_ON
 import com.duckduckgo.app.pixels.AppPixelName.AUTOCOMPLETE_RECENT_SITES_GENERAL_SETTINGS_TOGGLED_OFF
@@ -143,6 +144,7 @@ class GeneralSettingsViewModel @Inject constructor(
 
     fun onShowOnAppLaunchButtonClick() {
         sendCommand(Command.LaunchShowOnAppLaunchScreen)
+        pixel.fire(AppPixelName.SETTINGS_GENERAL_APP_LAUNCH_PRESSED)
     }
 
     private fun observeShowOnAppLaunchOption() {

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchStateReporterPlugin.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchStateReporterPlugin.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.generalsettings.showonapplaunch
+
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption
+import com.duckduckgo.app.generalsettings.showonapplaunch.store.ShowOnAppLaunchOptionDataStore
+import com.duckduckgo.app.statistics.api.BrowserFeatureStateReporterPlugin
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+
+interface ShowOnAppLaunchReporterPlugin
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = BrowserFeatureStateReporterPlugin::class,
+)
+@ContributesBinding(scope = AppScope::class, boundType = ShowOnAppLaunchReporterPlugin::class)
+class ShowOnAppLaunchStateReporterPlugin
+@Inject
+constructor(
+    private val dispatcherProvider: DispatcherProvider,
+    private val showOnAppLaunchOptionDataStore: ShowOnAppLaunchOptionDataStore,
+) : ShowOnAppLaunchReporterPlugin, BrowserFeatureStateReporterPlugin {
+
+    override fun featureStateParams(): Map<String, String> {
+        val option =
+            runBlocking(dispatcherProvider.io()) {
+                showOnAppLaunchOptionDataStore.optionFlow.first()
+            }
+        val dailyPixelValue = ShowOnAppLaunchOption.getDailyPixelValue(option)
+        return mapOf(PixelParameter.LAUNCH_SCREEN to dailyPixelValue)
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModel.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption
 import com.duckduckgo.app.generalsettings.showonapplaunch.store.ShowOnAppLaunchOptionDataStore
+import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import javax.inject.Inject
@@ -38,6 +39,7 @@ class ShowOnAppLaunchViewModel @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
     private val showOnAppLaunchOptionDataStore: ShowOnAppLaunchOptionDataStore,
     private val urlConverter: UrlConverter,
+    private val pixel: Pixel,
 ) : ViewModel() {
 
     data class ViewState(
@@ -65,6 +67,7 @@ class ShowOnAppLaunchViewModel @Inject constructor(
     fun onShowOnAppLaunchOptionChanged(option: ShowOnAppLaunchOption) {
         Timber.i("User changed show on app launch option to $option")
         viewModelScope.launch(dispatcherProvider.io()) {
+            firePixel(option)
             showOnAppLaunchOptionDataStore.setShowOnAppLaunchOption(option)
         }
     }
@@ -75,5 +78,10 @@ class ShowOnAppLaunchViewModel @Inject constructor(
             val convertedUrl = urlConverter.convertUrl(url)
             showOnAppLaunchOptionDataStore.setSpecificPageUrl(convertedUrl)
         }
+    }
+
+    private fun firePixel(option: ShowOnAppLaunchOption) {
+        val pixelName = ShowOnAppLaunchOption.getPixelName(option)
+        pixel.fire(pixelName)
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/model/ShowOnAppLaunchOption.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/model/ShowOnAppLaunchOption.kt
@@ -40,5 +40,11 @@ sealed class ShowOnAppLaunchOption(val id: Int) {
             NewTabPage -> SETTINGS_GENERAL_APP_LAUNCH_NEW_TAB_PAGE_SELECTED
             is SpecificPage -> SETTINGS_GENERAL_APP_LAUNCH_SPECIFIC_PAGE_SELECTED
         }
+
+        fun getDailyPixelValue(option: ShowOnAppLaunchOption) = when (option) {
+            LastOpenedTab -> "last_opened_tab"
+            NewTabPage -> "new_tab_page"
+            is SpecificPage -> "specific_page"
+        }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/model/ShowOnAppLaunchOption.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/model/ShowOnAppLaunchOption.kt
@@ -16,6 +16,10 @@
 
 package com.duckduckgo.app.generalsettings.showonapplaunch.model
 
+import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_GENERAL_APP_LAUNCH_LAST_OPENED_TAB_SELECTED
+import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_GENERAL_APP_LAUNCH_NEW_TAB_PAGE_SELECTED
+import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_GENERAL_APP_LAUNCH_SPECIFIC_PAGE_SELECTED
+
 sealed class ShowOnAppLaunchOption(val id: Int) {
 
     data object LastOpenedTab : ShowOnAppLaunchOption(1)
@@ -29,6 +33,12 @@ sealed class ShowOnAppLaunchOption(val id: Int) {
             2 -> NewTabPage
             3 -> SpecificPage("")
             else -> throw IllegalArgumentException("Unknown id: $id")
+        }
+
+        fun getPixelName(option: ShowOnAppLaunchOption) = when (option) {
+            LastOpenedTab -> SETTINGS_GENERAL_APP_LAUNCH_LAST_OPENED_TAB_SELECTED
+            NewTabPage -> SETTINGS_GENERAL_APP_LAUNCH_NEW_TAB_PAGE_SELECTED
+            is SpecificPage -> SETTINGS_GENERAL_APP_LAUNCH_SPECIFIC_PAGE_SELECTED
         }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -139,6 +139,10 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     SETTINGS_PRIVATE_SEARCH_MORE_SEARCH_SETTINGS_PRESSED("ms_private_search_more_search_settings_pressed"),
     SETTINGS_COOKIE_POPUP_PROTECTION_PRESSED("ms_cookie_popup_protection_setting_pressed"),
     SETTINGS_FIRE_BUTTON_PRESSED("ms_fire_button_setting_pressed"),
+    SETTINGS_GENERAL_APP_LAUNCH_PRESSED("m_settings_general_app_launch_pressed"),
+    SETTINGS_GENERAL_APP_LAUNCH_LAST_OPENED_TAB_SELECTED("m_settings_general_app_launch_last_opened_tab_selected"),
+    SETTINGS_GENERAL_APP_LAUNCH_NEW_TAB_PAGE_SELECTED("m_settings_general_app_launch_new_tab_page_selected"),
+    SETTINGS_GENERAL_APP_LAUNCH_SPECIFIC_PAGE_SELECTED("m_settings_general_app_launch_specific_page_selected"),
 
     SURVEY_CTA_SHOWN(pixelName = "mus_cs"),
     SURVEY_CTA_DISMISSED(pixelName = "mus_cd"),

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/GeneralSettingsViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/GeneralSettingsViewModelTest.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchO
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.NewTabPage
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.SpecificPage
 import com.duckduckgo.app.generalsettings.showonapplaunch.store.FakeShowOnAppLaunchOptionDataStore
+import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_GENERAL_APP_LAUNCH_PRESSED
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.history.api.NavigationHistory
@@ -228,6 +229,13 @@ internal class GeneralSettingsViewModelTest {
 
             assertEquals(NewTabPage, awaitItem()?.showOnAppLaunchSelectedOption)
         }
+    }
+
+    @Test
+    fun whenShowOnAppLaunchClickedThenPixelFiredEmitted() = runTest {
+        testee.onShowOnAppLaunchButtonClick()
+
+        verify(mockPixel).fire(SETTINGS_GENERAL_APP_LAUNCH_PRESSED)
     }
 
     private fun defaultViewState() = GeneralSettingsViewModel.ViewState(

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchStateReporterPluginTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchStateReporterPluginTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.generalsettings.showonapplaunch
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption
+import com.duckduckgo.app.generalsettings.showonapplaunch.store.FakeShowOnAppLaunchOptionDataStore
+import com.duckduckgo.app.generalsettings.showonapplaunch.store.ShowOnAppLaunchOptionDataStore
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.DispatcherProvider
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ShowOnAppLaunchReporterPluginTest {
+
+    @get:Rule val coroutineTestRule = CoroutineTestRule()
+
+    private val dispatcherProvider: DispatcherProvider = coroutineTestRule.testDispatcherProvider
+    private lateinit var testee: ShowOnAppLaunchStateReporterPlugin
+    private lateinit var fakeDataStore: ShowOnAppLaunchOptionDataStore
+
+    @Before
+    fun setup() {
+        fakeDataStore = FakeShowOnAppLaunchOptionDataStore(ShowOnAppLaunchOption.LastOpenedTab)
+
+        testee = ShowOnAppLaunchStateReporterPlugin(dispatcherProvider, fakeDataStore)
+    }
+
+    @Test
+    fun whenOptionIsSetToLastOpenedPageThenShouldReturnDailyPixelValue() = runTest {
+        fakeDataStore.setShowOnAppLaunchOption(ShowOnAppLaunchOption.LastOpenedTab)
+        val result = testee.featureStateParams()
+        assertEquals("last_opened_tab", result[PixelParameter.LAUNCH_SCREEN])
+    }
+
+    @Test
+    fun whenOptionIsSetToNewTabPageThenShouldReturnDailyPixelValue() = runTest {
+        fakeDataStore.setShowOnAppLaunchOption(ShowOnAppLaunchOption.NewTabPage)
+        val result = testee.featureStateParams()
+        assertEquals("new_tab_page", result[PixelParameter.LAUNCH_SCREEN])
+    }
+
+    @Test
+    fun whenOptionIsSetToSpecificPageThenShouldReturnDailyPixelValue() = runTest {
+        val specificPage = ShowOnAppLaunchOption.SpecificPage("example.com")
+        fakeDataStore.setShowOnAppLaunchOption(specificPage)
+        val result = testee.featureStateParams()
+        assertEquals("specific_page", result[PixelParameter.LAUNCH_SCREEN])
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModelTest.kt
@@ -19,9 +19,14 @@ package com.duckduckgo.app.generalsettings.showonapplaunch
 import app.cash.turbine.test
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.LastOpenedTab
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.NewTabPage
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.SpecificPage
 import com.duckduckgo.app.generalsettings.showonapplaunch.store.FakeShowOnAppLaunchOptionDataStore
+import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_GENERAL_APP_LAUNCH_LAST_OPENED_TAB_SELECTED
+import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_GENERAL_APP_LAUNCH_NEW_TAB_PAGE_SELECTED
+import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_GENERAL_APP_LAUNCH_SPECIFIC_PAGE_SELECTED
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.fakes.FakePixel
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -35,12 +40,14 @@ class ShowOnAppLaunchViewModelTest {
 
     private lateinit var testee: ShowOnAppLaunchViewModel
     private lateinit var fakeDataStore: FakeShowOnAppLaunchOptionDataStore
+    private lateinit var fakePixel: FakePixel
     private val dispatcherProvider: DispatcherProvider = coroutineTestRule.testDispatcherProvider
 
     @Before
     fun setup() {
         fakeDataStore = FakeShowOnAppLaunchOptionDataStore(LastOpenedTab)
-        testee = ShowOnAppLaunchViewModel(dispatcherProvider, fakeDataStore, FakeUrlConverter())
+        fakePixel = FakePixel()
+        testee = ShowOnAppLaunchViewModel(dispatcherProvider, fakeDataStore, FakeUrlConverter(), fakePixel)
     }
 
     @Test
@@ -80,6 +87,28 @@ class ShowOnAppLaunchViewModelTest {
             val updatedState = awaitItem()
             assertEquals(LastOpenedTab, updatedState.selectedOption)
         }
+    }
+
+    @Test
+    fun whenOptionChangedToLastOpenedPageThenLastOpenedPageIsFired() = runTest {
+        testee.onShowOnAppLaunchOptionChanged(NewTabPage)
+        testee.onShowOnAppLaunchOptionChanged(LastOpenedTab)
+        assertEquals(2, fakePixel.firedPixels.size)
+        assertEquals(SETTINGS_GENERAL_APP_LAUNCH_LAST_OPENED_TAB_SELECTED.pixelName, fakePixel.firedPixels.last())
+    }
+
+    @Test
+    fun whenOptionChangedToNewTabPageThenNewTabPagePixelIsFired() = runTest {
+        testee.onShowOnAppLaunchOptionChanged(NewTabPage)
+        assertEquals(1, fakePixel.firedPixels.size)
+        assertEquals(SETTINGS_GENERAL_APP_LAUNCH_NEW_TAB_PAGE_SELECTED.pixelName, fakePixel.firedPixels[0])
+    }
+
+    @Test
+    fun whenOptionChangedToSpecificPageThenSpecificPixelIsFired() = runTest {
+        testee.onShowOnAppLaunchOptionChanged(SpecificPage("https://example.com"))
+        assertEquals(1, fakePixel.firedPixels.size)
+        assertEquals(SETTINGS_GENERAL_APP_LAUNCH_SPECIFIC_PAGE_SELECTED.pixelName, fakePixel.firedPixels[0])
     }
 
     private class FakeUrlConverter : UrlConverter {

--- a/app/src/test/java/com/duckduckgo/fakes/FakePixel.kt
+++ b/app/src/test/java/com/duckduckgo/fakes/FakePixel.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.fakes
+
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelName
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType
+
+internal class FakePixel : Pixel {
+
+    val firedPixels = mutableListOf<String>()
+
+    override fun fire(
+        pixel: PixelName,
+        parameters: Map<String, String>,
+        encodedParameters: Map<String, String>,
+        type: PixelType,
+    ) {
+        firedPixels.add(pixel.pixelName)
+    }
+
+    override fun fire(
+        pixelName: String,
+        parameters: Map<String, String>,
+        encodedParameters: Map<String, String>,
+        type: PixelType,
+    ) {
+        firedPixels.add(pixelName)
+    }
+
+    override fun enqueueFire(
+        pixel: PixelName,
+        parameters: Map<String, String>,
+        encodedParameters: Map<String, String>,
+    ) {
+        firedPixels.add(pixel.pixelName)
+    }
+
+    override fun enqueueFire(
+        pixelName: String,
+        parameters: Map<String, String>,
+        encodedParameters: Map<String, String>,
+    ) {
+        firedPixels.add(pixelName)
+    }
+}

--- a/statistics/statistics-api/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/statistics/statistics-api/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -60,6 +60,7 @@ interface Pixel {
 
         // Loading Bar Experiment
         const val LOADING_BAR_EXPERIMENT = "loading_bar_exp"
+        const val LAUNCH_SCREEN = "launch_screen"
     }
 
     object PixelValues {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207908166761516/1208156273709090/f

### Description

Adds three pixels to the Show on App Launch feature:

- When the Show on App Launch screen is opened from General settings (temporary pixel)
- When selecting a new Show on App Launch option (temporary pixel)
- When the daily pixel is fired (permanent pixel)

### Steps to test this PR

_App launch pressed pixel_
- [x] Go to general settings screen
- [x] Click “Show on App Launch"
- [x] Checks logs to if `m_settings_general_app_launch_pressed` is sent 

_New option selected pixel_
- [x] Go to Show on App Launch screen
- [x] Click “New Tab Page”
- [x] Check logs for `m_settings_general_app_launch_new_tab_page_selected` pixel
- [x] Click “Specific Page"
- [x] Check logs for `m_settings_general_app_launch_specific_page_selected` pixel
- [x] Click “Last Opened Tab”
- [x] Check logs for `m_settings_general_app_launch_last_opened_tab_selected` pixel

_Daily pixel_
- [x] Launch app
- [x] Check daily pixel for “launch_screen” and check it’s the same as what you have selected for “Show on App Launch"

### UI changes

N/A