### PR TITLE
Update content scope scripts to version 6.23.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -2262,16 +2262,11 @@
      */
 
     /**
-     * @description
-     *
      * A wrapper for messaging on Windows.
      *
      * This requires 3 methods to be available, see {@link WindowsMessagingConfig} for details
      *
-     * @example
-     *
-     * ```javascript
-     * [[include:messaging/lib/examples/windows.example.js]]```
+     * @document messaging/lib/examples/windows.example.js
      *
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -2469,8 +2464,7 @@
      * Depending on where the script is running, we may want to restrict access to those globals. On the native
      * side those handlers `window.chrome.webview` handlers might be deleted and replaces with in-scope variables, such as:
      *
-     * ```ts
-     * [[include:messaging/lib/examples/windows.example.js]]```
+     * [Example](./examples/windows.example.js)
      *
      */
     class WindowsMessagingConfig {
@@ -2585,9 +2579,6 @@
     }
 
     /**
-     * @module Messaging Schema
-     *
-     * @description
      * These are all the shared data types used throughout. Transports receive these types and
      * can choose how to deliver the message to their respective native platforms.
      *
@@ -2596,6 +2587,9 @@
      * - Subscriptions via {@link Subscription}
      *
      * Note: For backwards compatibility, some platforms may alter the data shape within the transport.
+     *
+     * @module Messaging Schema
+     *
      */
 
     /**
@@ -2725,8 +2719,6 @@
     }
 
     /**
-     *
-     * @description
      *
      * A wrapper for messaging on WebKit platforms. It supports modern WebKit messageHandlers
      * along with encryption for older versions (like macOS Catalina)
@@ -3042,10 +3034,7 @@
      *
      * Please see {@link WebkitMessagingTransport} for details on how messages are sent/received
      *
-     * @example Webkit Messaging
-     *
-     * ```javascript
-     * [[include:messaging/lib/examples/webkit.example.js]]```
+     * [Example](./examples/webkit.example.js)
      */
     class WebkitMessagingConfig {
         /**
@@ -3154,16 +3143,10 @@
     }
 
     /**
-     * @description
      *
      * A wrapper for messaging on Android.
      *
      * You must share a {@link AndroidMessagingConfig} instance between features
-     *
-     * @example
-     *
-     * ```javascript
-     * [[include:messaging/lib/examples/windows.example.js]]```
      *
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -3319,7 +3302,7 @@
      * - `$messageSecret` matches {@link AndroidMessagingConfig.messageSecret}
      * - `$message` is JSON string that represents one of {@link MessageResponse} or {@link SubscriptionEvent}
      *
-     * ```kotlin
+     * ```
      * object ReplyHandler {
      *     fun constructReply(message: String, messageCallback: String, messageSecret: String): String {
      *         return """
@@ -3498,9 +3481,6 @@
     }
 
     /**
-     * @module Messaging
-     * @category Libraries
-     * @description
      *
      * An abstraction for communications between JavaScript and host platforms.
      *
@@ -3520,6 +3500,7 @@
      * - Schema: {@link "Messaging Schema"}
      * - Implementation Guide: {@link "Messaging Implementation Guide"}
      *
+     * @module Messaging
      */
 
     /**
@@ -3626,9 +3607,6 @@
      * It's useful for debugging, and for enabling scripts to run in
      * other environments - for example, testing in a browser without the need
      * for a full integration
-     *
-     * ```js
-     * [[include:messaging/lib/examples/test.example.js]]```
      */
     class TestTransportConfig {
         /**
@@ -11701,9 +11679,6 @@
     }
 
     /**
-     * @module Duck Player Thumbnails
-     *
-     * @description
      *
      * ## Decision flow for `mouseover` (appending Dax)
      *
@@ -11754,7 +11729,7 @@
      *         - `eventTarget` matches a CSS selector in `[config] allowedEventTargets`
      *     - otherwise, do nothing
      *
-     * [[include:injected/src/features/duckplayer/thumbnails.md]]
+     * @module Duck Player Thumbnails
      */
 
 
@@ -12282,8 +12257,6 @@
     /* eslint-disable promise/prefer-await-to-then */
     /**
      * @module Duck Player Video Overlay
-     *
-     * @description
      *
      * ## Decision flow for appending the Video Overlays
      *
@@ -13004,9 +12977,6 @@
     }
 
     /**
-     * @module Duck Player Overlays
-     *
-     * @description
      *
      * Duck Player Overlays are either the small Dax icons that appear on top of video thumbnails
      * when browsing YouTube. These icons allow users to open the video in Duck Player.
@@ -13035,9 +13005,9 @@
      *
      * For example, to enable the Duck Player Overlay on YouTube, the following config is used:
      *
-     * ```json
-     * [[include:injected/integration-test/test-pages/duckplayer/config/overlays-live.json]]```
+     * [📝 JSON example](../../integration-test/test-pages/duckplayer/config/overlays-live.json)
      *
+     * @module Duck Player Overlays
      */
 
     /**
@@ -13247,7 +13217,6 @@
 
     /**
      * @module Android integration
-     * @category Content Scope Scripts Integrations
      */
 
     function initCode () {

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/js/index.css
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/js/index.css
@@ -205,12 +205,15 @@ body[data-display=app] {
 .SwitchBarMobile_stateHidden {
   display: none;
 }
-.SwitchBarMobile_label {
+.SwitchBarMobile_labelRow {
   display: flex;
   align-items: center;
   justify-content: space-between;
   width: 100%;
   gap: 16px;
+}
+.SwitchBarMobile_label {
+  pointer-events: none;
 }
 .SwitchBarMobile_checkbox {
 }

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/js/index.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/js/index.js
@@ -1260,8 +1260,8 @@
     M.__r = 0;
   }
   function P(n2, l3, u3, t3, i3, o3, r3, f3, e3, c3, s3) {
-    var a3, p3, y3, d3, w3, _3 = t3 && t3.__k || v, g2 = l3.length;
-    for (u3.__d = e3, $(u3, l3, _3), e3 = u3.__d, a3 = 0; a3 < g2; a3++)
+    var a3, p3, y3, d3, w3, _3 = t3 && t3.__k || v, g3 = l3.length;
+    for (u3.__d = e3, $(u3, l3, _3), e3 = u3.__d, a3 = 0; a3 < g3; a3++)
       null != (y3 = u3.__k[a3]) && (p3 = -1 === y3.__i ? h : _3[y3.__i] || h, y3.__i = a3, O(n2, y3, p3, i3, o3, r3, f3, e3, c3, s3), d3 = y3.__e, y3.ref && p3.ref != y3.ref && (p3.ref && N(p3.ref, null, y3), s3.push(y3.ref, y3.__c || d3, y3)), null == w3 && null != d3 && (w3 = d3), 65536 & y3.__u || p3.__k === y3.__k ? e3 = I(y3, e3, n2) : "function" == typeof y3.type && void 0 !== y3.__d ? e3 = y3.__d : d3 && (e3 = d3.nextSibling), y3.__d = void 0, y3.__u &= -196609);
     u3.__d = e3, u3.__e = w3;
   }
@@ -1349,14 +1349,14 @@
     };
   }
   function O(n2, u3, t3, i3, o3, r3, f3, e3, c3, s3) {
-    var a3, h3, v3, p3, w3, _3, g2, m2, x3, C3, S2, M2, $2, I2, H, L2, T3 = u3.type;
+    var a3, h3, v3, p3, w3, _3, g3, m2, x3, C3, S2, M2, $2, I2, H, L2, T3 = u3.type;
     if (void 0 !== u3.constructor)
       return null;
     128 & t3.__u && (c3 = !!(32 & t3.__u), r3 = [e3 = u3.__e = t3.__e]), (a3 = l.__b) && a3(u3);
     n:
       if ("function" == typeof T3)
         try {
-          if (m2 = u3.props, x3 = "prototype" in T3 && T3.prototype.render, C3 = (a3 = T3.contextType) && i3[a3.__c], S2 = a3 ? C3 ? C3.props.value : a3.__ : i3, t3.__c ? g2 = (h3 = u3.__c = t3.__c).__ = h3.__E : (x3 ? u3.__c = h3 = new T3(m2, S2) : (u3.__c = h3 = new k(m2, S2), h3.constructor = T3, h3.render = q), C3 && C3.sub(h3), h3.props = m2, h3.state || (h3.state = {}), h3.context = S2, h3.__n = i3, v3 = h3.__d = true, h3.__h = [], h3._sb = []), x3 && null == h3.__s && (h3.__s = h3.state), x3 && null != T3.getDerivedStateFromProps && (h3.__s == h3.state && (h3.__s = d({}, h3.__s)), d(h3.__s, T3.getDerivedStateFromProps(m2, h3.__s))), p3 = h3.props, w3 = h3.state, h3.__v = u3, v3)
+          if (m2 = u3.props, x3 = "prototype" in T3 && T3.prototype.render, C3 = (a3 = T3.contextType) && i3[a3.__c], S2 = a3 ? C3 ? C3.props.value : a3.__ : i3, t3.__c ? g3 = (h3 = u3.__c = t3.__c).__ = h3.__E : (x3 ? u3.__c = h3 = new T3(m2, S2) : (u3.__c = h3 = new k(m2, S2), h3.constructor = T3, h3.render = q), C3 && C3.sub(h3), h3.props = m2, h3.state || (h3.state = {}), h3.context = S2, h3.__n = i3, v3 = h3.__d = true, h3.__h = [], h3._sb = []), x3 && null == h3.__s && (h3.__s = h3.state), x3 && null != T3.getDerivedStateFromProps && (h3.__s == h3.state && (h3.__s = d({}, h3.__s)), d(h3.__s, T3.getDerivedStateFromProps(m2, h3.__s))), p3 = h3.props, w3 = h3.state, h3.__v = u3, v3)
             x3 && null == T3.getDerivedStateFromProps && null != h3.componentWillMount && h3.componentWillMount(), x3 && null != h3.componentDidMount && h3.__h.push(h3.componentDidMount);
           else {
             if (x3 && null == T3.getDerivedStateFromProps && m2 !== p3 && null != h3.componentWillReceiveProps && h3.componentWillReceiveProps(m2, S2), !h3.__e && (null != h3.shouldComponentUpdate && false === h3.shouldComponentUpdate(m2, h3.__s, S2) || u3.__v === t3.__v)) {
@@ -1379,7 +1379,7 @@
             do {
               h3.__d = false, $2 && $2(u3), a3 = h3.render(h3.props, h3.state, h3.context), h3.state = h3.__s;
             } while (h3.__d && ++I2 < 25);
-          h3.state = h3.__s, null != h3.getChildContext && (i3 = d(d({}, i3), h3.getChildContext())), x3 && !v3 && null != h3.getSnapshotBeforeUpdate && (_3 = h3.getSnapshotBeforeUpdate(p3, w3)), P(n2, y(L2 = null != a3 && a3.type === b && null == a3.key ? a3.props.children : a3) ? L2 : [L2], u3, t3, i3, o3, r3, f3, e3, c3, s3), h3.base = u3.__e, u3.__u &= -161, h3.__h.length && f3.push(h3), g2 && (h3.__E = h3.__ = null);
+          h3.state = h3.__s, null != h3.getChildContext && (i3 = d(d({}, i3), h3.getChildContext())), x3 && !v3 && null != h3.getSnapshotBeforeUpdate && (_3 = h3.getSnapshotBeforeUpdate(p3, w3)), P(n2, y(L2 = null != a3 && a3.type === b && null == a3.key ? a3.props.children : a3) ? L2 : [L2], u3, t3, i3, o3, r3, f3, e3, c3, s3), h3.base = u3.__e, u3.__u &= -161, h3.__h.length && f3.push(h3), g3 && (h3.__E = h3.__ = null);
         } catch (n3) {
           if (u3.__v = null, c3 || null != r3) {
             for (u3.__u |= c3 ? 160 : 128; e3 && 8 === e3.nodeType && e3.nextSibling; )
@@ -1408,7 +1408,7 @@
     });
   }
   function z(u3, t3, i3, o3, r3, f3, e3, c3, s3) {
-    var a3, v3, p3, d3, _3, g2, m2, b2 = i3.props, k3 = t3.props, C3 = t3.type;
+    var a3, v3, p3, d3, _3, g3, m2, b2 = i3.props, k3 = t3.props, C3 = t3.type;
     if ("svg" === C3 ? r3 = "http://www.w3.org/2000/svg" : "math" === C3 ? r3 = "http://www.w3.org/1998/Math/MathML" : r3 || (r3 = "http://www.w3.org/1999/xhtml"), null != f3) {
       for (a3 = 0; a3 < f3.length; a3++)
         if ((_3 = f3[a3]) && "setAttribute" in _3 == !!C3 && (C3 ? _3.localName === C3 : 3 === _3.nodeType)) {
@@ -1438,13 +1438,13 @@
           A(u3, a3, null, _3, r3);
         }
       for (a3 in k3)
-        _3 = k3[a3], "children" == a3 ? d3 = _3 : "dangerouslySetInnerHTML" == a3 ? v3 = _3 : "value" == a3 ? g2 = _3 : "checked" == a3 ? m2 = _3 : c3 && "function" != typeof _3 || b2[a3] === _3 || A(u3, a3, _3, b2[a3], r3);
+        _3 = k3[a3], "children" == a3 ? d3 = _3 : "dangerouslySetInnerHTML" == a3 ? v3 = _3 : "value" == a3 ? g3 = _3 : "checked" == a3 ? m2 = _3 : c3 && "function" != typeof _3 || b2[a3] === _3 || A(u3, a3, _3, b2[a3], r3);
       if (v3)
         c3 || p3 && (v3.__html === p3.__html || v3.__html === u3.innerHTML) || (u3.innerHTML = v3.__html), t3.__k = [];
       else if (p3 && (u3.innerHTML = ""), P(u3, y(d3) ? d3 : [d3], t3, i3, o3, "foreignObject" === C3 ? "http://www.w3.org/1999/xhtml" : r3, f3, e3, f3 ? f3[0] : i3.__k && x(i3, 0), c3, s3), null != f3)
         for (a3 = f3.length; a3--; )
           w(f3[a3]);
-      c3 || (a3 = "value", "progress" === C3 && null == g2 ? u3.removeAttribute("value") : void 0 !== g2 && (g2 !== u3[a3] || "progress" === C3 && !g2 || "option" === C3 && g2 !== b2[a3]) && A(u3, a3, g2, b2[a3], r3), a3 = "checked", void 0 !== m2 && m2 !== u3[a3] && A(u3, a3, m2, b2[a3], r3));
+      c3 || (a3 = "value", "progress" === C3 && null == g3 ? u3.removeAttribute("value") : void 0 !== g3 && (g3 !== u3[a3] || "progress" === C3 && !g3 || "option" === C3 && g3 !== b2[a3]) && A(u3, a3, g3, b2[a3], r3), a3 = "checked", void 0 !== m2 && m2 !== u3[a3] && A(u3, a3, m2, b2[a3], r3));
     }
     return u3;
   }
@@ -1609,6 +1609,16 @@
   function x2(n2) {
     var u3 = r2.context[n2.__c], i3 = d2(t2++, 9);
     return i3.c = n2, u3 ? (null == i3.__ && (i3.__ = true, u3.sub(r2)), u3.props.value) : n2.__;
+  }
+  function g2() {
+    var n2 = d2(t2++, 11);
+    if (!n2.__) {
+      for (var u3 = r2.__v; null !== u3 && !u3.__m && null !== u3.__; )
+        u3 = u3.__;
+      var i3 = u3.__m || (u3.__m = [0, 0]);
+      n2.__ = "P" + i3[0] + "-" + i3[1]++;
+    }
+    return n2.__;
   }
   function j2() {
     for (var n2; n2 = f2.shift(); )
@@ -2419,6 +2429,7 @@
     switchBar: "SwitchBarMobile_switchBar",
     stateExiting: "SwitchBarMobile_stateExiting",
     stateHidden: "SwitchBarMobile_stateHidden",
+    labelRow: "SwitchBarMobile_labelRow",
     label: "SwitchBarMobile_label",
     checkbox: "SwitchBarMobile_checkbox",
     text: "SwitchBarMobile_text",
@@ -2494,13 +2505,14 @@
 
   // pages/duckplayer/app/components/Switch.jsx
   var import_classnames4 = __toESM(require_classnames(), 1);
-  function Switch({ checked, onChange, platformName = "ios" }) {
+  function Switch({ checked, onChange, id, platformName = "ios" }) {
     return /* @__PURE__ */ _(
       "button",
       {
         role: "switch",
         "aria-checked": checked,
         onClick: onChange,
+        id,
         className: (0, import_classnames4.default)(Switch_default.switch, {
           [Switch_default.ios]: platformName === "ios",
           [Switch_default.android]: platformName === "android"
@@ -2514,6 +2526,7 @@
   function SwitchBarMobile({ platformName }) {
     const { onChange, onDone, state } = x2(SwitchContext);
     const { t: t3 } = useTypedTranslation();
+    const inputId = g2();
     function blockClick(e3) {
       if (state === "exiting") {
         return e3.preventDefault();
@@ -2529,12 +2542,13 @@
       [SwitchBarMobile_default.stateExiting]: state === "exiting",
       [SwitchBarMobile_default.stateHidden]: state === "completed"
     });
-    return /* @__PURE__ */ _("div", { class: classes, "data-state": state, onTransitionEnd }, /* @__PURE__ */ _("label", { onClick: blockClick, class: SwitchBarMobile_default.label }, /* @__PURE__ */ _("span", { className: SwitchBarMobile_default.text }, t3("keepEnabled")), /* @__PURE__ */ _(
+    return /* @__PURE__ */ _("div", { class: classes, "data-state": state, "data-allow-animation": "true", onTransitionEnd }, /* @__PURE__ */ _("div", { class: SwitchBarMobile_default.labelRow, onClick: blockClick }, /* @__PURE__ */ _("label", { for: inputId, class: SwitchBarMobile_default.label }, /* @__PURE__ */ _("span", { className: SwitchBarMobile_default.text }, t3("keepEnabled"))), /* @__PURE__ */ _(
       Switch,
       {
         checked: state !== "showing",
         onChange,
-        platformName
+        platformName,
+        id: inputId
       }
     )));
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^10.15.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#13.1.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.22.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.23.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#7.0.2",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1724449523"
       },
@@ -22,12 +22,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.25.7.tgz",
-      "integrity": "sha512-0xZJFNE5XMpENsgfHYTw8FbX4kv53mFLn2i3XPoq69LyhYSCBJtitaHx9QnsVTrsogI4Z3+HtEfZ2/GFPOtf5g==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.25.9.tgz",
+      "integrity": "sha512-z88xeGxnzehn2sqZ8UdGQEvYErF1odv2CftxInpSYJt6uHuPe9YjahKZITGs3l5LeI9d2ROG+obuDAoSlqbNfQ==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.25.7",
+        "@babel/highlight": "^7.25.9",
         "picocolors": "^1.0.0"
       },
       "engines": {
@@ -35,21 +35,21 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.7.tgz",
-      "integrity": "sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.25.7.tgz",
-      "integrity": "sha512-iYyACpW3iW8Fw+ZybQK+drQre+ns/tKpXbNESfrhNnPLIklLbXr7MYJ6gPEd0iETGLOK+SxMjVvKb/ffmk+FEw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.25.9.tgz",
+      "integrity": "sha512-llL88JShoCsth8fF8R4SJnIn+WLvR6ccFxu1H3FlMhDontdcmZWf2HgIZ7AIqV3Xcck1idlohrN4EUBQz6klbw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.25.7",
+        "@babel/helper-validator-identifier": "^7.25.9",
         "chalk": "^2.4.2",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
@@ -71,7 +71,7 @@
       "hasInstallScript": true
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#3476f99208e2d61c258a6fb9a9003ba918f8467e",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#60572732465a4de743c26fe88263dff7c3966bb9",
       "workspaces": [
         "injected",
         "special-pages",
@@ -203,9 +203,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.7.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.6.tgz",
-      "integrity": "sha512-/d7Rnj0/ExXDMcioS78/kf1lMzYk4BZV8MZGTBKzTGZ6/406ukkbYlIsZmMPhcR5KlkunDHQLrtAVmSq7r+mSw==",
+      "version": "22.7.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.9.tgz",
+      "integrity": "sha512-jrTfRC7FM6nChvU7X2KqcrgquofrWLFDeYC1hKfwNWomVvrn7JIksqf344WN2X/y8xrgqBd2dJATZV4GbatBfg==",
       "dev": true,
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -620,16 +620,16 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.52",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.52.tgz",
-      "integrity": "sha512-j4OxQI5rc1Ve/4m/9o2WhWSC4jGc4uVbCINdOEJRAraCi0YqTqgMcxUx7DbmuP0G3PCixoof/RZB0Q5Kh9tagw=="
+      "version": "6.1.54",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.54.tgz",
+      "integrity": "sha512-5cc42+0G0EjYRDfIJHKraaT3I5kPm7j6or3Zh1T9sF+Ftj1T+isT4thicUyQQ1bwN7/xjHQIuY2fXCoXP8Haqg=="
     },
     "node_modules/tldts-experimental": {
-      "version": "6.1.52",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.52.tgz",
-      "integrity": "sha512-cBEsjlg5CoO6n3GofBxjUQ+b1uTmeNbhwADrzdVCOMzby7et1Woa3b7MkuqRvgK9K0u7lMvwxmVs8NKizW5HmQ==",
+      "version": "6.1.54",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.54.tgz",
+      "integrity": "sha512-3BqLLS3KLHD9Mx/62T5aXfGnrvnwXjNYnudy0dhtbs6VtPtn4v7IjcLc9uWFBsmYf2PCLtWf89Jk9ewS3K36+g==",
       "dependencies": {
-        "tldts-core": "^6.1.52"
+        "tldts-core": "^6.1.54"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^10.15.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#13.1.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.22.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.23.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#7.0.2",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1724449523"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass