### PR TITLE
Add AppTP WAU pixel

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
@@ -39,6 +39,7 @@ enum class DeviceShieldPixelNames(override val pixelName: String, val enqueue: B
     ATP_DISABLE_DAILY("m_atp_ev_disabled_d"),
 
     ATP_ENABLE_UNIQUE("m_atp_ev_enabled_u"),
+    ATP_ENABLE_MONTHLY("m_atp_ev_enabled_monthly"),
     ATP_ENABLE_FROM_REMINDER_NOTIFICATION_UNIQUE("m_atp_ev_enabled_reminder_notification_u"),
     ATP_ENABLE_FROM_REMINDER_NOTIFICATION_DAILY("m_atp_ev_enabled_reminder_notification_d"),
     ATP_ENABLE_FROM_REMINDER_NOTIFICATION("m_atp_ev_enabled_reminder_notification_c"),

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/pixels/RealDeviceShieldPixelsTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/pixels/RealDeviceShieldPixelsTest.kt
@@ -76,12 +76,10 @@ class RealDeviceShieldPixelsTest {
     }
 
     @Test
-    fun whenReportExactly28DaysApartThenFireMonthlyPixel() {
+    fun whenReportExactly28DaysApartThenDoNotFireMonthlyPixel() {
         val pixelName = DeviceShieldPixelNames.ATP_ENABLE_MONTHLY.pixelName
 
         deviceShieldPixels.reportEnabled()
-
-        verify(pixel).fire(pixelName)
 
         val pastDate = Instant.now()
             .minus(28, ChronoUnit.DAYS)
@@ -94,7 +92,7 @@ class RealDeviceShieldPixelsTest {
     }
 
     @Test
-    fun whenReportEnable28DaysApartDoNotReportMonthlyPixel() {
+    fun whenReportEnableMoreThan28DaysApartReportMonthlyPixel() {
         val pixelName = DeviceShieldPixelNames.ATP_ENABLE_MONTHLY.pixelName
 
         deviceShieldPixels.reportEnabled()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/69071770703008/1208808769852413/f

### Description
Add a pixel for AppTP MAU.

The pixel fires at most once every 28 days

### Steps to test this PR
You may want to change the polici to `REPLACE` in `scheduleDeviceShieldStatusReporting()` to trigger the pixel on every app  `onCreate`

_Test_
- [x] clean install from this branch and launch the app
- [x] enable AppTP
- [x] force close the app and re-open
- [x] verify the `m_atp_ev_enabled_monthly` is sent
- [x] force close the app and re-open
- [x] verify the `m_atp_ev_enabled_monthly` is NOT sent
- [x] move the device date no more that 28d from now
- [x] force close the app and re-open
- [x] verify the `m_atp_ev_enabled_monthly` is NOT sent
- [x] move the device date no more that 29d from now
- [x] force close the app and re-open
- [x] verify the `m_atp_ev_enabled_monthly` is sent


