### PR TITLE
Ensure autofill nightly tests succeed

### DIFF
--- a/.maestro/autofill/2_autofill_add_search_update_delete_creds.yaml
+++ b/.maestro/autofill/2_autofill_add_search_update_delete_creds.yaml
@@ -28,6 +28,9 @@ tags:
           - assertNotVisible:
                   id: view_menu_save
 
+          - scrollUntilVisible:
+              element:
+                id: usernameEditText
           - tapOn:
                 id: usernameEditText
           - inputText: "user"
@@ -35,14 +38,23 @@ tags:
           - assertVisible:
                 id: view_menu_save
 
+          - scrollUntilVisible:
+              element:
+                id: passwordEditText
           - tapOn:
                 id: passwordEditText
           - inputText: "123"
 
+          - scrollUntilVisible:
+              element:
+                id: domainEditText
           - tapOn:
                 id: domainEditText
           - inputText: "${output.addLogins.domains[output.addLogins.counter]}"
 
+          - scrollUntilVisible:
+              element:
+                id: notesEditText
           - tapOn:
                 id: notesEditText
           - inputText: "a note"
@@ -51,6 +63,9 @@ tags:
                 id: view_menu_save
                 retryTapIfNoChange: false
 
+          - scrollUntilVisible:
+             element:
+                text: "Last updated.*"
           - assertVisible: "Last updated.*"
 
           - tapOn: "Navigate up"
@@ -59,15 +74,24 @@ tags:
                 text: "Save and autofill passwords"
           - evalScript: ${output.addLogins.counter++}
 
+- scrollUntilVisible:
+    element:
+      text: "#"
 - assertVisible:
     text: "#"
 
+- scrollUntilVisible:
+    element:
+      text: "a.example.com"
 - assertVisible:
     text: "a.example.com"
 
 - assertNotVisible:
     text: "https://a.example.com"
 
+- scrollUntilVisible:
+    element:
+      text: "fill.dev"
 - assertVisible:
     text: "fill.dev"
 

--- a/.maestro/autofill/3_autofill_prompted_to_save_creds_on_form.yaml
+++ b/.maestro/autofill/3_autofill_prompted_to_save_creds_on_form.yaml
@@ -1,9 +1,9 @@
 appId: com.duckduckgo.mobile.android
 name: "Autofill: Prompted to save and update credentials on web form"
 tags:
-    - autofillNoAuthTests
+    - autofillNoAuthTestsModernWebView
 ---
-# Pre-requisite: on an autofill-eligible device
+# Pre-requisite: on an autofill-eligible device, including having a modern WebView
 
 - launchApp:
       clearState: true

--- a/.maestro/autofill/steps/delete_logins.yaml
+++ b/.maestro/autofill/steps/delete_logins.yaml
@@ -3,26 +3,35 @@ name: "Autofill: Delete credentials"
 ---
 # Pre-requisite: the user is viewing the password manager screen with some saved passwords added by a previous test step, on an autofill-eligible device
 
+- scrollUntilVisible:
+      element:
+          text: "192.168.0.100"
 - tapOn:
-    id: "item_container"
-    index: 1
+    text: "192.168.0.100"
 - tapOn: "More options"
 - tapOn: "Delete"
 - tapOn: "Delete"
 
+- scrollUntilVisible:
+      element:
+          text: "a.example.com"
 - tapOn:
-      id: "item_container"
-      index: 1
+    text: "a.example.com"
 - tapOn: "More options"
 - tapOn: "Delete"
 - tapOn: "Delete"
 
+- scrollUntilVisible:
+      element:
+          text: "fill.dev"
 - tapOn:
-    id: "item_container"
-    index: 1
+    text: "fill.dev"
 - tapOn: "More options"
 - tapOn: "Delete"
 - tapOn: "Delete"
 
+- scrollUntilVisible:
+    element:
+      text: "No passwords saved yet"
 - assertVisible:
     text: "No passwords saved yet"

--- a/.maestro/autofill/steps/manual_update.yaml
+++ b/.maestro/autofill/steps/manual_update.yaml
@@ -3,13 +3,18 @@ name: "Autofill: Manually updating an existing credential"
 ---
 # Pre-requisite: the user is viewing the password manager screen with some saved passwords added by a previous test step, on an autofill-eligible device
 
+- scrollUntilVisible:
+      element:
+          text: "a.example.com"
 - tapOn:
-    id: "item_container"
-    index: "1"
+    text: "a.example.com"
 
 - tapOn: "More options"
 - tapOn: "Edit"
 
+- scrollUntilVisible:
+      element:
+          id: notesEditText
 - tapOn:
     id: notesEditText
 
@@ -21,5 +26,8 @@ name: "Autofill: Manually updating an existing credential"
     id: view_menu_save
     retryTapIfNoChange: false
 
+- scrollUntilVisible:
+      element:
+          text: "new note"
 - assertVisible: "new note"
 - tapOn: "Navigate up"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/608920331025315/1208459234138716/f 

### Description
Autofill nightlies are failing because as of https://github.com/duckduckgo/Android/pull/5007, we require a more modern `WebView` than is available in Maestro Cloud emulators.

This PR:
- fixes one of the ways the tests fail, by ensuring the warning banner in password management screen doesn't upset the tests
- stops running the test which tests _actual_ `WebView` autofill as part of the nightly (won't be possible to run this on CI until either Maestro Cloud ships their emulators with a decent `WebView` version, or we run the tests on different infrastructure)
- adds some `scrollUntilVisible` to help add resilience to the tests running on smaller devices or when there are extra warning/promo banners above the items we want to tap on

### Steps to test this PR
- [ ] Make sure nightly job succeeds: https://github.com/duckduckgo/Android/actions/runs/11147826346