### PR TITLE
rollback privacy config

### DIFF
--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/network/PrivacyConfigService.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/network/PrivacyConfigService.kt
@@ -18,13 +18,13 @@ package com.duckduckgo.privacy.config.impl.network
 
 import com.duckduckgo.anvil.annotations.ContributesServiceApi
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.privacy.config.api.PRIVACY_REMOTE_CONFIG_URL
 import com.duckduckgo.privacy.config.impl.models.JsonPrivacyConfig
 import retrofit2.Response
 import retrofit2.http.GET
 
 @ContributesServiceApi(AppScope::class)
 interface PrivacyConfigService {
-    // @GET(PRIVACY_REMOTE_CONFIG_URL)
-    @GET("http://www.jsonblob.com/api/1293131135817998336")
+    @GET(PRIVACY_REMOTE_CONFIG_URL)
     suspend fun privacyConfig(): Response<JsonPrivacyConfig>
 }


### PR DESCRIPTION
Task/Issue URL: 

### Description
Very quick at merging https://github.com/duckduckgo/Android/pulls?q=is%3Apr+is%3Aclosed+author%3Amalmstein, didn’t realise Privacy Config was pointing to a JsonBlob

### Steps to test this PR
Verify Privacy Config Service points to the correct address