### PR TITLE
Ask user to swith account when reading code while signed in

### DIFF
--- a/sync/sync-impl/lint-baseline.xml
+++ b/sync/sync-impl/lint-baseline.xml
@@ -102,6 +102,28 @@
 
     <issue
         id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="        this.seamlessAccountSwitching().setRawStoredState(State(true))"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt"
+            line="62"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="        syncFeature.seamlessAccountSwitching().setRawStoredState(State(false))"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt"
+            line="136"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
         message="No one remembers what these constants map to. Use the API level integer value directly since it&apos;s self-defining."
         errorLine1="                if (appBuildConfig.sdkInt >= Build.VERSION_CODES.Q) {"
         errorLine2="                                             ~~~~~~~~~~~~~~~~~~~~~">
@@ -373,6 +395,28 @@
             file="src/test/java/com/duckduckgo/sync/impl/SyncRemoteFeatureToggleTest.kt"
             line="194"
             column="16"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="        this.seamlessAccountSwitching().setRawStoredState(State(true))"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt"
+            line="62"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="        syncFeature.seamlessAccountSwitching().setRawStoredState(State(false))"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt"
+            line="135"
+            column="9"/>
     </issue>
 
     <issue

--- a/sync/sync-impl/lint-baseline.xml
+++ b/sync/sync-impl/lint-baseline.xml
@@ -36,6 +36,17 @@
 
     <issue
         id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="        this.seamlessAccountSwitching().setRawStoredState(State(true))"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt"
+            line="100"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
         message="No one remembers what these constants map to. Use the API level integer value directly since it&apos;s self-defining."
         errorLine1="        return if (appBuildConfig.sdkInt != Build.VERSION_CODES.Q &amp;&amp; appBuildConfig.sdkInt != Build.VERSION_CODES.P) {"
         errorLine2="                                            ~~~~~~~~~~~~~~~~~~~~~">
@@ -107,7 +118,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt"
-            line="62"
+            line="63"
             column="9"/>
     </issue>
 
