### PR TITLE
Fix the missing last item in autocomplete list

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/LegacyOmnibarView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/LegacyOmnibarView.kt
@@ -184,7 +184,7 @@ class LegacyOmnibarView @JvmOverloads constructor(
 
     override fun getBehavior(): CoordinatorLayout.Behavior<AppBarLayout> {
         return when (omnibarPosition) {
-            OmnibarPosition.TOP -> TopAppBarBehavior(context)
+            OmnibarPosition.TOP -> TopAppBarBehavior(context, this)
             OmnibarPosition.BOTTOM -> BottomAppBarBehavior(context, this)
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/TopAppBarBehavior.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/TopAppBarBehavior.kt
@@ -20,13 +20,18 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.View
 import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.view.updateLayoutParams
 import com.duckduckgo.app.browser.R
 import com.google.android.material.appbar.AppBarLayout
 
 /*
  * This custom behavior prevents the top omnibar from hiding everywhere except for the browser view (i.e. the autocomplete suggestions)
  */
-class TopAppBarBehavior(context: Context, attrs: AttributeSet? = null) : AppBarLayout.Behavior(context, attrs) {
+class TopAppBarBehavior(
+    context: Context,
+    private val toolbar: LegacyOmnibarView,
+    attrs: AttributeSet? = null,
+) : AppBarLayout.Behavior(context, attrs) {
     override fun onNestedPreScroll(
         coordinatorLayout: CoordinatorLayout,
         child: AppBarLayout,
@@ -38,6 +43,17 @@ class TopAppBarBehavior(context: Context, attrs: AttributeSet? = null) : AppBarL
     ) {
         if (target.id == R.id.browserWebView) {
             super.onNestedPreScroll(coordinatorLayout, child, target, dx, dy, consumed, type)
+        } else {
+            offsetBottomByToolbar(target)
+        }
+    }
+
+    private fun offsetBottomByToolbar(view: View?) {
+        if (view?.layoutParams is CoordinatorLayout.LayoutParams) {
+            view.updateLayoutParams<CoordinatorLayout.LayoutParams> {
+                this.bottomMargin = toolbar.measuredHeight
+            }
+            view.requestLayout()
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1208417966104900/f

### Description

This PR fixes the missing last item from the autocomplete list, which is hidden when the omnibar position feature is available and the omnibar position is set to TOP.

### Steps to test this PR

_Feature 1_
- [ ] Make sure you have omnibar position settings: Settings -> Appearance -> Address bar
- [ ] Set the position to TOP
- [ ] Go to the browser
- [ ] Start typing semething
- [ ] Notice the autocomplete list is scrollable 
- [ ] Verify all items are visible when scrolling (compare by hiding the keyboard)

