### PR TITLE
Show on App Launch: Fix website showing after clear data action

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -379,7 +379,9 @@ open class BrowserActivity : DuckDuckGoActivity() {
             }
         }
 
-        viewModel.handleShowOnAppLaunchOption()
+        if (!intent.getBooleanExtra(LAUNCH_FROM_CLEAR_DATA_ACTION, false)) {
+            viewModel.handleShowOnAppLaunchOption()
+        }
     }
 
     private fun configureObservers() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -584,8 +584,6 @@ open class BrowserActivity : DuckDuckGoActivity() {
         const val OPEN_IN_CURRENT_TAB_EXTRA = "OPEN_IN_CURRENT_TAB_EXTRA"
         const val SELECTED_TEXT_EXTRA = "SELECTED_TEXT_EXTRA"
 
-        private const val APP_ENJOYMENT_DIALOG_TAG = "AppEnjoyment"
-
         private const val LAUNCH_FROM_EXTERNAL_EXTRA = "LAUNCH_FROM_EXTERNAL_EXTRA"
 
         private const val MAX_ACTIVE_TABS = 40

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -564,6 +564,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
             openInCurrentTab: Boolean = false,
             selectedText: Boolean = false,
             isExternal: Boolean = false,
+            isLaunchFromClearDataAction: Boolean = false,
         ): Intent {
             val intent = Intent(context, BrowserActivity::class.java)
             intent.putExtra(EXTRA_TEXT, queryExtra)
@@ -572,6 +573,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
             intent.putExtra(OPEN_IN_CURRENT_TAB_EXTRA, openInCurrentTab)
             intent.putExtra(SELECTED_TEXT_EXTRA, selectedText)
             intent.putExtra(LAUNCH_FROM_EXTERNAL_EXTRA, isExternal)
+            intent.putExtra(LAUNCH_FROM_CLEAR_DATA_ACTION, isLaunchFromClearDataAction)
             return intent
         }
 
@@ -585,6 +587,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
         const val SELECTED_TEXT_EXTRA = "SELECTED_TEXT_EXTRA"
 
         private const val LAUNCH_FROM_EXTERNAL_EXTRA = "LAUNCH_FROM_EXTERNAL_EXTRA"
+        private const val LAUNCH_FROM_CLEAR_DATA_ACTION = "LAUNCH_FROM_CLEAR_DATA_ACTION"
 
         private const val MAX_ACTIVE_TABS = 40
     }

--- a/app/src/main/java/com/duckduckgo/app/fire/FireActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/FireActivity.kt
@@ -80,7 +80,7 @@ class FireActivity : AppCompatActivity() {
             context: Context,
             notifyDataCleared: Boolean = false,
         ): Intent {
-            val intent = BrowserActivity.intent(context, notifyDataCleared = notifyDataCleared)
+            val intent = BrowserActivity.intent(context, notifyDataCleared = notifyDataCleared, isLaunchFromClearDataAction = true)
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
             return intent
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207908166761516/1208588631698784/f 

### Description

When clearing data with the fire button the website set for Specific Page would load if that option was enabled.

This stops that happening and instead shows the new tab page.

### Steps to test this PR

_Fire button_
- [x] Open Settings
- [x] Open General Settings
- [x] Open Show on App Launch feature
- [x] Enable Specific Page option
- [x] Leave default web address
- [x] Go back to Browser screen
- [x] Press the fire button
- [x] Wait until the app relaunches
- [x] The default webpage (duckduckgo.com) should not load
- [x] The new tab page should be visible

### UI changes

N/A

### Demo

https://github.com/user-attachments/assets/03298b73-9682-485d-8be7-50b5ad5d13a4