### PR TITLE
Avoid autocomplete scrolling over omnibar

### DIFF
--- a/app/src/main/res/layout/fragment_browser_tab.xml
+++ b/app/src/main/res/layout/fragment_browser_tab.xml
@@ -46,7 +46,7 @@
         android:layout_height="match_parent"
         android:background="?attr/daxColorSurface"
         android:clipToPadding="false"
-        android:elevation="4dp"
+        android:elevation="2dp"
         app:layout_behavior="@string/appbar_scrolling_view_behavior"
         tools:itemCount="3"
         tools:listitem="@layout/item_autocomplete_search_suggestion"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208619432765760/f

### Description
When a pulse animation is playing we don’t allow omnibar scrolling.
In that scenario, if autocomplete results are visible, we are scrolloing over the transparent bar.

### Steps to test this PR

_Feature 1_
- [x] Fresh install
- [x] Visit a random site (ideally with trackers)
- [x] Wait for the Dax dialog and pulse animation to start
- [x] Focus url bar, and write something to make autocomplete appear
- [x] scroll search results up
- [x] see how the content doesn’t scrolling over the omnibar

### UI changes
| Before  | After |
| ------ | ----- |
![url-bar-transparent](https://github.com/user-attachments/assets/6a8ccd13-87b5-44bb-b3ab-75a6d292e886)|https://github.com/user-attachments/assets/c9d2ea9a-1eab-48ee-8b0d-f1de5c03483e|