### PR TITLE
Add isReturningUser and isPrivacyProEligible targets and modularize target management

### DIFF
--- a/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesRemoteFeatureCodeGenerator.kt
+++ b/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesRemoteFeatureCodeGenerator.kt
@@ -118,7 +118,6 @@ class ContributesRemoteFeatureCodeGenerator : CodeGenerator {
                                 .flavorNameProvider({ appBuildConfig.flavor.name })
                                 .featureName(%S)
                                 .appVariantProvider({ appBuildConfig.variantName })
-                                .localeProvider({ appBuildConfig.deviceLocale })
                                 .callback(callback)
                                 // save empty variants will force the default variant to be set
                                 .forceDefaultVariantProvider({ variantManager.updateVariants(emptyList()) })
@@ -521,6 +520,8 @@ class ContributesRemoteFeatureCodeGenerator : CodeGenerator {
                                         variantKey = target.variantKey,
                                         localeCountry = target.localeCountry,
                                         localeLanguage = target.localeLanguage,
+                                        isReturningUser = target.isReturningUser,
+                                        isPrivacyProEligible = target.isPrivacyProEligible,
                                     )
                                 } ?: emptyList()
                                 val cohorts = jsonToggle?.cohorts?.map { cohort ->
@@ -727,11 +728,22 @@ class ContributesRemoteFeatureCodeGenerator : CodeGenerator {
                     .addParameter("variantKey", String::class.asClassName())
                     .addParameter("localeCountry", String::class.asClassName())
                     .addParameter("localeLanguage", String::class.asClassName())
+                    .addParameter("isReturningUser", Boolean::class.asClassName().copy(nullable = true))
+                    .addParameter("isPrivacyProEligible", Boolean::class.asClassName().copy(nullable = true))
                     .build(),
             )
             .addProperty(PropertySpec.builder("variantKey", String::class.asClassName()).initializer("variantKey").build())
             .addProperty(PropertySpec.builder("localeCountry", String::class.asClassName()).initializer("localeCountry").build())
             .addProperty(PropertySpec.builder("localeLanguage", String::class.asClassName()).initializer("localeLanguage").build())
+            .addProperty(
+                PropertySpec.builder("isReturningUser", Boolean::class.asClassName().copy(nullable = true)).initializer("isReturningUser").build(),
+            )
+            .addProperty(
+                PropertySpec
+                    .builder("isPrivacyProEligible", Boolean::class.asClassName().copy(nullable = true))
+                    .initializer("isPrivacyProEligible")
+                    .build(),
+            )
             .build()
     }
 

--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/ReturningUserToggleTargetMatcher.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/ReturningUserToggleTargetMatcher.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.experiments.impl
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.experiments.api.VariantManager
+import com.duckduckgo.experiments.impl.reinstalls.REINSTALL_VARIANT
+import com.duckduckgo.feature.toggles.api.Toggle.State.Target
+import com.duckduckgo.feature.toggles.api.Toggle.TargetMatcherPlugin
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+class ReturningUserToggleTargetMatcher @Inject constructor(
+    private val variantManager: VariantManager,
+) : TargetMatcherPlugin {
+    override fun matchesTargetProperty(target: Target): Boolean {
+        return target.isReturningUser?.let { isReturningUserTarget ->
+            val isReturningUser = variantManager.getVariantKey() == REINSTALL_VARIANT
+            isReturningUserTarget == isReturningUser
+        } ?: true
+    }
+}

--- a/experiments/experiments-impl/src/test/java/com/duckduckgo/experiments/impl/ReturningUserToggleTargetMatcherTest.kt
+++ b/experiments/experiments-impl/src/test/java/com/duckduckgo/experiments/impl/ReturningUserToggleTargetMatcherTest.kt
@@ -1,0 +1,62 @@
+package com.duckduckgo.experiments.impl
+
+import com.duckduckgo.experiments.api.VariantManager
+import com.duckduckgo.feature.toggles.api.Toggle
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class ReturningUserToggleTargetMatcherTest {
+    private val variantManager: VariantManager = mock()
+    private val matcher = ReturningUserToggleTargetMatcher(variantManager)
+
+    @Test
+    fun whenReturningUserAndNullTargetThenMatchesTargetReturnsTrue() {
+        whenever(variantManager.getVariantKey()).thenReturn("ru")
+
+        assertTrue(matcher.matchesTargetProperty(NULL_TARGET))
+    }
+
+    @Test
+    fun whenNotReturningUserAndNullTargetThenMatchesTargetReturnsTrue() {
+        whenever(variantManager.getVariantKey()).thenReturn("foo")
+
+        assertTrue(matcher.matchesTargetProperty(NULL_TARGET))
+    }
+
+    @Test
+    fun whenReturningUserAndTargetMatchesThenReturnTrue() {
+        whenever(variantManager.getVariantKey()).thenReturn("ru")
+
+        assertTrue(matcher.matchesTargetProperty(RU_TARGET))
+    }
+
+    @Test
+    fun whenNoReturningUserAndTargetMatchesThenReturnTrue() {
+        whenever(variantManager.getVariantKey()).thenReturn("foo")
+
+        assertTrue(matcher.matchesTargetProperty(NOT_RU_TARGET))
+    }
+
+    @Test
+    fun whenReturningUserAndTargetNotMatchingThenReturnFalse() {
+        whenever(variantManager.getVariantKey()).thenReturn("ru")
+
+        assertFalse(matcher.matchesTargetProperty(NOT_RU_TARGET))
+    }
+
+    @Test
+    fun whenNoReturningUserAndTargetNotMatchingThenReturnTrue() {
+        whenever(variantManager.getVariantKey()).thenReturn("foo")
+
+        assertFalse(matcher.matchesTargetProperty(RU_TARGET))
+    }
+
+    companion object {
+        private val NULL_TARGET = Toggle.State.Target(null, null, null, null, null)
+        private val RU_TARGET = NULL_TARGET.copy(isReturningUser = true)
+        private val NOT_RU_TARGET = NULL_TARGET.copy(isReturningUser = false)
+    }
+}

--- a/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureToggles.kt
+++ b/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureToggles.kt
@@ -29,7 +29,6 @@ import java.lang.reflect.Proxy
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
-import java.util.Locale
 import kotlin.random.Random
 import org.apache.commons.math3.distribution.EnumeratedIntegerDistribution
 
