### PR TITLE
Adding DuckPlayer Telemetry events

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -152,6 +152,7 @@ import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.ExtendedOnboardi
 import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.HighlightsOnboardingExperimentManager
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.pixels.AppPixelName.AUTOCOMPLETE_BANNER_SHOWN
+import com.duckduckgo.app.pixels.AppPixelName.DUCK_PLAYER_LANDSCAPE_LAYOUT_IMPRESSIONS
 import com.duckduckgo.app.pixels.AppPixelName.DUCK_PLAYER_SETTING_ALWAYS_DUCK_PLAYER
 import com.duckduckgo.app.pixels.AppPixelName.DUCK_PLAYER_SETTING_ALWAYS_OVERLAY_YOUTUBE
 import com.duckduckgo.app.pixels.AppPixelName.DUCK_PLAYER_SETTING_NEVER_OVERLAY_YOUTUBE
@@ -5194,6 +5195,20 @@ class BrowserTabViewModelTest {
             false,
         ) { "someUrl" }
         assertCommandNotIssued<Navigate>()
+    }
+
+    @Test
+    fun whenProcessJsCallbackMessageTelemetryEventThenFirePixel() = runTest {
+        whenever(mockEnabledToggle.isEnabled()).thenReturn(true)
+        whenever(mockDuckPlayer.getUserPreferences()).thenReturn(UserPreferences(overlayInteracted = true, privatePlayerMode = AlwaysAsk))
+        testee.processJsCallbackMessage(
+            DUCK_PLAYER_PAGE_FEATURE_NAME,
+            "telemetryEvent",
+            "id",
+            JSONObject("""{"attributes": {"name": "impression", "value": "landscape-layout"}}"""),
+            { "someUrl" },
+        )
+        verify(mockPixel).fire(DUCK_PLAYER_LANDSCAPE_LAYOUT_IMPRESSIONS)
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -5206,6 +5206,7 @@ class BrowserTabViewModelTest {
             "telemetryEvent",
             "id",
             JSONObject("""{"attributes": {"name": "impression", "value": "landscape-layout"}}"""),
+            false,
             { "someUrl" },
         )
         verify(mockPixel).fire(DUCK_PLAYER_LANDSCAPE_LAYOUT_IMPRESSIONS)

--- a/app/src/main/java/com/duckduckgo/app/browser/duckplayer/DuckPlayerJSHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/duckplayer/DuckPlayerJSHelper.kt
@@ -239,6 +239,27 @@ class DuckPlayerJSHelper @Inject constructor(
             "reportPageException", "reportInitException" -> {
                 Timber.tag(method).d(data.toString())
             }
+            "telemetryEvent" -> {
+                /**
+                 * incoming data looks like this, where `name` is used to discriminate,
+                 * and 'value' is linked to it (but is optional)
+                 *
+                 * {
+                 *   "attributes": {
+                 *     "name": "impression",
+                 *     "value": "landscape-layout"
+                 *   }
+                 * }
+                 *
+                 * Another event might look like this in the future: (note: no 'value' field)
+                 * {
+                 *   "attributes": {
+                 *     "name": "page-view"
+                 *   }
+                 * }
+                 */
+                Timber.tag(method).d(data.toString())
+            }
             "openSettings" -> {
                 return OpenDuckPlayerSettings
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/duckplayer/DuckPlayerJSHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/duckplayer/DuckPlayerJSHelper.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.app.browser.commands.Command.SendResponseToDuckPlayer
 import com.duckduckgo.app.browser.commands.Command.SendResponseToJs
 import com.duckduckgo.app.browser.commands.Command.SendSubscriptions
 import com.duckduckgo.app.browser.commands.NavigationCommand.Navigate
+import com.duckduckgo.app.pixels.AppPixelName.DUCK_PLAYER_LANDSCAPE_LAYOUT_IMPRESSIONS
 import com.duckduckgo.app.pixels.AppPixelName.DUCK_PLAYER_SETTING_ALWAYS_DUCK_PLAYER
 import com.duckduckgo.app.pixels.AppPixelName.DUCK_PLAYER_SETTING_ALWAYS_OVERLAY_YOUTUBE
 import com.duckduckgo.app.pixels.AppPixelName.DUCK_PLAYER_SETTING_ALWAYS_SERP
@@ -240,6 +241,13 @@ class DuckPlayerJSHelper @Inject constructor(
                 Timber.tag(method).d(data.toString())
             }
             "telemetryEvent" -> {
+                val attributes = data?.getJSONObject("attributes")
+
+                if (attributes?.getString("name") == "impression" && attributes.getString("value") == "landscape-layout") {
+                    pixel.fire(DUCK_PLAYER_LANDSCAPE_LAYOUT_IMPRESSIONS)
+                }
+
+                // TODO (cbarreiro) Abstract this to provide better support for telemetry events
                 /**
                  * incoming data looks like this, where `name` is used to discriminate,
                  * and 'value' is linked to it (but is optional)
@@ -258,7 +266,6 @@ class DuckPlayerJSHelper @Inject constructor(
                  *   }
                  * }
                  */
-                Timber.tag(method).d(data.toString())
             }
             "openSettings" -> {
                 return OpenDuckPlayerSettings

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -361,6 +361,7 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     DUCK_PLAYER_SETTING_NEVER_SERP("duckplayer_setting_never_overlay_serp"),
     DUCK_PLAYER_SETTING_NEVER_OVERLAY_YOUTUBE("duckplayer_setting_never_overlay_youtube"),
     DUCK_PLAYER_SETTING_ALWAYS_DUCK_PLAYER("duckplayer_setting_always_duck-player"),
+    DUCK_PLAYER_LANDSCAPE_LAYOUT_IMPRESSIONS("duckplayer_landscape_layout_impressions"),
 
     ADD_BOOKMARK_CONFIRM_EDITED("m_add_bookmark_confirm_edit"),
 

--- a/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerScriptsJsMessaging.kt
+++ b/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerScriptsJsMessaging.kt
@@ -131,6 +131,7 @@ class DuckPlayerScriptsJsMessaging @Inject constructor(
             "setUserValues",
             "reportPageException",
             "reportInitException",
+            "telemetryEvent"
         )
     }
 }

--- a/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerScriptsJsMessaging.kt
+++ b/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerScriptsJsMessaging.kt
@@ -131,7 +131,7 @@ class DuckPlayerScriptsJsMessaging @Inject constructor(
             "setUserValues",
             "reportPageException",
             "reportInitException",
-            "telemetryEvent"
+            "telemetryEvent",
         )
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1208637207606569/f

### Description

The DuckPlayer frontend will send an event when the landscape view is shown, this PR adds a pixel for it.

- Fire `duckplayer_landscape_layout_impressions` when the FE sends a telemetry event (https://app.asana.com/0/69071770703008/1208686513106880/f)
- iOS PR: https://github.com/duckduckgo/iOS/pull/3493

### Steps to test this PR

- ~install CSS at branch pr-releases/pr-1164~
- load DuckPlayer in landscape (or rotate)
- you should receive 1 event per page-load, and the pixel should fire.

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
