### PR TITLE
Convert enum to data class and store tag/pixel name

### DIFF
--- a/ad-click/ad-click-impl/src/test/java/com/duckduckgo/adclick/impl/pixels/RealAdClickPixelsTest.kt
+++ b/ad-click/ad-click-impl/src/test/java/com/duckduckgo/adclick/impl/pixels/RealAdClickPixelsTest.kt
@@ -22,7 +22,7 @@ import androidx.core.content.edit
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.adclick.impl.Exemption
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.common.test.api.InMemorySharedPreferences
 import java.time.Instant
 import java.util.concurrent.TimeUnit
@@ -248,7 +248,7 @@ class RealAdClickPixelsTest {
             pixel = eq(AdClickPixelName.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION),
             parameters = any(),
             encodedParameters = any(),
-            type = eq(COUNT),
+            type = eq(Count),
         )
     }
 
@@ -264,7 +264,7 @@ class RealAdClickPixelsTest {
             pixel = eq(AdClickPixelName.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION),
             parameters = eq(mapOf(AdClickPixelParameters.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION_COUNT to "1")),
             encodedParameters = any(),
-            type = eq(COUNT),
+            type = eq(Count),
         )
     }
 
@@ -283,7 +283,7 @@ class RealAdClickPixelsTest {
             pixel = eq(AdClickPixelName.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION),
             parameters = any(),
             encodedParameters = any(),
-            type = eq(COUNT),
+            type = eq(Count),
         )
     }
 
@@ -302,7 +302,7 @@ class RealAdClickPixelsTest {
             pixel = eq(AdClickPixelName.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION),
             parameters = eq(mapOf(AdClickPixelParameters.AD_CLICK_PAGELOADS_WITH_AD_ATTRIBUTION_COUNT to "1")),
             encodedParameters = any(),
-            type = eq(COUNT),
+            type = eq(Count),
         )
     }
 }

--- a/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/AnrOfflinePixelSender.kt
+++ b/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/AnrOfflinePixelSender.kt
@@ -21,7 +21,7 @@ import com.duckduckgo.anrs.api.AnrRepository
 import com.duckduckgo.app.statistics.api.OfflinePixel
 import com.duckduckgo.app.statistics.api.PixelSender
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesMultibinding
 import io.reactivex.Completable
@@ -47,7 +47,7 @@ class AnrOfflinePixelSender @Inject constructor(
                         ANR_CUSTOM_TAB to it.customTab.toString(),
                     ),
                     mapOf(),
-                    COUNT,
+                    Count,
                 ).ignoreElement().doOnComplete {
                     anrRepository.removeMostRecentAnr()
                 }

--- a/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/CrashOfflinePixelSender.kt
+++ b/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/CrashOfflinePixelSender.kt
@@ -22,7 +22,7 @@ import com.duckduckgo.app.anr.CrashPixel.APPLICATION_CRASH_GLOBAL_VERIFIED_INSTA
 import com.duckduckgo.app.anrs.store.UncaughtExceptionDao
 import com.duckduckgo.app.statistics.api.OfflinePixel
 import com.duckduckgo.app.statistics.api.PixelSender
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.browser.api.WebViewVersionProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.verifiedinstallation.IsVerifiedPlayStoreInstall
@@ -63,13 +63,13 @@ class CrashOfflinePixelSender @Inject constructor(
                         pixelName = APPLICATION_CRASH_GLOBAL_VERIFIED_INSTALL.pixelName,
                         parameters = params,
                         encodedParameters = emptyMap(),
-                        type = COUNT,
+                        type = Count,
                     )
                     pixels.add(verifiedPixel.ignoreElement())
                 }
 
                 val pixel =
