### PR TITLE
Add feature flag for opening in new tab

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -192,6 +192,9 @@ import com.duckduckgo.downloads.api.FileDownloader.PendingFileDownload
 import com.duckduckgo.duckplayer.api.DuckPlayer
 import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.DISABLED
 import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.ENABLED
+import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.Off
+import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.On
+import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.Unavailable
 import com.duckduckgo.duckplayer.api.DuckPlayer.UserPreferences
 import com.duckduckgo.duckplayer.api.PrivatePlayerMode.AlwaysAsk
 import com.duckduckgo.duckplayer.api.PrivatePlayerMode.Disabled
@@ -5054,10 +5057,10 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenProcessJsCallbackMessageOpenDuckPlayerWithUrlAndOpenInNewTabFalseThenNavigate() = runTest {
+    fun whenProcessJsCallbackMessageOpenDuckPlayerWithUrlAndOpenInNewTabOffThenNavigate() = runTest {
         whenever(mockEnabledToggle.isEnabled()).thenReturn(true)
         whenever(mockDuckPlayer.getUserPreferences()).thenReturn(UserPreferences(overlayInteracted = true, privatePlayerMode = AlwaysAsk))
-        whenever(mockDuckPlayer.shouldOpenDuckPlayerInNewTab()).thenReturn(false)
+        whenever(mockDuckPlayer.shouldOpenDuckPlayerInNewTab()).thenReturn(Off)
         testee.processJsCallbackMessage(
             DUCK_PLAYER_FEATURE_NAME,
             "openDuckPlayer",
@@ -5069,10 +5072,25 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenProcessJsCallbackMessageOpenDuckPlayerWithUrlAndOpenInNewTabTrueThenOpenInNewTab() = runTest {
+    fun whenProcessJsCallbackMessageOpenDuckPlayerWithUrlAndOpenInNewTabUnavailableThenNavigate() = runTest {
         whenever(mockEnabledToggle.isEnabled()).thenReturn(true)
         whenever(mockDuckPlayer.getUserPreferences()).thenReturn(UserPreferences(overlayInteracted = true, privatePlayerMode = AlwaysAsk))
-        whenever(mockDuckPlayer.shouldOpenDuckPlayerInNewTab()).thenReturn(true)
+        whenever(mockDuckPlayer.shouldOpenDuckPlayerInNewTab()).thenReturn(Unavailable)
+        testee.processJsCallbackMessage(
+            DUCK_PLAYER_FEATURE_NAME,
+            "openDuckPlayer",
+            "id",
+            JSONObject("""{ href: "duck://player/1234" }"""),
+            { "someUrl" },
+        )
+        assertCommandIssued<Navigate>()
+    }
+
+    @Test
+    fun whenProcessJsCallbackMessageOpenDuckPlayerWithUrlAndOpenInNewTabOnThenOpenInNewTab() = runTest {
+        whenever(mockEnabledToggle.isEnabled()).thenReturn(true)
+        whenever(mockDuckPlayer.getUserPreferences()).thenReturn(UserPreferences(overlayInteracted = true, privatePlayerMode = AlwaysAsk))
+        whenever(mockDuckPlayer.shouldOpenDuckPlayerInNewTab()).thenReturn(On)
         testee.processJsCallbackMessage(
             DUCK_PLAYER_FEATURE_NAME,
             "openDuckPlayer",

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -5104,7 +5104,7 @@ class BrowserTabViewModelTest {
     @Test
     fun whenProcessJsCallbackMessageOpenDuckPlayerWithoutUrlThenDoNotNavigate() = runTest {
         whenever(mockEnabledToggle.isEnabled()).thenReturn(true)
-        whenever(mockDuckPlayer.shouldOpenDuckPlayerInNewTab()).thenReturn(true)
+        whenever(mockDuckPlayer.shouldOpenDuckPlayerInNewTab()).thenReturn(On)
         whenever(mockDuckPlayer.getUserPreferences()).thenReturn(UserPreferences(overlayInteracted = true, privatePlayerMode = AlwaysAsk))
         testee.processJsCallbackMessage(
             DUCK_PLAYER_FEATURE_NAME,

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -75,6 +75,7 @@ import com.duckduckgo.duckplayer.api.DuckPlayer
 import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.ENABLED
 import com.duckduckgo.duckplayer.api.ORIGIN_QUERY_PARAM
 import com.duckduckgo.duckplayer.api.ORIGIN_QUERY_PARAM_SERP_AUTO
+import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.On
 import com.duckduckgo.duckplayer.impl.DUCK_PLAYER_OPEN_IN_YOUTUBE_PATH
 import com.duckduckgo.experiments.api.loadingbarexperiment.LoadingBarExperimentManager
 import com.duckduckgo.history.api.NavigationHistory
@@ -131,7 +132,7 @@ class BrowserWebViewClient @Inject constructor(
     init {
         appCoroutineScope.launch {
             duckPlayer.observeShouldOpenInNewTab().collect {
-                shouldOpenDuckPlayerInNewTab = it
+                shouldOpenDuckPlayerInNewTab = it is On
             }
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -73,9 +73,9 @@ import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.duckplayer.api.DuckPlayer
 import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.ENABLED
+import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.On
 import com.duckduckgo.duckplayer.api.ORIGIN_QUERY_PARAM
 import com.duckduckgo.duckplayer.api.ORIGIN_QUERY_PARAM_SERP_AUTO
-import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.On
 import com.duckduckgo.duckplayer.impl.DUCK_PLAYER_OPEN_IN_YOUTUBE_PATH
 import com.duckduckgo.experiments.api.loadingbarexperiment.LoadingBarExperimentManager
 import com.duckduckgo.history.api.NavigationHistory
@@ -85,7 +85,6 @@ import com.duckduckgo.user.agent.api.ClientBrandHintProvider
 import java.net.URI
 import javax.inject.Inject
 import kotlinx.coroutines.*
-import kotlinx.coroutines.flow.forEach
 import timber.log.Timber
 
 private const val ABOUT_BLANK = "about:blank"

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -127,7 +127,7 @@ class BrowserWebViewClient @Inject constructor(
     private var lastPageStarted: String? = null
     private var start: Long? = null
 
-    private var shouldOpenDuckPlayerInNewTab: Boolean = false
+    private var shouldOpenDuckPlayerInNewTab: Boolean = true
 
     init {
         appCoroutineScope.launch {
@@ -205,11 +205,7 @@ class BrowserWebViewClient @Inject constructor(
                         }
                         return true
                     } else {
-                        if (shouldOpenDuckPlayerInNewTab) {
-                            shouldOverrideWebRequest(url, webView, isForMainFrame, openInNewTab = true)
-                        } else {
-                            shouldOverrideWebRequest(url, webView, isForMainFrame, openInNewTab = false)
-                        }
+                        shouldOverrideWebRequest(url, webView, isForMainFrame, openInNewTab = shouldOpenDuckPlayerInNewTab)
                     }
                 }
                 is SpecialUrlDetector.UrlType.NonHttpAppLink -> {

--- a/app/src/main/java/com/duckduckgo/app/browser/duckplayer/DuckPlayerJSHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/duckplayer/DuckPlayerJSHelper.kt
@@ -36,6 +36,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.duckplayer.api.DuckPlayer
 import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.ENABLED
+import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.On
 import com.duckduckgo.duckplayer.api.DuckPlayer.UserPreferences
 import com.duckduckgo.duckplayer.api.ORIGIN_QUERY_PARAM
 import com.duckduckgo.duckplayer.api.ORIGIN_QUERY_PARAM_AUTO
@@ -207,7 +208,7 @@ class DuckPlayerJSHelper @Inject constructor(
                 return null
             }
             "openDuckPlayer" -> {
-                val openInNewTab = duckPlayer.shouldOpenDuckPlayerInNewTab()
+                val openInNewTab = duckPlayer.shouldOpenDuckPlayerInNewTab() is On
                 return data?.getString("href")?.let {
                     val newUrl = if (duckPlayer.getUserPreferences().privatePlayerMode == Enabled) {
                         it.toUri().buildUpon().appendQueryParameter(ORIGIN_QUERY_PARAM, ORIGIN_QUERY_PARAM_AUTO).build()

--- a/app/src/test/java/com/duckduckgo/duckplayer/impl/DuckPlayerSettingsViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/duckplayer/impl/DuckPlayerSettingsViewModelTest.kt
@@ -3,6 +3,8 @@ package com.duckduckgo.duckplayer.impl
 import app.cash.turbine.test
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.Off
+import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.On
 import com.duckduckgo.duckplayer.api.DuckPlayer.UserPreferences
 import com.duckduckgo.duckplayer.api.PrivatePlayerMode.AlwaysAsk
 import com.duckduckgo.duckplayer.api.PrivatePlayerMode.Disabled
@@ -16,7 +18,6 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -43,7 +44,7 @@ class DuckPlayerSettingsViewModelTest {
             whenever(duckPlayer.observeUserPreferences()).thenReturn(userPreferencesFlow)
             userPreferencesFlow.emit(UserPreferences(overlayInteracted = true, privatePlayerMode = AlwaysAsk))
             whenever(duckPlayer.getUserPreferences()).thenReturn(UserPreferences(overlayInteracted = true, privatePlayerMode = AlwaysAsk))
-            whenever(duckPlayer.shouldOpenDuckPlayerInNewTab()).thenReturn(false)
+            whenever(duckPlayer.shouldOpenDuckPlayerInNewTab()).thenReturn(Off)
             viewModel = DuckPlayerSettingsViewModel(duckPlayer, duckPlayerFeatureRepository, pixel)
         }
     }
@@ -84,7 +85,7 @@ class DuckPlayerSettingsViewModelTest {
     @Test
     fun whenViewModelIsCreatedAndPrivatePlayerModeIsDisabledThenEmitDisabled() = runTest {
         whenever(duckPlayer.observeUserPreferences()).thenReturn(flowOf(UserPreferences(overlayInteracted = true, privatePlayerMode = Disabled)))
-        whenever(duckPlayer.observeShouldOpenInNewTab()).thenReturn(flowOf(true))
+        whenever(duckPlayer.observeShouldOpenInNewTab()).thenReturn(flowOf(On))
         userPreferencesFlow.emit(UserPreferences(overlayInteracted = true, privatePlayerMode = Disabled))
         viewModel = DuckPlayerSettingsViewModel(duckPlayer, duckPlayerFeatureRepository, pixel)
 
@@ -96,14 +97,14 @@ class DuckPlayerSettingsViewModelTest {
     @Test
     fun whenViewModelIsCreatedAndPrivatePlayerModeIsAlwaysAndOpenInNewTabThenEmitAlwaysAndOpenInNewTab() = runTest {
         whenever(duckPlayer.observeUserPreferences()).thenReturn(flowOf(UserPreferences(overlayInteracted = true, privatePlayerMode = Enabled)))
-        whenever(duckPlayer.observeShouldOpenInNewTab()).thenReturn(flowOf(true))
+        whenever(duckPlayer.observeShouldOpenInNewTab()).thenReturn(flowOf(On))
         userPreferencesFlow.emit(UserPreferences(overlayInteracted = true, privatePlayerMode = Enabled))
         viewModel = DuckPlayerSettingsViewModel(duckPlayer, duckPlayerFeatureRepository, pixel)
 
         viewModel.viewState.test {
             awaitItem().let {
                 assertEquals(Enabled, it.privatePlayerMode)
-                assertTrue(it.openDuckPlayerInNewTab)
+                assertEquals(On, it.openDuckPlayerInNewTab)
             }
         }
     }

--- a/duckplayer/duckplayer-api/src/main/java/com/duckduckgo/duckplayer/api/DuckPlayer.kt
+++ b/duckplayer/duckplayer-api/src/main/java/com/duckduckgo/duckplayer/api/DuckPlayer.kt
@@ -184,9 +184,9 @@ interface DuckPlayer {
         destinationUrl: Uri,
     ): Boolean
 
-    suspend fun shouldOpenDuckPlayerInNewTab(): Boolean
+    suspend fun shouldOpenDuckPlayerInNewTab(): OpenDuckPlayerInNewTab
 
-    fun observeShouldOpenInNewTab(): Flow<Boolean>
+    fun observeShouldOpenInNewTab(): Flow<OpenDuckPlayerInNewTab>
 
     /**
      * Data class representing user preferences for Duck Player.
@@ -203,5 +203,11 @@ interface DuckPlayer {
         ENABLED,
         DISABLED,
         DISABLED_WIH_HELP_LINK,
+    }
+
+    sealed interface OpenDuckPlayerInNewTab {
+        data object On : OpenDuckPlayerInNewTab
+        data object Off : OpenDuckPlayerInNewTab
+        data object Unavailable : OpenDuckPlayerInNewTab
     }
 }

--- a/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerDataStore.kt
+++ b/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerDataStore.kt
@@ -194,7 +194,7 @@ class SharedPreferencesDuckPlayerDataStore @Inject constructor(
     private val duckPlayerOpenInNewTab: Flow<Boolean>
         get() = store.data
             .map { prefs ->
-                prefs[Keys.DUCK_PLAYER_OPEN_IN_NEW_TAB] ?: false
+                prefs[Keys.DUCK_PLAYER_OPEN_IN_NEW_TAB] ?: true
             }
             .distinctUntilChanged()
 

--- a/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerFeature.kt
+++ b/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerFeature.kt
@@ -42,4 +42,11 @@ interface DuckPlayerFeature {
      */
     @Toggle.DefaultValue(false)
     fun enableDuckPlayer(): Toggle
+
+    /**
+     * @return `true` when the remote config has the "openInNewTab" feature flag enabled
+     * If the remote feature is not present defaults to `false`
+     */
+    @Toggle.DefaultValue(false)
+    fun openInNewTab(): Toggle
 }

--- a/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerSettingsActivity.kt
+++ b/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerSettingsActivity.kt
@@ -29,6 +29,8 @@ import com.duckduckgo.common.ui.view.addClickableLink
 import com.duckduckgo.common.ui.view.dialog.RadioListAlertDialogBuilder
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.On
+import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.Unavailable
 import com.duckduckgo.duckplayer.api.DuckPlayerSettingsNoParams
 import com.duckduckgo.duckplayer.api.PrivatePlayerMode
 import com.duckduckgo.duckplayer.api.PrivatePlayerMode.AlwaysAsk
@@ -154,8 +156,9 @@ class DuckPlayerSettingsActivity : DuckDuckGoActivity() {
             is ViewState.Enabled -> {
                 binding.duckPlayerModeSelector.isEnabled = true
                 binding.duckPlayerDisabledSection.isVisible = false
-                binding.openDuckPlayerInNewTabToggle.isEnabled = viewState.privatePlayerMode != Disabled
-                binding.openDuckPlayerInNewTabToggle.setIsChecked(viewState.openDuckPlayerInNewTab)
+                binding.openDuckPlayerInNewTabToggle.isVisible =
+                    viewState.privatePlayerMode != Disabled && viewState.openDuckPlayerInNewTab != Unavailable
+                binding.openDuckPlayerInNewTabToggle.setIsChecked(viewState.openDuckPlayerInNewTab is On)
                 setDuckPlayerSectionVisibility(true)
             }
             is ViewState.DisabledWithHelpLink -> {

--- a/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerSettingsViewModel.kt
+++ b/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerSettingsViewModel.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.DISABLED_WIH_HELP_LINK
+import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab
 import com.duckduckgo.duckplayer.api.PrivatePlayerMode
 import com.duckduckgo.duckplayer.api.PrivatePlayerMode.AlwaysAsk
 import com.duckduckgo.duckplayer.api.PrivatePlayerMode.Disabled
@@ -73,14 +74,14 @@ class DuckPlayerSettingsViewModel @Inject constructor(
         data class LaunchDuckPlayerContingencyPage(val helpPageLink: String) : Command()
     }
 
-    sealed class ViewState(open val privatePlayerMode: PrivatePlayerMode = AlwaysAsk, open val openDuckPlayerInNewTab: Boolean) {
+    sealed class ViewState(open val privatePlayerMode: PrivatePlayerMode = AlwaysAsk, open val openDuckPlayerInNewTab: OpenDuckPlayerInNewTab) {
         data class Enabled(
             override val privatePlayerMode: PrivatePlayerMode,
-            override val openDuckPlayerInNewTab: Boolean,
+            override val openDuckPlayerInNewTab: OpenDuckPlayerInNewTab,
         ) : ViewState(privatePlayerMode, openDuckPlayerInNewTab)
         data class DisabledWithHelpLink(
             override val privatePlayerMode: PrivatePlayerMode,
-            override val openDuckPlayerInNewTab: Boolean,
+            override val openDuckPlayerInNewTab: OpenDuckPlayerInNewTab,
             val helpPageLink: String,
         ) : ViewState(privatePlayerMode, openDuckPlayerInNewTab)
     }

--- a/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/RealDuckPlayer.kt
+++ b/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/RealDuckPlayer.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.duckplayer.impl
 
 import android.content.res.Configuration
 import android.net.Uri
-import android.util.Log
 import android.webkit.MimeTypeMap
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
@@ -445,9 +444,7 @@ class RealDuckPlayer @Inject constructor(
 
     override fun observeShouldOpenInNewTab(): Flow<OpenDuckPlayerInNewTab> {
         return duckPlayerFeatureRepository.observeOpenInNewTab().map {
-            (if (!duckPlayerFeature.openInNewTab().isEnabled()) Unavailable else if (it) On else Off).also {
-                Log.d("Cris", "observeShouldOpenInNewTab: $it")
-            }
+            (if (!duckPlayerFeature.openInNewTab().isEnabled()) Unavailable else if (it) On else Off)
         }
     }
 }

--- a/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/RealDuckPlayer.kt
+++ b/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/RealDuckPlayer.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.duckplayer.impl
 
 import android.content.res.Configuration
 import android.net.Uri
+import android.util.Log
 import android.webkit.MimeTypeMap
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
@@ -35,6 +36,10 @@ import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState
 import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.DISABLED
 import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.DISABLED_WIH_HELP_LINK
 import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.ENABLED
+import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab
+import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.Off
+import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.On
+import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.Unavailable
 import com.duckduckgo.duckplayer.api.DuckPlayer.UserPreferences
 import com.duckduckgo.duckplayer.api.ORIGIN_QUERY_PARAM
 import com.duckduckgo.duckplayer.api.ORIGIN_QUERY_PARAM_AUTO
@@ -433,11 +438,16 @@ class RealDuckPlayer @Inject constructor(
             )
     }
 
-    override suspend fun shouldOpenDuckPlayerInNewTab(): Boolean {
-        return duckPlayerFeatureRepository.shouldOpenInNewTab()
+    override suspend fun shouldOpenDuckPlayerInNewTab(): OpenDuckPlayerInNewTab {
+        if (!duckPlayerFeature.openInNewTab().isEnabled()) return Unavailable
+        return if (duckPlayerFeatureRepository.shouldOpenInNewTab()) On else Off
     }
 
-    override fun observeShouldOpenInNewTab(): Flow<Boolean> {
-        return duckPlayerFeatureRepository.observeOpenInNewTab()
+    override fun observeShouldOpenInNewTab(): Flow<OpenDuckPlayerInNewTab> {
+        return duckPlayerFeatureRepository.observeOpenInNewTab().map {
+            (if (!duckPlayerFeature.openInNewTab().isEnabled()) Unavailable else if (it) On else Off).also {
+                Log.d("Cris", "observeShouldOpenInNewTab: $it")
+            }
+        }
     }
 }

--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
@@ -27,4 +27,4 @@ enum class PrivacyFeatureName(val value: String) {
     TrackingParametersFeatureName("trackingParameters"),
 }
 
-const val PRIVACY_REMOTE_CONFIG_URL = "https://staticcdn.duckduckgo.com/trackerblocking/config/v4/android-config.json"
+const val PRIVACY_REMOTE_CONFIG_URL = "https://www.jsonblob.com/api/1252645298605252608"

--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
@@ -27,4 +27,4 @@ enum class PrivacyFeatureName(val value: String) {
     TrackingParametersFeatureName("trackingParameters"),
 }
 
-const val PRIVACY_REMOTE_CONFIG_URL = "https://www.jsonblob.com/api/1252645298605252608"
+const val PRIVACY_REMOTE_CONFIG_URL = "https://staticcdn.duckduckgo.com/trackerblocking/config/v4/android-config.json"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1208511584623404/f 

### Description

### Steps to test this PR

_Feature 1_
- [x] Check that with the prod RC, the setting to open duck player in new tab is not available and Duck Player is opened in the same page

_Feature 2_
- [x] Go to FF inventory and turn DuckPlayer > newtab on
- [x] Check the setting to open Duck Player in new tab is now visible in Duck Player settings and works as expected 

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
