### PR TITLE
Onboarding: Dismiss in-context Dax dialog when opening new tab

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -5340,6 +5340,26 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun givenTrackersBlockedCtaShownWhenLaunchingTabSwitcherThenCtaIsDismissed() = runTest {
+        val cta = OnboardingDaxDialogCta.DaxTrackersBlockedCta(mockOnboardingStore, mockAppInstallStore, emptyList(), mockSettingsDataStore)
+        testee.ctaViewState.value = ctaViewState().copy(cta = cta)
+
+        testee.userLaunchingTabSwitcher()
+
+        verify(mockDismissedCtaDao).insert(DismissedCta(cta.ctaId))
+    }
+
+    @Test
+    fun givenTrackersBlockedCtaShownWhenUserRequestOpeningNewTabThenCtaIsDismissed() = runTest {
+        val cta = OnboardingDaxDialogCta.DaxTrackersBlockedCta(mockOnboardingStore, mockAppInstallStore, emptyList(), mockSettingsDataStore)
+        testee.ctaViewState.value = ctaViewState().copy(cta = cta)
+
+        testee.userRequestedOpeningNewTab()
+
+        verify(mockDismissedCtaDao).insert(DismissedCta(cta.ctaId))
+    }
+
+    @Test
     fun givenPrivacyShieldHighlightedWhenShieldIconSelectedThenStopPulse() = runTest {
         val cta = OnboardingDaxDialogCta.DaxTrackersBlockedCta(mockOnboardingStore, mockAppInstallStore, emptyList(), mockSettingsDataStore)
         testee.ctaViewState.value = ctaViewState().copy(cta = cta)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -999,6 +999,7 @@ class BrowserTabViewModel @Inject constructor(
                     pixel.fire(ONBOARDING_VISIT_SITE_CUSTOM, type = Unique())
                 }
             }
+
             is BrokenSitePromptDialogCta -> {
                 viewModelScope.launch(dispatchers.main()) {
                     command.value = HideBrokenSitePromptCta(currentCtaViewState().cta as BrokenSitePromptDialogCta)
@@ -2621,6 +2622,7 @@ class BrowserTabViewModel @Inject constructor(
         if (longPress) {
             pixel.fire(AppPixelName.TAB_MANAGER_NEW_TAB_LONG_PRESSED)
         }
+        onUserDismissedCta(ctaViewState.value?.cta)
     }
 
     fun onCtaShown() {
@@ -2702,9 +2704,11 @@ class BrowserTabViewModel @Inject constructor(
         }
     }
 
-    fun onUserDismissedCta(cta: Cta) {
-        viewModelScope.launch {
-            ctaViewModel.onUserDismissedCta(cta)
+    fun onUserDismissedCta(cta: Cta?) {
+        cta?.let {
+            viewModelScope.launch {
+                ctaViewModel.onUserDismissedCta(it)
+            }
         }
     }
 
@@ -2830,6 +2834,7 @@ class BrowserTabViewModel @Inject constructor(
         command.value = LaunchTabSwitcher
         pixel.fire(AppPixelName.TAB_MANAGER_CLICKED)
         fireDailyLaunchPixel()
+        onUserDismissedCta(ctaViewState.value?.cta)
     }
 
     private fun fireDailyLaunchPixel() {
@@ -3734,8 +3739,10 @@ class BrowserTabViewModel @Inject constructor(
         return when {
             lightModeEnabled && highlightsOnboardingExperimentManager.isHighlightsEnabled() ->
                 R.drawable.onboarding_experiment_background_bitmap_light
+
             !lightModeEnabled && highlightsOnboardingExperimentManager.isHighlightsEnabled() ->
                 R.drawable.onboarding_experiment_background_bitmap_dark
+
             lightModeEnabled -> R.drawable.onboarding_background_bitmap_light
             else -> R.drawable.onboarding_background_bitmap_dark
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201807753394693/1208788897307853/f

### Description
Dismiss in-context Dax dialog when opening new tab

### Steps to test this PR

_Tab Icon_
- [x] Fresh install
- [x] Navigate to any site
- [x] Check Trackers dialog is displayed
- [x] Tap on Tab Icon on the search bar to navigate to Tab switcher
- [x] Open a New Tab
- [x] Check visit site Dax dialog is not displayed. You will see end Dax dialog instead

_Long press in Tab Icon_
- [x] Fresh install
- [x] Navigate to any site
- [x] Check Trackers dialog is displayed
- [x] Long press on Tab Icon on the search bar
- [x] A New Tab will open
- [x] Check visit site Dax dialog is not displayed. You will see end Dax dialog instead


### No UI changes
