### PR TITLE
Open Duck Player videos in new tab

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -5000,9 +5000,10 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenProcessJsCallbackMessageOpenDuckPlayerWithUrlThenNavigate() = runTest {
+    fun whenProcessJsCallbackMessageOpenDuckPlayerWithUrlAndOpenInNewTabFalseThenNavigate() = runTest {
         whenever(mockEnabledToggle.isEnabled()).thenReturn(true)
         whenever(mockDuckPlayer.getUserPreferences()).thenReturn(UserPreferences(overlayInteracted = true, privatePlayerMode = AlwaysAsk))
+        whenever(mockDuckPlayer.shouldOpenDuckPlayerInNewTab()).thenReturn(false)
         testee.processJsCallbackMessage(
             DUCK_PLAYER_FEATURE_NAME,
             "openDuckPlayer",
@@ -5011,6 +5012,21 @@ class BrowserTabViewModelTest {
             { "someUrl" },
         )
         assertCommandIssued<Navigate>()
+    }
+
+    @Test
+    fun whenProcessJsCallbackMessageOpenDuckPlayerWithUrlAndOpenInNewTabTrueThenOpenInNewTab() = runTest {
+        whenever(mockEnabledToggle.isEnabled()).thenReturn(true)
+        whenever(mockDuckPlayer.getUserPreferences()).thenReturn(UserPreferences(overlayInteracted = true, privatePlayerMode = AlwaysAsk))
+        whenever(mockDuckPlayer.shouldOpenDuckPlayerInNewTab()).thenReturn(true)
+        testee.processJsCallbackMessage(
+            DUCK_PLAYER_FEATURE_NAME,
+            "openDuckPlayer",
+            "id",
+            JSONObject("""{ href: "duck://player/1234" }"""),
+            { "someUrl" },
+        )
+        assertCommandIssued<Command.OpenInNewTab>()
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -80,6 +80,7 @@ import java.security.interfaces.RSAPublicKey
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
@@ -137,11 +138,13 @@ class BrowserWebViewClientTest {
     private val mockDuckPlayer: DuckPlayer = mock()
     private val navigationHistory: NavigationHistory = mock()
     private val loadingBarExperimentManager: LoadingBarExperimentManager = mock()
+    private val openInNewTabFlow: MutableSharedFlow<Boolean> = MutableSharedFlow()
 
     @UiThreadTest
     @Before
     fun setup() {
         webView = TestWebView(context)
+        whenever(mockDuckPlayer.observeShouldOpenInNewTab()).thenReturn(openInNewTabFlow)
         testee = BrowserWebViewClient(
             webViewHttpAuthStore,
             trustedCertificateStore,
@@ -428,6 +431,33 @@ class BrowserWebViewClientTest {
         whenever(webResourceRequest.isForMainFrame).thenReturn(true)
         assertTrue(testee.shouldOverrideUrlLoading(webView, webResourceRequest))
         verify(listener).handleNonHttpAppLink(urlType)
+    }
+
+    @UiThreadTest
+    @Test
+    fun whenShouldLaunchDuckPlayerThenOpenInNewTabAndReturnTrue() = runTest {
+        openInNewTabFlow.emit(true)
+        val urlType = SpecialUrlDetector.UrlType.ShouldLaunchDuckPlayerLink(EXAMPLE_URL.toUri())
+        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
+        whenever(webResourceRequest.url).thenReturn(EXAMPLE_URL.toUri())
+        whenever(mockDuckPlayer.shouldOpenDuckPlayerInNewTab()).thenReturn(true)
+
+        assertTrue(testee.shouldOverrideUrlLoading(webView, webResourceRequest))
+        verify(listener).onShouldOverride()
+        verify(listener).openLinkInNewTab(EXAMPLE_URL.toUri())
+    }
+
+    @UiThreadTest
+    @Test
+    fun whenShouldLaunchDuckPlayerButNotOpenInNewTabThenReturnFalse() = runTest {
+        openInNewTabFlow.emit(false)
+        val urlType = SpecialUrlDetector.UrlType.ShouldLaunchDuckPlayerLink(EXAMPLE_URL.toUri())
+        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
+        whenever(webResourceRequest.url).thenReturn(EXAMPLE_URL.toUri())
+
+        assertFalse(testee.shouldOverrideUrlLoading(webView, webResourceRequest))
+        verify(listener).onShouldOverride()
+        verify(listener, never()).openLinkInNewTab(EXAMPLE_URL.toUri())
     }
 
     @UiThreadTest

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2904,6 +2904,10 @@ class BrowserTabViewModel @Inject constructor(
         command.value = OpenMessageInNewTab(message, tabId)
     }
 
+    override fun openLinkInNewTab(uri: Uri) {
+        command.value = OpenInNewTab(uri.toString(), tabId)
+    }
+
     override fun recoverFromRenderProcessGone() {
         webNavigationState?.let {
             navigationStateChanged(EmptyNavigationState(it))
@@ -3376,7 +3380,7 @@ class BrowserTabViewModel @Inject constructor(
             DUCK_PLAYER_FEATURE_NAME, DUCK_PLAYER_PAGE_FEATURE_NAME -> {
                 viewModelScope.launch(dispatchers.io()) {
                     val webViewUrl = withContext(dispatchers.main()) { getWebViewUrl() }
-                    val response = duckPlayerJSHelper.processJsCallbackMessage(featureName, method, id, data, webViewUrl)
+                    val response = duckPlayerJSHelper.processJsCallbackMessage(featureName, method, id, data, webViewUrl, tabId)
                     withContext(dispatchers.main()) {
                         response?.let {
                             command.value = it

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
@@ -76,6 +76,7 @@ interface WebViewClientListener {
     fun handleCloakedAmpLink(initialUrl: String)
     fun startProcessingTrackingLink()
     fun openMessageInNewTab(message: Message)
+    fun openLinkInNewTab(uri: Uri)
     fun recoverFromRenderProcessGone()
     fun requiresAuthentication(request: BasicAuthenticationRequest)
     fun closeCurrentTab()

--- a/app/src/main/java/com/duckduckgo/app/browser/duckplayer/DuckPlayerJSHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/duckplayer/DuckPlayerJSHelper.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.app.browser.commands.Command
 import com.duckduckgo.app.browser.commands.Command.OpenDuckPlayerOverlayInfo
 import com.duckduckgo.app.browser.commands.Command.OpenDuckPlayerPageInfo
 import com.duckduckgo.app.browser.commands.Command.OpenDuckPlayerSettings
+import com.duckduckgo.app.browser.commands.Command.OpenInNewTab
 import com.duckduckgo.app.browser.commands.Command.SendResponseToDuckPlayer
 import com.duckduckgo.app.browser.commands.Command.SendResponseToJs
 import com.duckduckgo.app.browser.commands.Command.SendSubscriptions
@@ -158,6 +159,7 @@ class DuckPlayerJSHelper @Inject constructor(
         id: String?,
         data: JSONObject?,
         url: String?,
+        tabId: String,
     ): Command? {
         when (method) {
             "getUserValues" -> if (id != null) {
@@ -202,7 +204,11 @@ class DuckPlayerJSHelper @Inject constructor(
             }
             "openDuckPlayer" -> {
                 return data?.getString("href")?.let {
-                    Navigate(it.toUri().buildUpon().appendQueryParameter("origin", "overlay").build().toString(), mapOf())
+                    if (duckPlayer.shouldOpenDuckPlayerInNewTab()) {
+                        OpenInNewTab(it.toUri().buildUpon().appendQueryParameter("origin", "overlay").build().toString(), tabId)
+                    } else {
+                        Navigate(it.toUri().buildUpon().appendQueryParameter("origin", "overlay").build().toString(), mapOf())
+                    }
                 }
             }
             "initialSetup" -> {

--- a/app/src/test/java/com/duckduckgo/duckplayer/impl/DuckPlayerSettingsViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/duckplayer/impl/DuckPlayerSettingsViewModelTest.kt
@@ -3,7 +3,6 @@ package com.duckduckgo.duckplayer.impl
 import app.cash.turbine.test
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.test.CoroutineTestRule
-import com.duckduckgo.duckplayer.api.DuckPlayer
 import com.duckduckgo.duckplayer.api.DuckPlayer.UserPreferences
 import com.duckduckgo.duckplayer.api.PrivatePlayerMode.AlwaysAsk
 import com.duckduckgo.duckplayer.api.PrivatePlayerMode.Disabled
@@ -13,9 +12,11 @@ import com.duckduckgo.duckplayer.impl.DuckPlayerPixelName.DUCK_PLAYER_SETTINGS_B
 import com.duckduckgo.duckplayer.impl.DuckPlayerPixelName.DUCK_PLAYER_SETTINGS_NEVER_SETTINGS
 import com.duckduckgo.duckplayer.impl.DuckPlayerSettingsViewModel.Command.OpenPlayerModeSelector
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -30,15 +31,19 @@ class DuckPlayerSettingsViewModelTest {
     @Suppress("unused")
     val coroutineRule = CoroutineTestRule()
 
-    private val duckPlayer: DuckPlayer = mock()
+    private val duckPlayer: DuckPlayerInternal = mock()
     private val duckPlayerFeatureRepository: DuckPlayerFeatureRepository = mock()
     private val pixel: Pixel = mock()
     private lateinit var viewModel: DuckPlayerSettingsViewModel
+    private val userPreferencesFlow: MutableSharedFlow<UserPreferences> = MutableSharedFlow()
 
     @Before
     fun setUp() {
         runTest {
+            whenever(duckPlayer.observeUserPreferences()).thenReturn(userPreferencesFlow)
+            userPreferencesFlow.emit(UserPreferences(overlayInteracted = true, privatePlayerMode = AlwaysAsk))
             whenever(duckPlayer.getUserPreferences()).thenReturn(UserPreferences(overlayInteracted = true, privatePlayerMode = AlwaysAsk))
+            whenever(duckPlayer.shouldOpenDuckPlayerInNewTab()).thenReturn(false)
             viewModel = DuckPlayerSettingsViewModel(duckPlayer, duckPlayerFeatureRepository, pixel)
         }
     }
@@ -79,10 +84,34 @@ class DuckPlayerSettingsViewModelTest {
     @Test
     fun whenViewModelIsCreatedAndPrivatePlayerModeIsDisabledThenEmitDisabled() = runTest {
         whenever(duckPlayer.observeUserPreferences()).thenReturn(flowOf(UserPreferences(overlayInteracted = true, privatePlayerMode = Disabled)))
+        whenever(duckPlayer.observeShouldOpenInNewTab()).thenReturn(flowOf(true))
+        userPreferencesFlow.emit(UserPreferences(overlayInteracted = true, privatePlayerMode = Disabled))
         viewModel = DuckPlayerSettingsViewModel(duckPlayer, duckPlayerFeatureRepository, pixel)
 
         viewModel.viewState.test {
             assertEquals(Disabled, awaitItem().privatePlayerMode)
         }
+    }
+
+    @Test
+    fun whenViewModelIsCreatedAndPrivatePlayerModeIsAlwaysAndOpenInNewTabThenEmitAlwaysAndOpenInNewTab() = runTest {
+        whenever(duckPlayer.observeUserPreferences()).thenReturn(flowOf(UserPreferences(overlayInteracted = true, privatePlayerMode = Enabled)))
+        whenever(duckPlayer.observeShouldOpenInNewTab()).thenReturn(flowOf(true))
+        userPreferencesFlow.emit(UserPreferences(overlayInteracted = true, privatePlayerMode = Enabled))
+        viewModel = DuckPlayerSettingsViewModel(duckPlayer, duckPlayerFeatureRepository, pixel)
+
+        viewModel.viewState.test {
+            awaitItem().let {
+                assertEquals(Enabled, it.privatePlayerMode)
+                assertTrue(it.openDuckPlayerInNewTab)
+            }
+        }
+    }
+
+    @Test
+    fun whenOpenInNewTabIsSetToTrueThenUpdatePreferences() = runTest {
+        viewModel.onOpenDuckPlayerInNewTabToggled(true)
+
+        verify(duckPlayer).setOpenInNewTab(true)
     }
 }

--- a/duckplayer/duckplayer-api/src/main/java/com/duckduckgo/duckplayer/api/DuckPlayer.kt
+++ b/duckplayer/duckplayer-api/src/main/java/com/duckduckgo/duckplayer/api/DuckPlayer.kt
@@ -175,7 +175,13 @@ interface DuckPlayer {
      * @param destinationUrl The destination URL.
      * @return True if the URL should launch Duck Player, false otherwise.
      */
-    suspend fun willNavigateToDuckPlayer(destinationUrl: Uri): Boolean
+    suspend fun willNavigateToDuckPlayer(
+        destinationUrl: Uri,
+    ): Boolean
+
+    suspend fun shouldOpenDuckPlayerInNewTab(): Boolean
+
+    fun observeShouldOpenInNewTab(): Flow<Boolean>
 
     /**
      * Data class representing user preferences for Duck Player.

--- a/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerDataStore.kt
+++ b/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerDataStore.kt
@@ -24,6 +24,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckplayer.impl.SharedPreferencesDuckPlayerDataStore.Keys.DUCK_PLAYER_DISABLED_HELP_PAGE
+import com.duckduckgo.duckplayer.impl.SharedPreferencesDuckPlayerDataStore.Keys.DUCK_PLAYER_OPEN_IN_NEW_TAB
 import com.duckduckgo.duckplayer.impl.SharedPreferencesDuckPlayerDataStore.Keys.DUCK_PLAYER_RC
 import com.duckduckgo.duckplayer.impl.SharedPreferencesDuckPlayerDataStore.Keys.DUCK_PLAYER_USER_ONBOARDED
 import com.duckduckgo.duckplayer.impl.SharedPreferencesDuckPlayerDataStore.Keys.DUCK_PLAYER_YOUTUBE_PATH
@@ -85,6 +86,12 @@ interface DuckPlayerDataStore {
     suspend fun setUserOnboarded()
 
     suspend fun getUserOnboarded(): Boolean
+
+    suspend fun setOpenInNewTab(enabled: Boolean)
+
+    fun observeOpenInNewTab(): Flow<Boolean>
+
+    suspend fun getOpenInNewTab(): Boolean
 }
 
 @ContributesBinding(AppScope::class)
@@ -104,6 +111,7 @@ class SharedPreferencesDuckPlayerDataStore @Inject constructor(
         val DUCK_PLAYER_YOUTUBE_VIDEO_ID_QUERY_PARAMS = stringPreferencesKey(name = "DUCK_PLAYER_YOUTUBE_VIDEO_ID_QUERY_PARAMS")
         val DUCK_PLAYER_YOUTUBE_EMBED_URL = stringPreferencesKey(name = "DUCK_PLAYER_YOUTUBE_EMBED_URL")
         val DUCK_PLAYER_USER_ONBOARDED = booleanPreferencesKey(name = "DUCK_PLAYER_USER_ONBOARDED")
+        val DUCK_PLAYER_OPEN_IN_NEW_TAB = booleanPreferencesKey(name = "DUCK_PLAYER_OPEN_IN_NEW_TAB")
     }
 
     private val overlayInteracted: Flow<Boolean>
@@ -180,6 +188,13 @@ class SharedPreferencesDuckPlayerDataStore @Inject constructor(
         get() = store.data
             .map { prefs ->
                 prefs[Keys.DUCK_PLAYER_USER_ONBOARDED] ?: false
+            }
+            .distinctUntilChanged()
+
+    private val duckPlayerOpenInNewTab: Flow<Boolean>
+        get() = store.data
+            .map { prefs ->
+                prefs[Keys.DUCK_PLAYER_OPEN_IN_NEW_TAB] ?: false
             }
             .distinctUntilChanged()
 
@@ -277,5 +292,17 @@ class SharedPreferencesDuckPlayerDataStore @Inject constructor(
 
     override suspend fun getUserOnboarded(): Boolean {
         return duckPlayerUserOnboarded.first()
+    }
+
+    override suspend fun setOpenInNewTab(enabled: Boolean) {
+        store.edit { prefs -> prefs[DUCK_PLAYER_OPEN_IN_NEW_TAB] = enabled }
+    }
+
+    override fun observeOpenInNewTab(): Flow<Boolean> {
+        return duckPlayerOpenInNewTab
+    }
+
+    override suspend fun getOpenInNewTab(): Boolean {
+        return duckPlayerOpenInNewTab.first()
     }
 }

--- a/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerFeatureRepository.kt
+++ b/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerFeatureRepository.kt
@@ -68,6 +68,9 @@ interface DuckPlayerFeatureRepository {
     suspend fun getYouTubeEmbedUrl(): String
     suspend fun isOnboarded(): Boolean
     suspend fun setUserOnboarded()
+    fun setOpenInNewTab(enabled: Boolean)
+    fun observeOpenInNewTab(): Flow<Boolean>
+    suspend fun shouldOpenInNewTab(): Boolean
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -201,5 +204,19 @@ class RealDuckPlayerFeatureRepository @Inject constructor(
 
     override suspend fun setUserOnboarded() {
         duckPlayerDataStore.setUserOnboarded()
+    }
+
+    override fun setOpenInNewTab(enabled: Boolean) {
+        appCoroutineScope.launch {
+            duckPlayerDataStore.setOpenInNewTab(enabled)
+        }
+    }
+
+    override fun observeOpenInNewTab(): Flow<Boolean> {
+        return duckPlayerDataStore.observeOpenInNewTab()
+    }
+
+    override suspend fun shouldOpenInNewTab(): Boolean {
+        return duckPlayerDataStore.getOpenInNewTab()
     }
 }

--- a/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerSettingsActivity.kt
+++ b/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerSettingsActivity.kt
@@ -75,6 +75,9 @@ class DuckPlayerSettingsActivity : DuckDuckGoActivity() {
         binding.duckPlayerDisabledLearnMoreButton.setOnClickListener {
             viewModel.onContingencyLearnMoreClicked()
         }
+        binding.openDuckPlayerInNewTabToggle.setOnCheckedChangeListener { _, isChecked ->
+            viewModel.onOpenDuckPlayerInNewTabToggled(isChecked)
+        }
     }
 
     private fun observeViewModel() {
@@ -151,6 +154,8 @@ class DuckPlayerSettingsActivity : DuckDuckGoActivity() {
             is ViewState.Enabled -> {
                 binding.duckPlayerModeSelector.isEnabled = true
                 binding.duckPlayerDisabledSection.isVisible = false
+                binding.openDuckPlayerInNewTabToggle.isEnabled = viewState.privatePlayerMode != Disabled
+                binding.openDuckPlayerInNewTabToggle.setIsChecked(viewState.openDuckPlayerInNewTab)
                 setDuckPlayerSectionVisibility(true)
             }
             is ViewState.DisabledWithHelpLink -> {

--- a/duckplayer/duckplayer-impl/src/main/res/layout/activity_duck_player_settings.xml
+++ b/duckplayer/duckplayer-impl/src/main/res/layout/activity_duck_player_settings.xml
@@ -125,6 +125,13 @@
                 app:primaryText="Open YouTube Videos in Duck Player"
                 />
 
+            <com.duckduckgo.common.ui.view.listitem.OneLineListItem
+                android:id="@+id/openDuckPlayerInNewTabToggle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="Open Duck Player in a new tab whenever possible"
+                app:showSwitch="true"/>
+
         </LinearLayout>
 
 

--- a/duckplayer/duckplayer-impl/src/main/res/values/donottranslate.xml
+++ b/duckplayer/duckplayer-impl/src/main/res/values/donottranslate.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2024 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources>
+    <string name="open_duck_player_in_a_new_tab_setting">Open Duck Player in a new tab whenever possible</string>
+</resources>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1208500747095747/f 

### Description

### Steps to test this PR

_Always Ask + Open in new tab + YT video -> New tab_
- [x] Set Duck Player settings to Always Ask (default) and open in new tab to true
- [x] Open a YT video
- [x] Click watch in Duck Player
- [x] Video is opened in a new tab

_Always Ask + Not open in new tab + YT video -> No new tab_
- [x] Set Duck Player settings to Always Ask (default) and open in new tab to false (default)
- [x] Open a YT video
- [x] Click watch in Duck Player
- [x] Video is not opened in a new tab

_Always + Open in new tab + From omnibar -> No new tab_
- [x] Set Duck Player settings to Always and open in new tab to true
- [x] Open a YT video directly from the omnibar
- [x] Video is opened automatically in Duck Player but not in a new tab

_Always + Open in new tab + Not from omnibar -> New tab_
- [x] Set Duck Player settings to Always and open in new tab to true
- [x] Open a YT video from a link on another site (not SERP)
- [x] Video is opened automatically in Duck Player and in a new tab

_Always ask + Open in new tab + From SERP -> New tab_
- [x] Set Duck Player settings to Always Ask (default) and open in new tab to true
- [x] Open a YT video from SERP
- [x] Click watch in Duck Player
- [x] Video is opened in a new tab

_Always ask + Not open in new tab + From SERP -> No new tab_
- [x] Set Duck Player settings to Always Ask (default) and open in new tab to false
- [x] Open a YT video from SERP
- [x] Click watch in Duck Player
- [x] Video is not opened in a new tab

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
