### PR TITLE
Add feature flag for sending full installer package ID

### DIFF
--- a/installation/installation-impl/build.gradle
+++ b/installation/installation-impl/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation JakeWharton.timber
     implementation AndroidX.lifecycle.runtime.ktx
     implementation AndroidX.lifecycle.commonJava8
+    implementation "androidx.datastore:datastore-preferences:_"
 
     testImplementation Testing.junit4
     testImplementation AndroidX.test.ext.junit

--- a/installation/installation-impl/src/main/java/com/duckduckgo/installation/impl/installer/di/InstallerModule.kt
+++ b/installation/installation-impl/src/main/java/com/duckduckgo/installation/impl/installer/di/InstallerModule.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.installation.impl.installer.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesTo
+import dagger.Module
+import dagger.Provides
+import dagger.SingleInstanceIn
+import javax.inject.Qualifier
+
+@Module
+@ContributesTo(AppScope::class)
+object InstallerModule {
+
+    private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
+        name = "com.duckduckgo.installation.impl.installer",
+    )
+
+    @Provides
+    @SingleInstanceIn(AppScope::class)
+    @InstallSourceFullPackageDataStore
+    fun provideInstallSourceFullPackageDataStore(context: Context): DataStore<Preferences> {
+        return context.dataStore
+    }
+
+    @Qualifier
+    annotation class InstallSourceFullPackageDataStore
+}

--- a/installation/installation-impl/src/main/java/com/duckduckgo/installation/impl/installer/fullpackage/InstallSourceFullPackageStore.kt
+++ b/installation/installation-impl/src/main/java/com/duckduckgo/installation/impl/installer/fullpackage/InstallSourceFullPackageStore.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.installation.impl.installer.fullpackage
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.installation.impl.installer.di.InstallerModule.InstallSourceFullPackageDataStore
+import com.duckduckgo.installation.impl.installer.fullpackage.InstallSourceFullPackageStore.IncludedPackages
+import com.duckduckgo.installation.impl.installer.fullpackage.feature.InstallSourceFullPackageListJsonParser
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+
+interface InstallSourceFullPackageStore {
+    suspend fun updateInstallSourceFullPackages(json: String)
+    suspend fun getInstallSourceFullPackages(): IncludedPackages
+
+    data class IncludedPackages(val list: List<String> = emptyList()) {
+
+        fun hasWildcard(): Boolean {
+            return list.contains("*")
+        }
+    }
+}
+
+@ContributesBinding(AppScope::class, boundType = InstallSourceFullPackageStore::class)
+@SingleInstanceIn(AppScope::class)
+class InstallSourceFullPackageStoreImpl @Inject constructor(
+    private val dispatchers: DispatcherProvider,
+    private val jsonParser: InstallSourceFullPackageListJsonParser,
+    @InstallSourceFullPackageDataStore private val dataStore: DataStore<Preferences>,
+) : InstallSourceFullPackageStore {
+
+    override suspend fun updateInstallSourceFullPackages(json: String) {
+        withContext(dispatchers.io()) {
+            val includedPackages = jsonParser.parseJson(json)
+            dataStore.edit {
+                it[packageInstallersKey] = includedPackages.list.toSet()
+            }
+        }
+    }
+
+    override suspend fun getInstallSourceFullPackages(): IncludedPackages {
+        return withContext(dispatchers.io()) {
+            val packageInstallers = dataStore.data.map { it[packageInstallersKey] }.firstOrNull()
+            return@withContext IncludedPackages(packageInstallers?.toList() ?: emptyList())
+        }
+    }
+
+    companion object {
+        val packageInstallersKey = stringSetPreferencesKey("package_installers")
+    }
+}

