### PR TITLE
Show on App Launch: Fix option item height

### DIFF
--- a/app/src/main/res/layout/activity_show_on_app_launch_setting.xml
+++ b/app/src/main/res/layout/activity_show_on_app_launch_setting.xml
@@ -40,18 +40,21 @@
                 android:id="@+id/lastOpenedTabCheckListItem"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:minHeight="@dimen/oneLineItemHeight"
                 app:primaryText="Last Opened Tab" />
 
             <com.duckduckgo.common.ui.view.listitem.RadioListItem
                 android:id="@+id/newTabCheckListItem"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:minHeight="@dimen/oneLineItemHeight"
                 app:primaryText="New Tab Page" />
 
             <com.duckduckgo.common.ui.view.listitem.RadioListItem
                 android:id="@+id/specificPageCheckListItem"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:minHeight="@dimen/oneLineItemHeight"
                 app:primaryText="Specific Page" />
 
             <com.duckduckgo.common.ui.view.text.DaxTextInput

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/listitem/RadioListItem.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/listitem/RadioListItem.kt
@@ -55,6 +55,13 @@ class RadioListItem @JvmOverloads constructor(
             0,
             R.style.Widget_DuckDuckGo_TwoLineListItem,
         ).apply {
+            if (hasValue(R.styleable.RadioListItem_android_minHeight)) {
+                binding.itemContainer.minHeight =
+                    getDimensionPixelSize(R.styleable.RadioListItem_android_minHeight, resources.getDimensionPixelSize(R.dimen.oneLineItemHeight))
+            } else {
+                binding.itemContainer.minHeight = resources.getDimensionPixelSize(R.dimen.oneLineItemHeight)
+            }
+
             binding.radioButton.isChecked = getBoolean(R.styleable.RadioListItem_android_checked, false)
 
             binding.primaryText.text = getString(R.styleable.RadioListItem_primaryText)

--- a/common/common-ui/src/main/res/layout/view_radio_list_item.xml
+++ b/common/common-ui/src/main/res/layout/view_radio_list_item.xml
@@ -32,6 +32,7 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/keyline_3"
         android:minWidth="0dp"
+        android:minHeight="0dp"
         android:padding="0dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/common/common-ui/src/main/res/values/attrs-radio-list-item.xml
+++ b/common/common-ui/src/main/res/values/attrs-radio-list-item.xml
@@ -27,5 +27,6 @@
         <attr name="leadingIconBackground" />
         <attr name="leadingEmojiIcon" format="string" />
         <attr name="showTrailingIcon" format="boolean" />
+        <attr name="android:minHeight"/>
     </declare-styleable>
 </resources>

--- a/network-protection/network-protection-impl/src/main/res/layout/item_geoswitching_country.xml
+++ b/network-protection/network-protection-impl/src/main/res/layout/item_geoswitching_country.xml
@@ -18,4 +18,5 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:minHeight="@dimen/twoLineItemWithLargeImageHeight"
     app:leadingIconBackground="circular" />


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207908166761516/1208648215243996/f

### Description

Fixes the height of the options on the Show on App Launch screen to 48dp. As a result of this we should do a follow up to add the possibility to our OneLine and TwoLineListItems to allow for a `RadioButton`

This was done with minimal code changes to reduce any effect on the VPN country selection list. 

### Steps to test this PR

_Show on App Launch_
- [x] Open Show on App Launch
- [x] Check items are 48dp high

_VPN Location List_
- [ ] Open VPN Location screen
- [ ] Check items are unchanged and remain 64dp high

### UI changes
| Before  | After |
| ------ | ----- |
![Screenshot_20241029_180839](https://github.com/user-attachments/assets/bdebe07f-ee70-4284-a1d5-9d2ef9f49060)|![Screenshot_20241029_180918](https://github.com/user-attachments/assets/454fc597-cc51-4d69-af67-4e182d16a37c)
|![Screenshot_20241029_181258](https://github.com/user-attachments/assets/97e6c3c0-d7a3-441c-ace8-54a21e459703)|![Screenshot_20241029_181003](https://github.com/user-attachments/assets/2782c2d8-54c2-47f0-9fcd-0b021db29819)
