### PR TITLE
Only add Origin param if query will navigate to Duck Player

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -204,7 +204,13 @@ class BrowserWebViewClient @Inject constructor(
                         }
                         return true
                     } else {
-                        shouldOverrideWebRequest(url, webView, isForMainFrame, openInNewTab = shouldOpenDuckPlayerInNewTab)
+                        shouldOverrideWebRequest(
+                            url,
+                            webView,
+                            isForMainFrame,
+                            openInNewTab = shouldOpenDuckPlayerInNewTab,
+                            willOpenDuckPlayer = true,
+                        )
                     }
                 }
                 is SpecialUrlDetector.UrlType.NonHttpAppLink -> {
@@ -310,6 +316,7 @@ class BrowserWebViewClient @Inject constructor(
         webView: WebView,
         isForMainFrame: Boolean,
         openInNewTab: Boolean = false,
+        willOpenDuckPlayer: Boolean = false,
     ): Boolean {
         if (requestRewriter.shouldRewriteRequest(url)) {
             webViewClientListener?.let { listener ->
@@ -330,9 +337,8 @@ class BrowserWebViewClient @Inject constructor(
                             loadUrl(listener, webView, url.toString())
                         }
                         return true
-                    } else if (webView.url?.let { duckDuckGoUrlDetector.isDuckDuckGoUrl(it) } == true) {
+                    } else if (willOpenDuckPlayer && webView.url?.let { duckDuckGoUrlDetector.isDuckDuckGoUrl(it) } == true) {
                         val newUrl = url.buildUpon().appendQueryParameter(ORIGIN_QUERY_PARAM, ORIGIN_QUERY_PARAM_SERP_AUTO).build()
-
                         if (openInNewTab) {
                             listener.openLinkInNewTab(newUrl)
                         } else {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202552961248957/1208628973892718/f

### Description
Only add Origin param if query will navigate to Duck Player

### Steps to test this PR

_Test origin param is still added if navigating to Duck Player_
- [x] Set Duck Player to Always
- [x] Search for a video
- [x] Click on a search result for a video
- [x] Check query param `origin=serp_auto` is added

_Test origin param is still added if navigating to Duck Player and opening in new tab_
- [x] Open FF inventory and enable "Duck player > open in new tab"
- [x] Set Duck Player to Always and enable open in new tab
- [x] Search for a video
- [x] Click on a search result for a video
- [x] Check query param `origin=serp_auto` is added and the video is opened in a new tab

_Test origin param is not added if not navigating to Duck Player_
- [x] Set Duck Player to Always
- [x] Search for a nytimes
- [x] Open nytimes site
- [x] Check query param `origin=serp_auto` is not added