--- a/installation/installation-impl/src/main/java/com/duckduckgo/installation/impl/installer/fullpackage/feature/InstallSourceFullPackageFeature.kt
+++ b/installation/installation-impl/src/main/java/com/duckduckgo/installation/impl/installer/fullpackage/feature/InstallSourceFullPackageFeature.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.installation.impl.installer.fullpackage.feature
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.FeatureSettings
+import com.duckduckgo.feature.toggles.api.RemoteFeatureStoreNamed
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.installation.impl.installer.fullpackage.InstallSourceFullPackageStore
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    boundType = InstallSourceFullPackageFeature::class,
+    featureName = "sendFullPackageInstallSource",
+    settingsStore = InstallSourceFullPackageFeatureSettingsStore::class,
+)
+/**
+ * This is the class that represents the feature flag for sending full installer package ID.
+ * This can be used to specify which app-installer package IDs we'd match on to send a pixel.
+ * A wildcard "*" can be used to match all package IDs.
+ */
+interface InstallSourceFullPackageFeature {
+    /**
+     * @return `true` when the remote config has the global "sendFullPackageInstallSource" feature flag enabled
+     *
+     * If the remote feature is not present defaults to `false`
+     */
+
+    @Toggle.DefaultValue(false)
+    fun self(): Toggle
+}
+
+@ContributesBinding(AppScope::class)
+@RemoteFeatureStoreNamed(InstallSourceFullPackageFeature::class)
+class InstallSourceFullPackageFeatureSettingsStore @Inject constructor(
+    private val dataStore: InstallSourceFullPackageStore,
+    private val dispatchers: DispatcherProvider,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+) : FeatureSettings.Store {
+
+    override fun store(jsonString: String) {
+        kotlin.runCatching {
+            appCoroutineScope.launch(dispatchers.io()) {
+                dataStore.updateInstallSourceFullPackages(jsonString)
+            }
+        }
+    }
+}

--- a/installation/installation-impl/src/main/java/com/duckduckgo/installation/impl/installer/fullpackage/feature/InstallSourceFullPackageListJsonParser.kt
+++ b/installation/installation-impl/src/main/java/com/duckduckgo/installation/impl/installer/fullpackage/feature/InstallSourceFullPackageListJsonParser.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.installation.impl.installer.fullpackage.feature
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.installation.impl.installer.fullpackage.InstallSourceFullPackageStore.IncludedPackages
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import javax.inject.Inject
+
+interface InstallSourceFullPackageListJsonParser {
+    suspend fun parseJson(json: String?): IncludedPackages
+}
+
+@ContributesBinding(AppScope::class)
+class InstallSourceFullPackageListJsonParserImpl @Inject constructor() : InstallSourceFullPackageListJsonParser {
+
+    private val jsonAdapter by lazy { buildJsonAdapter() }
+
+    private fun buildJsonAdapter(): JsonAdapter<SettingsJson> {
+        val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+        return moshi.adapter(SettingsJson::class.java)
+    }
+
+    override suspend fun parseJson(json: String?): IncludedPackages {
+        if (json == null) return IncludedPackages()
+
+        return kotlin.runCatching {
+            val parsed = jsonAdapter.fromJson(json)
+            return parsed?.asIncludedPackages() ?: IncludedPackages()
+        }.getOrDefault(IncludedPackages())
+    }
+
+    private fun SettingsJson.asIncludedPackages(): IncludedPackages {
+        return IncludedPackages(includedPackages.map { it })
+    }
+
+    private data class SettingsJson(
+        val includedPackages: List<String>,
+    )
+}

--- a/installation/installation-impl/src/test/java/com/duckduckgo/installation/impl/installer/fullpackage/IncludedPackagesTest.kt
+++ b/installation/installation-impl/src/test/java/com/duckduckgo/installation/impl/installer/fullpackage/IncludedPackagesTest.kt
@@ -1,0 +1,44 @@
+package com.duckduckgo.installation.impl.installer.fullpackage
+
+import com.duckduckgo.installation.impl.installer.fullpackage.InstallSourceFullPackageStore.IncludedPackages
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class IncludedPackagesTest {
+
+    @Test
+    fun whenEmptyThenDoesNotContainWildcard() {
+        val list = IncludedPackages(emptyList())
+        assertFalse(list.hasWildcard())
+    }
+
+    @Test
+    fun whenHasEntriesButNoWildcardThenDoesNotContainWildcard() {
+        val list = IncludedPackages(
+            listOf(
+                "not a wildcard",
+                "also not a wildcard",
+            ),
+        )
+        assertFalse(list.hasWildcard())
+    }
+
+    @Test
+    fun whenHasMultipleEntriesAndOneIsWildcardEntryThenDoesContainWildcard() {
+        val list = IncludedPackages(
+            listOf(
+                "not a wildcard",
+                "*",
+                "also not a wildcard",
+            ),
+        )
+        assertTrue(list.hasWildcard())
+    }
+
+    @Test
+    fun whenHasSingleWildcardEntryThenDoesContainWildcard() {
+        val list = IncludedPackages(listOf("*"))
+        assertTrue(list.hasWildcard())
+    }
+}

