### PR TITLE
Omnibar: React to Bottom Bar feature flag changes

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -826,7 +826,7 @@ class BrowserTabFragment :
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        omnibar = Omnibar(settingsDataStore.omnibarPosition, changeOmnibarPositionFeature, binding)
+        omnibar = Omnibar(settingsDataStore.omnibarPosition, changeOmnibarPositionFeature.refactor().isEnabled(), binding)
 
         webViewContainer = binding.webViewContainer
         configureObservers()

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
@@ -82,6 +82,61 @@ class Omnibar(
     private val binding: FragmentBrowserTabBinding,
 ) {
 
+    init {
+        when (omnibarPosition) {
+            OmnibarPosition.TOP -> {
+                if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+                    Timber.d("Omnibar: using NewOmnibar anchored TOP")
+                    binding.rootView.removeView(binding.legacyOmnibarBottom)
+                    binding.rootView.removeView(binding.legacyOmnibar)
+                    binding.rootView.removeView(binding.newOmnibarBottom)
+                } else {
+                    Timber.d("Omnibar: using LegacyOmnibar anchored TOP")
+                    binding.rootView.removeView(binding.newOmnibarBottom)
+                    binding.rootView.removeView(binding.newOmnibar)
+                    binding.rootView.removeView(binding.legacyOmnibarBottom)
+
+                    // remove the default top abb bar behavior
+                    removeAppBarBehavior(binding.autoCompleteSuggestionsList)
+                    removeAppBarBehavior(binding.browserLayout)
+                    removeAppBarBehavior(binding.focusedView)
+                    removeAppBarBehavior(binding.includeNewBrowserTab.newTabLayout)
+
+                    // prevent the touch event leaking to the webView below
+                    binding.newOmnibarBottom.setOnTouchListener { _, _ -> true }
+
+                    binding.newOmnibarBottom
+                }
+            }
+
+            OmnibarPosition.BOTTOM -> {
+                if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+                    Timber.d("Omnibar: using NewOmnibar anchored BOTTOM")
+                    binding.rootView.removeView(binding.legacyOmnibarBottom)
+                    binding.rootView.removeView(binding.legacyOmnibar)
+                    binding.rootView.removeView(binding.newOmnibar)
+
+                    // prevent the touch event leaking to the webView below
+                    binding.newOmnibarBottom.setOnTouchListener { _, _ -> true }
+                } else {
+                    Timber.d("Omnibar: using LegacyOmnibar anchored BOTTOM")
+                    binding.rootView.removeView(binding.newOmnibarBottom)
+                    binding.rootView.removeView(binding.newOmnibar)
+                    binding.rootView.removeView(binding.legacyOmnibar)
+
+                    // prevent the touch event leaking to the webView below
+                    binding.legacyOmnibarBottom.setOnTouchListener { _, _ -> true }
+                }
+
+                // remove the default top abb bar behavior
+                removeAppBarBehavior(binding.autoCompleteSuggestionsList)
+                removeAppBarBehavior(binding.browserLayout)
+                removeAppBarBehavior(binding.focusedView)
+                removeAppBarBehavior(binding.includeNewBrowserTab.newTabLayout)
+            }
+        }
+    }
+
     interface ItemPressedListener {
         fun onTabsButtonPressed()
         fun onTabsButtonLongPressed()
@@ -135,61 +190,25 @@ class Omnibar(
         ) : ViewMode()
     }
 
