### PR TITLE
Version Code for first Nightly ends in 1

### DIFF
--- a/versioning.gradle
+++ b/versioning.gradle
@@ -50,7 +50,7 @@ ext {
                 def newCode = Integer.parseInt(code) + 1
                 return newCode
             } else {
-                return 0
+                return 1
             }
         } else {
             return 0


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/0/414730916066338/1208559052787559

### Description
Fix versionCode script so it returns the proper number.
The first nightly after a prod release should be a 1, not a 0

### Steps to test this PR

_Current repo state, fetch all tags_
- [x] ./gradlew -q getBuildVersionCode -PversionNameSuffix=-nightly 
- [x] Verify result is 1
- [x] ./gradlew -q getBuildVersionCode
- [x] Verify result is 0