-                    pixelSender.sendPixel(APPLICATION_CRASH_GLOBAL.pixelName, params, emptyMap(), COUNT).ignoreElement().doOnComplete {
+                    pixelSender.sendPixel(APPLICATION_CRASH_GLOBAL.pixelName, params, emptyMap(), Count).ignoreElement().doOnComplete {
                         logcat { "Sent pixel with params: $params containing exception; deleting exception with id=${exception.hash}" }
                         uncaughtExceptionDao.delete(exception)
                     }

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -158,9 +158,9 @@ import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.api.StatisticsUpdater
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.DAILY
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.UNIQUE
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
 import com.duckduckgo.app.surrogates.SurrogateResponse
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
@@ -5197,8 +5197,8 @@ class BrowserTabViewModelTest {
         whenever(mockUserAllowListRepository.isDomainInUserAllowList("www.example.com")).thenReturn(true)
         testee.onPrivacyProtectionMenuClicked()
 
-        verify(mockPixel).fire(AppPixelName.BROWSER_MENU_ALLOWLIST_ADD, params, type = COUNT)
-        verify(mockPixel).fire(AppPixelName.BROWSER_MENU_ALLOWLIST_REMOVE, params, type = COUNT)
+        verify(mockPixel).fire(AppPixelName.BROWSER_MENU_ALLOWLIST_ADD, params, type = Count)
+        verify(mockPixel).fire(AppPixelName.BROWSER_MENU_ALLOWLIST_REMOVE, params, type = Count)
         verify(privacyProtectionsPopupExperimentExternalPixels).tryReportProtectionsToggledFromBrowserMenu(protectionsEnabled = false)
         verify(privacyProtectionsPopupExperimentExternalPixels).tryReportProtectionsToggledFromBrowserMenu(protectionsEnabled = true)
     }
@@ -5483,7 +5483,7 @@ class BrowserTabViewModelTest {
         val testParams = mapOf("daysSinceInstall" to "0", "from_onboarding" to "true")
 
         testee.onPrivacyShieldSelected()
-        verify(mockPixel).fire(pixel = PrivacyDashboardPixels.PRIVACY_DASHBOARD_FIRST_TIME_OPENED, parameters = testParams, type = UNIQUE)
+        verify(mockPixel).fire(pixel = PrivacyDashboardPixels.PRIVACY_DASHBOARD_FIRST_TIME_OPENED, parameters = testParams, type = Unique())
     }
 
     @Test
@@ -5516,7 +5516,7 @@ class BrowserTabViewModelTest {
 
         testee.onUserSubmittedQuery("foo")
 
-        verify(mockPixel).fire(ONBOARDING_SEARCH_CUSTOM, type = UNIQUE)
+        verify(mockPixel).fire(ONBOARDING_SEARCH_CUSTOM, type = Unique())
     }
 
     @Test
@@ -5527,7 +5527,7 @@ class BrowserTabViewModelTest {
 
         testee.onUserSubmittedQuery("foo")
 
-        verify(mockPixel).fire(ONBOARDING_VISIT_SITE_CUSTOM, type = UNIQUE)
+        verify(mockPixel).fire(ONBOARDING_VISIT_SITE_CUSTOM, type = Unique())
     }
 
     @Test
@@ -5578,7 +5578,7 @@ class BrowserTabViewModelTest {
 
         assertCommandIssued<Command.LaunchTabSwitcher>()
         verify(mockPixel).fire(AppPixelName.TAB_MANAGER_CLICKED)
-        verify(mockPixel).fire(AppPixelName.TAB_MANAGER_CLICKED_DAILY, emptyMap(), emptyMap(), DAILY)
+        verify(mockPixel).fire(AppPixelName.TAB_MANAGER_CLICKED_DAILY, emptyMap(), emptyMap(), Daily())
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -40,8 +40,8 @@ import com.duckduckgo.app.privacy.model.HttpsStatus
 import com.duckduckgo.app.privacy.model.TestEntity
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.UNIQUE
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.trackerdetection.model.Entity
@@ -173,32 +173,32 @@ class CtaViewModelTest {
     @Test
     fun whenCtaShownAndCtaIsDaxAndCanNotSendPixelThenPixelIsNotFired() {
         testee.onCtaShown(DaxBubbleCta.DaxIntroSearchOptionsCta(mockOnboardingStore, mockAppInstallStore))
-        verify(mockPixel, never()).fire(eq(SURVEY_CTA_SHOWN), any(), any(), eq(COUNT))
+        verify(mockPixel, never()).fire(eq(SURVEY_CTA_SHOWN), any(), any(), eq(Count))
     }
 
     @Test
     fun whenCtaShownAndCtaIsDaxAndCanSendPixelThenPixelIsFired() {
         whenever(mockOnboardingStore.onboardingDialogJourney).thenReturn("s:0")
         testee.onCtaShown(DaxBubbleCta.DaxEndCta(mockOnboardingStore, mockAppInstallStore))
-        verify(mockPixel, never()).fire(eq(SURVEY_CTA_SHOWN), any(), any(), eq(COUNT))
+        verify(mockPixel, never()).fire(eq(SURVEY_CTA_SHOWN), any(), any(), eq(Count))
     }
 
     @Test
     fun whenCtaShownAndCtaIsNotDaxThenPixelIsFired() {
         testee.onCtaShown(HomePanelCta.AddWidgetAuto)
-        verify(mockPixel).fire(eq(WIDGET_CTA_SHOWN), any(), any(), eq(COUNT))
+        verify(mockPixel).fire(eq(WIDGET_CTA_SHOWN), any(), any(), eq(Count))
     }
 
     @Test
     fun whenCtaLaunchedPixelIsFired() {
         testee.onUserClickCtaOkButton(HomePanelCta.AddWidgetAuto)
-        verify(mockPixel).fire(eq(WIDGET_CTA_LAUNCHED), any(), any(), eq(COUNT))
+        verify(mockPixel).fire(eq(WIDGET_CTA_LAUNCHED), any(), any(), eq(Count))
     }
 
     @Test
     fun whenCtaDismissedPixelIsFired() = runTest {
         testee.onUserDismissedCta(HomePanelCta.AddWidgetAuto)
-        verify(mockPixel).fire(eq(WIDGET_CTA_DISMISSED), any(), any(), eq(COUNT))
+        verify(mockPixel).fire(eq(WIDGET_CTA_DISMISSED), any(), any(), eq(Count))
     }
 
     @Test
@@ -745,7 +745,7 @@ class CtaViewModelTest {
         val site = site(url = privacyProUrl)
 
         val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true, site = site)
-        verify(mockPixel, never()).fire(eq(ONBOARDING_SKIP_MAJOR_NETWORK_UNIQUE), any(), any(), eq(UNIQUE))
+        verify(mockPixel, never()).fire(eq(ONBOARDING_SKIP_MAJOR_NETWORK_UNIQUE), any(), any(), eq(Unique()))
         assertNull(value)
     }
 
@@ -761,7 +761,7 @@ class CtaViewModelTest {
         whenever(mockDuckPlayer.isSimulatedYoutubeNoCookie(anyString())).thenReturn(false)
 
         val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true, site = site)
-        verify(mockPixel).fire(eq(ONBOARDING_SKIP_MAJOR_NETWORK_UNIQUE), any(), any(), eq(UNIQUE))
+        verify(mockPixel).fire(eq(ONBOARDING_SKIP_MAJOR_NETWORK_UNIQUE), any(), any(), eq(Unique()))
         assertNull(value)
     }
 

--- a/app/src/androidTest/java/com/duckduckgo/app/notification/NotificationRegistrarTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/notification/NotificationRegistrarTest.kt
@@ -23,7 +23,7 @@ import com.duckduckgo.app.notification.model.SchedulableNotificationPlugin
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.plugins.PluginPoint
@@ -76,7 +76,7 @@ class NotificationRegistrarTest {
     fun whenNotificationsPreviouslyOffAndNowOnThenPixelIsFiredAndSettingsUpdated() {
         whenever(mockSettingsDataStore.appNotificationsEnabled).thenReturn(false)
         testee.updateStatus(true)
-        verify(mockPixel).fire(eq(AppPixelName.NOTIFICATIONS_ENABLED), any(), any(), eq(COUNT))
+        verify(mockPixel).fire(eq(AppPixelName.NOTIFICATIONS_ENABLED), any(), any(), eq(Count))
         verify(mockSettingsDataStore).appNotificationsEnabled = true
     }
 
@@ -84,7 +84,7 @@ class NotificationRegistrarTest {
     fun whenNotificationsPreviouslyOffAndStillOffThenNoPixelIsFiredAndSettingsUnchanged() {
         whenever(mockSettingsDataStore.appNotificationsEnabled).thenReturn(false)
         testee.updateStatus(false)
-        verify(mockPixel, never()).fire(any<Pixel.PixelName>(), any(), any(), eq(COUNT))
+        verify(mockPixel, never()).fire(any<Pixel.PixelName>(), any(), any(), eq(Count))
         verify(mockSettingsDataStore, never()).appNotificationsEnabled = true
     }
 
@@ -92,7 +92,7 @@ class NotificationRegistrarTest {
     fun whenNotificationsPreviouslyOnAndStillOnThenNoPixelIsFiredAndSettingsUnchanged() {
         whenever(mockSettingsDataStore.appNotificationsEnabled).thenReturn(true)
         testee.updateStatus(true)
-        verify(mockPixel, never()).fire(any<Pixel.PixelName>(), any(), any(), eq(COUNT))
+        verify(mockPixel, never()).fire(any<Pixel.PixelName>(), any(), any(), eq(Count))
         verify(mockSettingsDataStore, never()).appNotificationsEnabled = false
     }
 
@@ -100,7 +100,7 @@ class NotificationRegistrarTest {
     fun whenNotificationsPreviouslyOnAndNowOffPixelIsFiredAndSettingsUpdated() {
         whenever(mockSettingsDataStore.appNotificationsEnabled).thenReturn(true)
         testee.updateStatus(false)
-        verify(mockPixel).fire(eq(AppPixelName.NOTIFICATIONS_DISABLED), any(), any(), eq(COUNT))
+        verify(mockPixel).fire(eq(AppPixelName.NOTIFICATIONS_DISABLED), any(), any(), eq(Count))
         verify(mockSettingsDataStore).appNotificationsEnabled = false
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/BrokenSiteViewModel.kt
@@ -31,7 +31,7 @@ import com.duckduckgo.app.brokensite.model.SiteProtectionsState.ENABLED
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.brokensite.api.BrokenSite
 import com.duckduckgo.brokensite.api.BrokenSiteSender
 import com.duckduckgo.brokensite.api.ReportFlow as BrokenSiteModelReportFlow
@@ -187,10 +187,10 @@ class BrokenSiteViewModel @Inject constructor(
             val pixelParams = privacyProtectionsPopupExperimentExternalPixels.getPixelParams()
             if (protectionsEnabled) {
                 userAllowListRepository.removeDomainFromUserAllowList(domain)
-                pixel.fire(AppPixelName.BROKEN_SITE_ALLOWLIST_REMOVE, pixelParams, type = COUNT)
+                pixel.fire(AppPixelName.BROKEN_SITE_ALLOWLIST_REMOVE, pixelParams, type = Count)
             } else {
                 userAllowListRepository.addDomainToUserAllowList(domain)
-                pixel.fire(AppPixelName.BROKEN_SITE_ALLOWLIST_ADD, pixelParams, type = COUNT)
+                pixel.fire(AppPixelName.BROKEN_SITE_ALLOWLIST_ADD, pixelParams, type = Count)
             }
             privacyProtectionsPopupExperimentExternalPixels.tryReportProtectionsToggledFromBrokenSiteReport(protectionsEnabled)
             protectionsToggleUsageListener.onPrivacyProtectionsToggleUsed()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -205,7 +205,7 @@ import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.FIRE_BUTTON_STATE
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.LOADING_BAR_EXPERIMENT
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.DAILY
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.ui.GridViewColumnCalculator
 import com.duckduckgo.app.tabs.ui.TabSwitcherActivity
@@ -2786,11 +2786,11 @@ class BrowserTabFragment :
                 pixel.fire(
                     AppPixelName.REFRESH_ACTION_DAILY_PIXEL.pixelName,
                     mapOf(LOADING_BAR_EXPERIMENT to loadingBarExperimentManager.variant.toBinaryString()),
-                    type = DAILY,
+                    type = Daily(),
                 )
             } else {
                 pixel.fire(AppPixelName.BROWSER_PULL_TO_REFRESH.pixelName)
-                pixel.fire(AppPixelName.REFRESH_ACTION_DAILY_PIXEL.pixelName, type = DAILY)
+                pixel.fire(AppPixelName.REFRESH_ACTION_DAILY_PIXEL.pixelName, type = Daily())
             }
         }
 
@@ -3641,11 +3641,11 @@ class BrowserTabFragment :
                             pixel.fire(
                                 AppPixelName.REFRESH_ACTION_DAILY_PIXEL.pixelName,
                                 mapOf(LOADING_BAR_EXPERIMENT to loadingBarExperimentManager.variant.toBinaryString()),
-                                type = DAILY,
+                                type = Daily(),
                             )
                         } else {
                             pixel.fire(AppPixelName.MENU_ACTION_REFRESH_PRESSED.pixelName)
-                            pixel.fire(AppPixelName.REFRESH_ACTION_DAILY_PIXEL.pixelName, type = DAILY)
+                            pixel.fire(AppPixelName.REFRESH_ACTION_DAILY_PIXEL.pixelName, type = Daily())
                         }
                     }
                 }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -145,9 +145,9 @@ import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.api.StatisticsUpdater
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.DAILY
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.UNIQUE
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
 import com.duckduckgo.app.surrogates.SurrogateResponse
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
@@ -816,7 +816,7 @@ class BrowserTabViewModel @Inject constructor(
         when (currentCtaViewState().cta) {
             is DaxBubbleCta.DaxIntroSearchOptionsCta -> {
                 if (!ctaViewModel.isSuggestedSearchOption(query)) {
-                    pixel.fire(ONBOARDING_SEARCH_CUSTOM, type = UNIQUE)
+                    pixel.fire(ONBOARDING_SEARCH_CUSTOM, type = Unique())
                 }
             }
 
@@ -824,7 +824,7 @@ class BrowserTabViewModel @Inject constructor(
             is OnboardingDaxDialogCta.DaxSiteSuggestionsCta,
             -> {
                 if (!ctaViewModel.isSuggestedSiteOption(query)) {
-                    pixel.fire(ONBOARDING_VISIT_SITE_CUSTOM, type = UNIQUE)
+                    pixel.fire(ONBOARDING_VISIT_SITE_CUSTOM, type = Unique())
                 }
             }
         }
@@ -2058,7 +2058,7 @@ class BrowserTabViewModel @Inject constructor(
                 onDeleteFavoriteRequested(favorite)
             } else {
                 pixel.fire(AppPixelName.MENU_ACTION_ADD_FAVORITE_PRESSED.pixelName)
-                pixel.fire(SavedSitesPixelName.MENU_ACTION_ADD_FAVORITE_PRESSED_DAILY.pixelName, type = DAILY)
+                pixel.fire(SavedSitesPixelName.MENU_ACTION_ADD_FAVORITE_PRESSED_DAILY.pixelName, type = Daily())
                 saveFavoriteSite(url, title ?: "")
             }
         }
@@ -2270,7 +2270,7 @@ class BrowserTabViewModel @Inject constructor(
         if (clickedFromCustomTab) {
             pixel.fire(CustomTabPixelNames.CUSTOM_TABS_MENU_DISABLE_PROTECTIONS_ALLOW_LIST_ADD)
         } else {
-            pixel.fire(AppPixelName.BROWSER_MENU_ALLOWLIST_ADD, pixelParams, type = COUNT)
+            pixel.fire(AppPixelName.BROWSER_MENU_ALLOWLIST_ADD, pixelParams, type = Count)
         }
         privacyProtectionsPopupExperimentExternalPixels.tryReportProtectionsToggledFromBrowserMenu(protectionsEnabled = false)
         userAllowListRepository.addDomainToUserAllowList(domain)
@@ -2285,7 +2285,7 @@ class BrowserTabViewModel @Inject constructor(
         if (clickedFromCustomTab) {
             pixel.fire(CustomTabPixelNames.CUSTOM_TABS_MENU_DISABLE_PROTECTIONS_ALLOW_LIST_REMOVE)
         } else {
-            pixel.fire(AppPixelName.BROWSER_MENU_ALLOWLIST_REMOVE, pixelParams, type = COUNT)
+            pixel.fire(AppPixelName.BROWSER_MENU_ALLOWLIST_REMOVE, pixelParams, type = Count)
         }
         privacyProtectionsPopupExperimentExternalPixels.tryReportProtectionsToggledFromBrowserMenu(protectionsEnabled = true)
         userAllowListRepository.removeDomainFromUserAllowList(domain)
@@ -2771,7 +2771,7 @@ class BrowserTabViewModel @Inject constructor(
     fun userLaunchingTabSwitcher() {
         command.value = LaunchTabSwitcher
         pixel.fire(AppPixelName.TAB_MANAGER_CLICKED)
-        pixel.fire(AppPixelName.TAB_MANAGER_CLICKED_DAILY, emptyMap(), emptyMap(), DAILY)
+        pixel.fire(AppPixelName.TAB_MANAGER_CLICKED_DAILY, emptyMap(), emptyMap(), Daily())
     }
 
     private fun isFireproofWebsite(domain: String? = site?.domain): Boolean {
@@ -3455,7 +3455,7 @@ class BrowserTabViewModel @Inject constructor(
                     "daysSinceInstall" to userBrowserProperties.daysSinceInstalled().toString(),
                     "from_onboarding" to "true",
                 ),
-                type = UNIQUE,
+                type = Unique(),
             )
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/indonesiamessage/IndonesiaNewTabSectionViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/indonesiamessage/IndonesiaNewTabSectionViewModel.kt
@@ -82,7 +82,7 @@ class IndonesiaNewTabSectionViewModel @Inject constructor(
     }
 
     fun onMessageShown() {
-        pixel.fire(AppPixelName.INDONESIA_MESSAGE_SHOWN, type = Pixel.PixelType.DAILY)
+        pixel.fire(AppPixelName.INDONESIA_MESSAGE_SHOWN, type = Pixel.PixelType.Daily())
     }
 
     companion object {

--- a/app/src/main/java/com/duckduckgo/app/browser/pageloadpixel/PageLoadedOfflinePixelSender.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pageloadpixel/PageLoadedOfflinePixelSender.kt
@@ -19,7 +19,7 @@ package com.duckduckgo.app.browser.pageloadpixel
 import com.duckduckgo.app.browser.WebViewPixelName
 import com.duckduckgo.app.statistics.api.OfflinePixel
 import com.duckduckgo.app.statistics.api.PixelSender
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesMultibinding
 import io.reactivex.Completable
@@ -57,7 +57,7 @@ class PageLoadedOfflinePixelSender @Inject constructor(
                     WebViewPixelName.WEB_PAGE_LOADED.pixelName,
                     params,
                     mapOf(),
-                    COUNT,
+                    Count,
                 ).ignoreElement().doOnComplete {
                     Timber.d("Sent page loaded pixel with params: $params")
                     pageLoadedPixelDao.delete(it)

--- a/app/src/main/java/com/duckduckgo/app/browser/pageloadpixel/firstpaint/PagePaintedOfflinePixelSender.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pageloadpixel/firstpaint/PagePaintedOfflinePixelSender.kt
@@ -47,7 +47,7 @@ class PagePaintedOfflinePixelSender @Inject constructor(
                     WebViewPixelName.WEB_PAGE_PAINTED.pixelName,
                     params,
                     mapOf(),
-                    Pixel.PixelType.COUNT,
+                    Pixel.PixelType.Count,
                 ).ignoreElement().doOnComplete {
                     dao.delete(it)
                 }

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -35,7 +35,7 @@ import com.duckduckgo.app.pixels.AppPixelName.ONBOARDING_SKIP_MAJOR_NETWORK_UNIQ
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.UNIQUE
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.widget.ui.WidgetCapabilities
 import com.duckduckgo.common.utils.DispatcherProvider
@@ -328,7 +328,7 @@ class CtaViewModel @Inject constructor(
                     )
 
         if (isDuckPlayerUrl) {
-            pixel.fire(pixel = ONBOARDING_SKIP_MAJOR_NETWORK_UNIQUE, type = UNIQUE)
+            pixel.fire(pixel = ONBOARDING_SKIP_MAJOR_NETWORK_UNIQUE, type = Unique())
         }
 
         return isDuckPlayerUrl

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModel.kt
@@ -40,7 +40,7 @@ import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_COMPARISON_CHART_SHO
 import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_INTRO_SHOWN_UNIQUE
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.UNIQUE
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
 import com.duckduckgo.di.scopes.FragmentScope
 import javax.inject.Inject
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
@@ -140,9 +140,9 @@ class WelcomePageViewModel @Inject constructor(
 
     fun onDialogShown(onboardingDialogType: PreOnboardingDialogType) {
         when (onboardingDialogType) {
-            INITIAL -> pixel.fire(PREONBOARDING_INTRO_SHOWN_UNIQUE, type = UNIQUE)
-            COMPARISON_CHART -> pixel.fire(PREONBOARDING_COMPARISON_CHART_SHOWN_UNIQUE, type = UNIQUE)
-            CELEBRATION -> pixel.fire(PREONBOARDING_AFFIRMATION_SHOWN_UNIQUE, type = UNIQUE)
+            INITIAL -> pixel.fire(PREONBOARDING_INTRO_SHOWN_UNIQUE, type = Unique())
+            COMPARISON_CHART -> pixel.fire(PREONBOARDING_COMPARISON_CHART_SHOWN_UNIQUE, type = Unique())
+            CELEBRATION -> pixel.fire(PREONBOARDING_AFFIRMATION_SHOWN_UNIQUE, type = Unique())
         }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
@@ -43,7 +43,7 @@ import com.duckduckgo.app.pixels.AppPixelName.PRIVACY_PRO_IS_ENABLED_AND_ELIGIBL
 import com.duckduckgo.app.privatesearch.PrivateSearchScreenNoParams
 import com.duckduckgo.app.settings.SettingsViewModel.Command
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.DAILY
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.app.webtrackingprotection.WebTrackingProtectionScreenNoParams
 import com.duckduckgo.app.widget.AddWidgetLauncher
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
@@ -227,7 +227,7 @@ class SettingsActivity : DuckDuckGoActivity() {
 
     private fun updatePrivacyPro(isPrivacyProEnabled: Boolean) {
         if (isPrivacyProEnabled) {
-            pixel.fire(PRIVACY_PRO_IS_ENABLED_AND_ELIGIBLE, type = DAILY)
+            pixel.fire(PRIVACY_PRO_IS_ENABLED_AND_ELIGIBLE, type = Daily())
             viewsPro.show()
         } else {
             viewsPro.gone()

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
@@ -35,7 +35,7 @@ import com.duckduckgo.app.onboarding.store.isNewUser
 import com.duckduckgo.app.pixels.AppPixelName.*
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.DAILY
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.app.systemsearch.SystemSearchViewModel.Command.UpdateVoiceSearch
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.SingleLiveEvent
@@ -403,7 +403,7 @@ class SystemSearchViewModel @Inject constructor(
 
     override fun onFavoriteAdded() {
         pixel.fire(SavedSitesPixelName.EDIT_BOOKMARK_ADD_FAVORITE_TOGGLED)
-        pixel.fire(SavedSitesPixelName.EDIT_BOOKMARK_ADD_FAVORITE_TOGGLED_DAILY, type = DAILY)
+        pixel.fire(SavedSitesPixelName.EDIT_BOOKMARK_ADD_FAVORITE_TOGGLED_DAILY, type = Daily())
     }
 
     override fun onFavoriteRemoved() {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -25,7 +25,7 @@ import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.DAILY
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType.GRID
@@ -152,7 +152,7 @@ class TabSwitcherViewModel @Inject constructor(
     fun onTabDraggingStarted() {
         viewModelScope.launch(dispatcherProvider.io()) {
             val params = mapOf("userState" to tabRepository.tabSwitcherData.first().userState.name)
-            pixel.fire(AppPixelName.TAB_MANAGER_REARRANGE_TABS_DAILY, parameters = params, encodedParameters = emptyMap(), DAILY)
+            pixel.fire(AppPixelName.TAB_MANAGER_REARRANGE_TABS_DAILY, parameters = params, encodedParameters = emptyMap(), Daily())
         }
     }
 

--- a/app/src/play/java/com/duckduckgo/referral/AppReferrerInstallPixelSender.kt
+++ b/app/src/play/java/com/duckduckgo/referral/AppReferrerInstallPixelSender.kt
@@ -70,7 +70,7 @@ class AppReferrerInstallPixelSender @Inject constructor(
             params[PIXEL_PARAM_ORIGIN] = originAttribute
         }
 
-        pixel.fire(pixel = AppPixelName.REFERRAL_INSTALL_UTM_CAMPAIGN, type = Pixel.PixelType.UNIQUE, parameters = params)
+        pixel.fire(pixel = AppPixelName.REFERRAL_INSTALL_UTM_CAMPAIGN, type = Pixel.PixelType.Unique(), parameters = params)
     }
 
     companion object {

--- a/app/src/test/java/com/duckduckgo/app/brokensite/api/BrokenSiteSubmitterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/brokensite/api/BrokenSiteSubmitterTest.kt
@@ -7,7 +7,7 @@ import com.duckduckgo.app.pixels.AppPixelName.BROKEN_SITE_REPORTED
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.statistics.model.Atb
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.app.trackerdetection.db.TdsMetadataDao
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
@@ -134,7 +134,7 @@ class BrokenSiteSubmitterTest {
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
         val encodedParamsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture(), eq(COUNT))
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture(), eq(Count))
         val params = paramsCaptor.firstValue
 
         assertEquals("false", params["vpnOn"])
@@ -149,7 +149,7 @@ class BrokenSiteSubmitterTest {
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
         val encodedParamsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture(), eq(COUNT))
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture(), eq(Count))
         val params = paramsCaptor.firstValue
 
         assertEquals("true", params["vpnOn"])
@@ -166,7 +166,7 @@ class BrokenSiteSubmitterTest {
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
         val encodedParamsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture(), eq(COUNT))
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture(), eq(Count))
         val params = paramsCaptor.firstValue
 
         assertEquals("false", params["protectionsState"])
@@ -183,7 +183,7 @@ class BrokenSiteSubmitterTest {
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
         val encodedParamsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture(), eq(COUNT))
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture(), eq(Count))
         val params = paramsCaptor.firstValue
 
         assertEquals("false", params["protectionsState"])
@@ -200,7 +200,7 @@ class BrokenSiteSubmitterTest {
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
         val encodedParamsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture(), eq(COUNT))
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture(), eq(Count))
         val params = paramsCaptor.firstValue
 
         assertEquals("false", params["protectionsState"])
@@ -219,7 +219,7 @@ class BrokenSiteSubmitterTest {
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
         val encodedParamsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture(), eq(COUNT))
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture(), eq(Count))
         val params = paramsCaptor.firstValue
 
         assertEquals("false", params["protectionsState"])
@@ -236,7 +236,7 @@ class BrokenSiteSubmitterTest {
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
         val encodedParamsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture(), eq(COUNT))
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture(), eq(Count))
         val params = paramsCaptor.firstValue
 
         assertEquals("true", params["protectionsState"])
@@ -252,7 +252,7 @@ class BrokenSiteSubmitterTest {
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
         val encodedParamsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture(), eq(COUNT))
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture(), eq(Count))
         val params = paramsCaptor.firstValue
 
         assertEquals(lastSentDay, params["lastSentDay"])
@@ -271,7 +271,7 @@ class BrokenSiteSubmitterTest {
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
         val encodedParamsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture(), eq(COUNT))
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture(), eq(Count))
         val params = paramsCaptor.firstValue
 
         assertEquals("", params["loginSite"])
@@ -289,7 +289,7 @@ class BrokenSiteSubmitterTest {
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
         val encodedParamsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture(), eq(COUNT))
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture(), eq(Count))
         val params = paramsCaptor.firstValue
 
         assertFalse(params.containsKey("loginSite"))
@@ -303,7 +303,7 @@ class BrokenSiteSubmitterTest {
         testee.submitBrokenSiteFeedback(brokenSite)
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), any(), eq(COUNT))
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), any(), eq(Count))
         val params = paramsCaptor.firstValue
 
         assertEquals("menu", params["reportFlow"])
@@ -317,7 +317,7 @@ class BrokenSiteSubmitterTest {
         testee.submitBrokenSiteFeedback(brokenSite)
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), any(), eq(COUNT))
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), any(), eq(Count))
         val params = paramsCaptor.firstValue
 
         assertEquals("dashboard", params["reportFlow"])