-    val newOmnibar: OmnibarLayout by lazy {
+    private val newOmnibar: OmnibarLayout by lazy {
         when (omnibarPosition) {
             OmnibarPosition.TOP -> {
-                Timber.d("Omnibar: using NewOmnibar anchored TOP")
-                binding.rootView.removeView(binding.legacyOmnibarBottom)
-                binding.rootView.removeView(binding.legacyOmnibar)
-                binding.rootView.removeView(binding.newOmnibarBottom)
                 binding.newOmnibar
             }
 
             OmnibarPosition.BOTTOM -> {
-                Timber.d("Omnibar: using NewOmnibar anchored BOTTOM")
-                binding.rootView.removeView(binding.legacyOmnibarBottom)
-                binding.rootView.removeView(binding.legacyOmnibar)
-                binding.rootView.removeView(binding.newOmnibar)
-
-                // remove the default top abb bar behavior
-                removeAppBarBehavior(binding.autoCompleteSuggestionsList)
-                removeAppBarBehavior(binding.browserLayout)
-                removeAppBarBehavior(binding.focusedView)
-                removeAppBarBehavior(binding.includeNewBrowserTab.newTabLayout)
-
-                // prevent the touch event leaking to the webView below
-                binding.newOmnibarBottom.setOnTouchListener { _, _ -> true }
-
                 binding.newOmnibarBottom
             }
         }
     }
 
-    val legacyOmnibar: LegacyOmnibarView by lazy {
+    private val legacyOmnibar: LegacyOmnibarView by lazy {
         when (omnibarPosition) {
             OmnibarPosition.TOP -> {
-                Timber.d("Omnibar: using LegacyOmnibar anchored TOP")
-                binding.rootView.removeView(binding.newOmnibarBottom)
-                binding.rootView.removeView(binding.newOmnibar)
-                binding.rootView.removeView(binding.legacyOmnibarBottom)
                 binding.legacyOmnibar
             }
 
             OmnibarPosition.BOTTOM -> {
-                Timber.d("Omnibar: using LegacyOmnibar anchored BOTTOM")
-                binding.rootView.removeView(binding.newOmnibarBottom)
-                binding.rootView.removeView(binding.newOmnibar)
-                binding.rootView.removeView(binding.legacyOmnibar)
-
-                // remove the default top abb bar behavior
-                removeAppBarBehavior(binding.autoCompleteSuggestionsList)
-                removeAppBarBehavior(binding.browserLayout)
-                removeAppBarBehavior(binding.focusedView)
-                removeAppBarBehavior(binding.includeNewBrowserTab.newTabLayout)
-
-                // prevent the touch event leaking to the webView below
-                binding.legacyOmnibarBottom.setOnTouchListener { _, _ -> true }
-
                 binding.legacyOmnibarBottom
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
@@ -78,14 +78,14 @@ import timber.log.Timber
 @SuppressLint("ClickableViewAccessibility")
 class Omnibar(
     val omnibarPosition: OmnibarPosition,
-    private val changeOmnibarPositionFeature: ChangeOmnibarPositionFeature,
+    private val refactorFlagEnabled: Boolean,
     private val binding: FragmentBrowserTabBinding,
 ) {
 
     init {
         when (omnibarPosition) {
             OmnibarPosition.TOP -> {
-                if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+                if (refactorFlagEnabled) {
                     Timber.d("Omnibar: using NewOmnibar anchored TOP")
                     binding.rootView.removeView(binding.legacyOmnibarBottom)
                     binding.rootView.removeView(binding.legacyOmnibar)
@@ -99,7 +99,7 @@ class Omnibar(
             }
 
             OmnibarPosition.BOTTOM -> {
-                if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+                if (refactorFlagEnabled) {
                     Timber.d("Omnibar: using NewOmnibar anchored BOTTOM")
                     binding.rootView.removeView(binding.legacyOmnibarBottom)
                     binding.rootView.removeView(binding.legacyOmnibar)
@@ -210,7 +210,7 @@ class Omnibar(
     }
 
     val findInPage: IncludeFindInPageBinding by lazy {
-        if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (refactorFlagEnabled) {
             newOmnibar.findInPage
         } else {
             legacyOmnibar.findInPage
@@ -218,7 +218,7 @@ class Omnibar(
     }
 
     val omnibarTextInput: KeyboardAwareEditText by lazy {
-        if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (refactorFlagEnabled) {
             newOmnibar.omnibarTextInput
         } else {
             legacyOmnibar.omnibarTextInput
@@ -226,7 +226,7 @@ class Omnibar(
     }
 
     val tabsMenu: TabSwitcherButton by lazy {
-        if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (refactorFlagEnabled) {
             newOmnibar.tabsMenu
         } else {
             legacyOmnibar.tabsMenu
@@ -234,7 +234,7 @@ class Omnibar(
     }
 
     val fireIconMenu: FrameLayout by lazy {
-        if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (refactorFlagEnabled) {
             newOmnibar.fireIconMenu
         } else {
             legacyOmnibar.fireIconMenu
@@ -242,7 +242,7 @@ class Omnibar(
     }
 
     val browserMenu: FrameLayout by lazy {
-        if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (refactorFlagEnabled) {
             newOmnibar.browserMenu
         } else {
             legacyOmnibar.browserMenu
@@ -250,7 +250,7 @@ class Omnibar(
     }
 
     val omniBarContainer: View by lazy {
-        if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (refactorFlagEnabled) {
             newOmnibar.omniBarContainer
         } else {
             legacyOmnibar.omniBarContainer
@@ -258,7 +258,7 @@ class Omnibar(
     }
 
     val toolbar: Toolbar by lazy {
-        if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (refactorFlagEnabled) {
             newOmnibar.toolbar
         } else {
             legacyOmnibar.toolbar
@@ -266,7 +266,7 @@ class Omnibar(
     }
 
     val toolbarContainer: View by lazy {
-        if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (refactorFlagEnabled) {
             newOmnibar.toolbarContainer
         } else {
             legacyOmnibar.toolbarContainer
@@ -274,7 +274,7 @@ class Omnibar(
     }
 
     val customTabToolbarContainer: IncludeCustomTabToolbarBinding by lazy {
-        if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (refactorFlagEnabled) {
             newOmnibar.customTabToolbarContainer
         } else {
             legacyOmnibar.customTabToolbarContainer
@@ -282,7 +282,7 @@ class Omnibar(
     }
 
     val browserMenuImageView: ImageView by lazy {
-        if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (refactorFlagEnabled) {
             newOmnibar.browserMenuImageView
         } else {
             legacyOmnibar.browserMenuImageView
@@ -290,7 +290,7 @@ class Omnibar(
     }
 
     val shieldIcon: LottieAnimationView by lazy {
-        if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (refactorFlagEnabled) {
             newOmnibar.shieldIcon
         } else {
             legacyOmnibar.shieldIcon
@@ -298,7 +298,7 @@ class Omnibar(
     }
 
     val pageLoadingIndicator: ProgressBar by lazy {
-        if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (refactorFlagEnabled) {
             newOmnibar.pageLoadingIndicator
         } else {
             legacyOmnibar.pageLoadingIndicator
@@ -306,7 +306,7 @@ class Omnibar(
     }
 
     val searchIcon: ImageView by lazy {
-        if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (refactorFlagEnabled) {
             newOmnibar.searchIcon
         } else {
             legacyOmnibar.searchIcon
@@ -314,7 +314,7 @@ class Omnibar(
     }
 
     val daxIcon: ImageView by lazy {
-        if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (refactorFlagEnabled) {
             newOmnibar.daxIcon
         } else {
             legacyOmnibar.daxIcon
@@ -322,7 +322,7 @@ class Omnibar(
     }
 
     val clearTextButton: ImageView by lazy {
-        if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (refactorFlagEnabled) {
             newOmnibar.clearTextButton
         } else {
             legacyOmnibar.clearTextButton
@@ -330,7 +330,7 @@ class Omnibar(
     }
 
     val placeholder: View by lazy {
-        if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (refactorFlagEnabled) {
             newOmnibar.placeholder
         } else {
             legacyOmnibar.placeholder
@@ -338,7 +338,7 @@ class Omnibar(
     }
 
     val voiceSearchButton: ImageView by lazy {
-        if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (refactorFlagEnabled) {
             newOmnibar.voiceSearchButton
         } else {
             legacyOmnibar.voiceSearchButton
@@ -346,7 +346,7 @@ class Omnibar(
     }
 
     val spacer: View by lazy {
-        if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (refactorFlagEnabled) {
             newOmnibar.spacer
         } else {
             legacyOmnibar.spacer
@@ -354,7 +354,7 @@ class Omnibar(
     }
 
     val textInputRootView: View by lazy {
-        if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (refactorFlagEnabled) {
             newOmnibar.omnibarTextInput.rootView
         } else {
             legacyOmnibar.omnibarTextInput.rootView
@@ -363,13 +363,13 @@ class Omnibar(
 
     var isScrollingEnabled: Boolean
         get() =
-            if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+            if (refactorFlagEnabled) {
                 newOmnibar.isScrollingEnabled
             } else {
                 legacyOmnibar.isScrollingEnabled
             }
         set(value) {
-            if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+            if (refactorFlagEnabled) {
                 newOmnibar.isScrollingEnabled = value
             } else {
                 legacyOmnibar.isScrollingEnabled = value
@@ -379,7 +379,7 @@ class Omnibar(
     fun setViewMode(viewMode: ViewMode) {
         when (viewMode) {
             Error -> {
-                if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+                if (refactorFlagEnabled) {
                     newOmnibar.decorate(Mode(viewMode))
                 } else {
                     setExpanded(true)
@@ -388,7 +388,7 @@ class Omnibar(
             }
 
             NewTab -> {
-                if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+                if (refactorFlagEnabled) {
                     newOmnibar.decorate(Mode(viewMode))
                 } else {
                     isScrollingEnabled = false
@@ -396,7 +396,7 @@ class Omnibar(
             }
 
             SSLWarning -> {
-                if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+                if (refactorFlagEnabled) {
                     newOmnibar.decorate(Mode(viewMode))
                 } else {
                     setExpanded(true)
@@ -407,7 +407,7 @@ class Omnibar(
             }
 
             else -> {
-                if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+                if (refactorFlagEnabled) {
                     newOmnibar.decorate(Mode(viewMode))
                 }
             }
@@ -415,7 +415,7 @@ class Omnibar(
     }
 
     fun setExpanded(expanded: Boolean) {
-        if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (refactorFlagEnabled) {
             newOmnibar.setExpanded(expanded)
         } else {
             legacyOmnibar.setExpanded(expanded)
@@ -426,7 +426,7 @@ class Omnibar(
         expanded: Boolean,
         animate: Boolean,
     ) {
-        if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (refactorFlagEnabled) {
             newOmnibar.setExpanded(expanded, animate)
         } else {
             legacyOmnibar.setExpanded(expanded, animate)
@@ -434,7 +434,7 @@ class Omnibar(
     }
 
     fun configureItemPressedListeners(listener: ItemPressedListener) {
-        if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (refactorFlagEnabled) {
             newOmnibar.setOmnibarItemPressedListener(listener)
         } else {
             tabsMenu.setOnClickListener {
@@ -460,7 +460,7 @@ class Omnibar(
     }
 
     fun addTextListener(listener: TextListener) {
-        if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (refactorFlagEnabled) {
             newOmnibar.setOmnibarTextListener(listener)
         } else {
             omnibarTextInput.onFocusChangeListener =
@@ -543,7 +543,7 @@ class Omnibar(
         viewState: LoadingViewState,
         onAnimationEnd: (Animator?) -> Unit,
     ) {
-        if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (refactorFlagEnabled) {
             newOmnibar.reduce(StateChange.LoadingStateChange(viewState, onAnimationEnd))
         } else {
             legacyOmnibar.onNewProgress(viewState.progress, onAnimationEnd)
@@ -552,7 +552,7 @@ class Omnibar(
 
     fun renderOmnibarViewState(viewState: OmnibarViewState) {
         Timber.d("Omnibar: renderOmnibarViewState $viewState")
-        if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (refactorFlagEnabled) {
             newOmnibar.reduce(StateChange.OmnibarStateChange(viewState))
         } else {
             if (viewState.navigationChange) {
@@ -584,7 +584,7 @@ class Omnibar(
         isCustomTab: Boolean,
         privacyShield: PrivacyShield,
     ) {
-        if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (refactorFlagEnabled) {
             newOmnibar.decorate(Decoration.PrivacyShieldChanged(privacyShield))
         } else {
             legacyOmnibar.setPrivacyShield(isCustomTab, privacyShield)
@@ -606,7 +606,7 @@ class Omnibar(
     }
 
     fun isPulseAnimationPlaying(): Boolean {
-        return if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+        return if (refactorFlagEnabled) {
             newOmnibar.isPulseAnimationPlaying()
         } else {
             legacyOmnibar.isPulseAnimationPlaying()
@@ -662,7 +662,7 @@ class Omnibar(
         viewState: BrowserViewState,
         tabDisplayedInCustomTabScreen: Boolean,
     ) {
-        if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (refactorFlagEnabled) {
             newOmnibar.decorate(
                 HighlightOmnibarItem(
                     fireButton = viewState.fireButton.isHighlighted(),
@@ -675,20 +675,20 @@ class Omnibar(
     }
 
     fun animateTabsCount() {
-        if (!changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (!refactorFlagEnabled) {
             tabsMenu.animateCount()
         }
     }
 
     fun renderTabIcon(tabs: List<TabEntity>) {
-        if (!changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (!refactorFlagEnabled) {
             tabsMenu.count = tabs.count()
             tabsMenu.hasUnread = tabs.firstOrNull { !it.viewed } != null
         }
     }
 
     fun incrementTabs(onTabsIncremented: () -> Unit) {
-        if (!changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (!refactorFlagEnabled) {
             setExpanded(true, true)
             tabsMenu.increment {
                 onTabsIncremented()
@@ -697,7 +697,7 @@ class Omnibar(
     }
 
     fun createCookiesAnimation(isCosmetic: Boolean) {
-        if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (refactorFlagEnabled) {
             newOmnibar.decorate(Decoration.LaunchCookiesAnimation(isCosmetic))
         } else {
             legacyOmnibar.createCookiesAnimation(isCosmetic)
@@ -705,7 +705,7 @@ class Omnibar(
     }
 
     fun cancelTrackersAnimation() {
-        if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (refactorFlagEnabled) {
             newOmnibar.decorate(Decoration.CancelAnimations)
         } else {
             legacyOmnibar.cancelTrackersAnimation()
@@ -713,7 +713,7 @@ class Omnibar(
     }
 
     fun startTrackersAnimation(events: List<Entity>?) {
-        if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (refactorFlagEnabled) {
             newOmnibar.decorate(Decoration.LaunchTrackersAnimation(events))
         } else {
             legacyOmnibar.startTrackersAnimation(events)
@@ -727,7 +727,7 @@ class Omnibar(
         onTabClosePressed: () -> Unit,
         onPrivacyShieldPressed: () -> Unit,
     ) {
-        if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (refactorFlagEnabled) {
             newOmnibar.decorate(Decoration.Mode(CustomTab(customTabToolbarColor, customTabDomainText)))
         } else {
             configureLegacyCustomTab(context, customTabToolbarColor, customTabDomainText, onTabClosePressed, onPrivacyShieldPressed)
@@ -800,7 +800,7 @@ class Omnibar(
     ) {
         val redirectedDomain = url?.extractDomain()
 
-        if (changeOmnibarPositionFeature.refactor().isEnabled()) {
+        if (refactorFlagEnabled) {
             newOmnibar.decorate(Decoration.ChangeCustomTabTitle(title, redirectedDomain, showDuckPlayerIcon))
         } else {
             customTabToolbarContainer.customTabTitle.text = title

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
@@ -95,17 +95,6 @@ class Omnibar(
                     binding.rootView.removeView(binding.newOmnibarBottom)
                     binding.rootView.removeView(binding.newOmnibar)
                     binding.rootView.removeView(binding.legacyOmnibarBottom)
-
-                    // remove the default top abb bar behavior
-                    removeAppBarBehavior(binding.autoCompleteSuggestionsList)
-                    removeAppBarBehavior(binding.browserLayout)
-                    removeAppBarBehavior(binding.focusedView)
-                    removeAppBarBehavior(binding.includeNewBrowserTab.newTabLayout)
-
-                    // prevent the touch event leaking to the webView below
-                    binding.newOmnibarBottom.setOnTouchListener { _, _ -> true }
-
-                    binding.newOmnibarBottom
                 }
             }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1174433894299346/1208667044987440/f

### Description
Ensure that the Omnibar code doesn’t hide the Omnibar view when the privacy config flag changes.

### Steps to test this PR

_From develop_
- [x] Install the app and navigate to a site
- [x] Open Feature Flag inventory
- [x] Disable the refactor flag
- [x] Navigate back to browser
- [x] Verify omnibar has disappeared
- [x] Open a New Tab
- [x] Verify omnibar looks good

_From this branch_
- [x] Install the app and navigate to a site
- [x] Open Feature Flag inventory
- [x] Disable the refactor flag
- [x] Navigate back to browser
- [x] Verify omnibar still there 
- [x] Open a New Tab
- [x] Verify omnibar looks good
