### PR TITLE
ADS: Add Checkbox to TextAlertDialog

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivity.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivity.kt
@@ -40,6 +40,8 @@ import com.duckduckgo.common.ui.notifyme.NotifyMeView
 import com.duckduckgo.common.ui.view.DaxDialogListener
 import com.duckduckgo.common.ui.view.DaxSwitch
 import com.duckduckgo.common.ui.view.TypewriterDaxDialog
+import com.duckduckgo.common.ui.view.button.ButtonType.DESTRUCTIVE
+import com.duckduckgo.common.ui.view.button.ButtonType.GHOST_ALT
 import com.duckduckgo.common.ui.view.dialog.StackedAlertDialogBuilder
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.view.gone
@@ -356,9 +358,8 @@ class DeviceShieldTrackerActivity :
         TextAlertDialogBuilder(this)
             .setTitle(R.string.atp_RemoveFeatureDialogTitle)
             .setMessage(R.string.atp_RemoveFeatureDialogMessage)
-            .setDestructiveButtons(true)
-            .setPositiveButton(R.string.atp_RemoveFeatureDialogRemove)
-            .setNegativeButton(R.string.atp_RemoveFeatureDialogCancel)
+            .setPositiveButton(R.string.atp_RemoveFeatureDialogRemove, DESTRUCTIVE)
+            .setNegativeButton(R.string.atp_RemoveFeatureDialogCancel, GHOST_ALT)
             .addEventListener(
                 object : TextAlertDialogBuilder.EventListener() {
                     override fun onPositiveButtonClicked() {

--- a/app/src/main/java/com/duckduckgo/app/launch/LaunchBridgeActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/launch/LaunchBridgeActivity.kt
@@ -26,7 +26,6 @@ import com.duckduckgo.app.onboarding.ui.OnboardingActivity
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.di.scopes.ActivityScope
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 @InjectWith(ActivityScope::class)
 class LaunchBridgeActivity : DuckDuckGoActivity() {
@@ -39,8 +38,6 @@ class LaunchBridgeActivity : DuckDuckGoActivity() {
         splashScreen.setKeepOnScreenCondition { true }
 
         setContentView(R.layout.activity_launch)
-
-        Timber.d("pixel request: launch")
 
         configureObservers()
 

--- a/app/src/main/java/com/duckduckgo/app/launch/LaunchBridgeActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/launch/LaunchBridgeActivity.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.app.onboarding.ui.OnboardingActivity
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.di.scopes.ActivityScope
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 @InjectWith(ActivityScope::class)
 class LaunchBridgeActivity : DuckDuckGoActivity() {
@@ -38,6 +39,8 @@ class LaunchBridgeActivity : DuckDuckGoActivity() {
         splashScreen.setKeepOnScreenCondition { true }
 
         setContentView(R.layout.activity_launch)
+
+        Timber.d("pixel request: launch")
 
         configureObservers()
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -53,6 +53,8 @@ import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.Close
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.CloseAllTabsRequest
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.ui.DuckDuckGoActivity
+import com.duckduckgo.common.ui.view.button.ButtonType.DESTRUCTIVE
+import com.duckduckgo.common.ui.view.button.ButtonType.GHOST_ALT
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.hide
@@ -483,9 +485,8 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
         TextAlertDialogBuilder(this)
             .setTitle(R.string.closeAppTabsConfirmationDialogTitle)
             .setMessage(R.string.closeAppTabsConfirmationDialogDescription)
-            .setDestructiveButtons(true)
-            .setPositiveButton(R.string.closeAppTabsConfirmationDialogClose)
-            .setNegativeButton(R.string.closeAppTabsConfirmationDialogCancel)
+            .setPositiveButton(R.string.closeAppTabsConfirmationDialogClose, DESTRUCTIVE)
+            .setNegativeButton(R.string.closeAppTabsConfirmationDialogCancel, GHOST_ALT)
             .addEventListener(
                 object : TextAlertDialogBuilder.EventListener() {
                     override fun onPositiveButtonClicked() {

--- a/app/src/main/res/layout/view_new_omnibar_bottom.xml
+++ b/app/src/main/res/layout/view_new_omnibar_bottom.xml
@@ -26,6 +26,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/toolbarContainer"
+        android:elevation="2dp"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="?attr/daxColorSurface">

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
@@ -60,6 +60,8 @@ import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsVie
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsViewModel.DuckAddressStatus.SettingActivationStatus
 import com.duckduckgo.autofill.impl.ui.credential.management.sorting.InitialExtractor
 import com.duckduckgo.common.ui.DuckDuckGoFragment
+import com.duckduckgo.common.ui.view.button.ButtonType.DESTRUCTIVE
+import com.duckduckgo.common.ui.view.button.ButtonType.GHOST_ALT
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.show
@@ -188,9 +190,8 @@ class AutofillManagementCredentialsMode : DuckDuckGoFragment(R.layout.fragment_a
                     TextAlertDialogBuilder(it)
                         .setTitle(dialogTitle)
                         .setMessage(dialogMessage)
-                        .setDestructiveButtons(true)
-                        .setPositiveButton(R.string.autofillDeleteLoginDialogDelete)
-                        .setNegativeButton(R.string.autofillDeleteLoginDialogCancel)
+                        .setPositiveButton(R.string.autofillDeleteLoginDialogDelete, DESTRUCTIVE)
+                        .setNegativeButton(R.string.autofillDeleteLoginDialogCancel, GHOST_ALT)
                         .addEventListener(
                             object : TextAlertDialogBuilder.EventListener() {
                                 override fun onPositiveButtonClicked() {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementListMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementListMode.kt
@@ -72,6 +72,8 @@ import com.duckduckgo.browser.api.ui.BrowserScreens.WebViewActivityWithParams
 import com.duckduckgo.common.ui.DuckDuckGoFragment
 import com.duckduckgo.common.ui.view.SearchBar
 import com.duckduckgo.common.ui.view.addClickableLink
+import com.duckduckgo.common.ui.view.button.ButtonType.DESTRUCTIVE
+import com.duckduckgo.common.ui.view.button.ButtonType.GHOST_ALT
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.prependIconToText
@@ -510,9 +512,8 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
                     TextAlertDialogBuilder(it)
                         .setTitle(dialogTitle)
                         .setMessage(dialogMessage)
-                        .setDestructiveButtons(true)
-                        .setPositiveButton(R.string.autofillDeleteLoginDialogDelete)
-                        .setNegativeButton(R.string.autofillDeleteLoginDialogCancel)
+                        .setPositiveButton(R.string.autofillDeleteLoginDialogDelete, DESTRUCTIVE)
+                        .setNegativeButton(R.string.autofillDeleteLoginDialogCancel, GHOST_ALT)
                         .addEventListener(
                             object : TextAlertDialogBuilder.EventListener() {
                                 override fun onPositiveButtonClicked() {
@@ -536,9 +537,8 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
                     TextAlertDialogBuilder(it)
                         .setTitle(dialogTitle)
                         .setMessage(dialogMessage)
-                        .setDestructiveButtons(true)
-                        .setPositiveButton(R.string.autofillDeleteLoginDialogDelete)
-                        .setNegativeButton(R.string.autofillDeleteLoginDialogCancel)
+                        .setPositiveButton(R.string.autofillDeleteLoginDialogDelete, DESTRUCTIVE)
+                        .setNegativeButton(R.string.autofillDeleteLoginDialogCancel, GHOST_ALT)
                         .setCancellable(true)
                         .addEventListener(
                             object : TextAlertDialogBuilder.EventListener() {
@@ -567,9 +567,8 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
             TextAlertDialogBuilder(it)
                 .setTitle(R.string.credentialManagementClearNeverForThisSiteDialogTitle)
                 .setMessage(R.string.credentialManagementInstructionNeverForThisSite)
-                .setDestructiveButtons(true)
-                .setPositiveButton(R.string.credentialManagementClearNeverForThisSiteDialogPositiveButton)
-                .setNegativeButton(R.string.credentialManagementClearNeverForThisSiteDialogNegativeButton)
+                .setPositiveButton(R.string.credentialManagementClearNeverForThisSiteDialogPositiveButton, DESTRUCTIVE)
+                .setNegativeButton(R.string.credentialManagementClearNeverForThisSiteDialogNegativeButton, GHOST_ALT)
                 .setCancellable(true)
                 .addEventListener(
                     object : TextAlertDialogBuilder.EventListener() {

--- a/autofill/autofill-internal/src/main/java/com/duckduckgo/autofill/internal/AutofillInternalSettingsActivity.kt
+++ b/autofill/autofill-internal/src/main/java/com/duckduckgo/autofill/internal/AutofillInternalSettingsActivity.kt
@@ -41,6 +41,8 @@ import com.duckduckgo.autofill.internal.databinding.ActivityAutofillInternalSett
 import com.duckduckgo.autofill.store.AutofillPrefsStore
 import com.duckduckgo.browser.api.UserBrowserProperties
 import com.duckduckgo.common.ui.DuckDuckGoActivity
+import com.duckduckgo.common.ui.view.button.ButtonType.DESTRUCTIVE
+import com.duckduckgo.common.ui.view.button.ButtonType.GHOST_ALT
 import com.duckduckgo.common.ui.view.dialog.RadioListAlertDialogBuilder
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.viewbinding.viewBinding
@@ -324,9 +326,8 @@ class AutofillInternalSettingsActivity : DuckDuckGoActivity() {
         TextAlertDialogBuilder(this@AutofillInternalSettingsActivity)
             .setTitle(R.string.autofillDevSettingsClearLogins)
             .setMessage(getString(R.string.autofillDevSettingsClearLoginsConfirmationMessage, count))
-            .setDestructiveButtons(true)
-            .setPositiveButton(R.string.autofillDevSettingsClearLoginsDeleteButton)
-            .setNegativeButton(R.string.autofillDevSettingsClearLoginsCancelButton)
+            .setPositiveButton(R.string.autofillDevSettingsClearLoginsDeleteButton, DESTRUCTIVE)
+            .setNegativeButton(R.string.autofillDevSettingsClearLoginsCancelButton, GHOST_ALT)
             .addEventListener(
                 object : TextAlertDialogBuilder.EventListener() {
                     override fun onPositiveButtonClicked() {

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/themepreview/ui/dialogs/DialogsFragment.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/themepreview/ui/dialogs/DialogsFragment.kt
@@ -102,9 +102,8 @@ class DialogsFragment : Fragment() {
                 RadioListAlertDialogBuilder(requireContext())
                     .setTitle(R.string.text_dialog_title)
                     .setMessage(R.string.text_dialog_message)
-                    .setPositiveButton(R.string.text_dialog_positive)
-                    .setNegativeButton(R.string.text_dialog_negative)
-                    .setDestructiveButtons(true)
+                    .setPositiveButton(R.string.text_dialog_positive, DESTRUCTIVE)
+                    .setNegativeButton(R.string.text_dialog_negative, GHOST_ALT)
                     .setOptions(listOf(R.string.text_dialog_option, R.string.text_dialog_option, R.string.text_dialog_option))
                     .addEventListener(
                         object : RadioListAlertDialogBuilder.EventListener() {

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/themepreview/ui/dialogs/DialogsFragment.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/themepreview/ui/dialogs/DialogsFragment.kt
@@ -204,6 +204,29 @@ class DialogsFragment : Fragment() {
             }
         }
 
+        view.findViewById<Button>(R.id.textAlertDialogCheckbox)?.let {
+            it.setOnClickListener {
+                TextAlertDialogBuilder(requireContext())
+                    .setTitle(R.string.text_dialog_title)
+                    .setMessage(R.string.text_dialog_message)
+                    .setPositiveButton(R.string.text_dialog_positive)
+                    .setNegativeButton(R.string.text_dialog_negative)
+                    .setCheckBoxText(R.string.text_dialog_checkbox)
+                    .addEventListener(
+                        object : TextAlertDialogBuilder.EventListener() {
+                            override fun onPositiveButtonClicked() {
+                                Snackbar.make(it, "Negative Button Clicked", Snackbar.LENGTH_SHORT).show()
+                            }
+
+                            override fun onNegativeButtonClicked() {
+                                Snackbar.make(it, "Negative Button Clicked", Snackbar.LENGTH_SHORT).show()
+                            }
+                        },
+                    )
+                    .show()
+            }
+        }
+
         view.findViewById<Button>(R.id.stackedAlertDialogWithImageButton)?.let {
             it.setOnClickListener {
                 StackedAlertDialogBuilder(requireContext())

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/themepreview/ui/dialogs/DialogsFragment.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/themepreview/ui/dialogs/DialogsFragment.kt
@@ -214,12 +214,17 @@ class DialogsFragment : Fragment() {
                     .setCheckBoxText(R.string.text_dialog_checkbox)
                     .addEventListener(
                         object : TextAlertDialogBuilder.EventListener() {
+                            var isChecked: Boolean = false
                             override fun onPositiveButtonClicked() {
-                                Snackbar.make(it, "Negative Button Clicked", Snackbar.LENGTH_SHORT).show()
+                                Snackbar.make(it, "Negative Button Clicked, Checked $isChecked ", Snackbar.LENGTH_SHORT).show()
                             }
 
                             override fun onNegativeButtonClicked() {
-                                Snackbar.make(it, "Negative Button Clicked", Snackbar.LENGTH_SHORT).show()
+                                Snackbar.make(it, "Negative Button Clicked, Checked $isChecked", Snackbar.LENGTH_SHORT).show()
+                            }
+
+                            override fun onCheckedChanged(checked: Boolean) {
+                                isChecked = checked
                             }
                         },
                     )

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/themepreview/ui/dialogs/DialogsFragment.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/themepreview/ui/dialogs/DialogsFragment.kt
@@ -26,6 +26,8 @@ import android.widget.Toast
 import androidx.fragment.app.Fragment
 import com.duckduckgo.common.ui.view.LottieDaxDialog
 import com.duckduckgo.common.ui.view.TypewriterDaxDialog
+import com.duckduckgo.common.ui.view.button.ButtonType.DESTRUCTIVE
+import com.duckduckgo.common.ui.view.button.ButtonType.GHOST_ALT
 import com.duckduckgo.common.ui.view.dialog.ActionBottomSheetDialog
 import com.duckduckgo.common.ui.view.dialog.PromoBottomSheetDialog
 import com.duckduckgo.common.ui.view.dialog.RadioListAlertDialogBuilder
@@ -141,9 +143,8 @@ class DialogsFragment : Fragment() {
                 TextAlertDialogBuilder(requireContext())
                     .setTitle(R.string.text_dialog_title)
                     .setMessage(R.string.text_dialog_message)
-                    .setDestructiveButtons(true)
-                    .setPositiveButton(R.string.text_dialog_positive)
-                    .setNegativeButton(R.string.text_dialog_negative)
+                    .setPositiveButton(R.string.text_dialog_positive, DESTRUCTIVE)
+                    .setNegativeButton(R.string.text_dialog_negative, GHOST_ALT)
                     .addEventListener(
                         object : TextAlertDialogBuilder.EventListener() {
                             override fun onPositiveButtonClicked() {

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/themepreview/ui/dialogs/DialogsFragment.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/themepreview/ui/dialogs/DialogsFragment.kt
@@ -27,6 +27,7 @@ import androidx.fragment.app.Fragment
 import com.duckduckgo.common.ui.view.LottieDaxDialog
 import com.duckduckgo.common.ui.view.TypewriterDaxDialog
 import com.duckduckgo.common.ui.view.button.ButtonType.DESTRUCTIVE
+import com.duckduckgo.common.ui.view.button.ButtonType.GHOST
 import com.duckduckgo.common.ui.view.button.ButtonType.GHOST_ALT
 import com.duckduckgo.common.ui.view.dialog.ActionBottomSheetDialog
 import com.duckduckgo.common.ui.view.dialog.PromoBottomSheetDialog
@@ -145,6 +146,27 @@ class DialogsFragment : Fragment() {
                     .setMessage(R.string.text_dialog_message)
                     .setPositiveButton(R.string.text_dialog_positive, DESTRUCTIVE)
                     .setNegativeButton(R.string.text_dialog_negative, GHOST_ALT)
+                    .addEventListener(
+                        object : TextAlertDialogBuilder.EventListener() {
+                            override fun onPositiveButtonClicked() {
+                                Snackbar.make(it, "Positive Button Clicked", Snackbar.LENGTH_SHORT).show()
+                            }
+
+                            override fun onNegativeButtonClicked() {
+                                Snackbar.make(it, "Negative Button Clicked", Snackbar.LENGTH_SHORT).show()
+                            }
+                        },
+                    )
+                    .show()
+            }
+        }
+
+        view.findViewById<Button>(R.id.textAlertSingleDialogButton)?.let {
+            it.setOnClickListener {
+                TextAlertDialogBuilder(requireContext())
+                    .setTitle(R.string.text_dialog_title)
+                    .setMessage(R.string.text_dialog_message)
+                    .setPositiveButton(R.string.text_dialog_positive, GHOST)
                     .addEventListener(
                         object : TextAlertDialogBuilder.EventListener() {
                             override fun onPositiveButtonClicked() {

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/button/DaxButton.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/button/DaxButton.kt
@@ -90,3 +90,11 @@ enum class Size {
         }
     }
 }
+
+enum class ButtonType {
+    PRIMARY,
+    GHOST,
+    SECONDARY,
+    DESTRUCTIVE,
+    GHOST_DESTRUCTIVE,
+}

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/button/DaxButton.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/button/DaxButton.kt
@@ -97,4 +97,17 @@ enum class ButtonType {
     SECONDARY,
     DESTRUCTIVE,
     GHOST_DESTRUCTIVE,
+    GHOST_ALT,
+    ;
+
+    fun getView(context: Context): DaxButton {
+        return when (this) {
+            PRIMARY -> DaxButtonPrimary(context, null)
+            GHOST -> DaxButtonGhost(context, null)
+            SECONDARY -> DaxButtonSecondary(context, null)
+            DESTRUCTIVE -> DaxButtonDestructive(context, null)
+            GHOST_DESTRUCTIVE -> DaxButtonGhostDestructive(context, null)
+            GHOST_ALT -> DaxButtonGhostAlt(context, null)
+        }
+    }
 }

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/button/DaxButtonGhostAlt.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/button/DaxButtonGhostAlt.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.ui.view.button
+
+import android.content.Context
+import android.util.AttributeSet
+import com.duckduckgo.mobile.android.R
+
+class DaxButtonGhostAlt @JvmOverloads constructor(
+    ctx: Context,
+    attrs: AttributeSet,
+    defStyleAttr: Int = R.attr.daxButtonGhostAlt,
+) : DaxButton(
+    ctx,
+    attrs,
+    defStyleAttr,
+)

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/button/DaxButtonGhostAlt.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/button/DaxButtonGhostAlt.kt
@@ -22,7 +22,7 @@ import com.duckduckgo.mobile.android.R
 
 class DaxButtonGhostAlt @JvmOverloads constructor(
     ctx: Context,
-    attrs: AttributeSet,
+    attrs: AttributeSet?,
     defStyleAttr: Int = R.attr.daxButtonGhostAlt,
 ) : DaxButton(
     ctx,

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/button/DaxButtonGhostDestructive.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/button/DaxButtonGhostDestructive.kt
@@ -22,7 +22,7 @@ import com.duckduckgo.mobile.android.R
 
 class DaxButtonGhostDestructive @JvmOverloads constructor(
     ctx: Context,
-    attrs: AttributeSet,
+    attrs: AttributeSet?,
     defStyleAttr: Int = R.attr.daxButtonGhostDestructive,
 ) : DaxButton(
     ctx,

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/button/DaxButtonPrimary.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/button/DaxButtonPrimary.kt
@@ -22,7 +22,7 @@ import com.duckduckgo.mobile.android.R
 
 class DaxButtonPrimary @JvmOverloads constructor(
     ctx: Context,
-    attrs: AttributeSet,
+    attrs: AttributeSet?,
     defStyleAttr: Int = R.attr.daxButtonPrimary,
 ) : DaxButton(
     ctx,

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/button/DaxButtonSecondary.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/button/DaxButtonSecondary.kt
@@ -22,7 +22,7 @@ import com.duckduckgo.mobile.android.R
 
 class DaxButtonSecondary @JvmOverloads constructor(
     ctx: Context,
-    attrs: AttributeSet,
+    attrs: AttributeSet?,
     defStyleAttr: Int = R.attr.daxButtonSecondary,
 ) : DaxButton(
     ctx,

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/dialog/RadioListAlertDialogBuilder.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/dialog/RadioListAlertDialogBuilder.kt
@@ -18,12 +18,12 @@ package com.duckduckgo.common.ui.view.dialog
 
 import android.content.Context
 import android.view.LayoutInflater
+import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.RadioGroup
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
-import androidx.core.content.ContextCompat
-import androidx.core.view.isVisible
+import com.duckduckgo.common.ui.view.button.ButtonType
 import com.duckduckgo.common.ui.view.button.DaxButton
 import com.duckduckgo.common.ui.view.button.RadioButton
 import com.duckduckgo.common.ui.view.gone
@@ -50,10 +50,11 @@ class RadioListAlertDialogBuilder(val context: Context) : DaxAlertDialog {
     private var titleText: CharSequence = ""
     private var messageText: CharSequence = ""
     private var positiveButtonText: CharSequence = ""
+    private var positiveButtonType: ButtonType = ButtonType.PRIMARY
     private var negativeButtonText: CharSequence = ""
+    private var negativeButtonType: ButtonType? = null
     private var optionList: MutableList<CharSequence> = mutableListOf()
     private var selectedOption: Int? = null
-    private var isDestructiveVersion: Boolean = false
 
     fun setTitle(@StringRes textId: Int): RadioListAlertDialogBuilder {
         titleText = context.getText(textId)
@@ -99,18 +100,21 @@ class RadioListAlertDialogBuilder(val context: Context) : DaxAlertDialog {
         return this
     }
 
-    fun setPositiveButton(@StringRes textId: Int): RadioListAlertDialogBuilder {
+    fun setPositiveButton(
+        @StringRes textId: Int,
+        buttonType: ButtonType = ButtonType.PRIMARY,
+    ): RadioListAlertDialogBuilder {
         positiveButtonText = context.getText(textId)
+        positiveButtonType = buttonType
         return this
     }
 
-    fun setNegativeButton(@StringRes textId: Int): RadioListAlertDialogBuilder {
+    fun setNegativeButton(
+        @StringRes textId: Int,
+        buttonType: ButtonType = ButtonType.GHOST,
+    ): RadioListAlertDialogBuilder {
         negativeButtonText = context.getText(textId)
-        return this
-    }
-
-    fun setDestructiveButtons(isDestructive: Boolean): RadioListAlertDialogBuilder {
-        isDestructiveVersion = isDestructive
+        negativeButtonType = buttonType
         return this
     }
 
@@ -175,8 +179,8 @@ class RadioListAlertDialogBuilder(val context: Context) : DaxAlertDialog {
             selectedOption?.let { check(it) }
             setOnCheckedChangeListener { _, checkedId ->
                 listener.onRadioItemSelected(checkedId)
-                binding.radioListDialogPositiveButton.isEnabled = true
-                binding.radioListDialogDestructivePositiveButton.isEnabled = true
+                // enable positive button added to the container
+                binding.radioListAlertDialogButtonContainer.getChildAt(1).isEnabled = true
             }
         }
 
@@ -187,35 +191,26 @@ class RadioListAlertDialogBuilder(val context: Context) : DaxAlertDialog {
         binding: DialogSingleChoiceAlertBinding,
         dialog: AlertDialog,
     ) {
-        binding.radioListDialogPositiveButton.isVisible = !isDestructiveVersion
-        binding.radioListDialogPositiveButton.isEnabled = selectedOption != null
-        binding.radioListDialogDestructivePositiveButton.isVisible = isDestructiveVersion
-        binding.radioListDialogDestructivePositiveButton.isEnabled = selectedOption != null
-        binding.radioListDialogNegativeButton.isVisible = !isDestructiveVersion
-        binding.radioListDestructiveDialogNegativeButton.isVisible = isDestructiveVersion
+        val negativeButton = negativeButtonType
+        if (negativeButton != null) {
+            val negativeButtonView = negativeButton.getView(context)
+            setButtonListener(negativeButtonView, negativeButtonText, dialog) { listener.onNegativeButtonClicked() }
 
-        if (isDestructiveVersion) {
-            setButtonListener(
-                binding.radioListDialogDestructivePositiveButton,
-                positiveButtonText,
-                dialog,
-            ) { listener.onPositiveButtonClicked(binding.radioListDialogRadioGroup.checkedRadioButtonId) }
-            setButtonListener(binding.radioListDestructiveDialogNegativeButton, negativeButtonText, dialog) { listener.onNegativeButtonClicked() }
-            // no need to get fancy, just change the button textColor
-            binding.radioListDestructiveDialogNegativeButton.setTextColor(
-                ContextCompat.getColorStateList(
-                    context,
-                    R.color.secondary_text_color_selector,
-                ),
+            binding.radioListAlertDialogButtonContainer.addView(negativeButtonView)
+            val layoutParams = negativeButtonView.layoutParams as ViewGroup.MarginLayoutParams
+            layoutParams.setMargins(
+                layoutParams.leftMargin,
+                layoutParams.topMargin,
+                context.resources.getDimensionPixelSize(R.dimen.keyline_2),
+                layoutParams.bottomMargin,
             )
-        } else {
-            setButtonListener(
-                binding.radioListDialogPositiveButton,
-                positiveButtonText,
-                dialog,
-            ) { listener.onPositiveButtonClicked(binding.radioListDialogRadioGroup.checkedRadioButtonId) }
-            setButtonListener(binding.radioListDialogNegativeButton, negativeButtonText, dialog) { listener.onNegativeButtonClicked() }
+            negativeButtonView.layoutParams = layoutParams
         }
+
+        val positiveButtonView = positiveButtonType.getView(context)
+        positiveButtonView.isEnabled = selectedOption != null
+        binding.radioListAlertDialogButtonContainer.addView(positiveButtonView)
+        setButtonListener(positiveButtonView, positiveButtonText, dialog) { listener.onNegativeButtonClicked() }
     }
 
     private fun setButtonListener(

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/dialog/TextAlertDialogBuilder.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/dialog/TextAlertDialogBuilder.kt
@@ -38,6 +38,7 @@ class TextAlertDialogBuilder(val context: Context) : DaxAlertDialog {
         open fun onDialogCancelled() {}
         open fun onPositiveButtonClicked() {}
         open fun onNegativeButtonClicked() {}
+        open fun onCheckedChanged(checked: Boolean) {}
     }
 
     internal class DefaultEventListener : EventListener()
@@ -116,6 +117,7 @@ class TextAlertDialogBuilder(val context: Context) : DaxAlertDialog {
         val binding: DialogTextAlertBinding = DialogTextAlertBinding.inflate(LayoutInflater.from(context))
 
         if (isCheckboxEnabled) {
+            binding.textAlertDialogCheckBox.text = checkBoxText
             binding.textAlertDialogCheckBox.show()
         }
 
@@ -181,8 +183,14 @@ class TextAlertDialogBuilder(val context: Context) : DaxAlertDialog {
             binding.textAlertDialogCancelButton.gone()
         }
 
+        binding.textAlertDialogCheckBox.setOnCheckedChangeListener { compoundButton, checked ->
+            listener.onCheckedChanged(checked)
+        }
+
         if (isDestructiveVersion) {
-            setButtonListener(binding.textAlertDialogPositiveDestructiveButton, positiveButtonText, dialog) { listener.onPositiveButtonClicked() }
+            setButtonListener(binding.textAlertDialogPositiveDestructiveButton, positiveButtonText, dialog) {
+                listener.onPositiveButtonClicked()
+            }
             setButtonListener(binding.textAlertDialogCancelDestructiveButton, negativeButtonText, dialog) { listener.onNegativeButtonClicked() }
             // no need to get fancy, just change the button textColor
             binding.textAlertDialogCancelDestructiveButton.setTextColor(

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/dialog/TextAlertDialogBuilder.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/dialog/TextAlertDialogBuilder.kt
@@ -25,6 +25,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import com.duckduckgo.common.ui.view.button.DaxButton
 import com.duckduckgo.common.ui.view.gone
+import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.mobile.android.R
 import com.duckduckgo.mobile.android.databinding.DialogTextAlertBinding
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -51,6 +52,8 @@ class TextAlertDialogBuilder(val context: Context) : DaxAlertDialog {
     private var negativeButtonText: CharSequence = ""
     private var isCancellable: Boolean = false
     private var isDestructiveVersion: Boolean = false
+    private var isCheckboxEnabled: Boolean = false
+    private var checkBoxText: CharSequence = ""
 
     fun setHeaderImageResource(@DrawableRes drawableId: Int): TextAlertDialogBuilder {
         headerImageDrawableId = drawableId
@@ -102,9 +105,19 @@ class TextAlertDialogBuilder(val context: Context) : DaxAlertDialog {
         return this
     }
 
+    fun setCheckBoxText(@StringRes textId: Int): TextAlertDialogBuilder {
+        isCheckboxEnabled = true
+        checkBoxText = context.getText(textId)
+        return this
+    }
+
     override fun build(): DaxAlertDialog {
         checkRequiredFieldsSet()
         val binding: DialogTextAlertBinding = DialogTextAlertBinding.inflate(LayoutInflater.from(context))
+
+        if (isCheckboxEnabled) {
+            binding.textAlertDialogCheckBox.show()
+        }
 
         val dialogBuilder = MaterialAlertDialogBuilder(context, R.style.Widget_DuckDuckGo_Dialog)
             .setView(binding.root)

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/dialog/TextAlertDialogBuilder.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/dialog/TextAlertDialogBuilder.kt
@@ -24,6 +24,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import com.duckduckgo.common.ui.view.button.DaxButton
+import com.duckduckgo.common.ui.view.button.DaxButtonGhost
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.mobile.android.R
@@ -120,6 +121,27 @@ class TextAlertDialogBuilder(val context: Context) : DaxAlertDialog {
             binding.textAlertDialogCheckBox.text = checkBoxText
             binding.textAlertDialogCheckBox.show()
         }
+
+        val ghostButtonDestructive = DaxButtonGhost(context, null)
+        ghostButtonDestructive.setTextColor(
+            ContextCompat.getColorStateList(
+                context,
+                R.color.destructive_text_color_selector,
+            ),
+        )
+        ghostButtonDestructive.setText(checkBoxText)
+
+        val ghostButton = DaxButtonGhost(context, null)
+        ghostButton.setTextColor(
+            ContextCompat.getColorStateList(
+                context,
+                R.color.secondary_text_color_selector,
+            ),
+        )
+        ghostButton.setText(checkBoxText)
+
+        binding.textAlertDialogButtonContainer.addView(ghostButton)
+        binding.textAlertDialogButtonContainer.addView(ghostButtonDestructive)
 
         val dialogBuilder = MaterialAlertDialogBuilder(context, R.style.Widget_DuckDuckGo_Dialog)
             .setView(binding.root)

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/dialog/TextAlertDialogBuilder.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/dialog/TextAlertDialogBuilder.kt
@@ -55,7 +55,6 @@ class TextAlertDialogBuilder(val context: Context) : DaxAlertDialog {
     private var negativeButtonType: ButtonType? = null
 
     private var isCancellable: Boolean = false
-    private var isDestructiveVersion: Boolean = false
     private var isCheckboxEnabled: Boolean = false
     private var checkBoxText: CharSequence = ""
 
@@ -104,11 +103,6 @@ class TextAlertDialogBuilder(val context: Context) : DaxAlertDialog {
 
     fun setCancellable(cancellable: Boolean): TextAlertDialogBuilder {
         isCancellable = cancellable
-        return this
-    }
-
-    fun setDestructiveButtons(isDestructive: Boolean): TextAlertDialogBuilder {
-        isDestructiveVersion = isDestructive
         return this
     }
 

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/dialog/TextAlertDialogBuilder.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/dialog/TextAlertDialogBuilder.kt
@@ -23,8 +23,9 @@ import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
+import com.duckduckgo.common.ui.view.button.ButtonType
 import com.duckduckgo.common.ui.view.button.DaxButton
-import com.duckduckgo.common.ui.view.button.DaxButtonGhost
+import com.duckduckgo.common.ui.view.button.DaxButtonPrimary
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.mobile.android.R
@@ -82,12 +83,12 @@ class TextAlertDialogBuilder(val context: Context) : DaxAlertDialog {
         return this
     }
 
-    fun setPositiveButton(@StringRes textId: Int): TextAlertDialogBuilder {
+    fun setPositiveButton(@StringRes textId: Int, buttonType: ButtonType = ButtonType.PRIMARY): TextAlertDialogBuilder {
         positiveButtonText = context.getText(textId)
         return this
     }
 
-    fun setNegativeButton(@StringRes textId: Int): TextAlertDialogBuilder {
+    fun setNegativeButton(@StringRes textId: Int, buttonType: ButtonType = ButtonType.GHOST): TextAlertDialogBuilder {
         negativeButtonText = context.getText(textId)
         return this
     }
@@ -122,23 +123,11 @@ class TextAlertDialogBuilder(val context: Context) : DaxAlertDialog {
             binding.textAlertDialogCheckBox.show()
         }
 
-        val ghostButtonDestructive = DaxButtonGhost(context, null)
-        ghostButtonDestructive.setTextColor(
-            ContextCompat.getColorStateList(
-                context,
-                R.color.destructive_text_color_selector,
-            ),
-        )
-        ghostButtonDestructive.setText(checkBoxText)
+        val ghostButtonDestructive = DaxButtonPrimary(context, null)
+        ghostButtonDestructive.setText("Keep")
 
-        val ghostButton = DaxButtonGhost(context, null)
-        ghostButton.setTextColor(
-            ContextCompat.getColorStateList(
-                context,
-                R.color.secondary_text_color_selector,
-            ),
-        )
-        ghostButton.setText(checkBoxText)
+        val ghostButton = DaxButtonPrimary(context, null)
+        ghostButton.setText("Keep")
 
         binding.textAlertDialogButtonContainer.addView(ghostButton)
         binding.textAlertDialogButtonContainer.addView(ghostButtonDestructive)

--- a/common/common-ui/src/main/res/color/button_ghost_alt_container_selector.xml
+++ b/common/common-ui/src/main/res/color/button_ghost_alt_container_selector.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2022 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="?attr/daxColorButtonGhostAltContainerPressed" android:state_checked="true"/>
+    <item android:color="@android:color/transparent" android:state_checked="false"/>
+</selector>

--- a/common/common-ui/src/main/res/color/button_ghost_alt_ripple_selector.xml
+++ b/common/common-ui/src/main/res/color/button_ghost_alt_ripple_selector.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2022 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:color="?attr/daxColorButtonGhostAltContainerPressed" android:state_pressed="true"/>
+    <item android:color="?attr/daxColorButtonGhostAltContainerPressed" android:state_focused="true" android:state_hovered="true"/>
+    <item android:color="?attr/daxColorButtonGhostAltContainerPressed" android:state_focused="true"/>
+    <item android:color="?attr/daxColorButtonGhostAltContainerPressed" android:state_hovered="true"/>
+    <item android:color="?attr/daxColorButtonGhostAltContainerPressed"/>
+
+</selector>

--- a/common/common-ui/src/main/res/color/button_ghost_alt_text_color_selector.xml
+++ b/common/common-ui/src/main/res/color/button_ghost_alt_text_color_selector.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false" android:color="?attr/daxColorTextDisabled" />
+    <item android:color="?attr/daxColorButtonGhostAltTextPressed" android:state_pressed="true"/>
+    <item android:color="?attr/daxColorButtonGhostAltText" android:state_enabled="true"/>
+</selector>

--- a/common/common-ui/src/main/res/layout/component_buttons.xml
+++ b/common/common-ui/src/main/res/layout/component_buttons.xml
@@ -212,6 +212,41 @@
             android:enabled="false"
             android:text="Ghost Destructive Disabled" />
 
+        <com.duckduckgo.common.ui.view.button.DaxButtonGhostAlt
+            android:id="@+id/dax_button_ghost_alt"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Ghost Alt Small" />
+
+        <com.duckduckgo.common.ui.view.button.DaxButtonGhostAlt
+            android:id="@+id/dax_button_ghost_alt_icon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:icon="@drawable/ic_arrow_left_24"
+            android:text="Ghost Alt Small" />
+
+        <com.duckduckgo.common.ui.view.button.DaxButtonGhostAlt
+            android:id="@+id/dax_button_ghost_alt_large"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Ghost Alt Large"
+            app:buttonSize="large" />
+
+        <com.duckduckgo.common.ui.view.button.DaxButtonGhostAlt
+            android:id="@+id/dax_button_ghost_alt_large_icon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:icon="@drawable/ic_bell"
+            android:text="Ghost Alt Large"
+            app:buttonSize="large" />
+
+        <com.duckduckgo.common.ui.view.button.DaxButtonGhostAlt
+            android:id="@+id/dax_button_ghost_alt_disabled"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:text="Ghost Alt Disabled" />
+
         <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
             android:id="@+id/label"
             android:layout_width="match_parent"

--- a/common/common-ui/src/main/res/layout/component_checkbox.xml
+++ b/common/common-ui/src/main/res/layout/component_checkbox.xml
@@ -57,4 +57,17 @@
       app:layout_constraintStart_toEndOf="@+id/checkbox_one"
       app:layout_constraintTop_toBottomOf="@+id/label" />
 
+    <CheckBox
+        android:id="@+id/checkbox_three"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/keyline_1"
+        android:layout_marginStart="@dimen/keyline_2"
+        android:layout_marginTop="@dimen/keyline_2"
+        android:text="@string/text_dialog_checkbox"
+        app:layout_constraintTop_toBottomOf="@+id/checkbox_one"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintHorizontal_chainStyle="packed"
+        app:layout_constraintStart_toStartOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/common/common-ui/src/main/res/layout/component_checkbox.xml
+++ b/common/common-ui/src/main/res/layout/component_checkbox.xml
@@ -61,13 +61,10 @@
         android:id="@+id/checkbox_three"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/keyline_1"
-        android:layout_marginStart="@dimen/keyline_2"
+        android:layout_marginStart="@dimen/keyline_4"
         android:layout_marginTop="@dimen/keyline_2"
         android:text="@string/text_dialog_checkbox"
         app:layout_constraintTop_toBottomOf="@+id/checkbox_one"
-        app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintHorizontal_chainStyle="packed"
         app:layout_constraintStart_toStartOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/common/common-ui/src/main/res/layout/dialog_single_choice_alert.xml
+++ b/common/common-ui/src/main/res/layout/dialog_single_choice_alert.xml
@@ -55,7 +55,7 @@
         app:layout_constraintHeight_max="@dimen/dialogRadioGroupHeightMax"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/radioListDialogMessage"
-        app:layout_constraintBottom_toTopOf="@id/radioListDialogPositiveButton"
+        app:layout_constraintBottom_toTopOf="@id/radioListAlertDialogButtonContainer"
         android:layout_marginBottom="@dimen/keyline_4">
 
         <RadioGroup
@@ -65,38 +65,14 @@
             app:layout_constraintTop_toBottomOf="@+id/radioListDialogMessage"/>
     </ScrollView>
 
-    <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
-        android:id="@+id/radioListDialogPositiveButton"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:id="@+id/radioListAlertDialogButtonContainer"
+        android:layout_width="0dp"
+        android:gravity="end"
         android:layout_height="wrap_content"
-        android:text="Positive"
+        android:orientation="horizontal"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"/>
-
-    <com.duckduckgo.common.ui.view.button.DaxButtonDestructive
-        android:id="@+id/radioListDialogDestructivePositiveButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Positive"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"/>
-
-    <com.duckduckgo.common.ui.view.button.DaxButtonGhost
-        android:id="@+id/radioListDialogNegativeButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/keyline_2"
-        android:text="Cancel"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/radioListDialogPositiveButton"/>
-
-    <com.duckduckgo.common.ui.view.button.DaxButtonGhost
-        android:id="@+id/radioListDestructiveDialogNegativeButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/keyline_2"
-        android:text="Cancel"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/radioListDialogDestructivePositiveButton"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/common/common-ui/src/main/res/layout/dialog_text_alert.xml
+++ b/common/common-ui/src/main/res/layout/dialog_text_alert.xml
@@ -67,58 +67,15 @@
         tools:text="Remember me"
         tools:visibility="visible" />
 
-    <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
-        android:id="@+id/textAlertDialogPositiveButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/keyline_4"
-        android:text="Positive"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/textAlertDialogCheckBox" />
-
-    <com.duckduckgo.common.ui.view.button.DaxButtonDestructive
-        android:id="@+id/textAlertDialogPositiveDestructiveButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/keyline_4"
-        android:text="Positive"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/textAlertDialogCheckBox" />
-
-    <com.duckduckgo.common.ui.view.button.DaxButtonGhost
-        android:id="@+id/textAlertDialogCancelButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/keyline_4"
-        android:layout_marginEnd="@dimen/keyline_2"
-        android:text="Cancel"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/textAlertDialogPositiveButton"
-        app:layout_constraintTop_toBottomOf="@+id/textAlertDialogCheckBox" />
-
-    <com.duckduckgo.common.ui.view.button.DaxButtonGhost
-        android:id="@+id/textAlertDialogCancelDestructiveButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/keyline_4"
-        android:layout_marginEnd="@dimen/keyline_2"
-        android:text="Cancel"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/textAlertDialogPositiveDestructiveButton"
-        app:layout_constraintTop_toBottomOf="@+id/textAlertDialogMessage" />
-
     <LinearLayout
         android:id="@+id/textAlertDialogButtonContainer"
         android:layout_width="0dp"
         android:gravity="end"
         android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/keyline_4"
         android:orientation="horizontal"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/textAlertDialogPositiveButton" />
+        app:layout_constraintTop_toBottomOf="@+id/textAlertDialogCheckBox" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/common/common-ui/src/main/res/layout/dialog_text_alert.xml
+++ b/common/common-ui/src/main/res/layout/dialog_text_alert.xml
@@ -58,12 +58,12 @@
         android:id="@+id/textAlertDialogCheckBox"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
         android:visibility="gone"
-        tools:visibility="visible"
+        android:layout_marginTop="@dimen/keyline_2"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textAlertDialogMessage"
         tools:text="Remember me"
-        app:layout_constraintTop_toBottomOf="@+id/textAlertDialogMessage"/>
+        tools:visibility="visible" />
 
     <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
         android:id="@+id/textAlertDialogPositiveButton"

--- a/common/common-ui/src/main/res/layout/dialog_text_alert.xml
+++ b/common/common-ui/src/main/res/layout/dialog_text_alert.xml
@@ -16,9 +16,9 @@
   ~ limitations under the License.
   -->
 
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:orientation="vertical"
@@ -54,6 +54,17 @@
         app:textType="secondary"
         app:typography="body1"/>
 
+    <CheckBox
+        android:id="@+id/textAlertDialogCheckBox"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        android:visibility="gone"
+        tools:visibility="visible"
+        tools:text="Remember me"
+        app:layout_constraintTop_toBottomOf="@+id/textAlertDialogMessage"/>
+
     <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
         android:id="@+id/textAlertDialogPositiveButton"
         android:layout_width="wrap_content"
@@ -62,7 +73,7 @@
         android:text="Positive"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/textAlertDialogMessage"/>
+        app:layout_constraintTop_toBottomOf="@+id/textAlertDialogCheckBox"/>
 
     <com.duckduckgo.common.ui.view.button.DaxButtonDestructive
         android:id="@+id/textAlertDialogPositiveDestructiveButton"
@@ -73,7 +84,7 @@
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/textAlertDialogMessage"/>
+        app:layout_constraintTop_toBottomOf="@+id/textAlertDialogCheckBox"/>
 
     <com.duckduckgo.common.ui.view.button.DaxButtonGhost
         android:id="@+id/textAlertDialogCancelButton"
@@ -84,7 +95,7 @@
         android:text="Cancel"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/textAlertDialogPositiveButton"
-        app:layout_constraintTop_toBottomOf="@+id/textAlertDialogMessage"/>
+        app:layout_constraintTop_toBottomOf="@+id/textAlertDialogCheckBox"/>
 
     <com.duckduckgo.common.ui.view.button.DaxButtonGhost
         android:id="@+id/textAlertDialogCancelDestructiveButton"

--- a/common/common-ui/src/main/res/layout/dialog_text_alert.xml
+++ b/common/common-ui/src/main/res/layout/dialog_text_alert.xml
@@ -19,10 +19,10 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    style="@style/Widget.DuckDuckGo.Dialog.Content"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:orientation="vertical"
-    style="@style/Widget.DuckDuckGo.Dialog.Content">
+    android:orientation="vertical">
 
     <ImageView
         android:id="@+id/textAlertDialogImage"
@@ -32,7 +32,8 @@
         android:importantForAccessibility="no"
         android:src="@drawable/ic_globe_gray_16dp"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" app:layout_constraintTop_toTopOf="parent"/>
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <com.duckduckgo.common.ui.view.text.DaxTextView
         android:id="@+id/textAlertDialogTitle"
@@ -41,7 +42,8 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/textAlertDialogImage"
-        app:textType="primary" app:typography="h2"/>
+        app:textType="primary"
+        app:typography="h2" />
 
     <com.duckduckgo.common.ui.view.text.DaxTextView
         android:id="@+id/textAlertDialogMessage"
@@ -52,14 +54,14 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/textAlertDialogTitle"
         app:textType="secondary"
-        app:typography="body1"/>
+        app:typography="body1" />
 
     <CheckBox
         android:id="@+id/textAlertDialogCheckBox"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:visibility="gone"
         android:layout_marginTop="@dimen/keyline_2"
+        android:visibility="gone"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/textAlertDialogMessage"
         tools:text="Remember me"
@@ -73,7 +75,7 @@
         android:text="Positive"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/textAlertDialogCheckBox"/>
+        app:layout_constraintTop_toBottomOf="@+id/textAlertDialogCheckBox" />
 
     <com.duckduckgo.common.ui.view.button.DaxButtonDestructive
         android:id="@+id/textAlertDialogPositiveDestructiveButton"
@@ -84,7 +86,7 @@
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/textAlertDialogCheckBox"/>
+        app:layout_constraintTop_toBottomOf="@+id/textAlertDialogCheckBox" />
 
     <com.duckduckgo.common.ui.view.button.DaxButtonGhost
         android:id="@+id/textAlertDialogCancelButton"
@@ -95,7 +97,7 @@
         android:text="Cancel"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/textAlertDialogPositiveButton"
-        app:layout_constraintTop_toBottomOf="@+id/textAlertDialogCheckBox"/>
+        app:layout_constraintTop_toBottomOf="@+id/textAlertDialogCheckBox" />
 
     <com.duckduckgo.common.ui.view.button.DaxButtonGhost
         android:id="@+id/textAlertDialogCancelDestructiveButton"
@@ -107,6 +109,16 @@
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/textAlertDialogPositiveDestructiveButton"
-        app:layout_constraintTop_toBottomOf="@+id/textAlertDialogMessage"/>
+        app:layout_constraintTop_toBottomOf="@+id/textAlertDialogMessage" />
+
+    <LinearLayout
+        android:id="@+id/textAlertDialogButtonContainer"
+        android:layout_width="0dp"
+        android:gravity="end"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textAlertDialogPositiveButton" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/common/common-ui/src/main/res/layout/dialog_text_alert.xml
+++ b/common/common-ui/src/main/res/layout/dialog_text_alert.xml
@@ -58,7 +58,7 @@
 
     <CheckBox
         android:id="@+id/textAlertDialogCheckBox"
-        android:layout_width="0dp"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/keyline_2"
         android:visibility="gone"

--- a/common/common-ui/src/main/res/layout/fragment_components_dialogs.xml
+++ b/common/common-ui/src/main/res/layout/fragment_components_dialogs.xml
@@ -65,12 +65,20 @@
             android:layout_height="wrap_content" />
 
         <com.duckduckgo.common.ui.view.button.DaxButtonSecondary
-                android:id="@+id/textAlertDialogOneButton"
-                app:buttonSize="large"
-                android:text="Text Alert Dialog With One Button"
-                android:layout_marginTop="16dp"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
+            android:id="@+id/textAlertDialogOneButton"
+            app:buttonSize="large"
+            android:text="Text Alert Dialog With One Button"
+            android:layout_marginTop="16dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <com.duckduckgo.common.ui.view.button.DaxButtonSecondary
+            android:id="@+id/textAlertDialogCheckbox"
+            app:buttonSize="large"
+            android:text="Text Alert Dialog With CheckBox"
+            android:layout_marginTop="16dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
 
         <com.duckduckgo.common.ui.view.button.DaxButtonSecondary
             app:buttonSize="large"

--- a/common/common-ui/src/main/res/layout/fragment_components_dialogs.xml
+++ b/common/common-ui/src/main/res/layout/fragment_components_dialogs.xml
@@ -57,6 +57,14 @@
             android:layout_height="wrap_content" />
 
         <com.duckduckgo.common.ui.view.button.DaxButtonSecondary
+            android:id="@+id/textAlertSingleDialogButton"
+            app:buttonSize="large"
+            android:text="Text Alert Single Button Dialog"
+            android:layout_marginTop="16dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <com.duckduckgo.common.ui.view.button.DaxButtonSecondary
             android:id="@+id/textAlertDialogCancellable"
             app:buttonSize="large"
             android:text="Text Alert Dialog Cancellable"

--- a/common/common-ui/src/main/res/values/attrs-button.xml
+++ b/common/common-ui/src/main/res/values/attrs-button.xml
@@ -28,6 +28,7 @@
     <attr name="daxButtonGhost" format="reference"/>
     <attr name="daxButtonDestructive" format="reference"/>
     <attr name="daxButtonGhostDestructive" format="reference"/>
+    <attr name="daxButtonGhostAlt" format="reference"/>
 
     <attr name="radioButtonStyle" format="reference"/>
 

--- a/common/common-ui/src/main/res/values/design-system-colors.xml
+++ b/common/common-ui/src/main/res/values/design-system-colors.xml
@@ -69,6 +69,7 @@
     <attr name="daxColorButtonPrimaryContainerPressed" format="color"/>
     <attr name="daxColorButtonSecondaryContainer" format="color"/>
     <attr name="daxColorButtonSecondaryContainerPressed" format="color"/>
+    <attr name="daxColorButtonGhostAltContainerPressed" format="color"/>
     <attr name="daxColorButtonDestructiveContainer" format="color"/>
     <attr name="daxColorButtonDestructiveContainerPressed" format="color"/>
     <attr name="daxColorButtonDestructiveGhostContainer" format="color"/>
@@ -79,6 +80,8 @@
     <attr name="daxColorButtonSecondaryText" format="color"/>
     <attr name="daxColorButtonSecondaryTextPressed" format="color"/>
     <attr name="daxColorButtonDestructiveGhostText" format="color"/>
+    <attr name="daxColorButtonGhostAltText" format="color"/>
+    <attr name="daxColorButtonGhostAltTextPressed" format="color"/>
     <attr name="daxColorButtonDestructiveGhostTextPressed" format="color"/>
 
     <attr name="daxColorSwitchTrackOn" format="color"/>

--- a/common/common-ui/src/main/res/values/design-system-theming.xml
+++ b/common/common-ui/src/main/res/values/design-system-theming.xml
@@ -76,6 +76,7 @@
         <item name="daxButtonDestructive">@style/Widget.DuckDuckGo.DaxButton.TextButton.Destructive</item>
         <item name="daxButtonGhost">@style/Widget.DuckDuckGo.DaxButton.Ghost</item>
         <item name="daxButtonGhostDestructive">@style/Widget.DuckDuckGo.DaxButton.DestructiveGhost</item>
+        <item name="daxButtonGhostAlt">@style/Widget.DuckDuckGo.DaxButton.DestructiveGhostAlt</item>
 
         <item name="twoLineListItemStyle">@style/Widget.DuckDuckGo.TwoLineListItem</item>
         <item name="oneLineListItemStyle">@style/Widget.DuckDuckGo.OneLineListItem</item>
@@ -177,10 +178,13 @@
         <item name="daxColorButtonDestructiveContainerPressed">@color/alertRedOnDarkPressed</item>
         <item name="daxColorButtonDestructiveGhostContainer">@android:color/transparent</item>
         <item name="daxColorButtonDestructiveGhostContainerPressed">@color/alertRedOnDarkDefault_18</item>
+        <item name="daxColorButtonGhostAltContainerPressed">@color/white12</item>
         <item name="daxColorButtonPrimaryText">@color/black84</item>
         <item name="daxColorButtonPrimaryTextPressed">@color/black84</item>
         <item name="daxColorButtonSecondaryText">@color/blue30</item>
         <item name="daxColorButtonSecondaryTextPressed">@color/blue20</item>
+        <item name="daxColorButtonGhostAltText">@color/white84</item>
+        <item name="daxColorButtonGhostAltTextPressed">@color/white84</item>
         <item name="daxColorButtonDestructiveGhostText">@color/alertRedOnDarkDefault</item>
         <item name="daxColorButtonDestructiveGhostTextPressed">@color/alertRedOnDarkTextPressed</item>
 
@@ -263,10 +267,13 @@
         <item name="daxColorButtonDestructiveContainerPressed">@color/alertRedOnLightPressed</item>
         <item name="daxColorButtonDestructiveGhostContainer">@android:color/transparent</item>
         <item name="daxColorButtonDestructiveGhostContainerPressed">@color/alertRedOnLightDefault</item>
+        <item name="daxColorButtonGhostAltContainerPressed">@color/black6</item>
         <item name="daxColorButtonPrimaryText">@color/white</item>
         <item name="daxColorButtonPrimaryTextPressed">@color/white</item>
         <item name="daxColorButtonSecondaryText">@color/blue50</item>
         <item name="daxColorButtonSecondaryTextPressed">@color/blue70</item>
+        <item name="daxColorButtonGhostAltText">@color/black60</item>
+        <item name="daxColorButtonGhostAltTextPressed">@color/black60</item>
         <item name="daxColorButtonDestructiveGhostText">@color/alertRedOnLightDefault</item>
         <item name="daxColorButtonDestructiveGhostTextPressed">@color/alertRedOnLightPressed</item>
 

--- a/common/common-ui/src/main/res/values/design-system-theming.xml
+++ b/common/common-ui/src/main/res/values/design-system-theming.xml
@@ -53,6 +53,7 @@
         <item name="bottomSheetDialogTheme">@style/Widget.DuckDuckGo.BottomSheetDialog</item>
         <item name="tabStyle">@style/Widget.DuckDuckGo.TabLayout</item>
         <item name="radioButtonStyle">@style/Widget.DuckDuckGo.RadioButton</item>
+        <item name="checkboxStyle">@style/Widget.DuckDuckGo.CheckBox</item>
         <item name="sliderStyle">@style/Widget.DuckDuckGo.Slider</item>
         <item name="switchStyle">@style/Widget.DuckDuckGo.v3.Switch</item>
         <item name="snackbarStyle">@style/Widget.DuckDuckGo.Snackbar</item>

--- a/common/common-ui/src/main/res/values/donottranslate.xml
+++ b/common/common-ui/src/main/res/values/donottranslate.xml
@@ -49,6 +49,7 @@
     <string name="text_dialog_positive" translatable="false">Keep using</string>
     <string name="text_dialog_negative" translatable="false">Negative</string>
     <string name="text_dialog_option" translatable="false">Option</string>
+    <string name="text_dialog_checkbox" translatable="false">Remember my choice</string>
 
     <!-- Defaults Searchbar -->
     <string name="searchbar_cleartextaction_content_description_default" translatable="false">Collapse</string>

--- a/common/common-ui/src/main/res/values/widgets.xml
+++ b/common/common-ui/src/main/res/values/widgets.xml
@@ -191,7 +191,7 @@
         <item name="android:textColor">?attr/daxColorPrimaryText</item>
         <item name="buttonTint">@color/radio_button_tint</item>
         <item name="android:textAppearance">?attr/textAppearanceBody1</item>
-        <item name="android:paddingStart">@dimen/keyline_4</item>
+        <item name="android:paddingStart">@dimen/keyline_2</item>
     </style>
 
     <!-- List Items -->

--- a/common/common-ui/src/main/res/values/widgets.xml
+++ b/common/common-ui/src/main/res/values/widgets.xml
@@ -175,6 +175,14 @@
         <item name="iconPadding">@dimen/keyline_2</item>
     </style>
 
+    <style name="Widget.DuckDuckGo.DaxButton.DestructiveGhostAlt" parent="Widget.MaterialComponents.Button.TextButton">
+        <item name="android:textColor">@color/button_ghost_alt_text_color_selector</item>
+        <item name="backgroundTint">@color/button_ghost_alt_container_selector</item>
+        <item name="rippleColor">@color/button_ghost_alt_ripple_selector</item>
+        <item name="iconTint">@color/button_ghost_alt_text_color_selector</item>
+        <item name="iconPadding">@dimen/keyline_2</item>
+    </style>
+
     <style name="Widget.DuckDuckGo.IconButton">
         <item name="android:background">@drawable/background_icon_button</item>
         <item name="android:padding">@dimen/keyline_5</item>

--- a/common/common-ui/src/main/res/values/widgets.xml
+++ b/common/common-ui/src/main/res/values/widgets.xml
@@ -187,6 +187,13 @@
         <item name="android:textAppearance">?attr/textAppearanceBody1</item>
     </style>
 
+    <style name="Widget.DuckDuckGo.CheckBox" parent="Widget.MaterialComponents.CompoundButton.CheckBox">
+        <item name="android:textColor">?attr/daxColorPrimaryText</item>
+        <item name="buttonTint">@color/radio_button_tint</item>
+        <item name="android:textAppearance">?attr/textAppearanceBody1</item>
+        <item name="android:paddingStart">@dimen/keyline_4</item>
+    </style>
+
     <!-- List Items -->
     <style name="Widget.DuckDuckGo.OneLineListItem">
         <item name="android:layout_width">match_parent</item>

--- a/privacy-config/privacy-config-internal/src/main/java/com/duckduckgo/privacy/config/internal/PrivacyConfigInternalSettingsActivity.kt
+++ b/privacy-config/privacy-config-internal/src/main/java/com/duckduckgo/privacy/config/internal/PrivacyConfigInternalSettingsActivity.kt
@@ -27,6 +27,7 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoActivity
+import com.duckduckgo.common.ui.view.button.ButtonType.DESTRUCTIVE
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.hide
@@ -153,8 +154,7 @@ class PrivacyConfigInternalSettingsActivity : DuckDuckGoActivity() {
         TextAlertDialogBuilder(this)
             .setTitle("Something went wrong :(")
             .setMessage(message)
-            .setDestructiveButtons(true)
-            .setPositiveButton(R.string.ok)
+            .setPositiveButton(R.string.ok, DESTRUCTIVE)
             .show()
     }
 

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksActivity.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksActivity.kt
@@ -40,6 +40,8 @@ import com.duckduckgo.app.tabs.BrowserNav
 import com.duckduckgo.browser.api.ui.BrowserScreens.BookmarksScreenNoParams
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.view.SearchBar
+import com.duckduckgo.common.ui.view.button.ButtonType.DESTRUCTIVE
+import com.duckduckgo.common.ui.view.button.ButtonType.GHOST_ALT
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.view.getColorFromAttr
 import com.duckduckgo.common.ui.view.gone
@@ -518,9 +520,8 @@ class BookmarksActivity : DuckDuckGoActivity(), BookmarksScreenPromotionPlugin.C
         TextAlertDialogBuilder(this)
             .setTitle(getString(R.string.deleteFolder, bookmarkFolder.name))
             .setMessage(getMessageString(bookmarkFolder))
-            .setDestructiveButtons(true)
-            .setPositiveButton(R.string.deleteSavedSiteConfirmationDialogDelete)
-            .setNegativeButton(R.string.deleteSavedSiteConfirmationDialogCancel)
+            .setPositiveButton(R.string.deleteSavedSiteConfirmationDialogDelete, DESTRUCTIVE)
+            .setNegativeButton(R.string.deleteSavedSiteConfirmationDialogCancel, GHOST_ALT)
             .addEventListener(
                 object : TextAlertDialogBuilder.EventListener() {
                     override fun onPositiveButtonClicked() {

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/dialogs/SavedSiteDialogFragment.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/dialogs/SavedSiteDialogFragment.kt
@@ -28,6 +28,8 @@ import android.view.WindowManager
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.DialogFragment
+import com.duckduckgo.common.ui.view.button.ButtonType.DESTRUCTIVE
+import com.duckduckgo.common.ui.view.button.ButtonType.GHOST_ALT
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.view.showKeyboard
 import com.duckduckgo.common.ui.view.text.DaxTextInput
@@ -223,9 +225,8 @@ abstract class SavedSiteDialogFragment : DialogFragment() {
         TextAlertDialogBuilder(requireContext())
             .setTitle(title)
             .setMessage(message)
-            .setDestructiveButtons(true)
-            .setPositiveButton(R.string.deleteSavedSiteConfirmationDialogDelete)
-            .setNegativeButton(R.string.deleteSavedSiteConfirmationDialogCancel)
+            .setPositiveButton(R.string.deleteSavedSiteConfirmationDialogDelete, DESTRUCTIVE)
+            .setNegativeButton(R.string.deleteSavedSiteConfirmationDialogCancel, GHOST_ALT)
             .addEventListener(
                 object : TextAlertDialogBuilder.EventListener() {
                     override fun onPositiveButtonClicked() {

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/RestoreSubscriptionActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/RestoreSubscriptionActivity.kt
@@ -141,7 +141,6 @@ class RestoreSubscriptionActivity : DuckDuckGoActivity() {
         TextAlertDialogBuilder(this)
             .setTitle(string.subscriptionNotFound)
             .setMessage(string.subscriptionNotFoundDescription)
-            .setDestructiveButtons(false)
             .setPositiveButton(string.viewPlans)
             .setNegativeButton(string.cancel)
             .addEventListener(
@@ -158,7 +157,6 @@ class RestoreSubscriptionActivity : DuckDuckGoActivity() {
         TextAlertDialogBuilder(this)
             .setTitle(string.somethingWentWrong)
             .setMessage(string.somethingWentWrongDescription)
-            .setDestructiveButtons(false)
             .setPositiveButton(string.ok)
             .show()
     }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionSettingsActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionSettingsActivity.kt
@@ -28,6 +28,8 @@ import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.browser.api.ui.BrowserScreens.WebViewActivityWithParams
 import com.duckduckgo.common.ui.DuckDuckGoActivity
+import com.duckduckgo.common.ui.view.button.ButtonType.DESTRUCTIVE
+import com.duckduckgo.common.ui.view.button.ButtonType.GHOST_ALT
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.show
@@ -98,9 +100,8 @@ class SubscriptionSettingsActivity : DuckDuckGoActivity() {
             TextAlertDialogBuilder(this)
                 .setTitle(string.removeFromDevice)
                 .setMessage(string.removeFromDeviceDescription)
-                .setDestructiveButtons(true)
-                .setPositiveButton(string.removeSubscription)
-                .setNegativeButton(string.cancel)
+                .setPositiveButton(string.removeSubscription, DESTRUCTIVE)
+                .setNegativeButton(string.cancel, GHOST_ALT)
                 .addEventListener(
                     object : TextAlertDialogBuilder.EventListener() {
                         override fun onPositiveButtonClicked() {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivity.kt
@@ -24,6 +24,8 @@ import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoActivity
+import com.duckduckgo.common.ui.view.button.ButtonType.DESTRUCTIVE
+import com.duckduckgo.common.ui.view.button.ButtonType.GHOST_ALT
 import com.duckduckgo.common.ui.view.dialog.CustomAlertDialogBuilder
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.view.makeSnackbarWithNoBottomInset
@@ -343,9 +345,8 @@ class SyncActivity : DuckDuckGoActivity() {
         TextAlertDialogBuilder(this)
             .setTitle(R.string.sync_delete_server_data_dialog_title)
             .setMessage(getString(R.string.sync_delete_server_data_dialog_content))
-            .setPositiveButton(R.string.sync_delete_server_data_dialog_primary_button)
-            .setNegativeButton(R.string.sync_delete_server_data_dialog_secondary_button)
-            .setDestructiveButtons(true)
+            .setPositiveButton(R.string.sync_delete_server_data_dialog_primary_button, DESTRUCTIVE)
+            .setNegativeButton(R.string.sync_delete_server_data_dialog_secondary_button, GHOST_ALT)
             .addEventListener(
                 object : TextAlertDialogBuilder.EventListener() {
                     override fun onPositiveButtonClicked() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1174433894299346/1208611782328138/f

### Description
This PR updates the TextAlertDialog with a few things:
- Adds a checkbox
- Allows for button configuration

The destructive combination was using the wrong type of buttons, so we added a GhostAlt version that can now be used.

### Steps to test this PR

_ADS Demo_
- [x] Open ADS Demo
- [x] Navigate to Dialogs tab
- [ ] Verify dialogs look as expectec\