### PR TITLE
Update Loading Bar Experiment caching logic

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -940,11 +940,13 @@ class BrowserWebViewClientTest {
         val mockWebView = getImmediatelyInvokedMockWebView()
 
         whenever(loadingBarExperimentManager.isExperimentEnabled()).thenReturn(true)
+        whenever(loadingBarExperimentManager.shouldSendUriLoadedPixel).thenReturn(true)
         whenever(loadingBarExperimentManager.variant).thenReturn(true)
         whenever(mockWebView.settings).thenReturn(mock())
         whenever(mockWebView.safeCopyBackForwardList()).thenReturn(TestBackForwardList())
         whenever(mockWebView.progress).thenReturn(100)
 
+        testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
         testee.onPageFinished(mockWebView, EXAMPLE_URL)
 
         verify(pixel).fire(
@@ -959,10 +961,12 @@ class BrowserWebViewClientTest {
         val mockWebView = getImmediatelyInvokedMockWebView()
 
         whenever(loadingBarExperimentManager.isExperimentEnabled()).thenReturn(false)
+        whenever(loadingBarExperimentManager.shouldSendUriLoadedPixel).thenReturn(true)
         whenever(mockWebView.settings).thenReturn(mock())
         whenever(mockWebView.safeCopyBackForwardList()).thenReturn(TestBackForwardList())
         whenever(mockWebView.progress).thenReturn(100)
 
+        testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
         testee.onPageFinished(mockWebView, EXAMPLE_URL)
 
         verify(pixel).fire(AppPixelName.URI_LOADED)
@@ -974,11 +978,31 @@ class BrowserWebViewClientTest {
         val mockWebView = getImmediatelyInvokedMockWebView()
 
         whenever(loadingBarExperimentManager.isExperimentEnabled()).thenReturn(true)
+        whenever(loadingBarExperimentManager.shouldSendUriLoadedPixel).thenReturn(true)
         whenever(loadingBarExperimentManager.variant).thenReturn(true)
         whenever(mockWebView.settings).thenReturn(mock())
         whenever(mockWebView.safeCopyBackForwardList()).thenReturn(TestBackForwardList())
         whenever(mockWebView.progress).thenReturn(50)
 
+        testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
+        testee.onPageFinished(mockWebView, EXAMPLE_URL)
+
+        verify(pixel, never()).fire(anyString(), any(), any(), any())
+    }
+
+    @UiThreadTest
+    @Test
+    fun whenShouldNotSendUriLoadedPixelThenNoPixelFired() {
+        val mockWebView = getImmediatelyInvokedMockWebView()
+
+        whenever(loadingBarExperimentManager.isExperimentEnabled()).thenReturn(true)
+        whenever(loadingBarExperimentManager.shouldSendUriLoadedPixel).thenReturn(false)
+        whenever(loadingBarExperimentManager.variant).thenReturn(true)
+        whenever(mockWebView.settings).thenReturn(mock())
+        whenever(mockWebView.safeCopyBackForwardList()).thenReturn(TestBackForwardList())
+        whenever(mockWebView.progress).thenReturn(100)
+
+        testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
         testee.onPageFinished(mockWebView, EXAMPLE_URL)
 
         verify(pixel, never()).fire(anyString(), any(), any(), any())

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -940,7 +940,7 @@ class BrowserWebViewClientTest {
         val mockWebView = getImmediatelyInvokedMockWebView()
 
         whenever(loadingBarExperimentManager.isExperimentEnabled()).thenReturn(true)
-        whenever(loadingBarExperimentManager.shouldSendUriLoadedPixel).thenReturn(true)
+        whenever(loadingBarExperimentManager.sendUriLoadedPixel).thenReturn(true)
         whenever(loadingBarExperimentManager.variant).thenReturn(true)
         whenever(mockWebView.settings).thenReturn(mock())
         whenever(mockWebView.safeCopyBackForwardList()).thenReturn(TestBackForwardList())
@@ -961,7 +961,7 @@ class BrowserWebViewClientTest {
         val mockWebView = getImmediatelyInvokedMockWebView()
 
         whenever(loadingBarExperimentManager.isExperimentEnabled()).thenReturn(false)
-        whenever(loadingBarExperimentManager.shouldSendUriLoadedPixel).thenReturn(true)
+        whenever(loadingBarExperimentManager.sendUriLoadedPixel).thenReturn(true)
         whenever(mockWebView.settings).thenReturn(mock())
         whenever(mockWebView.safeCopyBackForwardList()).thenReturn(TestBackForwardList())
         whenever(mockWebView.progress).thenReturn(100)
@@ -978,7 +978,7 @@ class BrowserWebViewClientTest {
         val mockWebView = getImmediatelyInvokedMockWebView()
 
         whenever(loadingBarExperimentManager.isExperimentEnabled()).thenReturn(true)
-        whenever(loadingBarExperimentManager.shouldSendUriLoadedPixel).thenReturn(true)
+        whenever(loadingBarExperimentManager.sendUriLoadedPixel).thenReturn(true)
         whenever(loadingBarExperimentManager.variant).thenReturn(true)
         whenever(mockWebView.settings).thenReturn(mock())
         whenever(mockWebView.safeCopyBackForwardList()).thenReturn(TestBackForwardList())
@@ -996,7 +996,7 @@ class BrowserWebViewClientTest {
         val mockWebView = getImmediatelyInvokedMockWebView()
 
         whenever(loadingBarExperimentManager.isExperimentEnabled()).thenReturn(true)
-        whenever(loadingBarExperimentManager.shouldSendUriLoadedPixel).thenReturn(false)
+        whenever(loadingBarExperimentManager.sendUriLoadedPixel).thenReturn(false)
         whenever(loadingBarExperimentManager.variant).thenReturn(true)
         whenever(mockWebView.settings).thenReturn(mock())
         whenever(mockWebView.safeCopyBackForwardList()).thenReturn(TestBackForwardList())

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -940,7 +940,7 @@ class BrowserWebViewClientTest {
         val mockWebView = getImmediatelyInvokedMockWebView()
 
         whenever(loadingBarExperimentManager.isExperimentEnabled()).thenReturn(true)
-        whenever(loadingBarExperimentManager.sendUriLoadedPixel).thenReturn(true)
+        whenever(loadingBarExperimentManager.shouldSendUriLoadedPixel).thenReturn(true)
         whenever(loadingBarExperimentManager.variant).thenReturn(true)
         whenever(mockWebView.settings).thenReturn(mock())
         whenever(mockWebView.safeCopyBackForwardList()).thenReturn(TestBackForwardList())
@@ -961,7 +961,7 @@ class BrowserWebViewClientTest {
         val mockWebView = getImmediatelyInvokedMockWebView()
 
         whenever(loadingBarExperimentManager.isExperimentEnabled()).thenReturn(false)
-        whenever(loadingBarExperimentManager.sendUriLoadedPixel).thenReturn(true)
+        whenever(loadingBarExperimentManager.shouldSendUriLoadedPixel).thenReturn(true)
         whenever(mockWebView.settings).thenReturn(mock())
         whenever(mockWebView.safeCopyBackForwardList()).thenReturn(TestBackForwardList())
         whenever(mockWebView.progress).thenReturn(100)
@@ -978,7 +978,7 @@ class BrowserWebViewClientTest {
         val mockWebView = getImmediatelyInvokedMockWebView()
 
         whenever(loadingBarExperimentManager.isExperimentEnabled()).thenReturn(true)
-        whenever(loadingBarExperimentManager.sendUriLoadedPixel).thenReturn(true)
+        whenever(loadingBarExperimentManager.shouldSendUriLoadedPixel).thenReturn(true)
         whenever(loadingBarExperimentManager.variant).thenReturn(true)
         whenever(mockWebView.settings).thenReturn(mock())
         whenever(mockWebView.safeCopyBackForwardList()).thenReturn(TestBackForwardList())
@@ -996,7 +996,7 @@ class BrowserWebViewClientTest {
         val mockWebView = getImmediatelyInvokedMockWebView()
 
         whenever(loadingBarExperimentManager.isExperimentEnabled()).thenReturn(true)
-        whenever(loadingBarExperimentManager.sendUriLoadedPixel).thenReturn(false)
+        whenever(loadingBarExperimentManager.shouldSendUriLoadedPixel).thenReturn(false)
         whenever(loadingBarExperimentManager.variant).thenReturn(true)
         whenever(mockWebView.settings).thenReturn(mock())
         whenever(mockWebView.safeCopyBackForwardList()).thenReturn(TestBackForwardList())

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -403,7 +403,7 @@ class BrowserWebViewClient @Inject constructor(
                                 navigationHistory.saveToHistory(url, navigationList.currentItem?.title)
                             }
                         }
-                        if (loadingBarExperimentManager.sendUriLoadedPixel) {
+                        if (loadingBarExperimentManager.shouldSendUriLoadedPixel) {
                             if (loadingBarExperimentManager.isExperimentEnabled()) {
                                 pixel.fire(
                                     AppPixelName.URI_LOADED.pixelName,

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -403,17 +403,17 @@ class BrowserWebViewClient @Inject constructor(
                                 navigationHistory.saveToHistory(url, navigationList.currentItem?.title)
                             }
                         }
+                        if (loadingBarExperimentManager.isExperimentEnabled()) {
+                            pixel.fire(
+                                AppPixelName.URI_LOADED.pixelName,
+                                mapOf(LOADING_BAR_EXPERIMENT to loadingBarExperimentManager.variant.toBinaryString()),
+                            )
+                        } else {
+                            pixel.fire(AppPixelName.URI_LOADED)
+                        }
                         start = null
                     }
                 }
-            }
-            if (loadingBarExperimentManager.isExperimentEnabled()) {
-                pixel.fire(
-                    AppPixelName.URI_LOADED.pixelName,
-                    mapOf(LOADING_BAR_EXPERIMENT to loadingBarExperimentManager.variant.toBinaryString()),
-                )
-            } else {
-                pixel.fire(AppPixelName.URI_LOADED)
             }
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -403,7 +403,7 @@ class BrowserWebViewClient @Inject constructor(
                                 navigationHistory.saveToHistory(url, navigationList.currentItem?.title)
                             }
                         }
-                        if (loadingBarExperimentManager.shouldSendUriLoadedPixel) {
+                        if (loadingBarExperimentManager.sendUriLoadedPixel) {
                             if (loadingBarExperimentManager.isExperimentEnabled()) {
                                 pixel.fire(
                                     AppPixelName.URI_LOADED.pixelName,

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -403,13 +403,15 @@ class BrowserWebViewClient @Inject constructor(
                                 navigationHistory.saveToHistory(url, navigationList.currentItem?.title)
                             }
                         }
-                        if (loadingBarExperimentManager.isExperimentEnabled()) {
-                            pixel.fire(
-                                AppPixelName.URI_LOADED.pixelName,
-                                mapOf(LOADING_BAR_EXPERIMENT to loadingBarExperimentManager.variant.toBinaryString()),
-                            )
-                        } else {
-                            pixel.fire(AppPixelName.URI_LOADED)
+                        if (loadingBarExperimentManager.shouldSendUriLoadedPixel) {
+                            if (loadingBarExperimentManager.isExperimentEnabled()) {
+                                pixel.fire(
+                                    AppPixelName.URI_LOADED.pixelName,
+                                    mapOf(LOADING_BAR_EXPERIMENT to loadingBarExperimentManager.variant.toBinaryString()),
+                                )
+                            } else {
+                                pixel.fire(AppPixelName.URI_LOADED)
+                            }
                         }
                         start = null
                     }

--- a/experiments/experiments-api/src/main/java/com/duckduckgo/experiments/api/loadingbarexperiment/LoadingBarExperimentManager.kt
+++ b/experiments/experiments-api/src/main/java/com/duckduckgo/experiments/api/loadingbarexperiment/LoadingBarExperimentManager.kt
@@ -20,5 +20,5 @@ interface LoadingBarExperimentManager {
     fun isExperimentEnabled(): Boolean
     suspend fun update()
     val variant: Boolean
-    val shouldSendUriLoadedPixel: Boolean
+    val sendUriLoadedPixel: Boolean
 }

--- a/experiments/experiments-api/src/main/java/com/duckduckgo/experiments/api/loadingbarexperiment/LoadingBarExperimentManager.kt
+++ b/experiments/experiments-api/src/main/java/com/duckduckgo/experiments/api/loadingbarexperiment/LoadingBarExperimentManager.kt
@@ -20,5 +20,5 @@ interface LoadingBarExperimentManager {
     fun isExperimentEnabled(): Boolean
     suspend fun update()
     val variant: Boolean
-    val sendUriLoadedPixel: Boolean
+    val shouldSendUriLoadedPixel: Boolean
 }

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/loadingbarexperiment/DuckDuckGoLoadingBarExperimentManager.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/loadingbarexperiment/DuckDuckGoLoadingBarExperimentManager.kt
@@ -16,11 +16,16 @@
 
 package com.duckduckgo.experiments.impl.loadingbarexperiment
 
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.di.IsMainProcess
+import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.experiments.api.loadingbarexperiment.LoadingBarExperimentManager
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import timber.log.Timber
 
 @ContributesBinding(AppScope::class)
@@ -28,30 +33,40 @@ import timber.log.Timber
 class DuckDuckGoLoadingBarExperimentManager @Inject constructor(
     private val loadingBarExperimentDataStore: LoadingBarExperimentDataStore,
     private val loadingBarExperimentFeature: LoadingBarExperimentFeature,
+    @AppCoroutineScope appCoroutineScope: CoroutineScope,
+    dispatcherProvider: DispatcherProvider,
+    @IsMainProcess isMainProcess: Boolean,
 ) : LoadingBarExperimentManager {
 
-    private var hasVariant: Boolean? = null
-    private var enabled: Boolean? = null
+    override val variant: Boolean
+        get() = cachedVariant
 
-    override fun isExperimentEnabled(): Boolean {
-        Timber.d("Loading bar experiment: Retrieving experiment status")
-        if (hasVariant == null) {
-            hasVariant = loadingBarExperimentDataStore.hasVariant
+    private var cachedVariant: Boolean = false
+    private var hasVariant: Boolean = false
+    private var enabled: Boolean = false
+
+    init {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            if (isMainProcess) {
+                Timber.d("Loading bar experiment: Experimental variables initialized")
+                loadToMemory()
+            }
         }
-
-        if (enabled == null) {
-            enabled = loadingBarExperimentFeature.self().isEnabled()
-        }
-
-        return hasVariant == true && enabled == true
     }
 
-    override suspend fun update() {
-        Timber.d("Loading bar experiment: Experimental variables updated")
+    private fun loadToMemory() {
+        cachedVariant = loadingBarExperimentDataStore.variant
         hasVariant = loadingBarExperimentDataStore.hasVariant
         enabled = loadingBarExperimentFeature.self().isEnabled()
     }
 
-    override val variant: Boolean
-        get() = loadingBarExperimentDataStore.variant
+    override fun isExperimentEnabled(): Boolean {
+        Timber.d("Loading bar experiment: Retrieving experiment status")
+        return hasVariant && enabled
+    }
+
+    override suspend fun update() {
+        Timber.d("Loading bar experiment: Experimental variables updated")
+        loadToMemory()
+    }
 }

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/loadingbarexperiment/DuckDuckGoLoadingBarExperimentManager.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/loadingbarexperiment/DuckDuckGoLoadingBarExperimentManager.kt
@@ -33,17 +33,22 @@ import timber.log.Timber
 class DuckDuckGoLoadingBarExperimentManager @Inject constructor(
     private val loadingBarExperimentDataStore: LoadingBarExperimentDataStore,
     private val loadingBarExperimentFeature: LoadingBarExperimentFeature,
+    private val uriLoadedPixelFeature: UriLoadedPixelFeature,
     @AppCoroutineScope appCoroutineScope: CoroutineScope,
     dispatcherProvider: DispatcherProvider,
     @IsMainProcess isMainProcess: Boolean,
 ) : LoadingBarExperimentManager {
 
+    private var cachedShouldSendUriLoadedPixel: Boolean = false
     private var cachedVariant: Boolean = false
     private var hasVariant: Boolean = false
     private var enabled: Boolean = false
 
     override val variant: Boolean
         get() = cachedVariant
+
+    override val shouldSendUriLoadedPixel: Boolean
+        get() = cachedShouldSendUriLoadedPixel
 
     init {
         appCoroutineScope.launch(dispatcherProvider.io()) {
@@ -68,5 +73,6 @@ class DuckDuckGoLoadingBarExperimentManager @Inject constructor(
         cachedVariant = loadingBarExperimentDataStore.variant
         hasVariant = loadingBarExperimentDataStore.hasVariant
         enabled = loadingBarExperimentFeature.self().isEnabled()
+        cachedShouldSendUriLoadedPixel = uriLoadedPixelFeature.self().isEnabled()
     }
 }

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/loadingbarexperiment/DuckDuckGoLoadingBarExperimentManager.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/loadingbarexperiment/DuckDuckGoLoadingBarExperimentManager.kt
@@ -39,7 +39,7 @@ class DuckDuckGoLoadingBarExperimentManager @Inject constructor(
     @IsMainProcess isMainProcess: Boolean,
 ) : LoadingBarExperimentManager {
 
-    private var cachedShouldSendUriLoadedPixel: Boolean = false
+    private var cachedSendUriLoadedPixel: Boolean = false
     private var cachedVariant: Boolean = false
     private var hasVariant: Boolean = false
     private var enabled: Boolean = false
@@ -47,8 +47,8 @@ class DuckDuckGoLoadingBarExperimentManager @Inject constructor(
     override val variant: Boolean
         get() = cachedVariant
 
-    override val shouldSendUriLoadedPixel: Boolean
-        get() = cachedShouldSendUriLoadedPixel
+    override val sendUriLoadedPixel: Boolean
+        get() = cachedSendUriLoadedPixel
 
     init {
         appCoroutineScope.launch(dispatcherProvider.io()) {
@@ -73,6 +73,6 @@ class DuckDuckGoLoadingBarExperimentManager @Inject constructor(
         cachedVariant = loadingBarExperimentDataStore.variant
         hasVariant = loadingBarExperimentDataStore.hasVariant
         enabled = loadingBarExperimentFeature.self().isEnabled()
-        cachedShouldSendUriLoadedPixel = uriLoadedPixelFeature.self().isEnabled()
+        cachedSendUriLoadedPixel = uriLoadedPixelFeature.self().isEnabled()
     }
 }

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/loadingbarexperiment/DuckDuckGoLoadingBarExperimentManager.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/loadingbarexperiment/DuckDuckGoLoadingBarExperimentManager.kt
@@ -38,12 +38,12 @@ class DuckDuckGoLoadingBarExperimentManager @Inject constructor(
     @IsMainProcess isMainProcess: Boolean,
 ) : LoadingBarExperimentManager {
 
-    override val variant: Boolean
-        get() = cachedVariant
-
     private var cachedVariant: Boolean = false
     private var hasVariant: Boolean = false
     private var enabled: Boolean = false
+
+    override val variant: Boolean
+        get() = cachedVariant
 
     init {
         appCoroutineScope.launch(dispatcherProvider.io()) {
@@ -54,12 +54,6 @@ class DuckDuckGoLoadingBarExperimentManager @Inject constructor(
         }
     }
 
-    private fun loadToMemory() {
-        cachedVariant = loadingBarExperimentDataStore.variant
-        hasVariant = loadingBarExperimentDataStore.hasVariant
-        enabled = loadingBarExperimentFeature.self().isEnabled()
-    }
-
     override fun isExperimentEnabled(): Boolean {
         Timber.d("Loading bar experiment: Retrieving experiment status")
         return hasVariant && enabled
@@ -68,5 +62,11 @@ class DuckDuckGoLoadingBarExperimentManager @Inject constructor(
     override suspend fun update() {
         Timber.d("Loading bar experiment: Experimental variables updated")
         loadToMemory()
+    }
+
+    private fun loadToMemory() {
+        cachedVariant = loadingBarExperimentDataStore.variant
+        hasVariant = loadingBarExperimentDataStore.hasVariant
+        enabled = loadingBarExperimentFeature.self().isEnabled()
     }
 }

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/loadingbarexperiment/DuckDuckGoLoadingBarExperimentManager.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/loadingbarexperiment/DuckDuckGoLoadingBarExperimentManager.kt
@@ -39,7 +39,7 @@ class DuckDuckGoLoadingBarExperimentManager @Inject constructor(
     @IsMainProcess isMainProcess: Boolean,
 ) : LoadingBarExperimentManager {
 
-    private var cachedSendUriLoadedPixel: Boolean = false
+    private var cachedShouldSendUriLoadedPixel: Boolean = false
     private var cachedVariant: Boolean = false
     private var hasVariant: Boolean = false
     private var enabled: Boolean = false
@@ -47,8 +47,8 @@ class DuckDuckGoLoadingBarExperimentManager @Inject constructor(
     override val variant: Boolean
         get() = cachedVariant
 
-    override val sendUriLoadedPixel: Boolean
-        get() = cachedSendUriLoadedPixel
+    override val shouldSendUriLoadedPixel: Boolean
+        get() = cachedShouldSendUriLoadedPixel
 
     init {
         appCoroutineScope.launch(dispatcherProvider.io()) {
@@ -73,6 +73,6 @@ class DuckDuckGoLoadingBarExperimentManager @Inject constructor(
         cachedVariant = loadingBarExperimentDataStore.variant
         hasVariant = loadingBarExperimentDataStore.hasVariant
         enabled = loadingBarExperimentFeature.self().isEnabled()
-        cachedSendUriLoadedPixel = uriLoadedPixelFeature.self().isEnabled()
+        cachedShouldSendUriLoadedPixel = uriLoadedPixelFeature.self().isEnabled()
     }
 }

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/loadingbarexperiment/UriLoadedPixelFeature.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/loadingbarexperiment/UriLoadedPixelFeature.kt
@@ -14,11 +14,18 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.experiments.api.loadingbarexperiment
+package com.duckduckgo.experiments.impl.loadingbarexperiment
 
-interface LoadingBarExperimentManager {
-    fun isExperimentEnabled(): Boolean
-    suspend fun update()
-    val variant: Boolean
-    val shouldSendUriLoadedPixel: Boolean
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "sendUriLoadedPixel",
+)
+interface UriLoadedPixelFeature {
+
+    @Toggle.DefaultValue(true)
+    fun self(): Toggle
 }

--- a/experiments/experiments-impl/src/test/java/com/duckduckgo/experiments/impl/loadingbarexperiment/DuckDuckGoLoadingBarExperimentManagerTest.kt
+++ b/experiments/experiments-impl/src/test/java/com/duckduckgo/experiments/impl/loadingbarexperiment/DuckDuckGoLoadingBarExperimentManagerTest.kt
@@ -146,19 +146,19 @@ class DuckDuckGoLoadingBarExperimentManagerTest {
     }
 
     @Test
-    fun whenSendUriLoadedPixelEnabledThenSendUriLoadedPixel() {
+    fun whenShouldSendUriLoadedPixelEnabledThenReturnTrue() {
         initialize()
 
-        assertTrue(testee.sendUriLoadedPixel)
+        assertTrue(testee.shouldSendUriLoadedPixel)
     }
 
     @Test
-    fun whenSendUriLoadedPixelDisabledThenDoNotSendUriLoadedPixel() {
+    fun whenShouldSendUriLoadedPixelDisabledThenReturnFalse() {
         whenever(mockUriLoadedKillSwitch.isEnabled()).thenReturn(false)
 
         initialize()
 
-        assertFalse(testee.sendUriLoadedPixel)
+        assertFalse(testee.shouldSendUriLoadedPixel)
     }
 
     private fun initialize() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1200204095367872/1208349807308363/f

### Description
- Updates the caching logic to load to memory on init.
- Also adds a kill switch to disable the URI loaded pixel.

### Steps to test this PR

Remove this from `LoadingBarExperimentVariantInitializer`:
```
loadingBarExperimentFeature.self().isEnabled() &&
loadingBarExperimentFeature.allocateVariants().isEnabled()
```

- [x] Install the app
- [x] Verify that the experimental parameters are sent
- [x] Kill the app
- [x] Open the app again
- [x] Verify that the correct experimental parameters are sent

_Kill switch_

- [x] Load a page
- [x] Verify that `m_uri_loaded` pixel is sent
- [x] Load the config linked in the task
- [x] Load a page
- [x] Verify that `m_uri_loaded` pixel is not sent

Privacy tests passed: https://github.com/duckduckgo/Android/actions/runs/10946311836 ✅
