### PR TITLE
Update content scope scripts to version 6.33.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -7192,7 +7192,7 @@
          * Support for modifying localStorage entries
          */
         modifyLocalStorage() {
-            /** @type {import('../types//webcompat-settings').WebCompatSettings['modifyLocalStorage']} */
+            /** @type {import('@duckduckgo/privacy-configuration/schema/features/webcompat').WebCompatSettings['modifyLocalStorage']} */
             const settings = this.getFeatureSetting('modifyLocalStorage');
 
             if (!settings || !settings.changes) return;
@@ -7208,7 +7208,7 @@
          * Support for proxying `window.webkit.messageHandlers`
          */
         messageHandlersFix() {
-            /** @type {import('../types//webcompat-settings').WebCompatSettings['messageHandlers']} */
+            /** @type {import('@duckduckgo/privacy-configuration/schema/features/webcompat').WebCompatSettings['messageHandlers']} */
             const settings = this.getFeatureSetting('messageHandlers');
 
             // Do nothing if `messageHandlers` is absent
@@ -13189,7 +13189,7 @@
 
             /**
              * Just the 'overlays' part of the settings object.
-             * @type {import("../types/duckplayer-settings.js").DuckPlayerSettings['overlays']}
+             * @type {import("@duckduckgo/privacy-configuration/schema/features/duckplayer").DuckPlayerSettings['overlays']}
              */
             const overlaySettings = this.getFeatureSetting('overlays');
             const overlaysEnabled = overlaySettings?.youtube?.state === 'enabled';

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^10.17.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#15.1.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.32.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.33.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#7.0.2",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1724449523"
       },
@@ -57,7 +57,7 @@
       "hasInstallScript": true
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#adca39c379b1a124f9990e9d0308c374f32f5018",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#96382a1140e2344f04e33fe9ae28da1290fa2d23",
       "workspaces": [
         "injected",
         "special-pages",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^10.17.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#15.1.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.32.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.33.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#7.0.2",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1724449523"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208752777730434/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass