### PR TITLE
Show on App Launch: Default to https for unknown schemes

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchUrlConverterImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchUrlConverterImpl.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.generalsettings.showonapplaunch
 
 import android.net.Uri
 import com.duckduckgo.app.generalsettings.showonapplaunch.store.ShowOnAppLaunchOptionDataStore
+import com.duckduckgo.common.utils.UrlScheme
 
 class ShowOnAppLaunchUrlConverterImpl : UrlConverter {
 
@@ -27,7 +28,7 @@ class ShowOnAppLaunchUrlConverterImpl : UrlConverter {
         val uri = Uri.parse(url.trim())
 
         val convertedUri = if (uri.scheme == null) {
-            Uri.Builder().scheme("http").authority(uri.path?.lowercase())
+            Uri.Builder().scheme(UrlScheme.https).authority(uri.path?.lowercase())
         } else {
             uri.buildUpon()
                 .scheme(uri.scheme?.lowercase())

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchUrlConverterImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchUrlConverterImplTest.kt
@@ -46,15 +46,15 @@ class ShowOnAppLaunchUrlConverterImplTest {
     }
 
     @Test
-    fun whenUrlHasNoSchemeThenHttpSchemeIsAdded() {
+    fun whenUrlHasNoSchemeThenHttpsSchemeIsAdded() {
         val result = urlConverter.convertUrl("www.example.com")
-        assertEquals("http://www.example.com", result)
+        assertEquals("https://www.example.com", result)
     }
 
     @Test
-    fun whenUrlHasNoSchemeAndSubdomainThenHttpSchemeIsAdded() {
+    fun whenUrlHasNoSchemeAndSubdomainThenHttpsSchemeIsAdded() {
         val result = urlConverter.convertUrl("example.com")
-        assertEquals("http://example.com", result)
+        assertEquals("https://example.com", result)
     }
 
     @Test
@@ -118,8 +118,8 @@ class ShowOnAppLaunchUrlConverterImplTest {
     }
 
     @Test
-    fun whenUrlIsNotAValidUrlReturnsInvalidUrlWithHttpScheme() {
+    fun whenUrlIsNotAValidUrlReturnsInvalidUrlWithHttpsScheme() {
         val result = urlConverter.convertUrl("example")
-        assertEquals("http://example", result)
+        assertEquals("https://example", result)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207908166761516/1208369545355290/f 

### Description

We’re now changing the default behaviour when a user enters a url without a scheme to use `https` rather than `http`

### Steps to test this PR

_Feature 1_
- [ ] Open "Show on App Launch" from General Settings
- [ ] Select `Specific Page”
- [ ] Enter a url without a scheme e.g. “bbc.com"
- [ ] Press back
- [ ] The url under "Show on App Launch” should be "https://bbc.com"

### UI changes

N/A