### PR TITLE
Site Permissions: Pixels

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/api/PixelParamRemovalInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/PixelParamRemovalInterceptor.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin.PixelPa
 import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin.PixelParameter.ATB
 import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin.PixelParameter.OS_VERSION
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.site.permissions.impl.SitePermissionsPixelName
 import com.squareup.anvil.annotations.ContributesMultibinding
 import javax.inject.Inject
 import okhttp3.Interceptor
@@ -87,6 +88,8 @@ object PixelInterceptorPixelsRequiringDataCleaning : PixelParamRemovalPlugin {
             HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_4XX_DAILY.pixelName to PixelParameter.removeAtb(),
             HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_5XX_DAILY.pixelName to PixelParameter.removeAtb(),
             AppPixelName.FEATURES_ENABLED_AT_SEARCH_TIME.pixelName to PixelParameter.removeAll(),
+            SitePermissionsPixelName.PERMISSION_DIALOG_CLICK.pixelName to PixelParameter.removeAtb(),
+            SitePermissionsPixelName.PERMISSION_DIALOG_IMPRESSION.pixelName to PixelParameter.removeAtb(),
         )
     }
 }

--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsDialogActivityLauncher.kt
@@ -220,7 +220,7 @@ class SitePermissionsDialogActivityLauncher @Inject constructor(
                     var rememberChoice = false
                     override fun onPositiveButtonClicked() {
                         onPermissionAllowed(rememberChoice)
-                        sendNegativeDialogClickPixel(rememberChoice = rememberChoice, type = pixelType)
+                        sendPositiveDialogClickPixel(rememberChoice = rememberChoice, type = pixelType)
                     }
 
                     override fun onNegativeButtonClicked() {

--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsPixelName.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsPixelName.kt
@@ -18,16 +18,7 @@ package com.duckduckgo.site.permissions.impl
 
 import com.duckduckgo.app.statistics.pixels.Pixel
 
-internal enum class SitePermissionsPixelName(override val pixelName: String) : Pixel.PixelName {
-    PRECISE_LOCATION_SYSTEM_DIALOG_ENABLE("m_pc_syd_e"),
-    PRECISE_LOCATION_SYSTEM_DIALOG_LATER("m_pc_syd_l"),
-    PRECISE_LOCATION_SYSTEM_DIALOG_NEVER("m_pc_syd_n"),
-    PRECISE_LOCATION_SETTINGS_LOCATION_PERMISSION_ENABLE("m_pc_s_l_e"),
-    PRECISE_LOCATION_SETTINGS_LOCATION_PERMISSION_DISABLE("m_pc_s_l_d"),
-    PRECISE_LOCATION_SITE_DIALOG_ALLOW_ALWAYS("m_pc_sd_aa"),
-    PRECISE_LOCATION_SITE_DIALOG_ALLOW_ONCE("m_pc_sd_ao"),
-    PRECISE_LOCATION_SITE_DIALOG_DENY_ALWAYS("m_pc_sd_da"),
-    PRECISE_LOCATION_SITE_DIALOG_DENY_ONCE("m_pc_sd_do"),
+enum class SitePermissionsPixelName(override val pixelName: String) : Pixel.PixelName {
     PERMISSION_DIALOG_IMPRESSION("m_site_permissions_dialog_impresssion"),
     PERMISSION_DIALOG_CLICK("m_site_permissions_dialog_click"),
 }

--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsPixelName.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/SitePermissionsPixelName.kt
@@ -28,4 +28,23 @@ internal enum class SitePermissionsPixelName(override val pixelName: String) : P
     PRECISE_LOCATION_SITE_DIALOG_ALLOW_ONCE("m_pc_sd_ao"),
     PRECISE_LOCATION_SITE_DIALOG_DENY_ALWAYS("m_pc_sd_da"),
     PRECISE_LOCATION_SITE_DIALOG_DENY_ONCE("m_pc_sd_do"),
+    PERMISSION_DIALOG_IMPRESSION("m_site_permissions_dialog_impresssion"),
+    PERMISSION_DIALOG_CLICK("m_site_permissions_dialog_click"),
+}
+
+object SitePermissionsPixelParameters {
+    const val PERMISSION_TYPE = "type"
+    const val PERMISSION_SELECTION = "selection"
+}
+
+object SitePermissionsPixelValues {
+    const val LOCATION = "location"
+    const val CAMERA = "camera"
+    const val MICROPHONE = "microphone"
+    const val CAMERA_AND_MICROPHONE = "camera_and_microphone"
+    const val DRM = "drm"
+    const val ALLOW_ALWAYS = "allow_always"
+    const val ALLOW_ONCE = "allow_once"
+    const val DENY_ALWAYS = "deny_always"
+    const val DENY_ONCE = "deny_once"
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1208750400255371/f

### Description
PIxels for the new site permission dialogs

### Steps to test this PR

_Impression pixel_
- [x] open app visit permission.site
- [x] tap on camera
- [x] verify `m_site_permissions_dialog_impresssion` with parameter `type:camera` is sent
- [x] tap on microphone
- [x] verify `m_site_permissions_dialog_impresssion` with parameter `type: microphone ` is sent
- [x] tap on camera + microphone
- [x] verify `m_site_permissions_dialog_impresssion` with parameter `type:camera_and_microphone` is sent
- [x] tap on drm
- [x] verify `m_site_permissions_dialog_impresssion` with parameter `type: drm ` is sent
- [x] tap on location
- [x] verify `m_site_permissions_dialog_impresssion` with parameter `type:location` is sent

_Click pixel_
- [x] open app visit permission.site
- [x] tap on camera and enable system permission
- [x] tap on Allow (checked box not pressed)
- [x] verify `m_site_permissions_dialog_click` with parameters `type:camera` and `selection:allow_once` is sent
- [x] tap on microphone and enable system permission
- [x] tap on Deny (checked box not pressed)
- [x] verify `m_site_permissions_dialog_click` with parameters `type:microphone` and `selection:deny_once` is sent
- [x] tap on drm
- [x] tap on Allow (checked box pressed)
- [x] verify `m_site_permissions_dialog_click` with parameters `type:drm` and `selection:allow_always` is sent
- [x] tap on location and enable system permissions
- [x] tap on Deny (checked box pressed)
- [x] verify `m_site_permissions_dialog_click` with parameters `type:location` and `selection:deny_always` is sent

Notes: Pixels don’t include ATB
