### PR TITLE
Show Not now as secondary button during autofill onboarding

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/saving/AutofillSavingCredentialsDialogFragment.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/saving/AutofillSavingCredentialsDialogFragment.kt
@@ -258,7 +258,7 @@ class AutofillSavingCredentialsDialogFragment : BottomSheetDialogFragment(), Cre
 
     private fun configureSecondaryButtons(isOnboarding: Boolean) {
         if (isOnboarding) {
-            secondaryButton.text = getString(R.string.saveOnboardingLoginDialogNotNow)
+            secondaryButton.text = getString(R.string.saveOnboardingLoginDialogSecondaryButton)
             secondaryButton.setOnClickListener {
                 onUserChoseNotNow()
                 animateClosed()

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/saving/AutofillSavingCredentialsDialogFragment.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/saving/AutofillSavingCredentialsDialogFragment.kt
@@ -64,6 +64,7 @@ import com.duckduckgo.autofill.impl.ui.credential.saving.AutofillSavingCredentia
 import com.duckduckgo.autofill.impl.ui.credential.saving.AutofillSavingCredentialsDialogFragment.DialogEvent.Shown
 import com.duckduckgo.autofill.impl.ui.credential.saving.AutofillSavingCredentialsViewModel.ViewState
 import com.duckduckgo.autofill.impl.ui.credential.saving.declines.AutofillDeclineCounter
+import com.duckduckgo.common.ui.view.button.DaxButton
 import com.duckduckgo.common.ui.view.prependIconToText
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.FragmentViewModelFactory
@@ -115,6 +116,8 @@ class AutofillSavingCredentialsDialogFragment : BottomSheetDialogFragment(), Cre
 
     private lateinit var keyFeaturesContainer: ViewGroup
 
+    private lateinit var secondaryButton: DaxButton
+
     private val viewModel by lazy {
         ViewModelProvider(this, viewModelFactory)[AutofillSavingCredentialsViewModel::class.java]
     }
@@ -157,12 +160,14 @@ class AutofillSavingCredentialsDialogFragment : BottomSheetDialogFragment(), Cre
 
     private fun renderViewState(viewState: ViewState) {
         keyFeaturesContainer.isVisible = viewState.expandedDialog
+        configureSecondaryButtons(viewState.expandedDialog)
         (dialog as? BottomSheetDialog)?.behavior?.isDraggable = viewState.expandedDialog
         pixelNameDialogEvent(Shown, viewState.expandedDialog)?.let { pixel.fire(it) }
     }
 
     private fun configureViews(binding: ContentAutofillSaveNewCredentialsBinding) {
         keyFeaturesContainer = binding.keyFeaturesContainer
+        secondaryButton = binding.secondaryButton
         (dialog as BottomSheetDialog).behavior.state = BottomSheetBehavior.STATE_EXPANDED
         configureCloseButtons(binding)
         configureSaveButton(binding)
@@ -222,6 +227,16 @@ class AutofillSavingCredentialsDialogFragment : BottomSheetDialogFragment(), Cre
         }
     }
 
+    private fun onUserChoseNotNow() {
+        pixelNameDialogEvent(Dismissed, isOnboardingMode())?.let { pixel.fire(it) }
+
+        // this is another way to refuse saving credentials, so ensure that normal logic still runs
+        onUserRejectedToSaveCredentials()
+
+        // avoid the standard cancellation logic from running
+        ignoreCancellationEvents = true
+    }
+
     private fun onUserChoseNeverSaveThisSite() {
         pixelNameDialogEvent(Exclude, isOnboardingMode())?.let { pixel.fire(it) }
         viewModel.addSiteToNeverSaveList(getOriginalUrl())
@@ -239,9 +254,21 @@ class AutofillSavingCredentialsDialogFragment : BottomSheetDialogFragment(), Cre
      */
     private fun configureCloseButtons(binding: ContentAutofillSaveNewCredentialsBinding) {
         binding.closeButton.setOnClickListener { animateClosed() }
-        binding.neverSaveForThisSiteButton.setOnClickListener {
-            onUserChoseNeverSaveThisSite()
-            animateClosed()
+    }
+
+    private fun configureSecondaryButtons(isOnboarding: Boolean) {
+        if (isOnboarding) {
+            secondaryButton.text = getString(R.string.saveOnboardingLoginDialogNotNow)
+            secondaryButton.setOnClickListener {
+                onUserChoseNotNow()
+                animateClosed()
+            }
+        } else {
+            secondaryButton.text = getString(R.string.saveLoginDialogNeverForThisSite)
+            secondaryButton.setOnClickListener {
+                onUserChoseNeverSaveThisSite()
+                animateClosed()
+            }
         }
     }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/saving/AutofillSavingCredentialsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/saving/AutofillSavingCredentialsViewModel.kt
@@ -46,7 +46,7 @@ class AutofillSavingCredentialsViewModel @Inject constructor(
         viewModelScope.launch(dispatchers.io()) {
             val shouldShowExpandedView = autofillDeclineCounter.declineCount() < 2 && autofillDeclineCounter.isDeclineCounterActive()
             _viewState.value = ViewState(shouldShowExpandedView)
-            Timber.d("Autofill: AutofillSavingCredentialsViewModel initialized")
+            Timber.d("Autofill: AutofillSavingCredentialsViewModel initialized with expanded view state: $shouldShowExpandedView")
         }
     }
 

--- a/autofill/autofill-impl/src/main/res/layout/content_autofill_save_new_credentials.xml
+++ b/autofill/autofill-impl/src/main/res/layout/content_autofill_save_new_credentials.xml
@@ -146,10 +146,9 @@
                 app:layout_constraintTop_toBottomOf="@id/keyFeaturesContainer" />
 
             <com.duckduckgo.common.ui.view.button.DaxButtonGhost
-                android:id="@+id/neverSaveForThisSiteButton"
+                android:id="@+id/secondaryButton"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:text="@string/saveLoginDialogNeverForThisSite"
                 app:buttonSize="large"
                 app:layout_constraintEnd_toEndOf="@id/saveLoginButton"
                 app:layout_constraintStart_toStartOf="@id/saveLoginButton"

--- a/autofill/autofill-impl/src/main/res/values-bg/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-bg/strings-autofill-impl.xml
@@ -56,7 +56,7 @@
 
     <string name="credentialManagementSuggestionsLabel">Предложения</string>
 
-    <string name="credentialManagementWebViewIncompatibleErrorMessage">Автоматичното попълване за пароли не е достъпно, защото Вашата версия на Android WebView е твърде стара.</string>
+    <string name="credentialManagementWebViewIncompatibleErrorMessage">Автоматичното попълване на пароли не е достъпно, тъй като Вашата версия на Android WebView е остаряла или несъвместима.</string>
 
     <string name="autofillManagementSearchClearDescription">Изчистване на въведеното търсене</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Няма резултати за \'%1$s\'</string>
@@ -145,6 +145,7 @@
     <string name="credentials_invalid_request_warning_notif"><b></b>\nСинхронизирането на пароли е на пауза\nНякои пароли са форматирани неправилно или са твърде дълги и не бяха синхронизирани.</string>
 
     <string name="saveLoginDialogNeverForThisSite">Никога не питай за този сайт</string>
+    <string name="saveOnboardingLoginDialogSecondaryButton">Не, благодаря</string>
     <string name="credentialManagementInstructionNeverForThisSite">Ако нулирате изключените сайтове, при следващото влизане в някой от тези сайтове ще бъдете подканени да запазите паролата за вход.</string>
     <string name="credentialManagementClearNeverForThisSiteList">Нулиране на изключените сайтове</string>
     <string name="credentialManagementClearNeverForThisSiteDialogTitle">Нулиране на изключените сайтове?</string>

--- a/autofill/autofill-impl/src/main/res/values-cs/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-cs/strings-autofill-impl.xml
@@ -56,7 +56,7 @@
 
     <string name="credentialManagementSuggestionsLabel">Navrhované</string>
 
-    <string name="credentialManagementWebViewIncompatibleErrorMessage">Automatické vyplňování hesel není dostupné, protože tvoje verze Android WebView je moc stará.</string>
+    <string name="credentialManagementWebViewIncompatibleErrorMessage">Automatické vyplňování hesel není dostupné, protože tvoje verze Android WebView je zastaralá nebo nekompatibilní.</string>
 
     <string name="autofillManagementSearchClearDescription">Vymazat vyhledávací vstup</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Žádné výsledky pro dotaz „%1$s“</string>
@@ -145,6 +145,7 @@
     <string name="credentials_invalid_request_warning_notif"><b>Synchronizace hesel je pozastavená</b>\nNěkterá hesla jsou nesprávně naformátovaná nebo moc dlouhá, takže jsme je nemohli synchronizovat.</string>
 
     <string name="saveLoginDialogNeverForThisSite">Na téhle stránce už se neptat</string>
+    <string name="saveOnboardingLoginDialogSecondaryButton">Ne, děkuji</string>
     <string name="credentialManagementInstructionNeverForThisSite">Pokud vyloučené weby resetuješ, při příštím přihlašování na některý z nich se ti zobrazí výzva k uložení hesla.</string>
     <string name="credentialManagementClearNeverForThisSiteList">Obnovit vyloučené stránky</string>
     <string name="credentialManagementClearNeverForThisSiteDialogTitle">Obnovit vyloučené stránky?</string>

--- a/autofill/autofill-impl/src/main/res/values-da/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-da/strings-autofill-impl.xml
@@ -56,7 +56,7 @@
 
     <string name="credentialManagementSuggestionsLabel">Foreslået</string>
 
-    <string name="credentialManagementWebViewIncompatibleErrorMessage">Automatisk udfyldning af adgangskoder er ikke tilgængelig, fordi din version af Android WebView er for gammel.</string>
+    <string name="credentialManagementWebViewIncompatibleErrorMessage">Automatisk udfyldning af adgangskoder er ikke tilgængelig, fordi din version af Android WebView er forældet eller inkompatibel.</string>
 
     <string name="autofillManagementSearchClearDescription">Ryd søgeinput</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Ingen resultater for \"%1$s\"</string>
@@ -145,6 +145,7 @@
     <string name="credentials_invalid_request_warning_notif"><b>Synkronisering af adgangskoder er sat på pause</b>\nNogle adgangskoder er formateret forkert eller er for lange og blev ikke synkroniseret.</string>
 
     <string name="saveLoginDialogNeverForThisSite">Spørg aldrig på dette websted</string>
+    <string name="saveOnboardingLoginDialogSecondaryButton">Nej tak</string>
     <string name="credentialManagementInstructionNeverForThisSite">Hvis du nulstiller ekskluderede websteder, vil du blive bedt om at gemme din adgangskode, næste gang du logger ind på en af disse sider.</string>
     <string name="credentialManagementClearNeverForThisSiteList">Nulstil ekskluderede websteder</string>
     <string name="credentialManagementClearNeverForThisSiteDialogTitle">Nulstil ekskluderede websteder?</string>

--- a/autofill/autofill-impl/src/main/res/values-de/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-de/strings-autofill-impl.xml
@@ -56,7 +56,7 @@
 
     <string name="credentialManagementSuggestionsLabel">Vorgeschlagen</string>
 
-    <string name="credentialManagementWebViewIncompatibleErrorMessage">Die automatische Vervollständigung von Passwörtern ist nicht verfügbar, da Ihre Version von Android WebView zu alt ist.</string>
+    <string name="credentialManagementWebViewIncompatibleErrorMessage">Die automatische Vervollständigung von Passwörtern ist nicht verfügbar, da deine Version von Android WebView nicht aktuell oder inkompatibel ist.</string>
 
     <string name="autofillManagementSearchClearDescription">Sucheingabe löschen</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Keine Ergebnisse für „%1$s“</string>
@@ -145,6 +145,7 @@
     <string name="credentials_invalid_request_warning_notif"><b>Die Passwort-Synchronisierung wurde angehalten</b>\nEinige Passwörter sind falsch formatiert oder zu lang und wurden nicht synchronisiert.\n\n</string>
 
     <string name="saveLoginDialogNeverForThisSite">Für diese Website niemals fragen</string>
+    <string name="saveOnboardingLoginDialogSecondaryButton">Nein, danke</string>
     <string name="credentialManagementInstructionNeverForThisSite">Wenn du die ausgeschlossenen Websites zurücksetzt, wirst du aufgefordert, dein Passwort zu speichern, wenn du dich das nächste Mal auf einer dieser Websites anmeldest.</string>
     <string name="credentialManagementClearNeverForThisSiteList">Ausgeschlossene Websites zurücksetzen</string>
     <string name="credentialManagementClearNeverForThisSiteDialogTitle">Ausgeschlossene Websites zurücksetzen?</string>

--- a/autofill/autofill-impl/src/main/res/values-el/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-el/strings-autofill-impl.xml
@@ -56,7 +56,7 @@
 
     <string name="credentialManagementSuggestionsLabel">Προτεινόμενο</string>
 
-    <string name="credentialManagementWebViewIncompatibleErrorMessage">Η αυτόματη συμπλήρωση κωδικών πρόσβασης δεν είναι διαθέσιμη καθώς η έκδοση του Android WebView είναι πολύ παλιά.</string>
+    <string name="credentialManagementWebViewIncompatibleErrorMessage">Η αυτόματη συμπλήρωση κωδικών πρόσβασης δεν είναι διαθέσιμη καθώς η έκδοση του Android WebView είναι παλιά ή μη συμβατή.</string>
 
     <string name="autofillManagementSearchClearDescription">Εκκαθάριση εισαγωγής αναζήτησης</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Δεν υπάρχουν αποτελέσματα για «%1$s»</string>
@@ -145,6 +145,7 @@
     <string name="credentials_invalid_request_warning_notif"><b>Ο συγχρονισμός κωδικών πρόσβασης έχει τεθεί σε παύση</b>\nΟρισμένοι κωδικοί πρόσβασης δεν έχουν μορφοποιηθεί σωστά ή είναι πολύ μεγάλοι και δεν συγχρονίστηκαν.</string>
 
     <string name="saveLoginDialogNeverForThisSite">Μην ζητάτε ποτέ αυτόν τον ιστότοπο</string>
+    <string name="saveOnboardingLoginDialogSecondaryButton">Όχι, ευχαριστώ</string>
     <string name="credentialManagementInstructionNeverForThisSite">Εάν κάνετε επαναφορά των αποκλεισμένων ιστότοπων, θα σας ζητηθεί να αποθηκεύσετε τον κωδικό πρόσβασής σας την επόμενη φορά που θα συνδεθείτε σε οποιονδήποτε από τους ιστότοπους αυτούς.</string>
     <string name="credentialManagementClearNeverForThisSiteList">Επαναφορά αποκλεισμένων ιστότοπων</string>
     <string name="credentialManagementClearNeverForThisSiteDialogTitle">Επαναφορά αποκλεισμένων ιστότοπων;</string>

--- a/autofill/autofill-impl/src/main/res/values-es/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-es/strings-autofill-impl.xml
@@ -56,7 +56,7 @@
 
     <string name="credentialManagementSuggestionsLabel">Sugerencias</string>
 
-    <string name="credentialManagementWebViewIncompatibleErrorMessage">La función de autocompletar para las contraseñas no está disponible porque tu versión de Android WebView es demasiado antigua.</string>
+    <string name="credentialManagementWebViewIncompatibleErrorMessage">La función de autocompletar para las contraseñas no está disponible porque tu versión de Android WebView está desfasada o es incompatible.</string>
 
     <string name="autofillManagementSearchClearDescription">Borrar búsqueda</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Sin resultados para «%1$s»</string>
@@ -145,6 +145,7 @@
     <string name="credentials_invalid_request_warning_notif"><b>La sincronización de contraseña está en pausa</b>\nAlgunas contraseñas tienen un formato incorrecto o son demasiado largas y no se han sincronizado.</string>
 
     <string name="saveLoginDialogNeverForThisSite">No preguntar nunca para esta página</string>
+    <string name="saveOnboardingLoginDialogSecondaryButton">No, gracias</string>
     <string name="credentialManagementInstructionNeverForThisSite">Si restableces los sitios excluidos, se te pedirá que guardes tu contraseña la próxima vez que accedas a cualquiera de estos sitios.</string>
     <string name="credentialManagementClearNeverForThisSiteList">Restablecer sitios excluidos</string>
     <string name="credentialManagementClearNeverForThisSiteDialogTitle">¿Restablecer sitios excluidos?</string>

--- a/autofill/autofill-impl/src/main/res/values-et/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-et/strings-autofill-impl.xml
@@ -56,7 +56,7 @@
 
     <string name="credentialManagementSuggestionsLabel">Soovitatud</string>
 
-    <string name="credentialManagementWebViewIncompatibleErrorMessage">Automaatne täitmine paroolide jaoks pole saadaval, sest sinu Android WebView\'i versioon on liiga vana.</string>
+    <string name="credentialManagementWebViewIncompatibleErrorMessage">Automaatne täitmine paroolide jaoks pole saadaval, sest sinu Android WebView\'i versioon on aegunud või ühildumatu.</string>
 
     <string name="autofillManagementSearchClearDescription">Tühjenda otsingusisend</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Päringule „%1$s” ei leitud tulemusi</string>
@@ -145,6 +145,7 @@
     <string name="credentials_invalid_request_warning_notif"><b>Paroolide sünkroonimine on peatatud</b>\nMõned paroolid on valesti vormindatud või liiga pikad ja neid ei sünkroonitud.</string>
 
     <string name="saveLoginDialogNeverForThisSite">Ära selle saidi kohta rohkem küsi</string>
+    <string name="saveOnboardingLoginDialogSecondaryButton">Ei, aitäh</string>
     <string name="credentialManagementInstructionNeverForThisSite">Kui lähtestad välistatud saidid, pakutakse sulle järgmisel korral, kui logid neile saitidele sisse, võimalust parool salvestada.</string>
     <string name="credentialManagementClearNeverForThisSiteList">Lähtesta välistatud saidid</string>
     <string name="credentialManagementClearNeverForThisSiteDialogTitle">Kas lähtestada välistatud saidid?</string>

--- a/autofill/autofill-impl/src/main/res/values-fi/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-fi/strings-autofill-impl.xml
@@ -56,7 +56,7 @@
 
     <string name="credentialManagementSuggestionsLabel">Ehdotettu</string>
 
-    <string name="credentialManagementWebViewIncompatibleErrorMessage">Salasanojen automaattinen täyttäminen ei ole käytettävissä, koska Android WebView -versiosi on liian vanha.</string>
+    <string name="credentialManagementWebViewIncompatibleErrorMessage">Salasanojen automaattinen täyttäminen ei ole käytettävissä, koska Android WebView -versiosi on vanhentunut tai yhteensopimaton.</string>
 
     <string name="autofillManagementSearchClearDescription">Tyhjennä hakusyöte</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Ei tuloksia haulla \'%1$s\'</string>
@@ -145,6 +145,7 @@
     <string name="credentials_invalid_request_warning_notif"><b>Salasanojen synkronointi keskeytetty</b>\nSalasanojen synkronointi on keskeytetty.\n\nJotkin salasanat on muotoiltu väärin tai ovat liian pitkiä, eikä niitä synkronoitu.</string>
 
     <string name="saveLoginDialogNeverForThisSite">Älä kysy enää tällä sivustolla</string>
+    <string name="saveOnboardingLoginDialogSecondaryButton">Ei kiitos</string>
     <string name="credentialManagementInstructionNeverForThisSite">Jos nollaat poissuljetut sivustot, sinua pyydetään tallentamaan salasanasi, kun seuraavan kerran kirjaudut sisään jollekin näistä sivustoista.</string>
     <string name="credentialManagementClearNeverForThisSiteList">Nollaa poissuljetut sivustot</string>
     <string name="credentialManagementClearNeverForThisSiteDialogTitle">Nollataanko poissuljetut sivustot?</string>

--- a/autofill/autofill-impl/src/main/res/values-fr/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-fr/strings-autofill-impl.xml
@@ -56,7 +56,7 @@
 
     <string name="credentialManagementSuggestionsLabel">Suggéré</string>
 
-    <string name="credentialManagementWebViewIncompatibleErrorMessage">La saisie automatique des mots de passe n\'est pas disponible car votre version d\'Android WebView est trop ancienne.</string>
+    <string name="credentialManagementWebViewIncompatibleErrorMessage">La saisie automatique des mots de passe n\'est pas disponible car votre version d\'Android WebView est obsolète ou incompatible.</string>
 
     <string name="autofillManagementSearchClearDescription">Effacer la recherche</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Aucun résultat pour « %1$s »</string>
@@ -145,6 +145,7 @@
     <string name="credentials_invalid_request_warning_notif"><b>La synchronisation des mots de passe est suspendue</b>\nCertains mots de passe sont mal formatés ou trop longs et n\'ont pas été synchronisés.</string>
 
     <string name="saveLoginDialogNeverForThisSite">Ne jamais demander pour ce site</string>
+    <string name="saveOnboardingLoginDialogSecondaryButton">Non merci</string>
     <string name="credentialManagementInstructionNeverForThisSite">Si vous réinitialisez les sites exclus, vous serez invité(e) à enregistrer votre mot de passe lors de votre prochaine connexion à l\'un de ces sites.</string>
     <string name="credentialManagementClearNeverForThisSiteList">Réinitialiser les sites exclus</string>
     <string name="credentialManagementClearNeverForThisSiteDialogTitle">Réinitialiser les sites exclus ?</string>

--- a/autofill/autofill-impl/src/main/res/values-hr/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-hr/strings-autofill-impl.xml
@@ -56,7 +56,7 @@
 
     <string name="credentialManagementSuggestionsLabel">Predloženo</string>
 
-    <string name="credentialManagementWebViewIncompatibleErrorMessage">Automatsko popunjavanje lozinki nije dostupno jer je vaša verzija Android WebViewa prestara.</string>
+    <string name="credentialManagementWebViewIncompatibleErrorMessage">Automatsko popunjavanje lozinki nije dostupno jer je tvoja verzija Android WebViewa zastarjela ili nekompatibilna.</string>
 
     <string name="autofillManagementSearchClearDescription">Obriši unos pretraživanja</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Nema rezultata za \"%1$s\"</string>
@@ -145,6 +145,7 @@
     <string name="credentials_invalid_request_warning_notif"><b>Sinkronizacija lozinki je pauzirana</b>\nNeke su lozinke formatirane pogrešno, ili su preduge i nisu sinkronizirane.\n\n</string>
 
     <string name="saveLoginDialogNeverForThisSite">Nikada ne traži za ovu web lokaciju</string>
+    <string name="saveOnboardingLoginDialogSecondaryButton">Ne, hvala</string>
     <string name="credentialManagementInstructionNeverForThisSite">Ako resetiraš isključene web lokacije, od tebe će se zatražiti da spremiš svoju lozinku sljedeći put kad se prijaviš na bilo koju od ovih lokacija.</string>
     <string name="credentialManagementClearNeverForThisSiteList">Resetiraj isključene web lokacije</string>
     <string name="credentialManagementClearNeverForThisSiteDialogTitle">Resetiraj isključene web lokacije?</string>

--- a/autofill/autofill-impl/src/main/res/values-hu/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-hu/strings-autofill-impl.xml
@@ -56,7 +56,7 @@
 
     <string name="credentialManagementSuggestionsLabel">Javasolt</string>
 
-    <string name="credentialManagementWebViewIncompatibleErrorMessage">A jelszavak automatikus kitöltése nem érhető el, mert az Android WebView verziója túl régi.</string>
+    <string name="credentialManagementWebViewIncompatibleErrorMessage">A jelszavak automatikus kitöltése nem érhető el, mert az Android WebView verziója elavult vagy nem kompatibilis.</string>
 
     <string name="autofillManagementSearchClearDescription">Megadott keresés törlése</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Nincs találat erre: „%1$s”</string>
@@ -145,6 +145,7 @@
     <string name="credentials_invalid_request_warning_notif"><b>Jelszó-szinkronizálás szüneteltetve</b>\nEgyes jelszavak helytelen formátumúak vagy túl hosszúak, és nem lettek szinkronizálva.</string>
 
     <string name="saveLoginDialogNeverForThisSite">Soha ne kérdezzen rá ennél a webhelynél</string>
+    <string name="saveOnboardingLoginDialogSecondaryButton">Nem, köszönöm</string>
     <string name="credentialManagementInstructionNeverForThisSite">A kizárt webhelyek visszaállítása esetén a rendszer a jelszavad mentését kéri, amikor legközelebb bejelentkezel ezen webhelyek bármelyikére.</string>
     <string name="credentialManagementClearNeverForThisSiteList">Kizárt webhelyek visszaállítása</string>
     <string name="credentialManagementClearNeverForThisSiteDialogTitle">Kizárt webhelyek visszaállítása?</string>

--- a/autofill/autofill-impl/src/main/res/values-it/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-it/strings-autofill-impl.xml
@@ -56,7 +56,7 @@
 
     <string name="credentialManagementSuggestionsLabel">Suggerimenti</string>
 
-    <string name="credentialManagementWebViewIncompatibleErrorMessage">La compilazione automatica delle password non è disponibile perché la versione di Android WebView in uso è troppo vecchia.</string>
+    <string name="credentialManagementWebViewIncompatibleErrorMessage">La compilazione automatica delle password non è disponibile perché la versione di Android WebView che usi è obsoleta o incompatibile.</string>
 
     <string name="autofillManagementSearchClearDescription">Elimina input di ricerca</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Nessun risultato per \"%1$s\"</string>
@@ -145,6 +145,7 @@
     <string name="credentials_invalid_request_warning_notif"><b>Sincronizzazione password in pausa</b>\nAlcune password sono formattate in modo errato o sono troppo lunghe e non sono state sincronizzate.</string>
 
     <string name="saveLoginDialogNeverForThisSite">Non chiedere mai per questo sito</string>
+    <string name="saveOnboardingLoginDialogSecondaryButton">No, grazie</string>
     <string name="credentialManagementInstructionNeverForThisSite">Se ripristini i siti esclusi, ti verrà richiesto di salvare la password la prossima volta che accederai a uno di questi siti.</string>
     <string name="credentialManagementClearNeverForThisSiteList">Ripristina siti esclusi</string>
     <string name="credentialManagementClearNeverForThisSiteDialogTitle">Ripristinare i siti esclusi?</string>

--- a/autofill/autofill-impl/src/main/res/values-lt/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-lt/strings-autofill-impl.xml
@@ -56,7 +56,7 @@
 
     <string name="credentialManagementSuggestionsLabel">Siūloma</string>
 
-    <string name="credentialManagementWebViewIncompatibleErrorMessage">Automatinis slaptažodžių įrašymas nepasiekiamas, nes jūsų „Android WebView“ versija yra per sena.</string>
+    <string name="credentialManagementWebViewIncompatibleErrorMessage">Automatinis slaptažodžių įrašymas nepasiekiamas, nes jūsų „Android WebView“ versija yra pasenusi arba nesuderinama.</string>
 
     <string name="autofillManagementSearchClearDescription">Išvalyti paieškos įvestį</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Rezultatų pagal paiešką „%1$s“ nerasta</string>
@@ -145,6 +145,7 @@
     <string name="credentials_invalid_request_warning_notif"><b>Slaptažodžių sinchronizavimas pristabdytas</b>\nKai kurie slaptažodžiai suformatuoti neteisingai arba yra per ilgi ir nebuvo sinchronizuoti.</string>
 
     <string name="saveLoginDialogNeverForThisSite">Niekada neklauskite šioje svetainėje</string>
+    <string name="saveOnboardingLoginDialogSecondaryButton">Ne, dėkoju</string>
     <string name="credentialManagementInstructionNeverForThisSite">Jei iš naujo nustatysite neįtrauktas svetaines, kitą kartą, kai prisijungsite prie bet kurios iš šių svetainių, būsite paraginti išsaugoti savo slaptažodį.</string>
     <string name="credentialManagementClearNeverForThisSiteList">Iš naujo nustatyti neįtrauktas svetaines</string>
     <string name="credentialManagementClearNeverForThisSiteDialogTitle">Iš naujo nustatyti neįtrauktas svetaines?</string>

--- a/autofill/autofill-impl/src/main/res/values-lv/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-lv/strings-autofill-impl.xml
@@ -56,7 +56,7 @@
 
     <string name="credentialManagementSuggestionsLabel">Ieteikts</string>
 
-    <string name="credentialManagementWebViewIncompatibleErrorMessage">Paroļu automātiskā aizpildīšana nav pieejama, jo tava Android WebView versija ir pārāk veca.</string>
+    <string name="credentialManagementWebViewIncompatibleErrorMessage">Paroļu automātiskā aizpildīšana nav pieejama, jo tava Android WebView versija ir novecojusi vai nesaderīga.</string>
 
     <string name="autofillManagementSearchClearDescription">Notīrīt meklēšanas ievadi</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Vaicājumam “%1$s” nav rezultātu</string>
@@ -145,6 +145,7 @@
     <string name="credentials_invalid_request_warning_notif"><b>Paroļu sinhronizācija ir pārtraukta</b>\nDažas paroles ir formatētas nepareizi vai ir pārāk garas un netika sinhronizētas.</string>
 
     <string name="saveLoginDialogNeverForThisSite">Nekad nejautāt par šo vietni</string>
+    <string name="saveOnboardingLoginDialogSecondaryButton">Nē, paldies</string>
     <string name="credentialManagementInstructionNeverForThisSite">Ja atiestatīsi izslēgtās vietnes, tev tiks piedāvāts saglabāt savus pieteikšanās datus, kad nākamreiz tajās pierakstīsies.</string>
     <string name="credentialManagementClearNeverForThisSiteList">Atiestatīt izslēgtās vietnes</string>
     <string name="credentialManagementClearNeverForThisSiteDialogTitle">Atiestatīt izslēgtās vietnes?</string>

--- a/autofill/autofill-impl/src/main/res/values-nb/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-nb/strings-autofill-impl.xml
@@ -56,7 +56,7 @@
 
     <string name="credentialManagementSuggestionsLabel">Forslag</string>
 
-    <string name="credentialManagementWebViewIncompatibleErrorMessage">Autofyll for passord er ikke tilgjengelig fordi din versjon av Android WebView er for gammel.</string>
+    <string name="credentialManagementWebViewIncompatibleErrorMessage">Autofyll for passord er ikke tilgjengelig fordi din versjon av Android WebView er utdatert eller inkompatibel.</string>
 
     <string name="autofillManagementSearchClearDescription">Tøm søkefeltet</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Ingen resultater for «%1$s»</string>
@@ -145,6 +145,7 @@
     <string name="credentials_invalid_request_warning_notif"><b>Synkronisering av passord er satt på pause</b>\nNoen passord er formatert feil eller for lange og ble ikke synkronisert.</string>
 
     <string name="saveLoginDialogNeverForThisSite">Aldri spør for dette nettstedet</string>
+    <string name="saveOnboardingLoginDialogSecondaryButton">Nei takk</string>
     <string name="credentialManagementInstructionNeverForThisSite">Hvis du tilbakestiller ekskluderte nettsteder, blir du bedt om å lagre passordet ditt neste gang du logger på disse nettstedene.</string>
     <string name="credentialManagementClearNeverForThisSiteList">Tilbakestill ekskluderte nettsteder</string>
     <string name="credentialManagementClearNeverForThisSiteDialogTitle">Vil du tilbakestille ekskluderte nettsteder?</string>

--- a/autofill/autofill-impl/src/main/res/values-nl/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-nl/strings-autofill-impl.xml
@@ -56,7 +56,7 @@
 
     <string name="credentialManagementSuggestionsLabel">Aanbevolen</string>
 
-    <string name="credentialManagementWebViewIncompatibleErrorMessage">Automatisch invullen voor wachtwoorden is niet beschikbaar omdat je versie van Android WebView te oud is.</string>
+    <string name="credentialManagementWebViewIncompatibleErrorMessage">Automatisch invullen voor wachtwoorden is niet beschikbaar omdat je versie van Android WebView verouderd of niet compatibel is.</string>
 
     <string name="autofillManagementSearchClearDescription">Zoekinvoer wissen</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Geen resultaten voor \'%1$s\'</string>
@@ -145,6 +145,7 @@
     <string name="credentials_invalid_request_warning_notif"><b>Synchronisatie onderbroken</b>\nSommige wachtwoorden hebben de verkeerde indeling of zijn te lang en werden niet gesynchroniseerd.</string>
 
     <string name="saveLoginDialogNeverForThisSite">Nooit vragen voor deze site</string>
+    <string name="saveOnboardingLoginDialogSecondaryButton">Nee, bedankt</string>
     <string name="credentialManagementInstructionNeverForThisSite">Als je uitgesloten sites opnieuw instelt, zie je de volgende keer dat je bij een van deze sites inlogt een melding om je wachtwoord op te slaan.</string>
     <string name="credentialManagementClearNeverForThisSiteList">Uitgesloten sites opnieuw instellen</string>
     <string name="credentialManagementClearNeverForThisSiteDialogTitle">Uitgesloten sites opnieuw instellen?</string>

--- a/autofill/autofill-impl/src/main/res/values-pl/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-pl/strings-autofill-impl.xml
@@ -56,7 +56,7 @@
 
     <string name="credentialManagementSuggestionsLabel">Sugerowane</string>
 
-    <string name="credentialManagementWebViewIncompatibleErrorMessage">Autouzupełnianie haseł jest niedostępne, ponieważ wersja Android WebView jest przestarzała.</string>
+    <string name="credentialManagementWebViewIncompatibleErrorMessage">Autouzupełnianie haseł jest niedostępne, ponieważ wykorzystywana wersja Android WebView jest nieaktualna lub niezgodna.</string>
 
     <string name="autofillManagementSearchClearDescription">Usuń treść wyszukiwania</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Nie znaleziono wyników dla frazy „%1$s”</string>
@@ -145,6 +145,7 @@
     <string name="credentials_invalid_request_warning_notif"><b>Synchronizacja haseł wstrzymana</b>\nNiektóre hasła mają niepoprawny format lub są za długie i nie zostały zsynchronizowane.</string>
 
     <string name="saveLoginDialogNeverForThisSite">Nigdy nie pytaj o tę witrynę</string>
+    <string name="saveOnboardingLoginDialogSecondaryButton">Nie, dziękuję</string>
     <string name="credentialManagementInstructionNeverForThisSite">Jeśli zresetujesz wykluczone witryny, przy następnym logowaniu do dowolnej z nich pojawi się monit o zapisanie hasła.</string>
     <string name="credentialManagementClearNeverForThisSiteList">Resetowanie wykluczonych witryn</string>
     <string name="credentialManagementClearNeverForThisSiteDialogTitle">Zresetować wykluczone witryny?</string>

--- a/autofill/autofill-impl/src/main/res/values-pt/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-pt/strings-autofill-impl.xml
@@ -56,7 +56,7 @@
 
     <string name="credentialManagementSuggestionsLabel">Sugerido</string>
 
-    <string name="credentialManagementWebViewIncompatibleErrorMessage">O preenchimento automático de palavras-passe não está disponível porque a tua versão do Android WebView é demasiado antiga.</string>
+    <string name="credentialManagementWebViewIncompatibleErrorMessage">O preenchimento automático de palavras-passe não está disponível porque a tua versão do Android WebView está desatualizada ou é incompatível.</string>
 
     <string name="autofillManagementSearchClearDescription">Limpar introdução da pesquisa</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Nenhum resultado para \"%1$s\"</string>
@@ -145,6 +145,7 @@
     <string name="credentials_invalid_request_warning_notif"><b>A sincronização de palavras-passe está em pausa</b>\nAlgumas palavras-passe estão formatadas incorretamente ou são demasiado longas e não foram sincronizadas.</string>
 
     <string name="saveLoginDialogNeverForThisSite">Nunca pedir para este site</string>
+    <string name="saveOnboardingLoginDialogSecondaryButton">Não, obrigado</string>
     <string name="credentialManagementInstructionNeverForThisSite">Se repuseres os sites excluídos, ser-te-á pedido que guardes a tua palavra-passe da próxima vez que iniciares sessão num destes sites.</string>
     <string name="credentialManagementClearNeverForThisSiteList">Repor sites excluídos</string>
     <string name="credentialManagementClearNeverForThisSiteDialogTitle">Repor sites excluídos?</string>

--- a/autofill/autofill-impl/src/main/res/values-ro/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-ro/strings-autofill-impl.xml
@@ -56,7 +56,7 @@
 
     <string name="credentialManagementSuggestionsLabel">Sugerat</string>
 
-    <string name="credentialManagementWebViewIncompatibleErrorMessage">Completarea automată a parolelor nu este disponibilă, deoarece versiunea ta de Android WebView este prea veche.</string>
+    <string name="credentialManagementWebViewIncompatibleErrorMessage">Completarea automată a parolelor nu este disponibilă, deoarece versiunea ta de Android WebView este învechită sau incompatibilă.</string>
 
     <string name="autofillManagementSearchClearDescription">Șterge datele introduse pentru căutare</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Nu există rezultate pentru „%1$s”</string>
@@ -145,6 +145,7 @@
     <string name="credentials_invalid_request_warning_notif"><b>Sincronizarea parolelor este întreruptă</b>\nUnele parole sunt formatate incorect sau sunt prea lungi și nu au fost sincronizate.</string>
 
     <string name="saveLoginDialogNeverForThisSite">Nu solicita niciodată pentru acest site</string>
+    <string name="saveOnboardingLoginDialogSecondaryButton">Nu, mulțumesc</string>
     <string name="credentialManagementInstructionNeverForThisSite">Dacă resetezi site-urile excluse, ți se va solicita să îți salvezi parola data viitoare când te conectezi la oricare dintre aceste site-uri.</string>
     <string name="credentialManagementClearNeverForThisSiteList">Resetează site-urile excluse</string>
     <string name="credentialManagementClearNeverForThisSiteDialogTitle">Resetezi site-urile excluse?</string>

--- a/autofill/autofill-impl/src/main/res/values-ru/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-ru/strings-autofill-impl.xml
@@ -56,7 +56,7 @@
 
     <string name="credentialManagementSuggestionsLabel">Рекомендации</string>
 
-    <string name="credentialManagementWebViewIncompatibleErrorMessage">Автозаполнение паролей недоступно, так как ваша версия Android WebView устарела.</string>
+    <string name="credentialManagementWebViewIncompatibleErrorMessage">Автозаполнение паролей недоступно: ваша версия Android WebView устарела или утратила совместимость.</string>
 
     <string name="autofillManagementSearchClearDescription">Сбросить поисковый запрос</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Поиск «%1$s» не дал результатов</string>
@@ -145,6 +145,7 @@
     <string name="credentials_invalid_request_warning_notif"><b>Синхронизация паролей на паузе</b>\nНекоторые пароли не синхронизируются из-за неверного формата или превышения ограничений по длине.</string>
 
     <string name="saveLoginDialogNeverForThisSite">Больше не спрашивать на этом сайте</string>
+    <string name="saveOnboardingLoginDialogSecondaryButton">Нет, спасибо</string>
     <string name="credentialManagementInstructionNeverForThisSite">Если вы очистите список исключений, при следующем входе на любой из этих сайтов система предложит вам сохранить пароль.</string>
     <string name="credentialManagementClearNeverForThisSiteList">Сбросить список исключений</string>
     <string name="credentialManagementClearNeverForThisSiteDialogTitle">Сбросить список исключений?</string>

--- a/autofill/autofill-impl/src/main/res/values-sk/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-sk/strings-autofill-impl.xml
@@ -56,7 +56,7 @@
 
     <string name="credentialManagementSuggestionsLabel">Navrhované</string>
 
-    <string name="credentialManagementWebViewIncompatibleErrorMessage">Automatické vypĺňanie hesiel nie je k dispozícii, pretože vaša verzia aplikácie Android WebView je príliš stará.</string>
+    <string name="credentialManagementWebViewIncompatibleErrorMessage">Automatické vypĺňanie hesiel nie je k dispozícii, pretože vaša verzia aplikácie Android WebView je zastaraná alebo nekompatibilná.</string>
 
     <string name="autofillManagementSearchClearDescription">Vymazať hľadaný výraz</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Žiadne výsledky pre „%1$s”</string>
@@ -145,6 +145,7 @@
     <string name="credentials_invalid_request_warning_notif">Heslá<b>sa nesynchronizujú\nNiektoré heslá sú nesprávne naformátované alebo sú príliš dlhé, a neboli synchronizované.</b></string>
 
     <string name="saveLoginDialogNeverForThisSite">Nikdy sa nepýtať na túto stránku</string>
+    <string name="saveOnboardingLoginDialogSecondaryButton">Nie, ďakujem</string>
     <string name="credentialManagementInstructionNeverForThisSite">Ak obnovíte vylúčené lokality, pri ďalšom prihlásení na niektorú z týchto lokalít dostanete výzvu na uloženie svojho hesla.</string>
     <string name="credentialManagementClearNeverForThisSiteList">Obnovenie vylúčených lokalít</string>
     <string name="credentialManagementClearNeverForThisSiteDialogTitle">Obnoviť vylúčené lokality?</string>

--- a/autofill/autofill-impl/src/main/res/values-sl/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-sl/strings-autofill-impl.xml
@@ -56,7 +56,7 @@
 
     <string name="credentialManagementSuggestionsLabel">Predlagano</string>
 
-    <string name="credentialManagementWebViewIncompatibleErrorMessage">Samodejno izpolnjevanje gesel ni na voljo, ker je vaša različica programa Android WebView prestara.</string>
+    <string name="credentialManagementWebViewIncompatibleErrorMessage">Samodejno izpolnjevanje gesel ni na voljo, ker je vaša različica programa Android WebView zastarela ali nezdružljiva.</string>
 
     <string name="autofillManagementSearchClearDescription">Počisti vhod iskanja</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Ni rezultatov za »%1$s«</string>
@@ -145,6 +145,7 @@
     <string name="credentials_invalid_request_warning_notif"><b>Sinhronizacija gesel je začasno zaustavljena</b>\nNekatera gesla so napačno oblikovana ali predolga in niso bila sinhronizirana.</string>
 
     <string name="saveLoginDialogNeverForThisSite">Nikoli ne vprašaj za to spletno mesto</string>
+    <string name="saveOnboardingLoginDialogSecondaryButton">Ne, hvala</string>
     <string name="credentialManagementInstructionNeverForThisSite">Če ponastavite izključena spletna mesta, boste ob naslednji prijavi na katero koli od teh spletnih mest pozvani, da shranite svojo prijavo.</string>
     <string name="credentialManagementClearNeverForThisSiteList">Ponastavi izključena spletna mesta</string>
     <string name="credentialManagementClearNeverForThisSiteDialogTitle">Želite ponastaviti izključena spletna mesta?</string>

--- a/autofill/autofill-impl/src/main/res/values-sv/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-sv/strings-autofill-impl.xml
@@ -56,7 +56,7 @@
 
     <string name="credentialManagementSuggestionsLabel">Förslag</string>
 
-    <string name="credentialManagementWebViewIncompatibleErrorMessage">Automatisk ifyllning för lösenord är inte tillgängligt eftersom din version av Android WebView är för gammal.</string>
+    <string name="credentialManagementWebViewIncompatibleErrorMessage">Automatisk ifyllning för lösenord är inte tillgängligt eftersom din version av Android WebView är för gammal eller inkompatibel.</string>
 
     <string name="autofillManagementSearchClearDescription">Rensa sökfältet</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">Inga resultat för ”%1$s”</string>
@@ -145,6 +145,7 @@
     <string name="credentials_invalid_request_warning_notif"><b>Lösenordssynkroniseringen har pausats</b>\nVissa lösenord är felaktigt formaterade eller för långa och har inte synkroniserats.</string>
 
     <string name="saveLoginDialogNeverForThisSite">Fråga aldrig för den här webbplatsen</string>
+    <string name="saveOnboardingLoginDialogSecondaryButton">Nej tack</string>
     <string name="credentialManagementInstructionNeverForThisSite">Om du återställer exkluderade webbplatser kommer du att uppmanas att spara ditt lösenord nästa gång du loggar in på någon av dessa webbplatser.</string>
     <string name="credentialManagementClearNeverForThisSiteList">Återställ exkluderade webbplatser</string>
     <string name="credentialManagementClearNeverForThisSiteDialogTitle">Återställ exkluderade webbplatser?</string>

--- a/autofill/autofill-impl/src/main/res/values-tr/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-tr/strings-autofill-impl.xml
@@ -56,7 +56,7 @@
 
     <string name="credentialManagementSuggestionsLabel">Önerilen</string>
 
-    <string name="credentialManagementWebViewIncompatibleErrorMessage">Android WebView sürümünüz çok eski olduğundan parolalar için otomatik doldurma kullanılamıyor.</string>
+    <string name="credentialManagementWebViewIncompatibleErrorMessage">Android WebView sürümünüz güncel değil veya uyumsuz olduğundan parolalar için otomatik doldurma kullanılamıyor.</string>
 
     <string name="autofillManagementSearchClearDescription">Arama girişini temizle</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for &apos;kittens&apos;">\'%1$s\' için sonuç yok</string>
@@ -145,6 +145,7 @@
     <string name="credentials_invalid_request_warning_notif"><b>Şifre Senkronizasyonu Durduruldu</b>\nBazı şifreler yanlış biçimlendirilmiş veya çok uzun olduğu için senkronize edilmedi.</string>
 
     <string name="saveLoginDialogNeverForThisSite">Bu Site için Hiçbir Zaman Sorma</string>
+    <string name="saveOnboardingLoginDialogSecondaryButton">Hayır Teşekkürler</string>
     <string name="credentialManagementInstructionNeverForThisSite">Hariç tutulan siteleri sıfırlarsanız, bu sitelerden herhangi birinde bir sonraki oturum açtığınızda şifrenizi kaydetmeniz istenecektir.</string>
     <string name="credentialManagementClearNeverForThisSiteList">Hariç Tutulan Siteleri Sıfırla</string>
     <string name="credentialManagementClearNeverForThisSiteDialogTitle">Hariç Tutulan Siteler Sıfırlansın mı?</string>

--- a/autofill/autofill-impl/src/main/res/values/donottranslate.xml
+++ b/autofill/autofill-impl/src/main/res/values/donottranslate.xml
@@ -17,6 +17,4 @@
 <resources>
     <!-- New Tab -->
     <string name="newTabPageShortcutPasswords">Passwords</string>
-
-    <string name="saveOnboardingLoginDialogSecondaryButton">No Thanks</string>
 </resources>

--- a/autofill/autofill-impl/src/main/res/values/donottranslate.xml
+++ b/autofill/autofill-impl/src/main/res/values/donottranslate.xml
@@ -17,4 +17,6 @@
 <resources>
     <!-- New Tab -->
     <string name="newTabPageShortcutPasswords">Passwords</string>
+
+    <string name="saveOnboardingLoginDialogNotNow">Not Now</string>
 </resources>

--- a/autofill/autofill-impl/src/main/res/values/donottranslate.xml
+++ b/autofill/autofill-impl/src/main/res/values/donottranslate.xml
@@ -18,5 +18,5 @@
     <!-- New Tab -->
     <string name="newTabPageShortcutPasswords">Passwords</string>
 
-    <string name="saveOnboardingLoginDialogNotNow">Not Now</string>
+    <string name="saveOnboardingLoginDialogSecondaryButton">No Thanks</string>
 </resources>

--- a/autofill/autofill-impl/src/main/res/values/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values/strings-autofill-impl.xml
@@ -56,7 +56,7 @@
 
     <string name="credentialManagementSuggestionsLabel">Suggested</string>
 
-    <string name="credentialManagementWebViewIncompatibleErrorMessage">Autofill for passwords is unavailable because your version of Android WebView is too old.</string>
+    <string name="credentialManagementWebViewIncompatibleErrorMessage">Autofill for passwords is unavailable because your version of Android WebView is outdated or incompatible.</string>
 
     <string name="autofillManagementSearchClearDescription">Clear search input</string>
     <string name="autofillManagementNoSearchResults" instruction="Placeholder is the query the user has searched for. e.g., No results for 'kittens'">No results for \'%1$s\'</string>
@@ -145,6 +145,7 @@
     <string name="credentials_invalid_request_warning_notif"><b>Password Sync is Paused</b>\nSome passwords are formatted incorrectly or too long and were not synced.</string>
 
     <string name="saveLoginDialogNeverForThisSite">Never Ask for This Site</string>
+    <string name="saveOnboardingLoginDialogSecondaryButton">No Thanks</string>
     <string name="credentialManagementInstructionNeverForThisSite">If you reset excluded sites, you will be prompted to save your password next time you sign in to any of these sites.</string>
     <string name="credentialManagementClearNeverForThisSiteList">Reset Excluded Sites</string>
     <string name="credentialManagementClearNeverForThisSiteDialogTitle">Reset Excluded Sites?</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203822806345703/1208592982102639/f 

### Description
During Autofill Onboarding show "Not Now" as secondary button.

### Steps to test this PR

_Feature 1_
- [x] fresh install
- [x] visit fill.dev and try a login
- [x] ensure on the dialog (onboarding), secondary button is not now
- [x] click Not Now
- [x] visit authenticationtest.com and try a login
- [x] ensure on the dialog (onboarding), secondary 
- [x] click not now
- [x] visit fill.dev again and try a login
- [x] ensure on the dialog (not onboarding anymote), secondary button is Never for this site


### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
