### PR TITLE
Fix RMF unique pixel: adding tag as part of unique type

### DIFF
--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/pixels/RemoteMessagingPixels.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/pixels/RemoteMessagingPixels.kt
@@ -20,6 +20,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.remote.messaging.api.RemoteMessage
+import com.duckduckgo.remote.messaging.impl.pixels.RemoteMessagingPixelName.REMOTE_MESSAGE_SHOWN_UNIQUE
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 
@@ -38,7 +39,11 @@ class RealRemoteMessagingPixels @Inject constructor(
     private val pixel: Pixel,
 ) : RemoteMessagingPixels {
     override fun fireRemoteMessageShownPixel(remoteMessage: RemoteMessage) {
-        pixel.fire(pixel = RemoteMessagingPixelName.REMOTE_MESSAGE_SHOWN_UNIQUE, parameters = remoteMessage.asPixelParams(), type = Unique())
+        pixel.fire(
+            pixel = REMOTE_MESSAGE_SHOWN_UNIQUE,
+            parameters = remoteMessage.asPixelParams(),
+            type = Unique("${REMOTE_MESSAGE_SHOWN_UNIQUE.pixelName}_${remoteMessage.id}"),
+        )
         pixel.fire(pixel = RemoteMessagingPixelName.REMOTE_MESSAGE_SHOWN, parameters = remoteMessage.asPixelParams())
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207619243206445/1208647599954669/f 

### Description
When sending unique RMF pixel, include tag so we can differentiate between other remote message pixels.

### Steps to test this PR

_Feature 1_
- [x] update remote message service to consume https://www.jsonblob.com/api/1284189194082443264
- [x] fresh install, and skip onboarding
- [x] on NTP you will see RMF card
- [x] ensure unique shown pixel is sent
- [x] update config at https://www.jsonblob.com/1284189194082443264, removing the message just displayed and bump version
- [x] restart the app
- [x] on NTP you will see a new RMF card
- [x] ensure unique shown pixel is sent
- [x] restart the app
- [x] on NTP you still see the previous RMF card
- [x] ensure unique shown is not sent

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
