### PR TITLE
Fix Duck Player not loading in Android 8. Fixes #5148

### DIFF
--- a/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/RealDuckPlayer.kt
+++ b/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/RealDuckPlayer.kt
@@ -308,7 +308,7 @@ class RealDuckPlayer @Inject constructor(
         webView: WebView,
     ): WebResourceResponse {
         val path = getDuckPlayerAssetsPath(url)
-        val mimeType = mimeTypeMap.getMimeTypeFromExtension(path?.substringAfterLast("."))
+        val mimeType = getMimeTypeFromExtension(path?.substringAfterLast("."))
 
         if (path != null && mimeType != null) {
             try {
@@ -333,6 +333,16 @@ class RealDuckPlayer @Inject constructor(
                     )
                 }
             }
+        }
+    }
+
+    private fun getMimeTypeFromExtension(extension: String?): String? {
+        return mimeTypeMap.getMimeTypeFromExtension(extension) ?: when (extension) {
+            "css" -> "text/css"
+            "html" -> "text/html"
+            "js" -> "application/javascript"
+            "jpg" -> "image/jpeg"
+            else -> null
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414730916066338/1208567891699607/f 

### Description
Fixes https://github.com/duckduckgo/Android/issues/5148
Looks like there's a bug in MimeTypeMap on Android that causes it to return null for JS files in some Android versions, which prevents Duck Player from loading. Added a fallback for such cases

### Steps to test this PR

_Feature 1_
- [x] Install app in a device running Android 8
- [x] If app crashes on startup due to an old webview, follow instructions here https://app.asana.com/0/0/1208589697450045/f
- [x] Search for a YouTube video
- [x] Open in Duck Player
- [x] Check Duck Player loads and is functional
