### PR TITLE
Fix popup menu IllegalStateException

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1026,11 +1026,13 @@ class BrowserTabFragment :
     private fun launchPopupMenu() {
         // small delay added to let keyboard disappear and avoid jarring transition
         binding.rootView.postDelayed(POPUP_MENU_DELAY) {
-            popupMenu.show(binding.rootView, omnibar.toolbar)
-            if (isActiveCustomTab()) {
-                pixel.fire(CustomTabPixelNames.CUSTOM_TABS_MENU_OPENED)
-            } else {
-                pixel.fire(AppPixelName.MENU_ACTION_POPUP_OPENED.pixelName)
+            if (isAdded) {
+                popupMenu.show(binding.rootView, omnibar.toolbar)
+                if (isActiveCustomTab()) {
+                    pixel.fire(CustomTabPixelNames.CUSTOM_TABS_MENU_OPENED)
+                } else {
+                    pixel.fire(AppPixelName.MENU_ACTION_POPUP_OPENED.pixelName)
+                }
             }
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1200204095367872/1208539373099910/f

### Description
Fixes a `IllegalStateException` when showing the omnibar menu.

### Steps to test this PR

- [x] Tap the omnibar menu
- [x] Verify that the omnibar is shown
