### PR TITLE
ADS: Support HTML tags in List Items text

### DIFF
--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/themepreview/ui/component/ComponentViewHolder.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/themepreview/ui/component/ComponentViewHolder.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.common.ui.view.expand.daxExpandableMenuItem
 import com.duckduckgo.common.ui.view.listitem.OneLineListItem
 import com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
 import com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+import com.duckduckgo.common.utils.extensions.html
 import com.duckduckgo.mobile.android.R
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.shape.ShapeAppearanceModel
@@ -298,6 +299,11 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
 
             view.findViewById<TwoLineListItem>(R.id.twoLineSwitchListItemWithSwitchDisabledChecked).apply {
                 quietlySetIsChecked(true, null)
+            }
+
+            view.findViewById<TwoLineListItem>(R.id.twoLineListItemWithHTMLTags).apply {
+                setPrimaryText(context.getString(R.string.dax_list_item_html_primary_text).html(context))
+                setSecondaryText(context.getString(R.string.dax_list_item_html_secondary_text).html(context))
             }
         }
     }

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/themepreview/ui/component/ComponentViewHolder.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/themepreview/ui/component/ComponentViewHolder.kt
@@ -220,6 +220,9 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
             view.findViewById<OneLineListItem>(R.id.oneLineListItemCustomTextColor).apply {
                 setClickListener { Snackbar.make(this, component.name, Snackbar.LENGTH_SHORT).show() }
             }
+            view.findViewById<OneLineListItem>(R.id.oneLineListItemWithLongTextTruncated).apply {
+                setPrimaryText(context.getString(R.string.dax_one_line_list_item_html_primary_text).html(context))
+            }
         }
     }
 

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/listitem/DaxListItem.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/listitem/DaxListItem.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.common.ui.view.recursiveEnable
 import com.duckduckgo.common.ui.view.setEnabledOpacity
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.view.text.DaxTextView
+import com.duckduckgo.common.utils.extensions.html
 import com.duckduckgo.mobile.android.R
 
 abstract class DaxListItem(
@@ -61,7 +62,7 @@ abstract class DaxListItem(
 
     /** Sets the primary text title */
     fun setPrimaryText(title: String?) {
-        primaryText.text = title
+        primaryText.text = title?.html(context)
     }
 
     /** Sets primary text color */
@@ -86,7 +87,7 @@ abstract class DaxListItem(
 
     /** Sets the secondary text title */
     fun setSecondaryText(title: String?) {
-        secondaryText?.text = title
+        secondaryText?.text = title?.html(context)
     }
 
     /** Sets secondary text color */

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/listitem/DaxListItem.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/listitem/DaxListItem.kt
@@ -35,7 +35,6 @@ import com.duckduckgo.common.ui.view.recursiveEnable
 import com.duckduckgo.common.ui.view.setEnabledOpacity
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.view.text.DaxTextView
-import com.duckduckgo.common.utils.extensions.html
 import com.duckduckgo.mobile.android.R
 
 abstract class DaxListItem(
@@ -61,8 +60,8 @@ abstract class DaxListItem(
     }
 
     /** Sets the primary text title */
-    fun setPrimaryText(title: String?) {
-        primaryText.text = title?.html(context)
+    fun setPrimaryText(title: CharSequence?) {
+        primaryText.text = title
     }
 
     /** Sets primary text color */
@@ -86,8 +85,8 @@ abstract class DaxListItem(
     }
 
     /** Sets the secondary text title */
-    fun setSecondaryText(title: String?) {
-        secondaryText?.text = title?.html(context)
+    fun setSecondaryText(title: CharSequence?) {
+        secondaryText?.text = title
     }
 
     /** Sets secondary text color */

--- a/common/common-ui/src/main/res/layout/component_one_line_item.xml
+++ b/common/common-ui/src/main/res/layout/component_one_line_item.xml
@@ -226,7 +226,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/oneLineListItemCustomTextColor"
-        app:primaryText="Item with custom text color asdasda sd asda sdasda s"/>
+        app:primaryText="Item with long primary text that expands to more lines as primaryTextTruncated is disabled by default"/>
 
     <com.duckduckgo.common.ui.view.listitem.OneLineListItem
         android:id="@+id/oneLineListItemWithLongTextTruncated"
@@ -236,7 +236,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/oneLineListItemWithLongText"
-        app:primaryText="Item with custom text color asdasda sd asda sdasda s"
+        app:primaryText="@string/dax_one_line_list_item_html_primary_text"
         app:primaryTextTruncated="true"/>
 
 

--- a/common/common-ui/src/main/res/layout/component_one_line_item.xml
+++ b/common/common-ui/src/main/res/layout/component_one_line_item.xml
@@ -236,7 +236,6 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/oneLineListItemWithLongText"
-        app:primaryText="@string/dax_one_line_list_item_html_primary_text"
         app:primaryTextTruncated="true"/>
 
 

--- a/common/common-ui/src/main/res/layout/component_two_line_item.xml
+++ b/common/common-ui/src/main/res/layout/component_two_line_item.xml
@@ -320,4 +320,14 @@
         app:secondaryText="With custom Secondary Text color"
         app:secondaryTextColorOverlay="@color/destructive_text_color_selector" />
 
+    <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+        android:id="@+id/twoLineListItemWithHTMLTags"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/twoLineSwitchListItemWithSecondaryTextColorOverlay"
+        app:primaryText="@string/dax_list_item_html_primary_text"
+        app:secondaryText="@string/dax_list_item_html_secondary_text" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/common/common-ui/src/main/res/layout/component_two_line_item.xml
+++ b/common/common-ui/src/main/res/layout/component_two_line_item.xml
@@ -327,7 +327,6 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/twoLineSwitchListItemWithSecondaryTextColorOverlay"
-        app:primaryText="@string/dax_list_item_html_primary_text"
-        app:secondaryText="@string/dax_list_item_html_secondary_text" />
+         />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/common/common-ui/src/main/res/values/donottranslate.xml
+++ b/common/common-ui/src/main/res/values/donottranslate.xml
@@ -50,6 +50,9 @@
     <string name="text_dialog_negative" translatable="false">Negative</string>
     <string name="text_dialog_option" translatable="false">Option</string>
     <string name="text_dialog_checkbox" translatable="false">Remember my choice</string>
+    <string name="dax_one_line_list_item_html_primary_text"><![CDATA[Item with <b>HTML tags</b> and <b>truncated</b> text: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.]]></string>
+    <string name="dax_list_item_html_primary_text"><![CDATA[<b>Two Line</b> Item]]></string>
+    <string name="dax_list_item_html_secondary_text"><![CDATA[With HTML tags in <b>primary</b> and <b>secondary</b> text]]></string>
 
     <!-- Defaults Searchbar -->
     <string name="searchbar_cleartextaction_content_description_default" translatable="false">Collapse</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208662352677643/f

### Description
Support HTML tags in List Items

### Steps to test this PR
- [x] Install from branch
- [x] Go to Settings > Android Design System Preview
- [x] Tap on List Items tab
- [x] Check there is an example for Single Line Items and it looks as expected
- [x] Check there is an example for Two Line Items and it looks as expected

### No UI changes
