### PR TITLE
Add allowList for Duck Player message handlers

### DIFF
--- a/content-scope-scripts/content-scope-scripts-impl/build.gradle
+++ b/content-scope-scripts/content-scope-scripts-impl/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation project(':browser-api')
     implementation project(':feature-toggles-api')
     implementation project(':js-messaging-api')
+    implementation project(':duckplayer-api')
 
     anvil project(':anvil-compiler')
     implementation project(':anvil-annotations')

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessaging.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessaging.kt
@@ -23,7 +23,6 @@ import com.duckduckgo.common.utils.AppUrl
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.contentscopescripts.impl.CoreContentScopeScripts
 import com.duckduckgo.di.scopes.FragmentScope
-import com.duckduckgo.duckplayer.api.DuckPlayer
 import com.duckduckgo.duckplayer.api.YOUTUBE_HOST
 import com.duckduckgo.duckplayer.api.YOUTUBE_MOBILE_HOST
 import com.duckduckgo.js.messaging.api.JsCallbackData
@@ -50,7 +49,6 @@ class ContentScopeScriptsJsMessaging @Inject constructor(
     private val jsMessageHelper: JsMessageHelper,
     private val dispatcherProvider: DispatcherProvider,
     private val coreContentScopeScripts: CoreContentScopeScripts,
-    private val duckPlayer: DuckPlayer,
     @Named("breakageMessageHandler") private val breakageHandler: JsMessageHandler,
 ) : JsMessaging {
 

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessaging.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessaging.kt
@@ -19,9 +19,13 @@ package com.duckduckgo.contentscopescripts.impl.messaging
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import androidx.core.net.toUri
+import com.duckduckgo.common.utils.AppUrl
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.contentscopescripts.impl.CoreContentScopeScripts
 import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.duckplayer.api.DuckPlayer
+import com.duckduckgo.duckplayer.api.YOUTUBE_HOST
+import com.duckduckgo.duckplayer.api.YOUTUBE_MOBILE_HOST
 import com.duckduckgo.js.messaging.api.JsCallbackData
 import com.duckduckgo.js.messaging.api.JsMessage
 import com.duckduckgo.js.messaging.api.JsMessageCallback
@@ -46,6 +50,7 @@ class ContentScopeScriptsJsMessaging @Inject constructor(
     private val jsMessageHelper: JsMessageHelper,
     private val dispatcherProvider: DispatcherProvider,
     private val coreContentScopeScripts: CoreContentScopeScripts,
+    private val duckPlayer: DuckPlayer,
     @Named("breakageMessageHandler") private val breakageHandler: JsMessageHandler,
 ) : JsMessaging {
 
@@ -122,12 +127,15 @@ class ContentScopeScriptsJsMessaging @Inject constructor(
 
     inner class DuckPlayerHandler : JsMessageHandler {
         override fun process(jsMessage: JsMessage, secret: String, jsMessageCallback: JsMessageCallback?) {
-            // TODO (cbarreiro): Add again when https://app.asana.com/0/0/1207602010403610/f is fixed
-            // if (jsMessage.id == null) return
             jsMessageCallback?.process(featureName, jsMessage.method, jsMessage.id ?: "", jsMessage.params)
         }
 
-        override val allowedDomains: List<String> = emptyList()
+        override val allowedDomains: List<String> = listOf(
+            AppUrl.Url.HOST,
+            YOUTUBE_HOST,
+            YOUTUBE_MOBILE_HOST,
+        )
+
         override val featureName: String = "duckPlayer"
         override val methods: List<String> = listOf(
             "getUserValues",

--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessagingTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessagingTest.kt
@@ -20,7 +20,6 @@ import android.webkit.WebView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.contentscopescripts.impl.CoreContentScopeScripts
-import com.duckduckgo.duckplayer.api.DuckPlayer
 import com.duckduckgo.js.messaging.api.JsMessageCallback
 import com.duckduckgo.js.messaging.api.JsMessageHandler
 import com.duckduckgo.js.messaging.api.JsMessageHelper
@@ -45,7 +44,6 @@ class ContentScopeScriptsJsMessagingTest {
     private val jsMessageHelper: JsMessageHelper = mock()
     private val coreContentScopeScripts: CoreContentScopeScripts = mock()
     private val breakageHandler: JsMessageHandler = mock()
-    private val mockDuckPlayer: DuckPlayer = mock()
     private lateinit var contentScopeScriptsJsMessaging: ContentScopeScriptsJsMessaging
 
     @Before
@@ -57,7 +55,6 @@ class ContentScopeScriptsJsMessagingTest {
             jsMessageHelper,
             coroutineRule.testDispatcherProvider,
             coreContentScopeScripts,
-            mockDuckPlayer,
             breakageHandler,
         )
     }

--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessagingTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessagingTest.kt
@@ -20,6 +20,7 @@ import android.webkit.WebView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.contentscopescripts.impl.CoreContentScopeScripts
+import com.duckduckgo.duckplayer.api.DuckPlayer
 import com.duckduckgo.js.messaging.api.JsMessageCallback
 import com.duckduckgo.js.messaging.api.JsMessageHandler
 import com.duckduckgo.js.messaging.api.JsMessageHelper
@@ -44,6 +45,7 @@ class ContentScopeScriptsJsMessagingTest {
     private val jsMessageHelper: JsMessageHelper = mock()
     private val coreContentScopeScripts: CoreContentScopeScripts = mock()
     private val breakageHandler: JsMessageHandler = mock()
+    private val mockDuckPlayer: DuckPlayer = mock()
     private lateinit var contentScopeScriptsJsMessaging: ContentScopeScriptsJsMessaging
 
     @Before
@@ -55,6 +57,7 @@ class ContentScopeScriptsJsMessagingTest {
             jsMessageHelper,
             coroutineRule.testDispatcherProvider,
             coreContentScopeScripts,
+            mockDuckPlayer,
             breakageHandler,
         )
     }

--- a/duckplayer/duckplayer-api/src/main/java/com/duckduckgo/duckplayer/api/DuckPlayer.kt
+++ b/duckplayer/duckplayer-api/src/main/java/com/duckduckgo/duckplayer/api/DuckPlayer.kt
@@ -178,13 +178,6 @@ interface DuckPlayer {
     suspend fun willNavigateToDuckPlayer(destinationUrl: Uri): Boolean
 
     /**
-     * Retrieves the YouTube embed URL.
-     *
-     * @return The YouTube embed URL.
-     */
-    suspend fun getYouTubeEmbedUrl(): String
-
-    /**
      * Data class representing user preferences for Duck Player.
      *
      * @property overlayInteracted A boolean indicating whether the overlay was interacted with.

--- a/duckplayer/duckplayer-api/src/main/java/com/duckduckgo/duckplayer/api/DuckPlayer.kt
+++ b/duckplayer/duckplayer-api/src/main/java/com/duckduckgo/duckplayer/api/DuckPlayer.kt
@@ -27,6 +27,9 @@ import com.duckduckgo.duckplayer.api.PrivatePlayerMode.Disabled
 import com.duckduckgo.duckplayer.api.PrivatePlayerMode.Enabled
 import kotlinx.coroutines.flow.Flow
 
+const val YOUTUBE_HOST = "youtube.com"
+const val YOUTUBE_MOBILE_HOST = "m.youtube.com"
+
 /**
  * DuckPlayer interface provides a set of methods for interacting with the DuckPlayer.
  */
@@ -173,6 +176,13 @@ interface DuckPlayer {
      * @return True if the URL should launch Duck Player, false otherwise.
      */
     suspend fun willNavigateToDuckPlayer(destinationUrl: Uri): Boolean
+
+    /**
+     * Retrieves the YouTube embed URL.
+     *
+     * @return The YouTube embed URL.
+     */
+    suspend fun getYouTubeEmbedUrl(): String
 
     /**
      * Data class representing user preferences for Duck Player.

--- a/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerScriptsJsMessaging.kt
+++ b/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerScriptsJsMessaging.kt
@@ -22,6 +22,7 @@ import androidx.core.net.toUri
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.extensions.toTldPlusOne
 import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.duckplayer.api.DuckPlayer
 import com.duckduckgo.js.messaging.api.JsCallbackData
 import com.duckduckgo.js.messaging.api.JsMessage
 import com.duckduckgo.js.messaging.api.JsMessageCallback
@@ -43,6 +44,7 @@ import logcat.logcat
 class DuckPlayerScriptsJsMessaging @Inject constructor(
     private val jsMessageHelper: JsMessageHelper,
     private val dispatcherProvider: DispatcherProvider,
+    private val duckPlayer: DuckPlayer,
 ) : JsMessaging {
     private val moshi = Moshi.Builder().add(JSONObjectAdapter()).build()
 
@@ -119,7 +121,9 @@ class DuckPlayerScriptsJsMessaging @Inject constructor(
             jsMessageCallback?.process(featureName, jsMessage.method, jsMessage.id ?: "", jsMessage.params)
         }
 
-        override val allowedDomains: List<String> = emptyList()
+        override val allowedDomains: List<String> = listOf(
+            runBlocking { duckPlayer.getYouTubeEmbedUrl() },
+        )
         override val featureName: String = "duckPlayerPage"
         override val methods: List<String> = listOf(
             "initialSetup",

--- a/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerScriptsJsMessaging.kt
+++ b/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerScriptsJsMessaging.kt
@@ -22,7 +22,6 @@ import androidx.core.net.toUri
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.extensions.toTldPlusOne
 import com.duckduckgo.di.scopes.ActivityScope
-import com.duckduckgo.duckplayer.api.DuckPlayer
 import com.duckduckgo.js.messaging.api.JsCallbackData
 import com.duckduckgo.js.messaging.api.JsMessage
 import com.duckduckgo.js.messaging.api.JsMessageCallback
@@ -44,7 +43,7 @@ import logcat.logcat
 class DuckPlayerScriptsJsMessaging @Inject constructor(
     private val jsMessageHelper: JsMessageHelper,
     private val dispatcherProvider: DispatcherProvider,
-    private val duckPlayer: DuckPlayer,
+    private val duckPlayer: DuckPlayerInternal,
 ) : JsMessaging {
     private val moshi = Moshi.Builder().add(JSONObjectAdapter()).build()
 

--- a/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/RealDuckPlayer.kt
+++ b/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/RealDuckPlayer.kt
@@ -66,8 +66,19 @@ private const val DUCK_PLAYER_URL_BASE = "$duck://$DUCK_PLAYER_DOMAIN/"
 private const val DUCK_PLAYER_ASSETS_PATH = "duckplayer/"
 private const val DUCK_PLAYER_ASSETS_INDEX_PATH = "${DUCK_PLAYER_ASSETS_PATH}index.html"
 
+interface DuckPlayerInternal : DuckPlayer {
+    /**
+     * Retrieves the YouTube embed URL.
+     *
+     * @return The YouTube embed URL.
+     */
+    suspend fun getYouTubeEmbedUrl(): String
+}
+
 @SingleInstanceIn(AppScope::class)
-@ContributesBinding(AppScope::class)
+
+@ContributesBinding(AppScope::class, boundType = DuckPlayer::class)
+@ContributesBinding(AppScope::class, boundType = DuckPlayerInternal::class)
 class RealDuckPlayer @Inject constructor(
     private val duckPlayerFeatureRepository: DuckPlayerFeatureRepository,
     private val duckPlayerFeature: DuckPlayerFeature,
@@ -75,7 +86,7 @@ class RealDuckPlayer @Inject constructor(
     private val duckPlayerLocalFilesPath: DuckPlayerLocalFilesPath,
     private val mimeTypeMap: MimeTypeMap,
     private val dispatchers: DispatcherProvider,
-) : DuckPlayer {
+) : DuckPlayerInternal {
 
     private var shouldForceYTNavigation = false
     private var shouldHideOverlay = false

--- a/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/RealDuckPlayer.kt
+++ b/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/RealDuckPlayer.kt
@@ -39,6 +39,8 @@ import com.duckduckgo.duckplayer.api.DuckPlayer.UserPreferences
 import com.duckduckgo.duckplayer.api.PrivatePlayerMode.AlwaysAsk
 import com.duckduckgo.duckplayer.api.PrivatePlayerMode.Disabled
 import com.duckduckgo.duckplayer.api.PrivatePlayerMode.Enabled
+import com.duckduckgo.duckplayer.api.YOUTUBE_HOST
+import com.duckduckgo.duckplayer.api.YOUTUBE_MOBILE_HOST
 import com.duckduckgo.duckplayer.impl.DuckPlayerPixelName.DUCK_PLAYER_DAILY_UNIQUE_VIEW
 import com.duckduckgo.duckplayer.impl.DuckPlayerPixelName.DUCK_PLAYER_OVERLAY_YOUTUBE_IMPRESSIONS
 import com.duckduckgo.duckplayer.impl.DuckPlayerPixelName.DUCK_PLAYER_OVERLAY_YOUTUBE_WATCH_HERE
@@ -57,8 +59,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 
-private const val YOUTUBE_HOST = "youtube.com"
-private const val YOUTUBE_MOBILE_HOST = "m.youtube.com"
 private const val DUCK_PLAYER_VIDEO_ID_QUERY_PARAM = "videoID"
 private const val DUCK_PLAYER_OPEN_IN_YOUTUBE_PATH = "openInYoutube"
 private const val DUCK_PLAYER_DOMAIN = "player"
@@ -367,6 +367,10 @@ class RealDuckPlayer @Inject constructor(
         } else {
             DuckPlayerPrimeBottomSheet.newInstance(fromDuckPlayerPage).show(fragmentManager, null)
         }
+    }
+
+    override suspend fun getYouTubeEmbedUrl(): String {
+        return duckPlayerFeatureRepository.getYouTubeEmbedUrl()
     }
 
     override suspend fun willNavigateToDuckPlayer(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1208375755367840/f

### Description
Only process duck-player related messages if the origin belongs to a given set of domains

### Steps to test this PR

_Feature 1_
- [x] Open a YouTube video 
- [x] Click the button to open in Duck Player
- [x] Check the app navigates to Duck Player
- [x] Click the settings button
- [x] Check native settings are launched


