### PR TITLE
Update content scope scripts to version 6.32.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^10.17.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#15.1.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.30.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.32.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#7.0.2",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1724449523"
       },
@@ -57,7 +57,7 @@
       "hasInstallScript": true
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#6018aa51c139daa03944d4215ba273acb33cfe94",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#adca39c379b1a124f9990e9d0308c374f32f5018",
       "workspaces": [
         "injected",
         "special-pages",
@@ -535,16 +535,16 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.59",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.59.tgz",
-      "integrity": "sha512-EiYgNf275AQyVORl8HQYYe7rTVnmLb4hkWK7wAk/12Ksy5EiHpmUmTICa4GojookBPC8qkLMBKKwCmzNA47ZPQ=="
+      "version": "6.1.60",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.60.tgz",
+      "integrity": "sha512-XHjoxak8SFQnHnmYHb3PcnW5TZ+9ErLZemZei3azuIRhQLw4IExsVbL3VZJdHcLeNaXq6NqawgpDPpjBOg4B5g=="
     },
     "node_modules/tldts-experimental": {
-      "version": "6.1.59",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.59.tgz",
-      "integrity": "sha512-blesi68v+a9ISgFoV1bCbGXoRiKCIk4Bw3tcbBwPjuUzlggK0zjsZuPC6sJ9EOJgKBiqOLqvrTiXGP5Ryc7E5Q==",
+      "version": "6.1.60",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.60.tgz",
+      "integrity": "sha512-EK0d4Gq524rR3aUn5qnqq+v8poLIhPMiBGcRd6E50JodIlAt5d1vRxHj+BQ4R+5tC/CnhbFg9ms3BYHlnBfnyw==",
       "dependencies": {
-        "tldts-core": "^6.1.59"
+        "tldts-core": "^6.1.60"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^10.17.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#15.1.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.30.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.32.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#7.0.2",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1724449523"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass