### PR TITLE
Add limiting logic

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -152,7 +152,7 @@ class CtaViewModelTest {
         whenever(mockDuckPlayer.getUserPreferences()).thenReturn(UserPreferences(false, AlwaysAsk))
         whenever(mockDuckPlayer.isYouTubeUrl(any())).thenReturn(false)
         whenever(mockDuckPlayer.isSimulatedYoutubeNoCookie(anyString())).thenReturn(false)
-        whenever(mockBrokenSitePrompt.shouldShowBrokenSitePrompt()).thenReturn(false)
+        whenever(mockBrokenSitePrompt.shouldShowBrokenSitePrompt(any())).thenReturn(false)
 
         testee = CtaViewModel(
             appInstallStore = mockAppInstallStore,
@@ -180,26 +180,26 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenCtaShownAndCtaIsDaxAndCanNotSendPixelThenPixelIsNotFired() {
+    fun whenCtaShownAndCtaIsDaxAndCanNotSendPixelThenPixelIsNotFired() = runTest {
         testee.onCtaShown(DaxBubbleCta.DaxIntroSearchOptionsCta(mockOnboardingStore, mockAppInstallStore))
         verify(mockPixel, never()).fire(eq(SURVEY_CTA_SHOWN), any(), any(), eq(Count))
     }
 
     @Test
-    fun whenCtaShownAndCtaIsDaxAndCanSendPixelThenPixelIsFired() {
+    fun whenCtaShownAndCtaIsDaxAndCanSendPixelThenPixelIsFired() = runTest {
         whenever(mockOnboardingStore.onboardingDialogJourney).thenReturn("s:0")
         testee.onCtaShown(DaxBubbleCta.DaxEndCta(mockOnboardingStore, mockAppInstallStore))
         verify(mockPixel, never()).fire(eq(SURVEY_CTA_SHOWN), any(), any(), eq(Count))
     }
 
     @Test
-    fun whenCtaShownAndCtaIsNotDaxThenPixelIsFired() {
+    fun whenCtaShownAndCtaIsNotDaxThenPixelIsFired() = runTest {
         testee.onCtaShown(HomePanelCta.AddWidgetAuto)
         verify(mockPixel).fire(eq(WIDGET_CTA_SHOWN), any(), any(), eq(Count))
     }
 
     @Test
-    fun whenCtaLaunchedPixelIsFired() {
+    fun whenCtaLaunchedPixelIsFired() = runTest {
         testee.onUserClickCtaOkButton(HomePanelCta.AddWidgetAuto)
         verify(mockPixel).fire(eq(WIDGET_CTA_LAUNCHED), any(), any(), eq(Count))
     }
@@ -284,7 +284,7 @@ class CtaViewModelTest {
     @Test
     fun whenRefreshCtaWhileBrowsingAndHideTipsIsTrueAndShouldShowBrokenSitePromptThenReturnBrokenSitePrompt() = runTest {
         whenever(mockSettingsDataStore.hideTips).thenReturn(true)
-        whenever(mockBrokenSitePrompt.shouldShowBrokenSitePrompt()).thenReturn(true)
+        whenever(mockBrokenSitePrompt.shouldShowBrokenSitePrompt(any())).thenReturn(true)
         val site = site(url = "http://www.facebook.com", entity = TestEntity("Facebook", "Facebook", 9.0))
 
         val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true, site = site)
@@ -685,14 +685,14 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenCtaShownIfCtaIsNotMarkedAsReadOnShowThenCtaNotInsertedInDatabase() {
+    fun whenCtaShownIfCtaIsNotMarkedAsReadOnShowThenCtaNotInsertedInDatabase() = runTest {
         testee.onCtaShown(OnboardingDaxDialogCta.DaxSerpCta(mockOnboardingStore, mockAppInstallStore))
 
         verify(mockDismissedCtaDao, never()).insert(DismissedCta(CtaId.DAX_DIALOG_SERP))
     }
 
     @Test
-    fun whenCtaShownIfCtaIsMarkedAsReadOnShowThenCtaInsertedInDatabase() {
+    fun whenCtaShownIfCtaIsMarkedAsReadOnShowThenCtaInsertedInDatabase() = runTest {
         testee.onCtaShown(OnboardingDaxDialogCta.DaxEndCta(mockOnboardingStore, mockAppInstallStore, mockSettingsDataStore))
 
         verify(mockDismissedCtaDao).insert(DismissedCta(CtaId.DAX_END))

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2880,7 +2880,9 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     fun onUserClickCtaOkButton(cta: Cta) {
-        ctaViewModel.onUserClickCtaOkButton(cta)
+        viewModelScope.launch {
+            ctaViewModel.onUserClickCtaOkButton(cta)
+        }
         val onboardingCommand = when (cta) {
             is HomePanelCta.AddWidgetAuto, is HomePanelCta.AddWidgetInstructions -> LaunchAddWidget
             is OnboardingDaxDialogCta -> onOnboardingCtaOkButtonClicked(cta)
@@ -3642,7 +3644,6 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     private fun onBrokenSiteCtaDismissButtonClicked(cta: BrokenSitePromptDialogCta): Command? {
-        onUserDismissedCta(cta)
         viewModelScope.launch {
             command.value = HideBrokenSitePromptCta(cta)
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1418,6 +1418,11 @@ class BrowserTabViewModel @Inject constructor(
                         }
                     }
                 }
+                ctaViewState.value?.cta?.let { cta ->
+                    if (cta is BrokenSitePromptDialogCta) {
+                        command.value = HideBrokenSitePromptCta(cta)
+                    }
+                }
             }
 
             is WebNavigationStateChange.PageNavigationCleared -> disableUserNavigation()

--- a/broken-site/broken-site-api/src/main/java/com/duckduckgo/brokensite/api/BrokenSitePrompt.kt
+++ b/broken-site/broken-site-api/src/main/java/com/duckduckgo/brokensite/api/BrokenSitePrompt.kt
@@ -32,5 +32,7 @@ interface BrokenSitePrompt {
 
     fun getUserRefreshesCount(): Int
 
-    suspend fun shouldShowBrokenSitePrompt(): Boolean
+    suspend fun shouldShowBrokenSitePrompt(url: String): Boolean
+
+    suspend fun ctaShown()
 }

--- a/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSitePomptDataStore.kt
+++ b/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSitePomptDataStore.kt
@@ -20,6 +20,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.brokensite.impl.SharedPreferencesDuckPlayerDataStore.Keys.COOL_DOWN_DAYS
@@ -47,8 +48,8 @@ interface BrokenSitePomptDataStore {
     suspend fun setDismissStreakResetDays(days: Int)
     suspend fun getDismissStreakResetDays(): Int
 
-    suspend fun setCoolDownDays(days: Int)
-    suspend fun getCoolDownDays(): Int
+    suspend fun setCoolDownDays(days: Long)
+    suspend fun getCoolDownDays(): Long
     suspend fun setDismissStreak(streak: Int)
     suspend fun getDismissStreak(): Int
     suspend fun setNextShownDate(nextShownDate: LocalDate?)
@@ -65,7 +66,7 @@ class SharedPreferencesDuckPlayerDataStore @Inject constructor(
     private object Keys {
         val MAX_DISMISS_STREAK = intPreferencesKey(name = "MAX_DISMISS_STREAK")
         val DISMISS_STREAK_RESET_DAYS = intPreferencesKey(name = "DISMISS_STREAK_RESET_DAYS")
-        val COOL_DOWN_DAYS = intPreferencesKey(name = "COOL_DOWN_DAYS")
+        val COOL_DOWN_DAYS = longPreferencesKey(name = "COOL_DOWN_DAYS")
         val DISMISS_STREAK = intPreferencesKey(name = "DISMISS_STREAK")
         val NEXT_SHOWN_DATE = stringPreferencesKey(name = "NEXT_SHOWN_DATE")
     }
@@ -84,11 +85,10 @@ class SharedPreferencesDuckPlayerDataStore @Inject constructor(
         }
         .distinctUntilChanged()
 
-    private val coolDownDays: Flow<Int> = store.data
+    private val coolDownDays: Flow<Long> = store.data
         .map { prefs ->
             prefs[COOL_DOWN_DAYS] ?: 7
         }
-        .distinctUntilChanged()
 
     private val dismissStreak: Flow<Int> = store.data
         .map { prefs ->
@@ -114,11 +114,11 @@ class SharedPreferencesDuckPlayerDataStore @Inject constructor(
 
     override suspend fun getDismissStreakResetDays(): Int = dismissStreakResetDays.first()
 
-    override suspend fun setCoolDownDays(days: Int) {
+    override suspend fun setCoolDownDays(days: Long) {
         store.edit { prefs -> prefs[COOL_DOWN_DAYS] = days }
     }
 
-    override suspend fun getCoolDownDays(): Int = coolDownDays.first()
+    override suspend fun getCoolDownDays(): Long = coolDownDays.first()
 
     override suspend fun setDismissStreak(streak: Int) {
         store.edit { prefs -> prefs[DISMISS_STREAK] = streak }

--- a/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSitePomptDataStore.kt
+++ b/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSitePomptDataStore.kt
@@ -91,7 +91,7 @@ class SharedPreferencesDuckPlayerDataStore @Inject constructor(
 
     private val dismissStreak: Flow<Int> = store.data
         .map { prefs ->
-            prefs[DISMISS_STREAK] ?: 7
+            prefs[DISMISS_STREAK] ?: 0
         }
         .distinctUntilChanged()
 

--- a/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSitePomptDataStore.kt
+++ b/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSitePomptDataStore.kt
@@ -32,7 +32,7 @@ import com.duckduckgo.brokensite.impl.di.BrokenSitePrompt
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
-import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
@@ -52,8 +52,8 @@ interface BrokenSitePomptDataStore {
     suspend fun getCoolDownDays(): Long
     suspend fun setDismissStreak(streak: Int)
     suspend fun getDismissStreak(): Int
-    suspend fun setNextShownDate(nextShownDate: LocalDate?)
-    suspend fun getNextShownDate(): LocalDate?
+    suspend fun setNextShownDate(nextShownDate: LocalDateTime?)
+    suspend fun getNextShownDate(): LocalDateTime?
 }
 
 @ContributesBinding(AppScope::class)
@@ -71,8 +71,7 @@ class SharedPreferencesDuckPlayerDataStore @Inject constructor(
         val NEXT_SHOWN_DATE = stringPreferencesKey(name = "NEXT_SHOWN_DATE")
     }
 
-    private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
-
+    private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
     private val maxDismissStreak: Flow<Int> = store.data
         .map { prefs ->
             prefs[MAX_DISMISS_STREAK] ?: 3
@@ -124,7 +123,7 @@ class SharedPreferencesDuckPlayerDataStore @Inject constructor(
         store.edit { prefs -> prefs[DISMISS_STREAK] = streak }
     }
 
-    override suspend fun setNextShownDate(nextShownDate: LocalDate?) {
+    override suspend fun setNextShownDate(nextShownDate: LocalDateTime?) {
         store.edit { prefs ->
 
             nextShownDate?.let {
@@ -139,7 +138,7 @@ class SharedPreferencesDuckPlayerDataStore @Inject constructor(
         return dismissStreak.first()
     }
 
-    override suspend fun getNextShownDate(): LocalDate? {
-        return nextShownDate.first()?.let { LocalDate.parse(it, formatter) }
+    override suspend fun getNextShownDate(): LocalDateTime? {
+        return nextShownDate.first()?.let { LocalDateTime.parse(it, formatter) }
     }
 }

--- a/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSitePromptInMemoryStore.kt
+++ b/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSitePromptInMemoryStore.kt
@@ -22,6 +22,7 @@ import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
 import java.time.LocalDateTime
 import javax.inject.Inject
+import timber.log.Timber
 
 interface BrokenSitePromptInMemoryStore {
     fun resetRefreshCount()
@@ -61,7 +62,8 @@ class RealBrokenSitePromptInMemoryStore @Inject constructor() : BrokenSitePrompt
         return refreshes?.let {
             val time = it.time.filter { time -> time.isAfter(t1) && time.isBefore(t2) }
             refreshes = it.copy(time = time)
-            it.time.size
+            Timber.d("Cris. $refreshes")
+            time.size
         } ?: 0
     }
 }

--- a/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSitePromptInMemoryStore.kt
+++ b/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSitePromptInMemoryStore.kt
@@ -59,7 +59,8 @@ class RealBrokenSitePromptInMemoryStore @Inject constructor() : BrokenSitePrompt
         t2: LocalDateTime,
     ): Int {
         return refreshes?.let {
-            refreshes = it.copy(time = it.time.filter { time -> time.isAfter(t1) && time.isBefore(t2) })
+            val time = it.time.filter { time -> time.isAfter(t1) && time.isBefore(t2) }
+            refreshes = it.copy(time = time)
             it.time.size
         } ?: 0
     }

--- a/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSiteReportRepository.kt
+++ b/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSiteReportRepository.kt
@@ -136,7 +136,6 @@ class RealBrokenSiteReportRepository(
 
     override suspend fun setNextShownDate(nextShownDate: LocalDateTime?) {
         brokenSitePromptDataStore.setNextShownDate(nextShownDate)
-        // Log.d("BrokenSitePrompt", "Next shown date set to $nextShownDate")
     }
 
     override suspend fun getDismissStreak(): Int {

--- a/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSiteReportRepository.kt
+++ b/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSiteReportRepository.kt
@@ -45,8 +45,8 @@ interface BrokenSiteReportRepository {
     suspend fun setDismissStreakResetDays(days: Int)
     suspend fun getDismissStreakResetDays(): Int
 
-    suspend fun setCoolDownDays(days: Int)
-    suspend fun getCoolDownDays(): Int
+    suspend fun setCoolDownDays(days: Long)
+    suspend fun getCoolDownDays(): Long
 
     suspend fun setBrokenSitePromptRCSettings(maxDismissStreak: Int, dismissStreakResetDays: Int, coolDownDays: Int)
 
@@ -56,6 +56,7 @@ interface BrokenSiteReportRepository {
     suspend fun incrementDismissStreak()
     suspend fun getDismissStreak(): Int
     suspend fun resetDismissStreak()
+
     fun resetRefreshCount()
     fun addRefresh(url: Uri, localDateTime: LocalDateTime)
     fun getAndUpdateUserRefreshesBetween(t1: LocalDateTime, t2: LocalDateTime): Int
@@ -113,11 +114,11 @@ class RealBrokenSiteReportRepository(
     override suspend fun getDismissStreakResetDays(): Int =
         brokenSitePromptDataStore.getDismissStreakResetDays()
 
-    override suspend fun setCoolDownDays(days: Int) {
+    override suspend fun setCoolDownDays(days: Long) {
         brokenSitePromptDataStore.setCoolDownDays(days)
     }
 
-    override suspend fun getCoolDownDays(): Int =
+    override suspend fun getCoolDownDays(): Long =
         brokenSitePromptDataStore.getCoolDownDays()
 
     override suspend fun setBrokenSitePromptRCSettings(
@@ -127,7 +128,7 @@ class RealBrokenSiteReportRepository(
     ) {
         setMaxDismissStreak(maxDismissStreak)
         setDismissStreakResetDays(dismissStreakResetDays)
-        setCoolDownDays(coolDownDays)
+        setCoolDownDays(coolDownDays.toLong())
     }
 
     override suspend fun resetDismissStreak() {
@@ -136,6 +137,7 @@ class RealBrokenSiteReportRepository(
 
     override suspend fun setNextShownDate(nextShownDate: LocalDate?) {
         brokenSitePromptDataStore.setNextShownDate(nextShownDate)
+        // Log.d("BrokenSitePrompt", "Next shown date set to $nextShownDate")
     }
 
     override suspend fun getDismissStreak(): Int {

--- a/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSiteReportRepository.kt
+++ b/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSiteReportRepository.kt
@@ -24,7 +24,6 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.formatters.time.DatabaseDateFormatter
 import com.duckduckgo.common.utils.sha256
 import java.time.Instant
-import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
@@ -50,8 +49,8 @@ interface BrokenSiteReportRepository {
 
     suspend fun setBrokenSitePromptRCSettings(maxDismissStreak: Int, dismissStreakResetDays: Int, coolDownDays: Int)
 
-    suspend fun setNextShownDate(nextShownDate: LocalDate?)
-    suspend fun getNextShownDate(): LocalDate?
+    suspend fun setNextShownDate(nextShownDate: LocalDateTime?)
+    suspend fun getNextShownDate(): LocalDateTime?
 
     suspend fun incrementDismissStreak()
     suspend fun getDismissStreak(): Int
@@ -135,7 +134,7 @@ class RealBrokenSiteReportRepository(
         brokenSitePromptDataStore.setDismissStreak(0)
     }
 
-    override suspend fun setNextShownDate(nextShownDate: LocalDate?) {
+    override suspend fun setNextShownDate(nextShownDate: LocalDateTime?) {
         brokenSitePromptDataStore.setNextShownDate(nextShownDate)
         // Log.d("BrokenSitePrompt", "Next shown date set to $nextShownDate")
     }
@@ -144,7 +143,7 @@ class RealBrokenSiteReportRepository(
         return brokenSitePromptDataStore.getDismissStreak()
     }
 
-    override suspend fun getNextShownDate(): LocalDate? {
+    override suspend fun getNextShownDate(): LocalDateTime? {
         return brokenSitePromptDataStore.getNextShownDate()
     }
 

--- a/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/RealBrokenSitePrompt.kt
+++ b/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/RealBrokenSitePrompt.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.brokensite.impl
 
 import android.net.Uri
-import android.util.Log
 import androidx.annotation.VisibleForTesting
 import com.duckduckgo.app.browser.DuckDuckGoUrlDetector
 import com.duckduckgo.brokensite.api.BrokenSitePrompt
@@ -25,6 +24,7 @@ import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
+import timber.log.Timber
 
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
 internal const val REFRESH_COUNT_WINDOW = 20L
@@ -50,9 +50,9 @@ class RealBrokenSitePrompt @Inject constructor(
 
             if (nextShownDate == null || newNextShownDate.isAfter(nextShownDate)) {
                 brokenSiteReportRepository.setNextShownDate(newNextShownDate)
-                Log.d("BrokenSitePrompt", "New next shown date: $newNextShownDate")
+                Timber.d("New next shown date: $newNextShownDate")
             } else {
-                Log.d("BrokenSitePrompt", "Next shown date not updated to $newNextShownDate, keeping existing value: $nextShownDate")
+                Timber.d("Next shown date not updated to $newNextShownDate, keeping existing value: $nextShownDate")
             }
         }
         brokenSiteReportRepository.incrementDismissStreak()
@@ -101,9 +101,9 @@ class RealBrokenSitePrompt @Inject constructor(
         val newNextShownDate = currentTimeProvider.localDateTimeNow().plusDays(brokenSiteReportRepository.getCoolDownDays())
         if (nextShownDate == null || newNextShownDate.isAfter(nextShownDate)) {
             brokenSiteReportRepository.setNextShownDate(newNextShownDate)
-            Log.d("BrokenSitePrompt", "New next shown date: $newNextShownDate")
+            Timber.d("New next shown date: $newNextShownDate")
         } else {
-            Log.d("BrokenSitePrompt", "Next shown date not updated to $newNextShownDate, keeping existing value: $nextShownDate")
+            Timber.d("Next shown date not updated to $newNextShownDate, keeping existing value: $nextShownDate")
         }
     }
 }

--- a/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/RealBrokenSitePrompt.kt
+++ b/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/RealBrokenSitePrompt.kt
@@ -44,17 +44,15 @@ class RealBrokenSitePrompt @Inject constructor(
 
     override suspend fun userDismissedPrompt() {
         if (!_featureEnabled) return
-        Log.d("BrokenSitePrompt", "User dismissed prompt, dismiss streak: ${brokenSiteReportRepository.getDismissStreak()}")
         if (brokenSiteReportRepository.getDismissStreak() >= brokenSiteReportRepository.getMaxDismissStreak() - 1) {
             val nextShownDate = brokenSiteReportRepository.getNextShownDate()
-            // TODO (cbarreiro): Add days, not seconds
-            // val newNextShownDate = currentTimeProvider.localDateTimeNow().plusDays(brokenSiteReportRepository.getDismissStreakResetDays().toLong())
-            val newNextShownDate = currentTimeProvider.localDateTimeNow().plusSeconds(brokenSiteReportRepository.getDismissStreakResetDays().toLong())
-
-            Log.d("BrokenSitePrompt", "User dismissed. Next shown date: $nextShownDate, new next show date: $newNextShownDate")
+            val newNextShownDate = currentTimeProvider.localDateTimeNow().plusDays(brokenSiteReportRepository.getDismissStreakResetDays().toLong())
 
             if (nextShownDate == null || newNextShownDate.isAfter(nextShownDate)) {
                 brokenSiteReportRepository.setNextShownDate(newNextShownDate)
+                Log.d("BrokenSitePrompt", "New next shown date: $newNextShownDate")
+            } else {
+                Log.d("BrokenSitePrompt", "Next shown date not updated to $newNextShownDate, keeping existing value: $nextShownDate")
             }
         }
         brokenSiteReportRepository.incrementDismissStreak()
@@ -62,7 +60,6 @@ class RealBrokenSitePrompt @Inject constructor(
 
     override suspend fun userAcceptedPrompt() {
         if (!_featureEnabled) return
-        Log.d("BrokenSitePrompt", "User accepted")
 
         brokenSiteReportRepository.resetDismissStreak()
     }
@@ -100,13 +97,13 @@ class RealBrokenSitePrompt @Inject constructor(
     }
 
     override suspend fun ctaShown() {
-        Log.d("BrokenSitePrompt", "CTA shown")
         val nextShownDate = brokenSiteReportRepository.getNextShownDate()
-        // TODO (cbarreiro): Add days, not seconds
-        // val newNextShownDate = currentTimeProvider.localDateTimeNow().plusDays(brokenSiteReportRepository.getCoolDownDays())
-        val newNextShownDate = currentTimeProvider.localDateTimeNow().plusSeconds(brokenSiteReportRepository.getCoolDownDays())
+        val newNextShownDate = currentTimeProvider.localDateTimeNow().plusDays(brokenSiteReportRepository.getCoolDownDays())
         if (nextShownDate == null || newNextShownDate.isAfter(nextShownDate)) {
             brokenSiteReportRepository.setNextShownDate(newNextShownDate)
+            Log.d("BrokenSitePrompt", "New next shown date: $newNextShownDate")
+        } else {
+            Log.d("BrokenSitePrompt", "Next shown date not updated to $newNextShownDate, keeping existing value: $nextShownDate")
         }
     }
 }

--- a/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/RealBrokenSitePrompt.kt
+++ b/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/RealBrokenSitePrompt.kt
@@ -44,18 +44,21 @@ class RealBrokenSitePrompt @Inject constructor(
 
     override suspend fun userDismissedPrompt() {
         if (!_featureEnabled) return
+        Timber.d("Cris. Dismiss streak: ${brokenSiteReportRepository.getDismissStreak()}")
         if (brokenSiteReportRepository.getDismissStreak() >= brokenSiteReportRepository.getMaxDismissStreak() - 1) {
+            brokenSiteReportRepository.resetDismissStreak()
             val nextShownDate = brokenSiteReportRepository.getNextShownDate()
             val newNextShownDate = currentTimeProvider.localDateTimeNow().plusDays(brokenSiteReportRepository.getDismissStreakResetDays().toLong())
 
             if (nextShownDate == null || newNextShownDate.isAfter(nextShownDate)) {
                 brokenSiteReportRepository.setNextShownDate(newNextShownDate)
-                Timber.d("New next shown date: $newNextShownDate")
+                Timber.d("Cris. Dismiss. New next shown date: $newNextShownDate")
             } else {
-                Timber.d("Next shown date not updated to $newNextShownDate, keeping existing value: $nextShownDate")
+                Timber.d("Cris. Dismiss. Next shown date not updated to $newNextShownDate, keeping existing value: $nextShownDate")
             }
+        } else {
+            brokenSiteReportRepository.incrementDismissStreak()
         }
-        brokenSiteReportRepository.incrementDismissStreak()
     }
 
     override suspend fun userAcceptedPrompt() {
@@ -101,9 +104,9 @@ class RealBrokenSitePrompt @Inject constructor(
         val newNextShownDate = currentTimeProvider.localDateTimeNow().plusDays(brokenSiteReportRepository.getCoolDownDays())
         if (nextShownDate == null || newNextShownDate.isAfter(nextShownDate)) {
             brokenSiteReportRepository.setNextShownDate(newNextShownDate)
-            Timber.d("New next shown date: $newNextShownDate")
+            Timber.d("Cris. Shown. New next shown date: $newNextShownDate")
         } else {
-            Timber.d("Next shown date not updated to $newNextShownDate, keeping existing value: $nextShownDate")
+            Timber.d("Cris. Shown. Next shown date not updated to $newNextShownDate, keeping existing value: $nextShownDate")
         }
     }
 }

--- a/broken-site/broken-site-impl/src/test/java/com/duckduckgo/brokensite/impl/RealBrokenSitePromptTest.kt
+++ b/broken-site/broken-site-impl/src/test/java/com/duckduckgo/brokensite/impl/RealBrokenSitePromptTest.kt
@@ -45,6 +45,8 @@ class RealBrokenSitePromptTest {
     @Test
     fun whenUserDismissedPromptAndNoNextShownDateThenIncrementDismissStreakAndDoNotUpdateNextShownDate() = runTest {
         whenever(mockBrokenSiteReportRepository.getNextShownDate()).thenReturn(null)
+        whenever(mockBrokenSiteReportRepository.getMaxDismissStreak()).thenReturn(3)
+        whenever(mockBrokenSiteReportRepository.getDismissStreak()).thenReturn(0)
 
         testee.userDismissedPrompt()
 
@@ -69,10 +71,12 @@ class RealBrokenSitePromptTest {
         }
 
     @Test
-    fun whenUserDismissedPromptMaxDismissStreakTimesAndNextShownDateLaterThanCooldownDaysThenResetDismissStreakAndDoNotUpdateNextShownDate() =
+    fun whenUserDismissedPromptMaxDismissStreakTimesAndNextShownDateLaterThanDismissStreakDaysThenResetDismissStreakAndDoNotUpdateNextShownDate() =
         runTest {
             whenever(mockBrokenSiteReportRepository.getNextShownDate()).thenReturn(LocalDateTime.now().plusDays(11))
             whenever(mockBrokenSiteReportRepository.getDismissStreak()).thenReturn(2)
+            whenever(mockBrokenSiteReportRepository.getMaxDismissStreak()).thenReturn(3)
+            whenever(mockBrokenSiteReportRepository.getDismissStreakResetDays()).thenReturn(2)
             whenever(mockCurrentTimeProvider.localDateTimeNow()).thenReturn(LocalDateTime.now())
 
             testee.userDismissedPrompt()

--- a/broken-site/broken-site-impl/src/test/java/com/duckduckgo/brokensite/impl/RealBrokenSitePromptTest.kt
+++ b/broken-site/broken-site-impl/src/test/java/com/duckduckgo/brokensite/impl/RealBrokenSitePromptTest.kt
@@ -53,7 +53,7 @@ class RealBrokenSitePromptTest {
     }
 
     @Test
-    fun whenUserDismissedPromptMaxDismissStreakTimesAndNextShownDateEarlierThanDismissStreakDaysThenIncrementDismissStreakAndUpdateNextShownDate() =
+    fun whenUserDismissedPromptMaxDismissStreakTimesAndNextShownDateEarlierThanDismissStreakDaysThenResetDismissStreakAndUpdateNextShownDate() =
         runTest {
             whenever(mockBrokenSiteReportRepository.getNextShownDate()).thenReturn(LocalDateTime.now().plusDays(5))
             whenever(mockBrokenSiteReportRepository.getDismissStreak()).thenReturn(2)
@@ -65,11 +65,11 @@ class RealBrokenSitePromptTest {
             val argumentCaptor = argumentCaptor<LocalDateTime>()
             verify(mockBrokenSiteReportRepository).setNextShownDate(argumentCaptor.capture())
             assertEquals(LocalDateTime.now().plusDays(30).toLocalDate(), argumentCaptor.firstValue.toLocalDate())
-            verify(mockBrokenSiteReportRepository).incrementDismissStreak()
+            verify(mockBrokenSiteReportRepository).resetDismissStreak()
         }
 
     @Test
-    fun whenUserDismissedPromptMaxDismissStreakTimesAndNextShownDateLaterThanCooldownDaysThenIncrementDismissStreakAndDoNotUpdateNextShownDate() =
+    fun whenUserDismissedPromptMaxDismissStreakTimesAndNextShownDateLaterThanCooldownDaysThenResetDismissStreakAndDoNotUpdateNextShownDate() =
         runTest {
             whenever(mockBrokenSiteReportRepository.getNextShownDate()).thenReturn(LocalDateTime.now().plusDays(11))
             whenever(mockBrokenSiteReportRepository.getDismissStreak()).thenReturn(2)
@@ -78,7 +78,7 @@ class RealBrokenSitePromptTest {
             testee.userDismissedPrompt()
 
             verify(mockBrokenSiteReportRepository, never()).setNextShownDate(any())
-            verify(mockBrokenSiteReportRepository).incrementDismissStreak()
+            verify(mockBrokenSiteReportRepository).resetDismissStreak()
         }
 
     @Test

--- a/broken-site/broken-site-impl/src/test/java/com/duckduckgo/brokensite/impl/RealBrokenSitePromptTest.kt
+++ b/broken-site/broken-site-impl/src/test/java/com/duckduckgo/brokensite/impl/RealBrokenSitePromptTest.kt
@@ -145,7 +145,7 @@ class RealBrokenSitePromptTest {
         whenever(mockCurrentTimeProvider.localDateTimeNow()).thenReturn(LocalDateTime.now())
         whenever(mockBrokenSiteReportRepository.getAndUpdateUserRefreshesBetween(any(), any())).thenReturn(REFRESH_COUNT_LIMIT)
 
-        val result = testee.shouldShowBrokenSitePrompt()
+        val result = testee.shouldShowBrokenSitePrompt(nonNullSite.url)
 
         assertTrue(result)
     }
@@ -155,7 +155,7 @@ class RealBrokenSitePromptTest {
         whenever(mockCurrentTimeProvider.localDateTimeNow()).thenReturn(LocalDateTime.now())
         whenever(mockBrokenSiteReportRepository.getAndUpdateUserRefreshesBetween(any(), any())).thenReturn(2)
 
-        val result = testee.shouldShowBrokenSitePrompt()
+        val result = testee.shouldShowBrokenSitePrompt(nonNullSite.url)
 
         assertFalse(result)
     }
@@ -165,7 +165,7 @@ class RealBrokenSitePromptTest {
         whenever(mockCurrentTimeProvider.localDateTimeNow()).thenReturn(LocalDateTime.now())
         fakeBrokenSitePromptRCFeature.self().setRawStoredState(State(false))
 
-        val result = testee.shouldShowBrokenSitePrompt()
+        val result = testee.shouldShowBrokenSitePrompt(nonNullSite.url)
 
         assertFalse(result)
     }

--- a/broken-site/broken-site-impl/src/test/java/com/duckduckgo/brokensite/impl/RealBrokenSiteReportRepositoryTest.kt
+++ b/broken-site/broken-site-impl/src/test/java/com/duckduckgo/brokensite/impl/RealBrokenSiteReportRepositoryTest.kt
@@ -21,7 +21,6 @@ import com.duckduckgo.brokensite.store.BrokenSiteDao
 import com.duckduckgo.brokensite.store.BrokenSiteDatabase
 import com.duckduckgo.brokensite.store.BrokenSiteLastSentReportEntity
 import com.duckduckgo.common.test.CoroutineTestRule
-import java.time.LocalDate
 import java.time.LocalDateTime
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -153,7 +152,7 @@ class RealBrokenSiteReportRepositoryTest {
 
     @Test
     fun whenSetNextShownDateCalledThenNextShownDateIsSet() = runTest {
-        val nextShownDate = LocalDate.now()
+        val nextShownDate = LocalDateTime.now()
 
         testee.setNextShownDate(nextShownDate)
 
@@ -172,7 +171,7 @@ class RealBrokenSiteReportRepositoryTest {
 
     @Test
     fun whenGetNextShownDateCalledThenReturnNextShownDate() = runTest {
-        val nextShownDate = LocalDate.now()
+        val nextShownDate = LocalDateTime.now()
         whenever(mockDataStore.getNextShownDate()).thenReturn(nextShownDate)
 
         val result = testee.getNextShownDate()

--- a/broken-site/broken-site-impl/src/test/java/com/duckduckgo/brokensite/impl/RealBrokenSiteReportRepositoryTest.kt
+++ b/broken-site/broken-site-impl/src/test/java/com/duckduckgo/brokensite/impl/RealBrokenSiteReportRepositoryTest.kt
@@ -137,7 +137,7 @@ class RealBrokenSiteReportRepositoryTest {
 
     @Test
     fun whenCoolDownDaysCalledThenCoolDownDaysIsCalled() = runTest {
-        val days = 7
+        val days = 7L
 
         testee.setCoolDownDays(days)
 

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/CurrentTimeProvider.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/CurrentTimeProvider.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.common.utils
 import android.os.SystemClock
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
+import java.time.LocalDate
 import java.time.LocalDateTime
 import javax.inject.Inject
 
@@ -28,6 +29,8 @@ interface CurrentTimeProvider {
     fun currentTimeMillis(): Long
 
     fun localDateTimeNow(): LocalDateTime
+
+    fun localDateNow(): LocalDate
 }
 
 @ContributesBinding(AppScope::class)
@@ -37,4 +40,6 @@ class RealCurrentTimeProvider @Inject constructor() : CurrentTimeProvider {
     override fun currentTimeMillis(): Long = System.currentTimeMillis()
 
     override fun localDateTimeNow(): LocalDateTime = LocalDateTime.now()
+
+    override fun localDateNow(): LocalDate = LocalDate.now()
 }

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/CurrentTimeProvider.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/CurrentTimeProvider.kt
@@ -19,7 +19,6 @@ package com.duckduckgo.common.utils
 import android.os.SystemClock
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
-import java.time.LocalDate
 import java.time.LocalDateTime
 import javax.inject.Inject
 
@@ -29,8 +28,6 @@ interface CurrentTimeProvider {
     fun currentTimeMillis(): Long
 
     fun localDateTimeNow(): LocalDateTime
-
-    fun localDateNow(): LocalDate
 }
 
 @ContributesBinding(AppScope::class)
@@ -40,6 +37,4 @@ class RealCurrentTimeProvider @Inject constructor() : CurrentTimeProvider {
     override fun currentTimeMillis(): Long = System.currentTimeMillis()
 
     override fun localDateTimeNow(): LocalDateTime = LocalDateTime.now()
-
-    override fun localDateNow(): LocalDate = LocalDate.now()
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1204920898013511/1208572901396846/f 

### Description

### Steps to test this PR

> [!WARNING]
> **pre-requisites:** Onboarding is completed, brokenSitePrompt RC flag is on (needs app restart)


> [!TIP]
> Cooldown is 7 days, and dismissStreakResetDays is 30 days. For easier testing, apply this patch (adds 7 seconds and 30 seconds instead) https://app.asana.com/app/asana/-/get_asset?asset_id=1208700930411217. Fresh install with this patch

> [!TIP]
> Filter logs for Next shown date to check when the prompt can be shown again




_Feature 1_
- [x] Load a site
- [x] Quickly refresh 3 times
- [x] Check prompt is shown

_Feature 1_
- [x] Load a site
- [x] Quickly refresh 3 times
- [x] Check prompt is shown
- [x] Click on a link on that site
- [x] Check prompt is dismissed

_Feature 1_
- [x] Load a site
- [x] Quickly refresh 2 times
- [x] Wait for more than 20 seconds
- [x] Refresh another time
- [x] Check prompt is not shown
- [x] Quickly refresh 2 more times
- [x] Check prompt is shown

_Feature 1_
- [x] Load a site
- [x] Quickly refresh 2 times
- [x] Open a new tab and load the same site
- [x] Refresh on the new tab
- [x] Check prompt is shown

_Feature 1_
- [x] Load a site
- [x] Quickly refresh 2 times
- [x] Switch to another tab
- [x] Load another site
- [x] Quickly refresh
- [x] Check prompt is not shown

_Feature 1_
- [x] Load a site
- [x] Quickly refresh 2 times
- [x] Load another site
- [x] Quickly refresh
- [x] Check prompt is not shown

_Feature 1_
- [x] Load a site
- [x] Quickly refresh 3 times
- [x] Check prompt is shown
- [x] Navigate to another site using the omnibar
- [x] Check prompt is dismissed

_Feature 1_
- [x] Load a site
- [x] Quickly refresh 3 times
- [x] Check prompt is shown

> [!WARNING]
> If you haven't applied the patch before, it's required for this test. https://app.asana.com/app/asana/-/get_asset?asset_id=1208700930411217. Fresh install and complete the onboarding after applying

_Feature 1_
- [x] Load a site
- [x] Refresh 3 times
- [x] Check logs, new next shown date should be ~7 seconds from now
- [x] Dismiss the prompt
- [x] Refresh another 3 times
- [x] Check next shown date is again ~7 seconds from now
- [x] Dismiss the prompt
- [x] Refresh another 3 times
- [x] Check next shown date is again ~7 seconds from now
- [x] Dismiss the prompt
- [x] Check next shown date is ~30 seconds from now


### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

