### PR TITLE
Adds logic and UI when Autofill Remote feature flag disabled

### DIFF
--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/promotion/PasswordsScreenPromotionPlugin.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/promotion/PasswordsScreenPromotionPlugin.kt
@@ -42,6 +42,7 @@ interface PasswordsScreenPromotionPlugin {
 
     companion object {
         const val PRIORITY_KEY_AUTOFILL_SUPPORT_WARNING = 50
+        const val PRIORITY_KEY_AUTOFILL_DISABLED_CONFIG_WARNING = 60
         const val PRIORITY_KEY_SURVEY = 100
         const val PRIORITY_KEY_SYNC_PROMO = 200
     }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/AutofillDisabledByConfigWarningUI.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/AutofillDisabledByConfigWarningUI.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import android.widget.FrameLayout
+import androidx.core.view.isVisible
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.anvil.annotations.PriorityKey
+import com.duckduckgo.autofill.api.promotion.PasswordsScreenPromotionPlugin
+import com.duckduckgo.autofill.api.promotion.PasswordsScreenPromotionPlugin.Companion.PRIORITY_KEY_AUTOFILL_DISABLED_CONFIG_WARNING
+import com.duckduckgo.autofill.impl.databinding.ViewAutofillConfigDisabledWarningBinding
+import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.di.scopes.ViewScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.android.support.AndroidSupportInjection
+import javax.inject.Inject
+
+@ContributesMultibinding(scope = AppScope::class)
+@PriorityKey(PRIORITY_KEY_AUTOFILL_DISABLED_CONFIG_WARNING)
+class AutofillDisabledByConfigWarningUI @Inject constructor(
+    private val internalAutofillCapabilityChecker: InternalAutofillCapabilityChecker,
+) : PasswordsScreenPromotionPlugin {
+
+    override suspend fun getView(context: Context, numberSavedPasswords: Int): View? {
+        val autofillConfigEnabled = internalAutofillCapabilityChecker.isAutofillEnabledByConfiguration("")
+        if (autofillConfigEnabled) return null
+
+        return AutofillDisabledByConfigWarningView(context)
+    }
+}
+
+@InjectWith(ViewScope::class)
+class AutofillDisabledByConfigWarningView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyle: Int = 0,
+) : FrameLayout(context, attrs, defStyle) {
+
+    private val binding: ViewAutofillConfigDisabledWarningBinding by viewBinding()
+
+    override fun onAttachedToWindow() {
+        AndroidSupportInjection.inject(this)
+        super.onAttachedToWindow()
+        binding.webViewUnsupportedWarningPanel.isVisible = true
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/InlineBrowserAutofill.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/InlineBrowserAutofill.kt
@@ -58,6 +58,11 @@ class InlineBrowserAutofill @Inject constructor(
                 return@withContext
             }
 
+            if (!autofillCapabilityChecker.canInjectCredentialsToWebView("")) {
+                Timber.w("Autofill injection on WebView is not supported; autofill will not work")
+                return@withContext
+            }
+
             configureModernIntegration(webView, autofillCallback, tabId)
         }
     }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModel.kt
