### PR TITLE
add metrics for account switching

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
@@ -45,6 +45,6 @@ interface SyncFeature {
     @Toggle.DefaultValue(true)
     fun gzipPatchRequests(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(true)
     fun seamlessAccountSwitching(): Toggle
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixelParamRemovalPlugin.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixelParamRemovalPlugin.kt
@@ -35,6 +35,13 @@ class SyncPixelParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugi
             SyncPixelName.SYNC_GET_OTHER_DEVICES_SCREEN_SHOWN.pixelName to PixelParameter.removeAtb(),
             SyncPixelName.SYNC_GET_OTHER_DEVICES_LINK_COPIED.pixelName to PixelParameter.removeAtb(),
             SyncPixelName.SYNC_GET_OTHER_DEVICES_LINK_SHARED.pixelName to PixelParameter.removeAtb(),
+
+            SyncPixelName.SYNC_ASK_USER_TO_SWITCH_ACCOUNT.pixelName to PixelParameter.removeAll(),
+            SyncPixelName.SYNC_USER_ACCEPTED_SWITCHING_ACCOUNT.pixelName to PixelParameter.removeAll(),
+            SyncPixelName.SYNC_USER_CANCELLED_SWITCHING_ACCOUNT.pixelName to PixelParameter.removeAll(),
+            SyncPixelName.SYNC_USER_SWITCHED_ACCOUNT.pixelName to PixelParameter.removeAll(),
+            SyncPixelName.SYNC_USER_SWITCHED_LOGOUT_ERROR.pixelName to PixelParameter.removeAll(),
+            SyncPixelName.SYNC_USER_SWITCHED_LOGIN_ERROR.pixelName to PixelParameter.removeAll(),
         )
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixelParamRemovalPlugin.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixelParamRemovalPlugin.kt
@@ -36,12 +36,12 @@ class SyncPixelParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugi
             SyncPixelName.SYNC_GET_OTHER_DEVICES_LINK_COPIED.pixelName to PixelParameter.removeAtb(),
             SyncPixelName.SYNC_GET_OTHER_DEVICES_LINK_SHARED.pixelName to PixelParameter.removeAtb(),
 
-            SyncPixelName.SYNC_ASK_USER_TO_SWITCH_ACCOUNT.pixelName to PixelParameter.removeAll(),
-            SyncPixelName.SYNC_USER_ACCEPTED_SWITCHING_ACCOUNT.pixelName to PixelParameter.removeAll(),
-            SyncPixelName.SYNC_USER_CANCELLED_SWITCHING_ACCOUNT.pixelName to PixelParameter.removeAll(),
-            SyncPixelName.SYNC_USER_SWITCHED_ACCOUNT.pixelName to PixelParameter.removeAll(),
-            SyncPixelName.SYNC_USER_SWITCHED_LOGOUT_ERROR.pixelName to PixelParameter.removeAll(),
-            SyncPixelName.SYNC_USER_SWITCHED_LOGIN_ERROR.pixelName to PixelParameter.removeAll(),
+            SyncPixelName.SYNC_ASK_USER_TO_SWITCH_ACCOUNT.pixelName to PixelParameter.removeAtb(),
+            SyncPixelName.SYNC_USER_ACCEPTED_SWITCHING_ACCOUNT.pixelName to PixelParameter.removeAtb(),
+            SyncPixelName.SYNC_USER_CANCELLED_SWITCHING_ACCOUNT.pixelName to PixelParameter.removeAtb(),
+            SyncPixelName.SYNC_USER_SWITCHED_ACCOUNT.pixelName to PixelParameter.removeAtb(),
+            SyncPixelName.SYNC_USER_SWITCHED_LOGOUT_ERROR.pixelName to PixelParameter.removeAtb(),
+            SyncPixelName.SYNC_USER_SWITCHED_LOGIN_ERROR.pixelName to PixelParameter.removeAtb(),
         )
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
@@ -81,6 +81,13 @@ interface SyncPixels {
         feature: SyncableType,
         apiError: Error,
     )
+
+    fun fireAskUserToSwitchAccount()
+    fun fireUserAcceptedSwitchingAccount()
+    fun fireUserCancelledSwitchingAccount()
+    fun fireUserSwitchedAccount()
+    fun fireUserSwitchedLogoutError()
+    fun fireUserSwitchedLoginError()
 }
 
 @ContributesBinding(AppScope::class)