@@ -331,7 +331,7 @@ class BrokenSiteSubmitterTest {
         testee.submitBrokenSiteFeedback(brokenSite)
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), any(), eq(COUNT))
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), any(), eq(Count))
         val params = paramsCaptor.firstValue
 
         assertFalse("reportFlow" in params)
@@ -345,7 +345,7 @@ class BrokenSiteSubmitterTest {
         testee.submitBrokenSiteFeedback(getBrokenSite())
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), any(), eq(COUNT))
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), any(), eq(Count))
 
         assertEquals("test_value", paramsCaptor.firstValue["test_key"])
     }
@@ -364,7 +364,7 @@ class BrokenSiteSubmitterTest {
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
         val encodedParamsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture(), eq(COUNT))
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture(), eq(Count))
         val params = paramsCaptor.firstValue
 
         assertEquals("en-US", params["locale"])
@@ -377,7 +377,7 @@ class BrokenSiteSubmitterTest {
         testee.submitBrokenSiteFeedback(brokenSite)
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), any(), eq(COUNT))
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), any(), eq(Count))
         val params = paramsCaptor.firstValue
 
         assertEquals("0", params["userRefreshCount"])
@@ -391,7 +391,7 @@ class BrokenSiteSubmitterTest {
         testee.submitBrokenSiteFeedback(brokenSite)
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), any(), eq(COUNT))
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), any(), eq(Count))
         val params = paramsCaptor.firstValue
 
         assertEquals("5", params["userRefreshCount"])
@@ -405,7 +405,7 @@ class BrokenSiteSubmitterTest {
         testee.submitBrokenSiteFeedback(brokenSite)
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), any(), eq(COUNT))
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), any(), eq(Count))
         val params = paramsCaptor.firstValue
 
         assertEquals("serp", params["openerContext"])
@@ -419,7 +419,7 @@ class BrokenSiteSubmitterTest {
         testee.submitBrokenSiteFeedback(brokenSite)
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), any(), eq(COUNT))
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), any(), eq(Count))
         val params = paramsCaptor.firstValue
 
         assertEquals("external", params["openerContext"])
@@ -433,7 +433,7 @@ class BrokenSiteSubmitterTest {
         testee.submitBrokenSiteFeedback(brokenSite)
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), any(), eq(COUNT))
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), any(), eq(Count))
         val params = paramsCaptor.firstValue
 
         assertEquals("navigation", params["openerContext"])
@@ -446,7 +446,7 @@ class BrokenSiteSubmitterTest {
         testee.submitBrokenSiteFeedback(brokenSite)
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), any(), eq(COUNT))
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), any(), eq(Count))
         val params = paramsCaptor.firstValue
 
         assertEquals("", params["openerContext"])
@@ -459,7 +459,7 @@ class BrokenSiteSubmitterTest {
         testee.submitBrokenSiteFeedback(brokenSite)
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), any(), eq(COUNT))
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), any(), eq(Count))
         val params = paramsCaptor.firstValue
 
         assertEquals("", params["jsPerformance"])
@@ -473,7 +473,7 @@ class BrokenSiteSubmitterTest {
         testee.submitBrokenSiteFeedback(brokenSite)
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), any(), eq(COUNT))
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), any(), eq(Count))
         val params = paramsCaptor.firstValue
 
         assertEquals("123.45", params["jsPerformance"])
@@ -487,7 +487,7 @@ class BrokenSiteSubmitterTest {
         testee.submitBrokenSiteFeedback(getBrokenSite())
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), any(), eq(COUNT))
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), any(), eq(Count))
         val params = paramsCaptor.firstValue
 
         assertEquals(webViewVersion, params["wvVersion"])
@@ -498,10 +498,10 @@ class BrokenSiteSubmitterTest {
         val brokenSite = getBrokenSite()
         testee.submitBrokenSiteFeedback(brokenSite)
 
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), any(), any(), eq(COUNT))
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), any(), any(), eq(Count))
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORTED), parameters = paramsCaptor.capture(), any(), eq(COUNT))
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORTED), parameters = paramsCaptor.capture(), any(), eq(Count))
         val params = paramsCaptor.firstValue
         assertEquals(brokenSite.siteUrl, params[Pixel.PixelParameter.URL])
     }
@@ -514,10 +514,10 @@ class BrokenSiteSubmitterTest {
         testee.submitBrokenSiteFeedback(brokenSite)
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), parameters = paramsCaptor.capture(), any(), eq(COUNT))
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), parameters = paramsCaptor.capture(), any(), eq(Count))
         assertEquals(brokenSite.siteUrl, paramsCaptor.lastValue["siteUrl"])
 
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORTED), parameters = paramsCaptor.capture(), any(), eq(COUNT))
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORTED), parameters = paramsCaptor.capture(), any(), eq(Count))
         assertEquals(brokenSite.siteUrl, paramsCaptor.lastValue[Pixel.PixelParameter.URL])
     }
 
