### PR TITLE
Avoid location permission messages for Duck AI

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1586,12 +1586,21 @@ class BrowserTabViewModel @Inject constructor(
         val permissionEntity = locationPermissionsRepository.getDomainPermission(domain)
         permissionEntity?.let {
             if (it.permission == LocationPermissionType.ALLOW_ALWAYS) {
+                Timber.d("Location Permission: domain $domain site url ${site?.url}")
                 if (!locationPermissionMessages.containsKey(domain)) {
                     setDomainHasLocationPermissionShown(domain)
-                    command.postValue(ShowDomainHasPermissionMessage(domain))
+                    if (shouldShowLocationPermissionMessage()) {
+                        Timber.d("Show location permission for $domain")
+                        command.postValue(ShowDomainHasPermissionMessage(domain))
+                    }
                 }
             }
         }
+    }
+
+    private fun shouldShowLocationPermissionMessage(): Boolean {
+        val url = site?.url ?: return true
+        return !duckDuckGoUrlDetector.isDuckDuckGoChatUrl(url)
     }
 
     private fun setDomainHasLocationPermissionShown(domain: String) {

--- a/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoUrlDetector.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoUrlDetector.kt
@@ -75,6 +75,14 @@ class DuckDuckGoUrlDetectorImpl @Inject constructor() : DuckDuckGoUrlDetector {
         return uri.getQueryParameter(ParamKey.VERTICAL)
     }
 
+    override fun isDuckDuckGoChatUrl(uri: String): Boolean {
+        return isDuckDuckGoVerticalUrl(uri) && isDuckAIChat(uri)
+    }
+
+    private fun isDuckAIChat(uri: String): Boolean {
+        return uri.toUri().queryParameterNames.contains(ParamKey.DUCK_AI)
+    }
+
     private fun String.toUri(): Uri {
         return Uri.parse(this)
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoUrlDetector.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoUrlDetector.kt
@@ -77,22 +77,12 @@ class DuckDuckGoUrlDetectorImpl @Inject constructor() : DuckDuckGoUrlDetector {
     }
 
     override fun isDuckDuckGoChatUrl(uri: String): Boolean {
-        return isDuckDuckGoUrl(uri) && isDuckAIChat(uri)
+        return isDuckDuckGoUrl(uri) && hasAIChatVertical(uri)
     }
 
-    private fun isDuckAIChat(uri: String): Boolean {
-        val hasChatVertical = hasChatVertical(uri)
-        val hasChatParameter = hasDuckAI(uri)
-        return hasChatVertical || hasChatParameter
-    }
-
-    private fun hasChatVertical(uri: String): Boolean {
+    private fun hasAIChatVertical(uri: String): Boolean {
         val vertical = extractVertical(uri)
         return vertical == ParamValue.CHAT_VERTICAL
-    }
-
-    private fun hasDuckAI(uri: String): Boolean {
-        return uri.toUri().queryParameterNames.contains(ParamKey.DUCK_AI)
     }
 
     private fun String.toUri(): Uri {

--- a/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoUrlDetector.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoUrlDetector.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.browser
 import android.net.Uri
 import com.duckduckgo.common.utils.AppUrl
 import com.duckduckgo.common.utils.AppUrl.ParamKey
+import com.duckduckgo.common.utils.AppUrl.ParamValue
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
@@ -76,10 +77,21 @@ class DuckDuckGoUrlDetectorImpl @Inject constructor() : DuckDuckGoUrlDetector {
     }
 
     override fun isDuckDuckGoChatUrl(uri: String): Boolean {
-        return isDuckDuckGoVerticalUrl(uri) && isDuckAIChat(uri)
+        return isDuckDuckGoUrl(uri) && isDuckAIChat(uri)
     }
 
     private fun isDuckAIChat(uri: String): Boolean {
+        val hasChatVertical = hasChatVertical(uri)
+        val hasChatParameter = hasDuckAI(uri)
+        return hasChatVertical || hasChatParameter
+    }
+
+    private fun hasChatVertical(uri: String): Boolean {
+        val vertical = extractVertical(uri)
+        return vertical == ParamValue.CHAT_VERTICAL
+    }
+
+    private fun hasDuckAI(uri: String): Boolean {
         return uri.toUri().queryParameterNames.contains(ParamKey.DUCK_AI)
     }
 

--- a/app/src/test/java/com/duckduckgo/app/browser/DuckDuckGoUrlDetectorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/DuckDuckGoUrlDetectorTest.kt
@@ -169,8 +169,14 @@ class DuckDuckGoUrlDetectorTest {
     }
 
     @Test
-    fun whenDDGAIChatThenReturnsTrue() {
+    fun whenDDGAIChatVerticalThenReturnsTrue() {
         val url = "https://duckduckgo.com/?q=restaurants+near+me&atb=v451-7ru&ko=-1&t=ddg_android&ia=chat"
+        assertTrue(testee.isDuckDuckGoChatUrl(url))
+    }
+
+    @Test
+    fun whenDDGAIChatParameterThenReturnsTrue() {
+        val url = "https://duckduckgo.com/?q=restaurants+near+me&atb=v451-7ru&ko=-1&t=ddg_android&duckai=1"
         assertTrue(testee.isDuckDuckGoChatUrl(url))
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/DuckDuckGoUrlDetectorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/DuckDuckGoUrlDetectorTest.kt
@@ -175,8 +175,14 @@ class DuckDuckGoUrlDetectorTest {
     }
 
     @Test
-    fun whenDDGAIChatParameterThenReturnsTrue() {
+    fun whenDDGAIChatParameterThenReturnsFalse() {
         val url = "https://duckduckgo.com/?q=restaurants+near+me&atb=v451-7ru&ko=-1&t=ddg_android&duckai=1"
+        assertFalse(testee.isDuckDuckGoChatUrl(url))
+    }
+
+    @Test
+    fun whenDDGAIChatVerticalAndAIChatParameterThenReturnsTrue() {
+        val url = "https://duckduckgo.com/?q=restaurants+near+me&atb=v451-7ru&ko=-1&t=ddg_android&ia=chat&duckai=1"
         assertTrue(testee.isDuckDuckGoChatUrl(url))
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/DuckDuckGoUrlDetectorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/DuckDuckGoUrlDetectorTest.kt
@@ -155,4 +155,22 @@ class DuckDuckGoUrlDetectorTest {
     fun whenUrlHasNoSchemeAndIsFromDuckDuckGoUrlThenReturnsFalse() {
         assertFalse(testee.isDuckDuckGoEmailUrl("duckduckgo.com/email"))
     }
+
+    @Test
+    fun whenDDGUrlContainsChatParameterThenCanBeRecognised() {
+        val vertical = testee.extractVertical("https://duckduckgo.com/?q=new+zealand+images&t=ffab&atb=v218-6&iar=images&iax=images&ia=images")
+        assertEquals("images", vertical)
+    }
+
+    @Test
+    fun whenDDGUrlNonChatThenReturnsFalse() {
+        val url = "https://duckduckgo.com/?q=restaurants+near+me&atb=v451-7ru&ko=-1&t=ddg_android&ia=web"
+        assertFalse(testee.isDuckDuckGoChatUrl(url))
+    }
+
+    @Test
+    fun whenDDGAIChatThenReturnsTrue() {
+        val url = "https://duckduckgo.com/?q=restaurants+near+me&atb=v451-7ru&ko=-1&t=ddg_android&ia=chat"
+        assertTrue(testee.isDuckDuckGoChatUrl(url))
+    }
 }

--- a/browser-api/src/main/java/com/duckduckgo/app/browser/DuckDuckGoUrlDetector.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/browser/DuckDuckGoUrlDetector.kt
@@ -65,4 +65,11 @@ interface DuckDuckGoUrlDetector {
      * @return the vertical of a given uri and null if it cannot find it.
      */
     fun extractVertical(uriString: String): String?
+
+    /**
+     * This method takes a [uri] and returns `true` or `false`.
+     * @return `true` if the given [uri] is a DuckDuckGo Chat and `false`
+     * otherwise.
+     */
+    fun isDuckDuckGoChatUrl(uri: String): Boolean
 }

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/AppUrl.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/AppUrl.kt
@@ -41,7 +41,6 @@ class AppUrl {
         const val HIDE_SERP = "ko"
         const val VERTICAL = "ia"
         const val VERTICAL_REWRITE = "iar"
-        const val DUCK_AI = "duckai"
     }
 
     object ParamValue {

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/AppUrl.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/AppUrl.kt
@@ -41,12 +41,14 @@ class AppUrl {
         const val HIDE_SERP = "ko"
         const val VERTICAL = "ia"
         const val VERTICAL_REWRITE = "iar"
+        const val DUCK_AI = "duckai"
     }
 
     object ParamValue {
         const val SOURCE = "ddg_android"
         const val SOURCE_EU_AUCTION = "ddg_androideu"
         const val HIDE_SERP = "-1"
+        const val CHAT_VERTICAL = "chat"
     }
 
     object StaticUrl {

--- a/privacy-protections-popup/privacy-protections-popup-impl/src/test/java/com/duckduckgo/privacyprotectionspopup/impl/PrivacyProtectionsPopupManagerImplTest.kt
+++ b/privacy-protections-popup/privacy-protections-popup-impl/src/test/java/com/duckduckgo/privacyprotectionspopup/impl/PrivacyProtectionsPopupManagerImplTest.kt
@@ -706,6 +706,7 @@ private class FakeDuckDuckGoUrlDetector : DuckDuckGoUrlDetector {
     override fun extractQuery(uriString: String): String? = throw UnsupportedOperationException()
     override fun isDuckDuckGoVerticalUrl(uri: String): Boolean = throw UnsupportedOperationException()
     override fun extractVertical(uriString: String): String? = throw UnsupportedOperationException()
+    override fun isDuckDuckGoChatUrl(uri: String): Boolean = throw UnsupportedOperationException()
 }
 
 private class FakePrivacyProtectionsPopupExperimentVariantRandomizer : PrivacyProtectionsPopupExperimentVariantRandomizer {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208539436428546/f

### Description
This PR avoids showing the location permission snackbar when user is in AI Chat

### Steps to test this PR
_Enable location permission from SERP_
- [x] Open app and search for restaurants near me
- [x] When prompted, allow for location permission ALWAYS
- [x] Close the app

_Duck AI directly_
- [x] navigate to duck.ai
- [x] verify that location snackbar doesn’t appear
- [x] Close the app

_AI Chat via SERP_
- [x] navigate to serp and open Duck AI from the SERP toolbar
- [x] verify that location snackbar doesn’t appear