@@ -255,6 +262,30 @@ class RealSyncPixels @Inject constructor(
         }
     }
 
+    override fun fireUserSwitchedAccount() {
+        pixel.fire(SyncPixelName.SYNC_USER_SWITCHED_ACCOUNT)
+    }
+
+    override fun fireAskUserToSwitchAccount() {
+        pixel.fire(SyncPixelName.SYNC_ASK_USER_TO_SWITCH_ACCOUNT)
+    }
+
+    override fun fireUserAcceptedSwitchingAccount() {
+        pixel.fire(SyncPixelName.SYNC_USER_ACCEPTED_SWITCHING_ACCOUNT)
+    }
+
+    override fun fireUserCancelledSwitchingAccount() {
+        pixel.fire(SyncPixelName.SYNC_USER_CANCELLED_SWITCHING_ACCOUNT)
+    }
+
+    override fun fireUserSwitchedLoginError() {
+        pixel.fire(SyncPixelName.SYNC_USER_SWITCHED_LOGIN_ERROR)
+    }
+
+    override fun fireUserSwitchedLogoutError() {
+        pixel.fire(SyncPixelName.SYNC_USER_SWITCHED_LOGOUT_ERROR)
+    }
+
     companion object {
         private const val SYNC_PIXELS_PREF_FILE = "com.duckduckgo.sync.pixels.v1"
     }
