### PR TITLE
Fix: Remove extra gap from the NTP

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/BottomAppBarBehavior.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/BottomAppBarBehavior.kt
@@ -57,7 +57,7 @@ class BottomAppBarBehavior<V : View>(
 
         if (dependency.id == R.id.browserLayout) {
             browserLayout = dependency as RelativeLayout
-        } else if (dependency.id != R.id.includeNewBrowserTab) {
+        } else {
             offsetBottomByToolbar(dependency)
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/TopAppBarBehavior.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/TopAppBarBehavior.kt
@@ -54,8 +54,6 @@ class TopAppBarBehavior(
             if (omnibar.isOmnibarScrollingEnabled()) {
                 super.onNestedPreScroll(coordinatorLayout, child, target, dx, dy, consumed, type)
             }
-        } else {
-            offsetBottomByToolbar(target)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/TopAppBarBehavior.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/TopAppBarBehavior.kt
@@ -33,6 +33,14 @@ class TopAppBarBehavior(
     private val omnibar: OmnibarBehaviour,
     attrs: AttributeSet? = null,
 ) : AppBarLayout.Behavior(context, attrs) {
+    override fun layoutDependsOn(parent: CoordinatorLayout, child: AppBarLayout, dependency: View): Boolean {
+        if (dependency.id != R.id.browserLayout) {
+            offsetBottomByToolbar(dependency)
+        }
+
+        return super.layoutDependsOn(parent, child, dependency)
+    }
+
     override fun onNestedPreScroll(
         coordinatorLayout: CoordinatorLayout,
         child: AppBarLayout,

--- a/app/src/main/res/layout/include_new_browser_tab.xml
+++ b/app/src/main/res/layout/include_new_browser_tab.xml
@@ -43,7 +43,6 @@
             android:id="@+id/newTabContainerLayout"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_marginBottom="?attr/actionBarSize"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent" />


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207418217763355/1208607329826486/f

### Description

This PR removes the extra gap in the new NTP. Even though it’s currently disabled, it might be enabled in the future and it might cause issues.

### Steps to test this PR

Before testing, please enable the new NTP by setting `internalAlwaysEnabled = true` in `NewTabPage`.

- [x] Set the toolbar position to the top
- [x] Open a new tab
- [x] Notice there is not extra gap at the bottom
- [x] Go to some website and notice the toolbar is displayed properly with no extra gaps
- [x] Switch the toolbar position to the bottom
- [x] Open a new tab 
- [x] Notice there is not extra gap at the bottom
- [x] Go to some website and notice the toolbar is displayed properly with no extra gaps
