### PR TITLE
Add APIs for safely interacting with some trickier WebView APIs

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -116,6 +116,8 @@ import com.duckduckgo.app.browser.R.string
 import com.duckduckgo.app.browser.SSLErrorType.NONE
 import com.duckduckgo.app.browser.WebViewErrorResponse.LOADING
 import com.duckduckgo.app.browser.WebViewErrorResponse.OMITTED
+import com.duckduckgo.app.browser.api.WebViewCapabilityChecker
+import com.duckduckgo.app.browser.api.WebViewCapabilityChecker.WebViewCapability
 import com.duckduckgo.app.browser.applinks.AppLinksLauncher
 import com.duckduckgo.app.browser.applinks.AppLinksSnackBarConfigurator
 import com.duckduckgo.app.browser.autocomplete.BrowserAutoCompleteSuggestionsAdapter
@@ -553,6 +555,9 @@ class BrowserTabFragment :
 
     @Inject
     lateinit var loadingBarExperimentManager: LoadingBarExperimentManager
+
+    @Inject
+    lateinit var webViewCapabilityChecker: WebViewCapabilityChecker
 
     /**
      * We use this to monitor whether the user was seeing the in-context Email Protection signup prompt
@@ -2526,8 +2531,7 @@ class BrowserTabFragment :
                 WebViewCompat.addDocumentStartJavaScript(webView, script, setOf("*"))
 
                 webView.safeAddWebMessageListener(
-                    dispatchers,
-                    webViewVersionProvider,
+                    webViewCapabilityChecker,
                     "ddgBlobDownloadObj",
                     setOf("*"),
                     object : WebViewCompat.WebMessageListener {
@@ -2609,8 +2613,8 @@ class BrowserTabFragment :
 
     private suspend fun isBlobDownloadWebViewFeatureEnabled(webView: DuckDuckGoWebView): Boolean {
         return withContext(dispatchers.io()) { webViewBlobDownloadFeature.self().isEnabled() } &&
-            webView.isWebMessageListenerSupported(dispatchers, webViewVersionProvider) &&
-            WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT)
+            webViewCapabilityChecker.isSupported(WebViewCapability.WebMessageListener) &&
+            webViewCapabilityChecker.isSupported(WebViewCapability.DocumentStartJavaScript)
     }
 
     private fun configureWebViewForAutofill(it: DuckDuckGoWebView) {

--- a/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoWebView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoWebView.kt
@@ -35,12 +35,9 @@ import androidx.core.view.NestedScrollingChildHelper
 import androidx.core.view.ViewCompat
 import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewCompat.WebMessageListener
-import androidx.webkit.WebViewFeature
+import com.duckduckgo.app.browser.api.WebViewCapabilityChecker
+import com.duckduckgo.app.browser.api.WebViewCapabilityChecker.WebViewCapability
 import com.duckduckgo.app.browser.navigation.safeCopyBackForwardList
-import com.duckduckgo.browser.api.WebViewVersionProvider
-import com.duckduckgo.common.utils.DispatcherProvider
-import com.duckduckgo.common.utils.extensions.compareSemanticVersion
-import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 /**
@@ -411,25 +408,14 @@ class DuckDuckGoWebView : WebView, NestedScrollingChild3 {
         }
     }
 
-    suspend fun isWebMessageListenerSupported(
-        dispatchers: DispatcherProvider,
-        webViewVersionProvider: WebViewVersionProvider,
-    ): Boolean {
-        return withContext(dispatchers.io()) {
-            webViewVersionProvider.getFullVersion()
-                .compareSemanticVersion(WEB_MESSAGE_LISTENER_WEBVIEW_VERSION)?.let { it >= 0 } ?: false
-        } && WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)
-    }
-
     @SuppressLint("RequiresFeature", "AddWebMessageListenerUsage")
     suspend fun safeAddWebMessageListener(
-        dispatchers: DispatcherProvider,
-        webViewVersionProvider: WebViewVersionProvider,
+        webViewCapabilityChecker: WebViewCapabilityChecker,
         jsObjectName: String,
         allowedOriginRules: Set<String>,
         listener: WebMessageListener,
     ): Boolean = runCatching {
-        if (isWebMessageListenerSupported(dispatchers, webViewVersionProvider) && !isDestroyed) {
+        if (webViewCapabilityChecker.isSupported(WebViewCapability.WebMessageListener) && !isDestroyed) {
             WebViewCompat.addWebMessageListener(
                 this,
                 jsObjectName,
@@ -447,11 +433,10 @@ class DuckDuckGoWebView : WebView, NestedScrollingChild3 {
 
     @SuppressLint("RequiresFeature", "RemoveWebMessageListenerUsage")
     suspend fun safeRemoveWebMessageListener(
-        dispatchers: DispatcherProvider,
-        webViewVersionProvider: WebViewVersionProvider,
+        webViewCapabilityChecker: WebViewCapabilityChecker,
         jsObjectName: String,
     ): Boolean = runCatching {
-        if (isWebMessageListenerSupported(dispatchers, webViewVersionProvider) && !isDestroyed) {
+        if (webViewCapabilityChecker.isSupported(WebViewCapability.WebMessageListener) && !isDestroyed) {
             WebViewCompat.removeWebMessageListener(
                 this,
                 jsObjectName,
@@ -472,6 +457,5 @@ class DuckDuckGoWebView : WebView, NestedScrollingChild3 {
          * We can't use that value directly as it was only added on Oreo, but we can apply the value anyway.
          */
         private const val IME_FLAG_NO_PERSONALIZED_LEARNING = 0x1000000
