### PR TITLE
Disable C2 compiler in unit tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -167,6 +167,9 @@ android {
     testOptions {
         unitTests.returnDefaultValues = true
         animationsDisabled = true
+        unitTests.all {
+            jvmArgs '-XX:+TieredCompilation', '-XX:TieredStopAtLevel=1'
+        }
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205617573940217/1208355525889878/f

### Description

This PR disables C2 compiler in unit tests. C2 compiler provides no value in the context of unit tests and may be responsible for JVM crashes that we're experiencing.

### Steps to test this PR

QA-optional

### No UI changes