### PR TITLE
GHA: Only execute nightly if changes made

### DIFF
--- a/.github/actions/check-for-changes-since-tag/action.yml
+++ b/.github/actions/check-for-changes-since-tag/action.yml
@@ -2,9 +2,6 @@ name: 'Check for code changes after a specific tag'
 description: 'Checks if there are any new commits to the develop branch since the specified tag'
 
 inputs:
-  github_token:
-    description: 'GitHub token'
-    required: true
   tag:
     description: 'Tag to check'
     required: true

--- a/.github/actions/check-for-changes-since-tag/action.yml
+++ b/.github/actions/check-for-changes-since-tag/action.yml
@@ -22,8 +22,9 @@ runs:
       run: |      
         # Check if there are any new commits since the tag
         new_commits=$(git rev-list ${{ inputs.tag }}..HEAD --count)
+        echo "$new_commits commits since ${{ inputs.tag }} tag"
         
-        if [ $new_commits -gt 0 ]; then
+        if [ $new_commits -gt 0 ]; then        
           echo "has_changes=true" >> $GITHUB_OUTPUT
         else
           echo "has_changes=false" >> $GITHUB_OUTPUT

--- a/.github/actions/check-for-changes-since-tag/action.yml
+++ b/.github/actions/check-for-changes-since-tag/action.yml
@@ -1,5 +1,5 @@
 name: 'Check for code changes after a specific tag'
-description: 'Checks if there are any new commits since the specified tag'
+description: 'Checks if there are any new commits to the develop branch since the specified tag'
 
 inputs:
   github_token:
@@ -21,7 +21,7 @@ runs:
       shell: bash
       run: |      
         # Check if there are any new commits since the tag
-        new_commits=$(git rev-list ${{ inputs.tag }}..HEAD --count)
+        new_commits=$(git rev-list ${{ inputs.tag }}..develop --count)
         echo "$new_commits commits since ${{ inputs.tag }} tag"
         
         if [ $new_commits -gt 0 ]; then        

--- a/.github/actions/check-for-changes-since-tag/action.yml
+++ b/.github/actions/check-for-changes-since-tag/action.yml
@@ -1,0 +1,30 @@
+name: 'Check for code changes after a specific tag'
+description: 'Checks if there are any new commits since the specified tag'
+
+inputs:
+  github_token:
+    description: 'GitHub token'
+    required: true
+  tag:
+    description: 'Tag to check'
+    required: true
+
+outputs:
+  has_changes:
+    description: Whether there are new commits since the last tag
+    value: ${{ steps.check_for_changes.outputs.has_changes }}
+
+runs:
+  using: 'composite'
+  steps:
+    - id: check_for_changes
+      shell: bash
+      run: |      
+        # Check if there are any new commits since the tag
+        new_commits=$(git rev-list ${{ inputs.tag }}..HEAD --count)
+        
+        if [ $new_commits -gt 0 ]; then
+          echo "has_changes=true" >> $GITHUB_OUTPUT
+        else
+          echo "has_changes=false" >> $GITHUB_OUTPUT
+        fi

--- a/.github/actions/check-for-changes-since-tag/action.yml
+++ b/.github/actions/check-for-changes-since-tag/action.yml
@@ -25,7 +25,7 @@ runs:
         echo "$new_commits commits since ${{ inputs.tag }} tag"
         
         if [ $new_commits -gt 0 ]; then        
-          echo "has_changes=false" >> $GITHUB_OUTPUT
-        else
           echo "has_changes=true" >> $GITHUB_OUTPUT
+        else
+          echo "has_changes=false" >> $GITHUB_OUTPUT
         fi

--- a/.github/actions/check-for-changes-since-tag/action.yml
+++ b/.github/actions/check-for-changes-since-tag/action.yml
@@ -25,7 +25,7 @@ runs:
         echo "$new_commits commits since ${{ inputs.tag }} tag"
         
         if [ $new_commits -gt 0 ]; then        
-          echo "has_changes=true" >> $GITHUB_OUTPUT
-        else
           echo "has_changes=false" >> $GITHUB_OUTPUT
+        else
+          echo "has_changes=true" >> $GITHUB_OUTPUT
         fi

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -22,7 +22,6 @@ jobs:
           submodules: recursive
           token: ${{ secrets.GT_DAXMOBILE }}
           fetch-depth: 0
-          ref: feature/david/11-20-gha_only_execute_nightly_if_changes_made
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -60,7 +59,7 @@ jobs:
         if: steps.check_for_changes.outputs.has_changes == 'false'
         run: |
           echo "No new commits since the last tag. Skipping nightly release."
-          echo "### Nightly release completed! :rocket:" >> $GITHUB_STEP_SUMMARY
+          echo "No new commits since the last tag. Skipping nightly release." >> $GITHUB_STEP_SUMMARY
           exit 0   
 
       - name: Decode upload keys

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -22,6 +22,7 @@ jobs:
           submodules: recursive
           token: ${{ secrets.GT_DAXMOBILE }}
           fetch-depth: 0
+          ref: feature/david/11-20-gha_only_execute_nightly_if_changes_made
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.check_for_changes.outputs.has_changes == 'false'
         run: |
           echo "No new commits since the last tag. Skipping release notes update."
-          exit 1
+          exit 0
 
       - name: Decode upload keys
         uses: davidSchuppa/base64Secret-toFile-action@199e78f212c854d2284fada7f3cd3aba3e37d208

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.check_for_changes.outputs.has_changes == 'false'
         run: |
           echo "No new commits since the last tag. Skipping nightly release."