--- a/installation/installation-impl/src/test/java/com/duckduckgo/installation/impl/installer/fullpackage/InstallSourceFullPackageStoreImplTest.kt
+++ b/installation/installation-impl/src/test/java/com/duckduckgo/installation/impl/installer/fullpackage/InstallSourceFullPackageStoreImplTest.kt
@@ -1,0 +1,102 @@
+package com.duckduckgo.installation.impl.installer.fullpackage
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.dataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.installation.impl.installer.fullpackage.InstallSourceFullPackageStore.IncludedPackages
+import com.duckduckgo.installation.impl.installer.fullpackage.feature.InstallSourceFullPackageListJsonParser
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class InstallSourceFullPackageStoreImplTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+
+    private val mockInstallSourceFullPackageListJsonParser: InstallSourceFullPackageListJsonParser = mock()
+    private val temporaryFolder = TemporaryFolder.builder().assureDeletion().build().also { it.create() }
+
+    private val testDataStore: DataStore<Preferences> =
+        PreferenceDataStoreFactory.create(
+            scope = coroutineTestRule.testScope,
+            produceFile = { temporaryFolder.newFile("temp.preferences_pb") },
+        )
+
+    private val testee = InstallSourceFullPackageStoreImpl(
+        dispatchers = coroutineTestRule.testDispatcherProvider,
+        jsonParser = mockInstallSourceFullPackageListJsonParser,
+        dataStore = testDataStore,
+    )
+
+    @Test
+    fun whenPackagesIsEmptyThenEmptySetReturned() = runTest {
+        configurePackages(emptySet())
+        val result = testee.getInstallSourceFullPackages()
+        assertTrue(result.list.isEmpty())
+    }
+
+    @Test
+    fun whenPackageHasSingleEntryThenCorrectSetReturned() = runTest {
+        configurePackages(setOf("a.b.c"))
+        val result = testee.getInstallSourceFullPackages()
+        assertEquals(1, result.list.size)
+    }
+
+    @Test
+    fun whenPackageHasMultipleUniqueEntriesThenCorrectSetReturned() = runTest {
+        configurePackages(setOf("some value", "*", "not a wildcard"))
+        val result = testee.getInstallSourceFullPackages()
+        assertEquals(3, result.list.size)
+    }
+
+    @Test
+    fun whenPackageHasMultipleEntriesWithDuplicatesThenCorrectSetReturned() = runTest {
+        configurePackages(setOf("this is a duplicate", "this is a duplicate", "unique"))
+        val result = testee.getInstallSourceFullPackages()
+        assertEquals(2, result.list.size)
+    }
+
+    @Test
+    fun whenUpdateFirstCalledThenListIsPersisted() = runTest {
+        val someJson = "{}"
+        whenever(mockInstallSourceFullPackageListJsonParser.parseJson(someJson)).thenReturn(IncludedPackages(listOf("a.b.c")))
+        testee.updateInstallSourceFullPackages(someJson)
+        assertTrue(testee.getInstallSourceFullPackages().list.contains("a.b.c"))
+    }
+
+    @Test
+    fun whenUpdateCalledAgainWithEmptyListThenListIsPersisted() = runTest {
+        val someJson = "{}"
+        whenever(mockInstallSourceFullPackageListJsonParser.parseJson(someJson)).thenReturn(IncludedPackages(listOf("a.b.c")))
+        testee.updateInstallSourceFullPackages(someJson)
+
+        whenever(mockInstallSourceFullPackageListJsonParser.parseJson(someJson)).thenReturn(IncludedPackages(emptyList()))
+        testee.updateInstallSourceFullPackages(someJson)
+
+        assertTrue(testee.getInstallSourceFullPackages().list.isEmpty())
+    }
+
+    @Test
+    fun whenUpdateCalledAgainWithDifferentListThenListIsPersisted() = runTest {
+        val someJson = "{}"
+        whenever(mockInstallSourceFullPackageListJsonParser.parseJson(someJson)).thenReturn(IncludedPackages(listOf("a.b.c")))
+        testee.updateInstallSourceFullPackages(someJson)
+
+        whenever(mockInstallSourceFullPackageListJsonParser.parseJson(someJson)).thenReturn(IncludedPackages(listOf("d.e.f")))
+        testee.updateInstallSourceFullPackages(someJson)
+
+        assertEquals("d.e.f", testee.getInstallSourceFullPackages().list[0])
+    }
+
+    private suspend fun configurePackages(set: Set<String>) {
+        testDataStore.edit { it[InstallSourceFullPackageStoreImpl.packageInstallersKey] = set }
+    }
+}

