### PR TITLE
Show on App Launch: Disable text entry when Specific Url not selected

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchActivity.kt
@@ -108,7 +108,10 @@ class ShowOnAppLaunchActivity : DuckDuckGoActivity() {
                     is SpecificPage -> {
                         uncheckLastOpenedTabCheckListItem()
                         uncheckNewTabCheckListItem()
-                        binding.specificPageCheckListItem.setChecked(true)
+                        with(binding) {
+                            specificPageCheckListItem.setChecked(true)
+                            specificPageUrlInput.isEditable = true
+                        }
                     }
                 }
 
@@ -130,6 +133,5 @@ class ShowOnAppLaunchActivity : DuckDuckGoActivity() {
     private fun uncheckSpecificPageCheckListItem() {
         binding.specificPageCheckListItem.setChecked(false)
         binding.specificPageUrlInput.isEditable = false
-        binding.specificPageUrlInput.isEditable = true
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchActivity.kt
@@ -115,7 +115,7 @@ class ShowOnAppLaunchActivity : DuckDuckGoActivity() {
                     }
                 }
 
-                if (binding.specificPageUrlInput.text != viewState.specificPageUrl) {
+                if (binding.specificPageUrlInput.text.isBlank()) {
                     binding.specificPageUrlInput.text = viewState.specificPageUrl
                 }
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207908166761516/1208685892092430/f 

### Description

- Disables Specific Url EditText if it Specific Url is not selected using updated disabled state from DS
- Saves user input for Specific Url when switching options

### Steps to test this PR

- [x] Open Show on App Launch screen
- [x] If Specific Url is selected change option
- [x] Check the Specific Url EditText is now in the [disabled state](https://www.figma.com/design/BOHDESHODUXK7wSRNBOHdu/%F0%9F%A4%96-Android-Components?node-id=14783-11394&t=NMEXm3w5UWt3iiPQ-4)
- [x] Select Specific Url 
- [x] Change the url
- [x] Select a new option
- [x] Check that the url you entered has not changed
- [x] Select Specific Url 
- [x] Delete the url
- [x] Press the up button
- [x] Check that the default url appears -> "https://duckduckgo.com" on the general settings screen

### UI changes

https://github.com/user-attachments/assets/92158d39-9ddc-43b0-81f3-77017a8ce767