### PR TITLE
Update content scope scripts to version 6.39.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
@@ -13,6 +13,10 @@
     const objectEntries = Object.entries;
     const objectDefineProperty = Object.defineProperty;
     const Proxy$1 = globalThis.Proxy;
+    globalThis.dispatchEvent?.bind(globalThis);
+    globalThis.addEventListener?.bind(globalThis);
+    globalThis.removeEventListener?.bind(globalThis);
+    globalThis.crypto?.randomUUID?.bind(globalThis.crypto);
 
     /* eslint-disable no-redeclare, no-global-assign */
     /* global cloneInto, exportFunction, false */
@@ -135,7 +139,7 @@
     }
 
     function isFeatureBroken(args, feature) {
-        return isWindowsSpecificFeature(feature)
+        return isPlatformSpecificFeature(feature)
             ? !args.site.enabledFeatures.includes(feature)
             : args.site.isBroken || args.site.allowlisted || !args.site.enabledFeatures.includes(feature);
     }
@@ -586,10 +590,14 @@
         return args.site.allowlisted || args.site.isBroken;
     }
 
-    const windowsSpecificFeatures = ['windowsPermissionUsage'];
+    /**
+     * @import {FeatureName} from "./features";
+     * @type {FeatureName[]}
+     */
+    const platformSpecificFeatures = ['windowsPermissionUsage', 'messageBridge'];
 
