### PR TITLE
Remove fixBlobDownloadWithIframes kill switch

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -67,13 +67,4 @@ interface AndroidBrowserConfigFeature {
      */
     @Toggle.DefaultValue(false)
     fun optimizeTrackerEvaluationV2(): Toggle
-
-    /**
-     * This feature flag guards a fix for blob downloads
-     *
-     * @return always returns `true` for internal builds
-     * @return `true` when the remote feature is enabled.
-     */
-    @Toggle.DefaultValue(true)
-    fun fixBlobDownloadWithIframes(): Toggle
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1198194956794324/1208351041752901/f

### Description
Remove the `fixBlobDownloadWithIframes` kill switch and all the (deactivated) code behind it

### Steps to test this PR
Just code review, we're removing code that doesn't execute
