### PR TITLE
Remove private constructor on VPN fragments

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/alwayson/AlwaysOnAlertDialogFragment.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/alwayson/AlwaysOnAlertDialogFragment.kt
@@ -25,6 +25,7 @@ import androidx.core.text.HtmlCompat
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.ui.store.AppTheme
+import com.duckduckgo.common.utils.extensions.getSerializable
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.mobile.android.vpn.R
 import com.duckduckgo.mobile.android.vpn.databinding.ContentVpnAlwaysOnAlertBinding
@@ -41,7 +42,7 @@ private enum class FragmentType {
 }
 
 @InjectWith(FragmentScope::class)
-class AlwaysOnAlertDialogFragment private constructor() : BottomSheetDialogFragment() {
+class AlwaysOnAlertDialogFragment : BottomSheetDialogFragment() {
 
     @Inject lateinit var appBuildConfig: AppBuildConfig
 
@@ -56,8 +57,13 @@ class AlwaysOnAlertDialogFragment private constructor() : BottomSheetDialogFragm
         super.onAttach(context)
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
         return ContentVpnAlwaysOnAlertBinding.inflate(inflater, container, false).apply {
+            fragmentType = requireArguments().getSerializable<FragmentType>(ARGUMENT_FRAGMENT_TYPE) ?: FragmentType.ALWAYS_ON
             configureViews(this)
         }.root
     }
@@ -143,16 +149,22 @@ class AlwaysOnAlertDialogFragment private constructor() : BottomSheetDialogFragm
     }
 
     companion object {
+        private const val ARGUMENT_FRAGMENT_TYPE = "fragmentType"
         fun newAlwaysOnDialog(listener: Listener): AlwaysOnAlertDialogFragment {
             return AlwaysOnAlertDialogFragment().apply {
                 this.listener = listener
-                this.fragmentType = FragmentType.ALWAYS_ON
+                arguments = Bundle().also {
+                    it.putSerializable(ARGUMENT_FRAGMENT_TYPE, FragmentType.ALWAYS_ON)
+                }
             }
         }
+
         fun newAlwaysOnLockdownDialog(listener: Listener): AlwaysOnAlertDialogFragment {
             return AlwaysOnAlertDialogFragment().apply {
                 this.listener = listener
-                this.fragmentType = FragmentType.ALWAYS_ON_LOCKDOWN
+                arguments = Bundle().also {
+                    it.putSerializable(ARGUMENT_FRAGMENT_TYPE, FragmentType.ALWAYS_ON_LOCKDOWN)
+                }
             }
         }
     }

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/extensions/FragmentExtensions.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/extensions/FragmentExtensions.kt
@@ -16,9 +16,20 @@
 
 package com.duckduckgo.common.utils.extensions
 
+import android.os.Build
+import android.os.Bundle
 import android.widget.EditText
 import androidx.fragment.app.Fragment
+import java.io.Serializable
 
 fun Fragment.showKeyboard(editText: EditText) = activity?.showKeyboard(editText)
 
 fun Fragment.hideKeyboard(editText: EditText) = activity?.hideKeyboard(editText)
+
+inline fun <reified T : Serializable> Bundle.getSerializable(name: String): T? =
+    if (Build.VERSION.SDK_INT >= 33) {
+        getSerializable(name, T::class.java)
+    } else {
+        @Suppress("DEPRECATION")
+        getSerializable(name) as? T
+    }

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/management/alwayson/NetworkProtectionAlwaysOnDialogFragment.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/management/alwayson/NetworkProtectionAlwaysOnDialogFragment.kt
@@ -24,6 +24,7 @@ import android.view.ViewGroup
 import androidx.annotation.StringRes
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.store.AppTheme
+import com.duckduckgo.common.utils.extensions.getSerializable
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.networkprotection.impl.R
 import com.duckduckgo.networkprotection.impl.databinding.DialogNetpAlwaysOnBinding
@@ -40,7 +41,7 @@ private enum class FragmentType {
 }
 
 @InjectWith(FragmentScope::class)
-class NetworkProtectionAlwaysOnDialogFragment private constructor() : BottomSheetDialogFragment() {
+class NetworkProtectionAlwaysOnDialogFragment : BottomSheetDialogFragment() {
 
     @Inject lateinit var appTheme: AppTheme
 
@@ -60,6 +61,7 @@ class NetworkProtectionAlwaysOnDialogFragment private constructor() : BottomShee
         savedInstanceState: Bundle?,
     ): View {
         return DialogNetpAlwaysOnBinding.inflate(inflater, container, false).apply {
+            fragmentType = requireArguments().getSerializable<FragmentType>(ARGUMENT_FRAGMENT_TYPE) ?: FragmentType.PROMOTION
             configureViews(this)
         }.root
     }
@@ -155,17 +157,22 @@ class NetworkProtectionAlwaysOnDialogFragment private constructor() : BottomShee
     }
 
     companion object {
+        private const val ARGUMENT_FRAGMENT_TYPE = "fragmentType"
         fun newPromotionDialog(listener: Listener): NetworkProtectionAlwaysOnDialogFragment {
             return NetworkProtectionAlwaysOnDialogFragment().apply {
                 this.listener = listener
-                this.fragmentType = FragmentType.PROMOTION
+                arguments = Bundle().also {
+                    it.putSerializable(ARGUMENT_FRAGMENT_TYPE, FragmentType.PROMOTION)
+                }
             }
         }
 
         fun newLockdownDialog(listener: Listener): NetworkProtectionAlwaysOnDialogFragment {
             return NetworkProtectionAlwaysOnDialogFragment().apply {
                 this.listener = listener
-                this.fragmentType = FragmentType.LOCKDOWN
+                arguments = Bundle().also {
+                    it.putSerializable(ARGUMENT_FRAGMENT_TYPE, FragmentType.LOCKDOWN)
+                }
             }
         }
     }

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/settings/geoswitching/NetpGeoswitchingCityChoiceDialogFragment.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/settings/geoswitching/NetpGeoswitchingCityChoiceDialogFragment.kt
@@ -43,7 +43,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
 @InjectWith(FragmentScope::class)
-class NetpGeoswitchingCityChoiceDialogFragment private constructor() : BottomSheetDialogFragment() {
+class NetpGeoswitchingCityChoiceDialogFragment : BottomSheetDialogFragment() {
     @Inject
     lateinit var netPGeoswitchingRepository: NetPGeoswitchingRepository
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1208589375218614/1208589638615157/f

### Description
Remove private constructors on some fragments that cause a crash on config change.

### Steps to test this PR

_Always on dialog_
- [ ] Install build
- [ ] Enable VPN
- [ ] Turn on "Block connections without VPN" for our VPN
- [ ] Re-enable VPN
- [ ] When Always on dialog is shown,, change orientation
- [ ] Verify no crash occurs, correct contents are shown and Go to Settings works

_Geoswitching_
- [ ] Open geoswitching
- [ ] Open cities for US
- [ ] Change orientation and select a city
- [ ] Verify no crash occurs and correct city is selected and set for the VPN
