### PR TITLE
Add pixels to blocklist experiments

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/blocklist/BlockList.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/blocklist/BlockList.kt
@@ -81,40 +81,19 @@ class BlockListPixelsPlugin @Inject constructor(private val inventory: FeatureTo
                 metric = "2xRefresh",
                 value = "1",
                 toggle = activeToggle,
-                conversionWindow = listOf(
-                    ConversionWindow(lowerWindow = 0, upperWindow = 0),
-                    ConversionWindow(lowerWindow = 0, upperWindow = 1),
-                    ConversionWindow(lowerWindow = 0, upperWindow = 2),
-                    ConversionWindow(lowerWindow = 0, upperWindow = 3),
-                    ConversionWindow(lowerWindow = 0, upperWindow = 4),
-                    ConversionWindow(lowerWindow = 0, upperWindow = 5),
-                ),
+                conversionWindow = (0..5).map { ConversionWindow(lowerWindow = 0, upperWindow = it) },
             ),
             MetricsPixel(
                 metric = "3xRefresh",
                 value = "1",
                 toggle = activeToggle,
-                conversionWindow = listOf(
-                    ConversionWindow(lowerWindow = 0, upperWindow = 0),
-                    ConversionWindow(lowerWindow = 0, upperWindow = 1),
-                    ConversionWindow(lowerWindow = 0, upperWindow = 2),
-                    ConversionWindow(lowerWindow = 0, upperWindow = 3),
-                    ConversionWindow(lowerWindow = 0, upperWindow = 4),
-                    ConversionWindow(lowerWindow = 0, upperWindow = 5),
-                ),
+                conversionWindow = (0..5).map { ConversionWindow(lowerWindow = 0, upperWindow = it) },
             ),
             MetricsPixel(
                 metric = "privacyToggleUsed",
                 value = "1",
                 toggle = activeToggle,
-                conversionWindow = listOf(
-                    ConversionWindow(lowerWindow = 0, upperWindow = 0),
-                    ConversionWindow(lowerWindow = 0, upperWindow = 1),
-                    ConversionWindow(lowerWindow = 0, upperWindow = 2),
-                    ConversionWindow(lowerWindow = 0, upperWindow = 3),
-                    ConversionWindow(lowerWindow = 0, upperWindow = 4),
-                    ConversionWindow(lowerWindow = 0, upperWindow = 5),
-                ),
+                conversionWindow = (0..5).map { ConversionWindow(lowerWindow = 0, upperWindow = it) },
             ),
         )
     }

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/blocklist/BlockList.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/blocklist/BlockList.kt
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.trackerdetection.blocklist
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.app.trackerdetection.blocklist.BlockList.Companion.EXPERIMENT_PREFIX
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.ConversionWindow
+import com.duckduckgo.feature.toggles.api.FeatureTogglesInventory
+import com.duckduckgo.feature.toggles.api.MetricsPixel
+import com.duckduckgo.feature.toggles.api.MetricsPixelPlugin
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.State.CohortName
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "blockList",
+)
+interface BlockList {
+    @Toggle.DefaultValue(false)
+    fun self(): Toggle
+
+    @Toggle.DefaultValue(false)
+    fun tdsNextExperimentBaseline(): Toggle
+
+    @Toggle.DefaultValue(false)
+    fun tdsNextExperimentBaselineBackup(): Toggle
+
+    @Toggle.DefaultValue(false)
+    fun tdsNextExperimentNov24(): Toggle
+
+    @Toggle.DefaultValue(false)
+    fun tdsNextExperimentDec24(): Toggle
+
+    @Toggle.DefaultValue(false)
+    fun tdsNextExperimentJan25(): Toggle
+
+    @Toggle.DefaultValue(false)
+    fun tdsNextExperimentFeb25(): Toggle
+
+    @Toggle.DefaultValue(false)
+    fun tdsNextExperimentMar25(): Toggle
+
+    enum class Cohorts(override val cohortName: String) : CohortName {
+        CONTROL("control"),
+        TREATMENT("treatment"),
+    }
+
+    companion object {
+        const val EXPERIMENT_PREFIX = "tds"
+        const val TREATMENT_URL = "treatmentUrl"
+        const val CONTROL_URL = "controlUrl"
+        const val NEXT_URL = "nextUrl"
+    }
+}
+
+@ContributesMultibinding(AppScope::class)
+class BlockListPixelsPlugin @Inject constructor(private val inventory: FeatureTogglesInventory) : MetricsPixelPlugin {
+
+    override suspend fun getMetrics(): List<MetricsPixel> {
+        val activeToggle = inventory.activeTdsFlag() ?: return emptyList()
+
+        return listOf(
+            MetricsPixel(
+                metric = "2xRefresh",
+                value = "1",
+                toggle = activeToggle,
+                conversionWindow = listOf(
+                    ConversionWindow(lowerWindow = 0, upperWindow = 0),
+                    ConversionWindow(lowerWindow = 0, upperWindow = 1),
+                    ConversionWindow(lowerWindow = 0, upperWindow = 2),
+                    ConversionWindow(lowerWindow = 0, upperWindow = 3),
+                    ConversionWindow(lowerWindow = 0, upperWindow = 4),
+                    ConversionWindow(lowerWindow = 0, upperWindow = 5),
+                ),
+            ),
+            MetricsPixel(
+                metric = "3xRefresh",
+                value = "1",
+                toggle = activeToggle,
+                conversionWindow = listOf(
+                    ConversionWindow(lowerWindow = 0, upperWindow = 0),
+                    ConversionWindow(lowerWindow = 0, upperWindow = 1),
+                    ConversionWindow(lowerWindow = 0, upperWindow = 2),
+                    ConversionWindow(lowerWindow = 0, upperWindow = 3),
+                    ConversionWindow(lowerWindow = 0, upperWindow = 4),
+                    ConversionWindow(lowerWindow = 0, upperWindow = 5),
+                ),
+            ),
+            MetricsPixel(
+                metric = "privacyToggleUsed",
+                value = "1",
+                toggle = activeToggle,
+                conversionWindow = listOf(
+                    ConversionWindow(lowerWindow = 0, upperWindow = 0),
+                    ConversionWindow(lowerWindow = 0, upperWindow = 1),
+                    ConversionWindow(lowerWindow = 0, upperWindow = 2),
+                    ConversionWindow(lowerWindow = 0, upperWindow = 3),
+                    ConversionWindow(lowerWindow = 0, upperWindow = 4),
+                    ConversionWindow(lowerWindow = 0, upperWindow = 5),
+                ),
+            ),
+        )
+    }
+}
+
+internal suspend fun BlockListPixelsPlugin.get2XRefresh(): MetricsPixel? {
+    return this.getMetrics().firstOrNull { it.metric == "2xRefresh" }
+}
+
+suspend fun BlockListPixelsPlugin.get3XRefresh(): MetricsPixel? {
+    return this.getMetrics().firstOrNull { it.metric == "3xRefresh" }
+}
+
+suspend fun BlockListPixelsPlugin.getPrivacyToggleUsed(): MetricsPixel? {
+    return this.getMetrics().firstOrNull { it.metric == "privacyToggleUsed" }
+}
+
+suspend fun FeatureTogglesInventory.activeTdsFlag(): Toggle? {
+    return this.getAllTogglesForParent("blockList").firstOrNull {
+        it.featureName().name.startsWith(EXPERIMENT_PREFIX) && it.isEnabled()
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/blocklist/BlockList.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/blocklist/BlockList.kt
@@ -113,8 +113,8 @@ class BlockListPrivacyConfigCallbackPlugin @Inject constructor(
     private val experimentAA: ExperimentTestAA,
 ) : PrivacyConfigCallbackPlugin {
     override fun onPrivacyConfigDownloaded() {
-        experimentAA.experimentTestAA().isEnabled(CONTROL)
         coroutineScope.launch {
+            experimentAA.experimentTestAA().isEnabled(CONTROL)
             inventory.activeTdsFlag()?.let {
                 trackerDataDownloader.downloadTds()
             }

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/blocklist/BlockList.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/blocklist/BlockList.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.trackerdetection.api.TrackerDataDownloader
 import com.duckduckgo.app.trackerdetection.blocklist.BlockList.Companion.EXPERIMENT_PREFIX
 import com.duckduckgo.app.trackerdetection.blocklist.ExperimentTestAA.Cohorts.CONTROL
+import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.ConversionWindow
 import com.duckduckgo.feature.toggles.api.FeatureTogglesInventory
@@ -111,9 +112,10 @@ class BlockListPrivacyConfigCallbackPlugin @Inject constructor(
     private val trackerDataDownloader: TrackerDataDownloader,
     @AppCoroutineScope private val coroutineScope: CoroutineScope,
     private val experimentAA: ExperimentTestAA,
+    private val dispatcherProvider: DispatcherProvider,
 ) : PrivacyConfigCallbackPlugin {
     override fun onPrivacyConfigDownloaded() {
-        coroutineScope.launch {
+        coroutineScope.launch(dispatcherProvider.io()) {
             experimentAA.experimentTestAA().isEnabled(CONTROL)
             inventory.activeTdsFlag()?.let {
                 trackerDataDownloader.downloadTds()

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/blocklist/BlockListPrivacyTogglePlugin.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/blocklist/BlockListPrivacyTogglePlugin.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.trackerdetection.blocklist
+
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.privacy.dashboard.api.PrivacyProtectionTogglePlugin
+import com.duckduckgo.privacy.dashboard.api.PrivacyToggleOrigin
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+class BlockListPrivacyTogglePlugin @Inject constructor(
+    private val blockListPixelsPlugin: BlockListPixelsPlugin,
+    private val pixel: Pixel,
+) : PrivacyProtectionTogglePlugin {
+
+    override suspend fun onToggleOn(origin: PrivacyToggleOrigin) {
+        // NOOP
+    }
+
+    override suspend fun onToggleOff(origin: PrivacyToggleOrigin) {
+        if (origin == PrivacyToggleOrigin.DASHBOARD) {
+            blockListPixelsPlugin.getPrivacyToggleUsed()?.getPixelDefinitions()?.forEach {
+                pixel.fire(it.pixelName, it.params)
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/trackerdetection/blocklist/BlockListInterceptorApiPluginTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/trackerdetection/blocklist/BlockListInterceptorApiPluginTest.kt
@@ -1,14 +1,30 @@
-package com.duckduckgo.app.trackerdetection
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.trackerdetection.blocklist
 
 import android.annotation.SuppressLint
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
-import com.duckduckgo.app.trackerdetection.BlockList.Cohorts.CONTROL
-import com.duckduckgo.app.trackerdetection.BlockList.Cohorts.TREATMENT
-import com.duckduckgo.app.trackerdetection.BlockList.Companion.CONTROL_URL
-import com.duckduckgo.app.trackerdetection.BlockList.Companion.NEXT_URL
-import com.duckduckgo.app.trackerdetection.BlockList.Companion.TREATMENT_URL
 import com.duckduckgo.app.trackerdetection.api.TDS_BASE_URL
 import com.duckduckgo.app.trackerdetection.api.TDS_PATH
+import com.duckduckgo.app.trackerdetection.blocklist.BlockList.Cohorts.CONTROL
+import com.duckduckgo.app.trackerdetection.blocklist.BlockList.Cohorts.TREATMENT
+import com.duckduckgo.app.trackerdetection.blocklist.BlockList.Companion.CONTROL_URL
+import com.duckduckgo.app.trackerdetection.blocklist.BlockList.Companion.NEXT_URL
+import com.duckduckgo.app.trackerdetection.blocklist.BlockList.Companion.TREATMENT_URL
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.test.api.FakeChain
 import com.duckduckgo.feature.toggles.api.FakeToggleStore
@@ -30,23 +46,23 @@ class BlockListInterceptorApiPluginTest {
     @Suppress("unused")
     val coroutineRule = CoroutineTestRule()
 
-    private lateinit var testFeature: TestFeature
+    private lateinit var testBlockListFeature: TestBlockListFeature
     private lateinit var inventory: FeatureTogglesInventory
     private lateinit var interceptor: BlockListInterceptorApiPlugin
 
     @Before
     fun setup() {
-        testFeature = FeatureToggles.Builder(
+        testBlockListFeature = FeatureToggles.Builder(
             FakeToggleStore(),
             featureName = "blockList",
-        ).build().create(TestFeature::class.java)
+        ).build().create(TestBlockListFeature::class.java)
 
         inventory = RealFeatureTogglesInventory(
             setOf(
                 FakeFeatureTogglesInventory(
                     features = listOf(
-                        testFeature.tdsNextExperimentTest(),
-                        testFeature.tdsNextExperimentAnotherTest(),
+                        testBlockListFeature.tdsNextExperimentTest(),
+                        testBlockListFeature.tdsNextExperimentAnotherTest(),
                     ),
                 ),
             ),
@@ -58,7 +74,7 @@ class BlockListInterceptorApiPluginTest {
 
     @Test
     fun `when multiple experiments enabled, use the first one`() {
-        testFeature.tdsNextExperimentTest().setRawStoredState(
+        testBlockListFeature.tdsNextExperimentTest().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -72,7 +88,7 @@ class BlockListInterceptorApiPluginTest {
                 ),
             ),
         )
-        testFeature.tdsNextExperimentAnotherTest().setRawStoredState(
+        testBlockListFeature.tdsNextExperimentAnotherTest().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -94,7 +110,7 @@ class BlockListInterceptorApiPluginTest {
 
     @Test
     fun `when cohort is treatment use treatment URL`() {
-        testFeature.tdsNextExperimentAnotherTest().setRawStoredState(
+        testBlockListFeature.tdsNextExperimentAnotherTest().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -116,7 +132,7 @@ class BlockListInterceptorApiPluginTest {
 
     @Test
     fun `when cohort is control use control URL`() {
-        testFeature.tdsNextExperimentAnotherTest().setRawStoredState(
+        testBlockListFeature.tdsNextExperimentAnotherTest().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -138,7 +154,7 @@ class BlockListInterceptorApiPluginTest {
 
     @Test
     fun `when feature is for next URL rollout then use next url`() {
-        testFeature.tdsNextExperimentAnotherTest().setRawStoredState(
+        testBlockListFeature.tdsNextExperimentAnotherTest().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -162,7 +178,7 @@ class BlockListInterceptorApiPluginTest {
 
     @Test
     fun `when feature name doesn't match prefix, it is ignored`() {
-        testFeature.nonMatchingFeatureName().setRawStoredState(
+        testBlockListFeature.nonMatchingFeatureName().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -197,7 +213,7 @@ abstract class TriggerTestScope private constructor()
     scope = TriggerTestScope::class,
     featureName = "blockList",
 )
-interface TestFeature {
+interface TestBlockListFeature {
     @DefaultValue(false)
     fun self(): Toggle
 

--- a/app/src/test/java/com/duckduckgo/app/trackerdetection/blocklist/BlockListPrivacyTogglePluginTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/trackerdetection/blocklist/BlockListPrivacyTogglePluginTest.kt
@@ -72,7 +72,7 @@ class BlockListPrivacyTogglePluginTest {
     }
 
     @Test
-    fun `when toggle is off and assigned to experiment and origin is not dashboard then do not pixels`() = runTest {
+    fun `when toggle is off and assigned to experiment and origin is not dashboard then do not send pixels`() = runTest {
         assignToExperiment()
 
         blockListPrivacyTogglePlugin.onToggleOff(MENU)

--- a/app/src/test/java/com/duckduckgo/app/trackerdetection/blocklist/BlockListPrivacyTogglePluginTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/trackerdetection/blocklist/BlockListPrivacyTogglePluginTest.kt
@@ -1,0 +1,99 @@
+package com.duckduckgo.app.trackerdetection.blocklist
+
+import android.annotation.SuppressLint
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.trackerdetection.blocklist.BlockList.Cohorts.TREATMENT
+import com.duckduckgo.app.trackerdetection.blocklist.BlockList.Companion.CONTROL_URL
+import com.duckduckgo.app.trackerdetection.blocklist.BlockList.Companion.TREATMENT_URL
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeToggleStore
+import com.duckduckgo.feature.toggles.api.FeatureToggles
+import com.duckduckgo.feature.toggles.api.FeatureTogglesInventory
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.feature.toggles.impl.RealFeatureTogglesInventory
+import com.duckduckgo.privacy.dashboard.api.PrivacyToggleOrigin.BREAKAGE_FORM
+import com.duckduckgo.privacy.dashboard.api.PrivacyToggleOrigin.DASHBOARD
+import com.duckduckgo.privacy.dashboard.api.PrivacyToggleOrigin.MENU
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.verify
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verifyNoInteractions
+
+@SuppressLint("DenyListedApi")
+class BlockListPrivacyTogglePluginTest {
+
+    @get:Rule
+    var coroutineRule = CoroutineTestRule()
+
+    private val pixel: Pixel = mock()
+    private lateinit var testBlockListFeature: TestBlockListFeature
+    private lateinit var inventory: FeatureTogglesInventory
+    private lateinit var blockListPixelsPlugin: BlockListPixelsPlugin
+    private lateinit var blockListPrivacyTogglePlugin: BlockListPrivacyTogglePlugin
+
+    @Before
+    fun setUp() {
+        testBlockListFeature = FeatureToggles.Builder(
+            FakeToggleStore(),
+            featureName = "blockList",
+        ).build().create(TestBlockListFeature::class.java)
+
+        inventory = RealFeatureTogglesInventory(
+            setOf(
+                FakeFeatureTogglesInventory(
+                    features = listOf(
+                        testBlockListFeature.tdsNextExperimentTest(),
+                        testBlockListFeature.tdsNextExperimentAnotherTest(),
+                    ),
+                ),
+            ),
+            coroutineRule.testDispatcherProvider,
+        )
+
+        blockListPixelsPlugin = BlockListPixelsPlugin(inventory)
+        blockListPrivacyTogglePlugin = BlockListPrivacyTogglePlugin(blockListPixelsPlugin, pixel)
+    }
+
+    @Test
+    fun `when toggle is off and assigned to experiment and origin dashboard then send pixels`() = runTest {
+        assignToExperiment()
+
+        blockListPrivacyTogglePlugin.onToggleOff(DASHBOARD)
+
+        blockListPixelsPlugin.getPrivacyToggleUsed()!!.getPixelDefinitions().forEach {
+            verify(pixel).fire(it.pixelName, it.params)
+        }
+    }
+
+    @Test
+    fun `when toggle is off and assigned to experiment and origin is not dashboard then do not pixels`() = runTest {
+        assignToExperiment()
+
+        blockListPrivacyTogglePlugin.onToggleOff(MENU)
+        verifyNoInteractions(pixel)
+
+        blockListPrivacyTogglePlugin.onToggleOff(BREAKAGE_FORM)
+        verifyNoInteractions(pixel)
+    }
+
+    private fun assignToExperiment() {
+        val enrollmentDateET = ZonedDateTime.now(ZoneId.of("America/New_York")).truncatedTo(ChronoUnit.DAYS).toString()
+        testBlockListFeature.tdsNextExperimentTest().setRawStoredState(
+            State(
+                remoteEnableState = true,
+                enable = true,
+                config = mapOf(
+                    TREATMENT_URL to "treatmentUrl",
+                    CONTROL_URL to "controlUrl",
+                ),
+                assignedCohort = State.Cohort(name = TREATMENT.cohortName, weight = 1, enrollmentDateET = enrollmentDateET),
+            ),
+        )
+    }
+}

--- a/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/MetricPixelInterceptor.kt
+++ b/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/MetricPixelInterceptor.kt
@@ -113,7 +113,7 @@ class MetricPixelInterceptor @Inject constructor(
         logcat { "Pixel URL request dropped: ${chain.request()}" }
 
         return Response.Builder()
-            .code(200)
+            .code(500)
             .protocol(Protocol.HTTP_2)
             .body("Experiment metrics pixel dropped".toResponseBody())
             .message("Dropped experiment metrics pixel")

--- a/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePlugin.kt
+++ b/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePlugin.kt
@@ -20,10 +20,15 @@ import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.statistics.api.AtbLifecyclePlugin
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.PixelDefinition
 import com.duckduckgo.feature.toggles.impl.MetricsPixelStore
 import com.duckduckgo.feature.toggles.impl.RetentionMetric.APP_USE
 import com.duckduckgo.feature.toggles.impl.RetentionMetric.SEARCH
 import com.squareup.anvil.annotations.ContributesMultibinding
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -41,10 +46,12 @@ class RetentionMetricsAtbLifecyclePlugin @Inject constructor(
         appCoroutineScope.launch {
             searchMetricPixelsPlugin.getMetrics().forEach { metric ->
                 metric.getPixelDefinitions().forEach { definition ->
-                    store.increaseMetricForPixelDefinition(definition, SEARCH)
-                    val searches = store.getMetricForPixelDefinition(definition, SEARCH)
-                    if (searches == metric.value.toInt()) {
-                        pixel.fire(definition.pixelName, definition.params)
+                    if (isInConversionWindow(definition)) {
+                        store.getMetricForPixelDefinition(definition, SEARCH).takeIf { it < metric.value.toInt() }?.let {
+                            store.increaseMetricForPixelDefinition(definition, SEARCH).takeIf { it == metric.value.toInt() }?.apply {
+                                pixel.fire(definition.pixelName, definition.params)
+                            }
+                        }
                     }
                 }
             }
@@ -55,13 +62,31 @@ class RetentionMetricsAtbLifecyclePlugin @Inject constructor(
         appCoroutineScope.launch {
             appUseMetricPixelsPlugin.getMetrics().forEach { metric ->
                 metric.getPixelDefinitions().forEach { definition ->
-                    store.increaseMetricForPixelDefinition(definition, APP_USE)
-                    val appUse = store.getMetricForPixelDefinition(definition, APP_USE)
-                    if (appUse == metric.value.toInt()) {
-                        pixel.fire(definition.pixelName, definition.params)
+                    if (isInConversionWindow(definition)) {
+                        store.getMetricForPixelDefinition(definition, APP_USE).takeIf { it < metric.value.toInt() }?.let {
+                            store.increaseMetricForPixelDefinition(definition, APP_USE).takeIf { it == metric.value.toInt() }?.apply {
+                                pixel.fire(definition.pixelName, definition.params)
+                            }
+                        }
                     }
                 }
             }
         }
+    }
+
+    private fun isInConversionWindow(definition: PixelDefinition): Boolean {
+        val enrollmentDate = definition.params["enrollmentDate"] ?: return false
+        val lowerWindow = definition.params["conversionWindowDays"]?.split("-")?.first()?.toInt() ?: return false
+        val upperWindow = definition.params["conversionWindowDays"]?.split("-")?.last()?.toInt() ?: return false
+        val daysDiff = daysBetweenTodayAnd(enrollmentDate)
+
+        return (daysDiff in lowerWindow..upperWindow)
+    }
+
+    private fun daysBetweenTodayAnd(date: String): Long {
+        val today = ZonedDateTime.now(ZoneId.of("America/New_York"))
+        val localDate = LocalDate.parse(date)
+        val zoneDateTime: ZonedDateTime = localDate.atStartOfDay(ZoneId.of("America/New_York"))
+        return ChronoUnit.DAYS.between(zoneDateTime, today)
     }
 }

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/MetricPixelInterceptorTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/MetricPixelInterceptorTest.kt
@@ -312,10 +312,11 @@ class FakeStore : MetricsPixelStore {
         list.add(tag)
     }
 
-    override fun increaseMetricForPixelDefinition(definition: PixelDefinition, metric: RetentionMetric) {
+    override suspend fun increaseMetricForPixelDefinition(definition: PixelDefinition, metric: RetentionMetric): Int {
         val tag = "${definition}_$metric"
         val count = metrics.getOrDefault(tag, 0)
         metrics[tag] = count + 1
+        return metrics[tag]!!
     }
 
     override suspend fun getMetricForPixelDefinition(definition: PixelDefinition, metric: RetentionMetric): Int {

--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
@@ -27,4 +27,4 @@ enum class PrivacyFeatureName(val value: String) {
     TrackingParametersFeatureName("trackingParameters"),
 }
 
-const val PRIVACY_REMOTE_CONFIG_URL = "https://staticcdn.duckduckgo.com/trackerblocking/config/v4/android-config.json"
+const val PRIVACY_REMOTE_CONFIG_URL = "https://jsonblob.com/api/1298581151181299712"

--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
@@ -27,4 +27,4 @@ enum class PrivacyFeatureName(val value: String) {
     TrackingParametersFeatureName("trackingParameters"),
 }
 
-const val PRIVACY_REMOTE_CONFIG_URL = "https://jsonblob.com/api/1298581151181299712"
+const val PRIVACY_REMOTE_CONFIG_URL = "https://staticcdn.duckduckgo.com/trackerblocking/config/v4/android-config.json"

--- a/privacy-dashboard/privacy-dashboard-api/src/main/java/com/duckduckgo/privacy/dashboard/api/PrivacyProtectionTogglePlugin.kt
+++ b/privacy-dashboard/privacy-dashboard-api/src/main/java/com/duckduckgo/privacy/dashboard/api/PrivacyProtectionTogglePlugin.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.dashboard.api
+
+interface PrivacyProtectionTogglePlugin {
+    /**
+     * Executed when the privacy toggle is switched on. It receives the [PrivacyToggleOrigin].
+     */
+    suspend fun onToggleOn(origin: PrivacyToggleOrigin)
+
+    /**
+     * Executed when the privacy toggle is switched off. It receives the [PrivacyToggleOrigin].
+     */
+    suspend fun onToggleOff(origin: PrivacyToggleOrigin)
+}
+
+enum class PrivacyToggleOrigin {
+    MENU,
+    DASHBOARD,
+    BREAKAGE_FORM,
+}

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/di/PrivacyProtectionTogglePluginPoint.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/di/PrivacyProtectionTogglePluginPoint.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.privacy.dashboard.impl.di
+
+import com.duckduckgo.anvil.annotations.ContributesPluginPoint
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.privacy.dashboard.api.PrivacyProtectionTogglePlugin
+
+@ContributesPluginPoint(
+    scope = AppScope::class,
+    boundType = PrivacyProtectionTogglePlugin::class,
+)
+@Suppress("unused")
+internal interface PrivacyProtectionTogglePluginPoint


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1125189844152671/1208618649788232/f 

### Description
Adds pixels for blocklist experiments as well as a new parameter to the breakage form

### Steps to test this PR

- [x] Change remote config to URL `https://jsonblob.com/api/1298581151181299712`
- [x] Install the app, finish the onboarding
- [x] Filter by `pixel sent`
- [x] Go to a website
- [x] Refresh it two times
- [x] A bunch of pixels like `experiment_metrics_tdsNextExperimentBaseline_treatment with params: {metric=2xRefresh, value=1, enrollmentDate=2024-10-28, conversionWindowDays=0} {}` should be sent.
- [x] Refresh three times
- [x] A bunch of pixels like `experiment_metrics_tdsNextExperimentBaseline_treatment with params: {metric=3xRefresh, value=1, enrollmentDate=2024-10-28, conversionWindowDays=0} {}` should be sent.
- [x] Send a broken site report
- [x] The epbf pixel should contain `blockListExperiment=tdsNextExperimentBaseline_treatment`
- [x] In the broken site report, disable protections
- [x] No pixel with the name `experiment_metrics_tdsNextExperimentBaseline_treatment` should be sent.
- [x] Re-enable protections
- [x] Go to the privacy dashboard, website not working and disable protections from there.
- [x] No pixel with the name `experiment_metrics_tdsNextExperimentBaseline_treatment` should be sent.
- [x] Re-enable protections
- [x] Go to the privacy dashboard, disable protections from there
- [x] A bunch of pixels like `experiment_metrics_tdsNextExperimentBaseline_treatment with params: {metric=privacyToggleUsed, value=1, enrollmentDate=2024-10-28, conversionWindowDays=0} {}` should be sent