### PR TITLE
Separate disabled state from non-editable state for DaxTextInput

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchActivity.kt
@@ -110,7 +110,7 @@ class ShowOnAppLaunchActivity : DuckDuckGoActivity() {
                         uncheckNewTabCheckListItem()
                         with(binding) {
                             specificPageCheckListItem.setChecked(true)
-                            specificPageUrlInput.isEditable = true
+                            specificPageUrlInput.isEnabled = true
                         }
                     }
                 }
@@ -132,6 +132,6 @@ class ShowOnAppLaunchActivity : DuckDuckGoActivity() {
 
     private fun uncheckSpecificPageCheckListItem() {
         binding.specificPageCheckListItem.setChecked(false)
-        binding.specificPageUrlInput.isEditable = false
+        binding.specificPageUrlInput.isEnabled = false
     }
 }

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/text/DaxTextInput.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/text/DaxTextInput.kt
@@ -201,10 +201,15 @@ class DaxTextInput @JvmOverloads constructor(
         get() = binding.internalEditText.isEnabled
         set(value) {
             binding.internalEditText.isEnabled = value
-            binding.internalInputLayout.isEnabled = value
-            binding.root.alpha = if (value) ENABLED_OPACITY else DISABLED_OPACITY
             handleIsEditableChangeForEndIcon(value)
         }
+
+    override fun setEnabled(enabled: Boolean) {
+        super.setEnabled(enabled)
+        binding.internalInputLayout.isEnabled = enabled
+        binding.internalPasswordIcon.isEnabled = enabled
+        binding.root.alpha = if (enabled) ENABLED_OPACITY else DISABLED_OPACITY
+    }
 
     override var error: String?
         get() = binding.internalInputLayout.error.toString()
@@ -219,8 +224,6 @@ class DaxTextInput @JvmOverloads constructor(
     }
 
     private fun handleIsEditableChangeForEndIcon(isEditable: Boolean) {
-        binding.internalPasswordIcon.isEnabled = isEditable
-
         if (binding.internalInputLayout.endIconMode != END_ICON_NONE) {
             binding.internalInputLayout.isEndIconVisible = !isEditable
             if (isEditable && isPassword) {

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/text/DaxTextInput.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/text/DaxTextInput.kt
@@ -138,6 +138,9 @@ class DaxTextInput @JvmOverloads constructor(
                 binding.internalEditText.inputType = binding.internalEditText.inputType or InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS
             }
 
+            val enabled = getBoolean(R.styleable.DaxTextInput_android_enabled, true)
+            isEnabled = enabled
+
             setFocusListener()
 
             recycle()

--- a/common/common-ui/src/main/res/layout/component_text_input_view.xml
+++ b/common/common-ui/src/main/res/layout/component_text_input_view.xml
@@ -179,6 +179,35 @@
             android:hint="Error"
             android:text="This is an error" />
 
+        <com.duckduckgo.common.ui.view.text.DaxTextInput
+            android:id="@+id/outlinedinputtext22"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/keyline_3"
+            android:enabled="false"
+            android:hint="Disabled text input"
+            android:text="This input is disabled" />
+
+        <com.duckduckgo.common.ui.view.text.DaxTextInput
+            android:id="@+id/outlinedinputtext23"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/keyline_3"
+            android:enabled="false"
+            app:type="multi_line"
+            android:hint="Disabled multi line input"
+            android:text="This input is disabled" />
+
+        <com.duckduckgo.common.ui.view.text.DaxTextInput
+            android:id="@+id/outlinedinputtext24"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/keyline_3"
+            android:enabled="false"
+            app:type="password"
+            android:hint="Disabled password"
+            android:text="This password input is disabled" />
+
     </LinearLayout>
 
 </androidx.core.widget.NestedScrollView>

--- a/common/common-ui/src/main/res/values/attrs-text-input.xml
+++ b/common/common-ui/src/main/res/values/attrs-text-input.xml
@@ -18,6 +18,7 @@
     <declare-styleable name="DaxTextInput">
         <attr name="android:hint" />
         <attr name="android:text" />
+        <attr name="android:enabled" />
         <attr name="android:minLines" />
         <attr name="capitalizeKeyboard" format="boolean" />
         <attr name="clickable" format="boolean" />


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208740714999313/f 

### Description
Separates non-editable state from disabled state of `DaxTextInput`. An input can be:
- non-editable but enabled (i.e., read-only text that isn't greyed out, with buttons in the view still working)
- disabled (i.e., non-editable and greyed out, and all buttons disabled too)

### Steps to test this PR

**Passwords**
- [x] Go to Passwords and tap ➕ to manually start adding a password
- [x] Verify the input fields behave correctly
- [x] Save the password; verify the fields correctly go to read-only mode (non-editable state), and that the buttons on the fields work (like copy password, reveal password etc...)
- [x] Edit the password again and verify the fields correctly go to editable state

**App launch setting**
- [x] Go to `Settings` -> `General` -> `Show on App Launch`
- [x] Verify the URL is greyed out and non-editable when it is not selected
- [x] Select it, and verify the URL is no longer greyed out, and is now editable
- [x] Unselect it again and make sure that works correctly

**Anything else that might be affected?**