### PR TITLE
Fixes autoconsent remote config not refreshed until app restart

### DIFF
--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/RealAutoconsent.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/RealAutoconsent.kt
@@ -28,11 +28,20 @@ import com.duckduckgo.autoconsent.impl.remoteconfig.AutoconsentFeature
 import com.duckduckgo.autoconsent.impl.store.AutoconsentSettingsRepository
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.anvil.annotations.ContributesMultibinding
 import javax.inject.Inject
 
-@ContributesBinding(AppScope::class)
+@ContributesBinding(
+    scope = AppScope::class,
+    boundType = Autoconsent::class,
+)
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = PrivacyConfigCallbackPlugin::class,
+)
 class RealAutoconsent @Inject constructor(
     private val messageHandlerPlugins: PluginPoint<MessageHandlerPlugin>,
     private val settingsRepository: AutoconsentSettingsRepository,
@@ -40,7 +49,7 @@ class RealAutoconsent @Inject constructor(
     private val autoconsent: AutoconsentFeature,
     private val userAllowlistRepository: UserAllowListRepository,
     private val unprotectedTemporary: UnprotectedTemporary,
-) : Autoconsent {
+) : Autoconsent, PrivacyConfigCallbackPlugin {
 
     private lateinit var autoconsentJs: String
 
@@ -107,5 +116,9 @@ class RealAutoconsent @Inject constructor(
             autoconsentJs = JsReader.loadJs("autoconsent-bundle.js")
         }
         return autoconsentJs
+    }
+
+    override fun onPrivacyConfigDownloaded() {
+        settingsRepository.invalidateCache()
     }
 }

--- a/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/Fakes.kt
+++ b/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/Fakes.kt
@@ -54,6 +54,7 @@ class FakeMessageHandlerPlugin : MessageHandlerPlugin {
 class FakeSettingsRepository : AutoconsentSettingsRepository {
     override var userSetting: Boolean = false
     override var firstPopupHandled: Boolean = false
+    override fun invalidateCache() {}
 }
 
 class FakeUnprotected(private val exceptionList: List<String>) : UnprotectedTemporary {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202552961248957/1208826230694543/f 

### Description
Fixes autoconsent config not refreshed untill app restart

### Steps to test this PR

_Feature 1_
- [x] fresh install
- [x] clear data before opening the app (this will ensure no remote config update happened in the background)
- [x] open the app
- [x] Go to settings
- [x] Ensure cookie popup is enabled

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
