### PR TITLE
Remove origin param from Duck Player

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.app.browser
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
@@ -205,6 +206,7 @@ import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.Unavailab
 import com.duckduckgo.duckplayer.api.DuckPlayer.UserPreferences
 import com.duckduckgo.duckplayer.api.PrivatePlayerMode.AlwaysAsk
 import com.duckduckgo.duckplayer.api.PrivatePlayerMode.Disabled
+import com.duckduckgo.duckplayer.api.PrivatePlayerMode.Enabled
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.feature.toggles.api.Toggle
@@ -297,6 +299,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
+@SuppressLint("DenyListedApi")
 @FlowPreview
 class BrowserTabViewModelTest {
 
@@ -5131,6 +5134,38 @@ class BrowserTabViewModelTest {
             { "someUrl" },
         )
         assertCommandIssued<Navigate>()
+    }
+
+    @Test
+    fun whenProcessJsCallbackMessageOpenDuckPlayerWithUrlAndOpenInNewTabThenSetOrigin() = runTest {
+        whenever(mockEnabledToggle.isEnabled()).thenReturn(true)
+        whenever(mockDuckPlayer.getUserPreferences()).thenReturn(UserPreferences(overlayInteracted = true, privatePlayerMode = AlwaysAsk))
+        whenever(mockDuckPlayer.shouldOpenDuckPlayerInNewTab()).thenReturn(Off)
+        testee.processJsCallbackMessage(
+            DUCK_PLAYER_FEATURE_NAME,
+            "openDuckPlayer",
+            "id",
+            JSONObject("""{ href: "duck://player/1234" }"""),
+            false,
+            { "someUrl" },
+        )
+        verify(mockDuckPlayer).willNavigateToDuckPlayerFromOverlay()
+    }
+
+    @Test
+    fun whenProcessJsCallbackMessageOpenDuckPlayerWithDuckPlayerAlwaysEnabledUrlAndOpenInNewTabThenSetOrigin() = runTest {
+        whenever(mockEnabledToggle.isEnabled()).thenReturn(true)
+        whenever(mockDuckPlayer.getUserPreferences()).thenReturn(UserPreferences(overlayInteracted = true, privatePlayerMode = Enabled))
+        whenever(mockDuckPlayer.shouldOpenDuckPlayerInNewTab()).thenReturn(Off)
+        testee.processJsCallbackMessage(
+            DUCK_PLAYER_FEATURE_NAME,
+            "openDuckPlayer",
+            "id",
+            JSONObject("""{ href: "duck://player/1234" }"""),
+            false,
+            { "someUrl" },
+        )
+        verify(mockDuckPlayer).willNavigateToDuckPlayerAutomatically()
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -198,6 +198,8 @@ import com.duckduckgo.downloads.api.DownloadStateListener
 import com.duckduckgo.downloads.api.FileDownloader
 import com.duckduckgo.downloads.api.FileDownloader.PendingFileDownload
 import com.duckduckgo.duckplayer.api.DuckPlayer
+import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerOrigin.AUTO
+import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerOrigin.OVERLAY
 import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.DISABLED
 import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.ENABLED
 import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.Off
@@ -5149,7 +5151,7 @@ class BrowserTabViewModelTest {
             false,
             { "someUrl" },
         )
-        verify(mockDuckPlayer).willNavigateToDuckPlayerFromOverlay()
+        verify(mockDuckPlayer).setDuckPlayerOrigin(OVERLAY)
     }
 
     @Test
@@ -5165,7 +5167,7 @@ class BrowserTabViewModelTest {
             false,
             { "someUrl" },
         )
-        verify(mockDuckPlayer).willNavigateToDuckPlayerAutomatically()
+        verify(mockDuckPlayer).setDuckPlayerOrigin(AUTO)
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -71,7 +71,7 @@ import com.duckduckgo.common.utils.device.DeviceInfo
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.duckplayer.api.DuckPlayer
-import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerOrigin.SERP
+import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerOrigin.SERP_AUTO
 import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab
 import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.Off
 import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.On
