### PR TITLE
Show on App Launch: Set feature toggle to off by default

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchFeature.kt
@@ -26,6 +26,6 @@ import com.duckduckgo.feature.toggles.api.Toggle
 )
 interface ShowOnAppLaunchFeature {
 
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(false)
     fun self(): Toggle
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
@@ -269,21 +269,21 @@ class BrowserViewModelTest {
     }
 
     @Test
-    fun whenHandleShowOnAppLaunchCalledThenShowOnAppLaunchHandled() = runTest {
-        testee.handleShowOnAppLaunchOption()
-
-        verify(showOnAppLaunchOptionHandler).handleAppLaunchOption()
-    }
-
-    @Test
-    fun whenShowOnAppLaunchFeatureToggleIsOffAndNewTabPageIsSetThenNoTabIsAdded() = runTest {
-        fakeShowOnAppLaunchFeatureToggle.self().setRawStoredState(State(enable = false))
-
+    fun whenHandleShowOnAppLaunchCalledThenNoTabIsAddedByDefault() = runTest {
         testee.handleShowOnAppLaunchOption()
 
         verify(mockTabRepository, never()).add()
         verify(mockTabRepository, never()).addFromSourceTab(url = any(), skipHome = any(), sourceTabId = any())
         verify(mockTabRepository, never()).addDefaultTab()
+    }
+
+    @Test
+    fun whenShowOnAppLaunchFeatureToggleIsOnThenShowOnAppLaunchHandled() = runTest {
+        fakeShowOnAppLaunchFeatureToggle.self().setRawStoredState(State(enable = true))
+
+        testee.handleShowOnAppLaunchOption()
+
+        verify(showOnAppLaunchOptionHandler).handleAppLaunchOption()
     }
 
     private fun initTestee() {

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/GeneralSettingsViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/GeneralSettingsViewModelTest.kt
@@ -270,26 +270,26 @@ internal class GeneralSettingsViewModelTest {
     }
 
     @Test
-    fun whenLaunchedThenShowOnAppLaunchIsVisibleByDefault() = runTest {
+    fun whenLaunchedThenShowOnAppLaunchIsNotVisibleByDefault() = runTest {
+        initTestee()
+
+        testee.viewState.test {
+            val state = awaitItem()
+
+            assertTrue(!state!!.isShowOnAppLaunchOptionVisible)
+        }
+    }
+
+    @Test
+    fun whenShowOnAppLaunchFeatureIsDisabledThenIsShowOnAppLaunchOptionIsVisible() = runTest {
+        fakeShowOnAppLaunchFeatureToggle.self().setRawStoredState(Toggle.State(enable = true))
+
         initTestee()
 
         testee.viewState.test {
             val state = awaitItem()
 
             assertTrue(state!!.isShowOnAppLaunchOptionVisible)
-        }
-    }
-
-    @Test
-    fun whenShowOnAppLaunchFeatureIsDisabledThenIsShowOnAppLaunchOptionIsHidden() = runTest {
-        fakeShowOnAppLaunchFeatureToggle.self().setRawStoredState(Toggle.State(enable = false))
-
-        initTestee()
-
-        testee.viewState.test {
-            val state = awaitItem()
-
-            assertFalse(state!!.isShowOnAppLaunchOptionVisible)
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208705964260532/f 

### Description

Defaults the feature toggle to off. I will raise a PR to add this to the remote config.

### Steps to test this PR

- [ ] Go to General section of Settings screen
- [ ] Check "Show on App Launch" is not visible
- [ ] Open Feature Flag Inventory screen
- [ ] Enable `showOnAppLaunch`
- [ ] Go to General section of Settings screen
- [ ] Check "Show on App Launch" is visible

### UI changes

N/A