### PR TITLE
add isSignedIn() to Subscriptions interface

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/view/message/PProUpsellBannerPlugin.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/view/message/PProUpsellBannerPlugin.kt
@@ -89,10 +89,6 @@ class PProUpsellBannerPlugin @Inject constructor(
         startActivity(browserNav.openInNewTab(this, PPRO_UPSELL_URL))
     }
 
-    private suspend fun Subscriptions.isUpsellEligible(): Boolean {
-        return getAccessToken() == null && isEligible()
-    }
-
     companion object {
         internal const val PRIORITY_PPRO_UPSELL_BANNER = PRIORITY_ACTION_REQUIRED - 1
         private const val PPRO_UPSELL_URL = "https://duckduckgo.com/pro?origin=funnel_pro_android_apptp_banner"

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/view/message/PproUpsellDisabledMessagePlugin.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/view/message/PproUpsellDisabledMessagePlugin.kt
@@ -72,10 +72,6 @@ class PproUpsellDisabledMessagePlugin @Inject constructor(
         startActivity(browserNav.openInNewTab(this, PPRO_UPSELL_URL))
     }
 
-    private suspend fun Subscriptions.isUpsellEligible(): Boolean {
-        return getAccessToken() == null && isEligible()
-    }
-
     companion object {
         internal const val PRIORITY_PPRO_DISABLED = PRIORITY_DISABLED - 1
         private const val PPRO_UPSELL_ANNOTATION = "ppro_upsell_link"

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/view/message/PproUpsellRevokedMessagePlugin.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/view/message/PproUpsellRevokedMessagePlugin.kt
@@ -70,10 +70,6 @@ class PproUpsellRevokedMessagePlugin @Inject constructor(
         startActivity(browserNav.openInNewTab(this, PPRO_UPSELL_URL))
     }
 
-    private suspend fun Subscriptions.isUpsellEligible(): Boolean {
-        return getAccessToken() == null && isEligible()
-    }
-
     companion object {
         internal const val PRIORITY_PPRO_REVOKED = PRIORITY_REVOKED - 1
         private const val PPRO_UPSELL_ANNOTATION = "ppro_upsell_link"

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/view/message/SubscriptionsExt.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/view/message/SubscriptionsExt.kt
@@ -19,5 +19,5 @@ package com.duckduckgo.mobile.android.vpn.ui.tracker_activity.view.message
 import com.duckduckgo.subscriptions.api.Subscriptions
 
 suspend fun Subscriptions.isUpsellEligible(): Boolean {
-    return getAccessToken() == null && isEligible()
+    return !isSignedIn() && isEligible()
 }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/view/message/SubscriptionsExt.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/view/message/SubscriptionsExt.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.ui.tracker_activity.view.message
+
+import com.duckduckgo.subscriptions.api.Subscriptions
+
+suspend fun Subscriptions.isUpsellEligible(): Boolean {
+    return getAccessToken() == null && isEligible()
+}

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/view/message/PProUpsellBannerPluginTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/view/message/PProUpsellBannerPluginTest.kt
@@ -35,6 +35,7 @@ class PProUpsellBannerPluginTest {
     @Test
     fun whenVPNIsDisabledAndUserNotEligibleToPProThenGetViewReturnsNull() = runTest {
         whenever(subscriptions.isEligible()).thenReturn(false)
+        whenever(subscriptions.isSignedIn()).thenReturn(false)
 
         val result = plugin.getView(context, VpnState(state = DISABLED)) {}
 
@@ -44,7 +45,7 @@ class PProUpsellBannerPluginTest {
     @Test
     fun whenVPNIsEnabledAndUserIsSubscriberToPProThenGetViewReturnsNull() = runTest {
         whenever(subscriptions.isEligible()).thenReturn(true)
-        whenever(subscriptions.getAccessToken()).thenReturn("123")
+        whenever(subscriptions.isSignedIn()).thenReturn(true)
 
         val result = plugin.getView(context, VpnState(state = ENABLED)) {}
 
@@ -54,7 +55,7 @@ class PProUpsellBannerPluginTest {
     @Test
     fun whenBannerDismissedThenGetViewReturnsNull() = runTest {
         whenever(subscriptions.isEligible()).thenReturn(true)
-        whenever(subscriptions.getAccessToken()).thenReturn(null)
+        whenever(subscriptions.isSignedIn()).thenReturn(false)
         vpnStore.dismissPproUpsellBanner()
 
         val result = plugin.getView(context, VpnState(state = ENABLED)) {}

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/view/message/PproUpsellDisabledMessagePluginTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/view/message/PproUpsellDisabledMessagePluginTest.kt
@@ -39,6 +39,7 @@ class PproUpsellDisabledMessagePluginTest {
     fun whenVPNIsDisabledWith3rdPartyOnAndUserNotEligibleToPProThenGetViewReturnsNull() = runTest {
         whenever(vpnDetector.isExternalVpnDetected()).thenReturn(true)
         whenever(subscriptions.isEligible()).thenReturn(false)
+        whenever(subscriptions.isSignedIn()).thenReturn(false)
 
         val result = plugin.getView(context, VpnState(state = DISABLED, stopReason = SELF_STOP())) {}
 
@@ -49,7 +50,7 @@ class PproUpsellDisabledMessagePluginTest {
     fun whenVPNIsDisabledWith3rdPartyOnAndUserIsSubscriberToPProThenGetViewReturnsNull() = runTest {
         whenever(vpnDetector.isExternalVpnDetected()).thenReturn(true)
         whenever(subscriptions.isEligible()).thenReturn(true)
-        whenever(subscriptions.getAccessToken()).thenReturn("123")
+        whenever(subscriptions.isSignedIn()).thenReturn(true)
 
         val result = plugin.getView(context, VpnState(state = DISABLED, stopReason = SELF_STOP())) {}
 
@@ -60,7 +61,7 @@ class PproUpsellDisabledMessagePluginTest {
     fun whenVPNIsDisabledWith3rdPartyOnAndUserIsEligibleToPproThenGetViewReturnsNotNull() = runTest {
         whenever(vpnDetector.isExternalVpnDetected()).thenReturn(true)
         whenever(subscriptions.isEligible()).thenReturn(true)
-        whenever(subscriptions.getAccessToken()).thenReturn(null)
+        whenever(subscriptions.isSignedIn()).thenReturn(false)
 
         val result = plugin.getView(context, VpnState(state = DISABLED, stopReason = SELF_STOP())) {}
 
@@ -71,7 +72,7 @@ class PproUpsellDisabledMessagePluginTest {
     fun whenVPNIsDisabledBy3rdPartyOnAndUserIsEligibleToPproThenGetViewReturnsNull() = runTest {
         whenever(vpnDetector.isExternalVpnDetected()).thenReturn(true)
         whenever(subscriptions.isEligible()).thenReturn(true)
-        whenever(subscriptions.getAccessToken()).thenReturn(null)
+        whenever(subscriptions.isSignedIn()).thenReturn(false)
 
         val result = plugin.getView(context, VpnState(state = DISABLED, stopReason = REVOKED)) {}
 
@@ -82,7 +83,7 @@ class PproUpsellDisabledMessagePluginTest {
     fun whenVPNIsEnablingWith3rdPartyOnAndUserIsEligibleToPproThenGetViewReturnsNull() = runTest {
         whenever(vpnDetector.isExternalVpnDetected()).thenReturn(true)
         whenever(subscriptions.isEligible()).thenReturn(true)
-        whenever(subscriptions.getAccessToken()).thenReturn(null)
+        whenever(subscriptions.isSignedIn()).thenReturn(false)
 
         val result = plugin.getView(context, VpnState(state = ENABLING)) {}
 
@@ -93,7 +94,7 @@ class PproUpsellDisabledMessagePluginTest {
     fun whenVPNIsEnabledAndUserIsEligibleToPproThenGetViewReturnsNull() = runTest {
         whenever(vpnDetector.isExternalVpnDetected()).thenReturn(true)
         whenever(subscriptions.isEligible()).thenReturn(true)
-        whenever(subscriptions.getAccessToken()).thenReturn(null)
+        whenever(subscriptions.isSignedIn()).thenReturn(false)
 
         val result = plugin.getView(context, VpnState(state = ENABLED)) {}
 

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/view/message/PproUpsellRevokedMessagePluginTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/view/message/PproUpsellRevokedMessagePluginTest.kt
@@ -36,6 +36,7 @@ class PproUpsellRevokedMessagePluginTest {
     @Test
     fun whenVPNIsDisabledBy3rdPartyAndUserNotEligibleToPProThenGetViewReturnsNull() = runTest {
         whenever(subscriptions.isEligible()).thenReturn(false)
+        whenever(subscriptions.isSignedIn()).thenReturn(false)
 
         val result = plugin.getView(context, VpnState(state = DISABLED, stopReason = REVOKED)) {}
 
@@ -45,7 +46,7 @@ class PproUpsellRevokedMessagePluginTest {
     @Test
     fun whenVPNIsDisabledBy3rdPartyOnAndUserIsSubscriberToPProThenGetViewReturnsNull() = runTest {
         whenever(subscriptions.isEligible()).thenReturn(true)
-        whenever(subscriptions.getAccessToken()).thenReturn("123")
+        whenever(subscriptions.isSignedIn()).thenReturn(true)
 
         val result = plugin.getView(context, VpnState(state = DISABLED, stopReason = REVOKED)) {}
 
@@ -55,7 +56,7 @@ class PproUpsellRevokedMessagePluginTest {
     @Test
     fun whenVPNIsDisabledBy3rdPartyOnAndUserIsEligibleToPproThenGetViewReturnsNotNull() = runTest {
         whenever(subscriptions.isEligible()).thenReturn(true)
-        whenever(subscriptions.getAccessToken()).thenReturn(null)
+        whenever(subscriptions.isSignedIn()).thenReturn(false)
 
         val result = plugin.getView(context, VpnState(state = DISABLED, stopReason = REVOKED)) {}
 
@@ -65,7 +66,7 @@ class PproUpsellRevokedMessagePluginTest {
     @Test
     fun whenVPNIsDisabledByUserAndUserIsEligibleToPproThenGetViewReturnsNull() = runTest {
         whenever(subscriptions.isEligible()).thenReturn(true)
-        whenever(subscriptions.getAccessToken()).thenReturn(null)
+        whenever(subscriptions.isSignedIn()).thenReturn(false)
 
         val result = plugin.getView(context, VpnState(state = DISABLED, stopReason = SELF_STOP())) {}
 
@@ -75,7 +76,7 @@ class PproUpsellRevokedMessagePluginTest {
     @Test
     fun whenVPNIsEnablingAndUserIsEligibleToPproThenGetViewReturnsNull() = runTest {
         whenever(subscriptions.isEligible()).thenReturn(true)
-        whenever(subscriptions.getAccessToken()).thenReturn(null)
+        whenever(subscriptions.isSignedIn()).thenReturn(false)
 
         val result = plugin.getView(context, VpnState(state = ENABLING)) {}
 
@@ -85,7 +86,7 @@ class PproUpsellRevokedMessagePluginTest {
     @Test
     fun whenVPNIsEnabledAndUserIsEligibleToPproThenGetViewReturnsNull() = runTest {
         whenever(subscriptions.isEligible()).thenReturn(true)
-        whenever(subscriptions.getAccessToken()).thenReturn(null)
+        whenever(subscriptions.isSignedIn()).thenReturn(false)
 
         val result = plugin.getView(context, VpnState(state = ENABLED)) {}
 

--- a/subscriptions/subscriptions-api/src/main/java/com/duckduckgo/subscriptions/api/Subscriptions.kt
+++ b/subscriptions/subscriptions-api/src/main/java/com/duckduckgo/subscriptions/api/Subscriptions.kt
@@ -23,6 +23,15 @@ import kotlinx.coroutines.flow.Flow
 interface Subscriptions {
 
     /**
+     * Checks if the user is currently signed in.
+     *
+     * Note: A signed-in user does not necessarily have an active subscription.
+     *
+     * @return `true` if the user is signed in; `false` otherwise
+     */
+    suspend fun isSignedIn(): Boolean
+
+    /**
      * This method returns a [String] with the access token for the authenticated user or [null] if it doesn't exist
      * or any errors arise.
      * @return [String]

--- a/subscriptions/subscriptions-dummy-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsDummy.kt
+++ b/subscriptions/subscriptions-dummy-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsDummy.kt
@@ -30,6 +30,8 @@ import kotlinx.coroutines.flow.flowOf
 
 @ContributesBinding(AppScope::class)
 class SubscriptionsDummy @Inject constructor() : Subscriptions {
+    override suspend fun isSignedIn(): Boolean = false
+
     override suspend fun getAccessToken(): String? = null
 
     override fun getEntitlementStatus(): Flow<List<Product>> = flowOf(emptyList())

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -59,6 +59,9 @@ class RealSubscriptions @Inject constructor(
     private val globalActivityStarter: GlobalActivityStarter,
     private val pixel: SubscriptionPixelSender,
 ) : Subscriptions {
+    override suspend fun isSignedIn(): Boolean =
+        subscriptionsManager.isSignedIn()
+
     override suspend fun getAccessToken(): String? {
         return when (val result = subscriptionsManager.getAccessToken()) {
             is AccessTokenResult.Success -> result.accessToken

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
@@ -133,6 +133,11 @@ interface SubscriptionsManager {
     suspend fun subscriptionStatus(): SubscriptionStatus
 
     /**
+     * Checks if user is signed in or not
+     */
+    suspend fun isSignedIn(): Boolean
+
+    /**
      * Flow to know if a user is signed in or not
      */
     val isSignedIn: Flow<Boolean>
@@ -205,7 +210,7 @@ class RealSubscriptionsManager @Inject constructor(
 
     private var removeExpiredSubscriptionOnCancelledPurchase: Boolean = false
 
-    private suspend fun isSignedIn(): Boolean {
+    override suspend fun isSignedIn(): Boolean {
         return !authRepository.getAuthToken().isNullOrBlank() && !authRepository.getAccessToken().isNullOrBlank()
     }
 

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/rmf/RMFPProSubscriberMatchingAttribute.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/rmf/RMFPProSubscriberMatchingAttribute.kt
@@ -40,7 +40,7 @@ class RMFPProSubscriberMatchingAttribute @Inject constructor(
 ) : JsonToMatchingAttributeMapper, AttributeMatcherPlugin {
     override suspend fun evaluate(matchingAttribute: MatchingAttribute): Boolean? {
         return when (matchingAttribute) {
-            is ProSubscriberMatchingAttribute -> subscriptions.isSubscribed() == matchingAttribute.remoteValue
+            is ProSubscriberMatchingAttribute -> subscriptions.isSignedIn() == matchingAttribute.remoteValue
             else -> null
         }
     }
@@ -57,10 +57,6 @@ class RMFPProSubscriberMatchingAttribute @Inject constructor(
             }
             else -> null
         }
-    }
-
-    private suspend fun Subscriptions.isSubscribed(): Boolean {
-        return getAccessToken() != null
     }
 }
 

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/rmf/RMFPProSubscriberMatchingAttributeTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/rmf/RMFPProSubscriberMatchingAttributeTest.kt
@@ -16,10 +16,10 @@ class RMFPProSubscriberMatchingAttributeTest {
 
     @Test
     fun evaluateWithWrongAttributeThenNull() = runTest {
-        whenever(subscriptions.getAccessToken()).thenReturn(null)
+        whenever(subscriptions.isSignedIn()).thenReturn(false)
         Assert.assertNull(attribute.evaluate(FakeStringMatchingAttribute { "" }))
 
-        whenever(subscriptions.getAccessToken()).thenReturn("token")
+        whenever(subscriptions.isSignedIn()).thenReturn(true)
         Assert.assertNull(attribute.evaluate(FakeStringMatchingAttribute { "" }))
 
         Assert.assertNull(attribute.map("wrong", JsonMatchingAttribute(value = false)))
@@ -28,16 +28,16 @@ class RMFPProSubscriberMatchingAttributeTest {
 
     @Test
     fun evaluateWithProEligibleMatchingAttributeThenValue() = runTest {
-        whenever(subscriptions.getAccessToken()).thenReturn(null)
+        whenever(subscriptions.isSignedIn()).thenReturn(false)
         Assert.assertTrue(attribute.evaluate(attribute.map("pproSubscriber", JsonMatchingAttribute(value = false))!!)!!)
 
-        whenever(subscriptions.getAccessToken()).thenReturn("token")
+        whenever(subscriptions.isSignedIn()).thenReturn(true)
         Assert.assertTrue(attribute.evaluate(attribute.map("pproSubscriber", JsonMatchingAttribute(value = true))!!)!!)
 
-        whenever(subscriptions.getAccessToken()).thenReturn(null)
+        whenever(subscriptions.isSignedIn()).thenReturn(false)
         Assert.assertFalse(attribute.evaluate(attribute.map("pproSubscriber", JsonMatchingAttribute(value = true))!!)!!)
 
-        whenever(subscriptions.getAccessToken()).thenReturn("token")
+        whenever(subscriptions.isSignedIn()).thenReturn(true)
         Assert.assertFalse(attribute.evaluate(attribute.map("pproSubscriber", JsonMatchingAttribute(value = false))!!)!!)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205648422731273/1208750628818068/f

### Description

This is a preparation for the upcoming behavior change of getAccessToken() - it will no longer guarantee a non-null response for a signed-in user.

### Steps to test this PR

QA-optional

### No UI changes