--- a/installation/installation-impl/src/test/java/com/duckduckgo/installation/impl/installer/fullpackage/feature/InstallSourceFullPackageListJsonParserImplTest.kt
+++ b/installation/installation-impl/src/test/java/com/duckduckgo/installation/impl/installer/fullpackage/feature/InstallSourceFullPackageListJsonParserImplTest.kt
@@ -1,0 +1,52 @@
+package com.duckduckgo.installation.impl.installer.fullpackage.feature
+
+import com.duckduckgo.common.test.FileUtilities
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+import org.junit.Test
+
+class InstallSourceFullPackageListJsonParserImplTest {
+
+    private val testee = InstallSourceFullPackageListJsonParserImpl()
+
+    @Test
+    fun whenGibberishInputThenReturnsReturnsEmptyPackages() = runTest {
+        val result = testee.parseJson("invalid json")
+        assertTrue(result.list.isEmpty())
+    }
+
+    @Test
+    fun whenInstallerListIsMissingFieldThenReturnsEmptyPackages() = runTest {
+        val result = testee.parseJson("{}")
+        assertTrue(result.list.isEmpty())
+    }
+
+    @Test
+    fun whenInstallerListIsEmptyThenReturnsEmptyPackages() = runTest {
+        val result = testee.parseJson("installerFullSource_emptyList".loadJsonFile())
+        assertTrue(result.list.isEmpty())
+    }
+
+    @Test
+    fun whenInstallerListHasSingleEntryThenReturnsSinglePackage() = runTest {
+        val result = testee.parseJson("installerFullSource_singleEntryList".loadJsonFile())
+        assertEquals(1, result.list.size)
+        assertEquals("a.b.c", result.list[0])
+    }
+
+    @Test
+    fun whenInstallerListHasMultipleEntriesThenReturnsMultiplePackages() = runTest {
+        val result = testee.parseJson("installerFullSource_multipleEntryList".loadJsonFile())
+        assertEquals(3, result.list.size)
+        assertEquals("a.b.c", result.list[0])
+        assertEquals("d.e.f", result.list[1])
+        assertEquals("g.h.i", result.list[2])
+    }
+
+    private fun String.loadJsonFile(): String {
+        return FileUtilities.loadText(
+            InstallSourceFullPackageListJsonParserImplTest::class.java.classLoader!!,
+            "json/$this.json",
+        )
+    }
+}

--- a/installation/installation-impl/src/test/resources/json/installerFullSource_emptyList.json
+++ b/installation/installation-impl/src/test/resources/json/installerFullSource_emptyList.json
@@ -1,0 +1,3 @@
+{
+    "includedPackages": []
+}

--- a/installation/installation-impl/src/test/resources/json/installerFullSource_multipleEntryList.json
+++ b/installation/installation-impl/src/test/resources/json/installerFullSource_multipleEntryList.json
@@ -1,0 +1,7 @@
+{
+    "includedPackages": [
+        "a.b.c",
+        "d.e.f",
+        "g.h.i"
+    ]
+}

--- a/installation/installation-impl/src/test/resources/json/installerFullSource_singleEntryList.json
+++ b/installation/installation-impl/src/test/resources/json/installerFullSource_singleEntryList.json
@@ -1,0 +1,3 @@
+{
+    "includedPackages": ["a.b.c"]
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/608920331025315/1208315780180367/f 

### Description
Defines a feature flag for how to handle full installer package IDs. 

### Steps to test this PR

**QA-optional**
- no observable change of behaviour in this PR (branch above will cover full testing). 

If you do want to check:
- [x] Hardcode remote config download to use `https://jsonblob.com/api/1289196933024178176`
- [x] Fresh install. Launch app and wait for remote config to download.
- Check the contents of the data store (e.g., using `Device Explorer`), which will live in `com.duckduckgo.mobile.android.debug/files/datastore/com.duckduckgo.installation.impl.installer.preferences_pb`
  - [x] Note, the contents of the file won't render nicely but you should be able to see example packages `a.b.c` and `d.e.f` in there. e.g., 👇 

<img src="https://github.com/user-attachments/assets/46a60ae1-3f7c-406b-9f10-7c079b5312d8" width="50%" />
