### PR TITLE
Update Settings design: Add feature flag & new Settings screen

### DIFF
--- a/app/src/internal/AndroidManifest.xml
+++ b/app/src/internal/AndroidManifest.xml
@@ -8,6 +8,10 @@
             android:label="@string/devSettingsTitle"
             android:parentActivityName="com.duckduckgo.app.settings.SettingsActivity" />
         <activity
+            android:name="com.duckduckgo.app.dev.settings.notifications.NotificationsActivity"
+            android:label="@string/devSettingsScreenNotificationsTitle"
+            android:parentActivityName="com.duckduckgo.app.dev.settings.DevSettingsActivity" />
+        <activity
             android:name="com.duckduckgo.app.audit.AuditSettingsActivity"
             android:label="@string/auditSettingsTitle"
             android:parentActivityName="com.duckduckgo.app.settings.SettingsActivity" />

--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/DevSettingsActivity.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/DevSettingsActivity.kt
@@ -34,8 +34,15 @@ import com.duckduckgo.app.browser.R.layout
 import com.duckduckgo.app.browser.databinding.ActivityDevSettingsBinding
 import com.duckduckgo.app.browser.webview.WebContentDebuggingFeature
 import com.duckduckgo.app.dev.settings.DevSettingsViewModel.Command
+import com.duckduckgo.app.dev.settings.DevSettingsViewModel.Command.ChangePrivacyConfigUrl
+import com.duckduckgo.app.dev.settings.DevSettingsViewModel.Command.CustomTabs
+import com.duckduckgo.app.dev.settings.DevSettingsViewModel.Command.Notifications
+import com.duckduckgo.app.dev.settings.DevSettingsViewModel.Command.OpenUASelector
+import com.duckduckgo.app.dev.settings.DevSettingsViewModel.Command.SendTdsIntent
+import com.duckduckgo.app.dev.settings.DevSettingsViewModel.Command.ShowSavedSitesClearedConfirmation
 import com.duckduckgo.app.dev.settings.customtabs.CustomTabsInternalSettingsActivity
 import com.duckduckgo.app.dev.settings.db.UAOverride
+import com.duckduckgo.app.dev.settings.notifications.NotificationsActivity
 import com.duckduckgo.app.dev.settings.privacy.TrackerDataDevReceiver.Companion.DOWNLOAD_TDS_INTENT_ACTION
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.menu.PopupMenu
@@ -98,6 +105,7 @@ class DevSettingsActivity : DuckDuckGoActivity() {
         binding.overrideUserAgentSelector.setOnClickListener { viewModel.onUserAgentSelectorClicked() }
         binding.overridePrivacyRemoteConfigUrl.setOnClickListener { viewModel.onRemotePrivacyUrlClicked() }
         binding.customTabs.setOnClickListener { viewModel.customTabsClicked() }
+        binding.notifications.setOnClickListener { viewModel.notificationsClicked() }
     }
 
     private fun observeViewModel() {
@@ -119,14 +127,14 @@ class DevSettingsActivity : DuckDuckGoActivity() {
             .launchIn(lifecycleScope)
     }
 
-    private fun processCommand(it: Command?) {
+    private fun processCommand(it: Command) {
         when (it) {
-            is Command.SendTdsIntent -> sendTdsIntent()
-            is Command.OpenUASelector -> showUASelector()
-            is Command.ShowSavedSitesClearedConfirmation -> showSavedSitesClearedConfirmation()
-            is Command.ChangePrivacyConfigUrl -> showChangePrivacyUrl()
-            is Command.CustomTabs -> showCustomTabs()
-            else -> TODO()
+            is SendTdsIntent -> sendTdsIntent()
+            is OpenUASelector -> showUASelector()
+            is ShowSavedSitesClearedConfirmation -> showSavedSitesClearedConfirmation()
+            is ChangePrivacyConfigUrl -> showChangePrivacyUrl()
+            is CustomTabs -> showCustomTabs()
+            Notifications -> showNotifications()
         }
     }
 
@@ -165,6 +173,10 @@ class DevSettingsActivity : DuckDuckGoActivity() {
     private fun showCustomTabs() {
         val options = ActivityOptions.makeSceneTransitionAnimation(this).toBundle()
         startActivity(CustomTabsInternalSettingsActivity.intent(this), options)
+    }
+
+    private fun showNotifications() {
+        startActivity(NotificationsActivity.intent(this))
     }
 
     companion object {

--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/DevSettingsViewModel.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/DevSettingsViewModel.kt
@@ -60,6 +60,7 @@ class DevSettingsViewModel @Inject constructor(
         object ShowSavedSitesClearedConfirmation : Command()
         object ChangePrivacyConfigUrl : Command()
         object CustomTabs : Command()
+        data object Notifications : Command()
     }
 
     private val viewState = MutableStateFlow(ViewState())
@@ -136,5 +137,9 @@ class DevSettingsViewModel @Inject constructor(
             savedSitesRepository.deleteAll()
             command.send(Command.ShowSavedSitesClearedConfirmation)
         }
+    }
+
+    fun notificationsClicked() {
+        viewModelScope.launch { command.send(Command.Notifications) }
     }
 }

--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/notifications/NotificationsActivity.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/notifications/NotificationsActivity.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.dev.settings.notifications
+
+import android.app.Notification
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.core.app.NotificationManagerCompat
+import androidx.lifecycle.Lifecycle.State.STARTED
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.app.browser.databinding.ActivityNotificationsBinding
+import com.duckduckgo.app.dev.settings.notifications.NotificationViewModel.Command.TriggerNotification
+import com.duckduckgo.app.dev.settings.notifications.NotificationViewModel.ViewState
+import com.duckduckgo.app.notification.NotificationFactory
+import com.duckduckgo.common.ui.DuckDuckGoActivity
+import com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.notification.checkPermissionAndNotify
+import com.duckduckgo.di.scopes.ActivityScope
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
+
+@InjectWith(ActivityScope::class)
+class NotificationsActivity : DuckDuckGoActivity() {
+
+    @Inject
+    lateinit var viewModel: NotificationViewModel
+
+    @Inject
+    lateinit var factory: NotificationFactory
+
+    private val binding: ActivityNotificationsBinding by viewBinding()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(binding.root)
+        setupToolbar(binding.includeToolbar.toolbar)
+
+        observeViewState()
+        observeCommands()
+    }
+
+    private fun observeViewState() {
+        viewModel.viewState.flowWithLifecycle(lifecycle, STARTED).onEach { render(it) }
+            .launchIn(lifecycleScope)
+    }
+
+    private fun observeCommands() {
+        viewModel.command.flowWithLifecycle(lifecycle, STARTED).onEach { command ->
+            when (command) {
+                is TriggerNotification -> addNotification(id = command.notificationItem.id, notification = command.notificationItem.notification)
+            }
+        }.launchIn(lifecycleScope)
+    }
+
+    private fun render(viewState: ViewState) {
+        viewState.scheduledNotifications.forEach { notificationItem ->
+            buildNotificationItem(
+
+                title = notificationItem.title,
+                subtitle = notificationItem.subtitle,
+                onClick = { viewModel.onNotificationItemClick(notificationItem) },
+            ).also {
+                binding.scheduledNotificationsContainer.addView(it)
+            }
+        }
+    }
+
+    private fun buildNotificationItem(
+        title: String,
+        subtitle: String,
+        onClick: () -> Unit,
+    ): TwoLineListItem {
+        return TwoLineListItem(this).apply {
+            setPrimaryText(title)
+            setSecondaryText(subtitle)
+            setOnClickListener { onClick() }
+        }
+    }
+
+    private fun addNotification(
+        id: Int,
+        notification: Notification
+    ) {
+        NotificationManagerCompat.from(this)
+            .checkPermissionAndNotify(context = this, id = id, notification = notification)
+    }
+
+    companion object {
+
+        fun intent(context: Context): Intent {
+            return Intent(context, NotificationsActivity::class.java)
+        }
+    }
+}

--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/notifications/NotificationsActivity.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/notifications/NotificationsActivity.kt
@@ -81,6 +81,16 @@ class NotificationsActivity : DuckDuckGoActivity() {
                 binding.scheduledNotificationsContainer.addView(it)
             }
         }
