### PR TITLE
Bug: Unable to delete autocomplete history items

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -1470,7 +1470,7 @@ class BrowserTabViewModelTest {
             whenever(mockAutoCompleteScorer.score("title", "https://foo.com".toUri(), 1, "title")).thenReturn(1)
             whenever(mockUserStageStore.getUserAppStage()).thenReturn(ESTABLISHED)
 
-            testee.autoCompleteSuggestionsShown()
+            testee.onAutoCompleteSuggestionsChanged()
             testee.autoCompleteStateFlow.value = "title"
             delay(500)
             testee.autoCompleteSuggestionsGone()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1777,6 +1777,7 @@ class BrowserTabFragment :
     }
 
     private fun autocompleteItemRemoved() {
+        viewModel.onAutoCompleteSuggestionsChanged()
         showKeyboardAndRestorePosition(autocompleteFirstVisibleItemPosition, autocompleteItemOffsetTop)
     }
 
@@ -3710,7 +3711,7 @@ class BrowserTabFragment :
                         binding.autoCompleteSuggestionsList.gone()
                     } else {
                         binding.autoCompleteSuggestionsList.show()
-                        viewModel.autoCompleteSuggestionsShown()
+                        viewModel.onAutoCompleteSuggestionsChanged()
                         autoCompleteSuggestionsAdapter.updateData(viewState.searchResults.query, viewState.searchResults.suggestions)
                         hideFocusedView()
                     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -3696,7 +3696,7 @@ class BrowserTabViewModel @Inject constructor(
         }
     }
 
-    fun autoCompleteSuggestionsShown() {
+    fun onAutoCompleteSuggestionsChanged() {
         configureAutoComplete()
     }
 

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
@@ -172,6 +172,10 @@ class SystemSearchActivity : DuckDuckGoActivity() {
         }
     }
 
+    fun onAutoCompleteSuggestionsChanged() {
+        configureAutoComplete()
+    }
+
     private fun sendLaunchPixels(intent: Intent) {
         when {
             launchedFromAssist(intent) -> pixel.fire(AppPixelName.APP_ASSIST_LAUNCH)
@@ -487,6 +491,7 @@ class SystemSearchActivity : DuckDuckGoActivity() {
     }
 
     private fun autocompleteItemRemoved() {
+        viewModel.onAutoCompleteSuggestionsChanged()
         showKeyboardAndRestorePosition()
     }
 

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchViewModel.kt
@@ -322,6 +322,10 @@ class SystemSearchViewModel @Inject constructor(
         }
     }
 
+    fun onAutoCompleteSuggestionsChanged() {
+        configureResults()
+    }
+
     private fun showRemoveSearchSuggestionDialog(suggestion: AutoCompleteSuggestion) {
         appCoroutineScope.launch(dispatchers.main()) {
             command.value = Command.ShowRemoveSearchSuggestionDialog(suggestion)

--- a/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDao.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDao.kt
@@ -23,7 +23,6 @@ import com.duckduckgo.app.tabs.model.TabSelectionEntity
 import com.duckduckgo.common.utils.swap
 import com.duckduckgo.di.scopes.AppScope
 import dagger.SingleInstanceIn
-import io.reactivex.Single
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -44,10 +43,6 @@ abstract class TabsDao {
 
     @Query("select * from tabs where deletable is 0 order by position")
     abstract fun flowTabs(): Flow<List<TabEntity>>
-
-    // TODO: ANA to remove this
-    @Query("select * from tabs where deletable is 0 order by position")
-    abstract fun singleTabs(): Single<List<TabEntity>>
 
     @Query("select * from tabs where deletable is 0 order by position")
     abstract fun liveTabs(): LiveData<List<TabEntity>>

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
@@ -34,7 +34,6 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import dagger.SingleInstanceIn
 import io.reactivex.Scheduler
-import io.reactivex.Single
 import io.reactivex.schedulers.Schedulers
 import java.util.UUID
 import javax.inject.Inject
@@ -81,8 +80,6 @@ class TabDataRepository @Inject constructor(
     private val siteData: LinkedHashMap<String, MutableLiveData<Site>> = LinkedHashMap()
 
     private var purgeDeletableTabsJob = ConflatedJob()
-
-    override fun getTabsObservable(): Single<List<TabEntity>> = tabsDao.singleTabs()
 
     override suspend fun add(
         url: String?,

--- a/browser-api/build.gradle
+++ b/browser-api/build.gradle
@@ -35,10 +35,6 @@ dependencies {
 
     // LiveData
     implementation AndroidX.lifecycle.liveDataKtx
-
-    // TODO: ANA to remove this
-    implementation "io.reactivex.rxjava2:rxjava:_"
-    implementation "io.reactivex.rxjava2:rxandroid:_"
 }
 android {
   namespace 'com.duckduckgo.browser.api'

--- a/browser-api/src/main/java/com/duckduckgo/app/tabs/model/TabRepository.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/tabs/model/TabRepository.kt
@@ -20,7 +20,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.duckduckgo.app.global.model.Site
 import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType
-import io.reactivex.Single
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharedFlow
 
@@ -43,8 +42,6 @@ interface TabRepository {
     val liveSelectedTab: LiveData<TabEntity>
 
     val tabSwitcherData: Flow<TabSwitcherData>
-
-    fun getTabsObservable(): Single<List<TabEntity>>
 
     /**
      * @return tabId of new record


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208592488628219/f

### Description
Fixed item deletion from suggestions.

### Steps to test this PR

Test in Browser:
- [x] Install from this  branch
- [x] Search for something, i.e. "dog food".
- [x] Search for "dog".
- [x] Long press and delete the "dog food" entry.
Verify:
- [x] That the keyboard is shown.
- [x] That the autocomplete list is shifted up (So the position of the entry is visible).
- [x] That the entry is deleted from the list.

Test using the widget
- [x] Install from this branch
- [x] Add the widget.
- [x] Search for something from the widget, i.e. "dog food".
- [x] Search for "dog".
- [x] Long press and delete the "dog food" entry.
Verify:
- [x] That the keyboard is shown.
- [x] That the autocomplete list is shifted up (So the position of the entry is visible).
- [x] That the entry is deleted from the list.

### NO UI changes
