### PR TITLE
BlockList crash when no config

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/blocklist/BlockListInterceptorApiPlugin.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/blocklist/BlockListInterceptorApiPlugin.kt
@@ -55,7 +55,7 @@ class BlockListInterceptorApiPlugin @Inject constructor(
                 activeExperiment.isEnabled(TREATMENT) -> activeExperiment.getConfig()[TREATMENT_URL]
                 activeExperiment.isEnabled(CONTROL) -> activeExperiment.getConfig()[CONTROL_URL]
                 else -> activeExperiment.getConfig()[NEXT_URL]
-            } ?: chain.proceed(request.build())
+            } ?: return chain.proceed(request.build())
             chain.proceed(request.url("$TDS_BASE_URL$path").build())
         } ?: chain.proceed(request.build())
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1208747413344538/f 

### Description
This PR fixes a bug where the blocklist feature makes the app crash when there's no config available.

### Steps to test this PR
See task
