### PR TITLE
Show on App Launch: Fix option observation race condition 

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/generalsettings/GeneralSettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/GeneralSettingsViewModel.kt
@@ -154,7 +154,7 @@ class GeneralSettingsViewModel @Inject constructor(
     private fun observeShowOnAppLaunchOption() {
         showOnAppLaunchOptionDataStore.optionFlow
             .onEach { showOnAppLaunchOption ->
-                _viewState.update { it!!.copy(showOnAppLaunchSelectedOption = showOnAppLaunchOption) }
+                _viewState.update { it?.copy(showOnAppLaunchSelectedOption = showOnAppLaunchOption) }
             }.launchIn(viewModelScope)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/GeneralSettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/GeneralSettingsViewModel.kt
@@ -154,7 +154,7 @@ class GeneralSettingsViewModel @Inject constructor(
     private fun observeShowOnAppLaunchOption() {
         showOnAppLaunchOptionDataStore.optionFlow
             .onEach { showOnAppLaunchOption ->
-                _viewState.update { it?.copy(showOnAppLaunchSelectedOption = showOnAppLaunchOption) }
+                _viewState.value?.let { state -> _viewState.update { state.copy(showOnAppLaunchSelectedOption = showOnAppLaunchOption) } }
             }.launchIn(viewModelScope)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208815135507669/f

### Description

Added a null check to the ViewState when attempting to update via observing the selected ShowOnAppLaunch option. 

### Steps to test this PR

- [ ] Launch the app and navigate to General Settings
- [ ] There should be no crash
- [ ] Open the Show on App Launch screen
- [ ] Change your option
- [ ] Navigate back
- [ ] The new Show on App Launch function should still be reflected on the General Settings screen

### UI changes
No UI changes