### PR TITLE
Fix and optimize the bottom bar scrolling

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/BottomAppBarBehavior.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/BottomAppBarBehavior.kt
@@ -27,7 +27,6 @@ import android.widget.RelativeLayout
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.ViewCompat
 import androidx.core.view.ViewCompat.NestedScrollType
-import androidx.core.view.updateLayoutParams
 import com.duckduckgo.app.browser.R
 import com.google.android.material.snackbar.Snackbar
 import kotlin.math.max
@@ -96,18 +95,20 @@ class BottomAppBarBehavior<V : View>(
             // only hide the app bar in the browser layout
             if (target.id == R.id.browserWebView) {
                 toolbar.translationY = max(0f, min(toolbar.height.toFloat(), toolbar.translationY + dy))
+                offsetBottomByToolbar(browserLayout)
             }
-
-            offsetBottomByToolbar(target)
         }
     }
 
     private fun offsetBottomByToolbar(view: View?) {
-        if (view?.layoutParams is CoordinatorLayout.LayoutParams) {
-            view.updateLayoutParams<CoordinatorLayout.LayoutParams> {
-                this.bottomMargin = omnibar.measuredHeight() - omnibar.getTranslation().roundToInt()
+        (view?.layoutParams as? CoordinatorLayout.LayoutParams)?.let { layoutParams ->
+            val newBottomMargin = omnibar.measuredHeight() - omnibar.getTranslation().roundToInt()
+            if (layoutParams.bottomMargin != newBottomMargin) {
+                layoutParams.bottomMargin = newBottomMargin
+                view.postOnAnimation {
+                    view.requestLayout()
+                }
             }
-            view.requestLayout()
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207418217763355/1208722298581325/f

### Description

This PR fixes an issue with bottom omnibar scrolling.

### Steps to test this PR

_The fix_
- [x] Enable the bottom omnibar position
- [x] Open some website
- [x] Slowly scroll the site up and down
- [x] Observe that the bottom omnibar is slowly hidden & shown
- [x] Notice there is no gap and the browser view moves with the omnibar

_Smoke tests_
- [x] Verify the bottom bar is displayed correctly in autocomplete
- [x] Verify the bottom bar is displayed correctly during onboarding
- [x] Verify the bottom bar is displayed correctly on NTP