@@ -529,10 +529,10 @@ class BrokenSiteSubmitterTest {
         testee.submitBrokenSiteFeedback(brokenSite)
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), parameters = paramsCaptor.capture(), any(), eq(COUNT))
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), parameters = paramsCaptor.capture(), any(), eq(Count))
         assertEquals(brokenSite.siteUrl, paramsCaptor.lastValue["siteUrl"])
 
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORTED), parameters = paramsCaptor.capture(), any(), eq(COUNT))
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORTED), parameters = paramsCaptor.capture(), any(), eq(Count))
         assertEquals(brokenSite.siteUrl, paramsCaptor.lastValue[Pixel.PixelParameter.URL])
     }
 
@@ -544,10 +544,10 @@ class BrokenSiteSubmitterTest {
         testee.submitBrokenSiteFeedback(brokenSite)
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), parameters = paramsCaptor.capture(), any(), eq(COUNT))
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), parameters = paramsCaptor.capture(), any(), eq(Count))
         assertEquals(TRACKING_URL, paramsCaptor.lastValue["siteUrl"])
 
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORTED), parameters = paramsCaptor.capture(), any(), eq(COUNT))
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORTED), parameters = paramsCaptor.capture(), any(), eq(Count))
         assertEquals(TRACKING_URL, paramsCaptor.lastValue[Pixel.PixelParameter.URL])
     }
 

--- a/app/src/test/java/com/duckduckgo/app/browser/defaultbrowsing/DefaultBrowserObserverTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/defaultbrowsing/DefaultBrowserObserverTest.kt
@@ -20,7 +20,7 @@ import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
@@ -68,7 +68,7 @@ class DefaultBrowserObserverTest {
 
         testee.onResume(mockOwner)
 
-        verify(mockPixel, never()).fire(eq(AppPixelName.DEFAULT_BROWSER_SET), any(), any(), eq(COUNT))
+        verify(mockPixel, never()).fire(eq(AppPixelName.DEFAULT_BROWSER_SET), any(), any(), eq(Count))
     }
 
     @Test
@@ -78,7 +78,7 @@ class DefaultBrowserObserverTest {
 
         testee.onResume(mockOwner)
 
-        verify(mockPixel, never()).fire(eq(AppPixelName.DEFAULT_BROWSER_SET), any(), any(), eq(COUNT))
+        verify(mockPixel, never()).fire(eq(AppPixelName.DEFAULT_BROWSER_SET), any(), any(), eq(Count))
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/httperrors/RealHttpErrorPixelsTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/httperrors/RealHttpErrorPixelsTest.kt
@@ -21,7 +21,7 @@ import android.content.SharedPreferences
 import androidx.core.content.edit
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.common.test.api.InMemorySharedPreferences
 import java.time.Instant
 import java.util.concurrent.TimeUnit
@@ -74,7 +74,7 @@ class RealHttpErrorPixelsTest {
             pixel = eq(HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_400_DAILY),
             parameters = any(),
             encodedParameters = any(),
-            type = eq(COUNT),
+            type = eq(Count),
         )
     }
 
@@ -90,7 +90,7 @@ class RealHttpErrorPixelsTest {
             pixel = eq(HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_400_DAILY),
             parameters = eq(mapOf(HttpErrorPixelParameters.HTTP_ERROR_CODE_COUNT to "1")),
             encodedParameters = any(),
-            type = eq(COUNT),
+            type = eq(Count),
         )
     }
 
@@ -109,7 +109,7 @@ class RealHttpErrorPixelsTest {
             pixel = eq(HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_400_DAILY),
             parameters = any(),
             encodedParameters = any(),
-            type = eq(COUNT),
+            type = eq(Count),
         )
     }
 
