### PR TITLE
Consider targets for normal and experiment features

### DIFF
--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/ExperimentFiltersManager.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/ExperimentFiltersManager.kt
@@ -30,7 +30,11 @@ import javax.inject.Inject
 import kotlinx.coroutines.runBlocking
 
 interface ExperimentFiltersManager {
-    fun addFilters(entity: VariantConfig): (AppBuildConfig) -> Boolean
+    /**
+     * This method computes the result of the filters
+     * @return returns `true` if the filters match the client state, else `false`
+     */
+    fun computeFilters(entity: VariantConfig): (AppBuildConfig) -> Boolean
 }
 
 @ContributesBinding(AppScope::class)
@@ -39,7 +43,7 @@ class ExperimentFiltersManagerImpl @Inject constructor(
     private val subscriptions: Subscriptions,
     private val dispatcherProvider: DispatcherProvider,
 ) : ExperimentFiltersManager {
-    override fun addFilters(entity: VariantConfig): (AppBuildConfig) -> Boolean {
+    override fun computeFilters(entity: VariantConfig): (AppBuildConfig) -> Boolean {
         if (entity.variantKey == "sc" || entity.variantKey == "se") {
             return { isSerpRegionToggleCountry() }
         }
@@ -51,7 +55,7 @@ class ExperimentFiltersManagerImpl @Inject constructor(
         )
 
         if (!entity.filters?.locale.isNullOrEmpty()) {
-            val userLocale = Locale.getDefault()
+            val userLocale = appBuildConfig.deviceLocale
             filters[LOCALE] = entity.filters!!.locale.contains(userLocale.toString())
         }
         if (!entity.filters?.androidVersion.isNullOrEmpty()) {

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/VariantManagerImpl.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/VariantManagerImpl.kt
@@ -47,9 +47,9 @@ class VariantManagerImpl @Inject constructor(
         experimentVariantRepository.updateAppReferrerVariant(variant)
     }
 
-    override fun updateVariants(variantConfig: List<VariantConfig>) {
-        val activeVariants = variantConfig.toVariants()
-        Timber.d("Variants update $variantConfig")
+    override fun updateVariants(variants: List<VariantConfig>) {
+        val activeVariants = variants.toVariants()
+        Timber.d("Variants update $variants")
         val currentVariantKey = experimentVariantRepository.getUserVariant()
 
         updateUserVariant(activeVariants, currentVariantKey)
@@ -84,14 +84,14 @@ class VariantManagerImpl @Inject constructor(
         Timber.i("Variant $currentVariantKey is still in use, no need to update")
     }
 
-    fun List<VariantConfig>.toVariants(): List<Variant> {
+    private fun List<VariantConfig>.toVariants(): List<Variant> {
         val activeVariants: MutableList<Variant> = mutableListOf()
         this.map { entity ->
             activeVariants.add(
                 Variant(
                     key = entity.variantKey,
                     weight = entity.weight ?: 0.0,
-                    filterBy = experimentFiltersManager.addFilters(entity),
+                    filterBy = experimentFiltersManager.computeFilters(entity),
                 ),
             )
         }

--- a/experiments/experiments-impl/src/test/java/com/duckduckgo/experiments/impl/ExperimentFiltersManagerImplTest.kt
+++ b/experiments/experiments-impl/src/test/java/com/duckduckgo/experiments/impl/ExperimentFiltersManagerImplTest.kt
@@ -51,59 +51,59 @@ class ExperimentFiltersManagerImplTest {
     }
 
     @Test
-    fun whenVariantComplyWithLocaleFilterThenAddFiltersReturnsTrue() {
+    fun whenVariantComplyWithLocaleFilterThenComputeFiltersReturnsTrue() {
         val locale = Locale("en", "US")
-        Locale.setDefault(locale)
+        whenever(mockAppBuildConfig.deviceLocale).thenReturn(locale)
         val testEntity = addActiveVariant(localeFilter = listOf("en_US"))
 
-        assertTrue(testee.addFilters(testEntity).invoke(mockAppBuildConfig))
+        assertTrue(testee.computeFilters(testEntity).invoke(mockAppBuildConfig))
     }
 
     @Test
-    fun whenVariantDoesNotComplyWithLocaleFilterThenAddFiltersReturnsFalse() {
+    fun whenVariantDoesNotComplyWithLocaleFilterThenComputeFiltersReturnsFalse() {
         val locale = Locale("en", "US")
-        Locale.setDefault(locale)
+        whenever(mockAppBuildConfig.deviceLocale).thenReturn(locale)
         val testEntity = addActiveVariant(localeFilter = listOf("de_DE"))
 
-        assertFalse(testee.addFilters(testEntity).invoke(mockAppBuildConfig))
+        assertFalse(testee.computeFilters(testEntity).invoke(mockAppBuildConfig))
     }
 
     @Test
-    fun whenVariantComplyWithAndroidVersionFilterThenAddFiltersReturnsTrue() {
+    fun whenVariantComplyWithAndroidVersionFilterThenComputeFiltersReturnsTrue() {
         whenever(mockAppBuildConfig.sdkInt).thenReturn(33)
         val testEntity = addActiveVariant(androidVersionFilter = listOf("33", "34"))
 
-        assertTrue(testee.addFilters(testEntity).invoke(mockAppBuildConfig))
+        assertTrue(testee.computeFilters(testEntity).invoke(mockAppBuildConfig))
     }
 
     @Test
-    fun whenVariantDoesNotComplyWithAndroidVersionFilterThenAddFiltersReturnsFalse() {
+    fun whenVariantDoesNotComplyWithAndroidVersionFilterThenComputeFiltersReturnsFalse() {
         whenever(mockAppBuildConfig.sdkInt).thenReturn(32)
         val testEntity = addActiveVariant(androidVersionFilter = listOf("33", "34"))
 
-        assertFalse(testee.addFilters(testEntity).invoke(mockAppBuildConfig))
+        assertFalse(testee.computeFilters(testEntity).invoke(mockAppBuildConfig))
     }
 
     @Test
-    fun whenVariantComplyWithPrivacyProEligibleFilterThenAddFiltersReturnsTrue() = runTest {
+    fun whenVariantComplyWithPrivacyProEligibleFilterThenComputeFiltersReturnsTrue() = runTest {
         whenever(mockSubscriptions.isEligible()).thenReturn(true)
         val testEntity = addActiveVariant(privacyProEligible = true)
 
-        assertTrue(testee.addFilters(testEntity).invoke(mockAppBuildConfig))
+        assertTrue(testee.computeFilters(testEntity).invoke(mockAppBuildConfig))
     }
 
     @Test
-    fun whenVariantDoesNotComplyWithPrivacyProEligibleFilterThenAddFiltersReturnsFalse() = runTest {
+    fun whenVariantDoesNotComplyWithPrivacyProEligibleFilterThenComputeFiltersReturnsFalse() = runTest {
         whenever(mockSubscriptions.isEligible()).thenReturn(false)
         val testEntity = addActiveVariant(privacyProEligible = true)
 
-        assertFalse(testee.addFilters(testEntity).invoke(mockAppBuildConfig))
+        assertFalse(testee.computeFilters(testEntity).invoke(mockAppBuildConfig))
     }
 
     @Test
-    fun whenVariantComplyWithAllFiltersThenAddFiltersReturnsTrue() = runTest {
+    fun whenVariantComplyWithAllFiltersThenComputeFiltersReturnsTrue() = runTest {
         val locale = Locale("en", "US")
-        Locale.setDefault(locale)
+        whenever(mockAppBuildConfig.deviceLocale).thenReturn(locale)
         whenever(mockAppBuildConfig.sdkInt).thenReturn(33)
         whenever(mockSubscriptions.isEligible()).thenReturn(false)
         val testEntity = addActiveVariant(
@@ -112,33 +112,33 @@ class ExperimentFiltersManagerImplTest {
             privacyProEligible = false,
         )
 
-        assertTrue(testee.addFilters(testEntity).invoke(mockAppBuildConfig))
+        assertTrue(testee.computeFilters(testEntity).invoke(mockAppBuildConfig))
     }
 
     @Test
-    fun whenVariantComplyWithLocaleFiltersAndDoesNotComplyWithAndroidVersionFilterThenAddFiltersReturnsFalse() {
+    fun whenVariantComplyWithLocaleFiltersAndDoesNotComplyWithAndroidVersionFilterThenComputeFiltersReturnsFalse() {
         val locale = Locale("en", "US")
-        Locale.setDefault(locale)
+        whenever(mockAppBuildConfig.deviceLocale).thenReturn(locale)
         whenever(mockAppBuildConfig.sdkInt).thenReturn(32)
         val testEntity = addActiveVariant(localeFilter = listOf("en_US"), androidVersionFilter = listOf("33", "34"))
 
-        assertFalse(testee.addFilters(testEntity).invoke(mockAppBuildConfig))
+        assertFalse(testee.computeFilters(testEntity).invoke(mockAppBuildConfig))
     }
 
     @Test
-    fun whenVariantComplyWithAndroidVersionFiltersAndDoesNotComplyWithLocaleFilterThenAddFiltersReturnsFalse() {
+    fun whenVariantComplyWithAndroidVersionFiltersAndDoesNotComplyWithLocaleFilterThenComputeFiltersReturnsFalse() {
         val locale = Locale("en", "US")
-        Locale.setDefault(locale)
+        whenever(mockAppBuildConfig.deviceLocale).thenReturn(locale)
         whenever(mockAppBuildConfig.sdkInt).thenReturn(33)
         val testEntity = addActiveVariant(localeFilter = listOf("de_DE"), androidVersionFilter = listOf("33", "34"))
 
-        assertFalse(testee.addFilters(testEntity).invoke(mockAppBuildConfig))
+        assertFalse(testee.computeFilters(testEntity).invoke(mockAppBuildConfig))
     }
 
     @Test
-    fun whenVariantComplyWithLocaleAndAndroidVersionFiltersAndDoesNotComplyWithPrivacyProEligibleThenAddFiltersReturnsFalse() = runTest {
+    fun whenVariantComplyWithLocaleAndAndroidVersionFiltersAndDoesNotComplyWithPrivacyProEligibleThenComputeFiltersReturnsFalse() = runTest {
         val locale = Locale("en", "US")
-        Locale.setDefault(locale)
+        whenever(mockAppBuildConfig.deviceLocale).thenReturn(locale)
         whenever(mockAppBuildConfig.sdkInt).thenReturn(33)
         whenever(mockSubscriptions.isEligible()).thenReturn(true)
         val testEntity = addActiveVariant(
@@ -147,7 +147,7 @@ class ExperimentFiltersManagerImplTest {
             privacyProEligible = false,
         )
 
-        assertFalse(testee.addFilters(testEntity).invoke(mockAppBuildConfig))
+        assertFalse(testee.computeFilters(testEntity).invoke(mockAppBuildConfig))
     }
 
     private fun addActiveVariant(

--- a/experiments/experiments-impl/src/test/java/com/duckduckgo/experiments/impl/VariantManagerImplTest.kt
+++ b/experiments/experiments-impl/src/test/java/com/duckduckgo/experiments/impl/VariantManagerImplTest.kt
@@ -43,7 +43,7 @@ class VariantManagerImplTest {
     fun setup() {
         // mock randomizer always returns the first active variant
         whenever(mockRandomizer.random(any())).thenReturn(0)
-        whenever(mockExperimentFiltersManager.addFilters(any())).thenReturn { true }
+        whenever(mockExperimentFiltersManager.computeFilters(any())).thenReturn { true }
 
         testee = VariantManagerImpl(
             mockRandomizer,

--- a/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureToggles.kt
+++ b/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureToggles.kt
@@ -294,13 +294,29 @@ internal class ToggleImpl constructor(
     private val forceDefaultVariant: () -> Unit,
 ) : Toggle {
 
-    private fun Toggle.State.isVariantTreated(variant: String?): Boolean {
-        // if no variants a present, we consider always treated
+    private fun Toggle.State.evaluateTargetMatching(isExperiment: Boolean): Boolean {
+        val variant = appVariantProvider.invoke()
+        // no targets then consider always treated
         if (this.targets.isEmpty()) {
             return true
         }
+        // if it's an experiment we only check target variants and ignore all the rest
+        val variantTargets = this.targets.mapNotNull { it.variantKey }
+        if (isExperiment && variantTargets.isNotEmpty()) {
+            return variantTargets.contains(variant)
+        }
+        // finally, check all other targets
+        val countryTarget = this.targets.mapNotNull { it.localeCountry?.lowercase() }
+        val languageTarget = this.targets.mapNotNull { it.localeLanguage?.lowercase() }
 
-        return this.targets.mapNotNull { it.variantKey }.contains(variant)
+        if (countryTarget.isNotEmpty() && !countryTarget.contains(localeProvider.invoke()?.country?.lowercase())) {
+            return false
+        }
+        if (languageTarget.isNotEmpty() && !languageTarget.contains(localeProvider.invoke()?.language?.lowercase())) {
+            return false
+        }
+
+        return true
     }
 
     override fun featureName(): FeatureName {
@@ -340,10 +356,10 @@ internal class ToggleImpl constructor(
     private fun isRolloutEnabled(): Boolean {
         fun evaluateLocalEnable(state: State, isExperiment: Boolean): Boolean {
             // variants are only considered for Experiment feature flags
-            val isVariantTreated = if (isExperiment) state.isVariantTreated(appVariantProvider.invoke()) else true
+            val doTargetsMatch = state.evaluateTargetMatching(isExperiment)
 
             return state.enable &&
-                isVariantTreated &&
+                doTargetsMatch &&
                 appVersionProvider.invoke() >= (state.minSupportedVersion ?: 0)
         }
         // check if it should always be enabled for internal builds

--- a/feature-toggles/feature-toggles-impl/lint-baseline.xml
+++ b/feature-toggles/feature-toggles-impl/lint-baseline.xml
@@ -70,11 +70,55 @@
     <issue
         id="DenyListedApi"
         message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="            testFeature.fooFeature().getRawStoredState()!!.targets,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
+            line="1554"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="            testFeature.fooFeature().getRawStoredState()!!.targets,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
+            line="1593"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="            testFeature.fooFeature().getRawStoredState()!!.targets,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
+            line="1640"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="            testFeature.fooFeature().getRawStoredState()!!.targets,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
+            line="1687"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
         errorLine1="        assertEquals(emptyList&lt;Toggle.State.Target>(), testFeature.fooFeature().getRawStoredState()!!.targets)"
         errorLine2="                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1544"
+            line="1716"
             column="56"/>
     </issue>
 
@@ -85,7 +129,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1606"
+            line="1778"
             column="13"/>
     </issue>
 
@@ -96,7 +140,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1615"
+            line="1787"
             column="13"/>
     </issue>
 
@@ -107,7 +151,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1623"
+            line="1795"
             column="13"/>
     </issue>
 
@@ -118,7 +162,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1682"
+            line="1854"
             column="13"/>
     </issue>
 
@@ -129,7 +173,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1691"
+            line="1863"
             column="13"/>
     </issue>
 
@@ -140,7 +184,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1747"
+            line="1919"
             column="13"/>
     </issue>
 
@@ -151,7 +195,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1756"
+            line="1928"
             column="13"/>
     </issue>
 
@@ -162,7 +206,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1797"
+            line="1969"
             column="13"/>
     </issue>
 
@@ -173,7 +217,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1838"
+            line="2010"
             column="13"/>
     </issue>
 
@@ -184,7 +228,62 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1879"
+            line="2051"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="            testFeature.experimentDisabledByDefault().getRawStoredState()!!.targets,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
+            line="2092"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="            testFeature.experimentDisabledByDefault().getRawStoredState()!!.targets,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
+            line="2123"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="            testFeature.experimentDisabledByDefault().getRawStoredState()!!.targets,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
+            line="2153"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="            testFeature.experimentDisabledByDefault().getRawStoredState()!!.targets,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
+            line="2183"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="            testFeature.experimentDisabledByDefault().getRawStoredState()!!.targets,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
+            line="2225"
             column="13"/>
     </issue>
 
@@ -195,7 +294,7 @@
         errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1913"
+            line="2259"
             column="43"/>
     </issue>
 
@@ -206,7 +305,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2109"
+            line="2455"
             column="13"/>
     </issue>
 
@@ -217,7 +316,7 @@
         errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2159"
+            line="2505"
             column="23"/>
     </issue>
 
@@ -228,7 +327,7 @@
         errorLine2="                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2209"
+            line="2555"
             column="24"/>
     </issue>
 
@@ -239,7 +338,7 @@
         errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2215"
+            line="2561"
             column="20"/>
     </issue>
 
@@ -250,7 +349,7 @@
         errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2221"
+            line="2567"
             column="20"/>
     </issue>
 
@@ -261,7 +360,7 @@
         errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2269"
+            line="2615"
             column="23"/>
     </issue>
 
@@ -272,7 +371,7 @@
         errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2303"
+            line="2649"
             column="23"/>
     </issue>
 
@@ -283,7 +382,7 @@
         errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2331"
+            line="2677"
             column="20"/>
     </issue>
 
@@ -294,7 +393,7 @@
         errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2630"
+            line="2976"
             column="20"/>
     </issue>
 
@@ -305,7 +404,7 @@
         errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2674"
+            line="3020"
             column="20"/>
     </issue>
 
@@ -316,7 +415,7 @@
         errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2900"
+            line="3246"
             column="20"/>
     </issue>
 
@@ -327,7 +426,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2910"
+            line="3256"
             column="13"/>
     </issue>
 
@@ -338,7 +437,7 @@
         errorLine2="                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2954"
+            line="3300"
             column="32"/>
     </issue>
 
@@ -349,7 +448,7 @@
         errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3036"
+            line="3382"
             column="23"/>
     </issue>
 
@@ -360,7 +459,7 @@
         errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3080"
+            line="3426"
             column="19"/>
     </issue>
 
@@ -371,7 +470,7 @@
         errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3121"
+            line="3467"
             column="19"/>
     </issue>
 
@@ -382,52 +481,52 @@
         errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3165"
+            line="3511"
             column="19"/>
     </issue>
 
     <issue
         id="DenyListedApi"
         message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
-        errorLine1="        var config = testFeature.fooFeature().getRawStoredState()?.config!!"
-        errorLine2="                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        errorLine1="        var stateConfig = testFeature.fooFeature().getRawStoredState()?.config!!"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3219"
-            column="22"/>
+            line="3565"
+            column="27"/>
     </issue>
 
     <issue
         id="DenyListedApi"
         message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
-        errorLine1="        config = testFeature.fooFeature().getRawStoredState()?.config!!"
-        errorLine2="                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        errorLine1="        stateConfig = testFeature.fooFeature().getRawStoredState()?.config!!"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3262"
-            column="18"/>
+            line="3612"
+            column="23"/>
     </issue>
 
     <issue
         id="DenyListedApi"
         message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
-        errorLine1="        config = testFeature.fooFeature().getRawStoredState()?.config!!"
-        errorLine2="                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        errorLine1="        stateConfig = testFeature.fooFeature().getRawStoredState()?.config!!"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3298"
-            column="18"/>
+            line="3652"
+            column="23"/>
     </issue>
 
     <issue
         id="DenyListedApi"
         message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
-        errorLine1="        config = testFeature.fooFeature().getRawStoredState()?.config!!"
-        errorLine2="                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        errorLine1="        stateConfig = testFeature.fooFeature().getRawStoredState()?.config!!"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3340"
-            column="18"/>
+            line="3696"
+            column="23"/>
     </issue>
 
     <issue
@@ -437,7 +536,7 @@
         errorLine2="               ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3367"
+            line="3727"
             column="16"/>
     </issue>
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1198194956794324/1208490749815531/f

### Description
Consider newly added (in abn) targets in normal feature and experiment features

Incidentally, I looked into the experiments and rename/documented some of the methods in there. As they were not clear to me. That's in the second commit, https://github.com/duckduckgo/Android/pull/5118/commits/6f578d9133220a12f7032e0bc4e6ce12803934d6

### Steps to test this PR
- [x] Add a different permutations of locale targets in sub-feature
- [x] Install the app, check targets are parsed and stored
- [x] Remove targets and launch app
- [x] Check targets change
- [x] Re-add targets and launch app
- [x] Check targets change
- [x] Add targets
- [x] Verify isEnabled() is true when targets match and false when they dont
