### PR TITLE
Update content scope scripts to version 6.35.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^10.17.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#15.1.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.33.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.35.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#7.0.2",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1724449523"
       },
@@ -57,13 +57,16 @@
       "hasInstallScript": true
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#96382a1140e2344f04e33fe9ae28da1290fa2d23",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#32c3e2bce3cc20a079d96b3ee23a9cde5d2337c3",
       "workspaces": [
         "injected",
         "special-pages",
         "messaging",
         "types-generator"
-      ]
+      ],
+      "dependencies": {
+        "immutable-json-patch": "^6.0.1"
+      }
     },
     "node_modules/@duckduckgo/privacy-dashboard": {
       "resolved": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#597bffc321a8f4b8d23b13aa0145406c393c0d8e",
@@ -301,6 +304,11 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/immutable-json-patch": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/immutable-json-patch/-/immutable-json-patch-6.0.1.tgz",
+      "integrity": "sha512-BHL/cXMjwFZlTOffiWNdY8ZTvNyYLrutCnWxrcKPHr5FqpAb6vsO6WWSPnVSys3+DruFN6lhHJJPHi8uELQL5g=="
+    },
     "node_modules/is-builtin-module": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
@@ -535,16 +543,16 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.60",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.60.tgz",
-      "integrity": "sha512-XHjoxak8SFQnHnmYHb3PcnW5TZ+9ErLZemZei3azuIRhQLw4IExsVbL3VZJdHcLeNaXq6NqawgpDPpjBOg4B5g=="
+      "version": "6.1.61",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.61.tgz",
+      "integrity": "sha512-In7VffkDWUPgwa+c9picLUxvb0RltVwTkSgMNFgvlGSWveCzGBemBqTsgJCL4EDFWZ6WH0fKTsot6yNhzy3ZzQ=="
     },
     "node_modules/tldts-experimental": {
-      "version": "6.1.60",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.60.tgz",
-      "integrity": "sha512-EK0d4Gq524rR3aUn5qnqq+v8poLIhPMiBGcRd6E50JodIlAt5d1vRxHj+BQ4R+5tC/CnhbFg9ms3BYHlnBfnyw==",
+      "version": "6.1.61",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.61.tgz",
+      "integrity": "sha512-1plwEyCpyYtVsZVtC169C5bStRlDk3cIniMHUeNmAJOjmQGx7SnLM8kS06PQAHx9PPY4Jm1VS6IXZzPC53XpbQ==",
       "dependencies": {
-        "tldts-core": "^6.1.60"
+        "tldts-core": "^6.1.61"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^10.17.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#15.1.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.33.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.35.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#7.0.2",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1724449523"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208772371483449/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass