### PR TITLE
Auto switch account if user only has 1 device connected when login

### DIFF
--- a/sync/sync-impl/lint-baseline.xml
+++ b/sync/sync-impl/lint-baseline.xml
@@ -36,6 +36,17 @@
 
     <issue
         id="DenyListedApi"
+        message="If you find yourself using this API in production, you&apos;re doing something wrong!!"
+        errorLine1="        this.seamlessAccountSwitching().setRawStoredState(State(true))"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt"
+            line="100"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="DenyListedApi"
         message="No one remembers what these constants map to. Use the API level integer value directly since it&apos;s self-defining."
         errorLine1="        return if (appBuildConfig.sdkInt != Build.VERSION_CODES.Q &amp;&amp; appBuildConfig.sdkInt != Build.VERSION_CODES.P) {"
         errorLine2="                                            ~~~~~~~~~~~~~~~~~~~~~">
@@ -107,7 +118,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt"
-            line="62"
+            line="63"
             column="9"/>
     </issue>
 
@@ -118,7 +129,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt"
-            line="136"
+            line="137"
             column="9"/>
     </issue>
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
@@ -74,7 +74,10 @@ class AppSyncAccountRepository @Inject constructor(
     private val syncPixels: SyncPixels,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
+    private val syncFeature: SyncFeature,
 ) : SyncAccountRepository {
+
+    private val connectedDevicesCached: MutableList<ConnectedDevice> = mutableListOf()
 
     override fun isSyncSupported(): Boolean {
         return syncStore.isEncryptionSupported()
@@ -109,8 +112,17 @@ class AppSyncAccountRepository @Inject constructor(
 
     private fun login(recoveryCode: RecoveryCode): Result<Boolean> {
         if (isSignedIn()) {
-            return Error(code = ALREADY_SIGNED_IN.code, reason = "Already signed in")
-                .alsoFireAlreadySignedInErrorPixel()
+            val allowSwitchAccount = syncFeature.seamlessAccountSwitching().isEnabled()
+            val error = Error(code = ALREADY_SIGNED_IN.code, reason = "Already signed in").alsoFireAlreadySignedInErrorPixel()
+            if (allowSwitchAccount && connectedDevicesCached.size == 1) {
+                val thisDeviceId = syncStore.deviceId.orEmpty()
+                val result = logout(thisDeviceId)
+                if (result is Error) {
+                    return result
+                }
+            } else {
+                return error
+            }
         }
 
         val primaryKey = recoveryCode.primaryKey
@@ -288,6 +300,7 @@ class AppSyncAccountRepository @Inject constructor(
 
         return when (val result = syncApi.getDevices(token)) {
             is Error -> {
+                connectedDevicesCached.clear()
                 result.alsoFireAccountErrorPixel().copy(code = GENERIC_ERROR.code)
             }
 
@@ -315,6 +328,11 @@ class AppSyncAccountRepository @Inject constructor(
                         }
                     }.sortedWith { a, b ->
                         if (a.thisDevice) -1 else 1
+                    }.also {
+                        connectedDevicesCached.apply {
+                            clear()
+                            addAll(it)
+                        }
                     },
                 )
             }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
@@ -45,6 +45,6 @@ interface SyncFeature {
     @Toggle.DefaultValue(true)
     fun gzipPatchRequests(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(true)
     fun seamlessAccountSwitching(): Toggle
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixelParamRemovalPlugin.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixelParamRemovalPlugin.kt
@@ -35,6 +35,13 @@ class SyncPixelParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugi
             SyncPixelName.SYNC_GET_OTHER_DEVICES_SCREEN_SHOWN.pixelName to PixelParameter.removeAtb(),
             SyncPixelName.SYNC_GET_OTHER_DEVICES_LINK_COPIED.pixelName to PixelParameter.removeAtb(),
             SyncPixelName.SYNC_GET_OTHER_DEVICES_LINK_SHARED.pixelName to PixelParameter.removeAtb(),
+
+            SyncPixelName.SYNC_ASK_USER_TO_SWITCH_ACCOUNT.pixelName to PixelParameter.removeAtb(),
+            SyncPixelName.SYNC_USER_ACCEPTED_SWITCHING_ACCOUNT.pixelName to PixelParameter.removeAtb(),
+            SyncPixelName.SYNC_USER_CANCELLED_SWITCHING_ACCOUNT.pixelName to PixelParameter.removeAtb(),
+            SyncPixelName.SYNC_USER_SWITCHED_ACCOUNT.pixelName to PixelParameter.removeAtb(),
+            SyncPixelName.SYNC_USER_SWITCHED_LOGOUT_ERROR.pixelName to PixelParameter.removeAtb(),
+            SyncPixelName.SYNC_USER_SWITCHED_LOGIN_ERROR.pixelName to PixelParameter.removeAtb(),
         )
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
@@ -81,6 +81,13 @@ interface SyncPixels {
         feature: SyncableType,
         apiError: Error,
     )
+
+    fun fireAskUserToSwitchAccount()
+    fun fireUserAcceptedSwitchingAccount()
+    fun fireUserCancelledSwitchingAccount()
+    fun fireUserSwitchedAccount()
+    fun fireUserSwitchedLogoutError()
+    fun fireUserSwitchedLoginError()
 }
 
 @ContributesBinding(AppScope::class)
@@ -255,6 +262,30 @@ class RealSyncPixels @Inject constructor(
         }
     }
 
+    override fun fireUserSwitchedAccount() {
+        pixel.fire(SyncPixelName.SYNC_USER_SWITCHED_ACCOUNT)
+    }
+
+    override fun fireAskUserToSwitchAccount() {
+        pixel.fire(SyncPixelName.SYNC_ASK_USER_TO_SWITCH_ACCOUNT)
+    }
+
+    override fun fireUserAcceptedSwitchingAccount() {
+        pixel.fire(SyncPixelName.SYNC_USER_ACCEPTED_SWITCHING_ACCOUNT)
+    }
+
+    override fun fireUserCancelledSwitchingAccount() {
+        pixel.fire(SyncPixelName.SYNC_USER_CANCELLED_SWITCHING_ACCOUNT)
+    }
+
+    override fun fireUserSwitchedLoginError() {
+        pixel.fire(SyncPixelName.SYNC_USER_SWITCHED_LOGIN_ERROR)
+    }
+
+    override fun fireUserSwitchedLogoutError() {
+        pixel.fire(SyncPixelName.SYNC_USER_SWITCHED_LOGOUT_ERROR)
+    }
+
     companion object {
         private const val SYNC_PIXELS_PREF_FILE = "com.duckduckgo.sync.pixels.v1"
     }
@@ -302,6 +333,12 @@ enum class SyncPixelName(override val pixelName: String) : Pixel.PixelName {
     SYNC_GET_OTHER_DEVICES_SCREEN_SHOWN("sync_get_other_devices"),
     SYNC_GET_OTHER_DEVICES_LINK_COPIED("sync_get_other_devices_copy"),
     SYNC_GET_OTHER_DEVICES_LINK_SHARED("sync_get_other_devices_share"),
+    SYNC_ASK_USER_TO_SWITCH_ACCOUNT("sync_ask_user_to_switch_account"),
+    SYNC_USER_ACCEPTED_SWITCHING_ACCOUNT("sync_user_accepted_switching_account"),
+    SYNC_USER_CANCELLED_SWITCHING_ACCOUNT("sync_user_cancelled_switching_account"),
+    SYNC_USER_SWITCHED_ACCOUNT("sync_user_switched_account"),
+    SYNC_USER_SWITCHED_LOGOUT_ERROR("sync_user_switched_logout_error"),
+    SYNC_USER_SWITCHED_LOGIN_ERROR("sync_user_switched_login_error"),
 }
 
 object SyncPixelParameters {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
@@ -131,6 +131,7 @@ class EnterCodeActivity : DuckDuckGoActivity() {
     }
 
     private fun askUserToSwitchAccount(it: AskToSwitchAccount) {
+        viewModel.onUserAskedToSwitchAccount()
         TextAlertDialogBuilder(this)
             .setTitle(R.string.sync_dialog_switch_account_header)
             .setMessage(R.string.sync_dialog_switch_account_description)
@@ -140,6 +141,10 @@ class EnterCodeActivity : DuckDuckGoActivity() {
                 object : TextAlertDialogBuilder.EventListener() {
                     override fun onPositiveButtonClicked() {
                         viewModel.onUserAcceptedJoiningNewAccount(it.encodedStringCode)
+                    }
+
+                    override fun onNegativeButtonClicked() {
+                        viewModel.onUserCancelledJoiningNewAccount()
                     }
                 },
             ).show()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.AskToSwitchAccount
+import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.LoginSuccess
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.ShowError
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.SwitchAccountSuccess
 import javax.inject.*
@@ -90,9 +91,12 @@ class EnterCodeViewModel @Inject constructor(
     private suspend fun authFlow(
         pastedCode: String,
     ) {
-        val result = syncAccountRepository.processCode(pastedCode)
-        when (result) {
-            is Result.Success -> command.send(Command.LoginSuccess)
+        val userSignedIn = syncAccountRepository.isSignedIn()
+        when (val result = syncAccountRepository.processCode(pastedCode)) {
+            is Result.Success -> {
+                val commandSuccess = if (userSignedIn) SwitchAccountSuccess else LoginSuccess
+                command.send(commandSuccess)
+            }
             is Result.Error -> {
                 processError(result, pastedCode)
             }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
@@ -136,6 +136,7 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
 
     fun onQRCodeScanned(qrCode: String) {
         viewModelScope.launch(dispatchers.io()) {
+            val userSignedIn = syncAccountRepository.isSignedIn()
             when (val result = syncAccountRepository.processCode(qrCode)) {
                 is Error -> {
                     emitError(result, qrCode)
@@ -143,7 +144,8 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
 
                 is Success -> {
                     syncPixels.fireLoginPixel()
-                    command.send(LoginSuccess)
+                    val commandSuccess = if (userSignedIn) SwitchAccountSuccess else LoginSuccess
+                    command.send(commandSuccess)
                 }
             }
         }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
@@ -144,7 +144,12 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
 
                 is Success -> {
                     syncPixels.fireLoginPixel()
-                    val commandSuccess = if (userSignedIn) SwitchAccountSuccess else LoginSuccess
+                    val commandSuccess = if (userSignedIn) {
+                        syncPixels.fireUserSwitchedAccount()
+                        SwitchAccountSuccess
+                    } else {
+                        LoginSuccess
+                    }
                     command.send(commandSuccess)
                 }
             }
@@ -177,6 +182,7 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
 
     fun onUserAcceptedJoiningNewAccount(encodedStringCode: String) {
         viewModelScope.launch(dispatchers.io()) {
+            syncPixels.fireUserAcceptedSwitchingAccount()
             val result = syncAccountRepository.logoutAndJoinNewAccount(encodedStringCode)
             if (result is Error) {
                 when (result.code) {
@@ -193,6 +199,7 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
                 }
             } else {
                 syncPixels.fireLoginPixel()
+                syncPixels.fireUserSwitchedAccount()
                 command.send(SwitchAccountSuccess)
             }
         }
@@ -212,5 +219,13 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    fun onUserCancelledJoiningNewAccount() {
+        syncPixels.fireUserCancelledSwitchingAccount()
+    }
+
+    fun onUserAskedToSwitchAccount() {
+        syncPixels.fireAskUserToSwitchAccount()
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceActivity.kt
@@ -133,6 +133,7 @@ class SyncWithAnotherDeviceActivity : DuckDuckGoActivity() {
     }
 
     private fun askUserToSwitchAccount(it: AskToSwitchAccount) {
+        viewModel.onUserAskedToSwitchAccount()
         TextAlertDialogBuilder(this)
             .setTitle(R.string.sync_dialog_switch_account_header)
             .setMessage(R.string.sync_dialog_switch_account_description)
@@ -142,6 +143,10 @@ class SyncWithAnotherDeviceActivity : DuckDuckGoActivity() {
                 object : TextAlertDialogBuilder.EventListener() {
                     override fun onPositiveButtonClicked() {
                         viewModel.onUserAcceptedJoiningNewAccount(it.encodedStringCode)
+                    }
+
+                    override fun onNegativeButtonClicked() {
+                        viewModel.onUserCancelledJoiningNewAccount()
                     }
                 },
             ).show()

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/TestSyncFixtures.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/TestSyncFixtures.kt
@@ -140,7 +140,8 @@ object TestSyncFixtures {
     )
     val loginSuccessResponse: Response<LoginResponse> = Response.success(loginResponseBody)
 
-    val listOfDevices = listOf(Device(deviceId = deviceId, deviceName = deviceName, jwIat = "", deviceType = deviceFactor))
+    val aDevice = Device(deviceId = deviceId, deviceName = deviceName, jwIat = "", deviceType = deviceFactor)
+    val listOfDevices = listOf(aDevice)
     val deviceResponse = DeviceResponse(DeviceEntries(listOfDevices))
     val getDevicesBodySuccessResponse: Response<DeviceResponse> = Response.success(deviceResponse)
     val getDevicesBodyErrorResponse: Response<DeviceResponse> = Response.error(

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
@@ -18,6 +18,9 @@ package com.duckduckgo.sync.impl
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.common.utils.DefaultDispatcherProvider
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.sync.TestSyncFixtures.aDevice
 import com.duckduckgo.sync.TestSyncFixtures.accountCreatedFailDupUser
 import com.duckduckgo.sync.TestSyncFixtures.accountCreatedSuccess
 import com.duckduckgo.sync.TestSyncFixtures.accountKeys
@@ -65,9 +68,8 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.INVALID_CODE
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
-import com.duckduckgo.sync.impl.pixels.*
+import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.store.SyncStore
-import java.lang.RuntimeException
 import kotlinx.coroutines.test.TestScope
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -94,13 +96,25 @@ class AppSyncAccountRepositoryTest {
     private var syncStore: SyncStore = mock()
     private var syncEngine: SyncEngine = mock()
     private var syncPixels: SyncPixels = mock()
+    private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java).apply {
+        this.seamlessAccountSwitching().setRawStoredState(State(true))
+    }
 
     private lateinit var syncRepo: SyncAccountRepository
 
     @Before
     fun before() {
-        syncRepo =
-            AppSyncAccountRepository(syncDeviceIds, nativeLib, syncApi, syncStore, syncEngine, syncPixels, TestScope(), DefaultDispatcherProvider())
+        syncRepo = AppSyncAccountRepository(
+            syncDeviceIds,
+            nativeLib,
+            syncApi,
+            syncStore,
+            syncEngine,
+            syncPixels,
+            TestScope(),
+            DefaultDispatcherProvider(),
+            syncFeature,
+        )
     }
 
     @Test
@@ -229,6 +243,39 @@ class AppSyncAccountRepositoryTest {
             secretKey = secretKey,
             token = token,
         )
+    }
+
+    @Test
+    fun whenSignedInAndProcessRecoveryCodeIfAllowSwitchAccountTrueThenSwitchAccountIfOnly1DeviceConnected() {
+        givenAuthenticatedDevice()
+        givenAccountWithConnectedDevices(1)
+        doAnswer {
+            givenUnauthenticatedDevice() // simulate logout locally
+            logoutSuccess
+        }.`when`(syncApi).logout(token, deviceId)
+        prepareForLoginSuccess()
+
+        val result = syncRepo.processCode(jsonRecoveryKeyEncoded)
+
+        verify(syncApi).logout(token, deviceId)
+        verify(syncApi).login(userId, hashedPassword, deviceId, deviceName, deviceFactor)
+
+        assertTrue(result is Success)
+    }
+
+    @Test
+    fun whenSignedInAndProcessRecoveryCodeIfAllowSwitchAccountTrueThenReturnErrorIfMultipleDevicesConnected() {
+        givenAuthenticatedDevice()
+        givenAccountWithConnectedDevices(2)
+        doAnswer {
+            givenUnauthenticatedDevice() // simulate logout locally
+            logoutSuccess
+        }.`when`(syncApi).logout(token, deviceId)
+        prepareForLoginSuccess()
+
+        val result = syncRepo.processCode(jsonRecoveryKeyEncoded)
+
+        assertEquals((result as Error).code, ALREADY_SIGNED_IN.code)
     }
 
     @Test
@@ -572,5 +619,16 @@ class AppSyncAccountRepositoryTest {
         whenever(nativeLib.encryptData(anyString(), primaryKey = eq(primaryKey))).thenAnswer {
             EncryptResult(0, it.arguments.first() as String)
         }
+    }
+
+    private fun givenAccountWithConnectedDevices(size: Int) {
+        prepareForEncryption()
+        val listOfDevices = mutableListOf<Device>()
+        for (i in 0 until size) {
+            listOfDevices.add(aDevice.copy(deviceId = "device$i"))
+        }
+        whenever(syncApi.getDevices(anyString())).thenReturn(Success(listOfDevices))
+
+        syncRepo.getConnectedDevices() as Success
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
@@ -47,6 +47,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -169,6 +170,34 @@ internal class EnterCodeViewModelTest {
         testee.commands().test {
             val command = awaitItem()
             assertTrue(command is SwitchAccountSuccess)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenSignedInUserScansRecoveryCodeAndLoginSucceedsThenReturnSwitchAccount() = runTest {
+        whenever(syncAccountRepository.isSignedIn()).thenReturn(true)
+        whenever(syncAccountRepository.processCode(jsonRecoveryKeyEncoded)).thenReturn(Success(true))
+        whenever(clipboard.pasteFromClipboard()).thenReturn(jsonRecoveryKeyEncoded)
+
+        testee.commands().test {
+            testee.onPasteCodeClicked()
+            val command = awaitItem()
+            assertTrue(command is SwitchAccountSuccess)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenSignedOutUserScansRecoveryCodeAndLoginSucceedsThenReturnLoginSuccess() = runTest {
+        whenever(syncAccountRepository.isSignedIn()).thenReturn(false)
+        whenever(syncAccountRepository.processCode(jsonRecoveryKeyEncoded)).thenReturn(Success(true))
+        whenever(clipboard.pasteFromClipboard()).thenReturn(jsonRecoveryKeyEncoded)
+
+        testee.commands().test {
+            testee.onPasteCodeClicked()
+            val command = awaitItem()
+            assertTrue(command is LoginSuccess)
             cancelAndIgnoreRemainingEvents()
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203822806345703/1208755822305613/f 

### Description
Introduces logic to switch the user account if sync has only 1 device connected.
When multiple devices connected, we still ask the user.

### Steps to test this PR

_Feature 1_
- [x] Fresh install
- [x] Go to Feature flags and enable FF seamlessAccountSwitching
- [x] Create a sync account
- [x] Save or copy the recovery code
- [x] logout
- [x] Create a new sync account
- [x] Go to "Sync With Another Device", and read or paste the recovery code
- [x] Ensure user is automatically switched to the other account

_Feature 1_
- [x] Fresh install
- [x] Go to Feature flags and enable FF seamlessAccountSwitching
- [x] Create a sync account
- [x] Save or copy the recovery code
- [x] logout
- [x] Join this account -> https://app.asana.com/0/1203822806345703/1208795798275452/f
- [x] you are connected to an account with more devices
- [x] Go to "Sync With Another Device", and read or paste the recovery code from the first account you created
- [x] Ensure you are asked to confirm switching accounts



### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
