### PR TITLE
Fix the OmnibarLayout crash

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -197,9 +197,17 @@ class OmnibarLayout @JvmOverloads constructor(
     )
 
     var isScrollingEnabled: Boolean
-        get() = viewModel.viewState.value.scrollingEnabled
+        get() {
+            return if (isAttachedToWindow) {
+                viewModel.viewState.value.scrollingEnabled
+            } else {
+                true
+            }
+        }
         set(value) {
-            viewModel.onOmnibarScrollingEnabledChanged(value)
+            if (isAttachedToWindow) {
+                viewModel.onOmnibarScrollingEnabledChanged(value)
+            }
         }
 
     private var coroutineScope: CoroutineScope? = null
@@ -250,31 +258,39 @@ class OmnibarLayout @JvmOverloads constructor(
 
         omnibarTextInput.onFocusChangeListener =
             View.OnFocusChangeListener { _, hasFocus: Boolean ->
-                viewModel.onOmnibarFocusChanged(hasFocus, omnibarTextInput.text.toString())
-                omnibarTextListener?.onFocusChanged(hasFocus, omnibarTextInput.text.toString())
+                if (isAttachedToWindow) {
+                    viewModel.onOmnibarFocusChanged(hasFocus, omnibarTextInput.text.toString())
+                    omnibarTextListener?.onFocusChanged(hasFocus, omnibarTextInput.text.toString())
+                }
             }
 
         omnibarTextInput.onBackKeyListener = object : KeyboardAwareEditText.OnBackKeyListener {
             override fun onBackKey(): Boolean {
-                viewModel.onBackKeyPressed()
-                omnibarTextListener?.onBackKeyPressed()
+                if (isAttachedToWindow) {
+                    viewModel.onBackKeyPressed()
+                    omnibarTextListener?.onBackKeyPressed()
+                }
                 return false
             }
         }
 
         omnibarTextInput.setOnEditorActionListener(
             TextView.OnEditorActionListener { _, actionId, keyEvent ->
-                if (actionId == EditorInfo.IME_ACTION_GO || keyEvent?.keyCode == KeyEvent.KEYCODE_ENTER) {
-                    viewModel.onEnterKeyPressed()
-                    omnibarTextListener?.onEnterPressed()
-                    return@OnEditorActionListener true
+                if (isAttachedToWindow) {
+                    if (actionId == EditorInfo.IME_ACTION_GO || keyEvent?.keyCode == KeyEvent.KEYCODE_ENTER) {
+                        viewModel.onEnterKeyPressed()
+                        omnibarTextListener?.onEnterPressed()
+                        return@OnEditorActionListener true
+                    }
                 }
                 false
             },
         )
 
         omnibarTextInput.setOnTouchListener { _, event ->
-            viewModel.onUserTouchedOmnibarTextInput(event.action)
+            if (isAttachedToWindow) {
+                viewModel.onUserTouchedOmnibarTextInput(event.action)
+            }
             false
         }
 
@@ -319,18 +335,24 @@ class OmnibarLayout @JvmOverloads constructor(
             return@setOnLongClickListener true
         }
         fireIconMenu.setOnClickListener {
-            viewModel.onFireIconPressed(isPulseAnimationPlaying())
+            if (isAttachedToWindow) {
+                viewModel.onFireIconPressed(isPulseAnimationPlaying())
+            }
             omnibarItemPressedListener?.onFireButtonPressed(isPulseAnimationPlaying())
         }
         browserMenu.setOnClickListener {
             omnibarItemPressedListener?.onBrowserMenuPressed()
         }
         shieldIcon.setOnClickListener {
-            viewModel.onPrivacyShieldButtonPressed()
+            if (isAttachedToWindow) {
+                viewModel.onPrivacyShieldButtonPressed()
+            }
             omnibarItemPressedListener?.onPrivacyShieldPressed()
         }
         clearTextButton.setOnClickListener {
-            viewModel.onClearTextButtonPressed()
+            if (isAttachedToWindow) {
+                viewModel.onClearTextButtonPressed()
+            }
             omnibarItemPressedListener?.onClearTextPressed()
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208618045189439/f

### Description

We need to make sure all attempts to access the `OmnibarLayout`’s ViewModel are checked to make sure the window is attached, otherwise the view may not be injected yet.

### Steps to test this PR

- [ ] Enable _Don’t keep activities_ option in Developer options
- [ ] Clear the app storage and start the app
- [ ] Go through the flow until the omnibar is visible
- [ ] Switch to a different app
- [ ] Come back to the app
- [ ] Notice the app doesn’t crash
- [ ] Go to settings and change the omnibar position
- [ ] Navigate back to the browser
- [ ] Notice the app doesn’t crash

