### PR TITLE
Add missing auto pixel when Duck Player set to always and navigating from YT thumbnail

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/duckplayer/DuckPlayerJSHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/duckplayer/DuckPlayerJSHelper.kt
@@ -37,8 +37,10 @@ import com.duckduckgo.duckplayer.api.DuckPlayer
 import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.ENABLED
 import com.duckduckgo.duckplayer.api.DuckPlayer.UserPreferences
 import com.duckduckgo.duckplayer.api.ORIGIN_QUERY_PARAM
+import com.duckduckgo.duckplayer.api.ORIGIN_QUERY_PARAM_AUTO
 import com.duckduckgo.duckplayer.api.ORIGIN_QUERY_PARAM_OVERLAY
 import com.duckduckgo.duckplayer.api.PrivatePlayerMode
+import com.duckduckgo.duckplayer.api.PrivatePlayerMode.Enabled
 import com.duckduckgo.js.messaging.api.JsCallbackData
 import com.duckduckgo.js.messaging.api.SubscriptionEventData
 import javax.inject.Inject
@@ -204,7 +206,14 @@ class DuckPlayerJSHelper @Inject constructor(
             }
             "openDuckPlayer" -> {
                 return data?.getString("href")?.let {
-                    Navigate(it.toUri().buildUpon().appendQueryParameter(ORIGIN_QUERY_PARAM, ORIGIN_QUERY_PARAM_OVERLAY).build().toString(), mapOf())
+                    if (duckPlayer.getUserPreferences().privatePlayerMode == Enabled) {
+                        Navigate(it.toUri().buildUpon().appendQueryParameter(ORIGIN_QUERY_PARAM, ORIGIN_QUERY_PARAM_AUTO).build().toString(), mapOf())
+                    } else {
+                        Navigate(
+                            it.toUri().buildUpon().appendQueryParameter(ORIGIN_QUERY_PARAM, ORIGIN_QUERY_PARAM_OVERLAY).build().toString(),
+                            mapOf(),
+                        )
+                    }
                 }
             }
             "initialSetup" -> {

--- a/duckplayer/duckplayer-impl/src/test/kotlin/com/duckduckgo/duckplayer/impl/RealDuckPlayerTest.kt
+++ b/duckplayer/duckplayer-impl/src/test/kotlin/com/duckduckgo/duckplayer/impl/RealDuckPlayerTest.kt
@@ -550,6 +550,20 @@ class RealDuckPlayerTest {
     }
 
     @Test
+    fun whenUriIsDuckPlayerUriWithOriginAuto_interceptProcessesDuckPlayerUri() = runTest {
+        val request: WebResourceRequest = mock()
+        val url: Uri = Uri.parse("duck://player/12345?origin=auto")
+        val webView: WebView = mock()
+        whenever(mockDuckPlayerFeatureRepository.getUserPreferences()).thenReturn(UserPreferences(true, Enabled))
+
+        val result = testee.intercept(request, url, webView)
+
+        verify(webView).loadUrl("https://www.youtube-nocookie.com?videoID=12345")
+        verify(mockPixel).fire(DUCK_PLAYER_VIEW_FROM_YOUTUBE_AUTOMATIC)
+        assertNotNull(result)
+    }
+
+    @Test
     fun whenUriIsDuckPlayerUriWithOpenInYouTube_interceptLoadsYouTubeUri() = runTest {
         val request: WebResourceRequest = mock()
         val url: Uri = Uri.parse("duck://player/openInYouTube?v=12345")
@@ -634,7 +648,6 @@ class RealDuckPlayerTest {
         val result = testee.intercept(request, url, webView)
 
         verify(webView).loadUrl("duck://player/12345?origin=auto")
-        verify(mockPixel).fire(DUCK_PLAYER_VIEW_FROM_YOUTUBE_AUTOMATIC)
         assertNotNull(result)
     }
 
@@ -677,7 +690,6 @@ class RealDuckPlayerTest {
         val result = testee.intercept(request, url, webView)
 
         verify(webView).loadUrl("duck://player/123456?origin=auto")
-        verify(mockPixel).fire(DUCK_PLAYER_VIEW_FROM_YOUTUBE_AUTOMATIC)
         assertNotNull(result)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1208529859806622/f 

### Description

### Steps to test this PR

_Always Ask + videos vertical_
- [x] Set Duck Player to "Ask every time"
- [x] Search for "Dog videos" 
- [x] Tap on a YT video from the videos carousel or videos vertical
- [x] Tap "Turn on Duck Player"
- [x] Check `duckplayer_view-from_serp` is fired

_Always ask + organic links_ 
- [x] Set Duck Player to "Ask every time"
- [x] Search for "Dog videos" 
- [x] Tap on a YT video from organic links
- [x] Tap "Turn on Duck Player"
- [x] Check `duckplayer_view-from_serp` is fired

_Always ask + overlay_ 
- [x] Open https://m.youtube.com/watch?v=j_saECXCoV0
- [x] Click on "Turn on Duck Player"
- [x] Check `duckplayer_view-from_youtube_main-overlay` is fired

_Always + videos vertical_
- [x] Set Duck Player to "Always"
- [x] Search for "Dog videos" 
- [x] Tap on a YT video from the videos carousel or videos vertical
- [x] Check `duckplayer_view-from_serp` is fired

_Always + organic links_ 
- [x] Set Duck Player to "Always"
- [x] Search for "Dog videos" 
- [x] Tap on a YT video from the videos carousel or videos vertical
- [x] Check `duckplayer_view-from_serp` is fired


_Always_ 
- [x] Open https://m.youtube.com/watch?v=j_saECXCoV0
- [x] Check `duckplayer_view-from_youtube_automatic` is fired
- [x] Tap "Watch on YouTube"
- [x] Scroll down to another video thumbail
- [x] Check `duckplayer_view-from_youtube_automatic` is fired