@@ -118,7 +129,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt"
-            line="136"
+            line="137"
             column="9"/>
     </issue>
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
@@ -74,7 +74,10 @@ class AppSyncAccountRepository @Inject constructor(
     private val syncPixels: SyncPixels,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
+    private val syncFeature: SyncFeature,
 ) : SyncAccountRepository {
+
+    private val connectedDevicesCached: MutableList<ConnectedDevice> = mutableListOf()
 
     override fun isSyncSupported(): Boolean {
         return syncStore.isEncryptionSupported()
@@ -108,9 +111,20 @@ class AppSyncAccountRepository @Inject constructor(
     }
 
     private fun login(recoveryCode: RecoveryCode): Result<Boolean> {
+        var wasUserLogout = false
         if (isSignedIn()) {
-            return Error(code = ALREADY_SIGNED_IN.code, reason = "Already signed in")
-                .alsoFireAlreadySignedInErrorPixel()
+            val allowSwitchAccount = syncFeature.seamlessAccountSwitching().isEnabled()
+            val error = Error(code = ALREADY_SIGNED_IN.code, reason = "Already signed in").alsoFireAlreadySignedInErrorPixel()
+            if (allowSwitchAccount && connectedDevicesCached.size == 1) {
+                val thisDeviceId = syncStore.deviceId.orEmpty()
+                val result = logout(thisDeviceId)
+                if (result is Error) {
+                    return result
+                }
+                wasUserLogout = true
+            } else {
+                return error
+            }
         }
 
         val primaryKey = recoveryCode.primaryKey
@@ -120,6 +134,9 @@ class AppSyncAccountRepository @Inject constructor(
 
         return performLogin(userId, deviceId, deviceName, primaryKey).onFailure {
             it.alsoFireLoginErrorPixel()
+            if (wasUserLogout) {
+                syncPixels.fireUserSwitchedLoginError()
+            }
             return it.copy(code = LOGIN_FAILED.code)
         }
     }
@@ -288,6 +305,7 @@ class AppSyncAccountRepository @Inject constructor(
 
         return when (val result = syncApi.getDevices(token)) {
             is Error -> {
+                connectedDevicesCached.clear()
                 result.alsoFireAccountErrorPixel().copy(code = GENERIC_ERROR.code)
             }
 
@@ -315,6 +333,11 @@ class AppSyncAccountRepository @Inject constructor(
                         }
                     }.sortedWith { a, b ->
                         if (a.thisDevice) -1 else 1
+                    }.also {
+                        connectedDevicesCached.apply {
+                            clear()
+                            addAll(it)
+                        }
                     },
                 )
             }
@@ -326,8 +349,17 @@ class AppSyncAccountRepository @Inject constructor(
     override fun logoutAndJoinNewAccount(stringCode: String): Result<Boolean> {
         val thisDeviceId = syncStore.deviceId.orEmpty()
         return when (val result = logout(thisDeviceId)) {
-            is Error -> result
-            is Result.Success -> processCode(stringCode)
+            is Error -> {
+                syncPixels.fireUserSwitchedLogoutError()
+                result
+            }
+            is Result.Success -> {
+                val loginResult = processCode(stringCode)
+                if (loginResult is Error) {
+                    syncPixels.fireUserSwitchedLoginError()
+                }
+                loginResult
+            }
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
@@ -45,6 +45,6 @@ interface SyncFeature {
     @Toggle.DefaultValue(true)
     fun gzipPatchRequests(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(true)
     fun seamlessAccountSwitching(): Toggle
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.sync.impl
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.InternalAlwaysEnabled
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
@@ -43,4 +44,7 @@ interface SyncFeature {
 
     @Toggle.DefaultValue(true)
     fun gzipPatchRequests(): Toggle
+
+    @Toggle.DefaultValue(false)
+    fun seamlessAccountSwitching(): Toggle
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixelParamRemovalPlugin.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixelParamRemovalPlugin.kt
@@ -35,6 +35,13 @@ class SyncPixelParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugi
             SyncPixelName.SYNC_GET_OTHER_DEVICES_SCREEN_SHOWN.pixelName to PixelParameter.removeAtb(),
             SyncPixelName.SYNC_GET_OTHER_DEVICES_LINK_COPIED.pixelName to PixelParameter.removeAtb(),
             SyncPixelName.SYNC_GET_OTHER_DEVICES_LINK_SHARED.pixelName to PixelParameter.removeAtb(),
+
+            SyncPixelName.SYNC_ASK_USER_TO_SWITCH_ACCOUNT.pixelName to PixelParameter.removeAtb(),
+            SyncPixelName.SYNC_USER_ACCEPTED_SWITCHING_ACCOUNT.pixelName to PixelParameter.removeAtb(),
+            SyncPixelName.SYNC_USER_CANCELLED_SWITCHING_ACCOUNT.pixelName to PixelParameter.removeAtb(),
+            SyncPixelName.SYNC_USER_SWITCHED_ACCOUNT.pixelName to PixelParameter.removeAtb(),
+            SyncPixelName.SYNC_USER_SWITCHED_LOGOUT_ERROR.pixelName to PixelParameter.removeAtb(),
+            SyncPixelName.SYNC_USER_SWITCHED_LOGIN_ERROR.pixelName to PixelParameter.removeAtb(),
         )
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
@@ -81,6 +81,13 @@ interface SyncPixels {
         feature: SyncableType,
         apiError: Error,
     )
+
+    fun fireAskUserToSwitchAccount()
+    fun fireUserAcceptedSwitchingAccount()
+    fun fireUserCancelledSwitchingAccount()
+    fun fireUserSwitchedAccount()
+    fun fireUserSwitchedLogoutError()
+    fun fireUserSwitchedLoginError()
 }
 
 @ContributesBinding(AppScope::class)
@@ -255,6 +262,30 @@ class RealSyncPixels @Inject constructor(
         }
     }
 
+    override fun fireUserSwitchedAccount() {
+        pixel.fire(SyncPixelName.SYNC_USER_SWITCHED_ACCOUNT)
+    }
+
+    override fun fireAskUserToSwitchAccount() {
+        pixel.fire(SyncPixelName.SYNC_ASK_USER_TO_SWITCH_ACCOUNT)
+    }
+
+    override fun fireUserAcceptedSwitchingAccount() {
+        pixel.fire(SyncPixelName.SYNC_USER_ACCEPTED_SWITCHING_ACCOUNT)
+    }
+
+    override fun fireUserCancelledSwitchingAccount() {
+        pixel.fire(SyncPixelName.SYNC_USER_CANCELLED_SWITCHING_ACCOUNT)
+    }
+
+    override fun fireUserSwitchedLoginError() {
+        pixel.fire(SyncPixelName.SYNC_USER_SWITCHED_LOGIN_ERROR)
+    }
+
+    override fun fireUserSwitchedLogoutError() {
+        pixel.fire(SyncPixelName.SYNC_USER_SWITCHED_LOGOUT_ERROR)
+    }
+
     companion object {
         private const val SYNC_PIXELS_PREF_FILE = "com.duckduckgo.sync.pixels.v1"
     }
@@ -302,6 +333,12 @@ enum class SyncPixelName(override val pixelName: String) : Pixel.PixelName {
     SYNC_GET_OTHER_DEVICES_SCREEN_SHOWN("sync_get_other_devices"),
     SYNC_GET_OTHER_DEVICES_LINK_COPIED("sync_get_other_devices_copy"),
     SYNC_GET_OTHER_DEVICES_LINK_SHARED("sync_get_other_devices_share"),
+    SYNC_ASK_USER_TO_SWITCH_ACCOUNT("sync_ask_user_to_switch_account"),
+    SYNC_USER_ACCEPTED_SWITCHING_ACCOUNT("sync_user_accepted_switching_account"),
+    SYNC_USER_CANCELLED_SWITCHING_ACCOUNT("sync_user_cancelled_switching_account"),
+    SYNC_USER_SWITCHED_ACCOUNT("sync_user_switched_account"),
+    SYNC_USER_SWITCHED_LOGOUT_ERROR("sync_user_switched_logout_error"),
+    SYNC_USER_SWITCHED_LOGIN_ERROR("sync_user_switched_login_error"),
 }
 
 object SyncPixelParameters {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
@@ -131,6 +131,7 @@ class EnterCodeActivity : DuckDuckGoActivity() {
     }
 
     private fun askUserToSwitchAccount(it: AskToSwitchAccount) {
+        viewModel.onUserAskedToSwitchAccount()
         TextAlertDialogBuilder(this)
             .setTitle(R.string.sync_dialog_switch_account_header)
             .setMessage(R.string.sync_dialog_switch_account_description)
@@ -140,6 +141,10 @@ class EnterCodeActivity : DuckDuckGoActivity() {
                 object : TextAlertDialogBuilder.EventListener() {
                     override fun onPositiveButtonClicked() {
                         viewModel.onUserAcceptedJoiningNewAccount(it.encodedStringCode)
+                    }
+
+                    override fun onNegativeButtonClicked() {
+                        viewModel.onUserCancelledJoiningNewAccount()
                     }
                 },
             ).show()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
@@ -132,7 +132,7 @@ class EnterCodeActivity : DuckDuckGoActivity() {
 
     private fun askUserToSwitchAccount(it: AskToSwitchAccount) {
         TextAlertDialogBuilder(this)
-            .setTitle(R.string.sync_dialog_error_title)
+            .setTitle(R.string.sync_dialog_switch_account_header)
             .setMessage(R.string.sync_dialog_switch_account_description)
             .setPositiveButton(R.string.sync_dialog_switch_account_primary_button)
             .setNegativeButton(R.string.sync_dialog_switch_account_secondary_button)

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
@@ -36,8 +36,10 @@ import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.AuthState
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.AuthState.Idle
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.AuthState.Loading
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command
-import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.LoginSucess
+import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.AskToSwitchAccount
+import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.LoginSuccess
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.ShowError
+import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.SwitchAccountSuccess
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.ViewState
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -96,13 +98,21 @@ class EnterCodeActivity : DuckDuckGoActivity() {
 
     private fun processCommand(command: Command) {
         when (command) {
-            LoginSucess -> {
+            LoginSuccess -> {
                 setResult(RESULT_OK)
                 finish()
             }
 
             is ShowError -> {
                 showError(command)
+            }
+
+            is AskToSwitchAccount -> askUserToSwitchAccount(command)
+            SwitchAccountSuccess -> {
+                val resultIntent = Intent()
+                resultIntent.putExtra(EXTRA_USER_SWITCHED_ACCOUNT, true)
+                setResult(RESULT_OK, resultIntent)
+                finish()
             }
         }
     }
@@ -120,6 +130,21 @@ class EnterCodeActivity : DuckDuckGoActivity() {
             ).show()
     }
 
+    private fun askUserToSwitchAccount(it: AskToSwitchAccount) {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_dialog_error_title)
+            .setMessage(R.string.sync_dialog_switch_account_description)
+            .setPositiveButton(R.string.sync_dialog_switch_account_primary_button)
+            .setNegativeButton(R.string.sync_dialog_switch_account_secondary_button)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() {
+                        viewModel.onUserAcceptedJoiningNewAccount(it.encodedStringCode)
+                    }
+                },
+            ).show()
+    }
+
     companion object {
         enum class Code {
             RECOVERY_CODE,
@@ -127,6 +152,8 @@ class EnterCodeActivity : DuckDuckGoActivity() {
         }
 
         private const val EXTRA_CODE_TYPE = "codeType"
+
+        const val EXTRA_USER_SWITCHED_ACCOUNT = "userSwitchedAccount"
 
         internal fun intent(context: Context, codeType: Code): Intent {
             return Intent(context, EnterCodeActivity::class.java).apply {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.AskToSwitchAccount
+import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.LoginSuccess
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.ShowError
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.SwitchAccountSuccess
 import javax.inject.*
@@ -90,9 +91,17 @@ class EnterCodeViewModel @Inject constructor(
     private suspend fun authFlow(
         pastedCode: String,
     ) {
-        val result = syncAccountRepository.processCode(pastedCode)
-        when (result) {
-            is Result.Success -> command.send(Command.LoginSuccess)
+        val userSignedIn = syncAccountRepository.isSignedIn()
+        when (val result = syncAccountRepository.processCode(pastedCode)) {
+            is Result.Success -> {
+                val commandSuccess = if (userSignedIn) {
+                    syncPixels.fireUserSwitchedAccount()
+                    SwitchAccountSuccess
+                } else {
+                    LoginSuccess
+                }
+                command.send(commandSuccess)
+            }
             is Result.Error -> {
                 processError(result, pastedCode)
             }
@@ -128,6 +137,7 @@ class EnterCodeViewModel @Inject constructor(
 
     fun onUserAcceptedJoiningNewAccount(encodedStringCode: String) {
         viewModelScope.launch(dispatchers.io()) {
+            syncPixels.fireUserAcceptedSwitchingAccount()
             val result = syncAccountRepository.logoutAndJoinNewAccount(encodedStringCode)
             if (result is Error) {
                 when (result.code) {
@@ -143,9 +153,17 @@ class EnterCodeViewModel @Inject constructor(
                     )
                 }
             } else {
-                syncPixels.fireLoginPixel()
+                syncPixels.fireUserSwitchedAccount()
                 command.send(SwitchAccountSuccess)
             }
         }
+    }
+
+    fun onUserCancelledJoiningNewAccount() {
+        syncPixels.fireUserCancelledSwitchingAccount()
+    }
+
+    fun onUserAskedToSwitchAccount() {
+        syncPixels.fireAskUserToSwitchAccount()
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
@@ -30,8 +30,13 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
 import com.duckduckgo.sync.impl.Clipboard
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.Result
+import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.SyncAccountRepository
+import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.AskToSwitchAccount
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.ShowError
+import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.SwitchAccountSuccess
 import javax.inject.*
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.channels.Channel
@@ -45,6 +50,8 @@ class EnterCodeViewModel @Inject constructor(
     private val syncAccountRepository: SyncAccountRepository,
     private val clipboard: Clipboard,
     private val dispatchers: DispatcherProvider,
+    private val syncFeature: SyncFeature,
+    private val syncPixels: SyncPixels,
 ) : ViewModel() {
 
     private val command = Channel<Command>(1, DROP_OLDEST)
@@ -66,8 +73,10 @@ class EnterCodeViewModel @Inject constructor(
     }
 
     sealed class Command {
-        object LoginSucess : Command()
+        data object LoginSuccess : Command()
+        data class AskToSwitchAccount(val encodedStringCode: String) : Command()
         data class ShowError(@StringRes val message: Int, val reason: String = "") : Command()
+        data object SwitchAccountSuccess : Command()
     }
 
     fun onPasteCodeClicked() {
@@ -83,34 +92,60 @@ class EnterCodeViewModel @Inject constructor(
     ) {
         val result = syncAccountRepository.processCode(pastedCode)
         when (result) {
-            is Result.Success -> command.send(Command.LoginSucess)
+            is Result.Success -> command.send(Command.LoginSuccess)
             is Result.Error -> {
-                when (result.code) {
-                    ALREADY_SIGNED_IN.code -> {
-                        showError(R.string.sync_login_authenticated_device_error, result.reason)
-                    }
-                    LOGIN_FAILED.code -> {
-                        showError(R.string.sync_connect_login_error, result.reason)
-                    }
-                    CONNECT_FAILED.code -> {
-                        showError(R.string.sync_connect_generic_error, result.reason)
-                    }
-                    CREATE_ACCOUNT_FAILED.code -> {
-                        showError(R.string.sync_create_account_generic_error, result.reason)
-                    }
-                    INVALID_CODE.code -> {
-                        viewState.value = viewState.value.copy(authState = AuthState.Error)
-                    }
-                    else -> {}
-                }
+                processError(result, pastedCode)
             }
         }
     }
 
-    private suspend fun showError(
-        message: Int,
-        reason: String,
-    ) {
-        command.send(ShowError(message = message, reason = reason))
+    private suspend fun processError(result: Error, pastedCode: String) {
+        if (result.code == ALREADY_SIGNED_IN.code && syncFeature.seamlessAccountSwitching().isEnabled()) {
+            command.send(AskToSwitchAccount(pastedCode))
+        } else {
+            if (result.code == INVALID_CODE.code) {
+                viewState.value = viewState.value.copy(authState = AuthState.Error)
+                return
+            }
+
+            when (result.code) {
+                ALREADY_SIGNED_IN.code -> R.string.sync_login_authenticated_device_error
+                LOGIN_FAILED.code -> R.string.sync_connect_login_error
+                CONNECT_FAILED.code -> R.string.sync_connect_generic_error
+                CREATE_ACCOUNT_FAILED.code -> R.string.sync_create_account_generic_error
+                INVALID_CODE.code -> R.string.sync_invalid_code_error
+                else -> null
+            }?.let { message ->
+                command.send(
+                    ShowError(
+                        message = message,
+                        reason = result.reason,
+                    ),
+                )
+            }
+        }
+    }
+
+    fun onUserAcceptedJoiningNewAccount(encodedStringCode: String) {
+        viewModelScope.launch(dispatchers.io()) {
+            val result = syncAccountRepository.logoutAndJoinNewAccount(encodedStringCode)
+            if (result is Error) {
+                when (result.code) {
+                    ALREADY_SIGNED_IN.code -> R.string.sync_login_authenticated_device_error
+                    LOGIN_FAILED.code -> R.string.sync_connect_login_error
+                    CONNECT_FAILED.code -> R.string.sync_connect_generic_error
+                    CREATE_ACCOUNT_FAILED.code -> R.string.sync_create_account_generic_error
+                    INVALID_CODE.code -> R.string.sync_invalid_code_error
+                    else -> null
+                }?.let { message ->
+                    command.send(
+                        ShowError(message = message, reason = result.reason),
+                    )
+                }
+            } else {
+                syncPixels.fireLoginPixel()
+                command.send(SwitchAccountSuccess)
+            }
+        }
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivity.kt
@@ -72,6 +72,8 @@ import com.duckduckgo.sync.impl.ui.setup.SetupAccountActivity.Companion.Screen.S
 import com.duckduckgo.sync.impl.ui.setup.SyncIntroContract
 import com.duckduckgo.sync.impl.ui.setup.SyncIntroContractInput
 import com.duckduckgo.sync.impl.ui.setup.SyncWithAnotherDeviceContract
+import com.duckduckgo.sync.impl.ui.setup.SyncWithAnotherDeviceContract.SyncWithAnotherDeviceContractOutput.DeviceConnected
+import com.duckduckgo.sync.impl.ui.setup.SyncWithAnotherDeviceContract.SyncWithAnotherDeviceContractOutput.SwitchAccountSuccess
 import com.google.android.material.snackbar.Snackbar
 import javax.inject.Inject
 import kotlinx.coroutines.flow.launchIn
@@ -134,9 +136,11 @@ class SyncActivity : DuckDuckGoActivity() {
         }
     }
 
-    private val syncWithAnotherDeviceFlow = registerForActivityResult(SyncWithAnotherDeviceContract()) { resultOk ->
-        if (resultOk) {
-            viewModel.onDeviceConnected()
+    private val syncWithAnotherDeviceFlow = registerForActivityResult(SyncWithAnotherDeviceContract()) { result ->
+        when (result) {
+            DeviceConnected -> viewModel.onDeviceConnected()
+            SwitchAccountSuccess -> viewModel.onLoginSuccess()
+            else -> {}
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectActivity.kt
@@ -39,6 +39,7 @@ import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.ShowError
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.ShowMessage
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.ViewState
 import com.duckduckgo.sync.impl.ui.setup.EnterCodeContract
+import com.duckduckgo.sync.impl.ui.setup.EnterCodeContract.EnterCodeContractOutput
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -50,8 +51,8 @@ class SyncConnectActivity : DuckDuckGoActivity() {
 
     private val enterCodeLauncher = registerForActivityResult(
         EnterCodeContract(),
-    ) { resultOk ->
-        if (resultOk) {
+    ) { result ->
+        if (result != EnterCodeContractOutput.Error) {
             viewModel.onLoginSuccess()
         }
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginActivity.kt
@@ -36,6 +36,7 @@ import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command.LoginSucess
 import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command.ReadTextCode
 import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command.ShowError
 import com.duckduckgo.sync.impl.ui.setup.EnterCodeContract
+import com.duckduckgo.sync.impl.ui.setup.EnterCodeContract.EnterCodeContractOutput
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
@@ -46,8 +47,8 @@ class SyncLoginActivity : DuckDuckGoActivity() {
 
     private val enterCodeLauncher = registerForActivityResult(
         EnterCodeContract(),
-    ) { resultOk ->
-        if (resultOk) {
+    ) { result ->
+        if (result != EnterCodeContractOutput.Error) {
             viewModel.onLoginSuccess()
         }
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceActivity.kt
@@ -134,7 +134,7 @@ class SyncWithAnotherDeviceActivity : DuckDuckGoActivity() {
 
     private fun askUserToSwitchAccount(it: AskToSwitchAccount) {
         TextAlertDialogBuilder(this)
-            .setTitle(R.string.sync_dialog_error_title)
+            .setTitle(R.string.sync_dialog_switch_account_header)
             .setMessage(R.string.sync_dialog_switch_account_description)
             .setPositiveButton(R.string.sync_dialog_switch_account_primary_button)
             .setNegativeButton(R.string.sync_dialog_switch_account_secondary_button)

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceActivity.kt
@@ -32,6 +32,13 @@ import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.databinding.ActivityConnectSyncBinding
 import com.duckduckgo.sync.impl.ui.EnterCodeActivity.Companion.Code.RECOVERY_CODE
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command
+import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.AskToSwitchAccount
+import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.FinishWithError
+import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.LoginSuccess
+import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.ReadTextCode
+import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.ShowError
+import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.ShowMessage
+import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.SwitchAccountSuccess
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.ViewState
 import com.duckduckgo.sync.impl.ui.setup.EnterCodeContract
 import com.google.android.material.snackbar.Snackbar
@@ -45,10 +52,8 @@ class SyncWithAnotherDeviceActivity : DuckDuckGoActivity() {
 
     private val enterCodeLauncher = registerForActivityResult(
         EnterCodeContract(),
-    ) { resultOk ->
-        if (resultOk) {
-            viewModel.onLoginSuccess()
-        }
+    ) { result ->
+        viewModel.onEnterCodeResult(result)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -95,20 +100,26 @@ class SyncWithAnotherDeviceActivity : DuckDuckGoActivity() {
 
     private fun processCommand(it: Command) {
         when (it) {
-            Command.ReadTextCode -> {
+            ReadTextCode -> {
                 enterCodeLauncher.launch(RECOVERY_CODE)
             }
-            Command.LoginSuccess -> {
+            is LoginSuccess -> {
                 setResult(RESULT_OK)
                 finish()
             }
-            Command.FinishWithError -> {
+            FinishWithError -> {
                 setResult(RESULT_CANCELED)
                 finish()
             }
-
-            is Command.ShowMessage -> Snackbar.make(binding.root, it.messageId, Snackbar.LENGTH_SHORT).show()
-            is Command.ShowError -> showError(it)
+            is ShowMessage -> Snackbar.make(binding.root, it.messageId, Snackbar.LENGTH_SHORT).show()
+            is ShowError -> showError(it)
+            is AskToSwitchAccount -> askUserToSwitchAccount(it)
+            SwitchAccountSuccess -> {
+                val resultIntent = Intent()
+                resultIntent.putExtra(EXTRA_USER_SWITCHED_ACCOUNT, true)
+                setResult(RESULT_OK, resultIntent)
+                finish()
+            }
         }
     }
 
@@ -121,7 +132,22 @@ class SyncWithAnotherDeviceActivity : DuckDuckGoActivity() {
         }
     }
 
-    private fun showError(it: Command.ShowError) {
+    private fun askUserToSwitchAccount(it: AskToSwitchAccount) {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_dialog_error_title)
+            .setMessage(R.string.sync_dialog_switch_account_description)
+            .setPositiveButton(R.string.sync_dialog_switch_account_primary_button)
+            .setNegativeButton(R.string.sync_dialog_switch_account_secondary_button)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() {
+                        viewModel.onUserAcceptedJoiningNewAccount(it.encodedStringCode)
+                    }
+                },
+            ).show()
+    }
+
+    private fun showError(it: ShowError) {
         TextAlertDialogBuilder(this)
             .setTitle(R.string.sync_dialog_error_title)
             .setMessage(getString(it.message) + "\n" + it.reason)
@@ -136,6 +162,8 @@ class SyncWithAnotherDeviceActivity : DuckDuckGoActivity() {
     }
 
     companion object {
+        const val EXTRA_USER_SWITCHED_ACCOUNT = "userSwitchedAccount"
+
         internal fun intent(context: Context): Intent {
             return Intent(context, SyncWithAnotherDeviceActivity::class.java)
         }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceActivity.kt
@@ -133,6 +133,7 @@ class SyncWithAnotherDeviceActivity : DuckDuckGoActivity() {
     }
 
     private fun askUserToSwitchAccount(it: AskToSwitchAccount) {
+        viewModel.onUserAskedToSwitchAccount()
         TextAlertDialogBuilder(this)
             .setTitle(R.string.sync_dialog_switch_account_header)
             .setMessage(R.string.sync_dialog_switch_account_description)
@@ -142,6 +143,10 @@ class SyncWithAnotherDeviceActivity : DuckDuckGoActivity() {
                 object : TextAlertDialogBuilder.EventListener() {
                     override fun onPositiveButtonClicked() {
                         viewModel.onUserAcceptedJoiningNewAccount(it.encodedStringCode)
+                    }
+
+                    override fun onNegativeButtonClicked() {
+                        viewModel.onUserCancelledJoiningNewAccount()
                     }
                 },
             ).show()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/setup/EnterCodeContract.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/setup/EnterCodeContract.kt
@@ -22,8 +22,10 @@ import android.content.Intent
 import androidx.activity.result.contract.ActivityResultContract
 import com.duckduckgo.sync.impl.ui.EnterCodeActivity
 import com.duckduckgo.sync.impl.ui.EnterCodeActivity.Companion.Code
+import com.duckduckgo.sync.impl.ui.EnterCodeActivity.Companion.EXTRA_USER_SWITCHED_ACCOUNT
+import com.duckduckgo.sync.impl.ui.setup.EnterCodeContract.EnterCodeContractOutput
 
-class EnterCodeContract : ActivityResultContract<Code, Boolean>() {
+class EnterCodeContract : ActivityResultContract<Code, EnterCodeContractOutput>() {
     override fun createIntent(
         context: Context,
         codeType: Code,
@@ -34,7 +36,24 @@ class EnterCodeContract : ActivityResultContract<Code, Boolean>() {
     override fun parseResult(
         resultCode: Int,
         intent: Intent?,
-    ): Boolean {
-        return resultCode == Activity.RESULT_OK
+    ): EnterCodeContractOutput {
+        when {
+            resultCode == Activity.RESULT_OK -> {
+                val userSwitchedAccount = intent?.getBooleanExtra(EXTRA_USER_SWITCHED_ACCOUNT, false) ?: false
+                return if (userSwitchedAccount) {
+                    EnterCodeContractOutput.SwitchAccountSuccess
+                } else {
+                    EnterCodeContractOutput.LoginSuccess
+                }
+            }
+
+            else -> return EnterCodeContractOutput.Error
+        }
+    }
+
+    sealed class EnterCodeContractOutput {
+        data object LoginSuccess : EnterCodeContractOutput()
+        data object SwitchAccountSuccess : EnterCodeContractOutput()
+        data object Error : EnterCodeContractOutput()
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/setup/SyncWithAnotherDeviceContract.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/setup/SyncWithAnotherDeviceContract.kt
@@ -21,8 +21,10 @@ import android.content.Context
 import android.content.Intent
 import androidx.activity.result.contract.ActivityResultContract
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherDeviceActivity
+import com.duckduckgo.sync.impl.ui.SyncWithAnotherDeviceActivity.Companion.EXTRA_USER_SWITCHED_ACCOUNT
+import com.duckduckgo.sync.impl.ui.setup.SyncWithAnotherDeviceContract.SyncWithAnotherDeviceContractOutput
 
-internal class SyncWithAnotherDeviceContract : ActivityResultContract<Void?, Boolean>() {
+internal class SyncWithAnotherDeviceContract : ActivityResultContract<Void?, SyncWithAnotherDeviceContractOutput>() {
     override fun createIntent(
         context: Context,
         input: Void?,
@@ -33,7 +35,23 @@ internal class SyncWithAnotherDeviceContract : ActivityResultContract<Void?, Boo
     override fun parseResult(
         resultCode: Int,
         intent: Intent?,
-    ): Boolean {
-        return resultCode == Activity.RESULT_OK
+    ): SyncWithAnotherDeviceContractOutput {
+        when {
+            resultCode == Activity.RESULT_OK -> {
+                val userSwitchedAccount = intent?.getBooleanExtra(EXTRA_USER_SWITCHED_ACCOUNT, false) ?: false
+                return if (userSwitchedAccount) {
+                    SyncWithAnotherDeviceContractOutput.SwitchAccountSuccess
+                } else {
+                    SyncWithAnotherDeviceContractOutput.DeviceConnected
+                }
+            }
+            else -> return SyncWithAnotherDeviceContractOutput.Error
+        }
+    }
+
+    sealed class SyncWithAnotherDeviceContractOutput {
+        data object DeviceConnected : SyncWithAnotherDeviceContractOutput()
+        data object SwitchAccountSuccess : SyncWithAnotherDeviceContractOutput()
+        data object Error : SyncWithAnotherDeviceContractOutput()
     }
 }

--- a/sync/sync-impl/src/main/res/values/donottranslate.xml
+++ b/sync/sync-impl/src/main/res/values/donottranslate.xml
@@ -30,7 +30,8 @@
     <string name="deviceIdSectionHeader">Device Id</string>
     <string name="deviceNameSectionHeader">Device Name</string>
 
-    <string name="sync_dialog_switch_account_primary_button">Switch Account</string>
+    <string name="sync_dialog_switch_account_header">This device is already synced.</string>
+    <string name="sync_dialog_switch_account_primary_button">Switch Sync</string>
     <string name="sync_dialog_switch_account_secondary_button">Cancel</string>
-    <string name="sync_dialog_switch_account_description">"You\'re already signed in to another account. Would you like to sign out and switch accounts?"</string>
+    <string name="sync_dialog_switch_account_description">This device is currently synced and backed up. Are you sure you want to sync it with a different backup or device?\nSwitching won\'t remove any data already synced to this device.</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values/donottranslate.xml
+++ b/sync/sync-impl/src/main/res/values/donottranslate.xml
@@ -30,4 +30,7 @@
     <string name="deviceIdSectionHeader">Device Id</string>
     <string name="deviceNameSectionHeader">Device Name</string>
 
+    <string name="sync_dialog_switch_account_primary_button">Switch Account</string>
+    <string name="sync_dialog_switch_account_secondary_button">Cancel</string>
+    <string name="sync_dialog_switch_account_description">"You\'re already signed in to another account. Would you like to sign out and switch accounts?"</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values/donottranslate.xml
+++ b/sync/sync-impl/src/main/res/values/donottranslate.xml
@@ -30,8 +30,8 @@
     <string name="deviceIdSectionHeader">Device Id</string>
     <string name="deviceNameSectionHeader">Device Name</string>
 
-    <string name="sync_dialog_switch_account_header">This device is already synced.</string>
+    <string name="sync_dialog_switch_account_header">Switch to a different Sync?</string>
     <string name="sync_dialog_switch_account_primary_button">Switch Sync</string>
     <string name="sync_dialog_switch_account_secondary_button">Cancel</string>
-    <string name="sync_dialog_switch_account_description">This device is currently synced and backed up. Are you sure you want to sync it with a different backup or device?\nSwitching won\'t remove any data already synced to this device.</string>
+    <string name="sync_dialog_switch_account_description">This device is already synced, are you sure you want to sync it with a different back up or device? Switching won\'t remove any data already synced to this device.</string>
 </resources>

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/TestSyncFixtures.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/TestSyncFixtures.kt
@@ -140,7 +140,8 @@ object TestSyncFixtures {
     )
     val loginSuccessResponse: Response<LoginResponse> = Response.success(loginResponseBody)
 
-    val listOfDevices = listOf(Device(deviceId = deviceId, deviceName = deviceName, jwIat = "", deviceType = deviceFactor))
+    val aDevice = Device(deviceId = deviceId, deviceName = deviceName, jwIat = "", deviceType = deviceFactor)
+    val listOfDevices = listOf(aDevice)
     val deviceResponse = DeviceResponse(DeviceEntries(listOfDevices))
     val getDevicesBodySuccessResponse: Response<DeviceResponse> = Response.success(deviceResponse)
     val getDevicesBodyErrorResponse: Response<DeviceResponse> = Response.error(

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
@@ -18,6 +18,9 @@ package com.duckduckgo.sync.impl
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.common.utils.DefaultDispatcherProvider
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.sync.TestSyncFixtures.aDevice
 import com.duckduckgo.sync.TestSyncFixtures.accountCreatedFailDupUser
 import com.duckduckgo.sync.TestSyncFixtures.accountCreatedSuccess
 import com.duckduckgo.sync.TestSyncFixtures.accountKeys
@@ -65,9 +68,8 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.INVALID_CODE
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
-import com.duckduckgo.sync.impl.pixels.*
+import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.store.SyncStore
-import java.lang.RuntimeException
 import kotlinx.coroutines.test.TestScope
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -94,13 +96,25 @@ class AppSyncAccountRepositoryTest {
     private var syncStore: SyncStore = mock()
     private var syncEngine: SyncEngine = mock()
     private var syncPixels: SyncPixels = mock()
+    private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java).apply {
+        this.seamlessAccountSwitching().setRawStoredState(State(true))
+    }
 
     private lateinit var syncRepo: SyncAccountRepository
 
     @Before
     fun before() {
-        syncRepo =
-            AppSyncAccountRepository(syncDeviceIds, nativeLib, syncApi, syncStore, syncEngine, syncPixels, TestScope(), DefaultDispatcherProvider())
+        syncRepo = AppSyncAccountRepository(
+            syncDeviceIds,
+            nativeLib,
+            syncApi,
+            syncStore,
+            syncEngine,
+            syncPixels,
+            TestScope(),
+            DefaultDispatcherProvider(),
+            syncFeature,
+        )
     }
 
     @Test
@@ -229,6 +243,39 @@ class AppSyncAccountRepositoryTest {
             secretKey = secretKey,
             token = token,
         )
+    }
+
+    @Test
+    fun whenSignedInAndProcessRecoveryCodeIfAllowSwitchAccountTrueThenSwitchAccountIfOnly1DeviceConnected() {
+        givenAuthenticatedDevice()
+        givenAccountWithConnectedDevices(1)
+        doAnswer {
+            givenUnauthenticatedDevice() // simulate logout locally
+            logoutSuccess
+        }.`when`(syncApi).logout(token, deviceId)
+        prepareForLoginSuccess()
+
+        val result = syncRepo.processCode(jsonRecoveryKeyEncoded)
+
+        verify(syncApi).logout(token, deviceId)
+        verify(syncApi).login(userId, hashedPassword, deviceId, deviceName, deviceFactor)
+
+        assertTrue(result is Success)
+    }
+
+    @Test
+    fun whenSignedInAndProcessRecoveryCodeIfAllowSwitchAccountTrueThenReturnErrorIfMultipleDevicesConnected() {
+        givenAuthenticatedDevice()
+        givenAccountWithConnectedDevices(2)
+        doAnswer {
+            givenUnauthenticatedDevice() // simulate logout locally
+            logoutSuccess
+        }.`when`(syncApi).logout(token, deviceId)
+        prepareForLoginSuccess()
+
+        val result = syncRepo.processCode(jsonRecoveryKeyEncoded)
+
+        assertEquals((result as Error).code, ALREADY_SIGNED_IN.code)
     }
 
     @Test
@@ -572,5 +619,16 @@ class AppSyncAccountRepositoryTest {
         whenever(nativeLib.encryptData(anyString(), primaryKey = eq(primaryKey))).thenAnswer {
             EncryptResult(0, it.arguments.first() as String)
         }
+    }
+
+    private fun givenAccountWithConnectedDevices(size: Int) {
+        prepareForEncryption()
+        val listOfDevices = mutableListOf<Device>()
+        for (i in 0 until size) {
+            listOfDevices.add(aDevice.copy(deviceId = "device$i"))
+        }
+        whenever(syncApi.getDevices(anyString())).thenReturn(Success(listOfDevices))
+
+        syncRepo.getConnectedDevices() as Success
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
@@ -47,6 +47,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -169,6 +170,34 @@ internal class EnterCodeViewModelTest {
         testee.commands().test {
             val command = awaitItem()
             assertTrue(command is SwitchAccountSuccess)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenSignedInUserScansRecoveryCodeAndLoginSucceedsThenReturnSwitchAccount() = runTest {
+        whenever(syncAccountRepository.isSignedIn()).thenReturn(true)
+        whenever(syncAccountRepository.processCode(jsonRecoveryKeyEncoded)).thenReturn(Success(true))
+        whenever(clipboard.pasteFromClipboard()).thenReturn(jsonRecoveryKeyEncoded)
+
+        testee.commands().test {
+            testee.onPasteCodeClicked()
+            val command = awaitItem()
+            assertTrue(command is SwitchAccountSuccess)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenSignedOutUserScansRecoveryCodeAndLoginSucceedsThenReturnLoginSuccess() = runTest {
+        whenever(syncAccountRepository.isSignedIn()).thenReturn(false)
+        whenever(syncAccountRepository.processCode(jsonRecoveryKeyEncoded)).thenReturn(Success(true))
+        whenever(clipboard.pasteFromClipboard()).thenReturn(jsonRecoveryKeyEncoded)
+
+        testee.commands().test {
+            testee.onPasteCodeClicked()
+            val command = awaitItem()
+            assertTrue(command is LoginSuccess)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
@@ -144,7 +144,7 @@ class SyncWithAnotherDeviceViewModelTest {
     }
 
     @Test
-    fun whenUserScansRecoveryCodeButSignedInThenCommandIsAskToSwithAccount() = runTest {
+    fun whenUserScansRecoveryCodeButSignedInThenCommandIsAskToSwitchAccount() = runTest {
         whenever(syncRepository.processCode(jsonRecoveryKeyEncoded)).thenReturn(Result.Error(code = ALREADY_SIGNED_IN.code))
         testee.commands().test {
             testee.onQRCodeScanned(jsonRecoveryKeyEncoded)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1208755822305612/f 

### Description
When a Sync signed in user reads a recovery code, ask them to confirm if they want to switch account.

Includes:
- Remote FF (disabled by default until implementation is completed)
- Logic to handle that scenario when reading a QR code or introducing text manually.


### Steps to test this PR

_Feature 1_
- [x] fresh install in 2 devices
- [x] Go to Feature flags and enable FF `seamlessAccountSwitching` on both
- [x] Create a Sync account in both devices (different ones)
- [x] From both devices access Sync settings and select "Sync With Another Device"
- [x] From one device, read the QR code from the other device
- [x] Ensure it appears a dialog asking the user to switch accounts appears
- [x] Click on switch account 
- [x] Confirm you are switched to the new account
- [x] Confirm you see the recovery code screen and Device connected screen after that

_Feature 2_ (continuation from previous test)
- [x] logout one device, and create a new sync account there
- [x] you should have again 2 devices on 2 different sync accounts
- [x] From both devices access Sync settings and select "Sync With Another Device"
- [x] From one device, click "share copy text" so you have the recovery code copied in the clipboard
- [x] Send the code to the other device
- [x] In the other device, from that "Sync With Another Device" screen, click on "Manually enter code"
- [x] Click on paste code (which should be the code you copied before)
- [x] Ensure it appears a dialog asking the user to switch accounts appears
- [x] Click on switch account 
- [x] Confirm you are switched to the new account
- [x] Confirm you see the recovery code screen and Device connected screen after that

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
