### PR TITLE
Enable SERP promo for PPro

### DIFF
--- a/subscriptions/subscriptions-impl/build.gradle
+++ b/subscriptions/subscriptions-impl/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation project(path: ':anvil-annotations')
 
     implementation project(path: ':di')
+    implementation project(path: ':cookies-api')
     implementation project(path: ':common-utils')
     implementation project(path: ':common-ui')
     implementation project(path: ':app-build-config-api')

--- a/subscriptions/subscriptions-impl/lint-baseline.xml
+++ b/subscriptions/subscriptions-impl/lint-baseline.xml
@@ -81,6 +81,94 @@
     <issue
         id="DenyListedApi"
         message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="        privacyProFeature.serpPromoCookie().setRawStoredState(Toggle.State(enable = true))"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/duckduckgo/subscriptions/impl/serp_promo/SerpPromoTest.kt"
+            line="30"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="        privacyProFeature.serpPromoCookie().setRawStoredState(Toggle.State(enable = false))"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/duckduckgo/subscriptions/impl/serp_promo/SerpPromoTest.kt"
+            line="39"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="        privacyProFeature.serpPromoCookie().setRawStoredState(Toggle.State(enable = true))"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/duckduckgo/subscriptions/impl/serp_promo/SerpPromoTest.kt"
+            line="48"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="        privacyProFeature.serpPromoCookie().setRawStoredState(Toggle.State(enable = false))"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/duckduckgo/subscriptions/impl/serp_promo/SerpPromoTest.kt"
+            line="57"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="        privacyProFeature.serpPromoCookie().setRawStoredState(Toggle.State(enable = true))"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/duckduckgo/subscriptions/impl/serp_promo/SerpPromoTest.kt"
+            line="66"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="        privacyProFeature.serpPromoCookie().setRawStoredState(Toggle.State(enable = false))"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/duckduckgo/subscriptions/impl/serp_promo/SerpPromoTest.kt"
+            line="75"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="        privacyProFeature.serpPromoCookie().setRawStoredState(Toggle.State(enable = true))"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/duckduckgo/subscriptions/impl/serp_promo/SerpPromoTest.kt"
+            line="84"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="        privacyProFeature.serpPromoCookie().setRawStoredState(Toggle.State(enable = false))"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/duckduckgo/subscriptions/impl/serp_promo/SerpPromoTest.kt"
+            line="93"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
         errorLine1="        privacyProFeature.allowPurchase().setRawStoredState(Toggle.State(enable = true))"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -136,6 +136,9 @@ interface PrivacyProFeature {
     // Kill switch
     @Toggle.DefaultValue(true)
     fun allowEmailFeedback(): Toggle
+
+    @Toggle.DefaultValue(true)
+    fun serpPromoCookie(): Toggle
 }
 
 @ContributesBinding(AppScope::class)

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/serp_promo/SerpPromo.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/serp_promo/SerpPromo.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.serp_promo
+
+import android.webkit.CookieManager
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.subscriptions.impl.PrivacyProFeature
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.anvil.annotations.ContributesMultibinding
+import com.squareup.anvil.annotations.ContributesTo
+import dagger.Lazy
+import dagger.Module
+import dagger.Provides
+import javax.inject.Inject
+import javax.inject.Qualifier
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import logcat.logcat
+
+interface SerpPromo {
+    suspend fun injectCookie(cookieValue: String?)
+}
+
+private const val HTTPS_WWW_SUBSCRIPTION_DDG_COM = ".subscriptions.duckduckgo.com"
+private const val SERP_PPRO_PROMO_COOKIE_NAME = "privacy_pro_access_token"
+
+@ContributesBinding(
+    scope = AppScope::class,
+    boundType = SerpPromo::class,
+)
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = MainProcessLifecycleObserver::class,
+)
+class RealSerpPromo @Inject constructor(
+    @InternalApi private val cookieManager: CookieManagerWrapper,
+    private val dispatcherProvider: DispatcherProvider,
+    private val privacyProFeature: Lazy<PrivacyProFeature>,
+) : SerpPromo, MainProcessLifecycleObserver {
+
+    override suspend fun injectCookie(cookieValue: String?) = withContext(dispatcherProvider.io()) {
+        if (privacyProFeature.get().serpPromoCookie().isEnabled()) {
+            synchronized(cookieManager) {
+                kotlin.runCatching {
+                    val cookieString = "$SERP_PPRO_PROMO_COOKIE_NAME=${cookieValue.orEmpty()};HttpOnly;Path=/;"
+                    cookieManager.setCookie(HTTPS_WWW_SUBSCRIPTION_DDG_COM, cookieString)
+                }
+            }
+            return@withContext
+        }
+    }
+
+    override fun onStart(owner: LifecycleOwner) {
+        owner.lifecycleScope.launch(dispatcherProvider.io()) {
+            if (privacyProFeature.get().serpPromoCookie().isEnabled()) {
+                kotlin.runCatching {
+                    val cookies = cookieManager.getCookie(HTTPS_WWW_SUBSCRIPTION_DDG_COM) ?: ""
+                    val pproCookies = cookies.split(";").filter { it.contains(SERP_PPRO_PROMO_COOKIE_NAME) }
+                    if (pproCookies.isEmpty()) {
+                        injectCookie("")
+                    }
+                }
+            }
+        }
+    }
+}
+
+// This class is basically a convenience wrapper for easier testing
+interface CookieManagerWrapper {
+    /**
+     * @return the cookie stored for the given [url] if any, null otherwise
+     */
+    fun getCookie(url: String): String?
+
+    fun setCookie(url: String, cookieString: String)
+}
+
+@Retention(AnnotationRetention.BINARY)
+@Qualifier
+private annotation class InternalApi
+
+@Module
+@ContributesTo(AppScope::class)
+object CookieManagerWrapperModule {
+    @Provides
+    @InternalApi
+    fun providesCookieManagerWrapper(): CookieManagerWrapper {
+        return CookieManagerWrapperImpl()
+    }
+}
+private class CookieManagerWrapperImpl constructor() : CookieManagerWrapper {
+
+    private val cookieManager: CookieManager by lazy { CookieManager.getInstance() }
+    override fun getCookie(url: String): String? {
+        return cookieManager.getCookie(url)
+    }
+
+    override fun setCookie(domain: String, cookie: String) {
+        logcat { "Setting cookie $cookie for domain $domain" }
+        cookieManager.setCookie(domain, cookie)
+        cookieManager.flush()
+    }
+}

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/store/SubscriptionsDataStore.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/store/SubscriptionsDataStore.kt
@@ -19,10 +19,7 @@ package com.duckduckgo.subscriptions.impl.store
 import android.content.SharedPreferences
 import androidx.core.content.edit
 import com.duckduckgo.data.store.api.SharedPreferencesProvider
