### PR TITLE
Update autoconsent to v11.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ddg-android",
       "version": "1.0.0",
       "dependencies": {
-        "@duckduckgo/autoconsent": "^11.4.0",
+        "@duckduckgo/autoconsent": "^11.5.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#15.1.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.35.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#7.0.2",
@@ -45,9 +45,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "11.4.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-11.4.0.tgz",
-      "integrity": "sha512-2MjhDVwpMlyFae5Hsq5S4YL8WbHe+ctzau8QF2i5eAxkcIKTDVWS8yMuC0scr+XCSx7pk7mVuWHts3WHjNVhGw==",
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-11.5.0.tgz",
+      "integrity": "sha512-mjMVTtJuHKPnX+poz5ZOPpUCPtoVh7nQeO7oXtsYEXZNSEIO/UIK9ozEWUI3Ta1utzQm4pN5wJwmsgmxNUXi/w==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "rollup-plugin-terser": "^7.0.2"
   },
   "dependencies": {
-    "@duckduckgo/autoconsent": "^11.4.0",
+    "@duckduckgo/autoconsent": "^11.5.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#15.1.0",
     "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.35.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#7.0.2",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1208781796802502/1208781796802502
Autoconsent Release: https://github.com/duckduckgo/autoconsent/releases/tag/v11.5.0


## Description
Updates Autoconsent to version [v11.5.0](https://github.com/duckduckgo/autoconsent/releases/tag/v11.5.0).

### Autoconsent v11.5.0 release notes
See release notes [here](https://github.com/duckduckgo/autoconsent/blob/v11.5.0/CHANGELOG.md)

## Steps to test
This release has been tested during Autoconsent development. You can check the release notes for more information.
1. Make sure that there's no unexpected failures in CI checks
2. (optional) smoke test some of the sites mentioned in the release notes
3. If there are problems, reach out to a CPM DRI