-        private const val WEB_MESSAGE_LISTENER_WEBVIEW_VERSION = "126.0.6478.40"
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/RealWebViewCapabilityChecker.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/RealWebViewCapabilityChecker.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser
+
+import androidx.webkit.WebViewFeature
+import com.duckduckgo.app.browser.api.WebViewCapabilityChecker
+import com.duckduckgo.app.browser.api.WebViewCapabilityChecker.WebViewCapability
+import com.duckduckgo.app.browser.api.WebViewCapabilityChecker.WebViewCapability.DocumentStartJavaScript
+import com.duckduckgo.app.browser.api.WebViewCapabilityChecker.WebViewCapability.WebMessageListener
+import com.duckduckgo.browser.api.WebViewVersionProvider
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.extensions.compareSemanticVersion
+import com.duckduckgo.di.scopes.FragmentScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+import kotlinx.coroutines.withContext
+
+@ContributesBinding(FragmentScope::class)
+class RealWebViewCapabilityChecker @Inject constructor(
+    private val dispatchers: DispatcherProvider,
+    private val webViewVersionProvider: WebViewVersionProvider,
+) : WebViewCapabilityChecker {
+
+    override suspend fun isSupported(capability: WebViewCapability): Boolean {
+        return when (capability) {
+            DocumentStartJavaScript -> isDocumentStartJavaScriptSupported()
+            WebMessageListener -> isWebMessageListenerSupported()
+        }
+    }
+
+    private suspend fun isWebMessageListenerSupported(): Boolean {
+        return withContext(dispatchers.io()) {
+            webViewVersionProvider.getFullVersion()
+                .compareSemanticVersion(WEB_MESSAGE_LISTENER_WEBVIEW_VERSION)?.let { it >= 0 } ?: false
+        } && WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)
+    }
+
+    private fun isDocumentStartJavaScriptSupported(): Boolean {
+        return WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT)
+    }
+
+    companion object {
+        // critical fixes didn't exist until this WebView version
+        private const val WEB_MESSAGE_LISTENER_WEBVIEW_VERSION = "126.0.6478.40"
+    }
+}

--- a/browser-api/src/main/java/com/duckduckgo/app/browser/api/WebViewCapabilityChecker.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/browser/api/WebViewCapabilityChecker.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.api
+
+/**
+ * Allows WebView capabilities to be queried.
+ * WebView capabilities depend on various conditions, such as WebView version, feature flags etc...
+ * Capabilities can change over time, so it's recommended to always check immediately before trying to use that capability.
+ */
+interface WebViewCapabilityChecker {
+
+    /**
+     * Check if a particular capability is currently supported by the WebView
+     */
+    suspend fun isSupported(capability: WebViewCapability): Boolean
+
+    /**
+     * WebView capabilities, which can be provided to [isSupported]
+     */
+    sealed interface WebViewCapability {
+        /**
+         * WebMessageListener
+         * The ability to post web messages to JS, and receive web messages from JS
+         */
+        data object WebMessageListener : WebViewCapability
+
+        /**
+         * DocumentStartJavaScript
+         * The ability to inject Javascript which is guaranteed to be executed first on the page, and available in all iframes
+         */
+        data object DocumentStartJavaScript : WebViewCapability
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1208402254099284/f 

### Description
Extracts some of the checks around safely using WebMessageListeners and AddDocumentStartJavacscript APIs so that they can be queried outside of a `DuckDuckGoWebView` instance, and therefore makes the checks possible from outside of the `app` module

### Steps to test this PR
- [ ] Check our existing use of web message listeners still work: verify the PDF can still be downloaded from the link in https://app.asana.com/0/1202552961248957/1206811138963758/f. 
