### PR TITLE
Use latest tag to retrieve versionCode for nightly releases

### DIFF
--- a/versioning.gradle
+++ b/versioning.gradle
@@ -31,15 +31,35 @@ ext {
     }
 
     buildNumberCode = {
-        filePath = "${CI_HOME_DIR}/build_number.properties"
-        if(!new File(filePath).exists()) return 0
-
         def suffix = getVersionNameSuffix()
         if (suffix?.trim()) {
-            def props = new Properties()
-            props.load(new FileInputStream(filePath))
-            String buildNumber = props["build"]
-            if (buildNumber == null) return 0 else return Integer.valueOf(buildNumber)
+            println("This is a nightly release, incrementing from previous release...")
+            String revision = 'git rev-list --tags --max-count=1'.execute().text
+            def stag = new StringBuilder(), serror = new StringBuilder()
+            def proc = "git describe --tags ${revision}".execute()
+            proc.consumeProcessOutput(stag, serror)
+            proc.waitForOrKill(1000)
+            def err = serror.toString()
+            if (err.isEmpty()){
+                def tag = stag.toString()
+                if (tag.contains('nightly')) {
+                    println("Last tag $tag was a nightly release, incrementing from previous one...")
+
+                    def (major, minor, patch, nightly) = tag.toLowerCase().tokenize('.')
+                    (major, minor, patch, nightly) = [major, minor, patch, nightly].collect { it.toString() }
+
+                    def (code, sufix) = nightly.toLowerCase().tokenize('-')
+                    (code, sufix) = [code, sufix].collect { it.toString() }
+
+                    def newCode = Integer.parseInt(code) + 1
+                    println("Previous code was $code, incrementing to $newCode")
+                    return newCode
+                } else {
+                    return 0
+                }
+            } else {
+                throw new IllegalStateException("Error retrieving git tag $err")
+            }
         } else {
             return 0
         }
@@ -96,5 +116,11 @@ tasks.register('incrementBuildNumber') {
 tasks.register('getBuildVersionName') {
     doLast {
         print buildVersionName()
+    }
+}
+
+tasks.register('getBuildVersionCode') {
+    doLast {
+        print buildNumberCode()
     }
 }

--- a/versioning.gradle
+++ b/versioning.gradle
@@ -1,10 +1,15 @@
+import javax.inject.Inject
+import org.gradle.api.provider.ValueSourceParameters
+import java.nio.charset.Charset
+
 ext {
 
     buildVersionCode = {
+        def versionCode = buildNumberCode()
         def versionName = getVersionName()
         def (major, minor, patch) = versionName.toLowerCase().tokenize('.')
         (major, minor, patch) = [major, minor, patch].collect { it.toInteger() }
-        (major * 10_000_000) + (minor * 10_000) + (patch * 1_000) + buildNumberCode()
+        (major * 10_000_000) + (minor * 10_000) + (patch * 1_000) + versionCode
     }
 
     getVersionName = {
@@ -33,32 +38,19 @@ ext {
     buildNumberCode = {
         def suffix = getVersionNameSuffix()
         if (suffix?.trim()) {
-            println("This is a nightly release, incrementing from previous release...")
-            String revision = 'git rev-list --tags --max-count=1'.execute().text
-            def stag = new StringBuilder(), serror = new StringBuilder()
-            def proc = "git describe --tags ${revision}".execute()
-            proc.consumeProcessOutput(stag, serror)
-            proc.waitForOrKill(1000)
-            def err = serror.toString()
-            if (err.isEmpty()){
-                def tag = stag.toString()
-                if (tag.contains('nightly')) {
-                    println("Last tag $tag was a nightly release, incrementing from previous one...")
+            def latestGitTagProvider = providers.of(LatestGitTagValueSource.class) {}
+            def tag = latestGitTagProvider.get()
+            if (tag.contains('nightly')) {
+                def (major, minor, patch, nightly) = tag.toLowerCase().tokenize('.')
+                (major, minor, patch, nightly) = [major, minor, patch, nightly].collect { it.toString() }
 
-                    def (major, minor, patch, nightly) = tag.toLowerCase().tokenize('.')
-                    (major, minor, patch, nightly) = [major, minor, patch, nightly].collect { it.toString() }
+                def (code, sufix) = nightly.toLowerCase().tokenize('-')
+                (code, sufix) = [code, sufix].collect { it.toString() }
 
-                    def (code, sufix) = nightly.toLowerCase().tokenize('-')
-                    (code, sufix) = [code, sufix].collect { it.toString() }
-
-                    def newCode = Integer.parseInt(code) + 1
-                    println("Previous code was $code, incrementing to $newCode")
-                    return newCode
-                } else {
-                    return 0
-                }
+                def newCode = Integer.parseInt(code) + 1
+                return newCode
             } else {
-                throw new IllegalStateException("Error retrieving git tag $err")
+                return 0
             }
         } else {
             return 0
@@ -122,5 +114,19 @@ tasks.register('getBuildVersionName') {
 tasks.register('getBuildVersionCode') {
     doLast {
         print buildNumberCode()
+    }
+}
+
+abstract class LatestGitTagValueSource implements ValueSource<String, ValueSourceParameters.None> {
+    @Inject
+    abstract ExecOperations getExecOperations()
+
+    String obtain() {
+        ByteArrayOutputStream output = new ByteArrayOutputStream()
+        execOperations.exec {
+            it.commandLine "git", "describe", "--tags", "--abbrev=0"
+            it.standardOutput = output
+        }
+        return new String(output.toByteArray(), Charset.defaultCharset())
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1174433894299346/1208382292008137/f

### Description

### Steps to test this PR

_Nightly_
- [ ] ./gradlew getBuildVersionCode -PversionNameSuffix=-nightly
- [ ] Verify that versionCode increments (Previous code was 5, incrementing to 6)

_Production_
- [ ] ./gradlew getBuildVersionCode
- [ ] Verify that versionCode is 0
