### PR TITLE
Omnibar: safe calling Android methods

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/LegacyOmnibarView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/LegacyOmnibarView.kt
@@ -138,6 +138,8 @@ class LegacyOmnibarView @JvmOverloads constructor(
     internal val trackersAnimation: LottieAnimationView by lazy { findViewById(R.id.trackersAnimation) }
     internal val duckPlayerIcon: ImageView by lazy { findViewById(R.id.duckPlayerIcon) }
 
+    private var privacyShield: PrivacyShield? = null
+
     init {
         val attr = context.theme.obtainStyledAttributes(attrs, R.styleable.LegacyOmnibarView, defStyle, 0)
         omnibarPosition = OmnibarPosition.entries[attr.getInt(R.styleable.LegacyOmnibarView_omnibarPosition, 0)]
@@ -163,6 +165,12 @@ class LegacyOmnibarView @JvmOverloads constructor(
         super.onAttachedToWindow()
 
         pulseAnimation = PulseAnimation(findViewTreeLifecycleOwner()!!)
+
+        val deferredPrivacyShield = privacyShield
+        if (deferredPrivacyShield != null) {
+            setPrivacyShield(false, privacyShield = deferredPrivacyShield)
+            privacyShield = null
+        }
     }
 
     override fun setExpanded(expanded: Boolean) {
@@ -197,6 +205,10 @@ class LegacyOmnibarView @JvmOverloads constructor(
         isCustomTab: Boolean,
         privacyShield: PrivacyShield,
     ) {
+        if (!isAttachedToWindow) {
+            this.privacyShield = privacyShield
+        }
+
         safeCall {
             val animationViewHolder = if (isCustomTab) {
                 customTabToolbarContainer.customTabShieldIcon

--- a/app/src/main/res/layout/view_legacy_omnibar.xml
+++ b/app/src/main/res/layout/view_legacy_omnibar.xml
@@ -116,6 +116,7 @@
                         android:gravity="center"
                         android:importantForAccessibility="no"
                         android:padding="6dp"
+                        android:visibility="gone"
                         android:src="@drawable/ic_find_search_20_a05" />
 
                     <FrameLayout

--- a/app/src/main/res/layout/view_legacy_omnibar_bottom.xml
+++ b/app/src/main/res/layout/view_legacy_omnibar_bottom.xml
@@ -116,6 +116,7 @@
                         android:gravity="center"
                         android:importantForAccessibility="no"
                         android:padding="6dp"
+                        android:visibility="gone"
                         android:src="@drawable/ic_find_search_20_a05" />
 
                     <FrameLayout


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1174433894299346/1208502796109620/f

### Description
This PR adds a safe way to call methods in the `LegacyOmnibarView`. This is needed because the way we interact with the Omnibar doesn’t take into account that Dagger might not have injected yet.

### Steps to test this PR
Smoke tests and QA