### PR TITLE
Support settings for top-level and sub-feature and remove sub-feature config

### DIFF
--- a/anvil/anvil-annotations/src/main/java/com/duckduckgo/anvil/annotations/ContributesRemoteFeature.kt
+++ b/anvil/anvil-annotations/src/main/java/com/duckduckgo/anvil/annotations/ContributesRemoteFeature.kt
@@ -55,7 +55,7 @@ annotation class ContributesRemoteFeature(
     val featureName: String,
 
     /** The class that implements the [FeatureSettings.Store] interface */
-    @Deprecated("Not needed anymore. Settings is now supported in top-leve and sub-features and Toggle#getSettings returns it")
+    @Deprecated("Not needed anymore. Settings is now supported in top-level and sub-features and Toggle#getSettings returns it")
     val settingsStore: KClass<*> = Unit::class,
 
     /** The class that implements the [FeatureExceptions.Store] interface */

--- a/anvil/anvil-annotations/src/main/java/com/duckduckgo/anvil/annotations/ContributesRemoteFeature.kt
+++ b/anvil/anvil-annotations/src/main/java/com/duckduckgo/anvil/annotations/ContributesRemoteFeature.kt
@@ -55,6 +55,7 @@ annotation class ContributesRemoteFeature(
     val featureName: String,
 
     /** The class that implements the [FeatureSettings.Store] interface */
+    @Deprecated("Not needed anymore. Settings is now supported in top-leve and sub-features and Toggle#getSettings returns it")
     val settingsStore: KClass<*> = Unit::class,
 
     /** The class that implements the [FeatureExceptions.Store] interface */

--- a/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesRemoteFeatureCodeGenerator.kt
+++ b/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesRemoteFeatureCodeGenerator.kt
@@ -528,7 +528,7 @@ class ContributesRemoteFeatureCodeGenerator : CodeGenerator {
                                         weight = cohort.weight,
                                     )
                                 } ?: emptyList()
-                                val config = jsonToggle?.config ?: emptyMap()
+                                val config = jsonToggle?.config?.toString()
                                 this.feature.get().invokeMethod(subfeature.key).setRawStoredState(
                                     Toggle.State(
                                         remoteEnableState = newStateValue,
@@ -781,10 +781,7 @@ class ContributesRemoteFeatureCodeGenerator : CodeGenerator {
                         "cohorts",
                         List::class.asClassName().parameterizedBy(FqName("JsonToggleCohort").asClassName(module)),
                     )
-                    .addParameter(
-                        "config",
-                        Map::class.asClassName().parameterizedBy(String::class.asClassName(), String::class.asClassName()),
-                    )
+                    .addParameter("config", FqName("org.json.JSONObject").asClassName(module).copy(nullable = true))
                     .build(),
             )
             .addProperty(
@@ -819,7 +816,7 @@ class ContributesRemoteFeatureCodeGenerator : CodeGenerator {
             )
             .addProperty(
                 PropertySpec
-                    .builder("config", Map::class.asClassName().parameterizedBy(String::class.asClassName(), String::class.asClassName()))
+                    .builder("config", FqName("org.json.JSONObject").asClassName(module).copy(nullable = true))
                     .initializer("config")
                     .build(),
             )

--- a/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesRemoteFeatureCodeGenerator.kt
+++ b/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesRemoteFeatureCodeGenerator.kt
@@ -498,6 +498,7 @@ class ContributesRemoteFeatureCodeGenerator : CodeGenerator {
                             minSupportedVersion = feature.minSupportedVersion,
                             targets = emptyList(),
                             cohorts = emptyList(),
+                            settings = feature.settings?.toString(),
                         )
                     )
         
@@ -528,7 +529,7 @@ class ContributesRemoteFeatureCodeGenerator : CodeGenerator {
                                         weight = cohort.weight,
                                     )
                                 } ?: emptyList()
-                                val config = jsonToggle?.config?.toString()
+                                val settings = jsonToggle?.settings?.toString()
                                 this.feature.get().invokeMethod(subfeature.key).setRawStoredState(
                                     Toggle.State(
                                         remoteEnableState = newStateValue,
@@ -539,7 +540,7 @@ class ContributesRemoteFeatureCodeGenerator : CodeGenerator {
                                         assignedCohort = previousAssignedCohort,
                                         targets = targets,
                                         cohorts = cohorts,
-                                        config = config,                                        
+                                        settings = settings,                                        
                                     ),
                                 )
                             } catch(e: Throwable) {
@@ -781,7 +782,7 @@ class ContributesRemoteFeatureCodeGenerator : CodeGenerator {
                         "cohorts",
                         List::class.asClassName().parameterizedBy(FqName("JsonToggleCohort").asClassName(module)),
                     )
-                    .addParameter("config", FqName("org.json.JSONObject").asClassName(module).copy(nullable = true))
+                    .addParameter("settings", FqName("org.json.JSONObject").asClassName(module).copy(nullable = true))
                     .build(),
             )
             .addProperty(
@@ -816,8 +817,8 @@ class ContributesRemoteFeatureCodeGenerator : CodeGenerator {
             )
             .addProperty(
                 PropertySpec
-                    .builder("config", FqName("org.json.JSONObject").asClassName(module).copy(nullable = true))
-                    .initializer("config")
+                    .builder("settings", FqName("org.json.JSONObject").asClassName(module).copy(nullable = true))
+                    .initializer("settings")
                     .build(),
             )
             .build()

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/blocklist/BlockList.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/blocklist/BlockList.kt
@@ -70,10 +70,7 @@ interface BlockList {
     }
 
     companion object {
-        const val EXPERIMENT_PREFIX = "tds"
-        const val TREATMENT_URL = "treatmentUrl"
-        const val CONTROL_URL = "controlUrl"
-        const val NEXT_URL = "nextUrl"
+        internal const val EXPERIMENT_PREFIX = "tds"
     }
 }
 

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/blocklist/BlockListInterceptorApiPlugin.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/blocklist/BlockListInterceptorApiPlugin.kt
@@ -20,12 +20,12 @@ import com.duckduckgo.app.global.api.ApiInterceptorPlugin
 import com.duckduckgo.app.trackerdetection.api.TDS_BASE_URL
 import com.duckduckgo.app.trackerdetection.blocklist.BlockList.Cohorts.CONTROL
 import com.duckduckgo.app.trackerdetection.blocklist.BlockList.Cohorts.TREATMENT
-import com.duckduckgo.app.trackerdetection.blocklist.BlockList.Companion.CONTROL_URL
-import com.duckduckgo.app.trackerdetection.blocklist.BlockList.Companion.NEXT_URL
-import com.duckduckgo.app.trackerdetection.blocklist.BlockList.Companion.TREATMENT_URL
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.FeatureTogglesInventory
 import com.squareup.anvil.annotations.ContributesMultibinding
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
 import javax.inject.Inject
 import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
@@ -38,8 +38,12 @@ import okhttp3.Response
 )
 class BlockListInterceptorApiPlugin @Inject constructor(
     private val inventory: FeatureTogglesInventory,
+    private val moshi: Moshi,
 ) : Interceptor, ApiInterceptorPlugin {
 
+    private val jsonAdapter: JsonAdapter<Map<String, String>> by lazy {
+        moshi.adapter(Types.newParameterizedType(Map::class.java, String::class.java, String::class.java))
+    }
     override fun intercept(chain: Chain): Response {
         val request = chain.request().newBuilder()
         val url = chain.request().url
@@ -51,10 +55,11 @@ class BlockListInterceptorApiPlugin @Inject constructor(
         }
 
         return activeExperiment?.let {
+            val config = activeExperiment.getConfig()?.let { jsonAdapter.fromJson(it) } ?: emptyMap()
             val path = when {
-                activeExperiment.isEnabled(TREATMENT) -> activeExperiment.getConfig()[TREATMENT_URL]
-                activeExperiment.isEnabled(CONTROL) -> activeExperiment.getConfig()[CONTROL_URL]
-                else -> activeExperiment.getConfig()[NEXT_URL]
+                activeExperiment.isEnabled(TREATMENT) -> config["treatmentUrl"]
+                activeExperiment.isEnabled(CONTROL) -> config["controlUrl"]
+                else -> config["nextUrl"]
             } ?: chain.proceed(request.build())
             chain.proceed(request.url("$TDS_BASE_URL$path").build())
         } ?: chain.proceed(request.build())

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/blocklist/BlockListInterceptorApiPlugin.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/blocklist/BlockListInterceptorApiPlugin.kt
@@ -60,7 +60,7 @@ class BlockListInterceptorApiPlugin @Inject constructor(
                 activeExperiment.isEnabled(TREATMENT) -> config["treatmentUrl"]
                 activeExperiment.isEnabled(CONTROL) -> config["controlUrl"]
                 else -> config["nextUrl"]
-            } ?: chain.proceed(request.build())
+            } ?: return chain.proceed(request.build())
             chain.proceed(request.url("$TDS_BASE_URL$path").build())
         } ?: chain.proceed(request.build())
     }

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/blocklist/BlockListInterceptorApiPlugin.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/blocklist/BlockListInterceptorApiPlugin.kt
@@ -55,7 +55,7 @@ class BlockListInterceptorApiPlugin @Inject constructor(
         }
 
         return activeExperiment?.let {
-            val config = activeExperiment.getConfig()?.let { jsonAdapter.fromJson(it) } ?: emptyMap()
+            val config = activeExperiment.getSettings()?.let { jsonAdapter.fromJson(it) } ?: emptyMap()
             val path = when {
                 activeExperiment.isEnabled(TREATMENT) -> config["treatmentUrl"]
                 activeExperiment.isEnabled(CONTROL) -> config["controlUrl"]

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/blocklist/BlockListInterceptorApiPlugin.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/blocklist/BlockListInterceptorApiPlugin.kt
@@ -55,7 +55,11 @@ class BlockListInterceptorApiPlugin @Inject constructor(
         }
 
         return activeExperiment?.let {
-            val config = activeExperiment.getSettings()?.let { jsonAdapter.fromJson(it) } ?: emptyMap()
+            val config = activeExperiment.getSettings()?.let {
+                runCatching {
+                    jsonAdapter.fromJson(it)
+                }.getOrDefault(emptyMap())
+            } ?: emptyMap()
             val path = when {
                 activeExperiment.isEnabled(TREATMENT) -> config["treatmentUrl"]
                 activeExperiment.isEnabled(CONTROL) -> config["controlUrl"]

--- a/app/src/test/java/com/duckduckgo/app/brokensite/api/BrokenSiteSubmitterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/brokensite/api/BrokenSiteSubmitterTest.kt
@@ -11,8 +11,6 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.app.trackerdetection.blocklist.BlockList.Cohorts.TREATMENT
-import com.duckduckgo.app.trackerdetection.blocklist.BlockList.Companion.CONTROL_URL
-import com.duckduckgo.app.trackerdetection.blocklist.BlockList.Companion.TREATMENT_URL
 import com.duckduckgo.app.trackerdetection.blocklist.FakeFeatureTogglesInventory
 import com.duckduckgo.app.trackerdetection.blocklist.TestBlockListFeature
 import com.duckduckgo.app.trackerdetection.db.TdsMetadataDao
@@ -43,6 +41,7 @@ import com.duckduckgo.privacy.config.api.PrivacyConfigData
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.privacyprotectionspopup.api.PrivacyProtectionsPopupExperimentExternalPixels
+import com.squareup.moshi.Moshi
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
@@ -67,6 +66,15 @@ import org.mockito.kotlin.whenever
 class BrokenSiteSubmitterTest {
     @get:Rule
     var coroutineRule = CoroutineTestRule()
+
+    private val moshi = Moshi.Builder().build()
+
+    private data class Config(
+        val treatmentUrl: String? = null,
+        val controlUrl: String? = null,
+        val nextUrl: String? = null,
+    )
+    private val configAdapter = moshi.adapter(Config::class.java)
 
     private val mockPixel: Pixel = mock()
 
@@ -605,10 +613,7 @@ class BrokenSiteSubmitterTest {
             State(
                 remoteEnableState = true,
                 enable = true,
-                config = mapOf(
-                    TREATMENT_URL to "treatmentUrl",
-                    CONTROL_URL to "controlUrl",
-                ),
+                config = configAdapter.toJson(Config(treatmentUrl = "treatmentUrl", controlUrl = "controlUrl")),
                 assignedCohort = State.Cohort(name = TREATMENT.cohortName, weight = 1, enrollmentDateET = enrollmentDateET),
             ),
         )

--- a/app/src/test/java/com/duckduckgo/app/brokensite/api/BrokenSiteSubmitterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/brokensite/api/BrokenSiteSubmitterTest.kt
@@ -613,7 +613,7 @@ class BrokenSiteSubmitterTest {
             State(
                 remoteEnableState = true,
                 enable = true,
-                config = configAdapter.toJson(Config(treatmentUrl = "treatmentUrl", controlUrl = "controlUrl")),
+                settings = configAdapter.toJson(Config(treatmentUrl = "treatmentUrl", controlUrl = "controlUrl")),
                 assignedCohort = State.Cohort(name = TREATMENT.cohortName, weight = 1, enrollmentDateET = enrollmentDateET),
             ),
         )

--- a/app/src/test/java/com/duckduckgo/app/browser/refreshpixels/RefreshPixelSenderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/refreshpixels/RefreshPixelSenderTest.kt
@@ -10,8 +10,6 @@ import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.app.trackerdetection.blocklist.BlockList.Cohorts.TREATMENT
-import com.duckduckgo.app.trackerdetection.blocklist.BlockList.Companion.CONTROL_URL
-import com.duckduckgo.app.trackerdetection.blocklist.BlockList.Companion.TREATMENT_URL
 import com.duckduckgo.app.trackerdetection.blocklist.BlockListPixelsPlugin
 import com.duckduckgo.app.trackerdetection.blocklist.FakeFeatureTogglesInventory
 import com.duckduckgo.app.trackerdetection.blocklist.TestBlockListFeature
@@ -24,6 +22,7 @@ import com.duckduckgo.feature.toggles.api.FeatureToggles
 import com.duckduckgo.feature.toggles.api.FeatureTogglesInventory
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.feature.toggles.impl.RealFeatureTogglesInventory
+import com.squareup.moshi.Moshi
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
@@ -47,6 +46,15 @@ class RefreshPixelSenderTest {
 
     @get:Rule
     var coroutineTestRule = CoroutineTestRule()
+
+    private val moshi = Moshi.Builder().build()
+
+    private data class Config(
+        val treatmentUrl: String? = null,
+        val controlUrl: String? = null,
+        val nextUrl: String? = null,
+    )
+    private val configAdapter = moshi.adapter(Config::class.java)
 
     private lateinit var db: AppDatabase
     private lateinit var refreshDao: RefreshDao
@@ -304,10 +312,7 @@ class RefreshPixelSenderTest {
             State(
                 remoteEnableState = true,
                 enable = true,
-                config = mapOf(
-                    TREATMENT_URL to "treatmentUrl",
-                    CONTROL_URL to "controlUrl",
-                ),
+                config = configAdapter.toJson(Config(treatmentUrl = "treatmentUrl", controlUrl = "controlUrl")),
                 assignedCohort = State.Cohort(name = TREATMENT.cohortName, weight = 1, enrollmentDateET = enrollmentDateET),
             ),
         )

--- a/app/src/test/java/com/duckduckgo/app/browser/refreshpixels/RefreshPixelSenderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/refreshpixels/RefreshPixelSenderTest.kt
@@ -312,7 +312,7 @@ class RefreshPixelSenderTest {
             State(
                 remoteEnableState = true,
                 enable = true,
-                config = configAdapter.toJson(Config(treatmentUrl = "treatmentUrl", controlUrl = "controlUrl")),
+                settings = configAdapter.toJson(Config(treatmentUrl = "treatmentUrl", controlUrl = "controlUrl")),
                 assignedCohort = State.Cohort(name = TREATMENT.cohortName, weight = 1, enrollmentDateET = enrollmentDateET),
             ),
         )

--- a/app/src/test/java/com/duckduckgo/app/trackerdetection/blocklist/BlockListInterceptorApiPluginTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/trackerdetection/blocklist/BlockListInterceptorApiPluginTest.kt
@@ -22,9 +22,6 @@ import com.duckduckgo.app.trackerdetection.api.TDS_BASE_URL
 import com.duckduckgo.app.trackerdetection.api.TDS_PATH
 import com.duckduckgo.app.trackerdetection.blocklist.BlockList.Cohorts.CONTROL
 import com.duckduckgo.app.trackerdetection.blocklist.BlockList.Cohorts.TREATMENT
-import com.duckduckgo.app.trackerdetection.blocklist.BlockList.Companion.CONTROL_URL
-import com.duckduckgo.app.trackerdetection.blocklist.BlockList.Companion.NEXT_URL
-import com.duckduckgo.app.trackerdetection.blocklist.BlockList.Companion.TREATMENT_URL
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.test.api.FakeChain
 import com.duckduckgo.feature.toggles.api.FakeToggleStore
@@ -34,6 +31,7 @@ import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.feature.toggles.api.Toggle.DefaultValue
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.feature.toggles.impl.RealFeatureTogglesInventory
+import com.squareup.moshi.Moshi
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
@@ -49,6 +47,14 @@ class BlockListInterceptorApiPluginTest {
     private lateinit var testBlockListFeature: TestBlockListFeature
     private lateinit var inventory: FeatureTogglesInventory
     private lateinit var interceptor: BlockListInterceptorApiPlugin
+    private val moshi = Moshi.Builder().build()
+
+    private data class Config(
+        val treatmentUrl: String? = null,
+        val controlUrl: String? = null,
+        val nextUrl: String? = null,
+    )
+    private val configAdapter = moshi.adapter(Config::class.java)
 
     @Before
     fun setup() {
@@ -69,7 +75,7 @@ class BlockListInterceptorApiPluginTest {
             coroutineRule.testDispatcherProvider,
         )
 
-        interceptor = BlockListInterceptorApiPlugin(inventory)
+        interceptor = BlockListInterceptorApiPlugin(inventory, moshi)
     }
 
     @Test
@@ -78,9 +84,8 @@ class BlockListInterceptorApiPluginTest {
             State(
                 remoteEnableState = true,
                 enable = true,
-                config = mapOf(
-                    TREATMENT_URL to "treatmentUrl",
-                    CONTROL_URL to "controlUrl",
+                config = configAdapter.toJson(
+                    Config(treatmentUrl = "treatmentUrl", controlUrl = "controlUrl"),
                 ),
                 cohorts = listOf(
                     State.Cohort(name = CONTROL.cohortName, weight = 0),
@@ -92,9 +97,8 @@ class BlockListInterceptorApiPluginTest {
             State(
                 remoteEnableState = true,
                 enable = true,
-                config = mapOf(
-                    TREATMENT_URL to "anotherTreatmentUrl",
-                    CONTROL_URL to "anotherControlUrl",
+                config = configAdapter.toJson(
+                    Config(treatmentUrl = "anotherTreatmentUrl", controlUrl = "anotherControlUrl"),
                 ),
                 cohorts = listOf(
                     State.Cohort(name = CONTROL.cohortName, weight = 0),
@@ -114,9 +118,8 @@ class BlockListInterceptorApiPluginTest {
             State(
                 remoteEnableState = true,
                 enable = true,
-                config = mapOf(
-                    TREATMENT_URL to "anotherTreatmentUrl",
-                    CONTROL_URL to "anotherControlUrl",
+                config = configAdapter.toJson(
+                    Config(treatmentUrl = "anotherTreatmentUrl", controlUrl = "anotherControlUrl"),
                 ),
                 cohorts = listOf(
                     State.Cohort(name = CONTROL.cohortName, weight = 0),
@@ -136,9 +139,8 @@ class BlockListInterceptorApiPluginTest {
             State(
                 remoteEnableState = true,
                 enable = true,
-                config = mapOf(
-                    TREATMENT_URL to "anotherTreatmentUrl",
-                    CONTROL_URL to "anotherControlUrl",
+                config = configAdapter.toJson(
+                    Config(treatmentUrl = "anotherTreatmentUrl", controlUrl = "anotherControlUrl"),
                 ),
                 cohorts = listOf(
                     State.Cohort(name = CONTROL.cohortName, weight = 1),
@@ -158,8 +160,8 @@ class BlockListInterceptorApiPluginTest {
             State(
                 remoteEnableState = true,
                 enable = true,
-                config = mapOf(
-                    NEXT_URL to "nextUrl",
+                config = configAdapter.toJson(
+                    Config(nextUrl = "nextUrl"),
                 ),
             ),
         )
@@ -182,9 +184,8 @@ class BlockListInterceptorApiPluginTest {
             State(
                 remoteEnableState = true,
                 enable = true,
-                config = mapOf(
-                    TREATMENT_URL to "anotherTreatmentUrl",
-                    CONTROL_URL to "anotherControlUrl",
+                config = configAdapter.toJson(
+                    Config(treatmentUrl = "anotherTreatmentUrl", controlUrl = "anotherControlUrl"),
                 ),
                 cohorts = listOf(
                     State.Cohort(name = CONTROL.cohortName, weight = 1),

--- a/app/src/test/java/com/duckduckgo/app/trackerdetection/blocklist/BlockListInterceptorApiPluginTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/trackerdetection/blocklist/BlockListInterceptorApiPluginTest.kt
@@ -84,7 +84,7 @@ class BlockListInterceptorApiPluginTest {
             State(
                 remoteEnableState = true,
                 enable = true,
-                config = configAdapter.toJson(
+                settings = configAdapter.toJson(
                     Config(treatmentUrl = "treatmentUrl", controlUrl = "controlUrl"),
                 ),
                 cohorts = listOf(
@@ -97,7 +97,7 @@ class BlockListInterceptorApiPluginTest {
             State(
                 remoteEnableState = true,
                 enable = true,
-                config = configAdapter.toJson(
+                settings = configAdapter.toJson(
                     Config(treatmentUrl = "anotherTreatmentUrl", controlUrl = "anotherControlUrl"),
                 ),
                 cohorts = listOf(
@@ -118,7 +118,7 @@ class BlockListInterceptorApiPluginTest {
             State(
                 remoteEnableState = true,
                 enable = true,
-                config = configAdapter.toJson(
+                settings = configAdapter.toJson(
                     Config(treatmentUrl = "anotherTreatmentUrl", controlUrl = "anotherControlUrl"),
                 ),
                 cohorts = listOf(
@@ -139,7 +139,7 @@ class BlockListInterceptorApiPluginTest {
             State(
                 remoteEnableState = true,
                 enable = true,
-                config = configAdapter.toJson(
+                settings = configAdapter.toJson(
                     Config(treatmentUrl = "anotherTreatmentUrl", controlUrl = "anotherControlUrl"),
                 ),
                 cohorts = listOf(
@@ -160,7 +160,7 @@ class BlockListInterceptorApiPluginTest {
             State(
                 remoteEnableState = true,
                 enable = true,
-                config = configAdapter.toJson(
+                settings = configAdapter.toJson(
                     Config(nextUrl = "nextUrl"),
                 ),
             ),
@@ -184,7 +184,7 @@ class BlockListInterceptorApiPluginTest {
             State(
                 remoteEnableState = true,
                 enable = true,
-                config = configAdapter.toJson(
+                settings = configAdapter.toJson(
                     Config(treatmentUrl = "anotherTreatmentUrl", controlUrl = "anotherControlUrl"),
                 ),
                 cohorts = listOf(

--- a/app/src/test/java/com/duckduckgo/app/trackerdetection/blocklist/BlockListPrivacyTogglePluginTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/trackerdetection/blocklist/BlockListPrivacyTogglePluginTest.kt
@@ -96,7 +96,7 @@ class BlockListPrivacyTogglePluginTest {
             State(
                 remoteEnableState = true,
                 enable = true,
-                config = configAdapter.toJson(Config(treatmentUrl = "treatmentUrl", controlUrl = "controlUrl")),
+                settings = configAdapter.toJson(Config(treatmentUrl = "treatmentUrl", controlUrl = "controlUrl")),
                 assignedCohort = State.Cohort(name = TREATMENT.cohortName, weight = 1, enrollmentDateET = enrollmentDateET),
             ),
         )

--- a/app/src/test/java/com/duckduckgo/app/trackerdetection/blocklist/BlockListPrivacyTogglePluginTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/trackerdetection/blocklist/BlockListPrivacyTogglePluginTest.kt
@@ -3,8 +3,6 @@ package com.duckduckgo.app.trackerdetection.blocklist
 import android.annotation.SuppressLint
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.trackerdetection.blocklist.BlockList.Cohorts.TREATMENT
-import com.duckduckgo.app.trackerdetection.blocklist.BlockList.Companion.CONTROL_URL
-import com.duckduckgo.app.trackerdetection.blocklist.BlockList.Companion.TREATMENT_URL
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeToggleStore
 import com.duckduckgo.feature.toggles.api.FeatureToggles
@@ -14,6 +12,7 @@ import com.duckduckgo.feature.toggles.impl.RealFeatureTogglesInventory
 import com.duckduckgo.privacy.dashboard.api.PrivacyToggleOrigin.BREAKAGE_FORM
 import com.duckduckgo.privacy.dashboard.api.PrivacyToggleOrigin.DASHBOARD
 import com.duckduckgo.privacy.dashboard.api.PrivacyToggleOrigin.MENU
+import com.squareup.moshi.Moshi
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
@@ -30,6 +29,15 @@ class BlockListPrivacyTogglePluginTest {
 
     @get:Rule
     var coroutineRule = CoroutineTestRule()
+
+    private val moshi = Moshi.Builder().build()
+
+    private data class Config(
+        val treatmentUrl: String? = null,
+        val controlUrl: String? = null,
+        val nextUrl: String? = null,
+    )
+    private val configAdapter = moshi.adapter(Config::class.java)
 
     private val pixel: Pixel = mock()
     private lateinit var testBlockListFeature: TestBlockListFeature
@@ -88,10 +96,7 @@ class BlockListPrivacyTogglePluginTest {
             State(
                 remoteEnableState = true,
                 enable = true,
-                config = mapOf(
-                    TREATMENT_URL to "treatmentUrl",
-                    CONTROL_URL to "controlUrl",
-                ),
+                config = configAdapter.toJson(Config(treatmentUrl = "treatmentUrl", controlUrl = "controlUrl")),
                 assignedCohort = State.Cohort(name = TREATMENT.cohortName, weight = 1, enrollmentDateET = enrollmentDateET),
             ),
         )

--- a/autofill/autofill-impl/build.gradle
+++ b/autofill/autofill-impl/build.gradle
@@ -71,6 +71,7 @@ dependencies {
     implementation "net.zetetic:android-database-sqlcipher:_"
 
     // Testing dependencies
+    testImplementation project(':common-test')
     testImplementation "org.mockito.kotlin:mockito-kotlin:_"
     testImplementation Testing.junit4
     testImplementation AndroidX.core

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/gpm/feature/AutofillImportPasswordSettings.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/gpm/feature/AutofillImportPasswordSettings.kt
@@ -49,7 +49,7 @@ class AutofillImportPasswordConfigStoreImpl @Inject constructor(
 
     override suspend fun getConfig(): AutofillImportPasswordSettings {
         return withContext(dispatchers.io()) {
-            val config = autofillFeature.canImportFromGooglePasswordManager().getConfig()?.let { jsonAdapter.fromJson(it) }
+            val config = autofillFeature.canImportFromGooglePasswordManager().getSettings()?.let { jsonAdapter.fromJson(it) }
             val launchUrl = config?.launchUrl ?: LAUNCH_URL_DEFAULT
             val javascriptConfig = config?.javascriptConfig?.toString() ?: JAVASCRIPT_CONFIG_DEFAULT
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/gpm/feature/AutofillImportPasswordSettings.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/gpm/feature/AutofillImportPasswordSettings.kt
@@ -49,7 +49,11 @@ class AutofillImportPasswordConfigStoreImpl @Inject constructor(
 
     override suspend fun getConfig(): AutofillImportPasswordSettings {
         return withContext(dispatchers.io()) {
-            val config = autofillFeature.canImportFromGooglePasswordManager().getSettings()?.let { jsonAdapter.fromJson(it) }
+            val config = autofillFeature.canImportFromGooglePasswordManager().getSettings()?.let {
+                runCatching {
+                    jsonAdapter.fromJson(it)
+                }.getOrNull()
+            }
             val launchUrl = config?.launchUrl ?: LAUNCH_URL_DEFAULT
             val javascriptConfig = config?.javascriptConfig?.toString() ?: JAVASCRIPT_CONFIG_DEFAULT
 

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/gpm/feature/AutofillImportPasswordConfigStoreImplTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/gpm/feature/AutofillImportPasswordConfigStoreImplTest.kt
@@ -74,7 +74,7 @@ class AutofillImportPasswordConfigStoreImplTest {
         autofillFeature.canImportFromGooglePasswordManager().setRawStoredState(
             State(
                 remoteEnableState = enabled,
-                config = adapter.toJson(config),
+                settings = adapter.toJson(config),
             ),
         )
     }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/gpm/feature/AutofillImportPasswordConfigStoreImplTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/gpm/feature/AutofillImportPasswordConfigStoreImplTest.kt
@@ -1,26 +1,36 @@
 package com.duckduckgo.autofill.impl.importing.gpm.feature
 
 import android.annotation.SuppressLint
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.autofill.api.AutofillFeature
 import com.duckduckgo.autofill.impl.importing.gpm.feature.AutofillImportPasswordConfigStoreImpl.Companion.JAVASCRIPT_CONFIG_DEFAULT
 import com.duckduckgo.autofill.impl.importing.gpm.feature.AutofillImportPasswordConfigStoreImpl.Companion.LAUNCH_URL_DEFAULT
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.test.json.JSONObjectAdapter
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(AndroidJUnit4::class)
 class AutofillImportPasswordConfigStoreImplTest {
 
     @get:Rule
     val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
 
+    private val moshi = Moshi.Builder().add(JSONObjectAdapter()).build()
+    private val adapter: JsonAdapter<Config> = moshi.adapter(Config::class.java)
+
     private val autofillFeature = FakeFeatureToggleFactory.create(AutofillFeature::class.java)
     private val testee = AutofillImportPasswordConfigStoreImpl(
         autofillFeature = autofillFeature,
         dispatchers = coroutineTestRule.testDispatcherProvider,
+        moshi = moshi,
     )
 
     @Test
@@ -37,35 +47,44 @@ class AutofillImportPasswordConfigStoreImplTest {
 
     @Test
     fun whenLaunchUrlNotSpecifiedInConfigThenDefaultUsed() = runTest {
-        configureFeature(config = emptyMap())
+        configureFeature(config = Config())
         assertEquals(LAUNCH_URL_DEFAULT, testee.getConfig().launchUrlGooglePasswords)
     }
 
     @Test
     fun whenLaunchUrlSpecifiedInConfigThenOverridesDefault() = runTest {
-        configureFeature(config = mapOf("launchUrl" to "https://example.com"))
+        configureFeature(config = Config(launchUrl = "https://example.com"))
         assertEquals("https://example.com", testee.getConfig().launchUrlGooglePasswords)
     }
 
     @Test
     fun whenJavascriptConfigNotSpecifiedInConfigThenDefaultUsed() = runTest {
-        configureFeature(config = emptyMap())
+        configureFeature(config = Config())
         assertEquals(JAVASCRIPT_CONFIG_DEFAULT, testee.getConfig().javascriptConfigGooglePasswords)
     }
 
     @Test
     fun whenJavascriptConfigSpecifiedInConfigThenOverridesDefault() = runTest {
-        configureFeature(config = mapOf("javascriptConfig" to """{"key": "value"}"""))
-        assertEquals("""{"key": "value"}""", testee.getConfig().javascriptConfigGooglePasswords)
+        configureFeature(config = Config(javascriptConfig = JavaScriptConfig(key = "value", domains = listOf("foo, bar"))))
+        assertEquals("""{"domains":["foo, bar"],"key":"value"}""", testee.getConfig().javascriptConfigGooglePasswords)
     }
 
     @SuppressLint("DenyListedApi")
-    private fun configureFeature(enabled: Boolean = true, config: Map<String, String> = emptyMap()) {
+    private fun configureFeature(enabled: Boolean = true, config: Config = Config()) {
         autofillFeature.canImportFromGooglePasswordManager().setRawStoredState(
             State(
                 remoteEnableState = enabled,
-                config = config,
+                config = adapter.toJson(config),
             ),
         )
     }
+
+    private data class Config(
+        val launchUrl: String? = null,
+        val javascriptConfig: JavaScriptConfig? = null,
+    )
+    private data class JavaScriptConfig(
+        val key: String,
+        val domains: List<String>,
+    )
 }

--- a/common/common-test/build.gradle
+++ b/common/common-test/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 
     implementation "io.reactivex.rxjava2:rxjava:_"
     implementation "io.reactivex.rxjava2:rxandroid:_"
+    implementation "com.squareup.moshi:moshi-kotlin:_"
     implementation Square.okHttp3.okHttp
     implementation KotlinX.coroutines.core
     // api because TestDispatcher is in the CoroutineTestRule public API

--- a/common/common-test/src/main/java/com/duckduckgo/common/test/json/JSONObjectAdapter.kt
+++ b/common/common-test/src/main/java/com/duckduckgo/common/test/json/JSONObjectAdapter.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.test.json
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.ToJson
+import okio.Buffer
+import org.json.JSONException
+import org.json.JSONObject
+
+class JSONObjectAdapter {
+
+    @FromJson
+    fun fromJson(reader: JsonReader): JSONObject? {
+        // Here we're expecting the JSON object, it is processed as Map<String, Any> by Moshi
+        return (reader.readJsonValue() as? Map<*, *>)?.let { data ->
+            try {
+                JSONObject(data)
+            } catch (e: JSONException) {
+                // Handle exception
+                return null
+            }
+        }
+    }
+
+    @ToJson
+    fun toJson(
+        writer: JsonWriter,
+        value: JSONObject?,
+    ) {
+        value?.let { writer.run { value(Buffer().writeUtf8(value.toString())) } }
+    }
+}

--- a/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureSettings.kt
+++ b/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureSettings.kt
@@ -15,7 +15,9 @@
  */
 package com.duckduckgo.feature.toggles.api
 
+@Deprecated(message = "Not needed anymore. Settings is now supported in top-leve and sub-features and Toggle#getSettings returns it")
 object FeatureSettings {
+    @Deprecated(message = "Not needed anymore. Settings is now supported in top-leve and sub-features and Toggle#getSettings returns it")
     interface Store {
         fun store(
             jsonString: String,

--- a/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureToggles.kt
+++ b/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureToggles.kt
@@ -194,9 +194,9 @@ interface Toggle {
     fun getRawStoredState(): State?
 
     /**
-     * @return a JSON string containing the config of the feature or null if not present in the remote config
+     * @return a JSON string containing the `settings`` of the feature or null if not present in the remote config
      */
-    fun getConfig(): String?
+    fun getSettings(): String?
 
     /**
      * @return a [Cohort] if one has been assigned or `null` otherwise.
@@ -224,7 +224,7 @@ interface Toggle {
         val metadataInfo: String? = null,
         val cohorts: List<Cohort> = emptyList(),
         val assignedCohort: Cohort? = null,
-        val config: String? = null,
+        val settings: String? = null,
     ) {
         data class Target(
             val variantKey: String?,
@@ -521,7 +521,7 @@ internal class ToggleImpl constructor(
         )
     }
 
-    override fun getConfig(): String? = store.get(key)?.config
+    override fun getSettings(): String? = store.get(key)?.settings
 
     override fun getCohort(): Cohort? {
         return store.get(key)?.assignedCohort

--- a/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureToggles.kt
+++ b/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureToggles.kt
@@ -194,9 +194,9 @@ interface Toggle {
     fun getRawStoredState(): State?
 
     /**
-     * @return a Map of <String, String> containing the config of the feature or an empty map
+     * @return a JSON string containing the config of the feature or null if not present in the remote config
      */
-    fun getConfig(): Map<String, String>
+    fun getConfig(): String?
 
     /**
      * @return a [Cohort] if one has been assigned or `null` otherwise.
@@ -224,7 +224,7 @@ interface Toggle {
         val metadataInfo: String? = null,
         val cohorts: List<Cohort> = emptyList(),
         val assignedCohort: Cohort? = null,
-        val config: Map<String, String> = emptyMap(),
+        val config: String? = null,
     ) {
         data class Target(
             val variantKey: String?,
@@ -521,7 +521,7 @@ internal class ToggleImpl constructor(
         )
     }
 
-    override fun getConfig(): Map<String, String> = store.get(key)?.config ?: emptyMap()
+    override fun getConfig(): String? = store.get(key)?.config
 
     override fun getCohort(): Cohort? {
         return store.get(key)?.assignedCohort

--- a/feature-toggles/feature-toggles-impl/lint-baseline.xml
+++ b/feature-toggles/feature-toggles-impl/lint-baseline.xml
@@ -8,7 +8,7 @@
         errorLine2="                                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="865"
+            line="867"
             column="68"/>
     </issue>
 
@@ -19,7 +19,7 @@
         errorLine2="                                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="900"
+            line="902"
             column="68"/>
     </issue>
 
@@ -30,7 +30,7 @@
         errorLine2="                                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="946"
+            line="948"
             column="68"/>
     </issue>
 
@@ -41,7 +41,7 @@
         errorLine2="                                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="951"
+            line="953"
             column="68"/>
     </issue>
 
@@ -52,7 +52,7 @@
         errorLine2="                                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1010"
+            line="1012"
             column="68"/>
     </issue>
 
@@ -63,7 +63,7 @@
         errorLine2="                                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1037"
+            line="1039"
             column="68"/>
     </issue>
 
@@ -74,7 +74,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1554"
+            line="1556"
             column="13"/>
     </issue>
 
@@ -85,7 +85,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1593"
+            line="1595"
             column="13"/>
     </issue>
 
@@ -96,7 +96,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1640"
+            line="1642"
             column="13"/>
     </issue>
 
@@ -107,7 +107,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1687"
+            line="1689"
             column="13"/>
     </issue>
 
@@ -118,7 +118,7 @@
         errorLine2="                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1716"
+            line="1718"
             column="56"/>
     </issue>
 
@@ -129,7 +129,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1778"
+            line="1780"
             column="13"/>
     </issue>
 
@@ -140,7 +140,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1787"
+            line="1789"
             column="13"/>
     </issue>
 
@@ -151,7 +151,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1795"
+            line="1797"
             column="13"/>
     </issue>
 
@@ -162,7 +162,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1854"
+            line="1856"
             column="13"/>
     </issue>
 
@@ -173,7 +173,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1863"
+            line="1865"
             column="13"/>
     </issue>
 
@@ -184,7 +184,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1919"
+            line="1921"
             column="13"/>
     </issue>
 
@@ -195,7 +195,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1928"
+            line="1930"
             column="13"/>
     </issue>
 
@@ -206,7 +206,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1969"
+            line="1971"
             column="13"/>
     </issue>
 
@@ -217,7 +217,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2010"
+            line="2012"
             column="13"/>
     </issue>
 
@@ -228,7 +228,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2051"
+            line="2053"
             column="13"/>
     </issue>
 
@@ -239,7 +239,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2092"
+            line="2094"
             column="13"/>
     </issue>
 
@@ -250,7 +250,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2123"
+            line="2125"
             column="13"/>
     </issue>
 
@@ -261,7 +261,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2153"
+            line="2155"
             column="13"/>
     </issue>
 
@@ -272,7 +272,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2183"
+            line="2185"
             column="13"/>
     </issue>
 
@@ -283,7 +283,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2225"
+            line="2227"
             column="13"/>
     </issue>
 
@@ -294,7 +294,7 @@
         errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2259"
+            line="2261"
             column="43"/>
     </issue>
 
@@ -305,7 +305,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2455"
+            line="2457"
             column="13"/>
     </issue>
 
@@ -316,7 +316,7 @@
         errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2505"
+            line="2507"
             column="23"/>
     </issue>
 
@@ -327,7 +327,7 @@
         errorLine2="                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2555"
+            line="2557"
             column="24"/>
     </issue>
 
@@ -338,7 +338,7 @@
         errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2561"
+            line="2563"
             column="20"/>
     </issue>
 
@@ -349,7 +349,7 @@
         errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2568"
+            line="2570"
             column="20"/>
     </issue>
 
@@ -360,7 +360,7 @@
         errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2617"
+            line="2619"
             column="23"/>
     </issue>
 
@@ -371,7 +371,7 @@
         errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2652"
+            line="2654"
             column="23"/>
     </issue>
 
@@ -382,7 +382,7 @@
         errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2681"
+            line="2683"
             column="20"/>
     </issue>
 
@@ -393,7 +393,7 @@
         errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2981"
+            line="2983"
             column="20"/>
     </issue>
 
@@ -404,7 +404,7 @@
         errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3025"
+            line="3027"
             column="20"/>
     </issue>
 
@@ -415,7 +415,7 @@
         errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3251"
+            line="3253"
             column="20"/>
     </issue>
 
@@ -426,7 +426,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3261"
+            line="3263"
             column="13"/>
     </issue>
 
@@ -437,7 +437,7 @@
         errorLine2="                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3305"
+            line="3307"
             column="32"/>
     </issue>
 
@@ -448,7 +448,7 @@
         errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3387"
+            line="3389"
             column="23"/>
     </issue>
 
@@ -459,7 +459,7 @@
         errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3431"
+            line="3433"
             column="19"/>
     </issue>
 
@@ -470,7 +470,7 @@
         errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3472"
+            line="3474"
             column="19"/>
     </issue>
 
@@ -481,51 +481,62 @@
         errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3516"
+            line="3518"
             column="19"/>
     </issue>
 
     <issue
         id="DenyListedApi"
         message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
-        errorLine1="        var stateConfig = testFeature.fooFeature().getRawStoredState()?.config!!"
+        errorLine1="        val topLevelStateConfig = testFeature.self().getRawStoredState()?.settings?.let { adapter.fromJson(it) } ?: emptyMap()"
+        errorLine2="                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
+            line="3594"
+            column="35"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="        var stateConfig = testFeature.fooFeature().getRawStoredState()?.settings?.let { adapter.fromJson(it) } ?: emptyMap()"
         errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3570"
+            line="3603"
             column="27"/>
     </issue>
 
     <issue
         id="DenyListedApi"
         message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
-        errorLine1="        stateConfig = testFeature.fooFeature().getRawStoredState()?.config!!"
+        errorLine1="        stateConfig = testFeature.fooFeature().getRawStoredState()?.settings?.let { adapter.fromJson(it) } ?: emptyMap()"
         errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3617"
+            line="3650"
             column="23"/>
     </issue>
 
     <issue
         id="DenyListedApi"
         message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
-        errorLine1="        stateConfig = testFeature.fooFeature().getRawStoredState()?.config!!"
+        errorLine1="        stateConfig = testFeature.fooFeature().getRawStoredState()?.settings?.let { adapter.fromJson(it) } ?: emptyMap()"
         errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3657"
+            line="3690"
             column="23"/>
     </issue>
 
     <issue
         id="DenyListedApi"
         message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
-        errorLine1="        stateConfig = testFeature.fooFeature().getRawStoredState()?.config!!"
+        errorLine1="        stateConfig = testFeature.fooFeature().getRawStoredState()?.settings?.let { adapter.fromJson(it) } ?: emptyMap()"
         errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3701"
+            line="3734"
             column="23"/>
     </issue>
 
@@ -536,7 +547,7 @@
         errorLine2="               ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3732"
+            line="3765"
             column="16"/>
     </issue>
 
@@ -855,7 +866,7 @@
         errorLine2="        ^">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/impl/MetricPixelInterceptorTest.kt"
-            line="48"
+            line="49"
             column="9"/>
     </issue>
 
@@ -866,7 +877,7 @@
         errorLine2="        ^">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/impl/MetricPixelInterceptorTest.kt"
-            line="74"
+            line="75"
             column="9"/>
     </issue>
 
@@ -877,7 +888,7 @@
         errorLine2="        ^">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/impl/MetricPixelInterceptorTest.kt"
-            line="100"
+            line="101"
             column="9"/>
     </issue>
 
@@ -888,7 +899,7 @@
         errorLine2="        ^">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/impl/MetricPixelInterceptorTest.kt"
-            line="126"
+            line="127"
             column="9"/>
     </issue>
 
@@ -899,7 +910,7 @@
         errorLine2="        ^">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/impl/MetricPixelInterceptorTest.kt"
-            line="152"
+            line="153"
             column="9"/>
     </issue>
 
@@ -910,7 +921,7 @@
         errorLine2="        ^">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/impl/MetricPixelInterceptorTest.kt"
-            line="182"
+            line="183"
             column="9"/>
     </issue>
 
@@ -921,7 +932,7 @@
         errorLine2="        ^">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/impl/MetricPixelInterceptorTest.kt"
-            line="208"
+            line="209"
             column="9"/>
     </issue>
 
@@ -932,7 +943,7 @@
         errorLine2="        ^">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/impl/MetricPixelInterceptorTest.kt"
-            line="234"
+            line="235"
             column="9"/>
     </issue>
 
@@ -943,7 +954,7 @@
         errorLine2="        ^">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/impl/MetricPixelInterceptorTest.kt"
-            line="260"
+            line="261"
             column="9"/>
     </issue>
 
@@ -965,7 +976,7 @@
         errorLine2="        ^">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt"
-            line="89"
+            line="168"
             column="9"/>
     </issue>
 
@@ -973,39 +984,6 @@
         id="DenyListedApi"
         message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
         errorLine1="        testFeature.fooFeature().setRawStoredState("
-        errorLine2="        ^">
-        <location
-            file="src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt"
-            line="96"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="DenyListedApi"
-        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
-        errorLine1="        testFeature.experimentFooFeature().setRawStoredState("
-        errorLine2="        ^">
-        <location
-            file="src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt"
-            line="131"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="DenyListedApi"
-        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
-        errorLine1="        testFeature.fooFeature().setRawStoredState("
-        errorLine2="        ^">
-        <location
-            file="src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt"
-            line="138"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="DenyListedApi"
-        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
-        errorLine1="        testFeature.experimentFooFeature().setRawStoredState("
         errorLine2="        ^">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt"
@@ -1016,11 +994,22 @@
     <issue
         id="DenyListedApi"
         message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="        testFeature.experimentFooFeature().setRawStoredState("
+        errorLine2="        ^">
+        <location
+            file="src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt"
+            line="192"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
         errorLine1="        testFeature.fooFeature().setRawStoredState("
         errorLine2="        ^">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt"
-            line="182"
+            line="199"
             column="9"/>
     </issue>
 
@@ -1031,7 +1020,7 @@
         errorLine2="        ^">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt"
-            line="202"
+            line="217"
             column="9"/>
     </issue>
 
@@ -1042,7 +1031,7 @@
         errorLine2="        ^">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt"
-            line="209"
+            line="224"
             column="9"/>
     </issue>
 
@@ -1053,7 +1042,7 @@
         errorLine2="        ^">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt"
-            line="229"
+            line="242"
             column="9"/>
     </issue>
 
@@ -1064,7 +1053,7 @@
         errorLine2="        ^">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt"
-            line="236"
+            line="249"
             column="9"/>
     </issue>
 
@@ -1075,7 +1064,7 @@
         errorLine2="        ^">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt"
-            line="273"
+            line="264"
             column="9"/>
     </issue>
 
@@ -1086,7 +1075,7 @@
         errorLine2="        ^">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/impl/metrics/RetentionMetricsAtbLifecyclePluginTest.kt"
-            line="280"
+            line="271"
             column="9"/>
     </issue>
 

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt
@@ -3542,10 +3542,21 @@ class ContributesRemoteFeatureCodeGeneratorTest {
                 {
                     "hash": "1",
                     "state": "disabled",
+                    "settings": {
+                        "foo": "foo/value",
+                        "bar": {
+                            "key": "value",
+                            "number": 2,
+                            "boolean": true,
+                            "complex": {
+                                "boolean": true
+                            }
+                        }
+                    },
                     "features": {
                         "fooFeature": {
                             "state": "enabled",
-                            "config": {
+                            "settings": {
                                 "foo": "foo/value",
                                 "bar": {
                                     "key": "value",
@@ -3580,8 +3591,17 @@ class ContributesRemoteFeatureCodeGeneratorTest {
             ),
         )
 
-        var stateConfig = testFeature.fooFeature().getRawStoredState()?.config?.let { adapter.fromJson(it) } ?: emptyMap()
-        var config = testFeature.fooFeature().getConfig()?.let { adapter.fromJson(it) } ?: emptyMap()
+        val topLevelStateConfig = testFeature.self().getRawStoredState()?.settings?.let { adapter.fromJson(it) } ?: emptyMap()
+        val topLevelConfig = testFeature.self().getSettings()?.let { adapter.fromJson(it) } ?: emptyMap()
+        assertTrue(topLevelStateConfig.size == 2)
+        assertEquals("foo/value", topLevelStateConfig["foo"])
+        assertEquals(mapOf("key" to "value", "number" to 2.0, "boolean" to true, "complex" to mapOf("boolean" to true)), topLevelStateConfig["bar"])
+        assertTrue(topLevelConfig.size == 2)
+        assertEquals("foo/value", topLevelConfig["foo"])
+        assertEquals(mapOf("key" to "value", "number" to 2.0, "boolean" to true, "complex" to mapOf("boolean" to true)), topLevelConfig["bar"])
+
+        var stateConfig = testFeature.fooFeature().getRawStoredState()?.settings?.let { adapter.fromJson(it) } ?: emptyMap()
+        var config = testFeature.fooFeature().getSettings()?.let { adapter.fromJson(it) } ?: emptyMap()
         assertTrue(stateConfig.size == 2)
         assertEquals("foo/value", stateConfig["foo"])
         assertEquals(mapOf("key" to "value", "number" to 2.0, "boolean" to true, "complex" to mapOf("boolean" to true)), stateConfig["bar"])
@@ -3600,7 +3620,7 @@ class ContributesRemoteFeatureCodeGeneratorTest {
                     "features": {
                         "fooFeature": {
                             "state": "enabled",
-                            "config": {
+                            "settings": {
                                 "foo": "foo/value"                                
                             },
                             "rollout": {
@@ -3627,8 +3647,8 @@ class ContributesRemoteFeatureCodeGeneratorTest {
             ),
         )
 
-        stateConfig = testFeature.fooFeature().getRawStoredState()?.config?.let { adapter.fromJson(it) } ?: emptyMap()
-        config = testFeature.fooFeature().getConfig()?.let { adapter.fromJson(it) } ?: emptyMap()
+        stateConfig = testFeature.fooFeature().getRawStoredState()?.settings?.let { adapter.fromJson(it) } ?: emptyMap()
+        config = testFeature.fooFeature().getSettings()?.let { adapter.fromJson(it) } ?: emptyMap()
         assertTrue(stateConfig.size == 1)
         assertEquals("foo/value", stateConfig["foo"])
         assertNull(stateConfig["bar"])
@@ -3667,8 +3687,8 @@ class ContributesRemoteFeatureCodeGeneratorTest {
             ),
         )
 
-        stateConfig = testFeature.fooFeature().getRawStoredState()?.config?.let { adapter.fromJson(it) } ?: emptyMap()
-        config = testFeature.fooFeature().getConfig()?.let { adapter.fromJson(it) } ?: emptyMap()
+        stateConfig = testFeature.fooFeature().getRawStoredState()?.settings?.let { adapter.fromJson(it) } ?: emptyMap()
+        config = testFeature.fooFeature().getSettings()?.let { adapter.fromJson(it) } ?: emptyMap()
         assertTrue(stateConfig.isEmpty())
         assertTrue(config.isEmpty())
 
@@ -3683,7 +3703,7 @@ class ContributesRemoteFeatureCodeGeneratorTest {
                     "features": {
                         "fooFeature": {
                             "state": "enabled",
-                            "config": {
+                            "settings": {
                                 "x": "x/value",
                                 "y": "y/value"
                             },
@@ -3711,8 +3731,8 @@ class ContributesRemoteFeatureCodeGeneratorTest {
             ),
         )
 
-        stateConfig = testFeature.fooFeature().getRawStoredState()?.config?.let { adapter.fromJson(it) } ?: emptyMap()
-        config = testFeature.fooFeature().getConfig()?.let { adapter.fromJson(it) } ?: emptyMap()
+        stateConfig = testFeature.fooFeature().getRawStoredState()?.settings?.let { adapter.fromJson(it) } ?: emptyMap()
+        config = testFeature.fooFeature().getSettings()?.let { adapter.fromJson(it) } ?: emptyMap()
         assertTrue(stateConfig.size == 2)
         assertEquals("x/value", stateConfig["x"])
         assertEquals("y/value", stateConfig["y"])

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt
@@ -36,6 +36,8 @@ import com.duckduckgo.feature.toggles.codegen.ContributesRemoteFeatureCodeGenera
 import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
 import dagger.Lazy
 import dagger.SingleInstanceIn
 import java.time.ZoneId
@@ -3525,6 +3527,10 @@ class ContributesRemoteFeatureCodeGeneratorTest {
 
     @Test
     fun `test config parsed correctly`() {
+        val moshi = Moshi.Builder().build()
+        val adapter = moshi.adapter<Map<String, Any>>(
+            Types.newParameterizedType(Map::class.java, String::class.java, Any::class.java),
+        )
         val feature = generatedFeatureNewInstance()
 
         val privacyPlugin = (feature as PrivacyFeaturePlugin)
@@ -3541,7 +3547,14 @@ class ContributesRemoteFeatureCodeGeneratorTest {
                             "state": "enabled",
                             "config": {
                                 "foo": "foo/value",
-                                "bar": "bar/value"
+                                "bar": {
+                                    "key": "value",
+                                    "number": 2,
+                                    "boolean": true,
+                                    "complex": {
+                                        "boolean": true
+                                    }
+                                }
                             },
                             "rollout": {
                                 "steps": [
@@ -3567,14 +3580,14 @@ class ContributesRemoteFeatureCodeGeneratorTest {
             ),
         )
 
-        var stateConfig = testFeature.fooFeature().getRawStoredState()?.config!!
-        var config = testFeature.fooFeature().getConfig()
+        var stateConfig = testFeature.fooFeature().getRawStoredState()?.config?.let { adapter.fromJson(it) } ?: emptyMap()
+        var config = testFeature.fooFeature().getConfig()?.let { adapter.fromJson(it) } ?: emptyMap()
         assertTrue(stateConfig.size == 2)
         assertEquals("foo/value", stateConfig["foo"])
-        assertEquals("bar/value", stateConfig["bar"])
+        assertEquals(mapOf("key" to "value", "number" to 2.0, "boolean" to true, "complex" to mapOf("boolean" to true)), stateConfig["bar"])
         assertTrue(config.size == 2)
         assertEquals("foo/value", config["foo"])
-        assertEquals("bar/value", config["bar"])
+        assertEquals(mapOf("key" to "value", "number" to 2.0, "boolean" to true, "complex" to mapOf("boolean" to true)), config["bar"])
 
         // Delete config key, should remove
         assertTrue(
@@ -3614,8 +3627,8 @@ class ContributesRemoteFeatureCodeGeneratorTest {
             ),
         )
 
-        stateConfig = testFeature.fooFeature().getRawStoredState()?.config!!
-        config = testFeature.fooFeature().getConfig()
+        stateConfig = testFeature.fooFeature().getRawStoredState()?.config?.let { adapter.fromJson(it) } ?: emptyMap()
+        config = testFeature.fooFeature().getConfig()?.let { adapter.fromJson(it) } ?: emptyMap()
         assertTrue(stateConfig.size == 1)
         assertEquals("foo/value", stateConfig["foo"])
         assertNull(stateConfig["bar"])
@@ -3623,7 +3636,7 @@ class ContributesRemoteFeatureCodeGeneratorTest {
         assertEquals("foo/value", config["foo"])
         assertNull(config["bar"])
 
-        // delete config, returns empty map
+        // delete config, returns empty
         assertTrue(
             privacyPlugin.store(
                 "testFeature",
@@ -3654,8 +3667,8 @@ class ContributesRemoteFeatureCodeGeneratorTest {
             ),
         )
 
-        stateConfig = testFeature.fooFeature().getRawStoredState()?.config!!
-        config = testFeature.fooFeature().getConfig()
+        stateConfig = testFeature.fooFeature().getRawStoredState()?.config?.let { adapter.fromJson(it) } ?: emptyMap()
+        config = testFeature.fooFeature().getConfig()?.let { adapter.fromJson(it) } ?: emptyMap()
         assertTrue(stateConfig.isEmpty())
         assertTrue(config.isEmpty())
 
@@ -3698,8 +3711,8 @@ class ContributesRemoteFeatureCodeGeneratorTest {
             ),
         )
 
-        stateConfig = testFeature.fooFeature().getRawStoredState()?.config!!
-        config = testFeature.fooFeature().getConfig()
+        stateConfig = testFeature.fooFeature().getRawStoredState()?.config?.let { adapter.fromJson(it) } ?: emptyMap()
+        config = testFeature.fooFeature().getConfig()?.let { adapter.fromJson(it) } ?: emptyMap()
         assertTrue(stateConfig.size == 2)
         assertEquals("x/value", stateConfig["x"])
         assertEquals("y/value", stateConfig["y"])


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1198194956794324/1208740919623939/f

### Description
We want to support `settings` for all top-level and sub-features because we can define schemas and validate them in the remote config

As a result we can remove the sub-feature `config`

### Steps to test this PR

_Test_
- [ ] test pass
- [ ] smoke test abn
- [ ] smoke test autofill

