### PR TITLE
Fix IllegalArgumentException when savedSiteAdded

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -3026,9 +3026,11 @@ class BrowserTabFragment :
     private fun savedSiteAdded(savedSiteChangedViewState: SavedSiteChangedViewState) {
         val dismissHandler = Handler(Looper.getMainLooper())
         val dismissRunnable = Runnable {
-            bookmarksBottomSheetDialog?.dialog?.let { dialog ->
-                if (dialog.isShowing) {
-                    dialog.dismiss()
+            if (isAdded) {
+                bookmarksBottomSheetDialog?.dialog?.let { dialog ->
+                    if (dialog.isShowing) {
+                        dialog.dismiss()
+                    }
                 }
             }
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208580918293540/f

### Description

- Another attempt at fixing an `IllegalArgumentException` when `savedSiteAdded`.
- First attempt: https://github.com/duckduckgo/Android/pull/4900

### Steps to test this PR

_Add bookmark_
- [x] Go to a site
- [x] Tap the overflow and “Add Bookmark"
- [x] Verify that the `BottomSheetDialog` dismisses automatically
