### PR TITLE
Update content scope scripts to version 6.17.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -14043,8 +14043,6 @@
             return
         }
 
-        console.log('did get initial setup ', initialSetup);
-
         if (!initialSetup) {
             console.error('cannot continue without user settings');
             return
@@ -14387,7 +14385,7 @@
 
             const locale = args?.locale || args?.language || 'en';
             const env = new Environment({
-                debug: true,
+                debug: args.debug,
                 injectName: "android",
                 platform: this.platform,
                 locale

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^10.15.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#13.1.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.16.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.17.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#5.1.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1724449523"
       },
@@ -71,7 +71,7 @@
       "hasInstallScript": true
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#4f0d109f13beec7e8beaf0bd5c0e2c1d528677f8",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#2bed9e2963b2a9232452911d0773fac8b56416a1",
       "hasInstallScript": true,
       "workspaces": [
         "packages/special-pages",
@@ -208,9 +208,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.5.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.5.tgz",
-      "integrity": "sha512-Xjs4y5UPO/CLdzpgR6GirZJx36yScjh73+2NlLlkFRSoQN8B0DpfXPdZGnvVmLRLOsqDpOfTNv7D9trgGhmOIA==",
+      "version": "22.7.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.0.tgz",
+      "integrity": "sha512-MOdOibwBs6KW1vfqz2uKMlxq5xAfAZ98SZjO8e3XnAbFnTJtAspqhWk7hrdSAs9/Y14ZWMiy7/MxMUzAOadYEw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -651,16 +651,16 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.46",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.46.tgz",
-      "integrity": "sha512-zA3ai/j4aFcmbqTvTONkSBuWs0Q4X4tJxa0gV9sp6kDbq5dAhQDSg0WUkReEm0fBAKAGNj+wPKCCsR8MYOYmwA=="
+      "version": "6.1.47",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.47.tgz",
+      "integrity": "sha512-6SWyFMnlst1fEt7GQVAAu16EGgFK0cLouH/2Mk6Ftlwhv3Ol40L0dlpGMcnnNiiOMyD2EV/aF3S+U2nKvvLvrA=="
     },
     "node_modules/tldts-experimental": {
-      "version": "6.1.46",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.46.tgz",
-      "integrity": "sha512-u99EeyzhUNRwJep1M1CXBGmQ6OWncv0bi98/9CBv+AX6ep0B3HOkl0iS+C2OisWWoMBXdNkdNQa85aLkyrWwlA==",
+      "version": "6.1.47",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.47.tgz",
+      "integrity": "sha512-XOcqmjaHA3hHQsV9TggV9bQ6Y+N4P/9Bnbmp/QQto+EcEBNTex10KnvPQBbQwLgLSarHEuTyC5PktohvIsYNBQ==",
       "dependencies": {
-        "tldts-core": "^6.1.46"
+        "tldts-core": "^6.1.47"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^10.15.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#13.1.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.16.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.17.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#5.1.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1724449523"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass