### PR TITLE
Add first batch of search/app_use retention pixels

### DIFF
--- a/feature-toggles/feature-toggles-impl/lint-baseline.xml
+++ b/feature-toggles/feature-toggles-impl/lint-baseline.xml
@@ -349,7 +349,7 @@
         errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2567"
+            line="2568"
             column="20"/>
     </issue>
 
@@ -360,7 +360,7 @@
         errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2615"
+            line="2617"
             column="23"/>
     </issue>
 
@@ -371,7 +371,7 @@
         errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2649"
+            line="2652"
             column="23"/>
     </issue>
 
@@ -382,7 +382,7 @@
         errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2677"
+            line="2681"
             column="20"/>
     </issue>
 
@@ -393,7 +393,7 @@
         errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2976"
+            line="2981"
             column="20"/>
     </issue>
 
@@ -404,7 +404,7 @@
         errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3020"
+            line="3025"
             column="20"/>
     </issue>
 
@@ -415,7 +415,7 @@
         errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3246"
+            line="3251"
             column="20"/>
     </issue>
 
@@ -426,7 +426,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3256"
+            line="3261"
             column="13"/>
     </issue>
 
@@ -437,7 +437,7 @@
         errorLine2="                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3300"
+            line="3305"
             column="32"/>
     </issue>
 
@@ -448,7 +448,7 @@
         errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3382"
+            line="3387"
             column="23"/>
     </issue>
 
@@ -459,7 +459,7 @@
         errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3426"
+            line="3431"
             column="19"/>
     </issue>
 
@@ -470,7 +470,7 @@
         errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3467"
+            line="3472"
             column="19"/>
     </issue>
 
@@ -481,7 +481,7 @@
         errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3511"
+            line="3516"
             column="19"/>
     </issue>
 
@@ -492,7 +492,7 @@
         errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3565"
+            line="3570"
             column="27"/>
     </issue>
 
@@ -503,7 +503,7 @@
         errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3612"
+            line="3617"
             column="23"/>
     </issue>
 
@@ -514,7 +514,7 @@
         errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3652"
+            line="3657"
             column="23"/>
     </issue>
 
@@ -525,7 +525,7 @@
         errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3696"
+            line="3701"
             column="23"/>
     </issue>
 
@@ -536,7 +536,7 @@
         errorLine2="               ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3727"
+            line="3732"
             column="16"/>
     </issue>
 
@@ -844,7 +844,7 @@
         errorLine2="                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/com/duckduckgo/feature/toggles/impl/MetricPixelInterceptor.kt"
-            line="68"
+            line="71"
             column="34"/>
     </issue>
 
@@ -855,7 +855,7 @@
         errorLine2="        ^">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/impl/MetricPixelInterceptorTest.kt"
-            line="47"
+            line="48"
             column="9"/>
     </issue>
 
@@ -866,7 +866,7 @@
         errorLine2="        ^">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/impl/MetricPixelInterceptorTest.kt"
-            line="73"
+            line="74"
             column="9"/>
     </issue>
 
@@ -877,7 +877,7 @@
         errorLine2="        ^">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/impl/MetricPixelInterceptorTest.kt"
-            line="99"
+            line="100"
             column="9"/>
     </issue>
 
@@ -888,7 +888,7 @@
         errorLine2="        ^">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/impl/MetricPixelInterceptorTest.kt"
-            line="125"
+            line="126"
             column="9"/>
     </issue>
 
@@ -899,7 +899,7 @@
         errorLine2="        ^">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/impl/MetricPixelInterceptorTest.kt"
-            line="151"
+            line="152"
             column="9"/>
     </issue>
 
@@ -910,7 +910,7 @@
         errorLine2="        ^">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/impl/MetricPixelInterceptorTest.kt"
-            line="181"
+            line="182"
             column="9"/>
     </issue>
 
@@ -921,7 +921,7 @@
         errorLine2="        ^">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/impl/MetricPixelInterceptorTest.kt"
-            line="207"
+            line="208"
             column="9"/>
     </issue>
 
@@ -932,7 +932,7 @@
         errorLine2="        ^">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/impl/MetricPixelInterceptorTest.kt"
-            line="233"
+            line="234"
             column="9"/>
     </issue>
 
@@ -943,7 +943,7 @@
         errorLine2="        ^">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/impl/MetricPixelInterceptorTest.kt"
-            line="259"
+            line="260"
             column="9"/>
     </issue>
 
@@ -956,6 +956,138 @@
             file="src/main/java/com/duckduckgo/feature/toggles/impl/RealFeatureTogglesImpl.kt"
             line="38"
             column="13"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="        testFeature.experimentFooFeature().setRawStoredState("
+        errorLine2="        ^">
+        <location
+            file="src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt"
+            line="89"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="        testFeature.fooFeature().setRawStoredState("
+        errorLine2="        ^">
+        <location
+            file="src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt"
+            line="96"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="        testFeature.experimentFooFeature().setRawStoredState("
+        errorLine2="        ^">
+        <location
+            file="src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt"
+            line="131"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="        testFeature.fooFeature().setRawStoredState("
+        errorLine2="        ^">
+        <location
+            file="src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt"
+            line="138"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="        testFeature.experimentFooFeature().setRawStoredState("
+        errorLine2="        ^">
+        <location
+            file="src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt"
+            line="175"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="        testFeature.fooFeature().setRawStoredState("
+        errorLine2="        ^">
+        <location
+            file="src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt"
+            line="182"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="        testFeature.experimentFooFeature().setRawStoredState("
+        errorLine2="        ^">
+        <location
+            file="src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt"
+            line="202"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="        testFeature.fooFeature().setRawStoredState("
+        errorLine2="        ^">
+        <location
+            file="src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt"
+            line="209"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="        testFeature.experimentFooFeature().setRawStoredState("
+        errorLine2="        ^">
+        <location
+            file="src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt"
+            line="229"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="        testFeature.fooFeature().setRawStoredState("
+        errorLine2="        ^">
+        <location
+            file="src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt"
+            line="236"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="        testFeature.experimentFooFeature().setRawStoredState("
+        errorLine2="        ^">
+        <location
+            file="src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt"
+            line="273"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="        testFeature.fooFeature().setRawStoredState("
+        errorLine2="        ^">
+        <location
+            file="src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt"
+            line="280"
+            column="9"/>
     </issue>
 
 </issues>

--- a/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/AppUseMetricPixelsPlugin.kt
+++ b/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/AppUseMetricPixelsPlugin.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.feature.toggles.impl.metrics
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.ConversionWindow
+import com.duckduckgo.feature.toggles.api.FeatureTogglesInventory
+import com.duckduckgo.feature.toggles.api.MetricsPixel
+import com.duckduckgo.feature.toggles.api.MetricsPixelPlugin
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+class AppUseMetricPixelsPlugin @Inject constructor(private val inventory: FeatureTogglesInventory) : MetricsPixelPlugin {
+
+    override suspend fun getMetrics(): List<MetricsPixel> {
+        return inventory.getAllActiveExperimentToggles().flatMap { toggle ->
+            listOf(
+                MetricsPixel(
+                    metric = "app_use",
+                    value = "1",
+                    toggle = toggle,
+                    conversionWindow = (1..7).map { ConversionWindow(lowerWindow = it, upperWindow = it) } +
+                        ConversionWindow(lowerWindow = 5, upperWindow = 7),
+                ),
+                MetricsPixel(
+                    metric = "app_use",
+                    value = "4",
+                    toggle = toggle,
+                    conversionWindow = listOf(
+                        ConversionWindow(lowerWindow = 5, upperWindow = 7),
+                        ConversionWindow(lowerWindow = 8, upperWindow = 15),
+                    ),
+                ),
+                MetricsPixel(
+                    metric = "app_use",
+                    value = "6",
+                    toggle = toggle,
+                    conversionWindow = listOf(
+                        ConversionWindow(lowerWindow = 5, upperWindow = 7),
+                        ConversionWindow(lowerWindow = 8, upperWindow = 15),
+                    ),
+                ),
+                MetricsPixel(
+                    metric = "app_use",
+                    value = "11",
+                    toggle = toggle,
+                    conversionWindow = listOf(
+                        ConversionWindow(lowerWindow = 5, upperWindow = 7),
+                        ConversionWindow(lowerWindow = 8, upperWindow = 15),
+                    ),
+                ),
+                MetricsPixel(
+                    metric = "app_use",
+                    value = "21",
+                    toggle = toggle,
+                    conversionWindow = listOf(
+                        ConversionWindow(lowerWindow = 5, upperWindow = 7),
+                        ConversionWindow(lowerWindow = 8, upperWindow = 15),
+                    ),
+                ),
+                MetricsPixel(
+                    metric = "app_use",
+                    value = "30",
+                    toggle = toggle,
+                    conversionWindow = listOf(
+                        ConversionWindow(lowerWindow = 5, upperWindow = 7),
+                        ConversionWindow(lowerWindow = 8, upperWindow = 15),
+                    ),
+                ),
+            )
+        }
+    }
+}