@@ -128,7 +128,7 @@ class RealHttpErrorPixelsTest {
             pixel = eq(HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_400_DAILY),
             parameters = eq(mapOf(HttpErrorPixelParameters.HTTP_ERROR_CODE_COUNT to "1")),
             encodedParameters = any(),
-            type = eq(COUNT),
+            type = eq(Count),
         )
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/indonesiamessage/IndonesiaNewTabSectionViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/indonesiamessage/IndonesiaNewTabSectionViewModelTest.kt
@@ -88,6 +88,6 @@ class IndonesiaNewTabSectionViewModelTest {
     fun whenOnMessageShownThenDailyPixelFired() = runTest {
         testee.onMessageShown()
 
-        verify(mockPixel).fire(AppPixelName.INDONESIA_MESSAGE_SHOWN, type = Pixel.PixelType.DAILY)
+        verify(mockPixel).fire(AppPixelName.INDONESIA_MESSAGE_SHOWN, type = Pixel.PixelType.Daily())
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/feedback/BrokenSiteViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/feedback/BrokenSiteViewModelTest.kt
@@ -26,7 +26,7 @@ import com.duckduckgo.app.brokensite.model.SiteProtectionsState
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.brokensite.api.BrokenSite
 import com.duckduckgo.brokensite.api.BrokenSiteSender
 import com.duckduckgo.brokensite.api.ReportFlow
@@ -744,11 +744,11 @@ class BrokenSiteViewModelTest {
         )
 
         testee.onProtectionsToggled(protectionsEnabled = false)
-        verify(mockPixel).fire(AppPixelName.BROKEN_SITE_ALLOWLIST_ADD, params, type = COUNT)
+        verify(mockPixel).fire(AppPixelName.BROKEN_SITE_ALLOWLIST_ADD, params, type = Count)
         verify(privacyProtectionsPopupExperimentExternalPixels).tryReportProtectionsToggledFromBrokenSiteReport(protectionsEnabled = false)
 
         testee.onProtectionsToggled(protectionsEnabled = true)
-        verify(mockPixel).fire(AppPixelName.BROKEN_SITE_ALLOWLIST_REMOVE, params, type = COUNT)
+        verify(mockPixel).fire(AppPixelName.BROKEN_SITE_ALLOWLIST_REMOVE, params, type = Count)
         verify(privacyProtectionsPopupExperimentExternalPixels).tryReportProtectionsToggledFromBrokenSiteReport(protectionsEnabled = true)
     }
 

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModelTest.kt
@@ -34,7 +34,7 @@ import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_COMPARISON_CHART_SHO
 import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_INTRO_SHOWN_UNIQUE
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.UNIQUE
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
 import com.duckduckgo.common.test.CoroutineTestRule
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
@@ -68,21 +68,21 @@ class WelcomePageViewModelTest {
     fun whenInitialDialogIsShownThenSendPixel() {
         testee.onDialogShown(PreOnboardingDialogType.INITIAL)
 
-        verify(mockPixel).fire(PREONBOARDING_INTRO_SHOWN_UNIQUE, type = UNIQUE)
+        verify(mockPixel).fire(PREONBOARDING_INTRO_SHOWN_UNIQUE, type = Unique())
     }
 
     @Test
     fun whenComparisonChartDialogIsShownThenSendPixel() {
         testee.onDialogShown(PreOnboardingDialogType.COMPARISON_CHART)
 
-        verify(mockPixel).fire(PREONBOARDING_COMPARISON_CHART_SHOWN_UNIQUE, type = UNIQUE)
+        verify(mockPixel).fire(PREONBOARDING_COMPARISON_CHART_SHOWN_UNIQUE, type = Unique())
     }
 
     @Test
     fun whenAffirmationDialogIsShownThenSendPixel() {
         testee.onDialogShown(PreOnboardingDialogType.CELEBRATION)
 
-        verify(mockPixel).fire(PREONBOARDING_AFFIRMATION_SHOWN_UNIQUE, type = UNIQUE)
+        verify(mockPixel).fire(PREONBOARDING_AFFIRMATION_SHOWN_UNIQUE, type = Unique())
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesMultipleReportReferenceTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesMultipleReportReferenceTest.kt
@@ -21,7 +21,7 @@ import com.duckduckgo.app.brokensite.api.BrokenSiteSubmitter
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.model.Atb
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.app.trackerdetection.db.TdsMetadataDao
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
@@ -195,7 +195,7 @@ class BrokenSitesMultipleReportReferenceTest(private val testCase: MultipleRepor
 
             val paramsCaptor = argumentCaptor<Map<String, String>>()
             val encodedParamsCaptor = argumentCaptor<Map<String, String>>()
-            verify(mockPixel).fire(eq(AppPixelName.BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture(), eq(COUNT))
+            verify(mockPixel).fire(eq(AppPixelName.BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture(), eq(Count))
 
             val params = paramsCaptor.firstValue
             val encodedParams = encodedParamsCaptor.firstValue

--- a/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesReferenceTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesReferenceTest.kt
@@ -23,7 +23,7 @@ import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.statistics.model.Atb
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.app.trackerdetection.db.TdsMetadataDao
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
@@ -183,7 +183,7 @@ class BrokenSitesReferenceTest(private val testCase: TestCase) {
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
         val encodedParamsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixel).fire(eq(AppPixelName.BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture(), eq(COUNT))
+        verify(mockPixel).fire(eq(AppPixelName.BROKEN_SITE_REPORT.pixelName), paramsCaptor.capture(), encodedParamsCaptor.capture(), eq(Count))
 
         val params = paramsCaptor.firstValue.toMutableMap()
         params["locale"] = "en-US"

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -25,7 +25,7 @@ import com.duckduckgo.adclick.api.AdClickManager
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.DAILY
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
@@ -305,7 +305,7 @@ class TabSwitcherViewModelTest {
         testee.onTabDraggingStarted()
 
         val params = mapOf("userState" to EXISTING.name)
-        verify(mockPixel).fire(AppPixelName.TAB_MANAGER_REARRANGE_TABS_DAILY, params, emptyMap(), DAILY)
+        verify(mockPixel).fire(AppPixelName.TAB_MANAGER_REARRANGE_TABS_DAILY, params, emptyMap(), Daily())
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -316,7 +316,7 @@ class TabSwitcherViewModelTest {
         advanceUntilIdle()
 
         val params = mapOf("userState" to NEW.name)
-        verify(mockPixel).fire(AppPixelName.TAB_MANAGER_REARRANGE_TABS_DAILY, params, emptyMap(), DAILY)
+        verify(mockPixel).fire(AppPixelName.TAB_MANAGER_REARRANGE_TABS_DAILY, params, emptyMap(), Daily())
     }
 
     @Test

--- a/app/src/testPlay/java/com/duckduckgo/app/referrer/AppReferrerInstallPixelSenderTest.kt
+++ b/app/src/testPlay/java/com/duckduckgo/app/referrer/AppReferrerInstallPixelSenderTest.kt
@@ -3,7 +3,7 @@ package com.duckduckgo.app.referrer
 import com.duckduckgo.app.pixels.AppPixelName.REFERRAL_INSTALL_UTM_CAMPAIGN
 import com.duckduckgo.app.referral.AppReferrerDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.UNIQUE
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.test.CoroutineTestRule
@@ -114,7 +114,7 @@ class AppReferrerInstallPixelSenderTest {
             eq(REFERRAL_INSTALL_UTM_CAMPAIGN),
             parameters = captor.capture(),
             encodedParameters = any(),
-            type = eq(UNIQUE),
+            type = eq(Unique()),
         )
     }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/engagement/EngagementPasswordAddedListener.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/engagement/EngagementPasswordAddedListener.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.autofill.impl.engagement
 
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.UNIQUE
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
 import com.duckduckgo.autofill.impl.PasswordStoreEventListener
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames
 import com.duckduckgo.browser.api.UserBrowserProperties
@@ -51,7 +51,7 @@ class EngagementPasswordAddedListener @Inject constructor(
             val daysInstalled = userBrowserProperties.daysSinceInstalled()
             Timber.v("onCredentialAdded. daysInstalled: $daysInstalled")
             if (daysInstalled < 7) {
-                pixel.fire(AutofillPixelNames.AUTOFILL_ENGAGEMENT_ONBOARDED_USER, type = UNIQUE)
+                pixel.fire(AutofillPixelNames.AUTOFILL_ENGAGEMENT_ONBOARDED_USER, type = Unique())
             }
         }
     }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/engagement/store/AutofillEngagementRepository.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/engagement/store/AutofillEngagementRepository.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.autofill.impl.engagement.store
 
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.DAILY
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENGAGEMENT_ACTIVE_USER
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENGAGEMENT_ENABLED_USER
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENGAGEMENT_STACKED_LOGINS
@@ -89,7 +89,7 @@ class DefaultAutofillEngagementRepository @Inject constructor(
         val numberStoredPasswords = getNumberStoredPasswords()
         val togglePixel = if (autofillStore.autofillEnabled) AUTOFILL_TOGGLED_ON_SEARCH else AUTOFILL_TOGGLED_OFF_SEARCH
         val bucket = engagementBucketing.bucketNumberOfSavedPasswords(numberStoredPasswords)
-        pixel.fire(togglePixel, mapOf("count_bucket" to bucket), type = DAILY)
+        pixel.fire(togglePixel, mapOf("count_bucket" to bucket), type = Daily())
     }
 
     private suspend fun DefaultAutofillEngagementRepository.processEvent(engagement: AutofillEngagementEntity) {
@@ -102,14 +102,14 @@ class DefaultAutofillEngagementRepository @Inject constructor(
         val numberStoredPasswords = getNumberStoredPasswords()
 
         if (autofilled && searched) {
-            pixel.fire(AUTOFILL_ENGAGEMENT_ACTIVE_USER, type = DAILY)
+            pixel.fire(AUTOFILL_ENGAGEMENT_ACTIVE_USER, type = Daily())
 
             val bucket = engagementBucketing.bucketNumberOfSavedPasswords(numberStoredPasswords)
-            pixel.fire(AUTOFILL_ENGAGEMENT_STACKED_LOGINS, mapOf("count_bucket" to bucket), type = DAILY)
+            pixel.fire(AUTOFILL_ENGAGEMENT_STACKED_LOGINS, mapOf("count_bucket" to bucket), type = Daily())
         }
 
         if (searched && numberStoredPasswords >= 10 && autofillStore.autofillEnabled) {
-            pixel.fire(AUTOFILL_ENGAGEMENT_ENABLED_USER, type = DAILY)
+            pixel.fire(AUTOFILL_ENGAGEMENT_ENABLED_USER, type = Daily())
         }
     }
 

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/engagement/EngagementPasswordAddedListenerTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/engagement/EngagementPasswordAddedListenerTest.kt
@@ -1,7 +1,7 @@
 package com.duckduckgo.autofill.impl.engagement
 
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.UNIQUE
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENGAGEMENT_ONBOARDED_USER
 import com.duckduckgo.browser.api.UserBrowserProperties
 import com.duckduckgo.common.test.CoroutineTestRule
@@ -58,10 +58,10 @@ class EngagementPasswordAddedListenerTest {
     }
 
     private fun verifyPixelSentOnce() {
-        verify(pixel).fire(AUTOFILL_ENGAGEMENT_ONBOARDED_USER, type = UNIQUE)
+        verify(pixel).fire(AUTOFILL_ENGAGEMENT_ONBOARDED_USER, type = Unique())
     }
 
     private fun verifyPixelNotSent() {
-        verify(pixel, never()).fire(AUTOFILL_ENGAGEMENT_ONBOARDED_USER, type = UNIQUE)
+        verify(pixel, never()).fire(AUTOFILL_ENGAGEMENT_ONBOARDED_USER, type = Unique())
     }
 }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/reporting/AutofillBreakageReportSenderImplTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/reporting/AutofillBreakageReportSenderImplTest.kt
@@ -2,7 +2,7 @@ package com.duckduckgo.autofill.impl.reporting
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.autofill.api.email.EmailManager
 import com.duckduckgo.autofill.impl.AutofillGlobalCapabilityChecker
@@ -161,7 +161,7 @@ class AutofillBreakageReportSenderImplTest {
 
     private fun sendReport(url: String = "https://example.com", protectionStatus: Boolean? = true) {
         testee.sendBreakageReport(url, protectionStatus)
-        verify(pixel).fire(eq(AUTOFILL_SITE_BREAKAGE_REPORT), paramsCaptor.capture(), any(), eq(COUNT))
+        verify(pixel).fire(eq(AUTOFILL_SITE_BREAKAGE_REPORT), paramsCaptor.capture(), any(), eq(Count))
     }
 
     private fun String.assertMatchesEmailProtection() {

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModelTest.kt
@@ -20,7 +20,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.autofill.api.AutofillSettingsLaunchSource
 import com.duckduckgo.autofill.api.AutofillSettingsLaunchSource.BrowserOverflow
 import com.duckduckgo.autofill.api.AutofillSettingsLaunchSource.BrowserSnackbar
@@ -181,7 +181,7 @@ class AutofillSettingsViewModelTest {
     @Test
     fun whenUserDisablesAutofillThenCorrectPixelFired() {
         testee.onDisableAutofill(aAutofillSettingsLaunchSource())
-        verify(pixel).fire(eq(AUTOFILL_ENABLE_AUTOFILL_TOGGLE_MANUALLY_DISABLED), any(), any(), eq(COUNT))
+        verify(pixel).fire(eq(AUTOFILL_ENABLE_AUTOFILL_TOGGLE_MANUALLY_DISABLED), any(), any(), eq(Count))
     }
 
     @Test
@@ -695,49 +695,49 @@ class AutofillSettingsViewModelTest {
     fun whenScreenLaunchedFromSnackbarThenCorrectLaunchPixelSent() {
         testee.sendLaunchPixel(BrowserSnackbar)
         val expectedParams = mapOf("source" to "browser_snackbar")
-        verify(pixel).fire(eq(AUTOFILL_MANAGEMENT_SCREEN_OPENED), eq(expectedParams), any(), eq(COUNT))
+        verify(pixel).fire(eq(AUTOFILL_MANAGEMENT_SCREEN_OPENED), eq(expectedParams), any(), eq(Count))
     }
 
     @Test
     fun whenScreenLaunchedFromBrowserThenCorrectLaunchPixelSent() {
         testee.sendLaunchPixel(BrowserOverflow)
         val expectedParams = mapOf("source" to "overflow_menu")
-        verify(pixel).fire(eq(AUTOFILL_MANAGEMENT_SCREEN_OPENED), eq(expectedParams), any(), eq(COUNT))
+        verify(pixel).fire(eq(AUTOFILL_MANAGEMENT_SCREEN_OPENED), eq(expectedParams), any(), eq(Count))
     }
 
     @Test
     fun whenScreenLaunchedFromSyncThenCorrectLaunchPixelSent() {
         testee.sendLaunchPixel(Sync)
         val expectedParams = mapOf("source" to "sync")
-        verify(pixel).fire(eq(AUTOFILL_MANAGEMENT_SCREEN_OPENED), eq(expectedParams), any(), eq(COUNT))
+        verify(pixel).fire(eq(AUTOFILL_MANAGEMENT_SCREEN_OPENED), eq(expectedParams), any(), eq(Count))
     }
 
     @Test
     fun whenScreenLaunchedFromDisablePromptThenCorrectLaunchPixelSent() {
         testee.sendLaunchPixel(DisableInSettingsPrompt)
         val expectedParams = mapOf("source" to "save_login_disable_prompt")
-        verify(pixel).fire(eq(AUTOFILL_MANAGEMENT_SCREEN_OPENED), eq(expectedParams), any(), eq(COUNT))
+        verify(pixel).fire(eq(AUTOFILL_MANAGEMENT_SCREEN_OPENED), eq(expectedParams), any(), eq(Count))
     }
 
     @Test
     fun whenScreenLaunchedFromNewTabShortcutThenCorrectLaunchPixelSent() {
         testee.sendLaunchPixel(NewTabShortcut)
         val expectedParams = mapOf("source" to "new_tab_page_shortcut")
-        verify(pixel).fire(eq(AUTOFILL_MANAGEMENT_SCREEN_OPENED), eq(expectedParams), any(), eq(COUNT))
+        verify(pixel).fire(eq(AUTOFILL_MANAGEMENT_SCREEN_OPENED), eq(expectedParams), any(), eq(Count))
     }
 
     @Test
     fun whenScreenLaunchedFromSettingsActivityThenCorrectLaunchPixelSent() {
         testee.sendLaunchPixel(SettingsActivity)
         val expectedParams = mapOf("source" to "settings")
-        verify(pixel).fire(eq(AUTOFILL_MANAGEMENT_SCREEN_OPENED), eq(expectedParams), any(), eq(COUNT))
+        verify(pixel).fire(eq(AUTOFILL_MANAGEMENT_SCREEN_OPENED), eq(expectedParams), any(), eq(Count))
     }
 
     @Test
     fun whenScreenLaunchedFromInternalDevSettingsActivityThenCorrectLaunchPixelSent() {
         testee.sendLaunchPixel(InternalDevSettings)
         val expectedParams = mapOf("source" to "internal_dev_settings")
-        verify(pixel).fire(eq(AUTOFILL_MANAGEMENT_SCREEN_OPENED), eq(expectedParams), any(), eq(COUNT))
+        verify(pixel).fire(eq(AUTOFILL_MANAGEMENT_SCREEN_OPENED), eq(expectedParams), any(), eq(Count))
     }
 
     @Test

--- a/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/RealDuckPlayer.kt
+++ b/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/RealDuckPlayer.kt
@@ -25,7 +25,7 @@ import android.webkit.WebView
 import androidx.core.net.toUri
 import androidx.fragment.app.FragmentManager
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.DAILY
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.UrlScheme.Companion.duck
 import com.duckduckgo.common.utils.UrlScheme.Companion.https
@@ -283,7 +283,7 @@ class RealDuckPlayer @Inject constructor(
         } else {
             val inputStream: InputStream = webView.context.assets.open(DUCK_PLAYER_ASSETS_INDEX_PATH)
             return WebResourceResponse("text/html", "UTF-8", inputStream).also {
-                pixel.fire(DUCK_PLAYER_DAILY_UNIQUE_VIEW, type = DAILY)
+                pixel.fire(DUCK_PLAYER_DAILY_UNIQUE_VIEW, type = Daily())
             }
         }
     }

--- a/duckplayer/duckplayer-impl/src/test/kotlin/com/duckduckgo/duckplayer/impl/RealDuckPlayerTest.kt
+++ b/duckplayer/duckplayer-impl/src/test/kotlin/com/duckduckgo/duckplayer/impl/RealDuckPlayerTest.kt
@@ -25,8 +25,8 @@ import android.webkit.WebView
 import androidx.core.net.toUri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.DAILY
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.common.utils.UrlScheme.Companion.duck
 import com.duckduckgo.common.utils.UrlScheme.Companion.https
 import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.DISABLED
@@ -238,7 +238,7 @@ class RealDuckPlayerTest {
 
         testee.sendDuckPlayerPixel(pixelName, pixelData)
 
-        verify(mockPixel).fire(DUCK_PLAYER_OVERLAY_YOUTUBE_IMPRESSIONS, pixelData, emptyMap(), COUNT)
+        verify(mockPixel).fire(DUCK_PLAYER_OVERLAY_YOUTUBE_IMPRESSIONS, pixelData, emptyMap(), Count)
     }
 
     @Test
@@ -247,7 +247,7 @@ class RealDuckPlayerTest {
 
         testee.sendDuckPlayerPixel(pixelName, emptyMap())
 
-        verify(mockPixel).fire(DUCK_PLAYER_OVERLAY_YOUTUBE_IMPRESSIONS, emptyMap(), emptyMap(), COUNT)
+        verify(mockPixel).fire(DUCK_PLAYER_OVERLAY_YOUTUBE_IMPRESSIONS, emptyMap(), emptyMap(), Count)
     }
 
     @Test
@@ -257,7 +257,7 @@ class RealDuckPlayerTest {
 
         testee.sendDuckPlayerPixel(pixelName, pixelData)
 
-        verify(mockPixel).fire(DUCK_PLAYER_VIEW_FROM_YOUTUBE_MAIN_OVERLAY, pixelData, emptyMap(), COUNT)
+        verify(mockPixel).fire(DUCK_PLAYER_VIEW_FROM_YOUTUBE_MAIN_OVERLAY, pixelData, emptyMap(), Count)
     }
 
     @Test
@@ -266,7 +266,7 @@ class RealDuckPlayerTest {
 
         testee.sendDuckPlayerPixel(pixelName, emptyMap())
 
-        verify(mockPixel).fire(DUCK_PLAYER_VIEW_FROM_YOUTUBE_MAIN_OVERLAY, emptyMap(), emptyMap(), COUNT)
+        verify(mockPixel).fire(DUCK_PLAYER_VIEW_FROM_YOUTUBE_MAIN_OVERLAY, emptyMap(), emptyMap(), Count)
     }
 
     @Test
@@ -276,7 +276,7 @@ class RealDuckPlayerTest {
 
         testee.sendDuckPlayerPixel(pixelName, pixelData)
 
-        verify(mockPixel).fire(DUCK_PLAYER_OVERLAY_YOUTUBE_WATCH_HERE, pixelData, emptyMap(), COUNT)
+        verify(mockPixel).fire(DUCK_PLAYER_OVERLAY_YOUTUBE_WATCH_HERE, pixelData, emptyMap(), Count)
     }
 
     @Test
@@ -285,7 +285,7 @@ class RealDuckPlayerTest {
 
         testee.sendDuckPlayerPixel(pixelName, emptyMap())
 
-        verify(mockPixel).fire(DUCK_PLAYER_OVERLAY_YOUTUBE_WATCH_HERE, emptyMap(), emptyMap(), COUNT)
+        verify(mockPixel).fire(DUCK_PLAYER_OVERLAY_YOUTUBE_WATCH_HERE, emptyMap(), emptyMap(), Count)
     }
 
     // endregion
@@ -607,7 +607,7 @@ class RealDuckPlayerTest {
         val result = testee.intercept(request, url, webView)
 
         verify(assets).open("duckplayer/index.html")
-        verify(mockPixel).fire(DUCK_PLAYER_DAILY_UNIQUE_VIEW, type = DAILY)
+        verify(mockPixel).fire(DUCK_PLAYER_DAILY_UNIQUE_VIEW, type = Daily())
         assertEquals("text/html", result?.mimeType)
     }
 

--- a/installation/installation-impl/src/test/java/InstallSourceLifecycleObserverTest.kt
+++ b/installation/installation-impl/src/test/java/InstallSourceLifecycleObserverTest.kt
@@ -19,7 +19,7 @@ package com.duckduckgo.installation.impl.installer
 import androidx.lifecycle.LifecycleOwner
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.installation.impl.installer.InstallationPixelName.APP_INSTALLER_PACKAGE_NAME
 import kotlinx.coroutines.test.runTest
@@ -55,13 +55,13 @@ class InstallSourceLifecycleObserverTest {
     @Test
     fun whenNotPreviouslyProcessedThenPixelSent() = runTest {
         testee.onCreate(mockLifecycleOwner)
-        verify(mockPixel).fire(eq(APP_INSTALLER_PACKAGE_NAME), any(), any(), eq(COUNT))
+        verify(mockPixel).fire(eq(APP_INSTALLER_PACKAGE_NAME), any(), any(), eq(Count))
     }
 
     @Test
     fun whenPreviouslyProcessedThenPixelNotSent() = runTest {
         testee.recordInstallSourceProcessed()
         testee.onCreate(mockLifecycleOwner)
-        verify(mockPixel, never()).fire(eq(APP_INSTALLER_PACKAGE_NAME), any(), any(), eq(COUNT))
+        verify(mockPixel, never()).fire(eq(APP_INSTALLER_PACKAGE_NAME), any(), any(), eq(Count))
     }
 }

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/pixels/NewTabPixels.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/pixels/NewTabPixels.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.newtabpage.impl.pixels
 
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.DAILY
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.plugins.ActivePluginPoint
 import com.duckduckgo.di.scopes.AppScope
@@ -91,7 +91,7 @@ class RealNewTabPixels @Inject constructor(
                 put(NewTabPixelParameters.FAVORITES_COUNT, getFavoritesParameterValue())
             }
             pixel.fire(NewTabPixelNames.NEW_TAB_DISPLAYED)
-            pixel.fire(pixel = NewTabPixelNames.NEW_TAB_DISPLAYED_UNIQUE, type = DAILY, parameters = paramsMap)
+            pixel.fire(pixel = NewTabPixelNames.NEW_TAB_DISPLAYED_UNIQUE, type = Daily(), parameters = paramsMap)
         }
     }
 

--- a/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/pixels/RealNewTabPixelsTest.kt
+++ b/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/pixels/RealNewTabPixelsTest.kt
@@ -1,7 +1,7 @@
 package com.duckduckgo.newtabpage.impl.pixels
 
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.DAILY
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.newtabpage.impl.disabledSectionPlugins
 import com.duckduckgo.newtabpage.impl.enabledSectionsPlugins
@@ -97,7 +97,7 @@ class RealNewTabPixelsTest {
         testee.fireNewTabDisplayed()
 
         verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED)
-        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED_UNIQUE, type = DAILY, parameters = paramsMap)
+        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED_UNIQUE, type = Daily(), parameters = paramsMap)
     }
 
     @Test
@@ -113,7 +113,7 @@ class RealNewTabPixelsTest {
         testee.fireNewTabDisplayed()
 
         verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED)
-        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED_UNIQUE, type = DAILY, parameters = paramsMap)
+        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED_UNIQUE, type = Daily(), parameters = paramsMap)
     }
 
     @Test
@@ -129,7 +129,7 @@ class RealNewTabPixelsTest {
         testee.fireNewTabDisplayed()
 
         verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED)
-        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED_UNIQUE, type = DAILY, parameters = paramsMap)
+        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED_UNIQUE, type = Daily(), parameters = paramsMap)
     }
 
     @Test
