### PR TITLE
Fix Disconnect/re-connect from notification when both VPN and AppTP are enabled

### DIFF
--- a/app-tracking-protection/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/Vpn.kt
+++ b/app-tracking-protection/vpn-api/src/main/java/com/duckduckgo/mobile/android/vpn/Vpn.kt
@@ -26,7 +26,15 @@ interface Vpn {
     suspend fun start()
 
     /**
-     * Disable the device VPN by stopping the VPN service
+     * Pauses the VPN tunnel.
+     * All features that were registered to use the VPN tunnel (eg. AppTP, NetP) continue to be registered and so a subsequent
+     * [start] call will re-enable them all
+     */
+    suspend fun pause()
+
+    /**
+     * Stops the VPN tunnel AND all features registered to use the VPN tunnel (eg. AppTP, NetP). A subsequent call to [start]
+     * will not re-start the VPN because no feature would be registered.
      */
     suspend fun stop()
 

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/di/VpnAppModule.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/di/VpnAppModule.kt
@@ -21,12 +21,7 @@ import android.content.res.Resources
 import android.net.ConnectivityManager
 import androidx.room.Room
 import com.duckduckgo.common.utils.DispatcherProvider
-import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.mobile.android.vpn.Vpn
-import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
-import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistryImpl
-import com.duckduckgo.mobile.android.vpn.VpnServiceWrapper
 import com.duckduckgo.mobile.android.vpn.stats.AppTrackerBlockingStatsRepository
 import com.duckduckgo.mobile.android.vpn.stats.RealAppTrackerBlockingStatsRepository
 import com.duckduckgo.mobile.android.vpn.store.*
@@ -86,25 +81,6 @@ object VpnAppModule {
     @SingleInstanceIn(AppScope::class)
     fun providesResources(context: Context): Resources {
         return context.resources
-    }
-
-    @Provides
-    @SingleInstanceIn(AppScope::class)
-    fun provideVpnFeaturesRegistry(
-        context: Context,
-        sharedPreferencesProvider: SharedPreferencesProvider,
-        dispatcherProvider: DispatcherProvider,
-    ): VpnFeaturesRegistry {
-        return VpnFeaturesRegistryImpl(VpnServiceWrapper(context, dispatcherProvider), sharedPreferencesProvider, dispatcherProvider)
-    }
-
-    @Provides
-    @SingleInstanceIn(AppScope::class)
-    fun provideVpnServiceWrapper(
-        context: Context,
-        dispatcherProvider: DispatcherProvider,
-    ): Vpn {
-        return VpnServiceWrapper(context, dispatcherProvider)
     }
 
     @Provides

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/VpnActionReceiver.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/VpnActionReceiver.kt
@@ -25,8 +25,10 @@ import android.os.SystemClock
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ReceiverScope
+import com.duckduckgo.mobile.android.app.tracking.AppTrackingProtection
 import com.duckduckgo.mobile.android.vpn.Vpn
 import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixels
+import com.duckduckgo.networkprotection.api.NetworkProtectionState
 import dagger.android.AndroidInjection
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
@@ -37,6 +39,10 @@ import logcat.logcat
 @InjectWith(ReceiverScope::class)
 class VpnActionReceiver : BroadcastReceiver() {
     @Inject lateinit var vpn: Vpn
+
+    @Inject lateinit var networkProtectionState: NetworkProtectionState
+
+    @Inject lateinit var appTrackingProtection: AppTrackingProtection
 
     @Inject lateinit var dispatcherProvider: DispatcherProvider
 
@@ -65,7 +71,10 @@ class VpnActionReceiver : BroadcastReceiver() {
             ACTION_VPN_DISABLE -> {
                 logcat { "Entire VPN will disabled because the user asked it" }
                 goAsync(pendingResult) {
+                    // instead of stopping the VPN, we stop the VPN features individually
                     vpn.stop()
+                    appTrackingProtection.stop()
+                    networkProtectionState.stop()
                 }
             }
 

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/VpnActionReceiver.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/VpnActionReceiver.kt
@@ -71,10 +71,7 @@ class VpnActionReceiver : BroadcastReceiver() {
             ACTION_VPN_DISABLE -> {
                 logcat { "Entire VPN will disabled because the user asked it" }
                 goAsync(pendingResult) {
-                    // instead of stopping the VPN, we stop the VPN features individually
                     vpn.stop()
-                    appTrackingProtection.stop()
-                    networkProtectionState.stop()
                 }
             }
 

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/notification/AppTPAndNetPEnabledNotificationContentPlugin.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/notification/AppTPAndNetPEnabledNotificationContentPlugin.kt
@@ -33,6 +33,7 @@ import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.runBlocking
 
@@ -77,6 +78,7 @@ class AppTPAndNetPEnabledNotificationContentPlugin @Inject constructor(
         }
 
         return repository.getVpnTrackers({ dateOfLastHour() })
+            .filter { isActive() } // make sure we only emit when this plugin is active
             .map { trackersBlocked ->
                 val trackingApps = trackersBlocked.trackingApps()
                 val location = networkProtectionState.serverLocation()

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/notification/AppTpEnabledNotificationContentPlugin.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/notification/AppTpEnabledNotificationContentPlugin.kt
@@ -79,6 +79,7 @@ class AppTpEnabledNotificationContentPlugin @Inject constructor(
         }
 
         return repository.getVpnTrackers({ dateOfLastHour() })
+            .filter { isActive() } // make sure we only emit when this plugin is active
             .map { trackersBlocked ->
                 val trackingApps = trackersBlocked.trackingApps()
                 val isEnabled = appTrackingProtection.isEnabled()

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/VpnFeaturesRegistryImplTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/VpnFeaturesRegistryImplTest.kt
@@ -20,7 +20,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.test.api.InMemorySharedPreferences
-import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
@@ -44,7 +43,7 @@ class VpnFeaturesRegistryImplTest {
     @Before
     fun setup() {
         val prefs = InMemorySharedPreferences()
-        vpnServiceWrapper = TestVpnServiceWrapper(coroutineTestRule.testDispatcherProvider)
+        vpnServiceWrapper = TestVpnServiceWrapper()
 
         whenever(
             sharedPreferencesProvider.getSharedPreferences(eq("com.duckduckgo.mobile.android.vpn.feature.registry.v1"), eq(true), eq(false)),
@@ -163,9 +162,7 @@ class VpnFeaturesRegistryImplTest {
         BAR("BAR"),
     }
 
-    private class TestVpnServiceWrapper constructor(
-        dispatcher: DispatcherProvider,
-    ) : VpnServiceWrapper(InstrumentationRegistry.getInstrumentation().context, dispatcher) {
+    private class TestVpnServiceWrapper constructor() : VpnServiceWrapper(InstrumentationRegistry.getInstrumentation().context) {
         private var isRunning = false
         var restartCount = 0
 

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/service/notification/AppTPAndNetPEnabledNotificationContentPluginTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/service/notification/AppTPAndNetPEnabledNotificationContentPluginTest.kt
@@ -137,6 +137,8 @@ class AppTPAndNetPEnabledNotificationContentPluginTest {
     @Test
     fun getUpdateContentThenReturnsCorrectInitialUpdatedNotificationContent() = runTest {
         whenever(networkProtectionState.serverLocation()).thenReturn("Stockholm, SE")
+        whenever(appTrackingProtection.isEnabled()).thenReturn(true)
+        whenever(networkProtectionState.isEnabled()).thenReturn(true)
 
         plugin.getUpdatedContent().test {
             val item = awaitItem()
@@ -151,6 +153,8 @@ class AppTPAndNetPEnabledNotificationContentPluginTest {
     @Test
     fun getUpdateContentOneCompanyThenReturnsCorrectUpdatedNotificationContent() = runTest {
         whenever(networkProtectionState.serverLocation()).thenReturn("Stockholm, SE")
+        whenever(appTrackingProtection.isEnabled()).thenReturn(true)
+        whenever(networkProtectionState.isEnabled()).thenReturn(true)
 
         plugin.getUpdatedContent().test {
             val trackers = listOf(aTrackerAndCompany())
@@ -169,6 +173,8 @@ class AppTPAndNetPEnabledNotificationContentPluginTest {
     @Test
     fun getUpdateContentMultipleDifferentAppsThenReturnsCorrectUpdatedNotificationContent() = runTest {
         whenever(networkProtectionState.serverLocation()).thenReturn("Stockholm, SE")
+        whenever(appTrackingProtection.isEnabled()).thenReturn(true)
+        whenever(networkProtectionState.isEnabled()).thenReturn(true)
 
         plugin.getUpdatedContent().test {
             val trackers = listOf(
@@ -193,6 +199,8 @@ class AppTPAndNetPEnabledNotificationContentPluginTest {
     @Test
     fun getUpdateContentMultipleDifferentAppsNoLocationThenReturnsCorrectUpdatedNotificationContent() = runTest {
         whenever(networkProtectionState.serverLocation()).thenReturn(null)
+        whenever(appTrackingProtection.isEnabled()).thenReturn(true)
+        whenever(networkProtectionState.isEnabled()).thenReturn(true)
 
         plugin.getUpdatedContent().test {
             val trackers = listOf(
@@ -217,6 +225,8 @@ class AppTPAndNetPEnabledNotificationContentPluginTest {
     @Test
     fun getUpdateContentTrackersWithoutEntityThenReturnsCorrectUpdatedNotificationContent() = runTest {
         whenever(networkProtectionState.serverLocation()).thenReturn("Stockholm, SE")
+        whenever(appTrackingProtection.isEnabled()).thenReturn(true)
+        whenever(networkProtectionState.isEnabled()).thenReturn(true)
 
         plugin.getUpdatedContent().test {
             appTrackerBlockingStatsRepository.insert(listOf(aTrackerAndCompany(), aTrackerAndCompany()))
@@ -232,6 +242,8 @@ class AppTPAndNetPEnabledNotificationContentPluginTest {
     @Test
     fun getUpdateContentTrackersWithoutEntityNoLocationThenReturnsCorrectUpdatedNotificationContent() = runTest {
         whenever(networkProtectionState.serverLocation()).thenReturn(null)
+        whenever(appTrackingProtection.isEnabled()).thenReturn(true)
+        whenever(networkProtectionState.isEnabled()).thenReturn(true)
 
         plugin.getUpdatedContent().test {
             appTrackerBlockingStatsRepository.insert(listOf(aTrackerAndCompany(), aTrackerAndCompany()))
@@ -247,6 +259,8 @@ class AppTPAndNetPEnabledNotificationContentPluginTest {
     @Test
     fun getUpdateContentMultipleSameThenReturnsCorrectUpdatedNotificationContent() = runTest {
         whenever(networkProtectionState.serverLocation()).thenReturn("Stockholm, SE")
+        whenever(appTrackingProtection.isEnabled()).thenReturn(true)
+        whenever(networkProtectionState.isEnabled()).thenReturn(true)
 
         plugin.getUpdatedContent().test {
             appTrackerBlockingStatsRepository.insert(listOf(aTrackerAndCompany(), aTrackerAndCompany()))
@@ -265,6 +279,8 @@ class AppTPAndNetPEnabledNotificationContentPluginTest {
     @Test
     fun getUpdateContentMultipleSameNoLocationThenReturnsCorrectUpdatedNotificationContent() = runTest {
         whenever(networkProtectionState.serverLocation()).thenReturn(null)
+        whenever(appTrackingProtection.isEnabled()).thenReturn(true)
+        whenever(networkProtectionState.isEnabled()).thenReturn(true)
 
         plugin.getUpdatedContent().test {
             appTrackerBlockingStatsRepository.insert(listOf(aTrackerAndCompany(), aTrackerAndCompany()))

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/service/notification/AppTpEnabledNotificationContentPluginTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/service/notification/AppTpEnabledNotificationContentPluginTest.kt
@@ -130,15 +130,12 @@ class AppTpEnabledNotificationContentPluginTest {
     }
 
     @Test
-    fun getUpdateContentAppTpNotEnabledThenReturnsCorrectInitialUpdatedNotificationContent() = runTest {
+    fun getUpdateContentAppTpNotEnabledThenReturnsNoContent() = runTest {
         whenever(appTrackingProtection.isEnabled()).thenReturn(false)
+        whenever(networkProtectionState.isEnabled()).thenReturn(false)
 
         plugin.getUpdatedContent().test {
-            val item = awaitItem()
-
-            item.assertTextEquals("")
-
-            cancelAndConsumeRemainingEvents()
+            expectNoEvents()
         }
     }
 
@@ -162,20 +159,16 @@ class AppTpEnabledNotificationContentPluginTest {
     }
 
     @Test
-    fun getUpdateContentOneCompanyAppTpNotEnabledThenReturnsCorrectUpdatedNotificationContent() = runTest {
+    fun getUpdateContentOneCompanyAppTpNotEnabledThenReturnsNoContent() = runTest {
         whenever(appTrackingProtection.isEnabled()).thenReturn(false)
+        whenever(networkProtectionState.isEnabled()).thenReturn(false)
 
         plugin.getUpdatedContent().test {
             val trackers = listOf(aTrackerAndCompany())
             appTrackerBlockingStatsRepository.insert(trackers)
             db.vpnAppTrackerBlockingDao().insertTrackerEntities(trackers.map { it.asEntity() })
 
-            skipItems(1)
-            val item = awaitItem()
-
-            item.assertTextEquals("")
-
-            cancelAndConsumeRemainingEvents()
+            expectNoEvents()
         }
     }
 
@@ -205,8 +198,9 @@ class AppTpEnabledNotificationContentPluginTest {
     }
 
     @Test
-    fun getUpdateContentMultipleDifferentAppsAppTpNotEnabledThenReturnsCorrectUpdatedNotificationContent() = runTest {
+    fun getUpdateContentMultipleDifferentAppsAppTpNotEnabledThenReturnsNoContent() = runTest {
         whenever(appTrackingProtection.isEnabled()).thenReturn(false)
+        whenever(networkProtectionState.isEnabled()).thenReturn(false)
 
         plugin.getUpdatedContent().test {
             val trackers = listOf(
@@ -220,12 +214,7 @@ class AppTpEnabledNotificationContentPluginTest {
             appTrackerBlockingStatsRepository.insert(trackers)
             db.vpnAppTrackerBlockingDao().insertTrackerEntities(trackers.map { it.asEntity() })
 
-            skipItems(1)
-            val item = awaitItem()
-
-            item.assertTextEquals("")
-
-            cancelAndConsumeRemainingEvents()
+            expectNoEvents()
         }
     }
 
@@ -265,16 +254,13 @@ class AppTpEnabledNotificationContentPluginTest {
     }
 
     @Test
-    fun getUpdateContentMultipleSameAppTpNotEnabledThenReturnsCorrectUpdatedNotificationContent() = runTest {
+    fun getUpdateContentMultipleSameAppTpNotEnabledThenReturnsNoContent() = runTest {
         whenever(appTrackingProtection.isEnabled()).thenReturn(false)
+        whenever(networkProtectionState.isEnabled()).thenReturn(false)
         plugin.getUpdatedContent().test {
             appTrackerBlockingStatsRepository.insert(listOf(aTrackerAndCompany(), aTrackerAndCompany()))
 
-            val item = expectMostRecentItem()
-
-            item.assertTextEquals("")
-
-            cancelAndConsumeRemainingEvents()
+            expectNoEvents()
         }
     }
 

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/snooze/VpnCallStateReceiver.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/snooze/VpnCallStateReceiver.kt
@@ -71,7 +71,7 @@ class VpnCallStateReceiver @Inject constructor(
                         if (state == TelephonyManager.CALL_STATE_IDLE) {
                             vpn.start()
                         } else {
-                            vpn.stop()
+                            vpn.pause()
                         }
                     }
                 }

--- a/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/WgVpnNetworkStackTest.kt
+++ b/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/WgVpnNetworkStackTest.kt
@@ -230,7 +230,7 @@ class WgVpnNetworkStackTest {
     }
 
     @Test
-    fun whenOnStopVpnWithSelfStopThenResetEnabledTimeInMillisAndServerDetails() = runTest {
+    fun whenOnStopVpnWithSelfPauseThenResetEnabledTimeInMillisAndServerDetails() = runTest {
         assertEquals(
             Result.success(Unit),
             wgVpnNetworkStack.onStopVpn(SELF_STOP()),
@@ -242,7 +242,7 @@ class WgVpnNetworkStackTest {
     }
 
     @Test
-    fun whenOnStopVpnWithRestartThenResetEnabledTimeInMillisAndServerDetails() = runTest {
+    fun whenOnPauseVpnWithRestartThenResetEnabledTimeInMillisAndServerDetails() = runTest {
         assertEquals(
             Result.success(Unit),
             wgVpnNetworkStack.onStopVpn(RESTART),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208536273997127/f

### Description
Fix bug when both AppTP and VPN are enabled and user `disconnects` from the notification. 
When that happens two notifications are showed with CTAs to re-enable AppTP and VPN resp.
Expected:
* AppTP enable enables just ApptP
* VPN enable just enables VPN

Actual
* either ApptP or VPN enable enable both

### Steps to test this PR

_Test Fix_
- [x] Enable both AppTP and VPN
- [x] In the combined AppTP/VPN notification press `Disconnect`
- [x] Verify two notifications, for AppTP and VPN are shown
- [x] Click on AppTP notification, enable CTA
- [x] verify only AppTP is enabled
- [x] Click on VPN notification, enable CTA
- [x] verify only VPN is enabled
- [x] repeat this test in the inverse order, before VPN then AppTP

_Test combined notification_
- [x] After doing _Test Fix_ above
- [x] open apps with trackers
- [x] verify AppTP blocks trackers and combined notification works as expected
- [x] smoke test

_Test AppTP_
- [x] smoke test AppTP only

_Test VPN_
- [x] smoke test VPN only