@@ -408,7 +408,7 @@ class BrowserWebViewClientTest {
 
     @UiThreadTest
     @Test
-    fun whenShouldOverrideWithShouldNavigateToDuckPlayerSetOriginToSerp() = runTest {
+    fun whenShouldOverrideWithShouldNavigateToDuckPlayerSetOriginToSerpAuto() = runTest {
         val urlType = SpecialUrlDetector.UrlType.ShouldLaunchDuckPlayerLink("duck://player/1234".toUri())
         whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
         whenever(webResourceRequest.isForMainFrame).thenReturn(true)
@@ -424,7 +424,7 @@ class BrowserWebViewClientTest {
         openInNewTabFlow.emit(Off)
 
         assertFalse(testee.shouldOverrideUrlLoading(mockWebView, webResourceRequest))
-        verify(mockDuckPlayer).setDuckPlayerOrigin(SERP)
+        verify(mockDuckPlayer).setDuckPlayerOrigin(SERP_AUTO)
     }
 
     @Test
@@ -533,7 +533,7 @@ class BrowserWebViewClientTest {
 
     @UiThreadTest
     @Test
-    fun whenShouldOverrideWithShouldNavigateToDuckPlayerFromSerpAndOpenInNewTabThenSetOriginToSerp() = runTest {
+    fun whenShouldOverrideWithShouldNavigateToDuckPlayerFromSerpAndOpenInNewTabThenSetOriginToSerpAuto() = runTest {
         val urlType = SpecialUrlDetector.UrlType.ShouldLaunchDuckPlayerLink("duck://player/1234".toUri())
         whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
         whenever(webResourceRequest.isForMainFrame).thenReturn(true)
@@ -550,7 +550,7 @@ class BrowserWebViewClientTest {
         openInNewTabFlow.emit(Off)
 
         assertFalse(testee.shouldOverrideUrlLoading(mockWebView, webResourceRequest))
-        verify(mockDuckPlayer).setDuckPlayerOrigin(SERP)
+        verify(mockDuckPlayer).setDuckPlayerOrigin(SERP_AUTO)
     }
 
     @UiThreadTest

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -71,6 +71,7 @@ import com.duckduckgo.common.utils.device.DeviceInfo
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.duckplayer.api.DuckPlayer
+import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerOrigin.SERP
 import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab
 import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.Off
 import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.On
@@ -423,7 +424,7 @@ class BrowserWebViewClientTest {
         openInNewTabFlow.emit(Off)
 
         assertFalse(testee.shouldOverrideUrlLoading(mockWebView, webResourceRequest))
-        verify(mockDuckPlayer).willNavigateToDuckPlayerFromSerp()
+        verify(mockDuckPlayer).setDuckPlayerOrigin(SERP)
     }
 
     @Test
@@ -549,7 +550,7 @@ class BrowserWebViewClientTest {
         openInNewTabFlow.emit(Off)
 
         assertFalse(testee.shouldOverrideUrlLoading(mockWebView, webResourceRequest))
-        verify(mockDuckPlayer).willNavigateToDuckPlayerFromSerp()
+        verify(mockDuckPlayer).setDuckPlayerOrigin(SERP)
     }
 
     @UiThreadTest

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -422,8 +422,7 @@ class BrowserWebViewClientTest {
         whenever(mockWebView.url).thenReturn("www.duckduckgo.com")
         openInNewTabFlow.emit(Off)
 
-        assertTrue(testee.shouldOverrideUrlLoading(mockWebView, webResourceRequest))
-        verify(mockWebView).loadUrl("www.youtube.com/watch?v=1234")
+        assertFalse(testee.shouldOverrideUrlLoading(mockWebView, webResourceRequest))
         verify(mockDuckPlayer).willNavigateToDuckPlayerFromSerp()
     }
 
@@ -549,8 +548,7 @@ class BrowserWebViewClientTest {
         whenever(mockWebView.url).thenReturn("www.duckduckgo.com")
         openInNewTabFlow.emit(Off)
 
-        assertTrue(testee.shouldOverrideUrlLoading(mockWebView, webResourceRequest))
-        verify(mockWebView).loadUrl("www.youtube.com/watch?v=1234")
+        assertFalse(testee.shouldOverrideUrlLoading(mockWebView, webResourceRequest))
         verify(mockDuckPlayer).willNavigateToDuckPlayerFromSerp()
     }
 

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -407,7 +407,7 @@ class BrowserWebViewClientTest {
 
     @UiThreadTest
     @Test
-    fun whenShouldOverrideWithShouldNavigateToDuckPlayerFromSerpThenAddQueryParam() = runTest {
+    fun whenShouldOverrideWithShouldNavigateToDuckPlayerSetOriginToSerp() = runTest {
         val urlType = SpecialUrlDetector.UrlType.ShouldLaunchDuckPlayerLink("duck://player/1234".toUri())
         whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
         whenever(webResourceRequest.isForMainFrame).thenReturn(true)
@@ -423,7 +423,8 @@ class BrowserWebViewClientTest {
         openInNewTabFlow.emit(Off)
 
         assertTrue(testee.shouldOverrideUrlLoading(mockWebView, webResourceRequest))
-        verify(mockWebView).loadUrl("www.youtube.com/watch?v=1234&origin=serp_auto")
+        verify(mockWebView).loadUrl("www.youtube.com/watch?v=1234")
+        verify(mockDuckPlayer).willNavigateToDuckPlayerFromSerp()
     }
 
     @Test
@@ -532,7 +533,7 @@ class BrowserWebViewClientTest {
 
     @UiThreadTest
     @Test
-    fun whenShouldOverrideWithShouldNavigateToDuckPlayerFromSerpAndOpenInNewTabThenAddQueryParam() = runTest {
+    fun whenShouldOverrideWithShouldNavigateToDuckPlayerFromSerpAndOpenInNewTabThenSetOriginToSerp() = runTest {
         val urlType = SpecialUrlDetector.UrlType.ShouldLaunchDuckPlayerLink("duck://player/1234".toUri())
         whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
         whenever(webResourceRequest.isForMainFrame).thenReturn(true)
@@ -549,7 +550,8 @@ class BrowserWebViewClientTest {
         openInNewTabFlow.emit(Off)
 
         assertTrue(testee.shouldOverrideUrlLoading(mockWebView, webResourceRequest))
-        verify(mockWebView).loadUrl("www.youtube.com/watch?v=1234&origin=serp_auto")
+        verify(mockWebView).loadUrl("www.youtube.com/watch?v=1234")
+        verify(mockDuckPlayer).willNavigateToDuckPlayerFromSerp()
     }
 
     @UiThreadTest

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -336,10 +336,10 @@ class BrowserWebViewClient @Inject constructor(
                         duckPlayer.willNavigateToDuckPlayerFromSerp()
                         if (openInNewTab) {
                             listener.openLinkInNewTab(url)
+                            return true
                         } else {
-                            loadUrl(listener, webView, url.toString())
+                            return false
                         }
-                        return true
                     } else if (openInNewTab) {
                         webViewClientListener?.openLinkInNewTab(url)
                         return true

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -70,6 +70,7 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.duckplayer.api.DuckPlayer
+import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerOrigin.SERP
 import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.ENABLED
 import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.On
 import com.duckduckgo.duckplayer.impl.DUCK_PLAYER_OPEN_IN_YOUTUBE_PATH
@@ -333,7 +334,7 @@ class BrowserWebViewClient @Inject constructor(
                         }
                         return true
                     } else if (willOpenDuckPlayer && webView.url?.let { duckDuckGoUrlDetector.isDuckDuckGoUrl(it) } == true) {
-                        duckPlayer.willNavigateToDuckPlayerFromSerp()
+                        duckPlayer.setDuckPlayerOrigin(SERP)
                         if (openInNewTab) {
                             listener.openLinkInNewTab(url)
                             return true

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -70,7 +70,7 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.duckplayer.api.DuckPlayer
-import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerOrigin.SERP
+import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerOrigin.SERP_AUTO
 import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.ENABLED
 import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.On
 import com.duckduckgo.duckplayer.impl.DUCK_PLAYER_OPEN_IN_YOUTUBE_PATH
@@ -334,7 +334,7 @@ class BrowserWebViewClient @Inject constructor(
                         }
                         return true
                     } else if (willOpenDuckPlayer && webView.url?.let { duckDuckGoUrlDetector.isDuckDuckGoUrl(it) } == true) {
-                        duckPlayer.setDuckPlayerOrigin(SERP)
+                        duckPlayer.setDuckPlayerOrigin(SERP_AUTO)
                         if (openInNewTab) {
                             listener.openLinkInNewTab(url)
                             return true

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -72,8 +72,6 @@ import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.duckplayer.api.DuckPlayer
 import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.ENABLED
 import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.On
-import com.duckduckgo.duckplayer.api.ORIGIN_QUERY_PARAM
-import com.duckduckgo.duckplayer.api.ORIGIN_QUERY_PARAM_SERP_AUTO
 import com.duckduckgo.duckplayer.impl.DUCK_PLAYER_OPEN_IN_YOUTUBE_PATH
 import com.duckduckgo.history.api.NavigationHistory
 import com.duckduckgo.privacy.config.api.AmpLinks
@@ -335,11 +333,11 @@ class BrowserWebViewClient @Inject constructor(
                         }
                         return true
                     } else if (willOpenDuckPlayer && webView.url?.let { duckDuckGoUrlDetector.isDuckDuckGoUrl(it) } == true) {
-                        val newUrl = url.buildUpon().appendQueryParameter(ORIGIN_QUERY_PARAM, ORIGIN_QUERY_PARAM_SERP_AUTO).build()
+                        duckPlayer.willNavigateToDuckPlayerFromSerp()
                         if (openInNewTab) {
-                            listener.openLinkInNewTab(newUrl)
+                            listener.openLinkInNewTab(url)
                         } else {
-                            loadUrl(listener, webView, newUrl.toString())
+                            loadUrl(listener, webView, url.toString())
                         }
                         return true
                     } else if (openInNewTab) {

--- a/app/src/main/java/com/duckduckgo/app/browser/duckplayer/DuckPlayerJSHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/duckplayer/DuckPlayerJSHelper.kt
@@ -16,7 +16,6 @@
 
 package com.duckduckgo.app.browser.duckplayer
 
-import androidx.core.net.toUri
 import com.duckduckgo.app.browser.DuckDuckGoUrlDetector
 import com.duckduckgo.app.browser.commands.Command
 import com.duckduckgo.app.browser.commands.Command.OpenDuckPlayerOverlayInfo
@@ -39,9 +38,6 @@ import com.duckduckgo.duckplayer.api.DuckPlayer
 import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.ENABLED
 import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.On
 import com.duckduckgo.duckplayer.api.DuckPlayer.UserPreferences
-import com.duckduckgo.duckplayer.api.ORIGIN_QUERY_PARAM
-import com.duckduckgo.duckplayer.api.ORIGIN_QUERY_PARAM_AUTO
-import com.duckduckgo.duckplayer.api.ORIGIN_QUERY_PARAM_OVERLAY
 import com.duckduckgo.duckplayer.api.PrivatePlayerMode
 import com.duckduckgo.duckplayer.api.PrivatePlayerMode.Enabled
 import com.duckduckgo.js.messaging.api.JsCallbackData
@@ -212,15 +208,15 @@ class DuckPlayerJSHelper @Inject constructor(
             "openDuckPlayer" -> {
                 val openInNewTab = duckPlayer.shouldOpenDuckPlayerInNewTab() is On
                 return data?.getString("href")?.let {
-                    val newUrl = if (duckPlayer.getUserPreferences().privatePlayerMode == Enabled) {
-                        it.toUri().buildUpon().appendQueryParameter(ORIGIN_QUERY_PARAM, ORIGIN_QUERY_PARAM_AUTO).build()
+                    if (duckPlayer.getUserPreferences().privatePlayerMode == Enabled) {
+                        duckPlayer.willNavigateToDuckPlayerAutomatically()
                     } else {
-                        it.toUri().buildUpon().appendQueryParameter(ORIGIN_QUERY_PARAM, ORIGIN_QUERY_PARAM_OVERLAY).build()
+                        duckPlayer.willNavigateToDuckPlayerFromOverlay()
                     }.toString()
                     if (openInNewTab && !isActiveCustomTab) {
-                        OpenInNewTab(newUrl, tabId)
+                        OpenInNewTab(it, tabId)
                     } else {
-                        Navigate(newUrl, mapOf())
+                        Navigate(it, mapOf())
                     }
                 }
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/duckplayer/DuckPlayerJSHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/duckplayer/DuckPlayerJSHelper.kt
@@ -35,6 +35,8 @@ import com.duckduckgo.app.pixels.AppPixelName.DUCK_PLAYER_SETTING_NEVER_SERP
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.duckplayer.api.DuckPlayer
+import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerOrigin.AUTO
+import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerOrigin.OVERLAY
 import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.ENABLED
 import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.On
 import com.duckduckgo.duckplayer.api.DuckPlayer.UserPreferences
@@ -209,10 +211,10 @@ class DuckPlayerJSHelper @Inject constructor(
                 val openInNewTab = duckPlayer.shouldOpenDuckPlayerInNewTab() is On
                 return data?.getString("href")?.let {
                     if (duckPlayer.getUserPreferences().privatePlayerMode == Enabled) {
-                        duckPlayer.willNavigateToDuckPlayerAutomatically()
+                        duckPlayer.setDuckPlayerOrigin(AUTO)
                     } else {
-                        duckPlayer.willNavigateToDuckPlayerFromOverlay()
-                    }.toString()
+                        duckPlayer.setDuckPlayerOrigin(OVERLAY)
+                    }
                     if (openInNewTab && !isActiveCustomTab) {
                         OpenInNewTab(it, tabId)
                     } else {

--- a/duckplayer/duckplayer-api/src/main/java/com/duckduckgo/duckplayer/api/DuckPlayer.kt
+++ b/duckplayer/duckplayer-api/src/main/java/com/duckduckgo/duckplayer/api/DuckPlayer.kt
@@ -31,9 +31,6 @@ const val YOUTUBE_HOST = "youtube.com"
 const val YOUTUBE_MOBILE_HOST = "m.youtube.com"
 const val ORIGIN_QUERY_PARAM = "origin"
 const val ORIGIN_QUERY_PARAM_SERP = "serp"
-const val ORIGIN_QUERY_PARAM_SERP_AUTO = "serp_auto"
-const val ORIGIN_QUERY_PARAM_OVERLAY = "overlay"
-const val ORIGIN_QUERY_PARAM_AUTO = "auto"
 
 /**
  * DuckPlayer interface provides a set of methods for interacting with the DuckPlayer.
@@ -179,6 +176,9 @@ interface DuckPlayer {
     fun shouldOpenDuckPlayerInNewTab(): OpenDuckPlayerInNewTab
 
     fun observeShouldOpenInNewTab(): Flow<OpenDuckPlayerInNewTab>
+    fun willNavigateToDuckPlayerFromSerp()
+    fun willNavigateToDuckPlayerAutomatically()
+    fun willNavigateToDuckPlayerFromOverlay()
 
     /**
      * Data class representing user preferences for Duck Player.

--- a/duckplayer/duckplayer-api/src/main/java/com/duckduckgo/duckplayer/api/DuckPlayer.kt
+++ b/duckplayer/duckplayer-api/src/main/java/com/duckduckgo/duckplayer/api/DuckPlayer.kt
@@ -22,6 +22,10 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import androidx.fragment.app.FragmentManager
+import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerOrigin.AUTO
+import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerOrigin.OVERLAY
+import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerOrigin.SERP
+import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerOrigin.SERP_AUTO
 import com.duckduckgo.duckplayer.api.PrivatePlayerMode.AlwaysAsk
 import com.duckduckgo.duckplayer.api.PrivatePlayerMode.Disabled
 import com.duckduckgo.duckplayer.api.PrivatePlayerMode.Enabled
@@ -173,12 +177,26 @@ interface DuckPlayer {
         destinationUrl: Uri,
     ): Boolean
 
+    /**
+     * Checks whether a duck Player will be opened in a new tab based on RC flag and user settings
+     *
+     * @return True if should open Duck Player in a new tab, false otherwise.
+     */
     fun shouldOpenDuckPlayerInNewTab(): OpenDuckPlayerInNewTab
 
+    /**
+     * Observes whether a duck Player will be opened in a new tab based on RC flag and user settings
+     *
+     * @return Flow. True if should open Duck Player in a new tab, false otherwise.
+     */
     fun observeShouldOpenInNewTab(): Flow<OpenDuckPlayerInNewTab>
-    fun willNavigateToDuckPlayerFromSerp()
-    fun willNavigateToDuckPlayerAutomatically()
-    fun willNavigateToDuckPlayerFromOverlay()
+
+    /**
+     * Sets the DuckPlayer origin.
+     *
+     * @param origin The DuckPlayer origin. [SERP], [SERP_AUTO], [AUTO], or [OVERLAY]
+     */
+    fun setDuckPlayerOrigin(origin: DuckPlayerOrigin)
 
     /**
      * Data class representing user preferences for Duck Player.
@@ -201,5 +219,12 @@ interface DuckPlayer {
         data object On : OpenDuckPlayerInNewTab
         data object Off : OpenDuckPlayerInNewTab
         data object Unavailable : OpenDuckPlayerInNewTab
+    }
+
+    enum class DuckPlayerOrigin {
+        SERP,
+        SERP_AUTO,
+        AUTO,
+        OVERLAY,
     }
 }

--- a/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/RealDuckPlayer.kt
+++ b/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/RealDuckPlayer.kt
@@ -33,15 +33,16 @@ import com.duckduckgo.common.utils.UrlScheme.Companion.duck
 import com.duckduckgo.common.utils.UrlScheme.Companion.https
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckplayer.api.DuckPlayer
-import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState
+import com.duckduckgo.duckplayer.api.DuckPlayer.*
+import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerOrigin.AUTO
+import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerOrigin.OVERLAY
+import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerOrigin.SERP_AUTO
 import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.DISABLED
 import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.DISABLED_WIH_HELP_LINK
 import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.ENABLED
-import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab
 import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.Off
 import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.On
 import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.Unavailable
-import com.duckduckgo.duckplayer.api.DuckPlayer.UserPreferences
 import com.duckduckgo.duckplayer.api.ORIGIN_QUERY_PARAM
 import com.duckduckgo.duckplayer.api.ORIGIN_QUERY_PARAM_SERP
 import com.duckduckgo.duckplayer.api.PrivatePlayerMode.AlwaysAsk
@@ -59,9 +60,6 @@ import com.duckduckgo.duckplayer.impl.DuckPlayerPixelName.DUCK_PLAYER_VIEW_FROM_
 import com.duckduckgo.duckplayer.impl.DuckPlayerPixelName.DUCK_PLAYER_VIEW_FROM_YOUTUBE_AUTOMATIC
 import com.duckduckgo.duckplayer.impl.DuckPlayerPixelName.DUCK_PLAYER_VIEW_FROM_YOUTUBE_MAIN_OVERLAY
 import com.duckduckgo.duckplayer.impl.DuckPlayerPixelName.DUCK_PLAYER_WATCH_ON_YOUTUBE
-import com.duckduckgo.duckplayer.impl.RealDuckPlayer.DuckPlayerOrigin.AUTO
-import com.duckduckgo.duckplayer.impl.RealDuckPlayer.DuckPlayerOrigin.OVERLAY
-import com.duckduckgo.duckplayer.impl.RealDuckPlayer.DuckPlayerOrigin.SERP_AUTO
 import com.duckduckgo.duckplayer.impl.ui.DuckPlayerPrimeBottomSheet
 import com.duckduckgo.duckplayer.impl.ui.DuckPlayerPrimeDialogFragment
 import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
@@ -488,22 +486,7 @@ class RealDuckPlayer @Inject constructor(
         }
     }
 
-    override fun willNavigateToDuckPlayerFromSerp() {
-        duckPlayerOrigin = SERP_AUTO
-    }
-
-    override fun willNavigateToDuckPlayerAutomatically() {
-        duckPlayerOrigin = AUTO
-    }
-
-    override fun willNavigateToDuckPlayerFromOverlay() {
-        duckPlayerOrigin = OVERLAY
-    }
-
-    enum class DuckPlayerOrigin {
-        SERP,
-        SERP_AUTO,
-        AUTO,
-        OVERLAY,
+    override fun setDuckPlayerOrigin(origin: DuckPlayerOrigin) {
+        duckPlayerOrigin = origin
     }
 }

--- a/duckplayer/duckplayer-impl/src/test/kotlin/com/duckduckgo/duckplayer/impl/RealDuckPlayerTest.kt
+++ b/duckplayer/duckplayer-impl/src/test/kotlin/com/duckduckgo/duckplayer/impl/RealDuckPlayerTest.kt
@@ -556,9 +556,10 @@ class RealDuckPlayerTest {
     @Test
     fun whenUriIsDuckPlayerUriWithOriginAuto_interceptProcessesDuckPlayerUri() = runTest {
         val request: WebResourceRequest = mock()
-        val url: Uri = Uri.parse("duck://player/12345?origin=auto")
+        val url: Uri = Uri.parse("duck://player/12345")
         val webView: WebView = mock()
         whenever(mockDuckPlayerFeatureRepository.getUserPreferences()).thenReturn(UserPreferences(true, Enabled))
+        testee.willNavigateToDuckPlayerAutomatically()
 
         val result = testee.intercept(request, url, webView)
 
@@ -655,7 +656,7 @@ class RealDuckPlayerTest {
 
         val result = testee.intercept(request, url, webView)
 
-        verify(webView).loadUrl("duck://player/12345?origin=auto")
+        verify(webView).loadUrl("duck://player/12345")
         assertNotNull(result)
     }
 
@@ -697,7 +698,7 @@ class RealDuckPlayerTest {
 
         val result = testee.intercept(request, url, webView)
 
-        verify(webView).loadUrl("duck://player/123456?origin=auto")
+        verify(webView).loadUrl("duck://player/123456")
         assertNotNull(result)
     }
 

--- a/duckplayer/duckplayer-impl/src/test/kotlin/com/duckduckgo/duckplayer/impl/RealDuckPlayerTest.kt
+++ b/duckplayer/duckplayer-impl/src/test/kotlin/com/duckduckgo/duckplayer/impl/RealDuckPlayerTest.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.common.utils.UrlScheme.Companion.duck
 import com.duckduckgo.common.utils.UrlScheme.Companion.https
+import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerOrigin.AUTO
 import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.DISABLED
 import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.DISABLED_WIH_HELP_LINK
 import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.ENABLED
@@ -559,7 +560,7 @@ class RealDuckPlayerTest {
         val url: Uri = Uri.parse("duck://player/12345")
         val webView: WebView = mock()
         whenever(mockDuckPlayerFeatureRepository.getUserPreferences()).thenReturn(UserPreferences(true, Enabled))
-        testee.willNavigateToDuckPlayerAutomatically()
+        testee.setDuckPlayerOrigin(AUTO)
 
         val result = testee.intercept(request, url, webView)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202552961248957/1208700688753511/f

### Description

### Steps to test this PR

_Feature 1_
- [x] Set Duck Player to Always Ask (default)
- [x] Search for a video
- [x] Click a search result
- [x] Click button to watch on Duck Player
- [x] Check `duckplayer_view-from_serp` is fired and no query params are added

_Feature 1_
- [x] From the last use case, press watch on YouTube
- [x] Refresh the video on YouTube so the overlay is shown
- [x] Click button to watch on Duck Player
- [x] Check `duckplayer_view-from_youtube_main-overlay` is fired and no query params are added

_Feature 1_
- [x] Set Duck Player to "Always"
- [x] Search for a video
- [x] Click a search result
- [x] Check `duckplayer_view-from_serp` is fired and no query params are added

_Feature 1_
- [x] Set Duck Player to "Always"
- [x] Open a YouTube video through the omnibar
- [x] Check `duckplayer_view-from_youtube_automatic` is fired and no query params are added


### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
