### PR TITLE
Include 10.x.x.x local net traffic through VPN

### DIFF
--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/config/WgVpnRoutes.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/config/WgVpnRoutes.kt
@@ -90,7 +90,7 @@ internal class WgVpnRoutes {
         val wgVpnRoutesIncludingLocal: Map<String, Int> = mapOf(
             "0.0.0.0" to 5,
             "8.0.0.0" to 7,
-            // Excluded range: 10.0.0.0 -> 10.255.255.255
+            "10.0.0.0" to 8,
             "11.0.0.0" to 8,
             "12.0.0.0" to 6,
             "16.0.0.0" to 4,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1198194956794324/1208714463179856/f

### Description
10.x.x.x range (traffic) should go through the VPN when local networks are included.

### Steps to test this PR
_Test_
- [x] install from this branch, launch and sign into PPro
- [x] in settigns -> VPN -> VPN settings disable `Exclude local Networks` setting
- [x] enable VPN
- [x] verify 10.x.x.x route is included (you can do that by filtering logcat by `Adding route`)
- [x] smoke test apps and browser, all should work normally
- [x] in settigns -> VPN -> VPN settings enable `Exclude local Networks` setting and navigate out of VPN settings for the VPN to re-configre
- [x] verify 10.x.x.x route is excluded (you can do that by filtering logcat by `Adding route`)
- [x] smoke test apps and browser, all should work normally