### PR TITLE
Add pixels for open in new tab

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -77,7 +77,6 @@ import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.On
 import com.duckduckgo.duckplayer.api.ORIGIN_QUERY_PARAM
 import com.duckduckgo.duckplayer.api.ORIGIN_QUERY_PARAM_SERP_AUTO
 import com.duckduckgo.duckplayer.impl.DUCK_PLAYER_OPEN_IN_YOUTUBE_PATH
-import com.duckduckgo.duckplayer.impl.DUCK_PLAYER_OPEN_IN_YOUTUBE_PATH
 import com.duckduckgo.experiments.api.loadingbarexperiment.LoadingBarExperimentManager
 import com.duckduckgo.history.api.NavigationHistory
 import com.duckduckgo.privacy.config.api.AmpLinks

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -77,6 +77,7 @@ import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.On
 import com.duckduckgo.duckplayer.api.ORIGIN_QUERY_PARAM
 import com.duckduckgo.duckplayer.api.ORIGIN_QUERY_PARAM_SERP_AUTO
 import com.duckduckgo.duckplayer.impl.DUCK_PLAYER_OPEN_IN_YOUTUBE_PATH
+import com.duckduckgo.duckplayer.impl.DUCK_PLAYER_OPEN_IN_YOUTUBE_PATH
 import com.duckduckgo.experiments.api.loadingbarexperiment.LoadingBarExperimentManager
 import com.duckduckgo.history.api.NavigationHistory
 import com.duckduckgo.privacy.config.api.AmpLinks

--- a/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerPixelName.kt
+++ b/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerPixelName.kt
@@ -31,4 +31,6 @@ enum class DuckPlayerPixelName(override val pixelName: String) : Pixel.PixelName
     DUCK_PLAYER_SETTINGS_BACK_TO_DEFAULT("duckplayer_setting_back-to-default"),
     DUCK_PLAYER_SETTINGS_NEVER_SETTINGS("duckplayer_setting_never_settings"),
     DUCK_PLAYER_SETTINGS_PRESSED("duckplayer_setting_pressed"),
+    DUCK_PLAYER_NEWTAB_SETTING_ON("duckplayer_newtab_setting-on"),
+    DUCK_PLAYER_NEWTAB_SETTING_OFF("duckplayer_newtab_setting-off"),
 }

--- a/duckplayer/duckplayer-impl/src/test/kotlin/com/duckduckgo/duckplayer/impl/RealDuckPlayerTest.kt
+++ b/duckplayer/duckplayer-impl/src/test/kotlin/com/duckduckgo/duckplayer/impl/RealDuckPlayerTest.kt
@@ -622,7 +622,11 @@ class RealDuckPlayerTest {
         val result = testee.intercept(request, url, webView)
 
         verify(mockAssets).open("duckplayer/index.html")
-        verify(mockPixel).fire(DUCK_PLAYER_DAILY_UNIQUE_VIEW, type = Daily(), parameters = mapOf("setting" to "always"))
+        verify(mockPixel).fire(
+            DUCK_PLAYER_DAILY_UNIQUE_VIEW,
+            type = Daily(),
+            parameters = mapOf("setting" to "always", "newtab" to "false"),
+        )
         assertEquals("text/html", result?.mimeType)
     }
 

--- a/duckplayer/duckplayer-impl/src/test/kotlin/com/duckduckgo/duckplayer/impl/RealDuckPlayerTest.kt
+++ b/duckplayer/duckplayer-impl/src/test/kotlin/com/duckduckgo/duckplayer/impl/RealDuckPlayerTest.kt
@@ -37,6 +37,8 @@ import com.duckduckgo.duckplayer.api.PrivatePlayerMode.AlwaysAsk
 import com.duckduckgo.duckplayer.api.PrivatePlayerMode.Disabled
 import com.duckduckgo.duckplayer.api.PrivatePlayerMode.Enabled
 import com.duckduckgo.duckplayer.impl.DuckPlayerPixelName.DUCK_PLAYER_DAILY_UNIQUE_VIEW
+import com.duckduckgo.duckplayer.impl.DuckPlayerPixelName.DUCK_PLAYER_NEWTAB_SETTING_OFF
+import com.duckduckgo.duckplayer.impl.DuckPlayerPixelName.DUCK_PLAYER_NEWTAB_SETTING_ON
 import com.duckduckgo.duckplayer.impl.DuckPlayerPixelName.DUCK_PLAYER_OVERLAY_YOUTUBE_IMPRESSIONS
 import com.duckduckgo.duckplayer.impl.DuckPlayerPixelName.DUCK_PLAYER_OVERLAY_YOUTUBE_WATCH_HERE
 import com.duckduckgo.duckplayer.impl.DuckPlayerPixelName.DUCK_PLAYER_VIEW_FROM_OTHER
@@ -752,6 +754,22 @@ class RealDuckPlayerTest {
         val result = testee.willNavigateToDuckPlayer(uri)
 
         assertFalse(result)
+    }
+
+    // endregion
+
+    // region openInNewTab
+
+    @Test
+    fun whenSetOpenInNewTabToTrueThenFirePixel() {
+        testee.setOpenInNewTab(true)
+        verify(mockPixel).fire(DUCK_PLAYER_NEWTAB_SETTING_ON)
+    }
+
+    @Test
+    fun whenSetOpenInNewTabToFalseThenFirePixel() {
+        testee.setOpenInNewTab(false)
+        verify(mockPixel).fire(DUCK_PLAYER_NEWTAB_SETTING_OFF)
     }
 
     // endregion


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1142021229838617/1208511584623405/f 

### Description

### Steps to test this PR

_Feature 1_
- [x] Toggle open Duck Player in new tab
- [x] Check `duckplayer_newtab_setting-on` and `duckplayer_newtab_setting-off` are sent

_Feature 2_
- [x] Open Duck Player
- [x] Check `duckplayer_daily-unique-view` is sent (or skipped if not the first time in the day) with params "newtab" to true or false depending on the open in new tab settings

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
