### PR TITLE
Fix surface theming

### DIFF
--- a/common/common-ui/src/main/res/values/design-system-theming.xml
+++ b/common/common-ui/src/main/res/values/design-system-theming.xml
@@ -123,6 +123,9 @@
         <item name="daxColorBlack">@color/black84</item>
         <item name="preferredStatusBarColor">?attr/daxColorSurface</item>
         <item name="preferredNavigationBarColor">?attr/daxColorSurface</item>
+
+        <!--disables the overlay so that elevated surfaces are always daxColorSurface-->
+        <item name="elevationOverlayEnabled">false</item>
     </style>
 
     <!-- The app theme will mostly contain values for colour attributes -->


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1200204095367872/1208412577276091/f

### Description
- Currently, an unintended overlay is being applied to elevated surfaces.
- Setting elevationOverlayEnabled to false removes the overlay.
  - With this change, surfaces will always be `daxColorSurface`, regardless of elevation (Expected behavior).

### Steps to test this PR

_Try all combinations of OS theme / app theme (i.e. App set to light, OS set to dark)_
- [ ] Check onboarding dialogs
- [ ] Check bottom sheets
- [ ] Check design system
- [ ] Smoke test

### UI changes
| Before  | After |
| ------ | ----- |
![app_light_system_dark](https://github.com/user-attachments/assets/f123d21d-7850-47cd-ae1f-d84ae30a65d5)|![app_light_system_dark_fixed](https://github.com/user-attachments/assets/df97582b-55db-4ea6-b609-8c9397e8cb6c)

| Before  | After |
| ------ | ----- |
![app_dark_system_dark](https://github.com/user-attachments/assets/d572976f-0027-40dc-b7c2-14e51d0359ae)|![app_dark_system_dark_fixed](https://github.com/user-attachments/assets/a007895e-d21a-4c8b-a27b-20eb480040d1)

| Before  | After |
| ------ | ----- |
![Screenshot_20240927_232411](https://github.com/user-attachments/assets/97ccddb2-bbd2-4238-952e-9815941f1c00)|![Screenshot_20240927_232424](https://github.com/user-attachments/assets/d9e99f9f-9137-4613-b25f-817b05f5164e)

| Before  | After |
| ------ | ----- |
![Screenshot_20240928_000758](https://github.com/user-attachments/assets/00fc5760-a34a-450a-be62-16cce3fef5b0)|![Screenshot_20240928_001815](https://github.com/user-attachments/assets/af648e89-572a-48d9-baa2-82881831f933)

