### PR TITLE
Fix ANR caused by Duck Player

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
@@ -34,7 +34,6 @@ import com.duckduckgo.privacy.config.api.TrackingParameters
 import com.duckduckgo.subscriptions.api.Subscriptions
 import java.net.URISyntaxException
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import timber.log.Timber
 
@@ -92,9 +91,7 @@ class SpecialUrlDetectorImpl(
 
         val uri = uriString.toUri()
 
-        val willNavigateToDuckPlayerDeferred = scope.async(dispatcherProvider.io()) { duckPlayer.willNavigateToDuckPlayer(uri) }
-
-        val willNavigateToDuckPlayer = runBlocking(dispatcherProvider.io()) { willNavigateToDuckPlayerDeferred.await() }
+        val willNavigateToDuckPlayer = runBlocking(dispatcherProvider.io()) { duckPlayer.willNavigateToDuckPlayer(uri) }
 
         if (willNavigateToDuckPlayer) {
             return UrlType.ShouldLaunchDuckPlayerLink(url = uri)

--- a/app/src/main/java/com/duckduckgo/app/browser/duckplayer/DuckPlayerJSHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/duckplayer/DuckPlayerJSHelper.kt
@@ -98,7 +98,7 @@ class DuckPlayerJSHelper @Inject constructor(
         }
     }
 
-    private suspend fun getInitialSetup(featureName: String, method: String, id: String): JsCallbackData {
+    private fun getInitialSetup(featureName: String, method: String, id: String): JsCallbackData {
         val userValues = duckPlayer.getUserPreferences()
         val privatePlayerMode = if (duckPlayer.getDuckPlayerState() == ENABLED) userValues.privatePlayerMode else PrivatePlayerMode.Disabled
 

--- a/duckplayer/duckplayer-api/src/main/java/com/duckduckgo/duckplayer/api/DuckPlayer.kt
+++ b/duckplayer/duckplayer-api/src/main/java/com/duckduckgo/duckplayer/api/DuckPlayer.kt
@@ -50,7 +50,7 @@ interface DuckPlayer {
      *
      * @return The current state of the DuckPlayer as a DuckPlayerState enum.
      */
-    suspend fun getDuckPlayerState(): DuckPlayerState
+    fun getDuckPlayerState(): DuckPlayerState
 
     /**
      * Sends a pixel with the given name and data.
@@ -65,7 +65,7 @@ interface DuckPlayer {
      *
      * @return The user values.
      */
-    suspend fun getUserPreferences(): UserPreferences
+    fun getUserPreferences(): UserPreferences
 
     /**
      * Checks if the DuckPlayer overlay should be hidden after navigating back from Duck Player
@@ -105,7 +105,7 @@ interface DuckPlayer {
      * @param uri The YouTube no-cookie URI.
      * @return The DuckPlayer URI.
      */
-    suspend fun createDuckPlayerUriFromYoutubeNoCookie(uri: Uri): String?
+    fun createDuckPlayerUriFromYoutubeNoCookie(uri: Uri): String?
 
     /**
      * Checks if a string is a DuckPlayer URI.
@@ -120,7 +120,7 @@ interface DuckPlayer {
      * @param uri The DuckPlayer URI.
      * @return The YouTube URI.
      */
-    suspend fun createYoutubeWatchUrlFromDuckPlayer(uri: Uri): String?
+    fun createYoutubeWatchUrlFromDuckPlayer(uri: Uri): String?
 
     /**
      * Checks if a URI is a simulated YouTube no-cookie URI.
@@ -136,7 +136,7 @@ interface DuckPlayer {
      * @param uri The URI to check.
      * @return True if the URI is a YouTube no-cookie URI, false otherwise.
      */
-    suspend fun isYoutubeWatchUrl(uri: Uri): Boolean
+    fun isYoutubeWatchUrl(uri: Uri): Boolean
 
     /**
      * Checks if a URI is a YouTube URL.
@@ -184,7 +184,7 @@ interface DuckPlayer {
         destinationUrl: Uri,
     ): Boolean
 
-    suspend fun shouldOpenDuckPlayerInNewTab(): OpenDuckPlayerInNewTab
+    fun shouldOpenDuckPlayerInNewTab(): OpenDuckPlayerInNewTab
 
     fun observeShouldOpenInNewTab(): Flow<OpenDuckPlayerInNewTab>
 

--- a/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerFeatureRepository.kt
+++ b/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerFeatureRepository.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.duckplayer.impl
 
 import com.duckduckgo.app.di.AppCoroutineScope
-import com.duckduckgo.app.di.IsMainProcess
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckplayer.api.DuckPlayer.UserPreferences
@@ -38,7 +37,7 @@ interface DuckPlayerFeatureRepository {
 
     fun setDuckPlayerRemoteConfigJson(jsonString: String)
 
-    suspend fun getUserPreferences(): UserPreferences
+    fun getUserPreferences(): UserPreferences
 
     fun observeUserPreferences(): Flow<UserPreferences>
 
@@ -46,7 +45,7 @@ interface DuckPlayerFeatureRepository {
 
     suspend fun storeDuckPlayerDisabledHelpPageLink(duckPlayerDisabledHelpPageLink: String?)
 
-    suspend fun getDuckPlayerDisabledHelpPageLink(): String?
+    fun getDuckPlayerDisabledHelpPageLink(): String?
 
     suspend fun storeYouTubePath(youtubePath: String)
 
@@ -60,17 +59,17 @@ interface DuckPlayerFeatureRepository {
 
     suspend fun storeYouTubeVideoIDQueryParam(youtubeVideoIDQueryParam: String)
 
-    suspend fun getVideoIDQueryParam(): String
-    suspend fun getYouTubeReferrerQueryParams(): List<String>
-    suspend fun getYouTubeReferrerHeaders(): List<String>
-    suspend fun getYouTubeWatchPath(): String
-    suspend fun getYouTubeUrl(): String
-    suspend fun getYouTubeEmbedUrl(): String
-    suspend fun isOnboarded(): Boolean
+    fun getVideoIDQueryParam(): String
+    fun getYouTubeReferrerQueryParams(): List<String>
+    fun getYouTubeReferrerHeaders(): List<String>
+    fun getYouTubeWatchPath(): String
+    fun getYouTubeUrl(): String
+    fun getYouTubeEmbedUrl(): String
+    fun isOnboarded(): Boolean
     suspend fun setUserOnboarded()
     fun setOpenInNewTab(enabled: Boolean)
     fun observeOpenInNewTab(): Flow<Boolean>
-    suspend fun shouldOpenInNewTab(): Boolean
+    fun shouldOpenInNewTab(): Boolean
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -79,32 +78,15 @@ class RealDuckPlayerFeatureRepository @Inject constructor(
     private val duckPlayerDataStore: DuckPlayerDataStore,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
-    @IsMainProcess isMainProcess: Boolean,
 ) : DuckPlayerFeatureRepository {
 
-    private var duckPlayerRC = "{}"
-
-    init {
-        if (isMainProcess) {
-            loadToMemory()
-        }
-    }
-
-    private fun loadToMemory() {
-        appCoroutineScope.launch(dispatcherProvider.io()) {
-            duckPlayerRC =
-                duckPlayerDataStore.getDuckPlayerRemoteConfigJson()
-        }
-    }
-
     override fun getDuckPlayerRemoteConfigJson(): String {
-        return duckPlayerRC
+        return duckPlayerDataStore.getDuckPlayerRemoteConfigJson()
     }
 
     override fun setDuckPlayerRemoteConfigJson(jsonString: String) {
         appCoroutineScope.launch(dispatcherProvider.io()) {
             duckPlayerDataStore.setDuckPlayerRemoteConfigJson(jsonString)
-            loadToMemory()
         }
     }
 
@@ -131,7 +113,7 @@ class RealDuckPlayerFeatureRepository @Inject constructor(
             }
     }
 
-    override suspend fun getUserPreferences(): UserPreferences {
+    override fun getUserPreferences(): UserPreferences {
         return UserPreferences(
             overlayInteracted = duckPlayerDataStore.getOverlayInteracted(),
             privatePlayerMode = when (duckPlayerDataStore.getPrivatePlayerMode()) {
@@ -146,7 +128,7 @@ class RealDuckPlayerFeatureRepository @Inject constructor(
         duckPlayerDataStore.storeDuckPlayerDisabledHelpPageLink(duckPlayerDisabledHelpPageLink)
     }
 
-    override suspend fun getDuckPlayerDisabledHelpPageLink(): String? {
+    override fun getDuckPlayerDisabledHelpPageLink(): String? {
         return duckPlayerDataStore.getDuckPlayerDisabledHelpPageLink()
     }
 
@@ -174,31 +156,31 @@ class RealDuckPlayerFeatureRepository @Inject constructor(
         duckPlayerDataStore.storeYoutubeEmbedUrl(embedUrl)
     }
 
-    override suspend fun getVideoIDQueryParam(): String {
+    override fun getVideoIDQueryParam(): String {
         return duckPlayerDataStore.getYouTubeVideoIDQueryParam()
     }
 
-    override suspend fun getYouTubeReferrerQueryParams(): List<String> {
+    override fun getYouTubeReferrerQueryParams(): List<String> {
         return duckPlayerDataStore.getYouTubeReferrerQueryParams()
     }
 
-    override suspend fun getYouTubeReferrerHeaders(): List<String> {
+    override fun getYouTubeReferrerHeaders(): List<String> {
         return duckPlayerDataStore.getYouTubeReferrerHeaders()
     }
 
-    override suspend fun getYouTubeWatchPath(): String {
+    override fun getYouTubeWatchPath(): String {
         return duckPlayerDataStore.getYouTubeWatchPath()
     }
 
-    override suspend fun getYouTubeUrl(): String {
+    override fun getYouTubeUrl(): String {
         return duckPlayerDataStore.getYouTubeUrl()
     }
 
-    override suspend fun getYouTubeEmbedUrl(): String {
+    override fun getYouTubeEmbedUrl(): String {
         return duckPlayerDataStore.getYoutubeEmbedUrl()
     }
 
-    override suspend fun isOnboarded(): Boolean {
+    override fun isOnboarded(): Boolean {
         return duckPlayerDataStore.getUserOnboarded()
     }
 
@@ -216,7 +198,7 @@ class RealDuckPlayerFeatureRepository @Inject constructor(
         return duckPlayerDataStore.observeOpenInNewTab()
     }
 
-    override suspend fun shouldOpenInNewTab(): Boolean {
+    override fun shouldOpenInNewTab(): Boolean {
         return duckPlayerDataStore.getOpenInNewTab()
     }
 }

--- a/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerSettingsViewModel.kt
+++ b/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerSettingsViewModel.kt
@@ -42,7 +42,6 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 
 @ContributesViewModel(ActivityScope::class)
 class DuckPlayerSettingsViewModel @Inject constructor(
@@ -65,7 +64,7 @@ class DuckPlayerSettingsViewModel @Inject constructor(
         }.stateIn(
             viewModelScope,
             started = SharingStarted.WhileSubscribed(),
-            initialValue = runBlocking { Enabled(duckPlayer.getUserPreferences().privatePlayerMode, duckPlayer.shouldOpenDuckPlayerInNewTab()) },
+            initialValue = Enabled(duckPlayer.getUserPreferences().privatePlayerMode, duckPlayer.shouldOpenDuckPlayerInNewTab()),
         )
 
     sealed class Command {

--- a/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/RealDuckPlayer.kt
+++ b/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/RealDuckPlayer.kt
@@ -112,16 +112,18 @@ class RealDuckPlayer @Inject constructor(
 
     private lateinit var duckPlayerDisabledHelpLink: String
 
-    override suspend fun getDuckPlayerState(): DuckPlayerState {
+    override fun getDuckPlayerState(): DuckPlayerState {
         if (!::duckPlayerDisabledHelpLink.isInitialized) {
             duckPlayerDisabledHelpLink = duckPlayerFeatureRepository.getDuckPlayerDisabledHelpPageLink() ?: ""
         }
         return if (isFeatureEnabled) {
             ENABLED
-        } else if (duckPlayerDisabledHelpLink.isNotBlank()) {
-            DISABLED_WIH_HELP_LINK
         } else {
-            DISABLED
+            if (duckPlayerDisabledHelpLink.isNotBlank()) {
+                DISABLED_WIH_HELP_LINK
+            } else {
+                DISABLED
+            }
         }
     }
 
@@ -137,10 +139,8 @@ class RealDuckPlayer @Inject constructor(
         duckPlayerFeatureRepository.setUserPreferences(UserPreferences(overlayInteracted, playerMode))
     }
 
-    override suspend fun getUserPreferences(): UserPreferences {
-        return duckPlayerFeatureRepository.getUserPreferences().let {
-            UserPreferences(it.overlayInteracted, it.privatePlayerMode)
-        }
+    override fun getUserPreferences(): UserPreferences {
+        return duckPlayerFeatureRepository.getUserPreferences()
     }
 
     override fun shouldHideDuckPlayerOverlay(): Boolean {
@@ -151,7 +151,7 @@ class RealDuckPlayer @Inject constructor(
         shouldHideOverlay = false
     }
 
-    private suspend fun shouldNavigateToDuckPlayer(): Boolean {
+    private fun shouldNavigateToDuckPlayer(): Boolean {
         if (!isFeatureEnabled) return false
         val result = getUserPreferences().privatePlayerMode == Enabled && !shouldForceYTNavigation
         return result
@@ -196,7 +196,7 @@ class RealDuckPlayer @Inject constructor(
         }
     }
 
-    private suspend fun createYoutubeNoCookieFromDuckPlayer(uri: Uri): String? {
+    private fun createYoutubeNoCookieFromDuckPlayer(uri: Uri): String? {
         if (!isFeatureEnabled) return null
         val embedUrl = duckPlayerFeatureRepository.getYouTubeEmbedUrl()
         uri.pathSegments?.firstOrNull()?.let { videoID ->
@@ -205,7 +205,7 @@ class RealDuckPlayer @Inject constructor(
         return null
     }
 
-    override suspend fun createYoutubeWatchUrlFromDuckPlayer(uri: Uri): String? {
+    override fun createYoutubeWatchUrlFromDuckPlayer(uri: Uri): String? {
         val videoIdQueryParam = duckPlayerFeatureRepository.getVideoIDQueryParam()
         val youTubeWatchPath = duckPlayerFeatureRepository.getYouTubeWatchPath()
         val youTubeHost = duckPlayerFeatureRepository.getYouTubeUrl()
@@ -217,7 +217,7 @@ class RealDuckPlayer @Inject constructor(
         return null
     }
 
-    private suspend fun youTubeRequestedFromDuckPlayer() {
+    private fun youTubeRequestedFromDuckPlayer() {
         shouldForceYTNavigation = true
         if (getUserPreferences().privatePlayerMode == AlwaysAsk) {
             shouldHideOverlay = true
@@ -263,9 +263,9 @@ class RealDuckPlayer @Inject constructor(
         return url.path?.takeIf { it.isNotBlank() }?.removePrefix("/")?.let { "$DUCK_PLAYER_ASSETS_PATH$it" }
     }
 
-    override suspend fun isYoutubeWatchUrl(uri: Uri): Boolean {
+    override fun isYoutubeWatchUrl(uri: Uri): Boolean {
         val youTubeWatchPath = duckPlayerFeatureRepository.getYouTubeWatchPath()
-        return isYouTubeUrl(uri) && uri.pathSegments.firstOrNull() == youTubeWatchPath
+        return (isYouTubeUrl(uri) && uri.pathSegments.firstOrNull() == youTubeWatchPath)
     }
 
     override fun isYouTubeUrl(uri: Uri): Boolean {
@@ -273,14 +273,14 @@ class RealDuckPlayer @Inject constructor(
         return host == YOUTUBE_HOST || host == YOUTUBE_MOBILE_HOST
     }
 
-    override suspend fun createDuckPlayerUriFromYoutubeNoCookie(uri: Uri): String? {
+    override fun createDuckPlayerUriFromYoutubeNoCookie(uri: Uri): String? {
         if (!isFeatureEnabled) return null
         return uri.getQueryParameter(DUCK_PLAYER_VIDEO_ID_QUERY_PARAM)?.let {
             "$DUCK_PLAYER_URL_BASE$it"
         }
     }
 
-    private suspend fun createDuckPlayerUriFromYoutube(uri: Uri): String {
+    private fun createDuckPlayerUriFromYoutube(uri: Uri): String {
         val videoIdQueryParam = duckPlayerFeatureRepository.getVideoIDQueryParam()
         val origin = uri.getQueryParameter(ORIGIN_QUERY_PARAM)?.let { it } ?: ORIGIN_QUERY_PARAM_AUTO
         return "$DUCK_PLAYER_URL_BASE${uri.getQueryParameter(videoIdQueryParam)}?$ORIGIN_QUERY_PARAM=$origin"
@@ -303,7 +303,8 @@ class RealDuckPlayer @Inject constructor(
         }
         return null
     }
-    private suspend fun processSimulatedYouTubeNoCookieUri(
+
+    private fun processSimulatedYouTubeNoCookieUri(
         url: Uri,
         webView: WebView,
     ): WebResourceResponse {
@@ -459,7 +460,7 @@ class RealDuckPlayer @Inject constructor(
             )
     }
 
-    override suspend fun shouldOpenDuckPlayerInNewTab(): OpenDuckPlayerInNewTab {
+    override fun shouldOpenDuckPlayerInNewTab(): OpenDuckPlayerInNewTab {
         if (!duckPlayerFeature.openInNewTab().isEnabled()) return Unavailable
         return if (duckPlayerFeatureRepository.shouldOpenInNewTab()) On else Off
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202552961248957/1208580918293550/f 

### Description
* Remove unnecessary async/await
* Improve caching strategy by migrating Flows to StateFlows and using .value instead of .first(). Since .value is a sync operation, this also allowed to get rid of quite a few suspend functions
* Remove manual caching from `DuckPlayerFeatureRepository`, as it's no longer needed and we can rely on StateFlows instead

### Steps to test this PR

_Feature 1_
- [x] Smoke test Duck Player

