### PR TITLE
Omit autofill toggled pixel in certain conditions

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/engagement/store/AutofillEngagementRepository.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/engagement/store/AutofillEngagementRepository.kt
@@ -18,11 +18,13 @@ package com.duckduckgo.autofill.impl.engagement.store
 
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
+import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENGAGEMENT_ACTIVE_USER
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENGAGEMENT_ENABLED_USER
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENGAGEMENT_STACKED_LOGINS
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_TOGGLED_OFF_SEARCH
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_TOGGLED_ON_SEARCH
+import com.duckduckgo.autofill.impl.securestorage.SecureStorage
 import com.duckduckgo.autofill.impl.store.InternalAutofillStore
 import com.duckduckgo.autofill.store.engagement.AutofillEngagementDao
 import com.duckduckgo.autofill.store.engagement.AutofillEngagementDatabase
@@ -64,6 +66,8 @@ class DefaultAutofillEngagementRepository @Inject constructor(
     private val autofillStore: InternalAutofillStore,
     private val engagementBucketing: AutofillEngagementBucketing,
     private val dispatchers: DispatcherProvider,
+    private val secureStorage: SecureStorage,
+    private val deviceAuthenticator: DeviceAuthenticator,
 ) : AutofillEngagementRepository {
 
     private val autofillEngagementDao: AutofillEngagementDao = engagementDb.autofillEngagementDao()
@@ -86,6 +90,11 @@ class DefaultAutofillEngagementRepository @Inject constructor(
     }
 
     private suspend fun processOnFirstSearchEvent() {
+        if (!canSendAutofillToggleStatus()) {
+            Timber.v("Unable to determine autofill toggle status")
+            return
+        }
+
         val numberStoredPasswords = getNumberStoredPasswords()
         val togglePixel = if (autofillStore.autofillEnabled) AUTOFILL_TOGGLED_ON_SEARCH else AUTOFILL_TOGGLED_OFF_SEARCH
         val bucket = engagementBucketing.bucketNumberOfSavedPasswords(numberStoredPasswords)
@@ -136,6 +145,14 @@ class DefaultAutofillEngagementRepository @Inject constructor(
 
     private fun todayString(): String {
         return DATE_FORMATTER.format(LocalDate.now())
+    }
+
+    private suspend fun canSendAutofillToggleStatus(): Boolean {
+        return withContext(dispatchers.io()) {
+            val secureStorageSupported = secureStorage.canAccessSecureStorage()
+            val deviceAuthEnabled = deviceAuthenticator.hasValidDeviceAuthentication()
+            secureStorageSupported && deviceAuthEnabled
+        }
     }
 
     companion object {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208140129736905/f 

### Description

### Steps to test this PR
Set logcat filter: `message~:"Unable to determine autofill toggle status" | message~:"Pixel sent: m_autofill_toggled"`

**Autofill working as normal**
Ensure autofill is supported (device auth set, modern WebView version)

- [ ] Fresh install
- [ ] Launch app and perform a search
- [ ] Should see in logs: `m_autofill_toggled`

**Autofill not available due to device auth being unset**
Remove system device auth

- [ ] Fresh install
- [ ] Launch app and perform a search
- [ ] Should see in logs: `Unable to determine autofill toggle status`
- [ ] Should **not** see** in logs: `m_autofill_toggled`