### PR TITLE
Prevent system autofill offering to save passwords

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
@@ -23,11 +23,11 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import android.view.autofill.AutofillManager
 import android.widget.CompoundButton
 import androidx.appcompat.app.ActionBar
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
-import androidx.core.content.ContextCompat.startActivity
 import androidx.core.graphics.drawable.toBitmap
 import androidx.core.view.MenuProvider
 import androidx.lifecycle.Lifecycle
@@ -237,6 +237,7 @@ class AutofillManagementCredentialsMode : DuckDuckGoFragment(R.layout.fragment_a
 
     override fun onDestroyView() {
         super.onDestroyView()
+        disableSystemAutofillServiceOnPasswordField()
         resetToolbarOnExit()
         binding.removeSaveStateWatcher(saveStateWatcher)
     }
@@ -502,6 +503,9 @@ class AutofillManagementCredentialsMode : DuckDuckGoFragment(R.layout.fragment_a
 
     private fun disableSystemAutofillServiceOnPasswordField() {
         binding.passwordEditText.importantForAutofill = View.IMPORTANT_FOR_AUTOFILL_NO_EXCLUDE_DESCENDANTS
+        context?.let {
+            it.getSystemService(AutofillManager::class.java)?.cancel()
+        }
     }
 
     private fun String.convertBlankToNull(): String? = this.ifBlank { null }


### PR DESCRIPTION
On Android 14, importantForAutofill is not respected so need to do something else to stop the system autofill provider prompt offering to save a password that our user has just manually entered or edited

Task/Issue URL: https://app.asana.com/0/1203822806345703/1208458715174512/f 

### Description

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
