### PR TITLE
New Omnibar: Fix privacy shield highlight alignment

### DIFF
--- a/app/src/main/res/layout/view_new_omnibar.xml
+++ b/app/src/main/res/layout/view_new_omnibar.xml
@@ -146,7 +146,8 @@
                         android:id="@+id/placeholder"
                         android:layout_width="32dp"
                         android:layout_height="32dp"
-                        android:gravity="center"
+                        android:layout_gravity="center"
+                        android:layout_marginEnd="@dimen/keyline_1"
                         android:visibility="invisible" />
 
                 </FrameLayout>

--- a/app/src/main/res/layout/view_new_omnibar_bottom.xml
+++ b/app/src/main/res/layout/view_new_omnibar_bottom.xml
@@ -145,6 +145,7 @@
                         android:id="@+id/placeholder"
                         android:layout_width="32dp"
                         android:layout_height="32dp"
+                        android:layout_marginEnd="@dimen/keyline_1"
                         android:gravity="center"
                         android:visibility="invisible" />
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201807753394693/1208590487067540/f

### Description
Center highlight alignment for privacy shield icon in address bar

### Steps to test this PR

- [x] Make sure you set an internal build to get the new omnibar design
- [x] Fresh install
- [x] Visit a website with trackers (bbc.co.uk)
- [x] After typing animation is finished, privacy shield highlight will appear
- [x] Make sure highlight is centered
- [x] Go to Settings > Appearance > Address Bar and set it to the bottom
- [x] Make sure highlight is also centered for the bottom bar address

### UI changes
| Before  | After |
| ------ | ----- |
![Screenshot 2024-10-22 at 14 13 39](https://github.com/user-attachments/assets/dd30aa38-b0e4-4e24-8a4a-b247c86b8cd8)|![Screenshot 2024-10-22 at 14 13 56](https://github.com/user-attachments/assets/48233a47-277e-4d26-8c9a-eab14ac98d5b)|
