### PR TITLE
Open Duck Player when YouTube navigation comes from redirect

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -550,6 +550,7 @@ class BrowserTabViewModelTest {
             coroutineRule.testScope,
             coroutineRule.testDispatcherProvider,
             DuckDuckGoUrlDetectorImpl(),
+            mockDuckPlayer,
         )
 
         accessibilitySettingsDataStore = AccessibilitySettingsSharedPreferences(

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -1920,6 +1920,31 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenSiteLoadedWithSimulatedYouTubeNoCookieAndDuckPlayerEnabledThenShowWebPageTitleWithDuckPlayerIcon() = runTest {
+        val url = "http://youtube-nocookie.com/videoID=1234"
+        val title = "Duck Player"
+        whenever(mockDuckPlayer.isSimulatedYoutubeNoCookie(anyString())).thenReturn(true)
+        whenever(mockDuckPlayer.getDuckPlayerState()).thenReturn(ENABLED)
+
+        loadUrl(url = url)
+        testee.titleReceived(newTitle = title, url = url)
+        val command = captureCommands().lastValue as Command.ShowWebPageTitle
+        assertTrue(command.showDuckPlayerIcon)
+    }
+
+    @Test
+    fun whenSiteLoadedWithDuckPlayerDisabledThenShowWebPageTitleWithoutDuckPlayerIcon() = runTest {
+        val url = "http://youtube-nocookie.com/videoID=1234"
+        val title = "Duck Player"
+        whenever(mockDuckPlayer.getDuckPlayerState()).thenReturn(DISABLED)
+
+        loadUrl(url = url)
+        testee.titleReceived(newTitle = title, url = url)
+        val command = captureCommands().lastValue as Command.ShowWebPageTitle
+        assertFalse(command.showDuckPlayerIcon)
+    }
+
+    @Test
     fun whenNoSiteAndUserSelectsToAddBookmarkThenBookmarkIsNotAdded() = runTest {
         val bookmark = Bookmark(
             id = UUID.randomUUID().toString(),
@@ -6056,7 +6081,6 @@ class BrowserTabViewModelTest {
         isBrowserShowing: Boolean = true,
     ) = runTest {
         whenever(mockDuckPlayer.isSimulatedYoutubeNoCookie(anyUri())).thenReturn(false)
-        whenever(mockDuckPlayer.getDuckPlayerState()).thenReturn(DISABLED)
         whenever(mockDuckPlayer.observeUserPreferences()).thenReturn(flowOf(UserPreferences(false, Disabled)))
 
         setBrowserShowing(isBrowserShowing)

--- a/app/src/androidTest/java/com/duckduckgo/app/tabs/model/TabDataRepositoryTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/tabs/model/TabDataRepositoryTest.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.app.tabs.store.TabSwitcherDataStore
 import com.duckduckgo.app.trackerdetection.EntityLookup
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.test.InstantSchedulersRule
+import com.duckduckgo.duckplayer.api.DuckPlayer
 import com.duckduckgo.privacy.config.api.ContentBlocking
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.consumeAsFlow
@@ -60,6 +61,8 @@ class TabDataRepositoryTest {
     var coroutinesTestRule = CoroutineTestRule()
 
     private val mockDao: TabsDao = mock()
+
+    private val mockDuckPlayer: DuckPlayer = mock()
 
     private val daoDeletableTabs = Channel<List<TabEntity>>()
 
@@ -438,6 +441,7 @@ class TabDataRepositoryTest {
                 coroutinesTestRule.testScope,
                 coroutinesTestRule.testDispatcherProvider,
                 duckDuckGoUrlDetector,
+                mockDuckPlayer,
             ),
             webViewPreviewPersister,
             faviconManager,

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1626,7 +1626,7 @@ class BrowserTabFragment :
             is Command.ScreenLock -> screenLock(it.data)
             is Command.ScreenUnlock -> screenUnlock()
             is Command.ShowFaviconsPrompt -> showFaviconsPrompt()
-            is Command.ShowWebPageTitle -> showWebPageTitleInCustomTab(it.title, it.url)
+            is Command.ShowWebPageTitle -> showWebPageTitleInCustomTab(it.title, it.url, it.showDuckPlayerIcon)
             is Command.ShowSSLError -> showSSLWarning(it.handler, it.error)
             is Command.HideSSLError -> hideSSLWarning()
             is Command.LaunchScreen -> launchScreen(it.screen, it.payload)
@@ -1725,6 +1725,7 @@ class BrowserTabFragment :
     private fun showWebPageTitleInCustomTab(
         title: String,
         url: String?,
+        showDuckPlayerIcon: Boolean,
     ) {
         if (isActiveCustomTab()) {
             omnibar.customTabToolbarContainer.customTabTitle.text = title
@@ -1737,6 +1738,8 @@ class BrowserTabFragment :
             omnibar.customTabToolbarContainer.customTabTitle.show()
             omnibar.customTabToolbarContainer.customTabDomainOnly.hide()
             omnibar.customTabToolbarContainer.customTabDomain.show()
+            omnibar.customTabToolbarContainer.customTabShieldIcon.isInvisible = showDuckPlayerIcon
+            omnibar.customTabToolbarContainer.customTabDuckPlayerIcon.isVisible = showDuckPlayerIcon
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1897,8 +1897,13 @@ class BrowserTabViewModel @Inject constructor(
 
     override fun titleReceived(newTitle: String, url: String?) {
         site?.title = newTitle
-        command.postValue(ShowWebPageTitle(newTitle, url))
-        onSiteChanged()
+        viewModelScope.launch(dispatchers.main()) {
+            val showDuckPlayerIcon = withContext(dispatchers.io()) {
+                url != null && duckPlayer.getDuckPlayerState() == ENABLED && duckPlayer.isSimulatedYoutubeNoCookie(url)
+            }
+            command.postValue(ShowWebPageTitle(newTitle, url, showDuckPlayerIcon))
+            onSiteChanged()
+        }
     }
 
     @AnyThread

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -180,6 +180,10 @@ class BrowserWebViewClient @Inject constructor(
                 }
                 is SpecialUrlDetector.UrlType.ShouldLaunchDuckPlayerLink -> {
                     if (isRedirect) {
+                        /*
+                        This forces shouldInterceptRequest to be called with the YouTube URL, otherwise that method is never executed and
+                        therefore the Duck Player page is never launched if YouTube comes from a redirect.
+                         */
                         webView.loadUrl(url.toString())
                         return true
                     } else {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -80,10 +80,7 @@ import com.duckduckgo.subscriptions.api.Subscriptions
 import com.duckduckgo.user.agent.api.ClientBrandHintProvider
 import java.net.URI
 import javax.inject.Inject
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.*
 import timber.log.Timber
 
 private const val ABOUT_BLANK = "about:blank"
@@ -133,7 +130,7 @@ class BrowserWebViewClient @Inject constructor(
         request: WebResourceRequest,
     ): Boolean {
         val url = request.url
-        return shouldOverride(view, url, request.isForMainFrame)
+        return shouldOverride(view, url, request.isForMainFrame, request.isRedirect)
     }
 
     /**
@@ -143,6 +140,7 @@ class BrowserWebViewClient @Inject constructor(
         webView: WebView,
         url: Uri,
         isForMainFrame: Boolean,
+        isRedirect: Boolean,
     ): Boolean {
         try {
             Timber.v("shouldOverride webViewUrl: ${webView.url} URL: $url")
@@ -180,7 +178,14 @@ class BrowserWebViewClient @Inject constructor(
                     }
                     false
                 }
-
+                is SpecialUrlDetector.UrlType.ShouldLaunchDuckPlayerLink -> {
+                    if (isRedirect) {
+                        webView.loadUrl(url.toString())
+                        return true
+                    } else {
+                        handleWebRequest(url, webView, isForMainFrame)
+                    }
+                }
                 is SpecialUrlDetector.UrlType.NonHttpAppLink -> {
                     Timber.i("Found non-http app link for ${urlType.uriString}")
                     if (isForMainFrame) {
@@ -201,29 +206,7 @@ class BrowserWebViewClient @Inject constructor(
 
                 is SpecialUrlDetector.UrlType.SearchQuery -> false
                 is SpecialUrlDetector.UrlType.Web -> {
-                    if (requestRewriter.shouldRewriteRequest(url)) {
-                        webViewClientListener?.let { listener ->
-                            val newUri = requestRewriter.rewriteRequestWithCustomQueryParams(url)
-                            loadUrl(listener, webView, newUri.toString())
-                            return true
-                        }
-                    }
-                    if (isForMainFrame) {
-                        webViewClientListener?.let { listener ->
-                            listener.willOverrideUrl(url.toString())
-                            clientProvider?.let { provider ->
-                                if (provider.shouldChangeBranding(url.toString())) {
-                                    provider.setOn(webView.settings, url.toString())
-                                    loadUrl(listener, webView, url.toString())
-                                    return true
-                                } else {
-                                    return false
-                                }
-                            }
-                            return false
-                        }
-                    }
-                    false
+                    handleWebRequest(url, webView, isForMainFrame)
                 }
 
                 is SpecialUrlDetector.UrlType.ExtractedAmpLink -> {
@@ -293,6 +276,36 @@ class BrowserWebViewClient @Inject constructor(
             }
             return false
         }
+    }
+
+    private fun handleWebRequest(
+        url: Uri,
+        webView: WebView,
+        isForMainFrame: Boolean,
+    ): Boolean {
+        if (requestRewriter.shouldRewriteRequest(url)) {
+            webViewClientListener?.let { listener ->
+                val newUri = requestRewriter.rewriteRequestWithCustomQueryParams(url)
+                loadUrl(listener, webView, newUri.toString())
+                return true
+            }
+        }
+        if (isForMainFrame) {
+            webViewClientListener?.let { listener ->
+                listener.willOverrideUrl(url.toString())
+                clientProvider?.let { provider ->
+                    if (provider.shouldChangeBranding(url.toString())) {
+                        provider.setOn(webView.settings, url.toString())
+                        loadUrl(listener, webView, url.toString())
+                        return true
+                    } else {
+                        return false
+                    }
+                }
+                return false
+            }
+        }
+        return false
     }
 
     @UiThread

--- a/app/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
@@ -94,7 +94,9 @@ class SpecialUrlDetectorImpl(
 
         val willNavigateToDuckPlayer = runBlocking { willNavigateToDuckPlayerDeferred.await() }
 
-        if (!willNavigateToDuckPlayer) {
+        if (willNavigateToDuckPlayer) {
+            return UrlType.ShouldLaunchDuckPlayerLink(url = uri)
+        } else {
             try {
                 val browsableIntent = Intent.parseUri(uriString, URI_ANDROID_APP_SCHEME).apply {
                     addCategory(Intent.CATEGORY_BROWSABLE)

--- a/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
@@ -157,6 +157,7 @@ sealed class Command {
     class ShowWebPageTitle(
         val title: String,
         val url: String?,
+        val showDuckPlayerIcon: Boolean = false,
     ) : Command()
     class CheckSystemLocationPermission(
         val domain: String,

--- a/app/src/main/java/com/duckduckgo/app/global/model/SiteFactoryImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/model/SiteFactoryImpl.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.trackerdetection.EntityLookup
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckplayer.api.DuckPlayer
 import com.duckduckgo.privacy.config.api.ContentBlocking
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
@@ -43,6 +44,7 @@ class SiteFactoryImpl @Inject constructor(
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
     private val duckDuckGoUrlDetector: DuckDuckGoUrlDetector,
+    private val duckPlayer: DuckPlayer,
 ) : SiteFactory {
 
     private val siteCache = LruCache<String, Site>(1)
@@ -74,6 +76,7 @@ class SiteFactoryImpl @Inject constructor(
                 appCoroutineScope,
                 dispatcherProvider,
                 RealBrokenSiteContext(duckDuckGoUrlDetector),
+                duckPlayer,
             ).also {
                 siteCache.put(cacheKey, it)
             }

--- a/app/src/main/java/com/duckduckgo/app/global/model/SiteMonitor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/model/SiteMonitor.kt
@@ -34,6 +34,7 @@ import com.duckduckgo.app.trackerdetection.model.TrackingEvent
 import com.duckduckgo.browser.api.brokensite.BrokenSiteContext
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.isHttps
+import com.duckduckgo.duckplayer.api.DuckPlayer
 import com.duckduckgo.privacy.config.api.ContentBlocking
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlinx.coroutines.CoroutineScope
@@ -51,6 +52,7 @@ class SiteMonitor(
     appCoroutineScope: CoroutineScope,
     dispatcherProvider: DispatcherProvider,
     brokenSiteContext: BrokenSiteContext,
+    private val duckPlayer: DuckPlayer,
 ) : Site {
 
     override var url: String = url
@@ -163,6 +165,7 @@ class SiteMonitor(
 
     override fun privacyProtection(): PrivacyShield {
         userAllowList = domain?.let { isAllowListed(it) } ?: false
+        if (duckPlayer.isDuckPlayerUri(url)) return UNKNOWN
         if (userAllowList || !isHttps) return UNPROTECTED
 
         if (!fullSiteDetailsAvailable) {

--- a/app/src/main/res/layout/include_custom_tab_toolbar.xml
+++ b/app/src/main/res/layout/include_custom_tab_toolbar.xml
@@ -45,7 +45,19 @@
         android:importantForAccessibility="no"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toEndOf="@id/customTabCloseIcon"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"/>
+
+    <ImageView
+        android:id="@+id/customTabDuckPlayerIcon"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:importantForAccessibility="no"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toEndOf="@id/customTabCloseIcon"
+        app:layout_constraintEnd_toStartOf="@+id/customTabTitle"
+        app:layout_constraintTop_toTopOf="parent"
+        android:src="@drawable/ic_duckplayer"
+        android:visibility="gone"/>
 
     <com.duckduckgo.common.ui.view.text.DaxTextView
         android:id="@+id/customTabTitle"

--- a/app/src/test/java/com/duckduckgo/app/brokensite/BrokenSiteDataTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/brokensite/BrokenSiteDataTest.kt
@@ -30,11 +30,14 @@ import com.duckduckgo.browser.api.brokensite.BrokenSiteData
 import com.duckduckgo.browser.api.brokensite.BrokenSiteData.ReportFlow.MENU
 import com.duckduckgo.browser.api.brokensite.BrokenSiteOpenerContext
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckplayer.api.DuckPlayer
 import com.duckduckgo.privacy.config.api.ContentBlocking
 import org.junit.Assert.*
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
@@ -48,7 +51,13 @@ class BrokenSiteDataTest {
 
     private val mockContentBlocking: ContentBlocking = mock()
     private val mockBrokenSiteContext: BrokenSiteContext = mock()
+    private val mockDuckPlayer: DuckPlayer = mock()
     private val mockBypassedSSLCertificatesRepository: BypassedSSLCertificatesRepository = mock()
+
+    @Before
+    fun setup() {
+        whenever(mockDuckPlayer.isDuckPlayerUri(any())).thenReturn(false)
+    }
 
     @Test
     fun whenSiteIsNullThenDataIsEmptyAndUpgradedIsFalse() {
@@ -259,6 +268,7 @@ class BrokenSiteDataTest {
             coroutineRule.testScope,
             coroutineRule.testDispatcherProvider,
             mockBrokenSiteContext,
+            mockDuckPlayer,
         )
     }
 

--- a/app/src/test/java/com/duckduckgo/app/browser/SpecialUrlDetectorImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/SpecialUrlDetectorImplTest.kt
@@ -170,7 +170,7 @@ class SpecialUrlDetectorImplTest {
     }
 
     @Test
-    fun whenWillNavigateToDuckPlayerThenDoNotReturnAppLink() = runTest {
+    fun whenWillNavigateToDuckPlayerThenReturnShouldLaunchDuckPlayerLink() = runTest {
         whenever(mockDuckPlayer.willNavigateToDuckPlayer(any())).thenReturn(true)
         val type = testee.determineType("https://example.com")
         whenever(mockPackageManager.resolveActivity(any(), eq(PackageManager.MATCH_DEFAULT_ONLY))).thenReturn(null)
@@ -181,7 +181,7 @@ class SpecialUrlDetectorImplTest {
                 ResolveInfo(),
             ),
         )
-        assertTrue(type is Web)
+        assertTrue(type is ShouldLaunchDuckPlayerLink)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/global/model/SiteMonitorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/global/model/SiteMonitorTest.kt
@@ -31,13 +31,16 @@ import com.duckduckgo.app.trackerdetection.model.TrackerType
 import com.duckduckgo.app.trackerdetection.model.TrackingEvent
 import com.duckduckgo.browser.api.brokensite.BrokenSiteContext
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckplayer.api.DuckPlayer
 import com.duckduckgo.privacy.config.api.ContentBlocking
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
@@ -71,7 +74,14 @@ class SiteMonitorTest {
 
     private val mockBrokenSiteContext: BrokenSiteContext = mock()
 
+    private val mockDuckPlayer: DuckPlayer = mock()
+
     private val mockBypassedSSLCertificatesRepository: BypassedSSLCertificatesRepository = mock()
+
+    @Before
+    fun setup() {
+        whenever(mockDuckPlayer.isDuckPlayerUri(any())).thenReturn(false)
+    }
 
     @Test
     fun whenUrlIsHttpsThenHttpsStatusIsSecure() {
@@ -85,6 +95,7 @@ class SiteMonitorTest {
             appCoroutineScope = coroutineRule.testScope,
             dispatcherProvider = coroutineRule.testDispatcherProvider,
             brokenSiteContext = mockBrokenSiteContext,
+            duckPlayer = mockDuckPlayer,
         )
         assertEquals(HttpsStatus.SECURE, testee.https)
     }
@@ -101,6 +112,7 @@ class SiteMonitorTest {
             appCoroutineScope = coroutineRule.testScope,
             dispatcherProvider = coroutineRule.testDispatcherProvider,
             brokenSiteContext = mockBrokenSiteContext,
+            duckPlayer = mockDuckPlayer,
         )
         assertEquals(HttpsStatus.NONE, testee.https)
     }
@@ -117,6 +129,7 @@ class SiteMonitorTest {
             appCoroutineScope = coroutineRule.testScope,
             dispatcherProvider = coroutineRule.testDispatcherProvider,
             brokenSiteContext = mockBrokenSiteContext,
+            duckPlayer = mockDuckPlayer,
         )
         testee.hasHttpResources = true
         assertEquals(HttpsStatus.MIXED, testee.https)
@@ -134,6 +147,7 @@ class SiteMonitorTest {
             appCoroutineScope = coroutineRule.testScope,
             dispatcherProvider = coroutineRule.testDispatcherProvider,
             brokenSiteContext = mockBrokenSiteContext,
+            duckPlayer = mockDuckPlayer,
         )
         assertEquals(HttpsStatus.NONE, testee.https)
     }
@@ -150,6 +164,7 @@ class SiteMonitorTest {
             appCoroutineScope = coroutineRule.testScope,
             dispatcherProvider = coroutineRule.testDispatcherProvider,
             brokenSiteContext = mockBrokenSiteContext,
+            duckPlayer = mockDuckPlayer,
         )
         assertEquals(document, testee.url)
     }
@@ -166,6 +181,7 @@ class SiteMonitorTest {
             appCoroutineScope = coroutineRule.testScope,
             dispatcherProvider = coroutineRule.testDispatcherProvider,
             brokenSiteContext = mockBrokenSiteContext,
+            duckPlayer = mockDuckPlayer,
         )
         assertEquals(0, testee.trackerCount)
     }
@@ -182,6 +198,7 @@ class SiteMonitorTest {
             appCoroutineScope = coroutineRule.testScope,
             dispatcherProvider = coroutineRule.testDispatcherProvider,
             brokenSiteContext = mockBrokenSiteContext,
+            duckPlayer = mockDuckPlayer,
         )
         testee.trackerDetected(
             TrackingEvent(
@@ -231,6 +248,7 @@ class SiteMonitorTest {
             appCoroutineScope = coroutineRule.testScope,
             dispatcherProvider = coroutineRule.testDispatcherProvider,
             brokenSiteContext = mockBrokenSiteContext,
+            duckPlayer = mockDuckPlayer,
         )
         testee.trackerDetected(
             TrackingEvent(
@@ -280,6 +298,7 @@ class SiteMonitorTest {
             appCoroutineScope = coroutineRule.testScope,
             dispatcherProvider = coroutineRule.testDispatcherProvider,
             brokenSiteContext = mockBrokenSiteContext,
+            duckPlayer = mockDuckPlayer,
         )
         testee.trackerDetected(
             TrackingEvent(
@@ -329,6 +348,7 @@ class SiteMonitorTest {
             appCoroutineScope = coroutineRule.testScope,
             dispatcherProvider = coroutineRule.testDispatcherProvider,
             brokenSiteContext = mockBrokenSiteContext,
+            duckPlayer = mockDuckPlayer,
         )
         testee.trackerDetected(
             TrackingEvent(
@@ -356,6 +376,7 @@ class SiteMonitorTest {
             appCoroutineScope = coroutineRule.testScope,
             dispatcherProvider = coroutineRule.testDispatcherProvider,
             brokenSiteContext = mockBrokenSiteContext,
+            duckPlayer = mockDuckPlayer,
         )
         testee.trackerDetected(
             TrackingEvent(
@@ -383,6 +404,7 @@ class SiteMonitorTest {
             appCoroutineScope = coroutineRule.testScope,
             dispatcherProvider = coroutineRule.testDispatcherProvider,
             brokenSiteContext = mockBrokenSiteContext,
+            duckPlayer = mockDuckPlayer,
         )
         testee.trackerDetected(
             TrackingEvent(
@@ -421,6 +443,7 @@ class SiteMonitorTest {
             appCoroutineScope = coroutineRule.testScope,
             dispatcherProvider = coroutineRule.testDispatcherProvider,
             brokenSiteContext = mockBrokenSiteContext,
+            duckPlayer = mockDuckPlayer,
         )
         assertFalse(testee.upgradedHttps)
     }
@@ -437,6 +460,7 @@ class SiteMonitorTest {
             appCoroutineScope = coroutineRule.testScope,
             dispatcherProvider = coroutineRule.testDispatcherProvider,
             brokenSiteContext = mockBrokenSiteContext,
+            duckPlayer = mockDuckPlayer,
         )
         assertEquals(0, testee.surrogates.size)
     }
@@ -453,6 +477,7 @@ class SiteMonitorTest {
             appCoroutineScope = coroutineRule.testScope,
             dispatcherProvider = coroutineRule.testDispatcherProvider,
             brokenSiteContext = mockBrokenSiteContext,
+            duckPlayer = mockDuckPlayer,
         )
         testee.surrogateDetected(SurrogateResponse())
         assertEquals(1, testee.surrogates.size)
@@ -470,6 +495,7 @@ class SiteMonitorTest {
             appCoroutineScope = coroutineRule.testScope,
             dispatcherProvider = coroutineRule.testDispatcherProvider,
             brokenSiteContext = mockBrokenSiteContext,
+            duckPlayer = mockDuckPlayer,
         )
         testee.trackerDetected(
             TrackingEvent(
@@ -519,6 +545,7 @@ class SiteMonitorTest {
             appCoroutineScope = coroutineRule.testScope,
             dispatcherProvider = coroutineRule.testDispatcherProvider,
             brokenSiteContext = mockBrokenSiteContext,
+            duckPlayer = mockDuckPlayer,
         )
         testee.trackerDetected(
             TrackingEvent(
@@ -653,6 +680,7 @@ class SiteMonitorTest {
         appCoroutineScope = coroutineRule.testScope,
         dispatcherProvider = coroutineRule.testDispatcherProvider,
         brokenSiteContext = mockBrokenSiteContext,
+        duckPlayer = mockDuckPlayer,
     )
 
     private fun givenSitePrivacyData(

--- a/browser-api/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
@@ -47,6 +47,7 @@ interface SpecialUrlDetector {
         class CloakedAmpLink(val ampUrl: String) : UrlType()
         class TrackingParameterLink(val cleanedUrl: String) : UrlType()
         data object ShouldLaunchPrivacyProLink : UrlType()
+        data class ShouldLaunchDuckPlayerLink(val url: Uri) : UrlType()
         class DuckScheme(val uriString: String) : UrlType()
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207252092703676/1208391013610683/f 

### Description
Fix bug where tracking links redirecting to YouTube wouldn't trigger Duck Player

### Steps to test this PR

_Feature 1_
- [x] Set Duck Player settings to Always enabled
- [x] Open https://clicks.aweber.com/y/ct/?l=pbFxrn&m=gzpbMhiix7McQMQ&b=cIoUrwlB2qpdga9S7Y8fWQ 
- [x] Check Duck Player is launched
- [x] Navigate back
- [x] Check you're taken to the previous page (or the customtab is closed if the navigation was initiated from an external link)