-          echo "No new commits since the last tag. Skipping nightly release." >> $GITHUB_STEP_SUMMARY
+          echo "### Nightly release completed! :rocket:" >> $GITHUB_STEP_SUMMARY
           exit 0   
 
       - name: Decode upload keys

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -59,10 +59,12 @@ jobs:
       - name: Notify if no changes
         if: steps.check_for_changes.outputs.has_changes == 'false'
         run: |
-          echo "No new commits since the last tag. Skipping release notes update."
-          exit 0
+          echo "No new commits since the last tag. Skipping nightly release."
+          echo "No new commits since the last tag. Skipping nightly release." >> $GITHUB_STEP_SUMMARY
+          exit 0   
 
       - name: Decode upload keys
+        if: steps.check_for_changes.outputs.has_changes == 'true'
         uses: davidSchuppa/base64Secret-toFile-action@199e78f212c854d2284fada7f3cd3aba3e37d208
         with:
           secret: ${{ secrets.UPLOAD_RELEASE_PROPERTIES }}
@@ -70,6 +72,7 @@ jobs:
           destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
 
       - name: Decode key file
+        if: steps.check_for_changes.outputs.has_changes == 'true'
         uses: davidSchuppa/base64Secret-toFile-action@199e78f212c854d2284fada7f3cd3aba3e37d208
         with:
           secret: ${{ secrets.UPLOAD_RELEASE_KEY }}
@@ -77,6 +80,7 @@ jobs:
           destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
 
       - name: Decode Play Store credentials file
+        if: steps.check_for_changes.outputs.has_changes == 'true'
         uses: davidSchuppa/base64Secret-toFile-action@199e78f212c854d2284fada7f3cd3aba3e37d208
         with:
           secret: ${{ secrets.UPLOAD_PLAY_CREDENTIALS }}
@@ -84,6 +88,7 @@ jobs:
           destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
 
       - name: Decode Firebase credentials file
+        if: steps.check_for_changes.outputs.has_changes == 'true'
         uses: davidSchuppa/base64Secret-toFile-action@199e78f212c854d2284fada7f3cd3aba3e37d208
         with:
           secret: ${{ secrets.UPLOAD_FIREBASE_CREDENTIALS }}
@@ -91,30 +96,36 @@ jobs:
           destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
 
       - name: Clean project
+        if: steps.check_for_changes.outputs.has_changes == 'true'
         run: |
           gradle clean          
 
       - name: Assemble the bundle
+        if: steps.check_for_changes.outputs.has_changes == 'true'
         run: gradle bundleInternalRelease -PversionNameSuffix=-nightly -PuseUploadSigning -PlatestTag=${{ steps.get_latest_tag.outputs.latest_tag }}
 
       - name: Generate nightly version name
+        if: steps.check_for_changes.outputs.has_changes == 'true'
         id: generate_version_name
         run: |
           output=$(gradle getBuildVersionName -PversionNameSuffix=-nightly -PlatestTag=${{ steps.get_latest_tag.outputs.latest_tag }} --quiet | tail -n 1)
           echo "version=$output" >> $GITHUB_OUTPUT
 
       - name: Capture App Bundle Path
+        if: steps.check_for_changes.outputs.has_changes == 'true'
         id: capture_output
         run: |
           output=$(find app/build/outputs/bundle/internalRelease -name "*.aab")
           echo "bundle_path=$output" >> $GITHUB_OUTPUT
 
       - name: Upload bundle to Play Store Internal track
+        if: steps.check_for_changes.outputs.has_changes == 'true'
         id: create_app_bundle
         run: |
           bundle exec fastlane deploy_dogfood aab_path:${{ steps.capture_output.outputs.bundle_path }}
 
       - name: Tag Nightly release
+        if: steps.check_for_changes.outputs.has_changes == 'true'
         id: tag_nightly_release
         run: |
           git checkout develop
@@ -122,10 +133,16 @@ jobs:
           git push origin ${{ steps.generate_version_name.outputs.version }}
 
       - name: Upload APK as artifact
+        if: steps.check_for_changes.outputs.has_changes == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: duckduckgo-${{ steps.generate_version_name.outputs.version }}.apk
           path: duckduckgo.apk
+
+      - name: Set successful summary
+        if: steps.check_for_changes.outputs.has_changes == 'true'
+        run: |
+          echo "### Nightly release completed! :rocket:" >> $GITHUB_STEP_SUMMARY    
 
       - name: Create Asana task when workflow failed
         if: ${{ failure() }}

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Check for changes
         id: check_for_changes
-        uses: ./.github/actions/check-for-changes
+        uses: ./.github/actions/check-for-changes-since-tag
         with:
            github_token: ${{ secrets.GT_DAXMOBILE }}
            tag: ${{ steps.get_latest_tag.outputs.latest_tag }}

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -48,6 +48,19 @@ jobs:
           echo "Latest tag: $output"
           echo "latest_tag=$output" >> $GITHUB_OUTPUT
 
+      - name: Check for changes
+        id: check_for_changes
+        uses: ./.github/actions/check-for-changes
+        with:
+           github_token: ${{ secrets.GT_DAXMOBILE }}
+           tag: ${{ steps.get_latest_tag.outputs.latest_tag }}
+
+      - name: Notify if no changes
+        if: steps.check_for_changes.outputs.has_changes == 'false'
+        run: |
+          echo "No new commits since the last tag. Skipping release notes update."
+          exit 1
+
       - name: Decode upload keys
         uses: davidSchuppa/base64Secret-toFile-action@199e78f212c854d2284fada7f3cd3aba3e37d208
         with:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1174433894299346/1208527152986496

### Description
Currently we make nightly releases daily, even if there are no new changes in develop.
This PR fixes that, so we only make nightly releases when there are new commits since the last tag.

### Steps to test this PR
See task for examples of runs