### PR TITLE
Add pixels for importing google passwords metrics

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/engagement/store/AutofillEngagementBucketing.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/engagement/store/AutofillEngagementBucketing.kt
@@ -26,7 +26,7 @@ import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 
 interface AutofillEngagementBucketing {
-    fun bucketNumberOfSavedPasswords(savedPasswords: Int): String
+    fun bucketNumberOfCredentials(numberOfCredentials: Int): String
 
     companion object {
         const val NONE = "none"
@@ -40,12 +40,12 @@ interface AutofillEngagementBucketing {
 @ContributesBinding(AppScope::class)
 class DefaultAutofillEngagementBucketing @Inject constructor() : AutofillEngagementBucketing {
 
-    override fun bucketNumberOfSavedPasswords(savedPasswords: Int): String {
+    override fun bucketNumberOfCredentials(numberOfCredentials: Int): String {
         return when {
-            savedPasswords == 0 -> NONE
-            savedPasswords < 4 -> FEW
-            savedPasswords < 11 -> SOME
-            savedPasswords < 50 -> MANY
+            numberOfCredentials == 0 -> NONE
+            numberOfCredentials < 4 -> FEW
+            numberOfCredentials < 11 -> SOME
+            numberOfCredentials < 50 -> MANY
             else -> LOTS
         }
     }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/engagement/store/AutofillEngagementRepository.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/engagement/store/AutofillEngagementRepository.kt
@@ -97,7 +97,7 @@ class DefaultAutofillEngagementRepository @Inject constructor(
 
         val numberStoredPasswords = getNumberStoredPasswords()
         val togglePixel = if (autofillStore.autofillEnabled) AUTOFILL_TOGGLED_ON_SEARCH else AUTOFILL_TOGGLED_OFF_SEARCH
-        val bucket = engagementBucketing.bucketNumberOfSavedPasswords(numberStoredPasswords)
+        val bucket = engagementBucketing.bucketNumberOfCredentials(numberStoredPasswords)
         pixel.fire(togglePixel, mapOf("count_bucket" to bucket), type = Daily())
     }
 
@@ -113,7 +113,7 @@ class DefaultAutofillEngagementRepository @Inject constructor(
         if (autofilled && searched) {
             pixel.fire(AUTOFILL_ENGAGEMENT_ACTIVE_USER, type = Daily())
 
-            val bucket = engagementBucketing.bucketNumberOfSavedPasswords(numberStoredPasswords)
+            val bucket = engagementBucketing.bucketNumberOfCredentials(numberStoredPasswords)
             pixel.fire(AUTOFILL_ENGAGEMENT_STACKED_LOGINS, mapOf("count_bucket" to bucket), type = Daily())
         }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/gpm/webflow/ImportGooglePasswordUrlToStageMapper.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/gpm/webflow/ImportGooglePasswordUrlToStageMapper.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.importing.gpm.webflow
+
+import com.duckduckgo.autofill.impl.importing.gpm.feature.AutofillImportPasswordConfigStore
+import com.duckduckgo.di.scopes.FragmentScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+import timber.log.Timber
+
+interface ImportGooglePasswordUrlToStageMapper {
+    suspend fun getStage(url: String?): String
+}
+
+@ContributesBinding(FragmentScope::class)
+class ImportGooglePasswordUrlToStageMapperImpl @Inject constructor(
+    private val importPasswordConfigStore: AutofillImportPasswordConfigStore,
+) : ImportGooglePasswordUrlToStageMapper {
+
+    override suspend fun getStage(url: String?): String {
+        val config = importPasswordConfigStore.getConfig()
+        val stage = config.urlMappings.firstOrNull { url?.startsWith(it.url) == true }?.key ?: UNKNOWN
+        return stage.also { Timber.d("Mapped as stage $it for $url") }
+    }
+
+    companion object {
+        const val UNKNOWN = "webflow-unknown"
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/gpm/webflow/ImportGooglePasswordsWebFlowFragment.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/gpm/webflow/ImportGooglePasswordsWebFlowFragment.kt
@@ -43,6 +43,7 @@ import com.duckduckgo.autofill.api.domain.app.LoginTriggerType
 import com.duckduckgo.autofill.impl.R
 import com.duckduckgo.autofill.impl.databinding.FragmentImportGooglePasswordsWebflowBinding
 import com.duckduckgo.autofill.impl.importing.blob.GooglePasswordBlobConsumer
+import com.duckduckgo.autofill.impl.importing.gpm.feature.AutofillImportPasswordConfigStore
 import com.duckduckgo.autofill.impl.importing.gpm.webflow.ImportGooglePasswordResult.Companion.RESULT_KEY
 import com.duckduckgo.autofill.impl.importing.gpm.webflow.ImportGooglePasswordResult.Companion.RESULT_KEY_DETAILS
 import com.duckduckgo.autofill.impl.importing.gpm.webflow.ImportGooglePasswordsWebFlowViewModel.UserCannotImportReason
@@ -113,6 +114,9 @@ class ImportGooglePasswordsWebFlowFragment :
 
     @Inject
     lateinit var browserAutofillConfigurator: BrowserAutofill.Configurator
+
+    @Inject
+    lateinit var importPasswordConfig: AutofillImportPasswordConfigStore
 
     private var binding: FragmentImportGooglePasswordsWebflowBinding? = null
 
@@ -283,8 +287,10 @@ class ImportGooglePasswordsWebFlowFragment :
 
     @SuppressLint("RequiresFeature")
     private suspend fun configurePasswordImportJavascript(webView: WebView) {
-        val script = passwordImporterScriptLoader.getScript()
-        WebViewCompat.addDocumentStartJavaScript(webView, script, setOf("*"))
+        if (importPasswordConfig.getConfig().canInjectJavascript) {
+            val script = passwordImporterScriptLoader.getScript()
+            WebViewCompat.addDocumentStartJavaScript(webView, script, setOf("*"))
+        }
     }
 
     private fun getToolbar() = (activity as ImportGooglePasswordsWebFlowActivity).binding.includeToolbar.toolbar

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
@@ -142,6 +142,15 @@ enum class AutofillPixelNames(override val pixelName: String) : Pixel.PixelName 
     AUTOFILL_TOGGLED_ON_SEARCH("m_autofill_toggled_on"),
     AUTOFILL_TOGGLED_OFF_SEARCH("m_autofill_toggled_off"),
 
+    AUTOFILL_IMPORT_GOOGLE_PASSWORDS_EMPTY_STATE_CTA_BUTTON_TAPPED("autofill_import_google_passwords_import_button_tapped"),
+    AUTOFILL_IMPORT_GOOGLE_PASSWORDS_EMPTY_STATE_CTA_BUTTON_SHOWN("autofill_import_google_passwords_import_button_shown"),
+    AUTOFILL_IMPORT_GOOGLE_PASSWORDS_OVERFLOW_MENU("autofill_import_google_passwords_overflow_menu_tapped"),
+    AUTOFILL_IMPORT_GOOGLE_PASSWORDS_PREIMPORT_PROMPT_DISPLAYED("autofill_import_google_passwords_preimport_prompt_displayed"),
+    AUTOFILL_IMPORT_GOOGLE_PASSWORDS_PREIMPORT_PROMPT_CONFIRMED("autofill_import_google_passwords_preimport_prompt_confirmed"),
+    AUTOFILL_IMPORT_GOOGLE_PASSWORDS_RESULT_FAILURE_ERROR_PARSING("autofill_import_google_passwords_result_parsing"),
+    AUTOFILL_IMPORT_GOOGLE_PASSWORDS_RESULT_FAILURE_USER_CANCELLED("autofill_import_google_passwords_result_user_cancelled"),
+    AUTOFILL_IMPORT_GOOGLE_PASSWORDS_RESULT_SUCCESS("autofill_import_google_passwords_result_success"),
+
     AUTOFILL_SYNC_DESKTOP_PASSWORDS_CTA_BUTTON("m_autofill_logins_import_no_passwords"),
     AUTOFILL_SYNC_DESKTOP_PASSWORDS_OVERFLOW_MENU("m_autofill_logins_import"),
     AUTOFILL_IMPORT_PASSWORDS_GET_DESKTOP_BROWSER("m_autofill_logins_import_get_desktop"),

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModel.kt
@@ -44,6 +44,7 @@ import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_DELETE_LOGIN
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENABLE_AUTOFILL_TOGGLE_MANUALLY_DISABLED
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENABLE_AUTOFILL_TOGGLE_MANUALLY_ENABLED
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_GOOGLE_PASSWORDS_EMPTY_STATE_CTA_BUTTON_SHOWN
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_MANAGEMENT_SCREEN_OPENED
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_MANUALLY_SAVE_CREDENTIAL
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_NEVER_SAVE_FOR_THIS_SITE_CONFIRMATION_PROMPT_CONFIRMED
@@ -796,8 +797,7 @@ class AutofillSettingsViewModel @Inject constructor(
     fun recordImportGooglePasswordButtonShown() {
         if (!importGooglePasswordButtonShownPixelSent) {
             importGooglePasswordButtonShownPixelSent = true
-
-            // pixel to show import button would fire here
+            pixel.fire(AUTOFILL_IMPORT_GOOGLE_PASSWORDS_EMPTY_STATE_CTA_BUTTON_SHOWN)
         }
     }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/importpassword/ImportPasswordsPixelSender.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/importpassword/ImportPasswordsPixelSender.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.ui.credential.management.importpassword
+
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.autofill.impl.engagement.store.AutofillEngagementBucketing
+import com.duckduckgo.autofill.impl.importing.gpm.webflow.ImportGooglePasswordsWebFlowViewModel.UserCannotImportReason
+import com.duckduckgo.autofill.impl.importing.gpm.webflow.ImportGooglePasswordsWebFlowViewModel.UserCannotImportReason.ErrorParsingCsv
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_GOOGLE_PASSWORDS_EMPTY_STATE_CTA_BUTTON_TAPPED
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_GOOGLE_PASSWORDS_OVERFLOW_MENU
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_GOOGLE_PASSWORDS_PREIMPORT_PROMPT_CONFIRMED
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_GOOGLE_PASSWORDS_PREIMPORT_PROMPT_DISPLAYED
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_GOOGLE_PASSWORDS_RESULT_FAILURE_ERROR_PARSING
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_GOOGLE_PASSWORDS_RESULT_FAILURE_USER_CANCELLED
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_GOOGLE_PASSWORDS_RESULT_SUCCESS
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SYNC_DESKTOP_PASSWORDS_CTA_BUTTON
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SYNC_DESKTOP_PASSWORDS_OVERFLOW_MENU
+import com.duckduckgo.di.scopes.FragmentScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface ImportPasswordsPixelSender {
+    fun onImportPasswordsDialogDisplayed()
+    fun onImportPasswordsDialogImportButtonClicked()
+    fun onUserCancelledImportPasswordsDialog()
+    fun onUserCancelledImportWebFlow(stage: String)
+    fun onImportSuccessful(savedCredentials: Int, numberSkipped: Int)
+    fun onImportFailed(reason: UserCannotImportReason)
+    fun onImportPasswordsButtonTapped()
+    fun onImportPasswordsOverflowMenuTapped()
+    fun onImportPasswordsViaDesktopSyncButtonTapped()
+    fun onImportPasswordsViaDesktopSyncOverflowMenuTapped()
+}
+
+@ContributesBinding(FragmentScope::class)
+class ImportPasswordsPixelSenderImpl @Inject constructor(
+    private val pixel: Pixel,
+    private val engagementBucketing: AutofillEngagementBucketing,
+) : ImportPasswordsPixelSender {
+
+    override fun onImportPasswordsDialogDisplayed() {
+        pixel.fire(AUTOFILL_IMPORT_GOOGLE_PASSWORDS_PREIMPORT_PROMPT_DISPLAYED)
+    }
+
+    override fun onImportPasswordsDialogImportButtonClicked() {
+        pixel.fire(AUTOFILL_IMPORT_GOOGLE_PASSWORDS_PREIMPORT_PROMPT_CONFIRMED)
+    }
+
+    override fun onUserCancelledImportPasswordsDialog() {
+        val params = mapOf(CANCELLATION_STAGE_KEY to PRE_IMPORT_DIALOG_STAGE)
+        pixel.fire(AUTOFILL_IMPORT_GOOGLE_PASSWORDS_RESULT_FAILURE_USER_CANCELLED, params)
+    }
+
+    override fun onUserCancelledImportWebFlow(stage: String) {
+        val params = mapOf(CANCELLATION_STAGE_KEY to stage)
+        pixel.fire(AUTOFILL_IMPORT_GOOGLE_PASSWORDS_RESULT_FAILURE_USER_CANCELLED, params)
+    }
+
+    override fun onImportSuccessful(savedCredentials: Int, numberSkipped: Int) {
+        val savedCredentialsBucketed = engagementBucketing.bucketNumberOfCredentials(savedCredentials)
+        val skippedCredentialsBucketed = engagementBucketing.bucketNumberOfCredentials(numberSkipped)
+        val params = mapOf(
+            "saved_credentials" to savedCredentialsBucketed,
+            "skipped_credentials" to skippedCredentialsBucketed,
+        )
+        pixel.fire(AUTOFILL_IMPORT_GOOGLE_PASSWORDS_RESULT_SUCCESS, params)
+    }
+
+    override fun onImportFailed(reason: UserCannotImportReason) {
+        val pixelName = when (reason) {
+            ErrorParsingCsv -> AUTOFILL_IMPORT_GOOGLE_PASSWORDS_RESULT_FAILURE_ERROR_PARSING
+        }
+        pixel.fire(pixelName)
+    }
+
+    override fun onImportPasswordsButtonTapped() {
+        pixel.fire(AUTOFILL_IMPORT_GOOGLE_PASSWORDS_EMPTY_STATE_CTA_BUTTON_TAPPED)
+    }
+
+    override fun onImportPasswordsOverflowMenuTapped() {
+        pixel.fire(AUTOFILL_IMPORT_GOOGLE_PASSWORDS_OVERFLOW_MENU)
+    }
+
+    override fun onImportPasswordsViaDesktopSyncButtonTapped() {
+        pixel.fire(AUTOFILL_SYNC_DESKTOP_PASSWORDS_CTA_BUTTON)
+    }
+
+    override fun onImportPasswordsViaDesktopSyncOverflowMenuTapped() {
+        pixel.fire(AUTOFILL_SYNC_DESKTOP_PASSWORDS_OVERFLOW_MENU)
+    }
+
+    companion object {
+        private const val CANCELLATION_STAGE_KEY = "stage"
+        private const val PRE_IMPORT_DIALOG_STAGE = "pre-import-dialog"
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/survey/AutofillSurvey.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/survey/AutofillSurvey.kt
@@ -89,7 +89,7 @@ class AutofillSurveyImpl @Inject constructor(
                 .appendQueryParameter(SurveyParams.MODEL, appBuildConfig.model)
                 .appendQueryParameter(SurveyParams.SOURCE, IN_APP)
                 .appendQueryParameter(SurveyParams.LAST_ACTIVE_DATE, appDaysUsedRepository.getLastActiveDay())
-                .appendQueryParameter(SurveyParams.NUMBER_PASSWORDS, passwordBucketing.bucketNumberOfSavedPasswords(passwordsSaved))
+                .appendQueryParameter(SurveyParams.NUMBER_PASSWORDS, passwordBucketing.bucketNumberOfCredentials(passwordsSaved))
 
             urlBuilder.build().toString()
         }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementListMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementListMode.kt
@@ -38,7 +38,6 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.RecyclerView
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.browser.favicon.FaviconManager
-import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.autofill.api.AutofillSettingsLaunchSource
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.api.promotion.PasswordsScreenPromotionPlugin
@@ -47,8 +46,6 @@ import com.duckduckgo.autofill.impl.databinding.FragmentAutofillManagementListMo
 import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator
 import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator.AuthConfiguration
 import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator.AuthResult.Success
-import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SYNC_DESKTOP_PASSWORDS_CTA_BUTTON
-import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SYNC_DESKTOP_PASSWORDS_OVERFLOW_MENU
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillManagementActivity
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillManagementRecyclerAdapter
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillManagementRecyclerAdapter.ContextMenuAction.CopyPassword
@@ -65,6 +62,7 @@ import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsVie
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsViewModel.ListModeCommand.ShowUserReportSentMessage
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillSettingsViewModel.ViewState
 import com.duckduckgo.autofill.impl.ui.credential.management.importpassword.ImportPasswordActivityParams
+import com.duckduckgo.autofill.impl.ui.credential.management.importpassword.ImportPasswordsPixelSender
 import com.duckduckgo.autofill.impl.ui.credential.management.importpassword.google.ImportFromGooglePasswordsDialog
 import com.duckduckgo.autofill.impl.ui.credential.management.sorting.CredentialGrouper
 import com.duckduckgo.autofill.impl.ui.credential.management.sorting.InitialExtractor
@@ -129,7 +127,7 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
     lateinit var screenPromotionPlugins: PluginPoint<PasswordsScreenPromotionPlugin>
 
     @Inject
-    lateinit var pixel: Pixel
+    lateinit var importPasswordsPixelSender: ImportPasswordsPixelSender
 
     val viewModel by lazy {
         ViewModelProvider(requireActivity(), viewModelFactory)[AutofillSettingsViewModel::class.java]
@@ -246,11 +244,12 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
     private fun configureImportPasswordsButton() {
         binding.emptyStateLayout.importPasswordsFromGoogleButton.setOnClickListener {
             viewModel.onImportPasswordsFromGooglePasswordManager()
+            importPasswordsPixelSender.onImportPasswordsButtonTapped()
         }
 
         binding.emptyStateLayout.importPasswordsViaDesktopSyncButton.setOnClickListener {
             launchImportPasswordsFromDesktopSyncScreen()
-            pixel.fire(AUTOFILL_SYNC_DESKTOP_PASSWORDS_CTA_BUTTON)
+            importPasswordsPixelSender.onImportPasswordsViaDesktopSyncButtonTapped()
         }
     }
 
@@ -299,12 +298,13 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
 
                         R.id.importGooglePasswords -> {
                             viewModel.onImportPasswordsFromGooglePasswordManager()
+                            importPasswordsPixelSender.onImportPasswordsOverflowMenuTapped()
                             true
                         }
 
                         R.id.syncDesktopPasswords -> {
                             launchImportPasswordsFromDesktopSyncScreen()
-                            pixel.fire(AUTOFILL_SYNC_DESKTOP_PASSWORDS_OVERFLOW_MENU)
+                            importPasswordsPixelSender.onImportPasswordsViaDesktopSyncOverflowMenuTapped()
                             true
                         }
 

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/engagement/store/DefaultAutofillEngagementBucketingTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/engagement/store/DefaultAutofillEngagementBucketingTest.kt
@@ -13,31 +13,31 @@ class DefaultAutofillEngagementBucketingTest {
 
     @Test
     fun whenZeroSavedPasswordsThenBucketIsNone() {
-        assertEquals(NONE, testee.bucketNumberOfSavedPasswords(0))
+        assertEquals(NONE, testee.bucketNumberOfCredentials(0))
     }
 
     @Test
     fun whenBetweenOneAndThreeSavedPasswordThenBucketIsFew() {
-        assertEquals(FEW, testee.bucketNumberOfSavedPasswords(1))
-        assertEquals(FEW, testee.bucketNumberOfSavedPasswords(2))
-        assertEquals(FEW, testee.bucketNumberOfSavedPasswords(3))
+        assertEquals(FEW, testee.bucketNumberOfCredentials(1))
+        assertEquals(FEW, testee.bucketNumberOfCredentials(2))
+        assertEquals(FEW, testee.bucketNumberOfCredentials(3))
     }
 
     @Test
     fun whenBetweenFourAndTenSavedPasswordThenBucketIsSome() {
-        assertEquals(SOME, testee.bucketNumberOfSavedPasswords(4))
-        assertEquals(SOME, testee.bucketNumberOfSavedPasswords(10))
+        assertEquals(SOME, testee.bucketNumberOfCredentials(4))
+        assertEquals(SOME, testee.bucketNumberOfCredentials(10))
     }
 
     @Test
     fun whenBetweenElevenAndFortyNineSavedPasswordThenBucketIsMany() {
-        assertEquals(MANY, testee.bucketNumberOfSavedPasswords(11))
-        assertEquals(MANY, testee.bucketNumberOfSavedPasswords(49))
+        assertEquals(MANY, testee.bucketNumberOfCredentials(11))
+        assertEquals(MANY, testee.bucketNumberOfCredentials(49))
     }
 
     @Test
     fun whenFiftyOrOverThenBucketIsMany() {
-        assertEquals(LOTS, testee.bucketNumberOfSavedPasswords(50))
-        assertEquals(LOTS, testee.bucketNumberOfSavedPasswords(Int.MAX_VALUE))
+        assertEquals(LOTS, testee.bucketNumberOfCredentials(50))
+        assertEquals(LOTS, testee.bucketNumberOfCredentials(Int.MAX_VALUE))
     }
 }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/gpm/webflow/ImportGooglePasswordUrlToStageMapperImplTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/gpm/webflow/ImportGooglePasswordUrlToStageMapperImplTest.kt
@@ -1,0 +1,69 @@
+package com.duckduckgo.autofill.impl.importing.gpm.webflow
+
+import com.duckduckgo.autofill.impl.importing.gpm.feature.AutofillImportPasswordConfigStore
+import com.duckduckgo.autofill.impl.importing.gpm.feature.AutofillImportPasswordSettings
+import com.duckduckgo.autofill.impl.importing.gpm.feature.UrlMapping
+import com.duckduckgo.autofill.impl.importing.gpm.webflow.ImportGooglePasswordUrlToStageMapperImpl.Companion.UNKNOWN
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class ImportGooglePasswordUrlToStageMapperImplTest {
+
+    private val importPasswordConfigStore: AutofillImportPasswordConfigStore = mock()
+
+    private val testee = ImportGooglePasswordUrlToStageMapperImpl(importPasswordConfigStore = importPasswordConfigStore)
+
+    @Before
+    fun setup() = runTest {
+        whenever(importPasswordConfigStore.getConfig()).thenReturn(config())
+    }
+
+    @Test
+    fun whenUrlIsEmptyStringThenStageIsUnknown() = runTest {
+        assertEquals(UNKNOWN, testee.getStage(""))
+    }
+
+    @Test
+    fun whenUrlIsNullThenStageIsUnknown() = runTest {
+        assertEquals(UNKNOWN, testee.getStage(null))
+    }
+
+    @Test
+    fun whenUrlStartsWithKnownMappingThenValueReturned() = runTest {
+        listOf(UrlMapping("key", "https://example.com")).configureMappings()
+        assertEquals("key", testee.getStage("https://example.com"))
+    }
+
+    @Test
+    fun whenUrlMatchesMultipleThenFirstValueReturned() = runTest {
+        listOf(
+            UrlMapping("key1", "https://example.com"),
+            UrlMapping("key2", "https://example.com"),
+        ).configureMappings()
+        assertEquals("key1", testee.getStage("https://example.com"))
+    }
+
+    @Test
+    fun whenUrlHasDifferentPrefixThenNotAMatch() = runTest {
+        listOf(UrlMapping("key", "https://example.com")).configureMappings()
+        assertEquals(UNKNOWN, testee.getStage("example.com"))
+    }
+
+    private suspend fun List<UrlMapping>.configureMappings() {
+        whenever(importPasswordConfigStore.getConfig()).thenReturn(config().copy(urlMappings = this))
+    }
+
+    private fun config(): AutofillImportPasswordSettings {
+        return AutofillImportPasswordSettings(
+            launchUrlGooglePasswords = "https://example.com",
+            canImportFromGooglePasswords = true,
+            canInjectJavascript = true,
+            javascriptConfigGooglePasswords = "{}",
+            urlMappings = emptyList(),
+        )
+    }
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/importpassword/google/ImportFromGooglePasswordsDialogViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/importpassword/google/ImportFromGooglePasswordsDialogViewModelTest.kt
@@ -5,8 +5,8 @@ import app.cash.turbine.test
 import com.duckduckgo.autofill.impl.importing.CredentialImporter
 import com.duckduckgo.autofill.impl.importing.CredentialImporter.ImportResult.Finished
 import com.duckduckgo.autofill.impl.importing.CredentialImporter.ImportResult.InProgress
-import com.duckduckgo.autofill.impl.importing.gpm.webflow.ImportGooglePasswordsWebFlowViewModel.UserCannotImportReason.EncryptedPassphrase
 import com.duckduckgo.autofill.impl.importing.gpm.webflow.ImportGooglePasswordsWebFlowViewModel.UserCannotImportReason.ErrorParsingCsv
+import com.duckduckgo.autofill.impl.ui.credential.management.importpassword.ImportPasswordsPixelSender
 import com.duckduckgo.autofill.impl.ui.credential.management.importpassword.google.ImportFromGooglePasswordsDialogViewModel.ViewMode
 import com.duckduckgo.autofill.impl.ui.credential.management.importpassword.google.ImportFromGooglePasswordsDialogViewModel.ViewMode.ImportSuccess
 import com.duckduckgo.autofill.impl.ui.credential.management.importpassword.google.ImportFromGooglePasswordsDialogViewModel.ViewMode.Importing
@@ -29,10 +29,13 @@ class ImportFromGooglePasswordsDialogViewModelTest {
     @get:Rule
     val coroutineTestRule: CoroutineTestRule = CoroutineTestRule(StandardTestDispatcher())
 
+    private val importPasswordsPixelSender: ImportPasswordsPixelSender = mock()
+
     private val credentialImporter: CredentialImporter = mock()
     private val testee = ImportFromGooglePasswordsDialogViewModel(
         credentialImporter = credentialImporter,
         dispatchers = coroutineTestRule.testDispatcherProvider,
+        importPasswordsPixelSender = importPasswordsPixelSender,
     )
 
     @Before
@@ -43,14 +46,6 @@ class ImportFromGooglePasswordsDialogViewModelTest {
     @Test
     fun whenParsingErrorOnImportThenViewModeUpdatedToError() = runTest {
         testee.onImportFlowFinishedWithError(ErrorParsingCsv)
-        testee.viewState.test {
-            assertTrue(awaitItem().viewMode is ViewMode.ImportError)
-        }
-    }
-
-    @Test
-    fun whenEncryptionErrorOnImportThenViewModeUpdatedToError() = runTest {
-        testee.onImportFlowFinishedWithError(EncryptedPassphrase)
         testee.viewState.test {
             assertTrue(awaitItem().viewMode is ViewMode.ImportError)
         }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/survey/AutofillSurveyImplTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/survey/AutofillSurveyImplTest.kt
@@ -93,7 +93,7 @@ class AutofillSurveyImplTest {
 
     @Test
     fun whenSurveyLaunchedThenSavedPasswordQueryParamAdded() = runTest {
-        whenever(passwordBucketing.bucketNumberOfSavedPasswords(any())).thenReturn("fromBucketing")
+        whenever(passwordBucketing.bucketNumberOfCredentials(any())).thenReturn("fromBucketing")
         val survey = getAvailableSurvey()
         val savedPasswordsBucket = survey.url.toUri().getQueryParameter("saved_passwords")
         assertEquals("fromBucketing", savedPasswordsBucket)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/608920331025315/1208787586139232/f 

### Description
Adds metrics around the import password flow. To support this in a flexible way, it also allows for the url mappings to be defined remotely for which stage of the flow a user dropped out at if they didn't go all the way through; if we ever need to, can override the default url mappings.

Logcat filter: `message~:"Pixel sent: autofill_import_google_passwords"`

### Steps to test this PR

**Setup**
- [x] Fresh install

**Cancelling the user journey**
- [x] Visit `Passwords` screen, and verify `autofill_import_google_passwords_import_button_shown` in logs for the import password button being shown
- [x] Tap on `Import Passwords From Google` button; verify`autofill_import_google_passwords_import_button_tapped` in logs
- [x] Verify `autofill_import_google_passwords_preimport_prompt_displayed` in logs
- [x] Dismiss the import dialog; verify`autofill_import_google_passwords_result_user_cancelled` in logs
- [x] Tap on `Import Passwords From Google` button again. 
- [x] This time, tap on the `Open Google Passwords` button; verify`autofill_import_google_passwords_preimport_prompt_confirmed` in logs
- [x] Tap the ✖️ button to quit the import flow; verify`autofill_import_google_passwords_result_user_cancelled` in logs, with `stage=webflow-pre-login`
- [x] Dismiss the dialog that is still showing, and verify there is not a further cancellation pixel in logs for when the dialog closes, as this is already covered by the ✖️ button cancellation
- [x] Launch the import flow again. This time tap on the `Sign in` button. Then ✖️ to exit the flow; verify `autofill_import_google_passwords_result_user_cancelled` with `stage=webflow-authenticate`
- [x] Launch the import flow again. This time, actually sign in, then ✖️ to exit the flow; verify `autofill_import_google_passwords_result_user_cancelled` with `stage=webflow-post-login-landing`
- [x] Launch the import flow again, and you'll be on the screen with the export button. tap ✖️ to exit the flow; verify `autofill_import_google_passwords_result_user_cancelled` with `stage=webflow-export`
- [x] Launch the import flow again. Tap the export button, and agree on the dialog. Then when prompted to authenticate, tap ✖️ to exit the flow; verify `autofill_import_google_passwords_result_user_cancelled` with `stage=webflow-authenticate`

**Succeeding**
- [x] Launch the import flow and fully complete it. Verify `autofill_import_google_passwords_result_success`, with the correct _bucket_  for `saved_credentials` and `skipped_credentials` based on bucket rules [defined here](https://app.asana.com/0/72649045549333/1207437778421216/f)
- [x] Repeat that, and you should get duplicates this time. Verify again, ensuring that `skipped_credentials` bucket is accurate.

**Overflow menu**
- [x] Now that you have saved passwords, `Import Passwords From Google` will appear in the overflow menu. Tap on that. Verify `autofill_import_google_passwords_overflow_menu_tapped` and `autofill_import_google_passwords_preimport_prompt_displayed` in logs

**Encrypted passphrase scenario**
- [x] Apply [patch](https://app.asana.com/0/488551667048375/1208796814221367/f)
- [x] Launch import flow and you'll see the error screen. Tap ✖️ to exit flow. Verify `autofill_import_google_passwords_result_user_cancelled` with `stage=webflow-passphrase-encryption`

**CSV parsing scenario**
- [x] Discard local changes
- [x] Apply [patch](https://app.asana.com/0/488551667048375/1208796814221368/f)
- [x] Launch import flow and carry on until you've exported. The patch will simulate an error. Verify `autofill_import_google_passwords_result_parsing` in logs.

**URL mapping via remote config**
- [x] Discard local changes
- [x] Apply [patch](https://app.asana.com/0/488551667048375/1208799215631036/f) to override the URL mappings
- [x] Fresh install. Launch password import flow and then ✖️ to exit. Verify in logs with filter `urlMappings` that the mappings from the patched jsonblob are used and override the local defaults. 

**Selectively disabling JS injection**
- [x] Discard local changes
- [x] Apply [patch](https://app.asana.com/0/488551667048375/1208799215631037/f) which simulates disabling remote config for JS injection specifically. 
- [x] Fresh install
- [x] Launch password import flow; verify you don't see any UI hints on which button to press
- [x] Complete the flow; verify it still works as expected