-import com.duckduckgo.di.scopes.AppScope
-import com.squareup.anvil.annotations.ContributesBinding
-import dagger.SingleInstanceIn
-import javax.inject.Inject
+import com.duckduckgo.subscriptions.impl.repository.AuthRepository
 
 interface SubscriptionsDataStore {
 
@@ -43,9 +40,11 @@ interface SubscriptionsDataStore {
     fun canUseEncryption(): Boolean
 }
 
-@ContributesBinding(AppScope::class)
-@SingleInstanceIn(AppScope::class)
-class SubscriptionsEncryptedDataStore @Inject constructor(
+/**
+ * THINK TWICE before using this class directly.
+ * Usages of this class should all go through [AuthRepository]
+ */
+internal class SubscriptionsEncryptedDataStore constructor(
     private val sharedPreferencesProvider: SharedPreferencesProvider,
 ) : SubscriptionsDataStore {
     private val encryptedPreferences: SharedPreferences? by lazy { encryptedPreferences() }

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixelSender
 import com.duckduckgo.subscriptions.impl.repository.AuthRepository
 import com.duckduckgo.subscriptions.impl.repository.FakeSubscriptionsDataStore
 import com.duckduckgo.subscriptions.impl.repository.RealAuthRepository
+import com.duckduckgo.subscriptions.impl.serp_promo.FakeSerpPromo
 import com.duckduckgo.subscriptions.impl.services.AccessTokenResponse
 import com.duckduckgo.subscriptions.impl.services.AccountResponse
 import com.duckduckgo.subscriptions.impl.services.AuthService
@@ -66,7 +67,8 @@ class RealSubscriptionsManagerTest {
     private val authService: AuthService = mock()
     private val subscriptionsService: SubscriptionsService = mock()
     private val authDataStore: SubscriptionsDataStore = FakeSubscriptionsDataStore()
-    private val authRepository = RealAuthRepository(authDataStore, coroutineRule.testDispatcherProvider)
+    private val serpPromo = FakeSerpPromo()
+    private val authRepository = RealAuthRepository(authDataStore, coroutineRule.testDispatcherProvider, serpPromo)
     private val emailManager: EmailManager = mock()
     private val playBillingManager: PlayBillingManager = mock()
     private val context: Context = mock()
@@ -928,7 +930,7 @@ class RealSubscriptionsManagerTest {
     @Test
     fun whenCanSupportEncryptionIfCannotThenReturnFalse() = runTest {
         val authDataStore: SubscriptionsDataStore = FakeSubscriptionsDataStore(supportEncryption = false)
-        val authRepository = RealAuthRepository(authDataStore, coroutineRule.testDispatcherProvider)
+        val authRepository = RealAuthRepository(authDataStore, coroutineRule.testDispatcherProvider, serpPromo)
         subscriptionsManager = RealSubscriptionsManager(
             authService,
             subscriptionsService,

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/repository/RealAuthRepositoryTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/repository/RealAuthRepositoryTest.kt
@@ -8,6 +8,7 @@ import com.duckduckgo.subscriptions.api.SubscriptionStatus.INACTIVE
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.NOT_AUTO_RENEWABLE
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.UNKNOWN
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.WAITING
+import com.duckduckgo.subscriptions.impl.serp_promo.FakeSerpPromo
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
 import org.junit.Rule
@@ -18,7 +19,8 @@ class RealAuthRepositoryTest {
     val coroutineRule = CoroutineTestRule()
 
     private val authStore = FakeSubscriptionsDataStore()
-    private val authRepository: AuthRepository = RealAuthRepository(authStore, coroutineRule.testDispatcherProvider)
+    private val serpPromo = FakeSerpPromo()
+    private val authRepository: AuthRepository = RealAuthRepository(authStore, coroutineRule.testDispatcherProvider, serpPromo)
 
     @Test
     fun whenClearAccountThenClearData() = runTest {
@@ -35,6 +37,13 @@ class RealAuthRepositoryTest {
         assertNull(authStore.authToken)
         assertNull(authStore.externalId)
         assertNull(authStore.email)
+    }
+
+    @Test
+    fun whenSetAccessTokenThenInjectSerpPromoCookie() = runTest {
+        authRepository.setAccessToken("token")
+
+        assertEquals("token", serpPromo.cookie)
     }
 
     @Test
@@ -113,6 +122,7 @@ class RealAuthRepositoryTest {
         val repository: AuthRepository = RealAuthRepository(
             FakeSubscriptionsDataStore(supportEncryption = false),
             coroutineRule.testDispatcherProvider,
+            serpPromo,
         )
         assertFalse(repository.canSupportEncryption())
     }

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/serp_promo/FakeSerpPromo.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/serp_promo/FakeSerpPromo.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.serp_promo
+
+class FakeSerpPromo : SerpPromo {
+    var cookie: String? = null
+        private set
+
+    override suspend fun injectCookie(cookieValue: String?) {
+        this.cookie = cookieValue
+    }
+}

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/serp_promo/SerpPromoTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/serp_promo/SerpPromoTest.kt
@@ -1,0 +1,99 @@
+package com.duckduckgo.subscriptions.impl.serp_promo
+
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.testing.TestLifecycleOwner
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.subscriptions.impl.PrivacyProFeature
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class SerpPromoTest {
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val cookieManager: CookieManagerWrapper = mock()
+    private val lifecycleOwner: LifecycleOwner = TestLifecycleOwner()
+    private var privacyProFeature = FakeFeatureToggleFactory.create(PrivacyProFeature::class.java)
+
+    private val serpPromo = RealSerpPromo(cookieManager, coroutineRule.testDispatcherProvider, { privacyProFeature })
+
+    @Test
+    fun whenInjectCookieThenSetCookie() = runTest {
+        privacyProFeature.serpPromoCookie().setRawStoredState(Toggle.State(enable = true))
+
+        serpPromo.injectCookie("value")
+
+        verify(cookieManager).setCookie(".subscriptions.duckduckgo.com", "privacy_pro_access_token=value;HttpOnly;Path=/;")
+    }
+
+    @Test
+    fun whenKillSwitchedInjectCookieThenNoop() = runTest {
+        privacyProFeature.serpPromoCookie().setRawStoredState(Toggle.State(enable = false))
+
+        serpPromo.injectCookie("value")
+
+        verify(cookieManager, never()).setCookie(any(), any())
+    }
+
+    @Test
+    fun whenOnStartThenSetEmptyCookie() = runTest {
+        privacyProFeature.serpPromoCookie().setRawStoredState(Toggle.State(enable = true))
+
+        serpPromo.onStart(lifecycleOwner)
+
+        verify(cookieManager).setCookie(".subscriptions.duckduckgo.com", "privacy_pro_access_token=;HttpOnly;Path=/;")
+    }
+
+    @Test
+    fun whenKillSwitchedOnStartThenNoop() = runTest {
+        privacyProFeature.serpPromoCookie().setRawStoredState(Toggle.State(enable = false))
+
+        serpPromo.onStart(lifecycleOwner)
+
+        verify(cookieManager, never()).setCookie(any(), any())
+    }
+
+    @Test
+    fun whenOnStartAndPromoCookieSetThenNoop() = runTest {
+        privacyProFeature.serpPromoCookie().setRawStoredState(Toggle.State(enable = true))
+        whenever(cookieManager.getCookie(any())).thenReturn("privacy_pro_access_token=value;")
+
+        serpPromo.onStart(lifecycleOwner)
+        verify(cookieManager, never()).setCookie(any(), any())
+    }
+
+    @Test
+    fun whenKillSwitchedOnStartAndPromoCookieSetThenNoop() = runTest {
+        privacyProFeature.serpPromoCookie().setRawStoredState(Toggle.State(enable = false))
+        whenever(cookieManager.getCookie(any())).thenReturn("privacy_pro_access_token=value;")
+
+        serpPromo.onStart(lifecycleOwner)
+        verify(cookieManager, never()).setCookie(any(), any())
+    }
+
+    @Test
+    fun whenOnStartAndOtherCookiesSetThenSetEmptyCookie() = runTest {
+        privacyProFeature.serpPromoCookie().setRawStoredState(Toggle.State(enable = true))
+        whenever(cookieManager.getCookie(any())).thenReturn("another_cookie=value;")
+
+        serpPromo.onStart(lifecycleOwner)
+        verify(cookieManager).setCookie(".subscriptions.duckduckgo.com", "privacy_pro_access_token=;HttpOnly;Path=/;")
+    }
+
+    @Test
+    fun whenKillSwitchedOnStartAndOtherCookiesSetThenNoop() = runTest {
+        privacyProFeature.serpPromoCookie().setRawStoredState(Toggle.State(enable = false))
+        whenever(cookieManager.getCookie(any())).thenReturn("another_cookie=value;")
+
+        serpPromo.onStart(lifecycleOwner)
+        verify(cookieManager, never()).setCookie(any(), any())
+    }
+}

--- a/subscriptions/subscriptions-internal/src/main/java/com/duckduckgo/subscriptions/internal/settings/CopySubscriptionDataView.kt
+++ b/subscriptions/subscriptions-internal/src/main/java/com/duckduckgo/subscriptions/internal/settings/CopySubscriptionDataView.kt
@@ -29,7 +29,7 @@ import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.di.scopes.ViewScope
-import com.duckduckgo.subscriptions.impl.store.SubscriptionsDataStore
+import com.duckduckgo.subscriptions.impl.repository.AuthRepository
 import com.duckduckgo.subscriptions.internal.SubsSettingPlugin
 import com.duckduckgo.subscriptions.internal.databinding.SubsSimpleViewBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -54,7 +54,7 @@ class CopySubscriptionDataView @JvmOverloads constructor(
     lateinit var appCoroutineScope: CoroutineScope
 
     @Inject
-    lateinit var subscriptionsDataStore: SubscriptionsDataStore
+    lateinit var authRepository: AuthRepository
 
     private val binding: SubsSimpleViewBinding by viewBinding()
 
@@ -74,21 +74,21 @@ class CopySubscriptionDataView @JvmOverloads constructor(
         val clipboardManager = context.getSystemService(ClipboardManager::class.java)
 
         appCoroutineScope.launch(dispatcherProvider.io()) {
-            val auth = subscriptionsDataStore.authToken
+            val auth = authRepository.getAuthToken()
             val authToken = if (auth.isNullOrBlank()) {
                 "No auth token found"
             } else {
                 auth
             }
 
-            val access = subscriptionsDataStore.accessToken
+            val access = authRepository.getAccessToken()
             val accessToken = if (access.isNullOrBlank()) {
                 "No access token found"
             } else {
                 access
             }
 
-            val external = subscriptionsDataStore.externalId
+            val external = authRepository.getExternalID()
             val externalId = if (external.isNullOrBlank()) {
                 "No external id found"
             } else {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1198194956794324/1208264562025856/f

### Description
Enable SERP Promo for PPro

### Steps to test this PR

_Test_
- [x] clean install from this branch
- [x] filter logcat by `privacy_pro_access_token`
- [x] launch the app
- [x] veriry `Setting cookie privacy_pro_access_token=; for domain .subscriptions.duckduckgo.com` logcat shows
- [x] open tab and navigate to `https://subscriptions.duckduckgo.com` (this page doesn't exist)
- [x] open chrome dev tools (chrome://inspect/#devices) in your desktop and inspect the webview
- [x] verify the `privacy_pro_access_token` is set for `.subscriptions.duckduckgo.com` with empty value
- [x] open tab and open duckduckgo.com
- [x] open chrome dev tools (chrome://inspect/#devices) in your desktop and inspect the webview
- [x] verify the `privacy_pro_access_token` is NOT set
- [x] go to settings -> sbyscription dev settings and recover your existing account
- [x] open tab and navigate to `https://subscriptions.duckduckgo.com` (or refresh an already open one)
- [x] open chrome dev tools (chrome://inspect/#devices) in your desktop and inspect the webview
- [x] verify the `privacy_pro_access_token` is set for `.subscriptions.duckduckgo.com` with token value
- [x] open tab and open duckduckgo.com
- [x] verify the `privacy_pro_access_token` is NOT set
- [x] remove the PPro account from this device
- [x] open tab and navigate to `https://subscriptions.duckduckgo.com` (or refresh an already open one)
- [x] verify the `privacy_pro_access_token` is set for `.subscriptions.duckduckgo.com` with empty value

