### PR TITLE
Update content scope scripts to version 6.19.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -7899,6 +7899,10 @@
             if (this.getFeatureSettingEnabled('screenLock')) {
                 this.screenLockFix();
             }
+
+            if (this.getFeatureSettingEnabled('modifyLocalStorage')) {
+                this.modifyLocalStorage();
+            }
         }
 
         /** Shim Web Share API in Android WebView */
@@ -8311,6 +8315,22 @@
             } catch {
                 // Ignore exceptions that could be caused by conflicting with other extensions
             }
+        }
+
+        /**
+         * Support for modifying localStorage entries
+         */
+        modifyLocalStorage () {
+            /** @type {import('../types//webcompat-settings').WebCompatSettings['modifyLocalStorage']} */
+            const settings = this.getFeatureSetting('modifyLocalStorage');
+
+            if (!settings || !settings.changes) return
+
+            settings.changes.forEach((change) => {
+                if (change.action === 'delete') {
+                    localStorage.removeItem(change.key);
+                }
+            });
         }
 
         /**

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/js/index.css
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/js/index.css
@@ -48,7 +48,7 @@ body[data-display=app] {
   padding: 16px;
 }
 
-/* pages/duckplayer/app/components/Fallback.module.css */
+/* shared/components/Fallback/Fallback.module.css */
 .Fallback_fallback {
   height: 100%;
   width: 100%;

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/js/index.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/js/index.js
@@ -1135,7 +1135,7 @@
     } catch (e3) {
       console.error("could not access handlers for %s, falling back to mock interface", opts.injectName);
     }
-    const fallback = new TestTransportConfig({
+    const fallback = opts.mockTransport?.() || new TestTransportConfig({
       /**
        * @param {import('@duckduckgo/messaging').NotificationMessage} msg
        */
@@ -2258,12 +2258,12 @@
     return q2(UserValuesContext).setEnabled;
   }
 
-  // pages/duckplayer/app/components/Fallback.module.css
+  // shared/components/Fallback/Fallback.module.css
   var Fallback_default = {
     fallback: "Fallback_fallback"
   };
 
-  // pages/duckplayer/app/components/Fallback.jsx
+  // shared/components/Fallback/Fallback.jsx
   function Fallback({ showDetails }) {
     return /* @__PURE__ */ y("div", { class: Fallback_default.fallback }, /* @__PURE__ */ y("div", null, /* @__PURE__ */ y("p", null, "Something went wrong!"), showDetails && /* @__PURE__ */ y("p", null, "Please check logs for a message called ", /* @__PURE__ */ y("code", null, "reportPageException"))));
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^10.15.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#13.1.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.17.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.19.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#5.1.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1724449523"
       },
@@ -71,7 +71,7 @@
       "hasInstallScript": true
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#2bed9e2963b2a9232452911d0773fac8b56416a1",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#1ed569676555d493c9c5575eaed22aa02569aac9",
       "hasInstallScript": true,
       "workspaces": [
         "packages/special-pages",
@@ -208,9 +208,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.7.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.0.tgz",
-      "integrity": "sha512-MOdOibwBs6KW1vfqz2uKMlxq5xAfAZ98SZjO8e3XnAbFnTJtAspqhWk7hrdSAs9/Y14ZWMiy7/MxMUzAOadYEw==",
+      "version": "22.7.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.2.tgz",
+      "integrity": "sha512-866lXSrpGpgyHBZUa2m9YNWqHDjjM0aBTJlNtYaGEw4rqY/dcD7deRVTbBBAJelfA7oaGDbNftXF/TL/A6RgoA==",
       "dev": true,
       "dependencies": {
         "undici-types": "~6.19.2"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^10.15.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#13.1.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.17.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.19.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#5.1.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1724449523"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208405283799536/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass