### PR TITLE
Open intents with direct DDG URL in a new browser tab, instead of Custom Tab

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/dispatchers/IntentDispatcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/dispatchers/IntentDispatcherViewModel.kt
@@ -21,6 +21,7 @@ import androidx.browser.customtabs.CustomTabsIntent
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.app.browser.DuckDuckGoUrlDetector
 import com.duckduckgo.app.global.intentText
 import com.duckduckgo.autofill.api.emailprotection.EmailProtectionLinkVerifier
 import com.duckduckgo.common.utils.DispatcherProvider
@@ -37,6 +38,7 @@ class IntentDispatcherViewModel @Inject constructor(
     private val customTabDetector: CustomTabDetector,
     private val dispatcherProvider: DispatcherProvider,
     private val emailProtectionLinkVerifier: EmailProtectionLinkVerifier,
+    private val duckDuckGoUrlDetector: DuckDuckGoUrlDetector,
 ) : ViewModel() {
 
     private val _viewState = MutableStateFlow(ViewState())
@@ -56,7 +58,8 @@ class IntentDispatcherViewModel @Inject constructor(
                 val intentText = intent?.intentText
                 val toolbarColor = intent?.getIntExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR, defaultColor) ?: defaultColor
                 val isEmailProtectionLink = emailProtectionLinkVerifier.shouldDelegateToInContextView(intentText, true)
-                val customTabRequested = hasSession && !isEmailProtectionLink
+                val isDuckDuckGoUrl = intentText?.let { duckDuckGoUrlDetector.isDuckDuckGoUrl(it) } ?: false
+                val customTabRequested = hasSession && !isEmailProtectionLink && !isDuckDuckGoUrl
 
                 Timber.d("Intent $intent received. Has extra session=$hasSession. Intent text=$intentText. Toolbar color=$toolbarColor")
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1208671518894266/1207149305479429/f

### Description

This change ensures that if DDG browser is selected to handle the browsable intent, and the URL is a `duckduckgo.com` domain, a new browser tab will be opened instead of an "embedded" Custom Tab.

### Steps to test this PR
There 3 easy ways to test, all require DDG to be the default browser application:
1. Use an external app like the [Android Browser Helper](https://github.com/GoogleChrome/android-browser-helper/) (method used in the video below).
2. Go to Settings -> Developer Settings -> Custom Tabs.
3. Inject an intent from ADB, for example:
```shell
adb shell am start -a android.intent.action.VIEW -d "https://duckduckgo.com/?q=test" --es "android.support.customtabs.extra.SESSION" "" com.duckduckgo.app.browser
```

### UI changes
| Before  | After |
| ------ | ----- |
<video src="https://github.com/user-attachments/assets/030ce01c-a6ee-4f9c-aee4-efeea3807d0f"> | <video src="https://github.com/user-attachments/assets/6d24ca26-0db3-4ad4-b1d9-cd015319a950"> |
