### PR TITLE
Edit temporary pixel for not showing trackers network dialog

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -764,8 +764,37 @@ class CtaViewModelTest {
         whenever(mockDuckPlayer.isSimulatedYoutubeNoCookie(any())).thenReturn(false)
 
         val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true, site = site)
-        verify(mockPixel).fire(eq(ONBOARDING_SKIP_MAJOR_NETWORK_UNIQUE), any(), any(), eq(Unique()))
         assertNull(value)
+    }
+
+    @Test
+    fun givenDuckPlayerSiteWhenRefreshCtaWhileBrowsingThenFireSkipMajorNetworkPixel() = runTest {
+        givenDaxOnboardingActive()
+        val site = site(url = "duck://player/12345", entity = TestEntity("Google", "Google", 9.0))
+
+        whenever(mockDuckPlayer.isDuckPlayerUri(any())).thenReturn(true)
+        whenever(mockDuckPlayer.getDuckPlayerState()).thenReturn(ENABLED)
+        whenever(mockDuckPlayer.getUserPreferences()).thenReturn(UserPreferences(false, AlwaysAsk))
+        whenever(mockDuckPlayer.isYouTubeUrl(any())).thenReturn(false)
+        whenever(mockDuckPlayer.isSimulatedYoutubeNoCookie(anyString())).thenReturn(false)
+
+        testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true, site = site)
+        verify(mockPixel).fire(eq(ONBOARDING_SKIP_MAJOR_NETWORK_UNIQUE), any(), any(), eq(Unique()))
+    }
+
+    @Test
+    fun givenDuckPlayerSiteWhenRefreshCtaWhileBrowsingAndTrackersDialogAlreadyShownThenDontSentSkipMajorNetworkPixel() = runTest {
+        givenDaxOnboardingActive()
+        val site = site(url = "duck://player/12345", entity = TestEntity("Google", "Google", 9.0))
+
+        whenever(mockDuckPlayer.isDuckPlayerUri(any())).thenReturn(true)
+        whenever(mockDuckPlayer.getDuckPlayerState()).thenReturn(ENABLED)
+        whenever(mockDuckPlayer.getUserPreferences()).thenReturn(UserPreferences(false, AlwaysAsk))
+        whenever(mockDuckPlayer.isYouTubeUrl(any())).thenReturn(false)
+        whenever(mockDuckPlayer.isSimulatedYoutubeNoCookie(anyString())).thenReturn(false)
+
+        testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true, site = site)
+        verify(mockPixel).fire(eq(ONBOARDING_SKIP_MAJOR_NETWORK_UNIQUE), any(), any(), eq(Unique()))
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -776,7 +776,7 @@ class CtaViewModelTest {
         whenever(mockDuckPlayer.getDuckPlayerState()).thenReturn(ENABLED)
         whenever(mockDuckPlayer.getUserPreferences()).thenReturn(UserPreferences(false, AlwaysAsk))
         whenever(mockDuckPlayer.isYouTubeUrl(any())).thenReturn(false)
-        whenever(mockDuckPlayer.isSimulatedYoutubeNoCookie(anyString())).thenReturn(false)
+        whenever(mockDuckPlayer.isSimulatedYoutubeNoCookie(any())).thenReturn(false)
 
         testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true, site = site)
         verify(mockPixel).fire(eq(ONBOARDING_SKIP_MAJOR_NETWORK_UNIQUE), any(), any(), eq(Unique()))
@@ -791,7 +791,7 @@ class CtaViewModelTest {
         whenever(mockDuckPlayer.getDuckPlayerState()).thenReturn(ENABLED)
         whenever(mockDuckPlayer.getUserPreferences()).thenReturn(UserPreferences(false, AlwaysAsk))
         whenever(mockDuckPlayer.isYouTubeUrl(any())).thenReturn(false)
-        whenever(mockDuckPlayer.isSimulatedYoutubeNoCookie(anyString())).thenReturn(false)
+        whenever(mockDuckPlayer.isSimulatedYoutubeNoCookie(any())).thenReturn(false)
 
         testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true, site = site)
         verify(mockPixel).fire(eq(ONBOARDING_SKIP_MAJOR_NETWORK_UNIQUE), any(), any(), eq(Unique()))

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -390,10 +390,6 @@ class CtaViewModel @Inject constructor(
                         duckPlayer.isDuckPlayerUri(url) || duckPlayer.isSimulatedYoutubeNoCookie(uri)
                     )
 
-        if (isDuckPlayerUrl) {
-            pixel.fire(pixel = ONBOARDING_SKIP_MAJOR_NETWORK_UNIQUE, type = Unique())
-        }
-
         return isDuckPlayerUrl
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208660560293084/f

### Description
Fire skip network pixel only if onboarding is still active

### Steps to test this PR
_Send pixel_
- [x] Fresh install
- [x] Go to any youtube URL
- [x] Check pixel `m_onboarding_skip_major_network_unique` is **sent**

_Ignore pixel_
- [x] Refresh youtube site or go to a different youtube URL
- [x] Check pixel `m_onboarding_skip_major_network_unique` is **ignored**

_Pixel **not** fired_
- [x] Go to any website with trackers (_e.g. bbc.co.uk_)
- [x] Tap 'Got it!' button
- [x] Go to any youtube URL
- [x] Check pixel `m_onboarding_skip_major_network_unique` is ** not sent or ignored**

### No UI changes