@@ -145,7 +145,7 @@ class RealNewTabPixelsTest {
         testee.fireNewTabDisplayed()
 
         verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED)
-        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED_UNIQUE, type = DAILY, parameters = paramsMap)
+        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED_UNIQUE, type = Daily(), parameters = paramsMap)
     }
 
     @Test
@@ -161,7 +161,7 @@ class RealNewTabPixelsTest {
         testee.fireNewTabDisplayed()
 
         verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED)
-        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED_UNIQUE, type = DAILY, parameters = paramsMap)
+        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED_UNIQUE, type = Daily(), parameters = paramsMap)
     }
 
     @Test
@@ -177,7 +177,7 @@ class RealNewTabPixelsTest {
         testee.fireNewTabDisplayed()
 
         verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED)
-        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED_UNIQUE, type = DAILY, parameters = paramsMap)
+        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED_UNIQUE, type = Daily(), parameters = paramsMap)
     }
 
     @Test
@@ -193,7 +193,7 @@ class RealNewTabPixelsTest {
         testee.fireNewTabDisplayed()
 
         verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED)
-        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED_UNIQUE, type = DAILY, parameters = paramsMap)
+        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED_UNIQUE, type = Daily(), parameters = paramsMap)
     }
 
     @Test
@@ -209,7 +209,7 @@ class RealNewTabPixelsTest {
         testee.fireNewTabDisplayed()
 
         verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED)
-        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED_UNIQUE, type = DAILY, parameters = paramsMap)
+        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED_UNIQUE, type = Daily(), parameters = paramsMap)
     }
 
     @Test
@@ -233,6 +233,6 @@ class RealNewTabPixelsTest {
         testee.fireNewTabDisplayed()
 
         verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED)
-        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED_UNIQUE, type = DAILY, parameters = paramsMap)
+        verify(pixel).fire(NewTabPixelNames.NEW_TAB_DISPLAYED_UNIQUE, type = Daily(), parameters = paramsMap)
     }
 }

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModel.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModel.kt
@@ -24,8 +24,8 @@ import com.duckduckgo.app.global.model.Site
 import com.duckduckgo.app.global.model.domain
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.UNIQUE
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
 import com.duckduckgo.app.trackerdetection.model.TrackerStatus.BLOCKED
 import com.duckduckgo.brokensite.api.BrokenSite
 import com.duckduckgo.brokensite.api.BrokenSiteSender
@@ -224,11 +224,11 @@ class PrivacyDashboardHybridViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             val pixelParams = privacyProtectionsPopupExperimentExternalPixels.getPixelParams()
-            pixel.fire(PRIVACY_DASHBOARD_OPENED, pixelParams, type = COUNT)
+            pixel.fire(PRIVACY_DASHBOARD_OPENED, pixelParams, type = Count)
             pixel.fire(
                 pixel = PRIVACY_DASHBOARD_FIRST_TIME_OPENED,
                 parameters = mapOf("daysSinceInstall" to userBrowserProperties.daysSinceInstalled().toString(), "from_onboarding" to "false"),
-                type = UNIQUE,
+                type = Unique(),
             )
         }
         privacyProtectionsPopupExperimentExternalPixels.tryReportPrivacyDashboardOpened()
@@ -320,14 +320,14 @@ class PrivacyDashboardHybridViewModel @Inject constructor(
                     if (dashboardOpenedFromCustomTab) {
                         pixel.fire(CUSTOM_TABS_PRIVACY_DASHBOARD_ALLOW_LIST_REMOVE)
                     } else {
-                        pixel.fire(PRIVACY_DASHBOARD_ALLOWLIST_REMOVE, pixelParams, type = COUNT)
+                        pixel.fire(PRIVACY_DASHBOARD_ALLOWLIST_REMOVE, pixelParams, type = Count)
                     }
                 } else {
                     userAllowListRepository.addDomainToUserAllowList(domain)
                     if (dashboardOpenedFromCustomTab) {
                         pixel.fire(CUSTOM_TABS_PRIVACY_DASHBOARD_ALLOW_LIST_ADD)
                     } else {
-                        pixel.fire(PRIVACY_DASHBOARD_ALLOWLIST_ADD, pixelParams, type = COUNT)
+                        pixel.fire(PRIVACY_DASHBOARD_ALLOWLIST_ADD, pixelParams, type = Count)
                     }
                 }
                 privacyProtectionsPopupExperimentExternalPixels.tryReportProtectionsToggledFromPrivacyDashboard(enabled)

--- a/privacy-dashboard/privacy-dashboard-impl/src/test/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModelTest.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/test/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModelTest.kt
@@ -25,7 +25,7 @@ import com.duckduckgo.app.global.model.Site
 import com.duckduckgo.app.global.model.domain
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.brokensite.api.BrokenSite
 import com.duckduckgo.brokensite.api.BrokenSiteSender
@@ -207,11 +207,11 @@ class PrivacyDashboardHybridViewModelTest {
         testee.onPrivacyProtectionsClicked(enabled = true)
         coroutineRule.testScope.advanceUntilIdle()
 
-        verify(pixel).fire(PRIVACY_DASHBOARD_OPENED, params, type = COUNT)
+        verify(pixel).fire(PRIVACY_DASHBOARD_OPENED, params, type = Count)
         verify(privacyProtectionsPopupExperimentExternalPixels).tryReportPrivacyDashboardOpened()
-        verify(pixel).fire(PRIVACY_DASHBOARD_ALLOWLIST_ADD, params, type = COUNT)
+        verify(pixel).fire(PRIVACY_DASHBOARD_ALLOWLIST_ADD, params, type = Count)
         verify(privacyProtectionsPopupExperimentExternalPixels).tryReportProtectionsToggledFromPrivacyDashboard(protectionsEnabled = false)
-        verify(pixel).fire(PRIVACY_DASHBOARD_ALLOWLIST_REMOVE, params, type = COUNT)
+        verify(pixel).fire(PRIVACY_DASHBOARD_ALLOWLIST_REMOVE, params, type = Count)
         verify(privacyProtectionsPopupExperimentExternalPixels).tryReportProtectionsToggledFromPrivacyDashboard(protectionsEnabled = true)
     }
 

