### PR TITLE
Improve search logic in feature inventory screen

### DIFF
--- a/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureToggles.kt
+++ b/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureToggles.kt
@@ -306,6 +306,17 @@ internal class ToggleImpl constructor(
     private val callback: FeatureTogglesCallback?,
 ) : Toggle {
 
+    override fun equals(other: Any?): Boolean {
+        if (other !is Toggle) {
+            return false
+        }
+        return this.featureName() == other.featureName()
+    }
+
+    override fun hashCode(): Int {
+        return this.featureName().hashCode()
+    }
+
     private fun Toggle.State.evaluateTargetMatching(isExperiment: Boolean): Boolean {
         val variant = appVariantProvider.invoke()
         // no targets then consider always treated


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1198194956794324/1208633884628758/f

### Description
Improve the (internal) feature flag inventory screen search logic:
Before:
* searches would filter feature flags that match the search text
After:
* searches filter feature flags that match the search text, but:
  * if match is a top-level features, all sub-features are also considered a match (even if their name doesn't match)
  * if match is a sub-feature, parent feature is also considered a match (even if its name doesn't match)

### Steps to test this PR

_Test_
- [x] install from this branch, open app -> settings -> feature flag inventory
- [x] search for a sub-feature by name
- [x] verify sub-feature and its parent top-level feature are displayed
- [x] search for a top-level feature by name (eg. autofill)
- [x] verify the top-level feature and ALL its sub-features are displayed
- [x] smoke test enable/disable features