@@ -302,6 +333,12 @@ enum class SyncPixelName(override val pixelName: String) : Pixel.PixelName {
     SYNC_GET_OTHER_DEVICES_SCREEN_SHOWN("sync_get_other_devices"),
     SYNC_GET_OTHER_DEVICES_LINK_COPIED("sync_get_other_devices_copy"),
     SYNC_GET_OTHER_DEVICES_LINK_SHARED("sync_get_other_devices_share"),
+    SYNC_ASK_USER_TO_SWITCH_ACCOUNT("sync_ask_user_to_switch_account"),
+    SYNC_USER_ACCEPTED_SWITCHING_ACCOUNT("sync_user_accepted_switching_account"),
+    SYNC_USER_CANCELLED_SWITCHING_ACCOUNT("sync_user_cancelled_switching_account"),
+    SYNC_USER_SWITCHED_ACCOUNT("sync_user_switched_account"),
+    SYNC_USER_SWITCHED_LOGOUT_ERROR("sync_user_switched_logout_error"),
+    SYNC_USER_SWITCHED_LOGIN_ERROR("sync_user_switched_login_error"),
 }
 
 object SyncPixelParameters {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
@@ -131,6 +131,7 @@ class EnterCodeActivity : DuckDuckGoActivity() {
     }
 
     private fun askUserToSwitchAccount(it: AskToSwitchAccount) {
+        viewModel.onUserAskedToSwitchAccount()
         TextAlertDialogBuilder(this)
             .setTitle(R.string.sync_dialog_switch_account_header)
             .setMessage(R.string.sync_dialog_switch_account_description)
@@ -140,6 +141,10 @@ class EnterCodeActivity : DuckDuckGoActivity() {
                 object : TextAlertDialogBuilder.EventListener() {
                     override fun onPositiveButtonClicked() {
                         viewModel.onUserAcceptedJoiningNewAccount(it.encodedStringCode)
+                    }
+
+                    override fun onDialogCancelled() {
+                        viewModel.onUserCancelledJoiningNewAccount()
                     }
                 },
             ).show()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
@@ -143,7 +143,7 @@ class EnterCodeActivity : DuckDuckGoActivity() {
                         viewModel.onUserAcceptedJoiningNewAccount(it.encodedStringCode)
                     }
 
-                    override fun onDialogCancelled() {
+                    override fun onNegativeButtonClicked() {
                         viewModel.onUserCancelledJoiningNewAccount()
                     }
                 },

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
@@ -144,7 +144,12 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
 
                 is Success -> {
                     syncPixels.fireLoginPixel()
-                    val commandSuccess = if (userSignedIn) SwitchAccountSuccess else LoginSuccess
+                    val commandSuccess = if (userSignedIn) {
+                        syncPixels.fireUserSwitchedAccount()
+                        SwitchAccountSuccess
+                    } else {
+                        LoginSuccess
+                    }
                     command.send(commandSuccess)
                 }
             }
@@ -177,6 +182,7 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
 
     fun onUserAcceptedJoiningNewAccount(encodedStringCode: String) {
         viewModelScope.launch(dispatchers.io()) {
+            syncPixels.fireUserAcceptedSwitchingAccount()
             val result = syncAccountRepository.logoutAndJoinNewAccount(encodedStringCode)
             if (result is Error) {
                 when (result.code) {
@@ -193,6 +199,7 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
                 }
             } else {
                 syncPixels.fireLoginPixel()
+                syncPixels.fireUserSwitchedAccount()
                 command.send(SwitchAccountSuccess)
             }
         }
@@ -212,5 +219,13 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    fun onUserCancelledJoiningNewAccount() {
+        syncPixels.fireUserCancelledSwitchingAccount()
+    }
+
+    fun onUserAskedToSwitchAccount() {
+        syncPixels.fireAskUserToSwitchAccount()
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceActivity.kt
@@ -145,7 +145,7 @@ class SyncWithAnotherDeviceActivity : DuckDuckGoActivity() {
                         viewModel.onUserAcceptedJoiningNewAccount(it.encodedStringCode)
                     }
 
-                    override fun onDialogCancelled() {
+                    override fun onNegativeButtonClicked() {
                         viewModel.onUserCancelledJoiningNewAccount()
                     }
                 },

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceActivity.kt
@@ -133,6 +133,7 @@ class SyncWithAnotherDeviceActivity : DuckDuckGoActivity() {
     }
 
     private fun askUserToSwitchAccount(it: AskToSwitchAccount) {
+        viewModel.onUserAskedToSwitchAccount()
         TextAlertDialogBuilder(this)
             .setTitle(R.string.sync_dialog_switch_account_header)
             .setMessage(R.string.sync_dialog_switch_account_description)
@@ -142,6 +143,10 @@ class SyncWithAnotherDeviceActivity : DuckDuckGoActivity() {
                 object : TextAlertDialogBuilder.EventListener() {
                     override fun onPositiveButtonClicked() {
                         viewModel.onUserAcceptedJoiningNewAccount(it.encodedStringCode)
+                    }
+
+                    override fun onDialogCancelled() {
+                        viewModel.onUserCancelledJoiningNewAccount()
                     }
                 },
             ).show()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1208755822305614/f 

### Description
Adds metrics around dialog engagement and errors.

### Steps to test this PR

_single device flow metrics_
- [x] Fresh install
- [x] Go to Feature flags and enable FF seamlessAccountSwitching
- [x] Create a sync account
- [x] Save or copy the recovery code
- [x] logout
- [x] Create a new sync account
- [x] Go to "Sync With Another Device", and read or paste the recovery code
- [x] Ensure user is automatically switched to the other account
- [x] Ensure following pixels where triggered: sync_user_switched_account

_multiple devices flow metrics_
- [x] Fresh install
- [x] Go to Feature flags and enable FF seamlessAccountSwitching
- [x] Create a sync account
- [x] Save or copy the recovery code
- [x] logout
- [x] Join this account -> https://app.asana.com/0/1203822806345703/1208795798275452/f
- [x] you are connected to an account with more devices
- [x] Go to "Sync With Another Device", and read or paste the recovery code from the first account you created
- [x] Ensure you are asked to confirm switching accounts
- [x] Ensure pixel is triggered: sync_ask_user_to_switch_account
- [ ] Click on Cancel and ensure pixel is triggered: sync_user_cancelled_switching_account
- [x] Repeat the connection but now click "Switch"
- [x] Ensure pixel is triggered: sync_user_accepted_switching_account
- [x] If Switch is successful, ensure pixel is triggered: sync_user_switched_account

_error metrics_
- [x] Fresh install
- [x] Go to Feature flags and enable FF seamlessAccountSwitching
- [x] Create a sync account
- [x] Save or copy the recovery code
- [x] INSTEAD OF LOGOUT, DELETE THE ACCOUNT (scroll to the bottom part of the screen)
- [x] Create a new sync account
- [x] Go to "Sync With Another Device", and read or paste the recovery code
- [x] This will fail since the account doesn't exist (you will see another error that says invalid_login_credentials, it's expected)
- [x] Ensure following pixels where triggered: sync_user_switched_logout_error
- [x] Going back you will be in logout state


### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
