### PR TITLE
Omnibar: Pixel and Clear action regressions

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -955,8 +955,10 @@ class BrowserTabFragment :
     }
 
     private fun onOmnibarClearTextButtonPressed() {
-        viewModel.onClearOmnibarTextInput()
-        omnibar.setText("")
+        if (!changeOmnibarPositionFeature.refactor().isEnabled()) {
+            viewModel.onClearOmnibarTextInput()
+            omnibar.setText("")
+        }
     }
 
     private fun configureCustomTab() {

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -296,11 +296,13 @@ class OmnibarLayout @JvmOverloads constructor(
 
         omnibarTextInput.replaceTextChangedListener(
             object : TextChangedWatcher() {
+                var clearQuery = true
                 override fun afterTextChanged(editable: Editable) {
                     if (isAttachedToWindow) {
                         viewModel.onInputStateChanged(
                             omnibarTextInput.text.toString(),
                             omnibarTextInput.hasFocus(),
+                            clearQuery,
                         )
                     }
                     omnibarTextListener?.onOmnibarTextChanged(
@@ -309,6 +311,11 @@ class OmnibarLayout @JvmOverloads constructor(
                             omnibarTextInput.hasFocus(),
                         ),
                     )
+                }
+
+                override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {
+                    Timber.d("Omnibar: $count characters beginning at $start are about to be replaced by new text with length $after")
+                    clearQuery = start == 0 && after == 0
                 }
             },
         )
@@ -445,7 +452,6 @@ class OmnibarLayout @JvmOverloads constructor(
     }
 
     private fun renderBrowserMode(viewState: ViewState) {
-        Timber.d("Omnibar: render browserMode $viewState")
         renderOutline(viewState.hasFocus)
         if (viewState.updateOmnibarText) {
             omnibarTextInput.setText(viewState.omnibarText)

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -296,13 +296,15 @@ class OmnibarLayout @JvmOverloads constructor(
 
         omnibarTextInput.replaceTextChangedListener(
             object : TextChangedWatcher() {
-                var clearQuery = true
+                var clearQuery = false
+                var deleteLastCharacter = false
                 override fun afterTextChanged(editable: Editable) {
                     if (isAttachedToWindow) {
                         viewModel.onInputStateChanged(
                             omnibarTextInput.text.toString(),
                             omnibarTextInput.hasFocus(),
                             clearQuery,
+                            deleteLastCharacter,
                         )
                     }
                     omnibarTextListener?.onOmnibarTextChanged(
@@ -316,6 +318,7 @@ class OmnibarLayout @JvmOverloads constructor(
                 override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {
                     Timber.d("Omnibar: $count characters beginning at $start are about to be replaced by new text with length $after")
                     clearQuery = start == 0 && after == 0
+                    deleteLastCharacter = count == 1 && clearQuery
                 }
             },
         )

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -501,6 +501,7 @@ class OmnibarLayoutViewModel @Inject constructor(
     }
 
     fun onUserTouchedOmnibarTextInput(touchAction: Int) {
+        Timber.d("Omnibar: onUserTouchedOmnibarTextInput")
         if (touchAction == ACTION_UP) {
             firePixelBasedOnCurrentUrl(
                 AppPixelName.ADDRESS_BAR_NEW_TAB_PAGE_CLICKED,

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -518,6 +518,12 @@ class OmnibarLayoutViewModel @Inject constructor(
             AppPixelName.ADDRESS_BAR_SERP_CANCELLED,
             AppPixelName.ADDRESS_BAR_WEBSITE_CANCELLED,
         )
+        _viewState.update {
+            it.copy(
+                omnibarText = it.url,
+                updateOmnibarText = true,
+            )
+        }
     }
 
     fun onEnterKeyPressed() {

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -405,29 +405,28 @@ class OmnibarLayoutViewModel @Inject constructor(
         query: String,
         hasFocus: Boolean,
         clearQuery: Boolean,
+        deleteLastCharacter: Boolean,
     ) {
-        Timber.d("Omnibar: onInputStateChanged to $query clearQuery $clearQuery")
         val showClearButton = hasFocus && query.isNotBlank()
         val showControls = !hasFocus || query.isBlank()
 
+        Timber.d("Omnibar: onInputStateChanged query $query hasFocus $hasFocus clearQuery $clearQuery deleteLastCharacter $deleteLastCharacter")
+
         _viewState.update {
-            val deletion = it.query.length == 1 && clearQuery
-            val shouldUpdateQuery = query.isNotBlank() && !clearQuery || deletion
-            val updatedQuery = if (shouldUpdateQuery) {
-                Timber.d("Omnibar: onInputStateChanged updating query to $query")
-                query
-            } else {
-                Timber.d("Omnibar: onInputStateChanged not updating query, stays as ${it.query}")
-                it.query
-            }
-            val omnibarText = if (deletion) {
+            val updatedQuery = if (deleteLastCharacter) {
+                Timber.d("Omnibar: deleting last character, old query ${it.query} also deleted")
                 it.url
+            } else if (clearQuery) {
+                Timber.d("Omnibar: clearing old query ${it.query}, we keep it as reference")
+                it.query
             } else {
+                Timber.d("Omnibar: not clearing or deleting old query ${it.query}, updating query to $query")
                 query
             }
+
             it.copy(
                 query = updatedQuery,
-                omnibarText = omnibarText,
+                omnibarText = query,
                 updateOmnibarText = false,
                 hasFocus = hasFocus,
                 showBrowserMenu = showControls,

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -815,6 +815,18 @@ class OmnibarLayoutViewModelTest {
         }
     }
 
+    @Test
+    fun whenOmnibarTextClearedAndBackPressedThenUrlIsShown() = runTest {
+        givenSiteLoaded(RANDOM_URL)
+        testee.onClearTextButtonPressed()
+        testee.onBackKeyPressed()
+
+        testee.viewState.test {
+            val viewState = awaitItem()
+            assertTrue(viewState.omnibarText == RANDOM_URL)
+        }
+    }
+
     private fun givenSiteLoaded(loadedUrl: String) {
         testee.onViewModeChanged(ViewMode.Browser(loadedUrl))
         testee.onExternalStateChange(

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -627,7 +627,8 @@ class OmnibarLayoutViewModelTest {
     fun whenInputStateChangedAndQueryEmptyThenViewStateCorrect() = runTest {
         val query = ""
         val hasFocus = true
-        testee.onInputStateChanged(query, hasFocus, shouldUpdate)
+        val clearQuery = true
+        testee.onInputStateChanged(query, hasFocus, clearQuery)
 
         testee.viewState.test {
             val viewState = awaitItem()
@@ -645,7 +646,8 @@ class OmnibarLayoutViewModelTest {
     fun whenInputStateChangedAndQueryNotEmptyThenViewStateCorrect() = runTest {
         val query = "query"
         val hasFocus = true
-        testee.onInputStateChanged(query, hasFocus, shouldUpdate)
+        val clearQuery = true
+        testee.onInputStateChanged(query, hasFocus, clearQuery)
 
         testee.viewState.test {
             val viewState = awaitItem()
@@ -824,6 +826,32 @@ class OmnibarLayoutViewModelTest {
         testee.viewState.test {
             val viewState = awaitItem()
             assertTrue(viewState.omnibarText == RANDOM_URL)
+        }
+    }
+
+    @Test
+    fun whenClearingInputWhileInSiteThenURLisShown() = runTest {
+        givenSiteLoaded(RANDOM_URL)
+        val hasFocus = true
+        val clearQuery = true
+        testee.onInputStateChanged("", hasFocus, clearQuery)
+
+        testee.viewState.test {
+            val viewState = awaitItem()
+            assertTrue(viewState.omnibarText == RANDOM_URL)
+        }
+    }
+
+    @Test
+    fun whenClearingInputWhileInSERPThenURLisShown() = runTest {
+        givenSiteLoaded(SERP_URL)
+        val hasFocus = true
+        val clearQuery = true
+        testee.onInputStateChanged("", hasFocus, clearQuery)
+
+        testee.viewState.test {
+            val viewState = awaitItem()
+            assertTrue(viewState.omnibarText == SERP_URL)
         }
     }
 

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -832,6 +832,7 @@ class OmnibarLayoutViewModelTest {
     @Test
     fun whenClearingInputWhileInSiteThenURLisShown() = runTest {
         givenSiteLoaded(RANDOM_URL)
+        testee.onClearTextButtonPressed()
         val hasFocus = true
         val clearQuery = true
         testee.onInputStateChanged("", hasFocus, clearQuery)
@@ -845,6 +846,9 @@ class OmnibarLayoutViewModelTest {
     @Test
     fun whenClearingInputWhileInSERPThenURLisShown() = runTest {
         givenSiteLoaded(SERP_URL)
+
+        testee.onClearTextButtonPressed()
+
         val hasFocus = true
         val clearQuery = true
         testee.onInputStateChanged("", hasFocus, clearQuery)

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -627,7 +627,7 @@ class OmnibarLayoutViewModelTest {
     fun whenInputStateChangedAndQueryEmptyThenViewStateCorrect() = runTest {
         val query = ""
         val hasFocus = true
-        testee.onInputStateChanged(query, hasFocus)
+        testee.onInputStateChanged(query, hasFocus, shouldUpdate)
 
         testee.viewState.test {
             val viewState = awaitItem()
@@ -645,7 +645,7 @@ class OmnibarLayoutViewModelTest {
     fun whenInputStateChangedAndQueryNotEmptyThenViewStateCorrect() = runTest {
         val query = "query"
         val hasFocus = true
-        testee.onInputStateChanged(query, hasFocus)
+        testee.onInputStateChanged(query, hasFocus, shouldUpdate)
 
         testee.viewState.test {
             val viewState = awaitItem()

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -628,7 +628,8 @@ class OmnibarLayoutViewModelTest {
         val query = ""
         val hasFocus = true
         val clearQuery = true
-        testee.onInputStateChanged(query, hasFocus, clearQuery)
+        val deleteLastCharacter = false
+        testee.onInputStateChanged(query, hasFocus, clearQuery, deleteLastCharacter)
 
         testee.viewState.test {
             val viewState = awaitItem()
@@ -647,7 +648,8 @@ class OmnibarLayoutViewModelTest {
         val query = "query"
         val hasFocus = true
         val clearQuery = true
-        testee.onInputStateChanged(query, hasFocus, clearQuery)
+        val deleteLastCharacter = false
+        testee.onInputStateChanged(query, hasFocus, clearQuery, deleteLastCharacter)
 
         testee.viewState.test {
             val viewState = awaitItem()
@@ -830,12 +832,15 @@ class OmnibarLayoutViewModelTest {
     }
 
     @Test
-    fun whenClearingInputWhileInSiteThenURLisShown() = runTest {
+    fun whenHidingKeyboardAfterClearingInputWhileInSiteThenURLisShown() = runTest {
         givenSiteLoaded(RANDOM_URL)
         testee.onClearTextButtonPressed()
         val hasFocus = true
         val clearQuery = true
-        testee.onInputStateChanged("", hasFocus, clearQuery)
+        val deleteLastCharacter = false
+        testee.onInputStateChanged("", hasFocus, clearQuery, deleteLastCharacter)
+        testee.onOmnibarFocusChanged(false, "")
+        testee.onInputStateChanged(RANDOM_URL, false, false, false)
 
         testee.viewState.test {
             val viewState = awaitItem()
@@ -844,18 +849,59 @@ class OmnibarLayoutViewModelTest {
     }
 
     @Test
-    fun whenClearingInputWhileInSERPThenURLisShown() = runTest {
+    fun whenHidingKeyboardAfterClearingInputWhileInSERPThenURLisShown() = runTest {
         givenSiteLoaded(SERP_URL)
-
-        testee.onClearTextButtonPressed()
 
         val hasFocus = true
         val clearQuery = true
-        testee.onInputStateChanged("", hasFocus, clearQuery)
+        val deleteLastCharacter = false
+
+        testee.onClearTextButtonPressed()
+        testee.onInputStateChanged("", hasFocus, clearQuery, deleteLastCharacter)
+        testee.onOmnibarFocusChanged(false, "")
+        testee.onInputStateChanged(SERP_URL, false, false, false)
 
         testee.viewState.test {
             val viewState = awaitItem()
             assertTrue(viewState.omnibarText == SERP_URL)
+        }
+    }
+
+    @Test
+    fun whenClosingKeyboardAfterDeletingLastCharacterFromOmnibaWhileInSERPThenURLisShown() = runTest {
+        givenSiteLoaded(SERP_URL)
+
+        val hasFocus = true
+        val clearQuery = true
+        val deleteLastCharacter = true
+
+        testee.onClearTextButtonPressed()
+        testee.onInputStateChanged("", hasFocus, clearQuery, deleteLastCharacter)
+        testee.onOmnibarFocusChanged(false, "")
+        testee.onInputStateChanged(SERP_URL, false, false, deleteLastCharacter)
+
+        testee.viewState.test {
+            val viewState = awaitItem()
+            assertTrue(viewState.omnibarText == SERP_URL)
+        }
+    }
+
+    @Test
+    fun whenClosingKeyboardAfterDeletingLastCharacterFromOmnibaWhileInSitehenURLisShown() = runTest {
+        givenSiteLoaded(RANDOM_URL)
+
+        val hasFocus = true
+        val clearQuery = true
+        val deleteLastCharacter = true
+
+        testee.onClearTextButtonPressed()
+        testee.onInputStateChanged("", hasFocus, clearQuery, deleteLastCharacter)
+        testee.onOmnibarFocusChanged(false, "")
+        testee.onInputStateChanged(RANDOM_URL, false, false, deleteLastCharacter)
+
+        testee.viewState.test {
+            val viewState = awaitItem()
+            assertTrue(viewState.omnibarText == RANDOM_URL)
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205782002757341/1208820359395089/f

### Description

### Steps to test this PR
Looks at this task for different scenarios: https://app.asana.com/0/1174433894299346/1208812333027437/f

_Pixel for clearing address bar - Site_
- [x] Navigate to a site
- [x] Tap into address bar
- [x] X to delete entry (don’t type anything new)
- [x] Swipe gesture to close keyboard 
- [x] Verify pixel `m_addressbar_focus_clear_entry_website` is fired only once

_Pixel for clearing address bar - SERP_
- [x] Navigate to a site
- [x] Tap into address bar
- [x] X to delete entry (don’t type anything new)
- [x] Swipe gesture to close keyboard 
- [x] Verify pixel `m_addressbar_focus_clear_entry_serp ` is fired only once

_Pixel for clearing address bar - NTP_
- [x] Navigate to a site
- [x] Tap into address bar
- [x] X to delete entry (don’t type anything new)
- [x] Swipe gesture to close keyboard 
- [x] Verify pixel `m_addressbar_focus_clear_entry_ntp ` is fired only once

_Swipe gesture to close keyboard - Site_
- [x] Navigate to a site
- [x] Tap into address bar
- [x] X to delete entry (don’t type anything new)
- [x] Swipe gesture to close keyboard 
- [x] Verify Site url is displayed

_Swipe gesture to close keyboard - SERP_
- [x] Enter a search query on SERP
- [x] Tap into address bar
- [x] X to delete entry (don’t type anything new)
- [x] Swipe gesture to close keyboard 
- [x] Verify query is displayed

_Manually close keyboard  + Scroll- Site_
- [x] Navigate to a site
- [x] Tap into address bar
- [x] X to delete entry (don’t type anything new)
- [x] Manually close keyboard
- [x] Scroll down the site
- [x] Verify Site url is displayed

_Manually close keyboard  + Scroll- SERP_
- [x] Enter a search query on SERP
- [x] Tap into address bar
- [x] X to delete entry (don’t type anything new)
- [x] Manually close keyboard
- [x] Scroll down the site
- [x] Verify query is displayed

_Close keyboard - Site_
- [x] Ensure 3 button navigation is enabled (via device Settings)
- [x] Navigate to a site
- [x] Tap into address bar
- [x] X to delete entry (don’t type anything new)
- [x] Close keyboard (press back)
- [x] Verify Site url is displayed

_Close keyboard - SERP_
- [x] Ensure 3 button navigation is enabled (via device Settings)
- [x] Enter a search query on SERP
- [x] Tap into address bar
- [x] X to delete entry (don’t type anything new)
- [x] Close keyboard (press back)
- [x] Verify query is displayed
