### PR TITLE
Remove restore protections when protection have been restored

### DIFF
--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/exclusion/ui/NetpAppExclusionListActivity.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/exclusion/ui/NetpAppExclusionListActivity.kt
@@ -103,7 +103,7 @@ class NetpAppExclusionListActivity :
     override fun onPrepareOptionsMenu(menu: Menu): Boolean {
         val restoreDefault = menu.findItem(R.id.netp_exclusion_menu_restore)
         // onPrepareOptionsMenu is called when overflow menu is being displayed, that's why this can be an imperative call
-        restoreDefault?.isEnabled = viewModel.canRestoreDefaults()
+        restoreDefault?.setVisible(viewModel.canRestoreDefaults())
 
         return super.onPrepareOptionsMenu(menu)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208280638257502/f

### Description
On the VPN exclusion list screen:
- Show context menu > Restore defaults IF there is something to restore
- ELSE, hide it

### Steps to test this PR

- [ ] Open VPN screen
- [ ] Open Excluded apps
- [ ] Click on context menu
- [ ] Confirm that "Restore Protection for All Apps" is NOT shown
- [ ] Exclude one app
- [ ] Confirm that "Restore Protection for All Apps" is shown