-    function isWindowsSpecificFeature(featureName) {
-        return windowsSpecificFeatures.includes(featureName);
+    function isPlatformSpecificFeature(featureName) {
+        return platformSpecificFeatures.includes(featureName);
     }
 
     function createCustomEvent(eventName, eventDetail) {
@@ -661,6 +669,7 @@
     const otherFeatures = /** @type {const} */ ([
         'clickToLoad',
         'cookie',
+        'messageBridge',
         'duckPlayer',
         'harmfulApis',
         'webCompat',
@@ -675,7 +684,7 @@
     /** @type {Record<string, FeatureName[]>} */
     const platformSupport = {
         apple: ['webCompat', ...baseFeatures],
-        'apple-isolated': ['duckPlayer', 'brokerProtection', 'performanceMetrics', 'clickToLoad'],
+        'apple-isolated': ['duckPlayer', 'brokerProtection', 'performanceMetrics', 'clickToLoad', 'messageBridge'],
         android: [...baseFeatures, 'webCompat', 'clickToLoad', 'breakageReporting', 'duckPlayer'],
         'android-autofill-password-import': ['autofillPasswordImport'],
         windows: ['cookie', ...baseFeatures, 'windowsPermissionUsage', 'duckPlayer', 'brokerProtection', 'breakageReporting'],
@@ -3215,6 +3224,26 @@
 
         /**
          * Return a specific setting from the feature settings
+         * If the "settings" key within the config has a "domains" key, it will be used to override the settings.
+         * This uses JSONPatch to apply the patches to settings before getting the setting value.
+         * For example.com getFeatureSettings('val') will return 1:
+         * ```json
+         *  {
+         *      "settings": {
+         *         "domains": [
+         *             {
+         *                "domain": "example.com",
+         *                "patchSettings": [
+         *                    { "op": "replace", "path": "/val", "value": 1 }
+         *                ]
+         *             }
+         *         ]
+         *      }
+         *  }
+         * ```
+         * "domain" can either be a string or an array of strings.
+
+         * For boolean states you should consider using getFeatureSettingEnabled.
          * @param {string} featureKeyName
          * @param {string} [featureName]
          * @returns {any}
@@ -3253,6 +3282,23 @@
         /**
          * For simple boolean settings, return true if the setting is 'enabled'
          * For objects, verify the 'state' field is 'enabled'.
+         * This allows for future forwards compatibility with more complex settings if required.
+         * For example:
+         * ```json
+         * {
+         *    "toggle": "enabled"
+         * }
+         * ```
+         * Could become later (without breaking changes):
+         * ```json
+         * {
+         *   "toggle": {
+         *       "state": "enabled",
+         *       "someOtherKey": 1
+         *   }
+         * }
+         * ```
+         * This also supports domain overrides as per `getFeatureSetting`.
          * @param {string} featureKeyName
          * @param {string} [featureName]
          * @returns {boolean}
@@ -3267,8 +3313,10 @@
 
         /**
          * Given a config key, interpret the value as a list of domain overrides, and return the elements that match the current page
+         * Consider using patchSettings instead as per `getFeatureSetting`.
          * @param {string} featureKeyName
          * @return {any[]}
+         * @private
          */
         matchDomainFeatureSetting(featureKeyName) {
             const domain = this.#args?.site.domain;
@@ -4076,7 +4124,13 @@
 
     function initCode() {
         // @ts-expect-error https://app.asana.com/0/1201614831475344/1203979574128023/f
-        const processedConfig = processConfig($CONTENT_SCOPE$, $USER_UNPROTECTED_DOMAINS$, $USER_PREFERENCES$);
+        const config = $CONTENT_SCOPE$;
+        // @ts-expect-error https://app.asana.com/0/1201614831475344/1203979574128023/f
+        const userUnprotectedDomains = $USER_UNPROTECTED_DOMAINS$;
+        // @ts-expect-error https://app.asana.com/0/1201614831475344/1203979574128023/f
+        const userPreferences = $USER_PREFERENCES$;
+
+        const processedConfig = processConfig(config, userUnprotectedDomains, userPreferences);
         if (isGloballyDisabled(processedConfig)) {
             return;
         }

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -9,12 +9,54 @@
     const customElementsDefine = globalThis.customElements?.define.bind(globalThis.customElements);
     const getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
     const getOwnPropertyDescriptors = Object.getOwnPropertyDescriptors;
+    const toString = Object.prototype.toString;
     const objectKeys = Object.keys;
     const objectEntries = Object.entries;
     const objectDefineProperty = Object.defineProperty;
     const URL$1 = globalThis.URL;
     const Proxy$1 = globalThis.Proxy;
+    const functionToString = Function.prototype.toString;
+    const TypeError$1 = globalThis.TypeError;
+    const Symbol = globalThis.Symbol;
     const hasOwnProperty = Object.prototype.hasOwnProperty;
+    const dispatchEvent = globalThis.dispatchEvent?.bind(globalThis);
+    const addEventListener = globalThis.addEventListener?.bind(globalThis);
+    const removeEventListener = globalThis.removeEventListener?.bind(globalThis);
+    const CustomEvent$1 = globalThis.CustomEvent;
+    const Promise$1 = globalThis.Promise;
+    const String$1 = globalThis.String;
+    const Map$1 = globalThis.Map;
+    const Error$2 = globalThis.Error;
+    const randomUUID = globalThis.crypto?.randomUUID?.bind(globalThis.crypto);
+
+    var capturedGlobals = /*#__PURE__*/Object.freeze({
+        __proto__: null,
+        CustomEvent: CustomEvent$1,
+        Error: Error$2,
+        Map: Map$1,
+        Promise: Promise$1,
+        Proxy: Proxy$1,
+        Reflect: Reflect$1,
+        Set: Set$1,
+        String: String$1,
+        Symbol: Symbol,
+        TypeError: TypeError$1,
+        URL: URL$1,
+        addEventListener: addEventListener,
+        customElementsDefine: customElementsDefine,
+        customElementsGet: customElementsGet,
+        dispatchEvent: dispatchEvent,
+        functionToString: functionToString,
+        getOwnPropertyDescriptor: getOwnPropertyDescriptor,
+        getOwnPropertyDescriptors: getOwnPropertyDescriptors,
+        hasOwnProperty: hasOwnProperty,
+        objectDefineProperty: objectDefineProperty,
+        objectEntries: objectEntries,
+        objectKeys: objectKeys,
+        randomUUID: randomUUID,
+        removeEventListener: removeEventListener,
+        toString: toString
+    });
 
     /* eslint-disable no-redeclare, no-global-assign */
     /* global cloneInto, exportFunction, false */
@@ -203,7 +245,7 @@
     }
 
     function isFeatureBroken(args, feature) {
-        return isWindowsSpecificFeature(feature)
+        return isPlatformSpecificFeature(feature)
             ? !args.site.enabledFeatures.includes(feature)
             : args.site.isBroken || args.site.allowlisted || !args.site.enabledFeatures.includes(feature);
     }
@@ -656,10 +698,14 @@
         return args.site.allowlisted || args.site.isBroken;
     }
 
-    const windowsSpecificFeatures = ['windowsPermissionUsage'];
+    /**
+     * @import {FeatureName} from "./features";
+     * @type {FeatureName[]}
+     */
+    const platformSpecificFeatures = ['windowsPermissionUsage', 'messageBridge'];
 
-    function isWindowsSpecificFeature(featureName) {
-        return windowsSpecificFeatures.includes(featureName);
+    function isPlatformSpecificFeature(featureName) {
+        return platformSpecificFeatures.includes(featureName);
     }
 
     function createCustomEvent(eventName, eventDetail) {
@@ -697,6 +743,7 @@
     const otherFeatures = /** @type {const} */ ([
         'clickToLoad',
         'cookie',
+        'messageBridge',
         'duckPlayer',
         'harmfulApis',
         'webCompat',
@@ -711,7 +758,7 @@
     /** @type {Record<string, FeatureName[]>} */
     const platformSupport = {
         apple: ['webCompat', ...baseFeatures],
-        'apple-isolated': ['duckPlayer', 'brokerProtection', 'performanceMetrics', 'clickToLoad'],
+        'apple-isolated': ['duckPlayer', 'brokerProtection', 'performanceMetrics', 'clickToLoad', 'messageBridge'],
         android: [...baseFeatures, 'webCompat', 'clickToLoad', 'breakageReporting', 'duckPlayer'],
         'android-autofill-password-import': ['autofillPasswordImport'],
         windows: ['cookie', ...baseFeatures, 'windowsPermissionUsage', 'duckPlayer', 'brokerProtection', 'breakageReporting'],
@@ -3990,6 +4037,26 @@
 
         /**
          * Return a specific setting from the feature settings
+         * If the "settings" key within the config has a "domains" key, it will be used to override the settings.
+         * This uses JSONPatch to apply the patches to settings before getting the setting value.
+         * For example.com getFeatureSettings('val') will return 1:
+         * ```json
+         *  {
+         *      "settings": {
+         *         "domains": [
+         *             {
+         *                "domain": "example.com",
+         *                "patchSettings": [
+         *                    { "op": "replace", "path": "/val", "value": 1 }
+         *                ]
+         *             }
+         *         ]
+         *      }
+         *  }
+         * ```
+         * "domain" can either be a string or an array of strings.
+
+         * For boolean states you should consider using getFeatureSettingEnabled.
          * @param {string} featureKeyName
          * @param {string} [featureName]
          * @returns {any}
@@ -4028,6 +4095,23 @@
         /**
          * For simple boolean settings, return true if the setting is 'enabled'
          * For objects, verify the 'state' field is 'enabled'.
+         * This allows for future forwards compatibility with more complex settings if required.
+         * For example:
+         * ```json
+         * {
+         *    "toggle": "enabled"
+         * }
+         * ```
+         * Could become later (without breaking changes):
+         * ```json
+         * {
+         *   "toggle": {
+         *       "state": "enabled",
+         *       "someOtherKey": 1
+         *   }
+         * }
+         * ```
+         * This also supports domain overrides as per `getFeatureSetting`.
          * @param {string} featureKeyName
          * @param {string} [featureName]
          * @returns {boolean}
@@ -4042,8 +4126,10 @@
 
         /**
          * Given a config key, interpret the value as a list of domain overrides, and return the elements that match the current page
+         * Consider using patchSettings instead as per `getFeatureSetting`.
          * @param {string} featureKeyName
          * @return {any[]}
+         * @private
          */
         matchDomainFeatureSetting(featureKeyName) {
             const domain = this.#args?.site.domain;
@@ -6021,8 +6107,470 @@
         }
     }
 
+    /**
+     * @param {unknown} input
+     * @return {input is Object}
+     */
+    function isObject(input) {
+        return toString.call(input) === '[object Object]';
+    }
+
+    /**
+     * @param {unknown} input
+     * @return {input is string}
+     */
+    function isString(input) {
+        return typeof input === 'string';
+    }
+
+    /**
+     * @import { Messaging } from "@duckduckgo/messaging";
+     * @typedef {Pick<Messaging, 'notify' | 'request' | 'subscribe'>} MessagingInterface
+     */
+
+    /**
+     * Sending this event
+     */
+    class InstallProxy {
+        static NAME = 'INSTALL_BRIDGE';
+        get name() {
+            return InstallProxy.NAME;
+        }
+
+        /**
+         * @param {object} params
+         * @param {string} params.featureName
+         * @param {string} params.id
+         */
+        constructor(params) {
+            this.featureName = params.featureName;
+            this.id = params.id;
+        }
+
+        /**
+         * @param {unknown} params
+         */
+        static create(params) {
+            if (!isObject(params)) return null;
+            if (!isString(params.featureName)) return null;
+            if (!isString(params.id)) return null;
+            return new InstallProxy({ featureName: params.featureName, id: params.id });
+        }
+    }
+
+    class DidInstall {
+        static NAME = 'DID_INSTALL';
+        get name() {
+            return DidInstall.NAME;
+        }
+        /**
+         * @param {object} params
+         * @param {string} params.id
+         */
+        constructor(params) {
+            this.id = params.id;
+        }
+
+        /**
+         * @param {unknown} params
+         */
+        static create(params) {
+            if (!isObject(params)) return null;
+            if (!isString(params.id)) return null;
+            return new DidInstall({ id: params.id });
+        }
+    }
+
+    class ProxyRequest {
+        static NAME = 'PROXY_REQUEST';
+        get name() {
+            return ProxyRequest.NAME;
+        }
+        /**
+         * @param {object} params
+         * @param {string} params.featureName
+         * @param {string} params.method
+         * @param {string} params.id
+         * @param {Record<string, any>} [params.params]
+         */
+        constructor(params) {
+            this.featureName = params.featureName;
+            this.method = params.method;
+            this.params = params.params;
+            this.id = params.id;
+        }
+        /**
+         * @param {unknown} params
+         */
+        static create(params) {
+            if (!isObject(params)) return null;
+            if (!isString(params.featureName)) return null;
+            if (!isString(params.method)) return null;
+            if (!isString(params.id)) return null;
+            if (params.params && !isObject(params.params)) return null;
+            return new ProxyRequest({
+                featureName: params.featureName,
+                method: params.method,
+                params: params.params,
+                id: params.id,
+            });
+        }
+    }
+
+    class ProxyResponse {
+        static NAME = 'PROXY_RESPONSE';
+        get name() {
+            return ProxyResponse.NAME;
+        }
+        /**
+         * @param {object} params
+         * @param {string} params.featureName
+         * @param {string} params.method
+         * @param {string} params.id
+         * @param {Record<string, any>} [params.result]
+         * @param {import("@duckduckgo/messaging").MessageError} [params.error]
+         */
+        constructor(params) {
+            this.featureName = params.featureName;
+            this.method = params.method;
+            this.result = params.result;
+            this.error = params.error;
+            this.id = params.id;
+        }
+        /**
+         * @param {unknown} params
+         */
+        static create(params) {
+            if (!isObject(params)) return null;
+            if (!isString(params.featureName)) return null;
+            if (!isString(params.method)) return null;
+            if (!isString(params.id)) return null;
+            if (params.result && !isObject(params.result)) return null;
+            if (params.error && !isObject(params.error)) return null;
+            return new ProxyResponse({
+                featureName: params.featureName,
+                method: params.method,
+                result: params.result,
+                error: params.error,
+                id: params.id,
+            });
+        }
+    }
+
+    /**
+     */
+    class ProxyNotification {
+        static NAME = 'PROXY_NOTIFICATION';
+        get name() {
+            return ProxyNotification.NAME;
+        }
+        /**
+         * @param {object} params
+         * @param {string} params.featureName
+         * @param {string} params.method
+         * @param {Record<string, any>} [params.params]
+         */
+        constructor(params) {
+            this.featureName = params.featureName;
+            this.method = params.method;
+            this.params = params.params;
+        }
+
+        /**
+         * @param {unknown} params
+         */
+        static create(params) {
+            if (!isObject(params)) return null;
+            if (!isString(params.featureName)) return null;
+            if (!isString(params.method)) return null;
+            if (params.params && !isObject(params.params)) return null;
+            return new ProxyNotification({
+                featureName: params.featureName,
+                method: params.method,
+                params: params.params,
+            });
+        }
+    }
+
+    class SubscriptionRequest {
+        static NAME = 'SUBSCRIPTION_REQUEST';
+        get name() {
+            return SubscriptionRequest.NAME;
+        }
+        /**
+         * @param {object} params
+         * @param {string} params.featureName
+         * @param {string} params.subscriptionName
+         * @param {string} params.id
+         */
+        constructor(params) {
+            this.featureName = params.featureName;
+            this.subscriptionName = params.subscriptionName;
+            this.id = params.id;
+        }
+        /**
+         * @param {unknown} params
+         */
+        static create(params) {
+            if (!isObject(params)) return null;
+            if (!isString(params.featureName)) return null;
+            if (!isString(params.subscriptionName)) return null;
+            if (!isString(params.id)) return null;
+            return new SubscriptionRequest({
+                featureName: params.featureName,
+                subscriptionName: params.subscriptionName,
+                id: params.id,
+            });
+        }
+    }
+
+    class SubscriptionResponse {
+        static NAME = 'SUBSCRIPTION_RESPONSE';
+        get name() {
+            return SubscriptionResponse.NAME;
+        }
+        /**
+         * @param {object} params
+         * @param {string} params.featureName
+         * @param {string} params.subscriptionName
+         * @param {string} params.id
+         * @param {Record<string, any>} [params.params]
+         */
+        constructor(params) {
+            this.featureName = params.featureName;
+            this.subscriptionName = params.subscriptionName;
+            this.id = params.id;
+            this.params = params.params;
+        }
+        /**
+         * @param {unknown} params
+         */
+        static create(params) {
+            if (!isObject(params)) return null;
+            if (!isString(params.featureName)) return null;
+            if (!isString(params.subscriptionName)) return null;
+            if (!isString(params.id)) return null;
+            if (params.params && !isObject(params.params)) return null;
+            return new SubscriptionResponse({
+                featureName: params.featureName,
+                subscriptionName: params.subscriptionName,
+                params: params.params,
+                id: params.id,
+            });
+        }
+    }
+
+    class SubscriptionUnsubscribe {
+        static NAME = 'SUBSCRIPTION_UNSUBSCRIBE';
+        get name() {
+            return SubscriptionUnsubscribe.NAME;
+        }
+        /**
+         * @param {object} params
+         * @param {string} params.id
+         */
+        constructor(params) {
+            this.id = params.id;
+        }
+        /**
+         * @param {unknown} params
+         */
+        static create(params) {
+            if (!isObject(params)) return null;
+            if (!isString(params.id)) return null;
+            return new SubscriptionUnsubscribe({
+                id: params.id,
+            });
+        }
+    }
+
+    /**
+     * @import { MessagingInterface } from "./schema.js"
+     * @typedef {Pick<import("../../captured-globals.js"),
+     *    "dispatchEvent" | "addEventListener" | "removeEventListener" | "CustomEvent" | "String" | "Error" | "randomUUID">
+     * } Captured
+     */
+    /** @type {Captured} */
+    const captured = capturedGlobals;
+
+    const ERROR_MSG = 'Did not install Message Bridge';
+
+    /**
+     * Try to create a message bridge.
+     *
+     * Note: This will throw an exception if the bridge cannot be established.
+     *
+     * @param {string} featureName
+     * @param {string} [token]
+     * @return {MessagingInterface}
+     * @throws {Error}
+     */
+    function createPageWorldBridge(featureName, token) {
+        /**
+         * This feature never operates without a featureName or token
+         */
+        if (typeof featureName !== 'string' || !token) {
+            throw new captured.Error(ERROR_MSG);
+        }
+        /**
+         * This feature never operates in a frame or insecure context
+         */
+        if (isBeingFramed() || !isSecureContext) {
+            throw new captured.Error(ERROR_MSG);
+        }
+
+        /**
+         * @param {string} eventName
+         * @return {`${string}-${string}`}
+         */
+        const appendToken = (eventName) => {
+            return `${eventName}-${token}`;
+        };
+
+        /**
+         * Create the sender to centralize the sending logic
+         * @param {{name: string} & Record<string, any>} incoming
+         */
+        const send = (incoming) => {
+            // when the token is absent, just silently fail
+            if (!token) return;
+            const event = new captured.CustomEvent(appendToken(incoming.name), { detail: incoming });
+            captured.dispatchEvent(event);
+        };
+
+        /**
+         * Events are synchronous (even across contexts), so we can figure out
+         * the result of installing the proxy before we return and give a
+         * better experience for consumers
+         */
+        let installed = false;
+        const id = random();
+        const evt = new InstallProxy({ featureName, id });
+        const evtName = appendToken(DidInstall.NAME + '-' + id);
+        const didInstall = (/** @type {CustomEvent<unknown>} */ e) => {
+            const result = DidInstall.create(e.detail);
+            if (result && result.id === id) {
+                installed = true;
+            }
+            captured.removeEventListener(evtName, didInstall);
+        };
+
+        captured.addEventListener(evtName, didInstall);
+        send(evt);
+
+        if (!installed) {
+            // leaving this as a generic message for now
+            throw new captured.Error(ERROR_MSG);
+        }
+
+        return createMessagingInterface(featureName, send, appendToken);
+    }
+
+    /**
+     * We are executing exclusively in secure contexts, so this should never fail
+     */
+    function random() {
+        if (typeof captured.randomUUID !== 'function') throw new Error('unreachable');
+        return captured.randomUUID();
+    }
+
+    /**
+     * @param {string} featureName
+     * @param {(evt: {name: string} & Record<string, any>) => void} send
+     * @param {(s: string) => string} appendToken
+     * @returns {MessagingInterface}
+     */
+    function createMessagingInterface(featureName, send, appendToken) {
+        return {
+            /**
+             * @param {string} method
+             * @param {Record<string, any>} params
+             */
+            notify(method, params) {
+                send(
+                    new ProxyNotification({
+                        method,
+                        params,
+                        featureName,
+                    }),
+                );
+            },
+
+            /**
+             * @param {string} method
+             * @param {Record<string, any>} params
+             * @returns {Promise<any>}
+             */
+            request(method, params) {
+                const id = random();
+
+                send(
+                    new ProxyRequest({
+                        method,
+                        params,
+                        featureName,
+                        id,
+                    }),
+                );
+
+                return new Promise((resolve, reject) => {
+                    const responseName = appendToken(ProxyResponse.NAME + '-' + id);
+                    const handler = (/** @type {CustomEvent<unknown>} */ e) => {
+                        const response = ProxyResponse.create(e.detail);
+                        if (response && response.id === id) {
+                            if ('error' in response && response.error) {
+                                reject(new Error(response.error.message));
+                            } else if ('result' in response) {
+                                resolve(response.result);
+                            }
+                            captured.removeEventListener(responseName, handler);
+                        }
+                    };
+                    captured.addEventListener(responseName, handler);
+                });
+            },
+
+            /**
+             * @param {string} name
+             * @param {(d: any) => void} callback
+             * @returns {() => void}
+             */
+            subscribe(name, callback) {
+                const id = random();
+
+                send(
+                    new SubscriptionRequest({
+                        subscriptionName: name,
+                        featureName,
+                        id,
+                    }),
+                );
+
+                const handler = (/** @type {CustomEvent<unknown>} */ e) => {
+                    const subscriptionEvent = SubscriptionResponse.create(e.detail);
+                    if (subscriptionEvent) {
+                        const { id: eventId, params } = subscriptionEvent;
+                        if (eventId === id) {
+                            callback(params);
+                        }
+                    }
+                };
+
+                const type = appendToken(SubscriptionResponse.NAME + '-' + id);
+                captured.addEventListener(type, handler);
+
+                return () => {
+                    captured.removeEventListener(type, handler);
+                    const evt = new SubscriptionUnsubscribe({ id });
+                    send(evt);
+                };
+            },
+        };
+    }
+
     class NavigatorInterface extends ContentFeature {
         load(args) {
+            // @ts-expect-error: Accessing private method
             if (this.matchDomainFeatureSetting('privilegedDomains').length) {
                 this.injectNavigatorInterface(args);
             }
@@ -6046,6 +6594,15 @@
                         platform: args.platform.name,
                         isDuckDuckGo() {
                             return DDGPromise.resolve(true);
+                        },
+                        /**
+                         * @import { MessagingInterface } from "./message-bridge/schema.js"
+                         * @param {string} featureName
+                         * @return {MessagingInterface}
+                         * @throws {Error}
+                         */
+                        createMessageBridge(featureName) {
+                            return createPageWorldBridge(featureName, args.messageSecret);
                         },
                     },
                     enumerable: true,
@@ -6373,10 +6930,12 @@
 
             // determine whether strict hide rules should be injected as a style tag
             if (shouldInjectStyleTag) {
+                // @ts-expect-error: Accessing private method
                 shouldInjectStyleTag = this.matchDomainFeatureSetting('styleTagExceptions').length === 0;
             }
 
             // collect all matching rules for domain
+            // @ts-expect-error: Accessing private method
             const activeDomainRules = this.matchDomainFeatureSetting('domains').flatMap((item) => item.rules);
 
             const overrideRules = activeDomainRules.filter((rule) => {
@@ -13365,7 +13924,13 @@
 
     function initCode() {
         // @ts-expect-error https://app.asana.com/0/1201614831475344/1203979574128023/f
-        const processedConfig = processConfig($CONTENT_SCOPE$, $USER_UNPROTECTED_DOMAINS$, $USER_PREFERENCES$);
+        const config = $CONTENT_SCOPE$;
+        // @ts-expect-error https://app.asana.com/0/1201614831475344/1203979574128023/f
+        const userUnprotectedDomains = $USER_UNPROTECTED_DOMAINS$;
+        // @ts-expect-error https://app.asana.com/0/1201614831475344/1203979574128023/f
+        const userPreferences = $USER_PREFERENCES$;
+
+        const processedConfig = processConfig(config, userUnprotectedDomains, userPreferences);
         if (isGloballyDisabled(processedConfig)) {
             return;
         }

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/js/index.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/js/index.js
@@ -1098,11 +1098,11 @@
         const opts2 = new WindowsMessagingConfig({
           methods: {
             // @ts-expect-error - not in @types/chrome
-            postMessage: window.chrome.webview.postMessage,
+            postMessage: globalThis.windowsInteropPostMessage,
             // @ts-expect-error - not in @types/chrome
-            addEventListener: window.chrome.webview.addEventListener,
+            addEventListener: globalThis.windowsInteropAddEventListener,
             // @ts-expect-error - not in @types/chrome
-            removeEventListener: window.chrome.webview.removeEventListener
+            removeEventListener: globalThis.windowsInteropRemoveEventListener
           }
         });
         return new Messaging(messageContext, opts2);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^11.5.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#15.1.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.35.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.39.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#7.0.2",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1724449523"
       },
@@ -26,6 +26,7 @@
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
       "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.25.9",
         "js-tokens": "^4.0.0",
@@ -40,6 +41,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
       "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -57,10 +59,12 @@
     },
     "node_modules/@duckduckgo/autofill": {
       "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#c992041d16ec10d790e6204dce9abf9966d1363c",
-      "hasInstallScript": true
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#32c3e2bce3cc20a079d96b3ee23a9cde5d2337c3",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#dfef00ef77f5181d1d8a4f7cc88f7b7c0514dd34",
+      "license": "Apache-2.0",
       "workspaces": [
         "injected",
         "special-pages",
@@ -79,16 +83,17 @@
       }
     },
     "node_modules/@duckduckgo/privacy-reference-tests": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#6133e7d9d9cd5f1b925cab1971b4d785dc639df7"
+      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#6133e7d9d9cd5f1b925cab1971b4d785dc639df7",
+      "license": "Apache-2.0"
     },
     "node_modules/@ghostery/adblocker": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.0.4.tgz",
-      "integrity": "sha512-n2z0IHzEfK/J7sBz2R6R69o9W7NdVJGc6IPMztMvGloPyJDv5D9mZNIfiz9EoLI9YHRIJd/lV3bMI7VJWVR1YA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.1.1.tgz",
+      "integrity": "sha512-FL4yWrpNTCmtbAfeLotUoo94ZyNqHdZpZRo4Qlk0guPzDGcOtW4/c84UzS9D/Z9Z4H3nWSCrW0q38pjwAbDykA==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-content": "^2.0.4",
-        "@ghostery/adblocker-extended-selectors": "^2.0.4",
+        "@ghostery/adblocker-content": "^2.1.1",
+        "@ghostery/adblocker-extended-selectors": "^2.1.1",
         "@remusao/guess-url-type": "^1.3.0",
         "@remusao/small": "^1.2.1",
         "@remusao/smaz": "^1.9.1",
@@ -96,18 +101,18 @@
       }
     },
     "node_modules/@ghostery/adblocker-content": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.0.4.tgz",
-      "integrity": "sha512-IhYx/5FY210+VfWlLZ7tPzo54XA2cAYzQesxjyGkVr4hl6gwV/ubeQzxzY3RdThS9v+ArbWGM/rGGpJjZtrTZA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.1.1.tgz",
+      "integrity": "sha512-1DKHmPnlQleXapaL36xZOwwZmpdbjMP/IcWdTTzyriyCDIFlSwBDT1DJ3xg0TK61ahZMEwz1MnTGM6X99z/5rQ==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-extended-selectors": "^2.0.4"
+        "@ghostery/adblocker-extended-selectors": "^2.1.1"
       }
     },
     "node_modules/@ghostery/adblocker-extended-selectors": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.0.4.tgz",
-      "integrity": "sha512-HIhTFpPn3lepYaudC2/yUxAFe1LhGzQCgPjv9kN2f7L9zwr96w1T+iL0jtaXnsrxLKeJ/krYR3gmNKhFcdsnEA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.1.1.tgz",
+      "integrity": "sha512-jEHjU2CarS2MtRYfm/6iTKMS1DVzepuwXSMKg1zTyHl+u4ZKvKNYFK7plD0nUlL5a8akyRkYwLheXnKsW3nChQ==",
       "license": "MPL-2.0"
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -115,6 +120,7 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
       "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -129,6 +135,7 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -138,6 +145,7 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
       "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -147,6 +155,7 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
       "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25"
@@ -156,13 +165,15 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
       "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -216,6 +227,7 @@
       "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
       "integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@rollup/pluginutils": "^3.0.8"
       },
@@ -228,6 +240,7 @@
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.3.0.tgz",
       "integrity": "sha512-Lus8rbUo1eEcnS4yTFKLZrVumLPY+YayBdWXgFSHYhTT2iJbMhoaaBL3xl5NCdeRytErGr8tZ0L71BMRmnlwSw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@rollup/pluginutils": "^3.1.0",
         "@types/resolve": "1.17.1",
@@ -248,6 +261,7 @@
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
       "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/estree": "0.0.39",
         "estree-walker": "^1.0.1",
@@ -264,13 +278,15 @@
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.9.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
-      "integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
+      "version": "22.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.1.tgz",
+      "integrity": "sha512-p8Yy/8sw1caA8CdRIQBG5tiLHmxtQKObCijiAa9Ez+d4+PRffM4054xbju0msf+cvhJpnFEeNjxmVT/0ipktrg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.8"
       }
@@ -280,6 +296,7 @@
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
       "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -289,6 +306,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -300,13 +318,15 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/builtin-modules": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
       "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       },
@@ -318,13 +338,15 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -333,7 +355,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
       "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -341,6 +364,7 @@
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -354,6 +378,7 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -363,6 +388,7 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -372,6 +398,7 @@
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -382,13 +409,15 @@
     "node_modules/immutable-json-patch": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/immutable-json-patch/-/immutable-json-patch-6.0.1.tgz",
-      "integrity": "sha512-BHL/cXMjwFZlTOffiWNdY8ZTvNyYLrutCnWxrcKPHr5FqpAb6vsO6WWSPnVSys3+DruFN6lhHJJPHi8uELQL5g=="
+      "integrity": "sha512-BHL/cXMjwFZlTOffiWNdY8ZTvNyYLrutCnWxrcKPHr5FqpAb6vsO6WWSPnVSys3+DruFN6lhHJJPHi8uELQL5g==",
+      "license": "ISC"
     },
     "node_modules/is-builtin-module": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
       "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "builtin-modules": "^3.3.0"
       },
@@ -404,6 +433,7 @@
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
       "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -418,13 +448,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
       "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jest-worker": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
       "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -438,31 +470,36 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -475,6 +512,7 @@
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -484,6 +522,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
       "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -501,6 +540,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -517,6 +557,7 @@
       "integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
       "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-terser",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "jest-worker": "^26.2.1",
@@ -545,13 +586,15 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/serialize-javascript": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
       "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "randombytes": "^2.1.0"
       }
@@ -561,6 +604,7 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -570,6 +614,7 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -580,6 +625,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -592,6 +638,7 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -604,6 +651,7 @@
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.36.0.tgz",
       "integrity": "sha512-IYV9eNMuFAV4THUspIRXkLakHnV6XO7FEdtKjf/mDyrnqUg9LnlOn6/RwRvM9SZjR4GUq8Nk8zj67FzVARr74w==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -618,23 +666,26 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.61",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.61.tgz",
-      "integrity": "sha512-In7VffkDWUPgwa+c9picLUxvb0RltVwTkSgMNFgvlGSWveCzGBemBqTsgJCL4EDFWZ6WH0fKTsot6yNhzy3ZzQ=="
+      "version": "6.1.63",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.63.tgz",
+      "integrity": "sha512-H1XCt54xY+QPbwhTgmxLkepX0MVHu3USfMmejiCOdkMbRcP22Pn2FVF127r/GWXVDmXTRezyF3Ckvhn4Fs6j7Q==",
+      "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "6.1.61",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.61.tgz",
-      "integrity": "sha512-1plwEyCpyYtVsZVtC169C5bStRlDk3cIniMHUeNmAJOjmQGx7SnLM8kS06PQAHx9PPY4Jm1VS6IXZzPC53XpbQ==",
+      "version": "6.1.63",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.63.tgz",
+      "integrity": "sha512-Xqxv4UvuTwC/sslspSbkw/52vvYCeZdEJwnv7VFlQEfYvK8fNuIpz5hoOvO7XuzfjqexMRRnVDYUyjqesTYESg==",
+      "license": "MIT",
       "dependencies": {
-        "tldts-core": "^6.1.61"
+        "tldts-core": "^6.1.63"
       }
     },
     "node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^11.5.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#15.1.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.35.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.39.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#7.0.2",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1724449523"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208822553682950/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass