### PR TITLE
Fix incorrect listeners invoked in dialogs

### DIFF
--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/themepreview/ui/dialogs/DialogsFragment.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/themepreview/ui/dialogs/DialogsFragment.kt
@@ -66,7 +66,7 @@ class DialogsFragment : Fragment() {
                     .addEventListener(
                         object : TextAlertDialogBuilder.EventListener() {
                             override fun onPositiveButtonClicked() {
-                                Snackbar.make(it, "Negative Button Clicked", Snackbar.LENGTH_SHORT).show()
+                                Snackbar.make(it, "Positive Button Clicked", Snackbar.LENGTH_SHORT).show()
                             }
 
                             override fun onNegativeButtonClicked() {
@@ -238,7 +238,7 @@ class DialogsFragment : Fragment() {
                         object : TextAlertDialogBuilder.EventListener() {
                             var isChecked: Boolean = false
                             override fun onPositiveButtonClicked() {
-                                Snackbar.make(it, "Negative Button Clicked, Checked $isChecked ", Snackbar.LENGTH_SHORT).show()
+                                Snackbar.make(it, "Positive Button Clicked, Checked $isChecked ", Snackbar.LENGTH_SHORT).show()
                             }
 
                             override fun onNegativeButtonClicked() {

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/dialog/RadioListAlertDialogBuilder.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/dialog/RadioListAlertDialogBuilder.kt
@@ -210,7 +210,9 @@ class RadioListAlertDialogBuilder(val context: Context) : DaxAlertDialog {
         val positiveButtonView = positiveButtonType.getView(context)
         positiveButtonView.isEnabled = selectedOption != null
         binding.radioListAlertDialogButtonContainer.addView(positiveButtonView)
-        setButtonListener(positiveButtonView, positiveButtonText, dialog) { listener.onNegativeButtonClicked() }
+        setButtonListener(positiveButtonView, positiveButtonText, dialog) {
+            listener.onPositiveButtonClicked(binding.radioListDialogRadioGroup.checkedRadioButtonId)
+        }
     }
 
     private fun setButtonListener(

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/dialog/TextAlertDialogBuilder.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/dialog/TextAlertDialogBuilder.kt
@@ -196,7 +196,7 @@ class TextAlertDialogBuilder(val context: Context) : DaxAlertDialog {
         }
 
         val positiveButtonView = positiveButtonType.getView(context)
-        setButtonListener(positiveButtonView, positiveButtonText, dialog) { listener.onNegativeButtonClicked() }
+        setButtonListener(positiveButtonView, positiveButtonText, dialog) { listener.onPositiveButtonClicked() }
         binding.textAlertDialogButtonContainer.addView(positiveButtonView)
 
         binding.textAlertDialogCheckBox.setOnCheckedChangeListener { compoundButton, checked ->


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205648422731273/1208638453759884/f

### Description

### Steps to test this PR

_TextAlertDialog_
- [x] Navigate to Settings -> Appearance
- [x] Tap on "Force Websites To Use Dark Theme"
- [x] In the dialog, tap "Relaunch Now" 
- [x] Verify that the app was restarted

_RadioListAlertDialog_
- [x] Navigate to Settings -> Fire Button
- [x] Tap on "Automatically Clear..."
- [x] In the dialog, change selected option and tap "Save"
- [x] Verify that setting value in the UI has been updated


### No UI changes