@@ -414,7 +414,8 @@ class AutofillSettingsViewModel @Inject constructor(
         combineJob = viewModelScope.launch(dispatchers.io()) {
             _viewState.value = _viewState.value.copy(
                 autofillEnabled = autofillStore.autofillEnabled,
-                isAutofillSupported = autofillCapabilityChecker.webViewSupportsAutofill(),
+                isAutofillSupported = autofillCapabilityChecker.webViewSupportsAutofill() &&
+                    autofillCapabilityChecker.isAutofillEnabledByConfiguration(""),
             )
 
             val allCredentials = autofillStore.getAllCredentials().distinctUntilChanged()

--- a/autofill/autofill-impl/src/main/res/layout/view_autofill_config_disabled_warning.xml
+++ b/autofill/autofill-impl/src/main/res/layout/view_autofill_config_disabled_warning.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2024 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<com.duckduckgo.common.ui.view.InfoPanel xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/webViewUnsupportedWarningPanel"
+    style="@style/Widget.DuckDuckGo.InfoPanel"
+    android:layout_margin="@dimen/keyline_4"
+    android:visibility="gone"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent"
+    app:panelBackground="@drawable/info_panel_alert_background"
+    app:panelDrawable="@drawable/ic_info_panel_alert"
+    app:panelText="@string/credentialManagementAutofillDisabledByConfigErrorMessage" />

--- a/autofill/autofill-impl/src/main/res/values/donottranslate.xml
+++ b/autofill/autofill-impl/src/main/res/values/donottranslate.xml
@@ -17,4 +17,6 @@
 <resources>
     <!-- New Tab -->
     <string name="newTabPageShortcutPasswords">Passwords</string>
+
+    <string name="credentialManagementAutofillDisabledByConfigErrorMessage">Autofill for passwords is currently unavailable. We’re working to restore this in a future app update.</string>
 </resources>

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/InlineBrowserAutofillTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/InlineBrowserAutofillTest.kt
@@ -95,6 +95,7 @@ class InlineBrowserAutofillTest {
         canSaveCredentials: Boolean = true,
         canGeneratePassword: Boolean = true,
         canAccessCredentialManagement: Boolean = true,
+        canIntegrateAutofillInWebView: Boolean = true,
         deviceWebViewSupportsAutofill: Boolean = true,
     ): InlineBrowserAutofill {
         val autofillFeature = FakeFeatureToggleFactory.create(AutofillFeature::class.java)
@@ -103,8 +104,10 @@ class InlineBrowserAutofillTest {
         autofillFeature.canSaveCredentials().setEnabled(State(enable = canSaveCredentials))
         autofillFeature.canGeneratePasswords().setEnabled(State(enable = canGeneratePassword))
         autofillFeature.canAccessCredentialManagement().setEnabled(State(enable = canAccessCredentialManagement))
+        autofillFeature.canIntegrateAutofillInWebView().setEnabled(State(enable = canIntegrateAutofillInWebView))
 
         whenever(capabilityChecker.webViewSupportsAutofill()).thenReturn(deviceWebViewSupportsAutofill)
+        whenever(capabilityChecker.canInjectCredentialsToWebView(any())).thenReturn(canIntegrateAutofillInWebView)
 
         return InlineBrowserAutofill(
             autofillCapabilityChecker = capabilityChecker,

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModelTest.kt
@@ -149,6 +149,7 @@ class AutofillSettingsViewModelTest {
     fun setup() = runTest {
         whenever(webUrlIdentifier.isLikelyAUrl(anyOrNull())).thenReturn(true)
         whenever(autofillCapabilityChecker.webViewSupportsAutofill()).thenReturn(true)
+        whenever(autofillCapabilityChecker.isAutofillEnabledByConfiguration(any())).thenReturn(true)
         whenever(mockStore.getAllCredentials()).thenReturn(emptyFlow())
         whenever(mockStore.getCredentialCount()).thenReturn(flowOf(0))
         whenever(neverSavedSiteRepository.neverSaveListCount()).thenReturn(emptyFlow())
@@ -929,6 +930,16 @@ class AutofillSettingsViewModelTest {
         testee.onViewCreated()
         testee.viewState.test {
             assertEquals(false, this.awaitItem().isAutofillSupported)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenAutofillConfigDisabledThenShowDisabledMode() = runTest {
+        whenever(autofillCapabilityChecker.isAutofillEnabledByConfiguration(any())).thenReturn(false)
+        testee.onViewCreated()
+        testee.viewState.test {
+            assertEquals(false, this.awaitItem().autofillEnabled)
             cancelAndIgnoreRemainingEvents()
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1208236187388612/f 

### Description
When remote flag disabled, we warn the user about it and disable autofill toggle.

### Steps to test this PR

_Feature 1_
- [ ] install this branch on a device with WebView > `126.0.6478.40`
- [ ] visit fill.dev
- [ ] ensure autofill works
- [ ] go to password manager screen
- [ ] ensure no warning message
- [ ] go to settings -> feature flag inventory -> disable `autofill` -> `canIntegrateAutofillInWebView`
- [ ] restart the app (fire button for simplicity
- [ ] Go to password manager screen
- [ ] ensure warning message is present
- [ ] ensure user can't interact with toggle

### UI changes
![image](https://github.com/user-attachments/assets/21ae4306-b09f-4596-b0bd-6710d3819ccd)

