### PR TITLE
fix omnibar taking focus when hiding keyboard

### DIFF
--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/extensions/ActivityExtensions.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/extensions/ActivityExtensions.kt
@@ -82,6 +82,5 @@ fun Activity.showKeyboard(editText: EditText) {
 }
 
 fun Activity.hideKeyboard(editText: EditText) {
-    editText.requestFocus()
     WindowInsetsControllerCompat(window, editText).hide(WindowInsetsCompat.Type.ime())
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202552961248957/1208407851630430/f

### Description
After we did https://github.com/duckduckgo/Android/pull/5033 the omnibar is taking focus more than usual, triggering onFocus changes in some unexpected scenarios (e.g: if we send the app to background, etc.)

After taking a look, the logic to show/hide keyboard was changed, and we now, for both methods, execute `editText.requestFocus()`. That seems correct for showing, but unsure for hiding. 

### Steps to test this PR

_Feature 1_
- just smoke test

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