@@ -39,7 +38,6 @@ class FeatureToggles private constructor(
     private val flavorNameProvider: () -> String,
     private val featureName: String,
     private val appVariantProvider: () -> String?,
-    private val localeProvider: () -> Locale?,
     private val forceDefaultVariant: () -> Unit,
     private val callback: FeatureTogglesCallback?,
 ) {
@@ -52,7 +50,6 @@ class FeatureToggles private constructor(
         private var flavorNameProvider: () -> String = { "" },
         private var featureName: String? = null,
         private var appVariantProvider: () -> String? = { "" },
-        private var localeProvider: () -> Locale? = { Locale.getDefault() },
         private var forceDefaultVariant: () -> Unit = { /** noop **/ },
         private var callback: FeatureTogglesCallback? = null,
     ) {
@@ -62,7 +59,6 @@ class FeatureToggles private constructor(
         fun flavorNameProvider(flavorNameProvider: () -> String) = apply { this.flavorNameProvider = flavorNameProvider }
         fun featureName(featureName: String) = apply { this.featureName = featureName }
         fun appVariantProvider(variantName: () -> String?) = apply { this.appVariantProvider = variantName }
-        fun localeProvider(locale: () -> Locale?) = apply { this.localeProvider = locale }
         fun forceDefaultVariantProvider(forceDefaultVariant: () -> Unit) = apply { this.forceDefaultVariant = forceDefaultVariant }
         fun callback(callback: FeatureTogglesCallback) = apply { this.callback = callback }
         fun build(): FeatureToggles {
@@ -82,7 +78,6 @@ class FeatureToggles private constructor(
                 flavorNameProvider = flavorNameProvider,
                 featureName = featureName!!,
                 appVariantProvider = appVariantProvider,
-                localeProvider = localeProvider,
                 forceDefaultVariant = forceDefaultVariant,
                 callback = this.callback,
             )
@@ -130,7 +125,6 @@ class FeatureToggles private constructor(
                 appVersionProvider = appVersionProvider,
                 flavorNameProvider = flavorNameProvider,
                 appVariantProvider = appVariantProvider,
-                localeProvider = localeProvider,
                 forceDefaultVariant = forceDefaultVariant,
                 callback = callback,
             ).also { featureToggleCache[method] = it }
@@ -230,6 +224,8 @@ interface Toggle {
             val variantKey: String?,
             val localeCountry: String?,
             val localeLanguage: String?,
+            val isReturningUser: Boolean?,
+            val isPrivacyProEligible: Boolean?,
         )
         data class Cohort(
             val name: String,
@@ -262,6 +258,18 @@ interface Toggle {
         fun set(key: String, state: State)
 
         fun get(key: String): State?
+    }
+
+    /**
+     * It is possible to add feature [Target]s.
+     * To do that, just add the property inside the [Target] and implement the [TargetMatcherPlugin] to do the matching
+     */
+    interface TargetMatcherPlugin {
+        /**
+         * Implement this method when adding a new target property.
+         * @return `true` if the target matches else false
+         */
+        fun matchesTargetProperty(target: State.Target): Boolean
     }
 
     /**
@@ -301,7 +309,6 @@ internal class ToggleImpl constructor(
     private val appVersionProvider: () -> Int,
     private val flavorNameProvider: () -> String = { "" },
     private val appVariantProvider: () -> String?,
-    private val localeProvider: () -> Locale?,
     private val forceDefaultVariant: () -> Unit,
     private val callback: FeatureTogglesCallback?,
 ) : Toggle {
@@ -315,31 +322,6 @@ internal class ToggleImpl constructor(
 
     override fun hashCode(): Int {
         return this.featureName().hashCode()
-    }
-
-    private fun Toggle.State.evaluateTargetMatching(isExperiment: Boolean): Boolean {
-        val variant = appVariantProvider.invoke()
-        // no targets then consider always treated
-        if (this.targets.isEmpty()) {
-            return true
-        }
-        // if it's an experiment we only check target variants and ignore all the rest
-        val variantTargets = this.targets.mapNotNull { it.variantKey }
-        if (isExperiment && variantTargets.isNotEmpty()) {
-            return variantTargets.contains(variant)
-        }
-        // finally, check all other targets
-        val countryTarget = this.targets.mapNotNull { it.localeCountry?.lowercase() }
-        val languageTarget = this.targets.mapNotNull { it.localeLanguage?.lowercase() }
-
-        if (countryTarget.isNotEmpty() && !countryTarget.contains(localeProvider.invoke()?.country?.lowercase())) {
-            return false
-        }
-        if (languageTarget.isNotEmpty() && !languageTarget.contains(localeProvider.invoke()?.language?.lowercase())) {
-            return false
-        }
-
-        return true
     }
 
     override fun featureName(): FeatureName {
@@ -381,6 +363,27 @@ internal class ToggleImpl constructor(
     }
 
     private fun isRolloutEnabled(): Boolean {
+        // This fun is in there because it should never be called outside this method
+        fun Toggle.State.evaluateTargetMatching(isExperiment: Boolean): Boolean {
+            val variant = appVariantProvider.invoke()
+            // no targets then consider always treated
+            if (this.targets.isEmpty()) {
+                return true
+            }
+            // if it's an experiment we only check target variants and ignore all the rest
+            // this is because the (retention) experiments define their targets some place else
+            val variantTargets = this.targets.mapNotNull { it.variantKey }
+            if (isExperiment && variantTargets.isNotEmpty()) {
+                return variantTargets.contains(variant)
+            }
+            // finally, check all other targets
+            val nonVariantTargets = this.targets.filter { it.variantKey == null }
+
+            // callback should never be null, but if it is, consider targets a match
+            return callback?.matchesToggleTargets(nonVariantTargets) ?: true
+        }
+
+        // This fun is in there because it should never be called outside this method
         fun evaluateLocalEnable(state: State, isExperiment: Boolean): Boolean {
             // variants are only considered for Experiment feature flags
             val doTargetsMatch = state.evaluateTargetMatching(isExperiment)
@@ -484,26 +487,12 @@ internal class ToggleImpl constructor(
                 cohorts[randomIndex.sample()]
             }.getOrNull()
         }
-        fun containsAndMatchCohortTargets(targets: State.Target?): Boolean {
-            return targets?.let {
-                targets.localeLanguage?.let { targetLanguage ->
-                    val deviceLocale = localeProvider.invoke()
-                    if (deviceLocale?.language != targetLanguage) {
-                        return false
-                    }
-                }
-                targets.localeCountry?.let { targetCountry ->
-                    val deviceLocale = localeProvider.invoke()
-                    if (deviceLocale?.country != targetCountry) {
-                        return false
-                    }
-                }
-                return true
-            } ?: return true // no targets mean any target
+        fun containsAndMatchCohortTargets(targets: List<State.Target>): Boolean {
+            return callback?.matchesToggleTargets(targets) ?: true
         }
 
         // In the remote config, targets is a list, but it should not be. So we pick the first one (?)
-        if (!containsAndMatchCohortTargets(targets.firstOrNull())) {
+        if (!containsAndMatchCohortTargets(targets)) {
             return null
         }
 

--- a/feature-toggles/feature-toggles-impl/lint-baseline.xml
+++ b/feature-toggles/feature-toggles-impl/lint-baseline.xml
@@ -8,7 +8,7 @@
         errorLine2="                                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="867"
+            line="868"
             column="68"/>
     </issue>
 
@@ -19,7 +19,7 @@
         errorLine2="                                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="902"
+            line="903"
             column="68"/>
     </issue>
 
@@ -30,7 +30,7 @@
         errorLine2="                                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="948"
+            line="949"
             column="68"/>
     </issue>
 
@@ -41,7 +41,7 @@
         errorLine2="                                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="953"
+            line="954"
             column="68"/>
     </issue>
 
@@ -52,7 +52,7 @@
         errorLine2="                                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1012"
+            line="1013"
             column="68"/>
     </issue>
 
@@ -63,7 +63,7 @@
         errorLine2="                                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1039"
+            line="1040"
             column="68"/>
     </issue>
 
@@ -74,7 +74,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1556"
+            line="1557"
             column="13"/>
     </issue>
 
@@ -85,7 +85,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1595"
+            line="1602"
             column="13"/>
     </issue>
 
@@ -96,7 +96,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1642"
+            line="1613"
             column="13"/>
     </issue>
 
@@ -107,7 +107,40 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1689"
+            line="1624"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="            testFeature.fooFeature().getRawStoredState()!!.targets,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
+            line="1663"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="            testFeature.fooFeature().getRawStoredState()!!.targets,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
+            line="1710"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="            testFeature.fooFeature().getRawStoredState()!!.targets,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
+            line="1757"
             column="13"/>
     </issue>
 
@@ -118,7 +151,7 @@
         errorLine2="                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1718"
+            line="1786"
             column="56"/>
     </issue>
 
@@ -129,7 +162,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1780"
+            line="1848"
             column="13"/>
     </issue>
 
@@ -140,29 +173,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1789"
-            column="13"/>
-    </issue>
-
-    <issue
-        id="DenyListedApi"
-        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
-        errorLine1="            testFeature.variantFeature().getRawStoredState()!!.targets,"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1797"
-            column="13"/>
-    </issue>
-
-    <issue
-        id="DenyListedApi"
-        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
-        errorLine1="            testFeature.experimentFooFeature().getRawStoredState()!!.targets,"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1856"
+            line="1857"
             column="13"/>
     </issue>
 
@@ -184,7 +195,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1921"
+            line="1924"
             column="13"/>
     </issue>
 
@@ -195,7 +206,29 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1930"
+            line="1933"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="            testFeature.experimentFooFeature().getRawStoredState()!!.targets,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
+            line="1989"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="            testFeature.variantFeature().getRawStoredState()!!.targets,"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
+            line="1998"
             column="13"/>
     </issue>
 
@@ -206,7 +239,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="1971"
+            line="2039"
             column="13"/>
     </issue>
 
@@ -217,7 +250,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2012"
+            line="2080"
             column="13"/>
     </issue>
 
@@ -228,7 +261,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2053"
+            line="2121"
             column="13"/>
     </issue>
 
@@ -239,7 +272,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2094"
+            line="2162"
             column="13"/>
     </issue>
 
@@ -250,7 +283,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2125"
+            line="2193"
             column="13"/>
     </issue>
 
@@ -261,7 +294,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2155"
+            line="2223"
             column="13"/>
     </issue>
 
@@ -272,7 +305,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2185"
+            line="2253"
             column="13"/>
     </issue>
 
@@ -283,7 +316,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2227"
+            line="2295"
             column="13"/>
     </issue>
 
@@ -294,7 +327,7 @@
         errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2261"
+            line="2329"
             column="43"/>
     </issue>
 
@@ -305,7 +338,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2457"
+            line="2525"
             column="13"/>
     </issue>
 
@@ -316,7 +349,7 @@
         errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2507"
+            line="2575"
             column="23"/>
     </issue>
 
@@ -327,7 +360,7 @@
         errorLine2="                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2557"
+            line="2625"
             column="24"/>
     </issue>
 
@@ -338,7 +371,7 @@
         errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2563"
+            line="2631"
             column="20"/>
     </issue>
 
@@ -349,7 +382,7 @@
         errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2570"
+            line="2638"
             column="20"/>
     </issue>
 
@@ -360,7 +393,7 @@
         errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2619"
+            line="2687"
             column="23"/>
     </issue>
 
@@ -371,7 +404,7 @@
         errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2654"
+            line="2722"
             column="23"/>
     </issue>
 
@@ -382,7 +415,7 @@
         errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2683"
+            line="2751"
             column="20"/>
     </issue>
 
@@ -393,7 +426,7 @@
         errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="2983"
+            line="3051"
             column="20"/>
     </issue>
 
@@ -404,7 +437,7 @@
         errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3027"
+            line="3095"
             column="20"/>
     </issue>
 
@@ -415,7 +448,7 @@
         errorLine2="                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3253"
+            line="3321"
             column="20"/>
     </issue>
 
@@ -426,7 +459,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3263"
+            line="3331"
             column="13"/>
     </issue>
 
@@ -437,7 +470,7 @@
         errorLine2="                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3307"
+            line="3375"
             column="32"/>
     </issue>
 
@@ -448,7 +481,7 @@
         errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3389"
+            line="3457"
             column="23"/>
     </issue>
 
@@ -459,7 +492,7 @@
         errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3433"
+            line="3501"
             column="19"/>
     </issue>
 
@@ -470,7 +503,7 @@
         errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3474"
+            line="3542"
             column="19"/>
     </issue>
 
@@ -481,7 +514,7 @@
         errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3518"
+            line="3586"
             column="19"/>
     </issue>
 
@@ -492,7 +525,7 @@
         errorLine2="                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3594"
+            line="3662"
             column="35"/>
     </issue>
 
@@ -503,7 +536,7 @@
         errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3603"
+            line="3671"
             column="27"/>
     </issue>
 
@@ -514,7 +547,7 @@
         errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3650"
+            line="3718"
             column="23"/>
     </issue>
 
@@ -525,7 +558,7 @@
         errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3690"
+            line="3758"
             column="23"/>
     </issue>
 
@@ -536,7 +569,7 @@
         errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3734"
+            line="3802"
             column="23"/>
     </issue>
 
@@ -547,7 +580,7 @@
         errorLine2="               ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt"
-            line="3765"
+            line="3833"
             column="16"/>
     </issue>
 
@@ -558,7 +591,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt"
-            line="80"
+            line="79"
             column="9"/>
     </issue>
 
@@ -569,7 +602,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt"
-            line="91"
+            line="90"
             column="9"/>
     </issue>
 
@@ -580,7 +613,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt"
-            line="108"
+            line="107"
             column="9"/>
     </issue>
 
@@ -591,7 +624,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt"
-            line="115"
+            line="114"
             column="9"/>
     </issue>
 
@@ -602,7 +635,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt"
-            line="137"
+            line="136"
             column="9"/>
     </issue>
 
@@ -613,7 +646,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt"
-            line="145"
+            line="144"
             column="9"/>
     </issue>
 
@@ -624,7 +657,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt"
-            line="225"
+            line="224"
             column="9"/>
     </issue>
 
@@ -635,7 +668,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt"
-            line="228"
+            line="227"
             column="9"/>
     </issue>
 
@@ -646,7 +679,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt"
-            line="231"
+            line="230"
             column="9"/>
     </issue>
 
@@ -657,7 +690,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt"
-            line="234"
+            line="233"
             column="9"/>
     </issue>
 
@@ -668,7 +701,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt"
-            line="237"
+            line="236"
             column="9"/>
     </issue>
 
@@ -679,7 +712,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt"
-            line="240"
+            line="239"
             column="9"/>
     </issue>
 
@@ -690,7 +723,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt"
-            line="251"
+            line="250"
             column="9"/>
     </issue>
 
@@ -701,7 +734,7 @@
         errorLine2="                                                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt"
-            line="253"
+            line="252"
             column="88"/>
     </issue>
 
@@ -712,7 +745,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt"
-            line="264"
+            line="263"
             column="9"/>
     </issue>
 
@@ -723,7 +756,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt"
-            line="278"
+            line="277"
             column="9"/>
     </issue>
 
@@ -734,7 +767,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt"
-            line="292"
+            line="291"
             column="9"/>
     </issue>
 
@@ -745,7 +778,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt"
-            line="303"
+            line="302"
             column="13"/>
     </issue>
 
@@ -756,7 +789,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt"
-            line="317"
+            line="316"
             column="9"/>
     </issue>
 
@@ -767,7 +800,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt"
-            line="333"
+            line="332"
             column="9"/>
     </issue>
 
@@ -778,7 +811,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt"
-            line="347"
+            line="346"
             column="9"/>
     </issue>
 
@@ -789,7 +822,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt"
-            line="363"
+            line="362"
             column="9"/>
     </issue>
 
@@ -800,7 +833,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt"
-            line="376"
+            line="375"
             column="9"/>
     </issue>
 
@@ -811,7 +844,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt"
-            line="389"
+            line="388"
             column="9"/>
     </issue>
 
@@ -822,7 +855,7 @@
         errorLine2="                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt"
-            line="391"
+            line="390"
             column="54"/>
     </issue>
 
@@ -833,7 +866,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt"
-            line="403"
+            line="402"
             column="9"/>
     </issue>
 
@@ -844,7 +877,7 @@
         errorLine2="           ~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt"
-            line="595"
+            line="594"
             column="12"/>
     </issue>
 

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt
@@ -22,7 +22,6 @@ import com.duckduckgo.feature.toggles.api.Cohorts.TREATMENT
 import com.duckduckgo.feature.toggles.api.Toggle.FeatureName
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.feature.toggles.api.Toggle.State.CohortName
-import com.duckduckgo.feature.toggles.api.Toggle.State.Target
 import com.duckduckgo.feature.toggles.internal.api.FeatureTogglesCallback
 import java.lang.IllegalStateException
 import kotlinx.coroutines.test.runTest
@@ -156,7 +155,7 @@ class FeatureTogglesTest {
         toggleStore.set(
             "test_forcesDefaultVariant",
             State(
-                targets = listOf(Target("na", localeCountry = null, localeLanguage = null)),
+                targets = listOf(State.Target("na", localeCountry = null, localeLanguage = null, null, null)),
             ),
         )
         assertNull(provider.variantKey)
@@ -428,7 +427,7 @@ class FeatureTogglesTest {
         val state = Toggle.State(
             remoteEnableState = null,
             enable = true,
-            targets = listOf(Toggle.State.Target("ma", localeCountry = null, localeLanguage = null)),
+            targets = listOf(State.Target("ma", localeCountry = null, localeLanguage = null, null, null)),
         )
 
         // Use directly the store because setRawStoredState() populates the local state when the remote state is null
@@ -446,7 +445,7 @@ class FeatureTogglesTest {
         val state = Toggle.State(
             remoteEnableState = null,
             enable = true,
-            targets = listOf(Toggle.State.Target(provider.variantKey!!, localeCountry = null, localeLanguage = null)),
+            targets = listOf(State.Target(provider.variantKey!!, localeCountry = null, localeLanguage = null, null, null)),
         )
 
         // Use directly the store because setRawStoredState() populates the local state when the remote state is null
@@ -464,7 +463,7 @@ class FeatureTogglesTest {
         val state = Toggle.State(
             remoteEnableState = null,
             enable = true,
-            targets = listOf(Toggle.State.Target("zz", localeCountry = null, localeLanguage = null)),
+            targets = listOf(State.Target("zz", localeCountry = null, localeLanguage = null, null, null)),
         )
 
         // Use directly the store because setRawStoredState() populates the local state when the remote state is null
@@ -491,8 +490,8 @@ class FeatureTogglesTest {
             remoteEnableState = null,
             enable = true,
             targets = listOf(
-                Toggle.State.Target("ma", localeCountry = null, localeLanguage = null),
-                Toggle.State.Target("mb", localeCountry = null, localeLanguage = null),
+                State.Target("ma", localeCountry = null, localeLanguage = null, null, null),
+                State.Target("mb", localeCountry = null, localeLanguage = null, null, null),
             ),
         )
 
@@ -512,8 +511,8 @@ class FeatureTogglesTest {
             remoteEnableState = null,
             enable = true,
             targets = listOf(
-                Toggle.State.Target("ma", localeCountry = null, localeLanguage = null),
-                Toggle.State.Target("zz", localeCountry = null, localeLanguage = null),
+                State.Target("ma", localeCountry = null, localeLanguage = null, null, null),
+                State.Target("zz", localeCountry = null, localeLanguage = null, null, null),
             ),
         )
 
@@ -620,6 +619,10 @@ private class FakeFeatureTogglesCallback : FeatureTogglesCallback {
         this.cohortName = cohortName
         this.enrollmentDate = enrollmentDate
         times++
+    }
+
+    override fun matchesToggleTargets(targets: List<Any>): Boolean {
+        return true
     }
 }
 

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt
@@ -1559,6 +1559,73 @@ class ContributesRemoteFeatureCodeGeneratorTest {
     }
 
     @Test
+    fun `test multiple languages`() {
+        val feature = generatedFeatureNewInstance()
+
+        val privacyPlugin = (feature as PrivacyFeaturePlugin)
+        featureTogglesCallback.locale = Locale(Locale.FRANCE.language, Locale.US.country)
+
+        // all disabled
+        assertTrue(
+            privacyPlugin.store(
+                "testFeature",
+                """
+                    {
+                        "state": "enabled",
+                        "features": {
+                            "fooFeature": {
+                                "state": "enabled",
+                                "targets": [
+                                    {
+                                        "localeCountry": "US",
+                                        "localeLanguage": "en"
+                                    },
+                                    {
+                                        "localeCountry": "FR",
+                                        "localeLanguage": "fr"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                """.trimIndent(),
+            ),
+        )
+
+        assertTrue(testFeature.self().isEnabled())
+        assertFalse(testFeature.fooFeature().isEnabled())
+        assertEquals(
+            listOf(
+                Toggle.State.Target(null, "US", "en", null, null),
+                Toggle.State.Target(null, "FR", "fr", null, null),
+            ),
+            testFeature.fooFeature().getRawStoredState()!!.targets,
+        )
+
+        featureTogglesCallback.locale = Locale.US
+        assertTrue(testFeature.self().isEnabled())
+        assertTrue(testFeature.fooFeature().isEnabled())
+        assertEquals(
+            listOf(
+                Toggle.State.Target(null, "US", "en", null, null),
+                Toggle.State.Target(null, "FR", "fr", null, null),
+            ),
+            testFeature.fooFeature().getRawStoredState()!!.targets,
+        )
+
+        featureTogglesCallback.locale = Locale.FRANCE
+        assertTrue(testFeature.self().isEnabled())
+        assertTrue(testFeature.fooFeature().isEnabled())
+        assertEquals(
+            listOf(
+                Toggle.State.Target(null, "US", "en", null, null),
+                Toggle.State.Target(null, "FR", "fr", null, null),
+            ),
+            testFeature.fooFeature().getRawStoredState()!!.targets,
+        )
+    }
+
+    @Test
     fun `test feature with multiple targets not matching`() {
         val feature = generatedFeatureNewInstance()
 

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.feature.toggles.api.Toggle.State.Cohort
 import com.duckduckgo.feature.toggles.api.Toggle.State.CohortName
 import com.duckduckgo.feature.toggles.codegen.ContributesRemoteFeatureCodeGeneratorTest.Cohorts.BLUE
 import com.duckduckgo.feature.toggles.codegen.ContributesRemoteFeatureCodeGeneratorTest.Cohorts.CONTROL
+import com.duckduckgo.feature.toggles.fakes.FakeFeatureTogglesCallback
 import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -66,6 +67,7 @@ class ContributesRemoteFeatureCodeGeneratorTest {
     private val appBuildConfig: AppBuildConfig = mock()
     private lateinit var variantManager: FakeVariantManager
     private lateinit var toggleStore: FakeToggleStore
+    private val featureTogglesCallback = FakeFeatureTogglesCallback()
 
     @Before
     fun setup() {
@@ -76,16 +78,15 @@ class ContributesRemoteFeatureCodeGeneratorTest {
             toggleStore,
             featureName = "testFeature",
             appVersionProvider = { appBuildConfig.versionCode },
-            localeProvider = { appBuildConfig.deviceLocale },
             flavorNameProvider = { appBuildConfig.flavor.name },
             appVariantProvider = { variantManager.getVariantKey() },
             forceDefaultVariant = { variantManager.updateVariants(emptyList()) },
+            callback = featureTogglesCallback,
         ).build().create(TestTriggerFeature::class.java)
         anotherTestFeature = FeatureToggles.Builder(
             toggleStore,
             featureName = "testFeature",
             appVersionProvider = { appBuildConfig.versionCode },
-            localeProvider = { appBuildConfig.deviceLocale },
             flavorNameProvider = { appBuildConfig.flavor.name },
             appVariantProvider = { variantManager.getVariantKey() },
             forceDefaultVariant = { variantManager.updateVariants(emptyList()) },
@@ -1523,7 +1524,7 @@ class ContributesRemoteFeatureCodeGeneratorTest {
         val feature = generatedFeatureNewInstance()
 
         val privacyPlugin = (feature as PrivacyFeaturePlugin)
-        whenever(appBuildConfig.deviceLocale).thenReturn(Locale(Locale.FRANCE.language, Locale.US.country))
+        featureTogglesCallback.locale = Locale(Locale.FRANCE.language, Locale.US.country)
 
         // all disabled
         assertTrue(
@@ -1552,7 +1553,7 @@ class ContributesRemoteFeatureCodeGeneratorTest {
         assertTrue(testFeature.self().isEnabled())
         assertTrue(testFeature.fooFeature().isEnabled())
         assertEquals(
-            listOf(Toggle.State.Target("mc", "US", "fr")),
+            listOf(Toggle.State.Target("mc", "US", "fr", null, null)),
             testFeature.fooFeature().getRawStoredState()!!.targets,
         )
     }
@@ -1562,7 +1563,7 @@ class ContributesRemoteFeatureCodeGeneratorTest {
         val feature = generatedFeatureNewInstance()
 
         val privacyPlugin = (feature as PrivacyFeaturePlugin)
-        whenever(appBuildConfig.deviceLocale).thenReturn(Locale.FRANCE)
+        featureTogglesCallback.locale = Locale.FRANCE
 
         // all disabled
         assertTrue(
@@ -1588,10 +1589,10 @@ class ContributesRemoteFeatureCodeGeneratorTest {
             ),
         )
 
-        assertTrue(testFeature.self().isEnabled())
-        assertFalse(testFeature.fooFeature().isEnabled())
+        // foo feature is not an experiment and the target has a variantKey. As this is a mistake, that target is invalidated, hence assertTrue
+        assertTrue(testFeature.fooFeature().isEnabled())
         assertEquals(
-            listOf(Toggle.State.Target("mc", "US", "fr")),
+            listOf(Toggle.State.Target("mc", "US", "fr", null, null)),
             testFeature.fooFeature().getRawStoredState()!!.targets,
         )
     }
@@ -1635,9 +1636,9 @@ class ContributesRemoteFeatureCodeGeneratorTest {
         assertTrue(testFeature.fooFeature().isEnabled())
         assertEquals(
             listOf(
-                Toggle.State.Target("mc", null, null),
-                Toggle.State.Target(null, "US", null),
-                Toggle.State.Target(null, null, "fr"),
+                Toggle.State.Target("mc", null, null, null, null),
+                Toggle.State.Target(null, "US", null, null, null),
+                Toggle.State.Target(null, null, "fr", null, null),
             ),
             testFeature.fooFeature().getRawStoredState()!!.targets,
         )
@@ -1648,7 +1649,7 @@ class ContributesRemoteFeatureCodeGeneratorTest {
         val feature = generatedFeatureNewInstance()
 
         val privacyPlugin = (feature as PrivacyFeaturePlugin)
-        whenever(appBuildConfig.deviceLocale).thenReturn(Locale.FRANCE)
+        featureTogglesCallback.locale = Locale.FRANCE
 
         // all disabled
         assertTrue(
@@ -1668,7 +1669,7 @@ class ContributesRemoteFeatureCodeGeneratorTest {
                                         "localeCountry": "US"
                                     },
                                     {
-                                        "localeLanguage": "fr"
+                                        "localeLanguage": "zh"
                                     }
                                 ]
                             }
@@ -1682,9 +1683,9 @@ class ContributesRemoteFeatureCodeGeneratorTest {
         assertFalse(testFeature.fooFeature().isEnabled())
         assertEquals(
             listOf(
-                Toggle.State.Target("mc", null, null),
-                Toggle.State.Target(null, "US", null),
-                Toggle.State.Target(null, null, "fr"),
+                Toggle.State.Target("mc", null, null, null, null),
+                Toggle.State.Target(null, "US", null, null, null),
+                Toggle.State.Target(null, null, "zh", null, null),
             ),
             testFeature.fooFeature().getRawStoredState()!!.targets,
         )
@@ -1774,8 +1775,8 @@ class ContributesRemoteFeatureCodeGeneratorTest {
         assertTrue(testFeature.fooFeature().isEnabled())
         assertEquals(
             listOf(
-                Toggle.State.Target("ma", localeCountry = null, localeLanguage = null),
-                Toggle.State.Target("mb", localeCountry = null, localeLanguage = null),
+                Toggle.State.Target("ma", localeCountry = null, localeLanguage = null, null, null),
+                Toggle.State.Target("mb", localeCountry = null, localeLanguage = null, null, null),
             ),
             testFeature.fooFeature().getRawStoredState()!!.targets,
         )
@@ -1783,8 +1784,8 @@ class ContributesRemoteFeatureCodeGeneratorTest {
         assertFalse(testFeature.experimentFooFeature().isEnabled())
         assertEquals(
             listOf(
-                Toggle.State.Target("ma", localeCountry = null, localeLanguage = null),
-                Toggle.State.Target("mb", localeCountry = null, localeLanguage = null),
+                Toggle.State.Target("ma", localeCountry = null, localeLanguage = null, null, null),
+                Toggle.State.Target("mb", localeCountry = null, localeLanguage = null, null, null),
             ),
             testFeature.experimentFooFeature().getRawStoredState()!!.targets,
         )
@@ -1792,7 +1793,7 @@ class ContributesRemoteFeatureCodeGeneratorTest {
         assertFalse(testFeature.variantFeature().isEnabled())
         assertEquals(
             listOf(
-                Toggle.State.Target("mc", localeCountry = null, localeLanguage = null),
+                Toggle.State.Target("mc", localeCountry = null, localeLanguage = null, null, null),
             ),
             testFeature.variantFeature().getRawStoredState()!!.targets,
         )
@@ -1850,8 +1851,8 @@ class ContributesRemoteFeatureCodeGeneratorTest {
         assertFalse(testFeature.experimentFooFeature().isEnabled())
         assertEquals(
             listOf(
-                Toggle.State.Target("ma", localeCountry = null, localeLanguage = null),
-                Toggle.State.Target("mb", localeCountry = null, localeLanguage = null),
+                Toggle.State.Target("ma", localeCountry = null, localeLanguage = null, null, null),
+                Toggle.State.Target("mb", localeCountry = null, localeLanguage = null, null, null),
             ),
             testFeature.experimentFooFeature().getRawStoredState()!!.targets,
         )
@@ -1860,7 +1861,7 @@ class ContributesRemoteFeatureCodeGeneratorTest {
         assertEquals(1, variantManager.saveVariantsCallCounter)
         assertEquals(
             listOf(
-                Toggle.State.Target("mc", localeCountry = null, localeLanguage = null),
+                Toggle.State.Target("mc", localeCountry = null, localeLanguage = null, null, null),
             ),
             testFeature.variantFeature().getRawStoredState()!!.targets,
         )
@@ -1915,8 +1916,8 @@ class ContributesRemoteFeatureCodeGeneratorTest {
         assertEquals("na", variantManager.variant)
         assertEquals(
             listOf(
-                Toggle.State.Target("ma", localeCountry = null, localeLanguage = null),
-                Toggle.State.Target("mb", localeCountry = null, localeLanguage = null),
+                Toggle.State.Target("ma", localeCountry = null, localeLanguage = null, null, null),
+                Toggle.State.Target("mb", localeCountry = null, localeLanguage = null, null, null),
             ),
             testFeature.experimentFooFeature().getRawStoredState()!!.targets,
         )
@@ -1925,7 +1926,7 @@ class ContributesRemoteFeatureCodeGeneratorTest {
         assertEquals("na", variantManager.variant)
         assertEquals(
             listOf(
-                Toggle.State.Target("mc", localeCountry = null, localeLanguage = null),
+                Toggle.State.Target("mc", localeCountry = null, localeLanguage = null, null, null),
             ),
             testFeature.variantFeature().getRawStoredState()!!.targets,
         )
@@ -1966,7 +1967,7 @@ class ContributesRemoteFeatureCodeGeneratorTest {
         assertEquals("", variantManager.getVariantKey())
         assertEquals(
             listOf(
-                Toggle.State.Target("mc", localeCountry = null, localeLanguage = null),
+                Toggle.State.Target("mc", localeCountry = null, localeLanguage = null, null, null),
             ),
             testFeature.experimentDisabledByDefault().getRawStoredState()!!.targets,
         )
@@ -2007,7 +2008,7 @@ class ContributesRemoteFeatureCodeGeneratorTest {
         assertEquals("", variantManager.getVariantKey())
         assertEquals(
             listOf(
-                Toggle.State.Target("", localeCountry = null, localeLanguage = null),
+                Toggle.State.Target("", localeCountry = null, localeLanguage = null, null, null),
             ),
             testFeature.experimentDisabledByDefault().getRawStoredState()!!.targets,
         )
@@ -2048,7 +2049,7 @@ class ContributesRemoteFeatureCodeGeneratorTest {
         assertEquals("mc", variantManager.getVariantKey())
         assertEquals(
             listOf(
-                Toggle.State.Target("mc", localeCountry = null, localeLanguage = null),
+                Toggle.State.Target("mc", localeCountry = null, localeLanguage = null, null, null),
             ),
             testFeature.experimentDisabledByDefault().getRawStoredState()!!.targets,
         )
@@ -2089,7 +2090,7 @@ class ContributesRemoteFeatureCodeGeneratorTest {
         assertTrue(testFeature.experimentDisabledByDefault().isEnabled()) // true because experiments only check variantKey
         assertEquals(
             listOf(
-                Toggle.State.Target("mc", localeCountry = "US", localeLanguage = null),
+                Toggle.State.Target("mc", localeCountry = "US", localeLanguage = null, null, null),
             ),
             testFeature.experimentDisabledByDefault().getRawStoredState()!!.targets,
         )
@@ -2120,7 +2121,7 @@ class ContributesRemoteFeatureCodeGeneratorTest {
         assertTrue(testFeature.experimentDisabledByDefault().isEnabled()) // true because experiments only check variantKey
         assertEquals(
             listOf(
-                Toggle.State.Target("mc", localeCountry = null, localeLanguage = "US"),
+                Toggle.State.Target("mc", localeCountry = null, localeLanguage = "US", null, null),
             ),
             testFeature.experimentDisabledByDefault().getRawStoredState()!!.targets,
         )
@@ -2150,7 +2151,7 @@ class ContributesRemoteFeatureCodeGeneratorTest {
         assertTrue(testFeature.experimentDisabledByDefault().isEnabled())
         assertEquals(
             listOf(
-                Toggle.State.Target("mc", localeCountry = null, localeLanguage = null),
+                Toggle.State.Target("mc", localeCountry = null, localeLanguage = null, null, null),
             ),
             testFeature.experimentDisabledByDefault().getRawStoredState()!!.targets,
         )
@@ -2180,7 +2181,7 @@ class ContributesRemoteFeatureCodeGeneratorTest {
         assertFalse(testFeature.experimentDisabledByDefault().isEnabled()) // true because experiments only check variantKey
         assertEquals(
             listOf(
-                Toggle.State.Target("ma", localeCountry = null, localeLanguage = null),
+                Toggle.State.Target("ma", localeCountry = null, localeLanguage = null, null, null),
             ),
             testFeature.experimentDisabledByDefault().getRawStoredState()!!.targets,
         )
@@ -2222,7 +2223,7 @@ class ContributesRemoteFeatureCodeGeneratorTest {
         assertTrue(testFeature.experimentDisabledByDefault().isEnabled())
         assertEquals(
             listOf(
-                Toggle.State.Target("mc", localeCountry = "US", localeLanguage = null),
+                Toggle.State.Target("mc", localeCountry = "US", localeLanguage = null, null, null),
             ),
             testFeature.experimentDisabledByDefault().getRawStoredState()!!.targets,
         )
@@ -2848,7 +2849,7 @@ class ContributesRemoteFeatureCodeGeneratorTest {
 
         val privacyPlugin = (feature as PrivacyFeaturePlugin)
 
-        whenever(appBuildConfig.deviceLocale).thenReturn(Locale(Locale.FRANCE.language, Locale.US.country))
+        featureTogglesCallback.locale = Locale(Locale.FRANCE.language, Locale.US.country)
 
         assertTrue(
             privacyPlugin.store(
@@ -2893,15 +2894,15 @@ class ContributesRemoteFeatureCodeGeneratorTest {
         assertFalse(testFeature.fooFeature().isEnabled(CONTROL))
         assertFalse(testFeature.fooFeature().isEnabled(BLUE))
 
-        whenever(appBuildConfig.deviceLocale).thenReturn(Locale(Locale.US.language, Locale.FRANCE.country))
+        featureTogglesCallback.locale = Locale(Locale.US.language, Locale.FRANCE.country)
         assertFalse(testFeature.fooFeature().isEnabled(CONTROL))
         assertFalse(testFeature.fooFeature().isEnabled(BLUE))
 
-        whenever(appBuildConfig.deviceLocale).thenReturn(Locale.US)
+        featureTogglesCallback.locale = Locale.US
         assertFalse(testFeature.fooFeature().isEnabled(CONTROL))
         assertFalse(testFeature.fooFeature().isEnabled(BLUE))
 
-        whenever(appBuildConfig.deviceLocale).thenReturn(Locale.FRANCE)
+        featureTogglesCallback.locale = Locale.FRANCE
         assertTrue(testFeature.fooFeature().isEnabled(CONTROL))
         assertFalse(testFeature.fooFeature().isEnabled(BLUE))
 

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/fakes/FakeFeatureTogglesCallback.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/fakes/FakeFeatureTogglesCallback.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.feature.toggles.fakes
+
+import com.duckduckgo.feature.toggles.api.Toggle.State.Target
+import com.duckduckgo.feature.toggles.internal.api.FeatureTogglesCallback
+import java.util.*
+
+class FakeFeatureTogglesCallback constructor() : FeatureTogglesCallback {
+    var locale = Locale.US
+    var isReturningUser = true
+    var isPrivacyProEligible = false
+
+    override fun onCohortAssigned(
+        experimentName: String,
+        cohortName: String,
+        enrollmentDate: String,
+    ) {
+        // no-op
+    }
+
+    override fun matchesToggleTargets(targets: List<Any>): Boolean {
+        if (targets.isEmpty()) return true
+
+        targets.forEach { target ->
+            if (target is Target) {
+                if (matchTarget(target)) {
+                    return true
+                }
+            } else {
+                throw RuntimeException("targets shall be of type Toggle.State.Target")
+            }
+        }
+
+        return false
+    }
+
+    private fun matchTarget(target: Target): Boolean {
+        fun matchLocale(targetCountry: String?, targetLanguage: String?): Boolean {
+            val countryMatches = targetCountry?.let { locale.country.lowercase() == targetCountry.lowercase() } ?: true
+            val languageMatches = targetLanguage?.let { locale.language.lowercase() == targetLanguage.lowercase() } ?: true
+
+            return countryMatches && languageMatches
+        }
+
+        fun matchReturningUser(targetIsReturningUser: Boolean?): Boolean {
+            return targetIsReturningUser?.let { targetIsReturningUser == isReturningUser } ?: true
+        }
+
+        fun matchPrivacyProEligible(targetPProEligible: Boolean?): Boolean {
+            return targetPProEligible?.let { targetPProEligible == isPrivacyProEligible } ?: true
+        }
+
+        return matchLocale(target.localeCountry, target.localeLanguage) &&
+            matchPrivacyProEligible(target.isPrivacyProEligible) &&
+            matchReturningUser(target.isReturningUser)
+    }
+}

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/LocaleToggleTargetMatcherTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/LocaleToggleTargetMatcherTest.kt
@@ -1,0 +1,82 @@
+package com.duckduckgo.feature.toggles.impl
+
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.feature.toggles.api.Toggle
+import java.util.Locale
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class LocaleToggleTargetMatcherTest {
+    private val appBuildConfig: AppBuildConfig = mock()
+    private val matcher = LocaleToggleTargetMatcher(appBuildConfig)
+
+    @Test
+    fun whenAnyLocaleAndNullTargetThenTrue() {
+        whenever(appBuildConfig.deviceLocale).thenReturn(Locale.US)
+
+        assertTrue(matcher.matchesTargetProperty(NULL_TARGET))
+    }
+
+    @Test
+    fun whenLocaleCountryNotMatchingTargetThenFalse() {
+        whenever(appBuildConfig.deviceLocale).thenReturn(Locale.CHINA)
+
+        assertFalse(matcher.matchesTargetProperty(US_COUNTRY_TARGET))
+    }
+
+    @Test
+    fun whenLocaleLanguageNotMatchingTargetThenFalse() {
+        whenever(appBuildConfig.deviceLocale).thenReturn(Locale.CHINA)
+
+        assertFalse(matcher.matchesTargetProperty(US_LANG_TARGET))
+    }
+
+    @Test
+    fun whenLocaleLanguageMatchesButNotCountryThenFalse() {
+        whenever(appBuildConfig.deviceLocale).thenReturn(Locale(Locale.US.language, Locale.FRANCE.country))
+
+        assertFalse(matcher.matchesTargetProperty(US_TARGET))
+    }
+
+    @Test
+    fun whenLocaleLanguageMatchesThenTrue() {
+        whenever(appBuildConfig.deviceLocale).thenReturn(Locale(Locale.US.language, Locale.FRANCE.country))
+
+        assertTrue(matcher.matchesTargetProperty(US_LANG_TARGET))
+    }
+
+    @Test
+    fun whenLocaleCountryMatchesButNotLanguageThenFalse() {
+        whenever(appBuildConfig.deviceLocale).thenReturn(Locale(Locale.FRANCE.language, Locale.US.country))
+
+        assertFalse(matcher.matchesTargetProperty(US_TARGET))
+    }
+
+    @Test
+    fun whenLocaleCountryMatchesThenTrue() {
+        whenever(appBuildConfig.deviceLocale).thenReturn(Locale(Locale.FRANCE.language, Locale.US.country))
+
+        assertTrue(matcher.matchesTargetProperty(US_COUNTRY_TARGET))
+    }
+
+    @Test
+    fun testIgnoreCasing() {
+        whenever(appBuildConfig.deviceLocale).thenReturn(Locale.US)
+
+        assertTrue(matcher.matchesTargetProperty(US_TARGET_LOWERCASE))
+    }
+
+    companion object {
+        private val NULL_TARGET = Toggle.State.Target(null, null, null, null, null)
+        private val US_COUNTRY_TARGET = NULL_TARGET.copy(localeCountry = Locale.US.country)
+        private val US_LANG_TARGET = NULL_TARGET.copy(localeLanguage = Locale.US.language)
+        private val US_TARGET = NULL_TARGET.copy(localeLanguage = Locale.US.language, localeCountry = Locale.US.country)
+        private val US_TARGET_LOWERCASE = NULL_TARGET.copy(
+            localeLanguage = Locale.US.language.lowercase(),
+            localeCountry = Locale.US.country.lowercase(),
+        )
+    }
+}

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/RealFeatureTogglesCallbackTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/impl/RealFeatureTogglesCallbackTest.kt
@@ -2,6 +2,8 @@ package com.duckduckgo.feature.toggles.impl
 
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
+import com.duckduckgo.common.utils.plugins.PluginPoint
+import com.duckduckgo.feature.toggles.api.Toggle.TargetMatcherPlugin
 import okio.ByteString.Companion.encode
 import org.junit.Test
 import org.mockito.Mockito.mock
@@ -9,7 +11,12 @@ import org.mockito.kotlin.verify
 
 class RealFeatureTogglesCallbackTest {
     private val pixel: Pixel = mock()
-    private val callback = RealFeatureTogglesCallback(pixel)
+    private val plugins: PluginPoint<TargetMatcherPlugin> = object : PluginPoint<TargetMatcherPlugin> {
+        override fun getPlugins(): Collection<TargetMatcherPlugin> {
+            TODO("Not yet implemented")
+        }
+    }
+    private val callback = RealFeatureTogglesCallback(pixel, plugins)
 
     @Test
     fun `test pixel is sent with correct parameters`() {

--- a/feature-toggles/feature-toggles-internal-api/src/main/java/com/duckduckgo/feature/toggles/internal/api/FeatureTogglesCallback.kt
+++ b/feature-toggles/feature-toggles-internal-api/src/main/java/com/duckduckgo/feature/toggles/internal/api/FeatureTogglesCallback.kt
@@ -26,4 +26,9 @@ interface FeatureTogglesCallback {
      * This method is called whenever a cohort is assigned to the FeatureToggle
      */
     fun onCohortAssigned(experimentName: String, cohortName: String, enrollmentDate: String)
+
+    /**
+     * @return `true` if the ANY of the remote feature targets match the device configuration, `false` otherwise
+     */
+    fun matchesToggleTargets(targets: List<Any>): Boolean
 }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsToggleTargetMatcherPlugin.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsToggleTargetMatcherPlugin.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle.State.Target
+import com.duckduckgo.feature.toggles.api.Toggle.TargetMatcherPlugin
+import com.duckduckgo.subscriptions.api.Subscriptions
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+import kotlinx.coroutines.runBlocking
+
+@ContributesMultibinding(AppScope::class)
+class SubscriptionsToggleTargetMatcherPlugin @Inject constructor(
+    private val subscriptions: Subscriptions,
+) : TargetMatcherPlugin {
+    override fun matchesTargetProperty(target: Target): Boolean {
+        return target.isPrivacyProEligible?.let { isPrivacyProEligible ->
+            // runBlocking sucks I know :shrug:
+            isPrivacyProEligible == runBlocking { subscriptions.isEligible() }
+        } ?: true
+    }
+}

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/SubscriptionsToggleTargetMatcherPluginTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/SubscriptionsToggleTargetMatcherPluginTest.kt
@@ -1,0 +1,64 @@
+package com.duckduckgo.subscriptions.impl
+
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.subscriptions.api.Subscriptions
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class SubscriptionsToggleTargetMatcherPluginTest {
+
+    private val subscriptions: Subscriptions = mock()
+    private val matcher = SubscriptionsToggleTargetMatcherPlugin(subscriptions)
+
+    @Test
+    fun whenIsEligibleAndNullTargetThenReturnTrue() = runTest {
+        whenever(subscriptions.isEligible()).thenReturn(true)
+
+        assertTrue(matcher.matchesTargetProperty(NULL_TARGET))
+    }
+
+    @Test
+    fun whenIsNotEligibleAndNullTargetThenReturnTrue() = runTest {
+        whenever(subscriptions.isEligible()).thenReturn(false)
+
+        assertTrue(matcher.matchesTargetProperty(NULL_TARGET))
+    }
+
+    @Test
+    fun whenIsEligibleAndAndTargetMatchesThenTrue() = runTest {
+        whenever(subscriptions.isEligible()).thenReturn(true)
+
+        assertTrue(matcher.matchesTargetProperty(ELIGIBLE_TARGET))
+    }
+
+    @Test
+    fun whenIsNotEligibleAndAndTargetMatchesThenTrue() = runTest {
+        whenever(subscriptions.isEligible()).thenReturn(false)
+
+        assertTrue(matcher.matchesTargetProperty(NOT_ELIGIBLE_TARGET))
+    }
+
+    @Test
+    fun whenIsEligibleAndAndTargetNotMatchingThenTrue() = runTest {
+        whenever(subscriptions.isEligible()).thenReturn(true)
+
+        assertFalse(matcher.matchesTargetProperty(NOT_ELIGIBLE_TARGET))
+    }
+
+    @Test
+    fun whenIsNotEligibleAndAndTargetNotMatchingThenTrue() = runTest {
+        whenever(subscriptions.isEligible()).thenReturn(false)
+
+        assertFalse(matcher.matchesTargetProperty(ELIGIBLE_TARGET))
+    }
+
+    companion object {
+        private val NULL_TARGET = Toggle.State.Target(null, null, null, null, null)
+        private val ELIGIBLE_TARGET = NULL_TARGET.copy(isPrivacyProEligible = true)
+        private val NOT_ELIGIBLE_TARGET = NULL_TARGET.copy(isPrivacyProEligible = false)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1198194956794324/1208710375047087/f

### Description
This PR adds couple new targets for FF, ie. isReturningUser and isPrivacyProEligible, both of type `Boolean`

The PR also modularizes the way we hande targets, turning them into plugins so that it's easier in the future to add targets without (almost) touching the toggles API

### Steps to test this PR
Added unit and integration tests 

_Test new targets_
- [ ] install from this branch
- [ ] create a test feature
- [ ] create a remote config for the test feature that contains `isPrivacyProEligible` as target
- [ ] in a client that is not eligigle for PPro verify the feature is always disabled
- [ ] in a client that is eligigle for PPro verify the feature is enabled when the feature is enabled in remote config
- [ ] create a remote config for the test feature that contains `isReturningUser ` as target
- [ ] in a fresh install verify the test feature is always disabled
- [ ] in a returning install verify the test feature is enabled when the feature is enabled in remote config