--- a/privacy-protections-popup/privacy-protections-popup-impl/src/test/java/com/duckduckgo/privacyprotectionspopup/impl/PrivacyProtectionsPopupPixelNameTest.kt
+++ b/privacy-protections-popup/privacy-protections-popup-impl/src/test/java/com/duckduckgo/privacyprotectionspopup/impl/PrivacyProtectionsPopupPixelNameTest.kt
@@ -16,9 +16,9 @@
 
 package com.duckduckgo.privacyprotectionspopup.impl
 
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.DAILY
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.UNIQUE
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -44,9 +44,9 @@ class PrivacyProtectionsPopupPixelNameTest(
     fun pixelNameSuffixShouldMatchPixelType() {
         val pixelName = pixel.pixelName
         val requiredSuffix = when (pixel.type) {
-            COUNT -> "_c"
-            DAILY -> "_d"
-            UNIQUE -> "_u"
+            is Count -> "_c"
+            is Daily -> "_d"
+            is Unique -> "_u"
         }
         assertTrue(
             "Pixel name should end with '$requiredSuffix': $pixelName",

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/pixels/RemoteMessagingPixels.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/pixels/RemoteMessagingPixels.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.remote.messaging.impl.pixels
 
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.remote.messaging.api.RemoteMessage
 import com.squareup.anvil.annotations.ContributesBinding
@@ -38,7 +38,7 @@ class RealRemoteMessagingPixels @Inject constructor(
     private val pixel: Pixel,
 ) : RemoteMessagingPixels {
     override fun fireRemoteMessageShownPixel(remoteMessage: RemoteMessage) {
-        pixel.fire(pixel = RemoteMessagingPixelName.REMOTE_MESSAGE_SHOWN_UNIQUE, parameters = remoteMessage.asPixelParams(), type = PixelType.UNIQUE)
+        pixel.fire(pixel = RemoteMessagingPixelName.REMOTE_MESSAGE_SHOWN_UNIQUE, parameters = remoteMessage.asPixelParams(), type = Unique())
         pixel.fire(pixel = RemoteMessagingPixelName.REMOTE_MESSAGE_SHOWN, parameters = remoteMessage.asPixelParams())
     }
 

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksViewModel.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksViewModel.kt
@@ -22,7 +22,7 @@ import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.DAILY
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.SingleLiveEvent
 import com.duckduckgo.di.scopes.ActivityScope
@@ -137,7 +137,7 @@ class BookmarksViewModel @Inject constructor(
 
     override fun onFavoriteAdded() {
         pixel.fire(SavedSitesPixelName.EDIT_BOOKMARK_ADD_FAVORITE_TOGGLED)
-        pixel.fire(SavedSitesPixelName.EDIT_BOOKMARK_ADD_FAVORITE_TOGGLED_DAILY, type = DAILY)
+        pixel.fire(SavedSitesPixelName.EDIT_BOOKMARK_ADD_FAVORITE_TOGGLED_DAILY, type = Daily())
     }
 
     override fun onFavoriteRemoved() {
@@ -162,7 +162,7 @@ class BookmarksViewModel @Inject constructor(
             pixel.fire(SavedSitesPixelName.FAVORITE_BOOKMARKS_ITEM_PRESSED)
         }
         pixel.fire(SavedSitesPixelName.BOOKMARK_LAUNCHED)
-        pixel.fire(SavedSitesPixelName.BOOKMARK_LAUNCHED_DAILY, type = DAILY)
+        pixel.fire(SavedSitesPixelName.BOOKMARK_LAUNCHED_DAILY, type = Daily())
         command.value = OpenSavedSite(savedSite.url)
     }
 

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionViewModel.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionViewModel.kt
@@ -24,7 +24,7 @@ import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.DAILY
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.savedsites.api.SavedSitesRepository
@@ -134,7 +134,7 @@ class FavouritesNewTabSectionViewModel @Inject constructor(
 
             withContext(dispatchers.main()) {
                 pixel.fire(EDIT_FAVOURITE_DIALOG_SHOWN)
-                pixel.fire(pixel = EDIT_FAVOURITE_DIALOG_SHOWN_DAILY, type = DAILY)
+                pixel.fire(pixel = EDIT_FAVOURITE_DIALOG_SHOWN_DAILY, type = Daily())
                 command.send(
                     ShowEditSavedSiteDialog(
                         SavedSiteChangedViewState(
@@ -263,7 +263,7 @@ class FavouritesNewTabSectionViewModel @Inject constructor(
 
     fun onFavoriteAdded() {
         pixel.fire(EDIT_BOOKMARK_ADD_FAVORITE_TOGGLED)
-        pixel.fire(EDIT_BOOKMARK_ADD_FAVORITE_TOGGLED_DAILY, type = DAILY)
+        pixel.fire(EDIT_BOOKMARK_ADD_FAVORITE_TOGGLED_DAILY, type = Daily())
     }
 
     fun onFavoriteRemoved() {
@@ -272,6 +272,6 @@ class FavouritesNewTabSectionViewModel @Inject constructor(
 
     fun onFavoriteClicked() {
         pixel.fire(FAVOURITE_CLICKED)
-        pixel.fire(FAVOURITE_CLICKED_DAILY, type = DAILY)
+        pixel.fire(FAVOURITE_CLICKED_DAILY, type = Daily())
     }
 }

--- a/statistics/statistics-api/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/statistics/statistics-api/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -16,7 +16,7 @@
 
 package com.duckduckgo.app.statistics.pixels
 
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 
 /** Primary interface for sending anonymous analytics events (pixels). */
 interface Pixel {
@@ -85,22 +85,24 @@ interface Pixel {
         const val FIRE_ANIMATION_NONE = "fann"
     }
 
-    enum class PixelType {
+    sealed class PixelType {
 
         /**
          * Pixel is a every-occurrence pixel. Sent every time fire() is invoked.
          */
-        COUNT,
+        data object Count : PixelType()
 
         /**
          * Pixel is a first-in-day pixel. Subsequent attempts to fire such pixel on a given calendar day (UTC) will be ignored.
+         * By default, the pixel name will be used to avoid resending the pixel again, you can override this by adding your own tag instead.
          */
-        DAILY,
+        data class Daily(val tag: String? = null) : PixelType()
 
         /**
          * Pixel is a once-ever pixel. Subsequent attempts to fire such pixel will be ignored.
+         * By default, the pixel name will be used to avoid resending the pixel again, you can override this by adding your own tag instead.
          */
-        UNIQUE,
+        data class Unique(val tag: String? = null) : PixelType()
     }
 
     /**
@@ -117,7 +119,7 @@ interface Pixel {
         pixel: PixelName,
         parameters: Map<String, String> = emptyMap(),
         encodedParameters: Map<String, String> = emptyMap(),
-        type: PixelType = COUNT,
+        type: PixelType = Count,
     )
 
     /**
@@ -134,7 +136,7 @@ interface Pixel {
         pixelName: String,
         parameters: Map<String, String> = emptyMap(),
         encodedParameters: Map<String, String> = emptyMap(),
-        type: PixelType = COUNT,
+        type: PixelType = Count,
     )
 
     /**

--- a/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/api/RxPixelSender.kt
+++ b/statistics/statistics-impl/src/main/java/com/duckduckgo/app/statistics/api/RxPixelSender.kt
@@ -21,6 +21,9 @@ import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.statistics.config.StatisticsLibraryConfig
 import com.duckduckgo.app.statistics.model.PixelEntity
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
 import com.duckduckgo.app.statistics.store.PendingPixelDao
 import com.duckduckgo.app.statistics.store.PixelFiredRepository
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
@@ -166,9 +169,9 @@ class RxPixelSender @Inject constructor(
         type: Pixel.PixelType,
     ): Boolean =
         when (type) {
-            Pixel.PixelType.COUNT -> true
-            Pixel.PixelType.DAILY -> !pixelFiredRepository.hasDailyPixelFiredToday(pixelName)
-            Pixel.PixelType.UNIQUE -> !pixelFiredRepository.hasUniquePixelFired(pixelName)
+            is Count -> true
+            is Daily -> !pixelFiredRepository.hasDailyPixelFiredToday(type.tag ?: pixelName)
+            is Unique -> !pixelFiredRepository.hasUniquePixelFired(type.tag ?: pixelName)
         }
 
     private suspend fun storePixelFired(
@@ -176,9 +179,9 @@ class RxPixelSender @Inject constructor(
         type: Pixel.PixelType,
     ) {
         when (type) {
-            Pixel.PixelType.COUNT -> {} // no-op
-            Pixel.PixelType.DAILY -> pixelFiredRepository.storeDailyPixelFiredToday(pixelName)
-            Pixel.PixelType.UNIQUE -> pixelFiredRepository.storeUniquePixelFired(pixelName)
+            is Count -> {} // no-op
+            is Daily -> pixelFiredRepository.storeDailyPixelFiredToday(type.tag ?: pixelName)
+            is Unique -> pixelFiredRepository.storeUniquePixelFired(type.tag ?: pixelName)
         }
     }
 }

--- a/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/pixels/RxBasedPixelTest.kt
+++ b/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/pixels/RxBasedPixelTest.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.app.statistics.pixels
 
 import com.duckduckgo.app.statistics.api.PixelSender
 import com.duckduckgo.app.statistics.api.PixelSender.SendPixelResult.PIXEL_SENT
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.app.statistics.pixels.RxBasedPixelTest.TestPixels.TEST
 import com.duckduckgo.common.test.InstantSchedulersRule
 import io.reactivex.Completable
@@ -48,7 +48,7 @@ class RxBasedPixelTest {
         val pixel = RxBasedPixel(mockPixelSender)
         pixel.fire(TEST)
 
-        verify(mockPixelSender).sendPixel("test", emptyMap(), emptyMap(), COUNT)
+        verify(mockPixelSender).sendPixel("test", emptyMap(), emptyMap(), Count)
     }
 
     @Test
@@ -58,7 +58,7 @@ class RxBasedPixelTest {
         val pixel = RxBasedPixel(mockPixelSender)
         pixel.fire(TEST)
 
-        verify(mockPixelSender).sendPixel("test", emptyMap(), emptyMap(), COUNT)
+        verify(mockPixelSender).sendPixel("test", emptyMap(), emptyMap(), Count)
     }
 
     @Test
@@ -69,7 +69,7 @@ class RxBasedPixelTest {
         val params = mapOf("param1" to "value1", "param2" to "value2")
 
         pixel.fire(TEST, params)
-        verify(mockPixelSender).sendPixel("test", params, emptyMap(), COUNT)
+        verify(mockPixelSender).sendPixel("test", params, emptyMap(), Count)
     }
 
     @Test

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/feedback/pixels/PrivacyProUnifiedFeedbackPixel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/feedback/pixels/PrivacyProUnifiedFeedbackPixel.kt
@@ -17,8 +17,8 @@
 package com.duckduckgo.subscriptions.impl.feedback.pixels
 
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.DAILY
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.subscriptions.impl.pixels.pixelNameSuffix
 
 enum class PrivacyProUnifiedFeedbackPixel(
@@ -28,47 +28,47 @@ enum class PrivacyProUnifiedFeedbackPixel(
 ) {
     PPRO_FEEDBACK_FEATURE_REQUEST(
         baseName = "m_ppro_feedback_feature-request",
-        types = setOf(COUNT),
+        types = setOf(Count),
         withSuffix = false,
     ),
     PPRO_FEEDBACK_GENERAL_FEEDBACK(
         baseName = "m_ppro_feedback_general-feedback",
-        types = setOf(COUNT),
+        types = setOf(Count),
         withSuffix = false,
     ),
     PPRO_FEEDBACK_REPORT_ISSUE(
         baseName = "m_ppro_feedback_report-issue",
-        types = setOf(COUNT),
+        types = setOf(Count),
         withSuffix = false,
     ),
     IMPRESSION_PPRO_FEEDBACK_GENERAL_SCREEN(
         baseName = "m_ppro_feedback_general-screen_show",
-        types = setOf(COUNT, DAILY),
+        types = setOf(Count, Daily()),
         withSuffix = true,
     ),
     IMPRESSION_PPRO_FEEDBACK_ACTION_SCREEN(
         baseName = "m_ppro_feedback_actions-screen_show",
-        types = setOf(COUNT, DAILY),
+        types = setOf(Count, Daily()),
         withSuffix = true,
     ),
     IMPRESSION_PPRO_FEEDBACK_CATEGORY_SCREEN(
         baseName = "m_ppro_feedback_category-screen_show",
-        types = setOf(COUNT, DAILY),
+        types = setOf(Count, Daily()),
         withSuffix = true,
     ),
     IMPRESSION_PPRO_FEEDBACK_SUBCATEGORY_SCREEN(
         baseName = "m_ppro_feedback_subcategory-screen_show",
-        types = setOf(COUNT, DAILY),
+        types = setOf(Count, Daily()),
         withSuffix = true,
     ),
     IMPRESSION_PPRO_FEEDBACK_SUBMIT_SCREEN(
         baseName = "m_ppro_feedback_submit-screen_show",
-        types = setOf(COUNT, DAILY),
+        types = setOf(Count, Daily()),
         withSuffix = true,
     ),
     PPRO_FEEDBACK_SUBMIT_SCREEN_FAQ_CLICK(
         baseName = "m_ppro_feedback_submit-screen-faq_click",
-        types = setOf(COUNT, DAILY),
+        types = setOf(Count, Daily()),
         withSuffix = true,
     ), ;
 

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixel.kt
@@ -17,10 +17,9 @@
 package com.duckduckgo.subscriptions.impl.pixels
 
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.DAILY
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.UNIQUE
-import java.util.EnumSet
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
 
 enum class SubscriptionPixel(
     private val baseName: String,
@@ -29,140 +28,140 @@ enum class SubscriptionPixel(
 ) {
     SUBSCRIPTION_ACTIVE(
         baseName = "m_privacy-pro_app_subscription_active",
-        type = DAILY,
+        type = Daily(),
     ),
     OFFER_SCREEN_SHOWN(
         baseName = "m_privacy-pro_offer_screen_impression",
-        type = COUNT,
+        type = Count,
     ),
     OFFER_SUBSCRIBE_CLICK(
         baseName = "m_privacy-pro_terms-conditions_subscribe_click",
-        types = EnumSet.of(COUNT, DAILY),
+        types = setOf(Count, Daily()),
     ),
     PURCHASE_FAILURE_OTHER(
         baseName = "m_privacy-pro_app_subscription-purchase_failure_other",
-        types = EnumSet.of(COUNT, DAILY),
+        types = setOf(Count, Daily()),
     ),
     PURCHASE_FAILURE_STORE(
         baseName = "m_privacy-pro_app_subscription-purchase_failure_store",
-        types = EnumSet.of(COUNT, DAILY),
+        types = setOf(Count, Daily()),
     ),
     PURCHASE_FAILURE_BACKEND(
         baseName = "m_privacy-pro_app_subscription-purchase_failure_backend",
-        types = EnumSet.of(COUNT, DAILY),
+        types = setOf(Count, Daily()),
     ),
     PURCHASE_FAILURE_ACCOUNT_CREATION(
         baseName = "m_privacy-pro_app_subscription-purchase_failure_account-creation",
-        types = EnumSet.of(COUNT, DAILY),
+        types = setOf(Count, Daily()),
     ),
     PURCHASE_SUCCESS(
         baseName = "m_privacy-pro_app_subscription-purchase_success",
-        types = EnumSet.of(COUNT, DAILY),
+        types = setOf(Count, Daily()),
     ),
     PURCHASE_SUCCESS_ORIGIN(
         baseName = "m_subscribe",
-        type = COUNT,
+        type = Count,
         withSuffix = false,
     ),
     OFFER_RESTORE_PURCHASE_CLICK(
         baseName = "m_privacy-pro_offer_restore-purchase_click",
-        type = COUNT,
+        type = Count,
     ),
     ACTIVATE_SUBSCRIPTION_ENTER_EMAIL_CLICK(
         baseName = "m_privacy-pro_activate-subscription_enter-email_click",
-        types = EnumSet.of(COUNT, DAILY),
+        types = setOf(Count, Daily()),
     ),
     ACTIVATE_SUBSCRIPTION_RESTORE_PURCHASE_CLICK(
         baseName = "m_privacy-pro_activate-subscription_restore-purchase_click",
-        types = EnumSet.of(COUNT, DAILY),
+        types = setOf(Count, Daily()),
     ),
     RESTORE_USING_EMAIL_SUCCESS(
         baseName = "m_privacy-pro_app_subscription-restore-using-email_success",
-        types = EnumSet.of(COUNT, DAILY),
+        types = setOf(Count, Daily()),
     ),
     RESTORE_USING_STORE_SUCCESS(
         baseName = "m_privacy-pro_app_subscription-restore-using-store_success",
-        types = EnumSet.of(COUNT, DAILY),
+        types = setOf(Count, Daily()),
     ),
     RESTORE_USING_STORE_FAILURE_SUBSCRIPTION_NOT_FOUND(
         baseName = "m_privacy-pro_app_subscription-restore-using-store_failure_not-found",
-        types = EnumSet.of(COUNT, DAILY),
+        types = setOf(Count, Daily()),
     ),
     RESTORE_USING_STORE_FAILURE_OTHER(
         baseName = "m_privacy-pro_app_subscription-restore-using-store_failure_other",
-        types = EnumSet.of(COUNT, DAILY),
+        types = setOf(Count, Daily()),
     ),
     RESTORE_AFTER_PURCHASE_ATTEMPT_SUCCESS(
         baseName = "m_privacy-pro_app_subscription-restore-after-purchase-attempt_success",
-        type = COUNT,
+        type = Count,
     ),
     SUBSCRIPTION_ACTIVATED(
         baseName = "m_privacy-pro_app_subscription_activated",
-        type = UNIQUE,
+        type = Unique(),
     ),
     ONBOARDING_ADD_DEVICE_CLICK(
         baseName = "m_privacy-pro_welcome_add-device_click",
-        type = UNIQUE,
+        type = Unique(),
     ),
     ADD_DEVICE_ENTER_EMAIL_CLICK(
         baseName = "m_privacy-pro_add-device_enter-email_click",
-        type = COUNT,
+        type = Count,
     ),
     ONBOARDING_VPN_CLICK(
         baseName = "m_privacy-pro_welcome_vpn_click",
-        type = UNIQUE,
+        type = Unique(),
     ),
     ONBOARDING_PIR_CLICK(
         baseName = "m_privacy-pro_welcome_personal-information-removal_click",
-        type = UNIQUE,
+        type = Unique(),
     ),
     ONBOARDING_IDTR_CLICK(
         baseName = "m_privacy-pro_welcome_identity-theft-restoration_click",
-        type = UNIQUE,
+        type = Unique(),
     ),
     SUBSCRIPTION_SETTINGS_SHOWN(
         baseName = "m_privacy-pro_settings_screen_impression",
-        type = COUNT,
+        type = Count,
     ),
     APP_SETTINGS_PIR_CLICK(
         baseName = "m_privacy-pro_app-settings_personal-information-removal_click",
-        type = COUNT,
+        type = Count,
     ),
     APP_SETTINGS_IDTR_CLICK(
         baseName = "m_privacy-pro_app-settings_identity-theft-restoration_click",
-        type = COUNT,
+        type = Count,
     ),
     APP_SETTINGS_RESTORE_PURCHASE_CLICK(
         baseName = "m_privacy-pro_app-settings_restore-purchase_click",
-        type = COUNT,
+        type = Count,
     ),
     SUBSCRIPTION_SETTINGS_CHANGE_PLAN_OR_BILLING_CLICK(
         baseName = "m_privacy-pro_settings_change-plan-or-billing_click",
-        type = COUNT,
+        type = Count,
     ),
     SUBSCRIPTION_SETTINGS_REMOVE_FROM_DEVICE_CLICK(
         baseName = "m_privacy-pro_settings_remove-from-device_click",
-        type = COUNT,
+        type = Count,
     ),
     SUBSCRIPTION_PRICE_MONTHLY_CLICK(
         baseName = "m_privacy-pro_offer_monthly-price_click",
-        type = COUNT,
+        type = Count,
     ),
     SUBSCRIPTION_PRICE_YEARLY_CLICK(
         baseName = "m_privacy-pro_offer_yearly-price_click",
-        type = COUNT,
+        type = Count,
     ),
     SUBSCRIPTION_ONBOARDING_FAQ_CLICK(
         baseName = "m_privacy-pro_welcome_faq_click",
-        type = UNIQUE,
+        type = Unique(),
     ),
     SUBSCRIPTION_ADD_EMAIL_SUCCESS(
         baseName = "m_privacy-pro_app_add-email_success",
-        type = UNIQUE,
+        type = Unique(),
     ),
     SUBSCRIPTION_PRIVACY_PRO_REDIRECT(
         baseName = "m_privacy-pro_app_redirect",
-        type = COUNT,
+        type = Count,
     ),
     ;
 
@@ -170,7 +169,7 @@ enum class SubscriptionPixel(
         baseName: String,
         type: PixelType,
         withSuffix: Boolean = true,
-    ) : this(baseName, EnumSet.of(type), withSuffix)
+    ) : this(baseName, setOf(type), withSuffix)
 
     fun getPixelNames(): Map<PixelType, String> =
         types.associateWith { type -> if (withSuffix) "${baseName}_${type.pixelNameSuffix}" else baseName }
@@ -178,7 +177,7 @@ enum class SubscriptionPixel(
 
 internal val PixelType.pixelNameSuffix: String
     get() = when (this) {
-        COUNT -> "c"
-        DAILY -> "d"
-        UNIQUE -> "u"
+        is Count -> "c"
+        is Daily -> "d"
+        is Unique -> "u"
     }

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelTest.kt
@@ -1,8 +1,8 @@
 package com.duckduckgo.subscriptions.impl.pixels
 
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.COUNT
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.DAILY
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.UNIQUE
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.PURCHASE_SUCCESS_ORIGIN
 import org.junit.Assert.*
 import org.junit.Test
@@ -27,9 +27,9 @@ class SubscriptionPixelTest(
         if (pixel == PURCHASE_SUCCESS_ORIGIN) return
         pixel.getPixelNames().forEach { (pixelType, pixelName) ->
             val expectedSuffix = when (pixelType) {
-                COUNT -> "_c"
-                DAILY -> "_d"
-                UNIQUE -> "_u"
+                is Count -> "_c"
+                is Daily -> "_d"
+                is Unique -> "_u"
             }
 
             assertTrue(pixelName.endsWith(expectedSuffix))

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
@@ -151,28 +151,28 @@ class RealSyncPixels @Inject constructor(
             API_CODE.COUNT_LIMIT.code -> {
                 pixel.fire(
                     String.format(Locale.US, SYNC_OBJECT_LIMIT_EXCEEDED_DAILY.pixelName, feature.field),
-                    type = Pixel.PixelType.DAILY,
+                    type = Pixel.PixelType.Daily(),
                 )
             }
 
             API_CODE.CONTENT_TOO_LARGE.code -> {
                 pixel.fire(
                     String.format(Locale.US, SyncPixelName.SYNC_REQUEST_SIZE_LIMIT_EXCEEDED_DAILY.pixelName, feature.field),
-                    type = Pixel.PixelType.DAILY,
+                    type = Pixel.PixelType.Daily(),
                 )
             }
 
             API_CODE.VALIDATION_ERROR.code -> {
                 pixel.fire(
                     String.format(Locale.US, SyncPixelName.SYNC_VALIDATION_ERROR_DAILY.pixelName, feature.field),
-                    type = Pixel.PixelType.DAILY,
+                    type = Pixel.PixelType.Daily(),
                 )
             }
 
             API_CODE.TOO_MANY_REQUESTS_1.code, API_CODE.TOO_MANY_REQUESTS_2.code -> {
                 pixel.fire(
                     String.format(Locale.US, SyncPixelName.SYNC_TOO_MANY_REQUESTS_DAILY.pixelName, feature.field),
-                    type = Pixel.PixelType.DAILY,
+                    type = Pixel.PixelType.Daily(),
                 )
             }
         }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/pixels/SyncPixelsTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/pixels/SyncPixelsTest.kt
@@ -123,21 +123,21 @@ class RealSyncPixelsTest {
     fun whenfireDailyApiErrorForObjectLimitExceededThenPixelSent() {
         testee.fireDailySyncApiErrorPixel(SyncableType.BOOKMARKS, Error(code = API_CODE.COUNT_LIMIT.code))
 
-        verify(pixel).fire("m_sync_bookmarks_object_limit_exceeded_daily", emptyMap(), emptyMap(), type = Pixel.PixelType.DAILY)
+        verify(pixel).fire("m_sync_bookmarks_object_limit_exceeded_daily", emptyMap(), emptyMap(), type = Pixel.PixelType.Daily())
     }
 
     @Test
     fun whenfireDailyApiErrorForRequestSizeLimitExceededThenPixelSent() {
         testee.fireDailySyncApiErrorPixel(SyncableType.BOOKMARKS, Error(code = API_CODE.CONTENT_TOO_LARGE.code))
 
-        verify(pixel).fire("m_sync_bookmarks_request_size_limit_exceeded_daily", emptyMap(), emptyMap(), type = Pixel.PixelType.DAILY)
+        verify(pixel).fire("m_sync_bookmarks_request_size_limit_exceeded_daily", emptyMap(), emptyMap(), type = Pixel.PixelType.Daily())
     }
 
     @Test
     fun whenfireDailyApiErrorForValidationErrorThenPixelSent() {
         testee.fireDailySyncApiErrorPixel(SyncableType.BOOKMARKS, Error(code = API_CODE.VALIDATION_ERROR.code))
 
-        verify(pixel).fire("m_sync_bookmarks_validation_error_daily", emptyMap(), emptyMap(), type = Pixel.PixelType.DAILY)
+        verify(pixel).fire("m_sync_bookmarks_validation_error_daily", emptyMap(), emptyMap(), type = Pixel.PixelType.Daily())
     }
 
     @Test
@@ -145,7 +145,7 @@ class RealSyncPixelsTest {
         testee.fireDailySyncApiErrorPixel(SyncableType.BOOKMARKS, Error(code = API_CODE.TOO_MANY_REQUESTS_1.code))
         testee.fireDailySyncApiErrorPixel(SyncableType.BOOKMARKS, Error(code = API_CODE.TOO_MANY_REQUESTS_2.code))
 
-        verify(pixel, times(2)).fire("m_sync_bookmarks_too_many_requests_daily", emptyMap(), emptyMap(), type = Pixel.PixelType.DAILY)
+        verify(pixel, times(2)).fire("m_sync_bookmarks_too_many_requests_daily", emptyMap(), emptyMap(), type = Pixel.PixelType.Daily())
     }
 
     private fun givenSomeDailyStats(): DailyStats {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1125189844152671/1208390039947645/f 

### Description
This PRs changes the PixelType from enum to sealed class to add the option of storing a tag rather than the pixel name to avoid sending duplicated pixels (unique/daily)

### Steps to test this PR
- [ ] Check code changes
- [ ] Tests pass