+
+        viewState.vpnNotifications.forEach { notificationItem ->
+            buildNotificationItem(
+                title = notificationItem.title,
+                subtitle = notificationItem.subtitle,
+                onClick = { viewModel.onNotificationItemClick(notificationItem) },
+            ).also {
+                binding.vpnNotificationsContainer.addView(it)
+            }
+        }
     }
 
     private fun buildNotificationItem(

--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/notifications/NotificationsActivity.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/notifications/NotificationsActivity.kt
@@ -34,9 +34,9 @@ import com.duckduckgo.common.ui.view.listitem.TwoLineListItem
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.notification.checkPermissionAndNotify
 import com.duckduckgo.di.scopes.ActivityScope
+import javax.inject.Inject
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import javax.inject.Inject
 
 @InjectWith(ActivityScope::class)
 class NotificationsActivity : DuckDuckGoActivity() {
@@ -74,7 +74,6 @@ class NotificationsActivity : DuckDuckGoActivity() {
     private fun render(viewState: ViewState) {
         viewState.scheduledNotifications.forEach { notificationItem ->
             buildNotificationItem(
-
                 title = notificationItem.title,
                 subtitle = notificationItem.subtitle,
                 onClick = { viewModel.onNotificationItemClick(notificationItem) },
@@ -98,7 +97,7 @@ class NotificationsActivity : DuckDuckGoActivity() {
 
     private fun addNotification(
         id: Int,
-        notification: Notification
+        notification: Notification,
     ) {
         NotificationManagerCompat.from(this)
             .checkPermissionAndNotify(context = this, id = id, notification = notification)

--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/notifications/NotificationsViewModel.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/notifications/NotificationsViewModel.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.dev.settings.notifications
 
 import android.app.Notification
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
@@ -43,14 +44,17 @@ import kotlinx.coroutines.withContext
 
 @ContributesViewModel(ActivityScope::class)
 class NotificationViewModel @Inject constructor(
+    private val applicationContext: Context,
     private val dispatcher: DispatcherProvider,
     private val schedulableNotificationPluginPoint: PluginPoint<SchedulableNotificationPlugin>,
     private val factory: NotificationFactory,
     private val surveyRepository: SurveyRepository,
+    private val netPDisabledNotificationBuilder: NetPDisabledNotificationBuilder,
 ) : ViewModel() {
 
     data class ViewState(
         val scheduledNotifications: List<NotificationItem> = emptyList(),
+        val vpnNotifications: List<NotificationItem> = emptyList(),
     ) {
 
         data class NotificationItem(
@@ -93,7 +97,19 @@ class NotificationViewModel @Inject constructor(
                 )
             }
 
-            _viewState.update { it.copy(scheduledNotifications = scheduledNotificationItems) }
+            val netPDisabledNotificationItem = NotificationItem(
+                id = 0,
+                title = "NetP Disabled",
+                subtitle = "NetP is disabled",
+                notification = netPDisabledNotificationBuilder.buildVpnAccessRevokedNotification(applicationContext),
+            )
+
+            _viewState.update {
+                it.copy(
+                    scheduledNotifications = scheduledNotificationItems,
+                    vpnNotifications = listOf(netPDisabledNotificationItem),
+                )
+            }
         }
     }
 

--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/notifications/NotificationsViewModel.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/notifications/NotificationsViewModel.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.dev.settings.notifications
+
+import android.app.Notification
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.app.dev.settings.notifications.NotificationViewModel.ViewState.NotificationItem
+import com.duckduckgo.app.notification.NotificationFactory
+import com.duckduckgo.app.notification.model.SchedulableNotificationPlugin
+import com.duckduckgo.app.survey.api.SurveyRepository
+import com.duckduckgo.app.survey.model.Survey
+import com.duckduckgo.app.survey.model.Survey.Status.SCHEDULED
+import com.duckduckgo.app.survey.notification.SurveyAvailableNotification
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.plugins.PluginPoint
+import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.networkprotection.impl.notification.NetPDisabledNotificationBuilder
+import javax.inject.Inject
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+@ContributesViewModel(ActivityScope::class)
+class NotificationViewModel @Inject constructor(
+    private val dispatcher: DispatcherProvider,
+    private val schedulableNotificationPluginPoint: PluginPoint<SchedulableNotificationPlugin>,
+    private val factory: NotificationFactory,
+    private val surveyRepository: SurveyRepository,
+) : ViewModel() {
+
+    data class ViewState(
+        val scheduledNotifications: List<NotificationItem> = emptyList(),
+    ) {
+
+        data class NotificationItem(
+            val id: Int,
+            val title: String,
+            val subtitle: String,
+            val notification: Notification
+        )
+    }
+
+    sealed class Command {
+        data class TriggerNotification(val notificationItem: NotificationItem) : Command()
+    }
+
+    private val _viewState = MutableStateFlow(ViewState())
+    val viewState = _viewState.asStateFlow()
+
+    private val _command = Channel<Command>(1, BufferOverflow.DROP_OLDEST)
+    val command = _command.receiveAsFlow()
+
+    init {
+        viewModelScope.launch {
+            val scheduledNotificationItems = schedulableNotificationPluginPoint.getPlugins().map { plugin ->
+
+                // The survey notification will crash if we do not have a survey in the database
+                if (plugin.getSchedulableNotification().javaClass == SurveyAvailableNotification::class.java) {
+                    withContext(dispatcher.io()) {
+                        addTestSurvey()
+                    }
+                }
+
+                // the survey intent hits the DB, so we need to do this on IO
+                val launchIntent = withContext(dispatcher.io()) { plugin.getLaunchIntent() }
+
+                NotificationItem(
+                    id = plugin.getSpecification().systemId,
+                    title = plugin.getSpecification().title,
+                    subtitle = plugin.getSpecification().description,
+                    notification = factory.createNotification(plugin.getSpecification(), launchIntent, null),
+                )
+            }
+
+            _viewState.update { it.copy(scheduledNotifications = scheduledNotificationItems) }
+        }
+    }
+
+    private fun addTestSurvey() {
+        surveyRepository.persistSurvey(
+            Survey(
+                "testSurveyId",
+                "https://youtu.be/dQw4w9WgXcQ?si=iztopgFbXoWUnoOE",
+                daysInstalled = 1,
+                status = SCHEDULED,
+            ),
+        )
+    }
+
+    fun onNotificationItemClick(notificationItem: NotificationItem) {
+        viewModelScope.launch {
+            _command.send(Command.TriggerNotification(notificationItem))
+        }
+    }
+}

--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/notifications/NotificationsViewModel.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/notifications/NotificationsViewModel.kt
@@ -57,7 +57,7 @@ class NotificationViewModel @Inject constructor(
             val id: Int,
             val title: String,
             val subtitle: String,
-            val notification: Notification
+            val notification: Notification,
         )
     }
 

--- a/app/src/internal/res/layout/activity_dev_settings.xml
+++ b/app/src/internal/res/layout/activity_dev_settings.xml
@@ -88,6 +88,13 @@
                 app:secondaryText="@string/devSettingsScreenCustomTabsSubtitle"
                 />
 
+            <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+                android:id="@+id/notifications"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="@string/devSettingsScreenNotificationsTitle"
+                app:secondaryText="@string/devSettingsScreenNotificationsSubtitle" />
+
             <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
                 android:id="@+id/privacyTitle"
                 android:layout_width="wrap_content"

--- a/app/src/internal/res/layout/activity_notifications.xml
+++ b/app/src/internal/res/layout/activity_notifications.xml
@@ -48,6 +48,18 @@
                 android:layout_height="wrap_content"
                 android:orientation="vertical" />
 
+            <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+                android:id="@+id/vpnNotificationsTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:primaryText="@string/devSettingsNotificationsVPNTitle" />
+
+            <LinearLayout
+                android:id="@+id/vpnNotificationsContainer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical" />
+
         </LinearLayout>
 
     </ScrollView>

--- a/app/src/internal/res/layout/activity_notifications.xml
+++ b/app/src/internal/res/layout/activity_notifications.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2021 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context="com.duckduckgo.app.dev.settings.notifications.NotificationsActivity">
+
+    <include
+        android:id="@+id/includeToolbar"
+        layout="@layout/include_default_toolbar" />
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:orientation="vertical"
+            android:layout_height="wrap_content">
+
+            <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+                android:id="@+id/scheduledNotificationsTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:primaryText="@string/devSettingsNotificationsScheduledTitle" />
+
+            <LinearLayout
+                android:id="@+id/scheduledNotificationsContainer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical" />
+
+        </LinearLayout>
+
+    </ScrollView>
+</LinearLayout>

--- a/app/src/internal/res/values/donottranslate.xml
+++ b/app/src/internal/res/values/donottranslate.xml
@@ -38,7 +38,7 @@
     <string name="devSettingsScreenUserAgentOverride">Override UserAgent</string>
     <string name="devSettingsScreenPrivacyRemoteConfigUrlOverride">Override Privacy Remote Config URL</string>
     <string name="devSettingsScreenCustomTabs">Custom Tabs</string>
-    <string name="devSettingsScreenNotificationTitle">Notifications</string>
+    <string name="devSettingsScreenNotificationsTitle">Notifications</string>
     <string name="devSettingsScreenNotificationsSubtitle">Trigger notifications for testing</string>
     <string name="devSettingsScreenPrivacyRemoteConfigUrlOverrideSubtitle">Click here to customize the Privacy Remote Config URL</string>
     <string name="devSettingsScreenCustomTabsSubtitle">Load a Custom Tab for a specified URL</string>
@@ -88,5 +88,8 @@
     <string name="customTabsInvalidUrl">Invalid URL</string>
     <string name="customTabsEmptyUrl">Enter a URL</string>
     <string name="customTabsDefaultBrowserTitle">Default Browser</string>
+
+    <!-- Notifications -->
+    <string name="devSettingsNotificationsScheduledTitle">Scheduled Notifications</string>
 
 </resources>

--- a/app/src/internal/res/values/donottranslate.xml
+++ b/app/src/internal/res/values/donottranslate.xml
@@ -91,5 +91,6 @@
 
     <!-- Notifications -->
     <string name="devSettingsNotificationsScheduledTitle">Scheduled Notifications</string>
+    <string name="devSettingsNotificationsVPNTitle">VPN Notifications</string>
 
 </resources>

--- a/app/src/internal/res/values/donottranslate.xml
+++ b/app/src/internal/res/values/donottranslate.xml
@@ -38,6 +38,8 @@
     <string name="devSettingsScreenUserAgentOverride">Override UserAgent</string>
     <string name="devSettingsScreenPrivacyRemoteConfigUrlOverride">Override Privacy Remote Config URL</string>
     <string name="devSettingsScreenCustomTabs">Custom Tabs</string>
+    <string name="devSettingsScreenNotificationTitle">Notifications</string>
+    <string name="devSettingsScreenNotificationsSubtitle">Trigger notifications for testing</string>
     <string name="devSettingsScreenPrivacyRemoteConfigUrlOverrideSubtitle">Click here to customize the Privacy Remote Config URL</string>
     <string name="devSettingsScreenCustomTabsSubtitle">Load a Custom Tab for a specified URL</string>
     <string name="devSettingsScreenUserAgentSelectorTitle">UserAgent</string>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -326,6 +326,15 @@
             </intent-filter>
         </activity>
         <activity
+            android:name="com.duckduckgo.app.settings.NewSettingsActivity"
+            android:exported="true"
+            android:label="New Settings"
+            android:parentActivityName=".BrowserActivity">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE_PREFERENCES" />
+            </intent-filter>
+        </activity>
+        <activity
             android:name="com.duckduckgo.app.feedback.ui.common.FeedbackActivity"
             android:exported="false"
             android:label="@string/feedbackActivityTitle"

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -531,7 +531,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
     }
 
     fun launchSettings() {
-        if(settings.isNewSettingsEnabled) {
+        if (settings.isNewSettingsEnabled) {
             globalActivityStarter.start(this, NewSettingsScreenNoParams)
         } else {
             startActivity(SettingsActivity.intent(this))

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -66,6 +66,7 @@ import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.autofill.api.emailprotection.EmailProtectionLinkVerifier
 import com.duckduckgo.browser.api.ui.BrowserScreens.BookmarksScreenNoParams
+import com.duckduckgo.browser.api.ui.BrowserScreens.NewSettingsScreenNoParams
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.view.gone
@@ -77,6 +78,7 @@ import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.privacy.dashboard.api.ui.PrivacyDashboardHybridScreenParams.PrivacyDashboardPrimaryScreen
 import com.duckduckgo.savedsites.impl.bookmarks.BookmarksActivity.Companion.SAVED_SITE_URL_EXTRA
+import com.duckduckgo.settings.api.Settings
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -128,6 +130,9 @@ open class BrowserActivity : DuckDuckGoActivity() {
 
     @Inject
     lateinit var appBuildConfig: AppBuildConfig
+
+    @Inject
+    lateinit var settings: Settings
 
     private val lastActiveTabs = TabList()
 
@@ -526,7 +531,11 @@ open class BrowserActivity : DuckDuckGoActivity() {
     }
 
     fun launchSettings() {
-        startActivity(SettingsActivity.intent(this))
+        if(settings.isNewSettingsEnabled) {
+            globalActivityStarter.start(this, NewSettingsScreenNoParams)
+        } else {
+            startActivity(SettingsActivity.intent(this))
+        }
     }
 
     fun launchSitePermissionsSettings() {

--- a/app/src/main/java/com/duckduckgo/app/global/shortcut/AppShortcutCreator.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/shortcut/AppShortcutCreator.kt
@@ -29,13 +29,17 @@ import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.app.settings.NewSettingsActivity
 import com.duckduckgo.app.settings.SettingsActivity
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.appbuildconfig.api.isInternalBuild
+import com.duckduckgo.browser.api.ui.BrowserScreens.NewSettingsScreenNoParams
 import com.duckduckgo.common.ui.themepreview.ui.AppComponentsActivity
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.savedsites.impl.bookmarks.BookmarksActivity
+import com.duckduckgo.settings.api.Settings
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
 import dagger.Provides
@@ -74,6 +78,8 @@ class AppShortcutCreator @Inject constructor(
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val appBuildConfig: AppBuildConfig,
     private val dispatchers: DispatcherProvider,
+    private val globalActivityStarter: GlobalActivityStarter,
+    private val settings: Settings,
 ) {
 
     fun configureAppShortcuts() {
@@ -136,7 +142,11 @@ class AppShortcutCreator @Inject constructor(
 
     private fun buildAndroidDesignSystemShortcut(context: Context): ShortcutInfo {
         val browserActivity = BrowserActivity.intent(context).also { it.action = Intent.ACTION_VIEW }
-        val settingsActivity = SettingsActivity.intent(context).also { it.action = Intent.ACTION_VIEW }
+        val settingsActivity = if(settings.isNewSettingsEnabled) {
+            NewSettingsActivity.intent(context).also { it.action = Intent.ACTION_VIEW }
+        }else {
+            SettingsActivity.intent(context).also { it.action = Intent.ACTION_VIEW }
+        }
         val adsActivity = AppComponentsActivity.intent(context).also { it.action = Intent.ACTION_VIEW }
 
         val stackBuilder = TaskStackBuilder.create(context)

--- a/app/src/main/java/com/duckduckgo/app/global/shortcut/AppShortcutCreator.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/shortcut/AppShortcutCreator.kt
@@ -33,7 +33,6 @@ import com.duckduckgo.app.settings.NewSettingsActivity
 import com.duckduckgo.app.settings.SettingsActivity
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.appbuildconfig.api.isInternalBuild
-import com.duckduckgo.browser.api.ui.BrowserScreens.NewSettingsScreenNoParams
 import com.duckduckgo.common.ui.themepreview.ui.AppComponentsActivity
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
@@ -142,9 +141,9 @@ class AppShortcutCreator @Inject constructor(
 
     private fun buildAndroidDesignSystemShortcut(context: Context): ShortcutInfo {
         val browserActivity = BrowserActivity.intent(context).also { it.action = Intent.ACTION_VIEW }
-        val settingsActivity = if(settings.isNewSettingsEnabled) {
+        val settingsActivity = if (settings.isNewSettingsEnabled) {
             NewSettingsActivity.intent(context).also { it.action = Intent.ACTION_VIEW }
-        }else {
+        } else {
             SettingsActivity.intent(context).also { it.action = Intent.ACTION_VIEW }
         }
         val adsActivity = AppComponentsActivity.intent(context).also { it.action = Intent.ACTION_VIEW }

--- a/app/src/main/java/com/duckduckgo/app/notification/model/ClearDataNotification.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/model/ClearDataNotification.kt
@@ -33,9 +33,9 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.browser.api.ui.BrowserScreens.NewSettingsScreenNoParams
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.mobile.android.R as CommonR
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.settings.api.Settings
-import com.duckduckgo.mobile.android.R as CommonR
 import com.squareup.anvil.annotations.ContributesMultibinding
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope

--- a/app/src/main/java/com/duckduckgo/app/settings/NewSettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/NewSettingsActivity.kt
@@ -1,0 +1,443 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.settings
+
+import android.app.ActivityOptions
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import androidx.core.view.isVisible
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.app.about.AboutScreenNoParams
+import com.duckduckgo.app.accessibility.AccessibilityScreens
+import com.duckduckgo.app.appearance.AppearanceScreen
+import com.duckduckgo.app.browser.BrowserActivity
+import com.duckduckgo.app.browser.databinding.ActivitySettingsNewBinding
+import com.duckduckgo.app.email.ui.EmailProtectionUnsupportedScreenNoParams
+import com.duckduckgo.app.firebutton.FireButtonScreenNoParams
+import com.duckduckgo.app.generalsettings.GeneralSettingsScreenNoParams
+import com.duckduckgo.app.global.view.launchDefaultAppActivity
+import com.duckduckgo.app.permissions.PermissionsScreenNoParams
+import com.duckduckgo.app.pixels.AppPixelName
+import com.duckduckgo.app.pixels.AppPixelName.PRIVACY_PRO_IS_ENABLED_AND_ELIGIBLE
+import com.duckduckgo.app.privatesearch.PrivateSearchScreenNoParams
+import com.duckduckgo.app.settings.SettingsViewModel.Command
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
+import com.duckduckgo.app.webtrackingprotection.WebTrackingProtectionScreenNoParams
+import com.duckduckgo.app.widget.AddWidgetLauncher
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.autoconsent.impl.ui.AutoconsentSettingsActivity
+import com.duckduckgo.autofill.api.AutofillScreens.AutofillSettingsScreen
+import com.duckduckgo.autofill.api.AutofillSettingsLaunchSource
+import com.duckduckgo.browser.api.ui.BrowserScreens.NewSettingsScreenNoParams
+import com.duckduckgo.common.ui.DuckDuckGoActivity
+import com.duckduckgo.common.ui.view.gone
+import com.duckduckgo.common.ui.view.listitem.CheckListItem
+import com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+import com.duckduckgo.common.ui.view.show
+import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.plugins.PluginPoint
+import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.internal.features.api.InternalFeaturePlugin
+import com.duckduckgo.macos.api.MacOsScreenWithEmptyParams
+import com.duckduckgo.mobile.android.app.tracking.ui.AppTrackingProtectionScreens.AppTrackerActivityWithEmptyParams
+import com.duckduckgo.mobile.android.app.tracking.ui.AppTrackingProtectionScreens.AppTrackerOnboardingActivityWithEmptyParamsParams
+import com.duckduckgo.navigation.api.GlobalActivityStarter
+import com.duckduckgo.settings.api.DuckPlayerSettingsPlugin
+import com.duckduckgo.settings.api.ProSettingsPlugin
+import com.duckduckgo.sync.api.SyncActivityWithEmptyParams
+import com.duckduckgo.windows.api.ui.WindowsScreenWithEmptyParams
+import javax.inject.Inject
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import timber.log.Timber
+
+
+@InjectWith(ActivityScope::class)
+@ContributeToActivityStarter(NewSettingsScreenNoParams::class, screenName = "newSettings")
+class NewSettingsActivity : DuckDuckGoActivity() {
+
+    private val viewModel: SettingsViewModel by bindViewModel()
+    private val binding: ActivitySettingsNewBinding by viewBinding()
+
+    @Inject
+    lateinit var pixel: Pixel
+
+    @Inject
+    lateinit var internalFeaturePlugins: PluginPoint<InternalFeaturePlugin>
+
+    @Inject
+    lateinit var addWidgetLauncher: AddWidgetLauncher
+
+    @Inject
+    lateinit var appBuildConfig: AppBuildConfig
+
+    @Inject
+    lateinit var globalActivityStarter: GlobalActivityStarter
+
+    @Inject
+    lateinit var _proSettingsPlugin: PluginPoint<ProSettingsPlugin>
+    private val proSettingsPlugin by lazy {
+        _proSettingsPlugin.getPlugins()
+    }
+
+    @Inject
+    lateinit var _duckPlayerSettingsPlugin: PluginPoint<DuckPlayerSettingsPlugin>
+    private val duckPlayerSettingsPlugin by lazy {
+        _duckPlayerSettingsPlugin.getPlugins()
+    }
+
+    private val viewsPrivacy
+        get() = binding.includeSettings.contentSettingsPrivacy
+
+    private val viewsSettings
+        get() = binding.includeSettings.contentSettingsSettings
+
+    private val viewsMore
+        get() = binding.includeSettings.contentSettingsMore
+
+    private val viewsInternal
+        get() = binding.includeSettings.contentSettingsInternal
+
+    private val viewsPro
+        get() = binding.includeSettings.settingsSectionPro
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContentView(binding.root)
+        setupToolbar(binding.includeToolbar.toolbar)
+
+        configureUiEventHandlers()
+        configureInternalFeatures()
+        configureSettings()
+        lifecycle.addObserver(viewModel)
+        observeViewModel()
+
+        intent?.getStringExtra(BrowserActivity.LAUNCH_FROM_NOTIFICATION_PIXEL_NAME)?.let {
+            viewModel.onLaunchedFromNotification(it)
+        }
+    }
+
+    private fun configureUiEventHandlers() {
+        with(viewsPrivacy) {
+            setAsDefaultBrowserSetting.setClickListener { viewModel.onDefaultBrowserSettingClicked() }
+            privateSearchSetting.setClickListener { viewModel.onPrivateSearchSettingClicked() }
+            webTrackingProtectionSetting.setClickListener { viewModel.onWebTrackingProtectionSettingClicked() }
+            cookiePopupProtectionSetting.setClickListener { viewModel.onCookiePopupProtectionSettingClicked() }
+            emailSetting.setClickListener { viewModel.onEmailProtectionSettingClicked() }
+            vpnSetting.setClickListener { viewModel.onAppTPSettingClicked() }
+        }
+
+        with(viewsSettings) {
+            homeScreenWidgetSetting.setClickListener { viewModel.userRequestedToAddHomeScreenWidget() }
+            autofillLoginsSetting.setClickListener { viewModel.onAutofillSettingsClick() }
+            syncSetting.setClickListener { viewModel.onSyncSettingClicked() }
+            fireButtonSetting.setClickListener { viewModel.onFireButtonSettingClicked() }
+            permissionsSetting.setClickListener { viewModel.onPermissionsSettingClicked() }
+            appearanceSetting.setClickListener { viewModel.onAppearanceSettingClicked() }
+            accessibilitySetting.setClickListener { viewModel.onAccessibilitySettingClicked() }
+            aboutSetting.setClickListener { viewModel.onAboutSettingClicked() }
+            generalSetting.setClickListener { viewModel.onGeneralSettingClicked() }
+        }
+
+        with(viewsMore) {
+            macOsSetting.setClickListener { viewModel.onMacOsSettingClicked() }
+            windowsSetting.setClickListener { viewModel.windowsSettingClicked() }
+        }
+    }
+
+    private fun configureSettings() {
+        if (proSettingsPlugin.isEmpty()) {
+            viewsPro.gone()
+        } else {
+            proSettingsPlugin.forEach { plugin ->
+                viewsPro.addView(plugin.getView(this))
+            }
+        }
+
+        if (duckPlayerSettingsPlugin.isEmpty()) {
+            viewsSettings.settingsSectionDuckPlayer.gone()
+        } else {
+            duckPlayerSettingsPlugin.forEach { plugin ->
+                viewsSettings.settingsSectionDuckPlayer.addView(plugin.getView(this))
+            }
+        }
+    }
+
+    private fun configureInternalFeatures() {
+        viewsInternal.settingsSectionInternal.visibility = if (internalFeaturePlugins.getPlugins().isEmpty()) View.GONE else View.VISIBLE
+        internalFeaturePlugins.getPlugins().forEach { feature ->
+            Timber.v("Adding internal feature ${feature.internalFeatureTitle()}")
+            val view = TwoLineListItem(this).apply {
+                setPrimaryText(feature.internalFeatureTitle())
+                setSecondaryText(feature.internalFeatureSubtitle())
+            }
+            viewsInternal.settingsInternalFeaturesContainer.addView(view)
+            view.setClickListener { feature.onInternalFeatureClicked(this) }
+        }
+    }
+
+    private fun observeViewModel() {
+        viewModel.viewState()
+            .flowWithLifecycle(lifecycle, Lifecycle.State.RESUMED)
+            .distinctUntilChanged()
+            .onEach { viewState ->
+                viewState.let {
+                    updateDefaultBrowserViewVisibility(it)
+                    updateDeviceShieldSettings(
+                        it.appTrackingProtectionEnabled,
+                        it.appTrackingProtectionOnboardingShown,
+                    )
+                    updateEmailSubtitle(it.emailAddress)
+                    updateAutofill(it.showAutofill)
+                    updateSyncSetting(visible = it.showSyncSetting)
+                    updateAutoconsent(it.isAutoconsentEnabled)
+                    updatePrivacyPro(it.isPrivacyProEnabled)
+                    updateDuckPlayer(it.isDuckPlayerEnabled)
+                }
+            }.launchIn(lifecycleScope)
+
+        viewModel.commands()
+            .flowWithLifecycle(lifecycle, Lifecycle.State.CREATED)
+            .onEach { processCommand(it) }
+            .launchIn(lifecycleScope)
+    }
+
+    private fun updatePrivacyPro(isPrivacyProEnabled: Boolean) {
+        if (isPrivacyProEnabled) {
+            pixel.fire(PRIVACY_PRO_IS_ENABLED_AND_ELIGIBLE, type = Daily())
+            viewsPro.show()
+        } else {
+            viewsPro.gone()
+        }
+    }
+
+    private fun updateDuckPlayer(isDuckPlayerEnabled: Boolean) {
+        if (isDuckPlayerEnabled) {
+            viewsSettings.settingsSectionDuckPlayer.show()
+        } else {
+            viewsSettings.settingsSectionDuckPlayer.gone()
+        }
+    }
+
+    private fun updateAutofill(autofillEnabled: Boolean) = with(viewsSettings.autofillLoginsSetting) {
+        visibility = if (autofillEnabled) {
+            View.VISIBLE
+        } else {
+            View.GONE
+        }
+    }
+
+    private fun updateEmailSubtitle(emailAddress: String?) {
+        if (emailAddress.isNullOrEmpty()) {
+            viewsPrivacy.emailSetting.setSecondaryText(getString(com.duckduckgo.app.browser.R.string.settingsEmailProtectionSubtitle))
+            viewsPrivacy.emailSetting.setItemStatus(CheckListItem.CheckItemStatus.DISABLED)
+        } else {
+            viewsPrivacy.emailSetting.setSecondaryText(emailAddress)
+            viewsPrivacy.emailSetting.setItemStatus(CheckListItem.CheckItemStatus.ENABLED)
+        }
+    }
+
+    private fun updateSyncSetting(visible: Boolean) {
+        with(viewsSettings.syncSetting) {
+            isVisible = visible
+        }
+    }
+
+    private fun updateAutoconsent(enabled: Boolean) {
+        if (enabled) {
+            viewsPrivacy.cookiePopupProtectionSetting.setSecondaryText(getString(com.duckduckgo.app.browser.R.string.cookiePopupProtectionEnabled))
+            viewsPrivacy.cookiePopupProtectionSetting.setItemStatus(CheckListItem.CheckItemStatus.ENABLED)
+        } else {
+            viewsPrivacy.cookiePopupProtectionSetting.setSecondaryText(getString(com.duckduckgo.app.browser.R.string.cookiePopupProtectionDescription))
+            viewsPrivacy.cookiePopupProtectionSetting.setItemStatus(CheckListItem.CheckItemStatus.DISABLED)
+        }
+    }
+
+    private fun processCommand(it: Command?) {
+        when (it) {
+            is Command.LaunchDefaultBrowser -> launchDefaultAppScreen()
+            is Command.LaunchAutofillSettings -> launchAutofillSettings()
+            is Command.LaunchAccessibilitySettings -> launchAccessibilitySettings()
+            is Command.LaunchAppTPTrackersScreen -> launchAppTPTrackersScreen()
+            is Command.LaunchAppTPOnboarding -> launchAppTPOnboardingScreen()
+            is Command.LaunchEmailProtection -> launchEmailProtectionScreen(it.url)
+            is Command.LaunchEmailProtectionNotSupported -> launchEmailProtectionNotSupported()
+            is Command.LaunchAddHomeScreenWidget -> launchAddHomeScreenWidget()
+            is Command.LaunchMacOs -> launchMacOsScreen()
+            is Command.LaunchWindows -> launchWindowsScreen()
+            is Command.LaunchSyncSettings -> launchSyncSettings()
+            is Command.LaunchPrivateSearchWebPage -> launchPrivateSearchScreen()
+            is Command.LaunchWebTrackingProtectionScreen -> launchWebTrackingProtectionScreen()
+            is Command.LaunchCookiePopupProtectionScreen -> launchCookiePopupProtectionScreen()
+            is Command.LaunchFireButtonScreen -> launchFireButtonScreen()
+            is Command.LaunchPermissionsScreen -> launchPermissionsScreen()
+            is Command.LaunchAppearanceScreen -> launchAppearanceScreen()
+            is Command.LaunchAboutScreen -> launchAboutScreen()
+            is Command.LaunchGeneralSettingsScreen -> launchGeneralSettingsScreen()
+            null -> TODO()
+        }
+    }
+
+    private fun updateDefaultBrowserViewVisibility(it: SettingsViewModel.ViewState) {
+        with(viewsPrivacy.setAsDefaultBrowserSetting) {
+            visibility = if (it.showDefaultBrowserSetting) {
+                if (it.isAppDefaultBrowser) {
+                    setItemStatus(CheckListItem.CheckItemStatus.ENABLED)
+                    setSecondaryText(getString(com.duckduckgo.app.browser.R.string.settingsDefaultBrowserSetDescription))
+                } else {
+                    setItemStatus(CheckListItem.CheckItemStatus.DISABLED)
+                    setSecondaryText(getString(com.duckduckgo.app.browser.R.string.settingsDefaultBrowserNotSetDescription))
+                }
+                View.VISIBLE
+            } else {
+                View.GONE
+            }
+        }
+    }
+
+    private fun updateDeviceShieldSettings(
+        appTPEnabled: Boolean,
+        appTrackingProtectionOnboardingShown: Boolean,
+    ) {
+        with(viewsPrivacy) {
+            if (appTPEnabled) {
+                vpnSetting.setSecondaryText(getString(com.duckduckgo.app.browser.R.string.atp_SettingsDeviceShieldEnabled))
+                vpnSetting.setItemStatus(CheckListItem.CheckItemStatus.ENABLED)
+            } else {
+                if (appTrackingProtectionOnboardingShown) {
+                    vpnSetting.setSecondaryText(getString(com.duckduckgo.app.browser.R.string.atp_SettingsDeviceShieldDisabled))
+                    vpnSetting.setItemStatus(CheckListItem.CheckItemStatus.WARNING)
+                } else {
+                    vpnSetting.setSecondaryText(getString(com.duckduckgo.app.browser.R.string.atp_SettingsDeviceShieldNeverEnabled))
+                    vpnSetting.setItemStatus(CheckListItem.CheckItemStatus.DISABLED)
+                }
+            }
+        }
+    }
+
+    private fun launchDefaultAppScreen() {
+        launchDefaultAppActivity()
+    }
+
+    private fun launchAutofillSettings() {
+        val options = ActivityOptions.makeSceneTransitionAnimation(this).toBundle()
+        globalActivityStarter.start(this, AutofillSettingsScreen(source = AutofillSettingsLaunchSource.SettingsActivity), options)
+    }
+
+    private fun launchAccessibilitySettings() {
+        val options = ActivityOptions.makeSceneTransitionAnimation(this).toBundle()
+        globalActivityStarter.start(this, AccessibilityScreens.Default, options)
+    }
+
+    private fun launchEmailProtectionScreen(url: String) {
+        val options = ActivityOptions.makeSceneTransitionAnimation(this).toBundle()
+        startActivity(BrowserActivity.intent(this, url, interstitialScreen = true), options)
+        this.finish()
+    }
+
+    private fun launchEmailProtectionNotSupported() {
+        val options = ActivityOptions.makeSceneTransitionAnimation(this).toBundle()
+        globalActivityStarter.start(this, EmailProtectionUnsupportedScreenNoParams, options)
+    }
+
+    private fun launchMacOsScreen() {
+        val options = ActivityOptions.makeSceneTransitionAnimation(this).toBundle()
+        globalActivityStarter.start(this, MacOsScreenWithEmptyParams, options)
+    }
+
+    private fun launchWindowsScreen() {
+        val options = ActivityOptions.makeSceneTransitionAnimation(this).toBundle()
+        globalActivityStarter.start(this, WindowsScreenWithEmptyParams, options)
+    }
+
+    private fun launchSyncSettings() {
+        val options = ActivityOptions.makeSceneTransitionAnimation(this).toBundle()
+        globalActivityStarter.start(this, SyncActivityWithEmptyParams, options)
+    }
+
+    private fun launchAppTPTrackersScreen() {
+        val options = ActivityOptions.makeSceneTransitionAnimation(this).toBundle()
+        globalActivityStarter.start(this, AppTrackerActivityWithEmptyParams, options)
+    }
+
+    private fun launchAppTPOnboardingScreen() {
+        val options = ActivityOptions.makeSceneTransitionAnimation(this).toBundle()
+        globalActivityStarter.start(this, AppTrackerOnboardingActivityWithEmptyParamsParams, options)
+    }
+
+    private fun launchAddHomeScreenWidget() {
+        pixel.fire(AppPixelName.SETTINGS_ADD_HOME_SCREEN_WIDGET_CLICKED)
+        addWidgetLauncher.launchAddWidget(this)
+    }
+
+    private fun launchPrivateSearchScreen() {
+        val options = ActivityOptions.makeSceneTransitionAnimation(this).toBundle()
+        globalActivityStarter.start(this, PrivateSearchScreenNoParams, options)
+    }
+
+    private fun launchWebTrackingProtectionScreen() {
+        val options = ActivityOptions.makeSceneTransitionAnimation(this).toBundle()
+        globalActivityStarter.start(this, WebTrackingProtectionScreenNoParams, options)
+    }
+
+    private fun launchCookiePopupProtectionScreen() {
+        val options = ActivityOptions.makeSceneTransitionAnimation(this).toBundle()
+        startActivity(AutoconsentSettingsActivity.intent(this), options)
+    }
+
+    private fun launchFireButtonScreen() {
+        val options = ActivityOptions.makeSceneTransitionAnimation(this).toBundle()
+        globalActivityStarter.start(this, FireButtonScreenNoParams, options)
+    }
+
+    private fun launchPermissionsScreen() {
+        val options = ActivityOptions.makeSceneTransitionAnimation(this).toBundle()
+        globalActivityStarter.start(this, PermissionsScreenNoParams, options)
+    }
+
+    private fun launchAppearanceScreen() {
+        val options = ActivityOptions.makeSceneTransitionAnimation(this).toBundle()
+        globalActivityStarter.start(this, AppearanceScreen.Default, options)
+    }
+
+    private fun launchAboutScreen() {
+        val options = ActivityOptions.makeSceneTransitionAnimation(this).toBundle()
+        globalActivityStarter.start(this, AboutScreenNoParams, options)
+    }
+
+    private fun launchGeneralSettingsScreen() {
+        val options = ActivityOptions.makeSceneTransitionAnimation(this).toBundle()
+        globalActivityStarter.start(this, GeneralSettingsScreenNoParams, options)
+    }
+
+    companion object {
+        const val LAUNCH_FROM_NOTIFICATION_PIXEL_NAME = "LAUNCH_FROM_NOTIFICATION_PIXEL_NAME"
+
+        fun intent(context: Context): Intent {
+            return Intent(context, NewSettingsActivity::class.java)
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/settings/NewSettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/NewSettingsActivity.kt
@@ -73,7 +73,6 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import timber.log.Timber
 
-
 @InjectWith(ActivityScope::class)
 @ContributeToActivityStarter(NewSettingsScreenNoParams::class, screenName = "newSettings")
 class NewSettingsActivity : DuckDuckGoActivity() {
@@ -271,7 +270,9 @@ class NewSettingsActivity : DuckDuckGoActivity() {
             viewsPrivacy.cookiePopupProtectionSetting.setSecondaryText(getString(com.duckduckgo.app.browser.R.string.cookiePopupProtectionEnabled))
             viewsPrivacy.cookiePopupProtectionSetting.setItemStatus(CheckListItem.CheckItemStatus.ENABLED)
         } else {
-            viewsPrivacy.cookiePopupProtectionSetting.setSecondaryText(getString(com.duckduckgo.app.browser.R.string.cookiePopupProtectionDescription))
+            viewsPrivacy.cookiePopupProtectionSetting.setSecondaryText(
+                getString(com.duckduckgo.app.browser.R.string.cookiePopupProtectionDescription),
+            )
             viewsPrivacy.cookiePopupProtectionSetting.setItemStatus(CheckListItem.CheckItemStatus.DISABLED)
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/settings/NewSettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/NewSettingsViewModel.kt
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.settings
+
+import android.annotation.SuppressLint
+import androidx.annotation.VisibleForTesting
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
+import com.duckduckgo.app.pixels.AppPixelName.*
+import com.duckduckgo.app.settings.NewSettingsViewModel.Command.LaunchAboutScreen
+import com.duckduckgo.app.settings.NewSettingsViewModel.Command.LaunchAccessibilitySettings
+import com.duckduckgo.app.settings.NewSettingsViewModel.Command.LaunchAddHomeScreenWidget
+import com.duckduckgo.app.settings.NewSettingsViewModel.Command.LaunchAppTPOnboarding
+import com.duckduckgo.app.settings.NewSettingsViewModel.Command.LaunchAppTPTrackersScreen
+import com.duckduckgo.app.settings.NewSettingsViewModel.Command.LaunchAppearanceScreen
+import com.duckduckgo.app.settings.NewSettingsViewModel.Command.LaunchAutofillSettings
+import com.duckduckgo.app.settings.NewSettingsViewModel.Command.LaunchCookiePopupProtectionScreen
+import com.duckduckgo.app.settings.NewSettingsViewModel.Command.LaunchDefaultBrowser
+import com.duckduckgo.app.settings.NewSettingsViewModel.Command.LaunchEmailProtection
+import com.duckduckgo.app.settings.NewSettingsViewModel.Command.LaunchEmailProtectionNotSupported
+import com.duckduckgo.app.settings.NewSettingsViewModel.Command.LaunchFireButtonScreen
+import com.duckduckgo.app.settings.NewSettingsViewModel.Command.LaunchGeneralSettingsScreen
+import com.duckduckgo.app.settings.NewSettingsViewModel.Command.LaunchMacOs
+import com.duckduckgo.app.settings.NewSettingsViewModel.Command.LaunchPermissionsScreen
+import com.duckduckgo.app.settings.NewSettingsViewModel.Command.LaunchPrivateSearchWebPage
+import com.duckduckgo.app.settings.NewSettingsViewModel.Command.LaunchSyncSettings
+import com.duckduckgo.app.settings.NewSettingsViewModel.Command.LaunchWebTrackingProtectionScreen
+import com.duckduckgo.app.settings.NewSettingsViewModel.Command.LaunchWindows
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.autoconsent.api.Autoconsent
+import com.duckduckgo.autofill.api.AutofillCapabilityChecker
+import com.duckduckgo.autofill.api.email.EmailManager
+import com.duckduckgo.common.utils.ConflatedJob
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.duckplayer.api.DuckPlayer
+import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.DISABLED_WIH_HELP_LINK
+import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.ENABLED
+import com.duckduckgo.mobile.android.app.tracking.AppTrackingProtection
+import com.duckduckgo.subscriptions.api.Subscriptions
+import com.duckduckgo.sync.api.DeviceSyncState
+import javax.inject.Inject
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+@SuppressLint("NoLifecycleObserver")
+@ContributesViewModel(ActivityScope::class)
+class NewSettingsViewModel @Inject constructor(
+    private val defaultWebBrowserCapability: DefaultBrowserDetector,
+    private val appTrackingProtection: AppTrackingProtection,
+    private val pixel: Pixel,
+    private val emailManager: EmailManager,
+    private val autofillCapabilityChecker: AutofillCapabilityChecker,
+    private val deviceSyncState: DeviceSyncState,
+    private val dispatcherProvider: DispatcherProvider,
+    private val autoconsent: Autoconsent,
+    private val subscriptions: Subscriptions,
+    private val duckPlayer: DuckPlayer,
+) : ViewModel(), DefaultLifecycleObserver {
+
+    data class ViewState(
+        val showDefaultBrowserSetting: Boolean = false,
+        val isAppDefaultBrowser: Boolean = false,
+        val appTrackingProtectionOnboardingShown: Boolean = false,
+        val appTrackingProtectionEnabled: Boolean = false,
+        val emailAddress: String? = null,
+        val showAutofill: Boolean = false,
+        val showSyncSetting: Boolean = false,
+        val isAutoconsentEnabled: Boolean = false,
+        val isPrivacyProEnabled: Boolean = false,
+        val isDuckPlayerEnabled: Boolean = false,
+    )
+
+    sealed class Command {
+        data object LaunchDefaultBrowser : Command()
+        data class LaunchEmailProtection(val url: String) : Command()
+        data object LaunchEmailProtectionNotSupported : Command()
+        data object LaunchAutofillSettings : Command()
+        data object LaunchAccessibilitySettings : Command()
+        data object LaunchAddHomeScreenWidget : Command()
+        data object LaunchAppTPTrackersScreen : Command()
+        data object LaunchAppTPOnboarding : Command()
+        data object LaunchMacOs : Command()
+        data object LaunchWindows : Command()
+        data object LaunchSyncSettings : Command()
+        data object LaunchPrivateSearchWebPage : Command()
+        data object LaunchWebTrackingProtectionScreen : Command()
+        data object LaunchCookiePopupProtectionScreen : Command()
+        data object LaunchFireButtonScreen : Command()
+        data object LaunchPermissionsScreen : Command()
+        data object LaunchAppearanceScreen : Command()
+        data object LaunchAboutScreen : Command()
+        data object LaunchGeneralSettingsScreen : Command()
+    }
+
+    private val viewState = MutableStateFlow(ViewState())
+
+    private val command = Channel<Command>(1, BufferOverflow.DROP_OLDEST)
+    private val appTPPollJob = ConflatedJob()
+
+    init {
+        pixel.fire(SETTINGS_OPENED)
+    }
+
+    override fun onStart(owner: LifecycleOwner) {
+        super.onStart(owner)
+        start()
+        startPollingAppTPState()
+    }
+
+    override fun onStop(owner: LifecycleOwner) {
+        super.onStop(owner)
+        appTPPollJob.cancel()
+    }
+
+    @VisibleForTesting
+    internal fun start() {
+        val defaultBrowserAlready = defaultWebBrowserCapability.isDefaultBrowser()
+
+        viewModelScope.launch {
+            viewState.emit(
+                currentViewState().copy(
+                    isAppDefaultBrowser = defaultBrowserAlready,
+                    showDefaultBrowserSetting = defaultWebBrowserCapability.deviceSupportsDefaultBrowserConfiguration(),
+                    appTrackingProtectionOnboardingShown = appTrackingProtection.isOnboarded(),
+                    appTrackingProtectionEnabled = appTrackingProtection.isRunning(),
+                    emailAddress = emailManager.getEmailAddress(),
+                    showAutofill = autofillCapabilityChecker.canAccessCredentialManagementScreen(),
+                    showSyncSetting = deviceSyncState.isFeatureEnabled(),
+                    isAutoconsentEnabled = autoconsent.isSettingEnabled(),
+                    isPrivacyProEnabled = subscriptions.isEligible(),
+                    isDuckPlayerEnabled = duckPlayer.getDuckPlayerState().let { it == ENABLED || it == DISABLED_WIH_HELP_LINK },
+                ),
+            )
+        }
+    }
+
+    // FIXME
+    // We need to fix this. This logic as inside the start method but it messes with the unit tests
+    // because when doing runningBlockingTest {} there is no delay and the tests crashes because this
+    // becomes a while(true) without any delay
+    private fun startPollingAppTPState() {
+        appTPPollJob += viewModelScope.launch(dispatcherProvider.io()) {
+            while (isActive) {
+                val isDeviceShieldEnabled = appTrackingProtection.isRunning()
+                val currentState = currentViewState()
+                viewState.value = currentState.copy(
+                    appTrackingProtectionOnboardingShown = appTrackingProtection.isOnboarded(),
+                    appTrackingProtectionEnabled = isDeviceShieldEnabled,
+                    isPrivacyProEnabled = subscriptions.isEligible(),
+                )
+                delay(1_000)
+            }
+        }
+    }
+
+    fun viewState(): StateFlow<ViewState> {
+        return viewState
+    }
+
+    fun commands(): Flow<Command> {
+        return command.receiveAsFlow()
+    }
+
+    fun userRequestedToAddHomeScreenWidget() {
+        viewModelScope.launch { command.send(LaunchAddHomeScreenWidget) }
+    }
+
+    fun onDefaultBrowserSettingClicked() {
+        val defaultBrowserSelected = defaultWebBrowserCapability.isDefaultBrowser()
+        viewModelScope.launch {
+            viewState.emit(currentViewState().copy(isAppDefaultBrowser = defaultBrowserSelected))
+            command.send(LaunchDefaultBrowser)
+        }
+        pixel.fire(SETTINGS_DEFAULT_BROWSER_PRESSED)
+    }
+
+    fun onPrivateSearchSettingClicked() {
+        viewModelScope.launch { command.send(LaunchPrivateSearchWebPage) }
+        pixel.fire(SETTINGS_PRIVATE_SEARCH_PRESSED)
+    }
+
+    fun onWebTrackingProtectionSettingClicked() {
+        viewModelScope.launch { command.send(LaunchWebTrackingProtectionScreen) }
+        pixel.fire(SETTINGS_WEB_TRACKING_PROTECTION_PRESSED)
+    }
+
+    fun onCookiePopupProtectionSettingClicked() {
+        viewModelScope.launch { command.send(LaunchCookiePopupProtectionScreen) }
+        pixel.fire(SETTINGS_COOKIE_POPUP_PROTECTION_PRESSED)
+    }
+
+    fun onAutofillSettingsClick() {
+        viewModelScope.launch { command.send(LaunchAutofillSettings) }
+    }
+
+    fun onAccessibilitySettingClicked() {
+        viewModelScope.launch { command.send(LaunchAccessibilitySettings) }
+        pixel.fire(SETTINGS_ACCESSIBILITY_PRESSED)
+    }
+
+    fun onAboutSettingClicked() {
+        viewModelScope.launch { command.send(LaunchAboutScreen) }
+        pixel.fire(SETTINGS_ABOUT_PRESSED)
+    }
+
+    fun onGeneralSettingClicked() {
+        viewModelScope.launch { command.send(LaunchGeneralSettingsScreen) }
+        pixel.fire(SETTINGS_GENERAL_PRESSED)
+    }
+
+    fun onEmailProtectionSettingClicked() {
+        viewModelScope.launch {
+            val command = if (emailManager.isEmailFeatureSupported()) {
+                LaunchEmailProtection(EMAIL_PROTECTION_URL)
+            } else {
+                LaunchEmailProtectionNotSupported
+            }
+            this@NewSettingsViewModel.command.send(command)
+        }
+        pixel.fire(SETTINGS_EMAIL_PROTECTION_PRESSED)
+    }
+
+    fun onMacOsSettingClicked() {
+        viewModelScope.launch { command.send(LaunchMacOs) }
+        pixel.fire(SETTINGS_MAC_APP_PRESSED)
+    }
+
+    fun windowsSettingClicked() {
+        viewModelScope.launch {
+            command.send(LaunchWindows)
+        }
+        pixel.fire(SETTINGS_WINDOWS_APP_PRESSED)
+    }
+
+    fun onAppTPSettingClicked() {
+        viewModelScope.launch {
+            if (appTrackingProtection.isOnboarded()) {
+                command.send(LaunchAppTPTrackersScreen)
+            } else {
+                command.send(LaunchAppTPOnboarding)
+            }
+            pixel.fire(SETTINGS_APPTP_PRESSED)
+        }
+    }
+
+    private fun currentViewState(): ViewState {
+        return viewState.value
+    }
+
+    fun onSyncSettingClicked() {
+        viewModelScope.launch { command.send(LaunchSyncSettings) }
+        pixel.fire(SETTINGS_SYNC_PRESSED)
+    }
+
+    fun onFireButtonSettingClicked() {
+        viewModelScope.launch { command.send(LaunchFireButtonScreen) }
+        pixel.fire(SETTINGS_FIRE_BUTTON_PRESSED)
+    }
+
+    fun onPermissionsSettingClicked() {
+        viewModelScope.launch { command.send(LaunchPermissionsScreen) }
+        pixel.fire(SETTINGS_PERMISSIONS_PRESSED)
+    }
+
+    fun onAppearanceSettingClicked() {
+        viewModelScope.launch { command.send(LaunchAppearanceScreen) }
+        pixel.fire(SETTINGS_APPEARANCE_PRESSED)
+    }
+
+    fun onLaunchedFromNotification(pixelName: String) {
+        pixel.fire(pixelName)
+    }
+
+    companion object {
+        const val EMAIL_PROTECTION_URL = "https://duckduckgo.com/email"
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsNewTabShortcutPlugin.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsNewTabShortcutPlugin.kt
@@ -20,12 +20,14 @@ import android.content.Context
 import com.duckduckgo.anvil.annotations.ContributesActivePlugin
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.app.browser.R
+import com.duckduckgo.browser.api.ui.BrowserScreens.NewSettingsScreenNoParams
 import com.duckduckgo.browser.api.ui.BrowserScreens.SettingsScreenNoParams
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.newtabpage.api.NewTabPageShortcutPlugin
 import com.duckduckgo.newtabpage.api.NewTabShortcut
+import com.duckduckgo.settings.api.Settings
 import javax.inject.Inject
 
 @ContributesActivePlugin(
@@ -36,6 +38,7 @@ import javax.inject.Inject
 class SettingsNewTabShortcutPlugin @Inject constructor(
     private val globalActivityStarter: GlobalActivityStarter,
     private val setting: SettingsNewTabShortcutSetting,
+    private val settings: Settings,
 ) : NewTabPageShortcutPlugin {
 
     inner class SettingsShortcut() : NewTabShortcut {
@@ -49,7 +52,11 @@ class SettingsNewTabShortcutPlugin @Inject constructor(
     }
 
     override fun onClick(context: Context) {
-        globalActivityStarter.start(context, SettingsScreenNoParams)
+        if (settings.isNewSettingsEnabled) {
+            globalActivityStarter.start(context, NewSettingsScreenNoParams)
+        } else {
+            globalActivityStarter.start(context, SettingsScreenNoParams)
+        }
     }
 
     override suspend fun isUserEnabled(): Boolean {

--- a/app/src/main/java/com/duckduckgo/app/settings/UpdatedSettingsFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/UpdatedSettingsFeature.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.settings
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "updatedSettings",
+)
+interface UpdatedSettingsFeature {
+
+    @Toggle.DefaultValue(false)
+    fun self(): Toggle
+
+    val isEnabled: Boolean
+        get() = self().isEnabled()
+}

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -52,6 +52,7 @@ import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.Close
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.CloseAllTabsRequest
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.browser.api.ui.BrowserScreens.NewSettingsScreenNoParams
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.view.button.ButtonType.DESTRUCTIVE
 import com.duckduckgo.common.ui.view.button.ButtonType.GHOST_ALT
@@ -61,6 +62,8 @@ import com.duckduckgo.common.ui.view.hide
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.navigation.api.GlobalActivityStarter
+import com.duckduckgo.settings.api.Settings
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import javax.inject.Inject
@@ -112,6 +115,12 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
 
     @Inject
     lateinit var appBuildConfig: AppBuildConfig
+
+    @Inject
+    lateinit var globalActivityStarter: GlobalActivityStarter
+
+    @Inject
+    lateinit var settings: Settings
 
     private val viewModel: TabSwitcherViewModel by bindViewModel()
 
@@ -458,7 +467,11 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
     }
 
     private fun showSettings() {
-        startActivity(SettingsActivity.intent(this))
+        if(settings.isNewSettingsEnabled) {
+            globalActivityStarter.start(this, NewSettingsScreenNoParams)
+        } else {
+            startActivity(SettingsActivity.intent(this))
+        }
         viewModel.onSettingsMenuPressed()
     }
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -467,7 +467,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
     }
 
     private fun showSettings() {
-        if(settings.isNewSettingsEnabled) {
+        if (settings.isNewSettingsEnabled) {
             globalActivityStarter.start(this, NewSettingsScreenNoParams)
         } else {
             startActivity(SettingsActivity.intent(this))

--- a/app/src/main/res/layout/activity_settings_new.xml
+++ b/app/src/main/res/layout/activity_settings_new.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2024 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="com.duckduckgo.app.settings.SettingsActivity">
+
+    <include
+        android:id="@+id/includeToolbar"
+        layout="@layout/include_default_toolbar" />
+
+    <include
+        android:id="@+id/includeSettings"
+        layout="@layout/content_settings" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/browser-api/src/main/java/com/duckduckgo/browser/api/ui/BrowserScreens.kt
+++ b/browser-api/src/main/java/com/duckduckgo/browser/api/ui/BrowserScreens.kt
@@ -39,6 +39,11 @@ sealed class BrowserScreens {
     object SettingsScreenNoParams : GlobalActivityStarter.ActivityParams
 
     /**
+     * Use this model to launch the New Settings screen
+     */
+    object NewSettingsScreenNoParams : GlobalActivityStarter.ActivityParams
+
+    /**
      * Use this model to launch the New Tab Settings screen
      */
     object NewTabSettingsScreenNoParams : GlobalActivityStarter.ActivityParams

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/notification/NetPDisabledNotificationBuilder.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/notification/NetPDisabledNotificationBuilder.kt
@@ -181,7 +181,7 @@ class RealNetPDisabledNotificationBuilder @Inject constructor(
     override fun buildVpnAccessRevokedNotification(context: Context): Notification {
         registerChannel(context)
 
-        val intent = if(settings.isNewSettingsEnabled) {
+        val intent = if (settings.isNewSettingsEnabled) {
             globalActivityStarter.startIntent(context, NewSettingsScreenNoParams)
         } else {
             globalActivityStarter.startIntent(context, SettingsScreenNoParams)

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/notification/NetPDisabledNotificationBuilder.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/notification/NetPDisabledNotificationBuilder.kt
@@ -25,6 +25,7 @@ import android.content.Intent
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.TaskStackBuilder
+import com.duckduckgo.browser.api.ui.BrowserScreens.NewSettingsScreenNoParams
 import com.duckduckgo.browser.api.ui.BrowserScreens.SettingsScreenNoParams
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
@@ -32,6 +33,7 @@ import com.duckduckgo.networkprotection.impl.R
 import com.duckduckgo.networkprotection.impl.subscription.NetpSubscriptionManager
 import com.duckduckgo.networkprotection.impl.subscription.isActive
 import com.duckduckgo.networkprotection.impl.subscription.isExpired
+import com.duckduckgo.settings.api.Settings
 import com.squareup.anvil.annotations.ContributesBinding
 import java.text.DateFormat
 import java.text.SimpleDateFormat
@@ -58,6 +60,7 @@ class RealNetPDisabledNotificationBuilder @Inject constructor(
     private val netPNotificationActions: NetPNotificationActions,
     private val globalActivityStarter: GlobalActivityStarter,
     private val netpSubscriptionManager: NetpSubscriptionManager,
+    private val settings: Settings,
 ) : NetPDisabledNotificationBuilder {
     private val defaultDateTimeFormatter = SimpleDateFormat.getTimeInstance(DateFormat.SHORT)
 
@@ -178,7 +181,11 @@ class RealNetPDisabledNotificationBuilder @Inject constructor(
     override fun buildVpnAccessRevokedNotification(context: Context): Notification {
         registerChannel(context)
 
-        val intent = globalActivityStarter.startIntent(context, SettingsScreenNoParams)
+        val intent = if(settings.isNewSettingsEnabled) {
+            globalActivityStarter.startIntent(context, NewSettingsScreenNoParams)
+        } else {
+            globalActivityStarter.startIntent(context, SettingsScreenNoParams)
+        }
         val pendingIntent: PendingIntent? = android.app.TaskStackBuilder.create(context).run {
             addNextIntentWithParentStack(intent)
             getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)

--- a/settings/settings-api/src/main/java/com/duckduckgo/settings/api/Settings.kt
+++ b/settings/settings-api/src/main/java/com/duckduckgo/settings/api/Settings.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.settings.api
+
+interface Settings {
+
+    val isNewSettingsEnabled: Boolean
+}

--- a/settings/settings-impl/src/main/java/com/duckduckgo/settings/impl/UpdatedSettingsFeature.kt
+++ b/settings/settings-impl/src/main/java/com/duckduckgo/settings/impl/UpdatedSettingsFeature.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.settings.impl
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultValue
+
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "updatedSettings",
+)
+interface UpdatedSettingsFeature{
+
+    @DefaultValue(false)
+    fun self(): Toggle
+}

--- a/settings/settings-impl/src/main/java/com/duckduckgo/settings/impl/UpdatedSettingsFeature.kt
+++ b/settings/settings-impl/src/main/java/com/duckduckgo/settings/impl/UpdatedSettingsFeature.kt
@@ -25,7 +25,7 @@ import com.duckduckgo.feature.toggles.api.Toggle.DefaultValue
     scope = AppScope::class,
     featureName = "updatedSettings",
 )
-interface UpdatedSettingsFeature{
+interface UpdatedSettingsFeature {
 
     @DefaultValue(false)
     fun self(): Toggle

--- a/settings/settings-impl/src/main/java/com/duckduckgo/settings/impl/store/RealSettings.kt
+++ b/settings/settings-impl/src/main/java/com/duckduckgo/settings/impl/store/RealSettings.kt
@@ -27,7 +27,7 @@ import javax.inject.Inject
 @SingleInstanceIn(AppScope::class)
 class RealSettings @Inject constructor(
     private val updatedSettingsFeature: UpdatedSettingsFeature,
-): Settings {
+) : Settings {
 
     override val isNewSettingsEnabled: Boolean
         get() = updatedSettingsFeature.self().isEnabled()

--- a/settings/settings-impl/src/main/java/com/duckduckgo/settings/impl/store/RealSettings.kt
+++ b/settings/settings-impl/src/main/java/com/duckduckgo/settings/impl/store/RealSettings.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.settings.impl.store
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.settings.api.Settings
+import com.duckduckgo.settings.impl.UpdatedSettingsFeature
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+@ContributesBinding(AppScope::class)
+@SingleInstanceIn(AppScope::class)
+class RealSettings @Inject constructor(
+    private val updatedSettingsFeature: UpdatedSettingsFeature,
+): Settings {
+
+    override val isNewSettingsEnabled: Boolean
+        get() = updatedSettingsFeature.self().isEnabled()
+}

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -179,7 +179,7 @@ class PrivacyProFeatureStore @Inject constructor(
 
     private fun SharedPreferences.save(
         key: String,
-        state: State
+        state: State,
     ) {
         coroutineScope.launch(dispatcherProvider.io()) {
             edit(commit = true) { putString(key, stateAdapter.toJson(state)) }

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsTest.kt
@@ -26,12 +26,14 @@ import com.duckduckgo.browser.api.ui.BrowserScreens.SettingsScreenNoParams
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.navigation.api.GlobalActivityStarter.ActivityParams
+import com.duckduckgo.settings.api.Settings
 import com.duckduckgo.subscriptions.api.Product.NetP
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.AUTO_RENEWABLE
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.UNKNOWN
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.WAITING
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixelSender
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionsWebViewActivityWithParams
+import dagger.Lazy
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
@@ -58,12 +60,14 @@ class RealSubscriptionsTest {
     private val mockSubscriptionsManager: SubscriptionsManager = mock()
     private val globalActivityStarter: GlobalActivityStarter = mock()
     private val pixel: SubscriptionPixelSender = mock()
+    private val settings: Lazy<Settings> = mock()
     private lateinit var subscriptions: RealSubscriptions
 
     @Before
     fun before() = runTest {
         whenever(mockSubscriptionsManager.canSupportEncryption()).thenReturn(true)
-        subscriptions = RealSubscriptions(mockSubscriptionsManager, globalActivityStarter, pixel)
+        whenever(settings.get()).thenReturn(mock())
+        subscriptions = RealSubscriptions(mockSubscriptionsManager, globalActivityStarter, pixel, settings)
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208785611228225/f

### Description

Adds a feature flag and new screen for the new updated Settings screen designs. 

For now it's the same layout as before, this is just laying the groundwork for the rest of the implementation. 

So you can see that the flag is working, the new Settings screen has a temporary title of "New Settings" which will be removed when the UI changes enough that it's perceivable.

I also added the ability to trigger notifications from dev settings so it's easier to test the ClearData notification route to opening settings.

### Steps to test this PR

- [ ] Turn on the feature flag "updatedSettings" 

_Opening Settings from the Browser menu_
- [ ] Click overflow menu
- [ ] Press Settings button
- [ ] Ensure "New Settings" is displayed at the top

_Opening Settings from ADS shortcut_
- [ ] Add the ADS shortcut via phone homescreen
- [ ] Press Shortcut 
- [ ] ADS screen should open
- [ ] Press back
- [ ] Ensure "New Settings" is displayed at the top

_Clear Data Notification_
- [ ] Open new Notifications screen in Dev Settings
- [ ] Click "Data clearing set to manual" 
- [ ] Click on the notification
- [ ] Ensure "New Settings" is displayed at the top

_VPN Disabled Notification_
- [ ] Open new Notifications screen in Dev Settings
- [ ] Click "NetP Disabled" 
- [ ] Click on the notification
- [ ] Ensure "New Settings" is displayed at the top

_Clear Data Notification_
- [ ] Open new Notifications screen in Dev Settings
- [ ] Click "Data clearing set to manual" 
- [ ] Click on the notification
- [ ] Ensure "New Settings" is displayed at the top

_New Tab Page_
- [ ] Ensure "pluginNewTabPage" feature flag is enabled
- [ ] Open a new tab
- [ ] Click the "Settings" shortcut
- [ ] Ensure "New Settings" is displayed at the top

_Tab Switcher_
- [ ] Open Tab Switcher screen
- [ ] Click overflow menu
- [ ] Click "Settings"
- [ ] Ensure "New Settings" is displayed at the top

_Privacy Pro_
- [ ] Simplest way to see it is to edit ln 126 in `SpecialUrlDetector` to true and load a web page 
- [ ] Press back
- [ ] New settings should be visible

### UI changes

N/A
