### PR TITLE
Temporary pixel for visit site suggestions CTA display count

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -575,6 +575,7 @@ class BrowserTabViewModelTest {
             highlightsOnboardingExperimentManager = mockHighlightsOnboardingExperimentManager,
             brokenSitePrompt = mockBrokenSitePrompt,
             extendedOnboardingPixelsPlugin = extendedOnboardingPixelsPlugin,
+            userBrowserProperties = mockUserBrowserProperties,
         )
 
         val siteFactory = SiteFactoryImpl(

--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -54,6 +54,7 @@ import com.duckduckgo.app.trackerdetection.model.TrackerType
 import com.duckduckgo.app.trackerdetection.model.TrackingEvent
 import com.duckduckgo.app.widget.ui.WidgetCapabilities
 import com.duckduckgo.brokensite.api.BrokenSitePrompt
+import com.duckduckgo.browser.api.UserBrowserProperties
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.test.InstantSchedulersRule
 import com.duckduckgo.duckplayer.api.DuckPlayer
@@ -124,6 +125,8 @@ class CtaViewModelTest {
 
     private val mockBrokenSitePrompt: BrokenSitePrompt = mock()
 
+    private val mockUserBrowserProperties: UserBrowserProperties = mock()
+
     private val requiredDaxOnboardingCtas: List<CtaId> = listOf(
         CtaId.DAX_INTRO,
         CtaId.DAX_DIALOG_SERP,
@@ -183,6 +186,7 @@ class CtaViewModelTest {
             highlightsOnboardingExperimentManager = mockHighlightsOnboardingExperimentManager,
             brokenSitePrompt = mockBrokenSitePrompt,
             extendedOnboardingPixelsPlugin = extendedOnboardingPixelsPlugin,
+            userBrowserProperties = mockUserBrowserProperties,
         )
     }
 

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -163,8 +163,9 @@ class CtaViewModel @Inject constructor(
         }
 
         // Temporary pixel
-        val isVisitSiteSuggestionsCta = cta is DaxBubbleCta.DaxIntroVisitSiteOptionsCta || cta is DaxBubbleCta.DaxExperimentIntroVisitSiteOptionsCta ||
-            cta is OnboardingDaxDialogCta.DaxSiteSuggestionsCta || cta is OnboardingDaxDialogCta.DaxExperimentSiteSuggestionsCta
+        val isVisitSiteSuggestionsCta =
+            cta is DaxBubbleCta.DaxIntroVisitSiteOptionsCta || cta is DaxBubbleCta.DaxExperimentIntroVisitSiteOptionsCta ||
+                cta is OnboardingDaxDialogCta.DaxSiteSuggestionsCta || cta is OnboardingDaxDialogCta.DaxExperimentSiteSuggestionsCta
         if (isVisitSiteSuggestionsCta) {
             if (userBrowserProperties.daysSinceInstalled() <= 3) {
                 val count = onboardingStore.visitSiteCtaDisplayCount ?: 0

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -167,7 +167,6 @@ class CtaViewModel @Inject constructor(
             cta is OnboardingDaxDialogCta.DaxSiteSuggestionsCta || cta is OnboardingDaxDialogCta.DaxExperimentSiteSuggestionsCta
         if (isVisitSiteSuggestionsCta) {
             if (userBrowserProperties.daysSinceInstalled() <= 3) {
-                onboardingStore.clearVisitSiteCtaDisplayCount()
                 val count = onboardingStore.visitSiteCtaDisplayCount ?: 0
                 pixel.fire(AppPixelName.ONBOARDING_VISIT_SITE_CTA_SHOWN, mapOf("count" to count.toString()))
                 onboardingStore.visitSiteCtaDisplayCount = count + 1

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -167,7 +167,7 @@ class CtaViewModel @Inject constructor(
             cta is DaxBubbleCta.DaxIntroVisitSiteOptionsCta || cta is DaxBubbleCta.DaxExperimentIntroVisitSiteOptionsCta ||
                 cta is OnboardingDaxDialogCta.DaxSiteSuggestionsCta || cta is OnboardingDaxDialogCta.DaxExperimentSiteSuggestionsCta
         if (isVisitSiteSuggestionsCta) {
-            if (userBrowserProperties.daysSinceInstalled() <= 3) {
+            if (userBrowserProperties.daysSinceInstalled() <= MIN_DAYS_TO_COUNT_ONBOARDING_CTA_SHOWN) {
                 val count = onboardingStore.visitSiteCtaDisplayCount ?: 0
                 pixel.fire(AppPixelName.ONBOARDING_VISIT_SITE_CTA_SHOWN, mapOf("count" to count.toString()))
                 onboardingStore.visitSiteCtaDisplayCount = count + 1
@@ -589,5 +589,6 @@ class CtaViewModel @Inject constructor(
 
     companion object {
         private const val MAX_TABS_OPEN_FIRE_EDUCATION = 2
+        private const val MIN_DAYS_TO_COUNT_ONBOARDING_CTA_SHOWN = 3
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/store/OnboardingStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/store/OnboardingStore.kt
@@ -20,7 +20,9 @@ import com.duckduckgo.app.cta.ui.DaxBubbleCta.DaxDialogIntroOption
 
 interface OnboardingStore {
     var onboardingDialogJourney: String?
+    var visitSiteCtaDisplayCount: Int?
     fun getSearchOptions(): List<DaxDialogIntroOption>
     fun getSitesOptions(): List<DaxDialogIntroOption>
     fun getExperimentSearchOptions(): List<DaxDialogIntroOption>
+    fun clearVisitSiteCtaDisplayCount()
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/store/OnboardingStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/store/OnboardingStore.kt
@@ -20,7 +20,7 @@ import com.duckduckgo.app.cta.ui.DaxBubbleCta.DaxDialogIntroOption
 
 interface OnboardingStore {
     var onboardingDialogJourney: String?
-    var visitSiteCtaDisplayCount: Int?
+    var visitSiteCtaDisplayCount: Int
     fun getSearchOptions(): List<DaxDialogIntroOption>
     fun getSitesOptions(): List<DaxDialogIntroOption>
     fun getExperimentSearchOptions(): List<DaxDialogIntroOption>

--- a/app/src/main/java/com/duckduckgo/app/onboarding/store/OnboardingStoreImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/store/OnboardingStoreImpl.kt
@@ -35,6 +35,10 @@ class OnboardingStoreImpl @Inject constructor(
         get() = preferences.getString(ONBOARDING_JOURNEY, null)
         set(dialogJourney) = preferences.edit { putString(ONBOARDING_JOURNEY, dialogJourney) }
 
+    override var visitSiteCtaDisplayCount: Int?
+        get() = preferences.getInt(VISIT_SITE_CTA_DISPLAY_COUNT, 0)
+        set(count) = preferences.edit { putInt(VISIT_SITE_CTA_DISPLAY_COUNT, count ?: 0) }
+
     override fun getSearchOptions(): List<DaxDialogIntroOption> {
         val country = Locale.getDefault().country
         val language = Locale.getDefault().language
@@ -207,8 +211,13 @@ class OnboardingStoreImpl @Inject constructor(
         )
     }
 
+    override fun clearVisitSiteCtaDisplayCount() {
+        preferences.edit { remove(VISIT_SITE_CTA_DISPLAY_COUNT) }
+    }
+
     companion object {
         const val FILENAME = "com.duckduckgo.app.onboarding.settings"
         const val ONBOARDING_JOURNEY = "onboardingJourney"
+        const val VISIT_SITE_CTA_DISPLAY_COUNT = "visitSiteCtaDisplayCount"
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/store/OnboardingStoreImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/store/OnboardingStoreImpl.kt
@@ -35,9 +35,9 @@ class OnboardingStoreImpl @Inject constructor(
         get() = preferences.getString(ONBOARDING_JOURNEY, null)
         set(dialogJourney) = preferences.edit { putString(ONBOARDING_JOURNEY, dialogJourney) }
 
-    override var visitSiteCtaDisplayCount: Int?
+    override var visitSiteCtaDisplayCount: Int
         get() = preferences.getInt(VISIT_SITE_CTA_DISPLAY_COUNT, 0)
-        set(count) = preferences.edit { putInt(VISIT_SITE_CTA_DISPLAY_COUNT, count ?: 0) }
+        set(count) = preferences.edit { putInt(VISIT_SITE_CTA_DISPLAY_COUNT, count) }
 
     override fun getSearchOptions(): List<DaxDialogIntroOption> {
         val country = Locale.getDefault().country

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -49,6 +49,7 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     ONBOARDING_DAX_CTA_OK_BUTTON("m_odc_ok"),
     ONBOARDING_DAX_CTA_CANCEL_BUTTON("m_onboarding_dax_cta_cancel"),
     ONBOARDING_SKIP_MAJOR_NETWORK_UNIQUE("m_onboarding_skip_major_network_unique"),
+    ONBOARDING_VISIT_SITE_CTA_SHOWN("onboarding_visit_site_cta_shown"),
 
     BROWSER_MENU_ALLOWLIST_ADD("mb_wla"),
     BROWSER_MENU_ALLOWLIST_REMOVE("mb_wlr"),

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/OnboardingDaxDialogTests.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/OnboardingDaxDialogTests.kt
@@ -36,6 +36,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.widget.ui.WidgetCapabilities
 import com.duckduckgo.brokensite.api.BrokenSitePrompt
+import com.duckduckgo.browser.api.UserBrowserProperties
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.duckplayer.api.DuckPlayer
@@ -78,6 +79,7 @@ class OnboardingDaxDialogTests {
     private val mockHighlightsOnboardingExperimentManager: HighlightsOnboardingExperimentManager = mock()
     private val mockBrokenSitePrompt: BrokenSitePrompt = mock()
     private val mockExtendedOnboardingPixelsPlugin: ExtendedOnboardingPixelsPlugin = mock()
+    private val mockUserBrowserProperties: UserBrowserProperties = mock()
 
     val mockEnabledToggle: Toggle = org.mockito.kotlin.mock { on { it.isEnabled() } doReturn true }
     val mockDisabledToggle: Toggle = org.mockito.kotlin.mock { on { it.isEnabled() } doReturn false }
@@ -99,6 +101,7 @@ class OnboardingDaxDialogTests {
             mockHighlightsOnboardingExperimentManager,
             mockBrokenSitePrompt,
             mockExtendedOnboardingPixelsPlugin,
+            mockUserBrowserProperties,
         )
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208778105886340/f

### Description
Add temporary pixel for counting display of visit site suggestions dialog

### Steps to test this PR

_Feature 1_
- [x] Fresh install
- [x] Once in the browser, tap on a search suggestion
- [x] Dismiss SERP dialog
- [x] _Logcat:_ Check `onboarding_visit_site_cta_shown` pixel is fired with parameter `count = 0`
- [x] Open a new tab
- [x] _Logcat:_ Check `onboarding_visit_site_cta_shown` pixel is fired with parameter `count = 1`
- [x] Close and open the app
- [x] _Logcat:_ Check `onboarding_visit_site_cta_shown` pixel is fired with parameter `count = 2`
- [x] Perform a search
- [x] Open a new tab
- [x] _Logcat:_ Check `onboarding_visit_site_cta_shown` pixel is fired with parameter `count = 3`
- [x] Tap on a site suggestion or navigate to a site
- [x] Check Trackers dialog appears
- [x] Open a new tab
- [x] Check End dialog is shown and `onboarding_visit_site_cta_shown` pixel is not fired

### No UI changes