--- a/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePlugin.kt
+++ b/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePlugin.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.feature.toggles.impl.metrics
+
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.statistics.api.AtbLifecyclePlugin
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.impl.MetricsPixelStore
+import com.duckduckgo.feature.toggles.impl.RetentionMetric.APP_USE
+import com.duckduckgo.feature.toggles.impl.RetentionMetric.SEARCH
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+@ContributesMultibinding(AppScope::class)
+class RetentionMetricsAtbLifecyclePlugin @Inject constructor(
+    private val searchMetricPixelsPlugin: SearchMetricPixelsPlugin,
+    private val appUseMetricPixelsPlugin: AppUseMetricPixelsPlugin,
+    private val store: MetricsPixelStore,
+    private val pixel: Pixel,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+) : AtbLifecyclePlugin {
+
+    override fun onSearchRetentionAtbRefreshed(oldAtb: String, newAtb: String) {
+        appCoroutineScope.launch {
+            searchMetricPixelsPlugin.getMetrics().forEach { metric ->
+                metric.getPixelDefinitions().forEach { definition ->
+                    store.increaseMetricForPixelDefinition(definition, SEARCH)
+                    val searches = store.getMetricForPixelDefinition(definition, SEARCH)
+                    if (searches == metric.value.toInt()) {
+                        pixel.fire(definition.pixelName, definition.params)
+                    }
+                }
+            }
+        }
+    }
+
+    override fun onAppRetentionAtbRefreshed(oldAtb: String, newAtb: String) {
+        appCoroutineScope.launch {
+            appUseMetricPixelsPlugin.getMetrics().forEach { metric ->
+                metric.getPixelDefinitions().forEach { definition ->
+                    store.increaseMetricForPixelDefinition(definition, APP_USE)
+                    val appUse = store.getMetricForPixelDefinition(definition, APP_USE)
+                    if (appUse == metric.value.toInt()) {
+                        pixel.fire(definition.pixelName, definition.params)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/SearchMetricPixelsPlugin.kt
+++ b/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/SearchMetricPixelsPlugin.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.feature.toggles.impl.metrics
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.ConversionWindow
+import com.duckduckgo.feature.toggles.api.FeatureTogglesInventory
+import com.duckduckgo.feature.toggles.api.MetricsPixel
+import com.duckduckgo.feature.toggles.api.MetricsPixelPlugin
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+class SearchMetricPixelsPlugin @Inject constructor(private val inventory: FeatureTogglesInventory) : MetricsPixelPlugin {
+
+    override suspend fun getMetrics(): List<MetricsPixel> {
+        return inventory.getAllActiveExperimentToggles().flatMap { toggle ->
+            listOf(
+                MetricsPixel(
+                    metric = "search",
+                    value = "1",
+                    toggle = toggle,
+                    conversionWindow = (0..7).map { ConversionWindow(lowerWindow = it, upperWindow = it) } +
+                        ConversionWindow(lowerWindow = 5, upperWindow = 7),
+                ),
+                MetricsPixel(
+                    metric = "search",
+                    value = "4",
+                    toggle = toggle,
+                    conversionWindow = listOf(
+                        ConversionWindow(lowerWindow = 5, upperWindow = 7),
+                        ConversionWindow(lowerWindow = 8, upperWindow = 15),
+                    ),
+                ),
+                MetricsPixel(
+                    metric = "search",
+                    value = "6",
+                    toggle = toggle,
+                    conversionWindow = listOf(
+                        ConversionWindow(lowerWindow = 5, upperWindow = 7),
+                        ConversionWindow(lowerWindow = 8, upperWindow = 15),
+                    ),
+                ),
+                MetricsPixel(
+                    metric = "search",
+                    value = "11",
+                    toggle = toggle,
+                    conversionWindow = listOf(
+                        ConversionWindow(lowerWindow = 5, upperWindow = 7),
+                        ConversionWindow(lowerWindow = 8, upperWindow = 15),
+                    ),
+                ),
+                MetricsPixel(
+                    metric = "search",
+                    value = "21",
+                    toggle = toggle,
+                    conversionWindow = listOf(
+                        ConversionWindow(lowerWindow = 5, upperWindow = 7),
+                        ConversionWindow(lowerWindow = 8, upperWindow = 15),
+                    ),
+                ),
+                MetricsPixel(
+                    metric = "search",
+                    value = "30",
+                    toggle = toggle,
+                    conversionWindow = listOf(
+                        ConversionWindow(lowerWindow = 5, upperWindow = 7),
+                        ConversionWindow(lowerWindow = 8, upperWindow = 15),
+                    ),
+                ),
+            )
+        }
+    }
+}

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.feature.toggles.impl.metrics
+
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelName
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeToggleStore
+import com.duckduckgo.feature.toggles.api.FeatureToggles
+import com.duckduckgo.feature.toggles.api.FeatureTogglesInventory
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.feature.toggles.codegen.TestTriggerFeature
+import com.duckduckgo.feature.toggles.impl.FakePluginPoint
+import com.duckduckgo.feature.toggles.impl.FakeStore
+import com.duckduckgo.feature.toggles.impl.RealFeatureTogglesInventory
+import com.duckduckgo.feature.toggles.impl.RetentionMetric
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class RetentionMetricsAtbLifecyclePluginTest {
+    @get:Rule
+    @Suppress("unused")
+    val coroutineRule = CoroutineTestRule()
+
+    private val store = FakeStore()
+    private lateinit var testFeature: TestTriggerFeature
+    private lateinit var pluginPoint: FakePluginPoint
+    private lateinit var inventory: FeatureTogglesInventory
+    private lateinit var searchMetricPixelsPlugin: SearchMetricPixelsPlugin
+    private lateinit var appUseMetricPixelsPlugin: AppUseMetricPixelsPlugin
+    private lateinit var atbLifecyclePlugin: RetentionMetricsAtbLifecyclePlugin
+    private val pixel = FakePixel()
+
+    @Before
+    fun setup() {
+        testFeature = FeatureToggles.Builder(
+            FakeToggleStore(),
+            featureName = "testFeature",
+        ).build().create(TestTriggerFeature::class.java)
+
+        inventory = RealFeatureTogglesInventory(
+            setOf(
+                FakeFeatureTogglesInventory(
+                    features = listOf(
+                        testFeature.experimentFooFeature(),
+                        testFeature.fooFeature(),
+                    ),
+                ),
+            ),
+            coroutineRule.testDispatcherProvider,
+        )
+
+        searchMetricPixelsPlugin = SearchMetricPixelsPlugin(inventory)
+        appUseMetricPixelsPlugin = AppUseMetricPixelsPlugin(inventory)
+
+        pluginPoint = FakePluginPoint(testFeature)
+        atbLifecyclePlugin = RetentionMetricsAtbLifecyclePlugin(
+            searchMetricPixelsPlugin = SearchMetricPixelsPlugin(inventory),
+            appUseMetricPixelsPlugin = AppUseMetricPixelsPlugin(inventory),
+            store = store,
+            pixel = pixel,
+            appCoroutineScope = coroutineRule.testScope,
+        )
+    }
+
+    @Test
+    fun `when search atb refreshed and matches metric, pixel sent to all active experiments`() = runTest {
+        setCohorts()
+
+        atbLifecyclePlugin.onSearchRetentionAtbRefreshed("", "")
+
+        searchMetricPixelsPlugin.getMetrics().forEach { metric ->
+            metric.getPixelDefinitions().forEach { definition ->
+                if (metric.value == "1") {
+                    assertTrue(pixel.firedPixels.contains("${definition.pixelName}${definition.params}"))
+                } else {
+                    assertFalse(pixel.firedPixels.contains("${definition.pixelName}${definition.params}"))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `when app use atb refreshed and matches metric, pixel sent to all active experiments`() = runTest {
+        setCohorts()
+
+        atbLifecyclePlugin.onAppRetentionAtbRefreshed("", "")
+
+        appUseMetricPixelsPlugin.getMetrics().forEach { metric ->
+            metric.getPixelDefinitions().forEach { definition ->
+                if (metric.value == "1") {
+                    assertTrue(pixel.firedPixels.contains("${definition.pixelName}${definition.params}"))
+                } else {
+                    assertFalse(pixel.firedPixels.contains("${definition.pixelName}${definition.params}"))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `when search atb refreshed, fire all pixels which metric matches the number of searches done`() = runTest {
+        setCohorts()
+
+        searchMetricPixelsPlugin.getMetrics().forEach { metric ->
+            metric.getPixelDefinitions().forEach { definition ->
+                val tag = "${definition}_${RetentionMetric.SEARCH}"
+                store.metrics[tag] = 3
+            }
+        }
+
+        atbLifecyclePlugin.onSearchRetentionAtbRefreshed("", "")
+
+        searchMetricPixelsPlugin.getMetrics().forEach { metric ->
+            metric.getPixelDefinitions().forEach { definition ->
+                if (metric.value == "4") {
+                    assertTrue(pixel.firedPixels.contains("${definition.pixelName}${definition.params}"))
+                } else {
+                    assertFalse(pixel.firedPixels.contains("${definition.pixelName}${definition.params}"))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `when app use atb refreshed, fire all pixels which metric matches the number of app use`() = runTest {
+        setCohorts()
+
+        appUseMetricPixelsPlugin.getMetrics().forEach { metric ->
+            metric.getPixelDefinitions().forEach { definition ->
+                val tag = "${definition}_${RetentionMetric.APP_USE}"
+                store.metrics[tag] = 3
+            }
+        }
+
+        atbLifecyclePlugin.onAppRetentionAtbRefreshed("", "")
+
+        appUseMetricPixelsPlugin.getMetrics().forEach { metric ->
+            metric.getPixelDefinitions().forEach { definition ->
+                if (metric.value == "4") {
+                    assertTrue(pixel.firedPixels.contains("${definition.pixelName}${definition.params}"))
+                } else {
+                    assertFalse(pixel.firedPixels.contains("${definition.pixelName}${definition.params}"))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `when search atb refreshed, only fire pixels with active experiments`() = runTest {
+        val today = ZonedDateTime.now(ZoneId.of("America/New_York")).truncatedTo(ChronoUnit.DAYS).toString()
+        testFeature.experimentFooFeature().setRawStoredState(
+            State(
+                remoteEnableState = false,
+                enable = false,
+                assignedCohort = State.Cohort(name = "control", weight = 1, enrollmentDateET = today),
+            ),
+        )
+        testFeature.fooFeature().setRawStoredState(
+            State(
+                remoteEnableState = true,
+                enable = true,
+                assignedCohort = State.Cohort(name = "control", weight = 1, enrollmentDateET = today),
+            ),
+        )
+
+        atbLifecyclePlugin.onSearchRetentionAtbRefreshed("", "")
+
+        assertTrue(pixel.firedPixels.none { it.contains("experimentFooFeature") })
+    }
+
+    @Test
+    fun `when search atb refreshed, only fire pixels from experiments with cohorts assigned`() = runTest {
+        val today = ZonedDateTime.now(ZoneId.of("America/New_York")).truncatedTo(ChronoUnit.DAYS).toString()
+        testFeature.experimentFooFeature().setRawStoredState(
+            State(
+                remoteEnableState = true,
+                enable = true,
+                assignedCohort = null,
+            ),
+        )
+        testFeature.fooFeature().setRawStoredState(
+            State(
+                remoteEnableState = true,
+                enable = true,
+                assignedCohort = State.Cohort(name = "control", weight = 1, enrollmentDateET = today),
+            ),
+        )
+
+        atbLifecyclePlugin.onSearchRetentionAtbRefreshed("", "")
+
+        assertTrue(pixel.firedPixels.none { it.contains("experimentFooFeature") })
+    }
+
+    private fun setCohorts() {
+        val today = ZonedDateTime.now(ZoneId.of("America/New_York")).truncatedTo(ChronoUnit.DAYS).toString()
+        testFeature.experimentFooFeature().setRawStoredState(
+            State(
+                remoteEnableState = true,
+                enable = true,
+                assignedCohort = State.Cohort(name = "control", weight = 1, enrollmentDateET = today),
+            ),
+        )
+        testFeature.fooFeature().setRawStoredState(
+            State(
+                remoteEnableState = true,
+                enable = true,
+                assignedCohort = State.Cohort(name = "control", weight = 1, enrollmentDateET = today),
+            ),
+        )
+    }
+}
+
+class FakeFeatureTogglesInventory(private val features: List<Toggle>) : FeatureTogglesInventory {
+    override suspend fun getAll(): List<Toggle> {
+        return features
+    }
+}
+
+private class FakePixel : Pixel {
+
+    val firedPixels = mutableListOf<String>()
+
+    override fun fire(
+        pixel: PixelName,
+        parameters: Map<String, String>,
+        encodedParameters: Map<String, String>,
+        type: PixelType,
+    ) {
+        firedPixels.add(pixel.pixelName + parameters)
+    }
+
+    override fun fire(
+        pixelName: String,
+        parameters: Map<String, String>,
+        encodedParameters: Map<String, String>,
+        type: PixelType,
+    ) {
+        firedPixels.add(pixelName + parameters)
+    }
+
+    override fun enqueueFire(
+        pixel: PixelName,
+        parameters: Map<String, String>,
+        encodedParameters: Map<String, String>,
+    ) {
+        firedPixels.add(pixel.pixelName + parameters)
+    }
+
+    override fun enqueueFire(
+        pixelName: String,
+        parameters: Map<String, String>,
+        encodedParameters: Map<String, String>,
+    ) {
+        firedPixels.add(pixelName + parameters)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1125189844152671/1208600117694835/f 

### Description
Adds search and app_use metrics definitions as well as firing pixels with them. 

### Steps to test this PR

- [x] Apply the patch from the task
- [x] Launch the app and go to a website.
- [x] Click on the menu and then refresh (to get added to 3 experiments)
- [x] Make a search
- [x] 3 pixels with the metric search, value 1 and window 0 should be sent.
- [x] Make another search (don't refresh), no pixels with metric search should be sent.
- [x] Make two more searches.
- [x] Close the app and launch again
- [x] 3 pixels with the metric app_use, value 1 and window 0 should be sent.
- [x] Close and launch again
- [x] No pixels should be sent