### PR TITLE
Use safeWebMessageHandler code for autofill integration

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoWebView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoWebView.kt
@@ -62,7 +62,7 @@ class DuckDuckGoWebView : WebView, NestedScrollingChild3 {
     private var nestedScrollHelper: NestedScrollingChildHelper = NestedScrollingChildHelper(this)
     private val helper = CoordinatorLayoutHelper()
 
-    private var isDestroyed: Boolean = false
+    var isDestroyed: Boolean = false
     var isSafeWebViewEnabled: Boolean = false
 
     constructor(context: Context) : this(context, null)

--- a/app/src/main/java/com/duckduckgo/app/browser/RealWebViewCapabilityChecker.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/RealWebViewCapabilityChecker.kt
@@ -24,12 +24,12 @@ import com.duckduckgo.app.browser.api.WebViewCapabilityChecker.WebViewCapability
 import com.duckduckgo.browser.api.WebViewVersionProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.extensions.compareSemanticVersion
-import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 import kotlinx.coroutines.withContext
 
-@ContributesBinding(FragmentScope::class)
+@ContributesBinding(AppScope::class)
 class RealWebViewCapabilityChecker @Inject constructor(
     private val dispatchers: DispatcherProvider,
     private val webViewVersionProvider: WebViewVersionProvider,

--- a/app/src/main/java/com/duckduckgo/app/browser/SafeWebMessageHandlerImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/SafeWebMessageHandlerImpl.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser
+
+import android.annotation.SuppressLint
+import android.webkit.WebView
+import androidx.webkit.WebViewCompat
+import androidx.webkit.WebViewCompat.WebMessageListener
+import com.duckduckgo.app.browser.api.SafeWebMessageHandler
+import com.duckduckgo.app.browser.api.WebViewCapabilityChecker
+import com.duckduckgo.app.browser.api.WebViewCapabilityChecker.WebViewCapability
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+import timber.log.Timber
+
+@SuppressLint("RequiresFeature", "AddWebMessageListenerUsage", "RemoveWebMessageListenerUsage")
+@ContributesBinding(AppScope::class)
+class SafeWebMessageHandlerImpl @Inject constructor(
+    private val webViewCapabilityChecker: WebViewCapabilityChecker,
+) : SafeWebMessageHandler {
+
+    override suspend fun addWebMessageListener(
+        webView: WebView,
+        jsObjectName: String,
+        allowedOriginRules: Set<String>,
+        listener: WebMessageListener,
+    ): Boolean = runCatching {
+        if (webViewCapabilityChecker.isSupported(WebViewCapability.WebMessageListener) && !isDestroyed(webView)) {
+            WebViewCompat.addWebMessageListener(webView, jsObjectName, allowedOriginRules, listener)
+            true
+        } else {
+            false
+        }
+    }.getOrElse { exception ->
+        Timber.e(exception, "Error adding WebMessageListener: $jsObjectName")
+        false
+    }
+
+    override suspend fun removeWebMessageListener(
+        webView: WebView,
+        jsObjectName: String,
+    ): Boolean = runCatching {
+        if (webViewCapabilityChecker.isSupported(WebViewCapability.WebMessageListener) && !isDestroyed(webView)) {
+            WebViewCompat.removeWebMessageListener(webView, jsObjectName)
+            true
+        } else {
+            false
+        }
+    }.getOrElse { exception ->
+        Timber.e(exception, "Error removing WebMessageListener: $jsObjectName")
+        false
+    }
+
+    /**
+     * Can only check destroyed flag for DuckDuckGoWebView for now. If a normal WebView, assume not destroyed.
+     */
+    private fun isDestroyed(webView: WebView): Boolean {
+        return if (webView is DuckDuckGoWebView) {
+            webView.isDestroyed
+        } else {
+            false
+        }
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/InlineBrowserAutofill.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/InlineBrowserAutofill.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.autofill.impl
 
 import android.annotation.SuppressLint
 import android.webkit.WebView
-import androidx.webkit.WebViewCompat
+import com.duckduckgo.app.browser.api.SafeWebMessageHandler
 import com.duckduckgo.autofill.api.AutofillFeature
 import com.duckduckgo.autofill.api.BrowserAutofill
 import com.duckduckgo.autofill.api.Callback
@@ -90,7 +90,7 @@ class InlineBrowserAutofill @Inject constructor(
         }
     }
 
-    private fun WebView.addWebMessageListener(
+    private suspend fun WebView.addWebMessageListener(
         messageListener: AutofillWebMessageListener,
         autofillCallback: Callback,
         tabId: String,
@@ -106,7 +106,7 @@ class InlineBrowserAutofill @Inject constructor(
 }
 
 interface AutofillWebMessageAttacher {
-    fun addListener(
+    suspend fun addListener(
         webView: WebView,
         listener: AutofillWebMessageListener,
     )
@@ -114,14 +114,16 @@ interface AutofillWebMessageAttacher {
 
 @SuppressLint("RequiresFeature")
 @ContributesBinding(FragmentScope::class)
-class AutofillWebMessageAttacherImpl @Inject constructor() : AutofillWebMessageAttacher {
+class AutofillWebMessageAttacherImpl @Inject constructor(
+    private val safeWebMessageHandler: SafeWebMessageHandler,
+) : AutofillWebMessageAttacher {
 
     @SuppressLint("AddWebMessageListenerUsage")
     // suppress AddWebMessageListenerUsage, we don't have access to DuckDuckGoWebView here.
-    override fun addListener(
+    override suspend fun addListener(
         webView: WebView,
         listener: AutofillWebMessageListener,
     ) {
-        WebViewCompat.addWebMessageListener(webView, listener.key, listener.origins, listener)
+        safeWebMessageHandler.addWebMessageListener(webView, listener.key, listener.origins, listener)
     }
 }

--- a/browser-api/build.gradle
+++ b/browser-api/build.gradle
@@ -35,6 +35,8 @@ dependencies {
 
     // LiveData
     implementation AndroidX.lifecycle.liveDataKtx
+
+    implementation AndroidX.webkit
 }
 android {
   namespace 'com.duckduckgo.browser.api'

--- a/browser-api/src/main/java/com/duckduckgo/app/browser/api/SafeWebMessageHandler.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/browser/api/SafeWebMessageHandler.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.api
+
+import android.webkit.WebView
+import androidx.webkit.WebViewCompat.WebMessageListener
+
+/**
+ * Add and remove web message listeners to a WebView, guarded by extra checks to ensure WebView compatibility
+ */
+interface SafeWebMessageHandler {
+
+    suspend fun addWebMessageListener(
+        webView: WebView,
+        jsObjectName: String,
+        allowedOriginRules: Set<String>,
+        listener: WebMessageListener,
+    ): Boolean
+
+    suspend fun removeWebMessageListener(
+        webView: WebView,
+        jsObjectName: String,
+    ): Boolean
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/608920331025315/1208501035862472/f 

### Description
Pulls the logic for safely adding/removing a web message listener outside of `app` module so that it can be used elsewhere, and lets autofill use it for its WebView integration.

### Steps to test this PR
Nothing else using that extracted logic yet, so nothing else will have changed.

- [x] Smoke test autofill
