### PR TITLE
Onboarding: Privacy Pro dialog FF

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -758,6 +758,7 @@ class CtaViewModelTest {
         givenDaxOnboardingActive()
         whenever(mockSubscriptions.isEligible()).thenReturn(true)
         whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockEnabledToggle)
+        whenever(mockExtendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockEnabledToggle)
         whenever(mockExtendedOnboardingFeatureToggles.testPrivacyProOnboardingCopyNov24()).thenReturn(mockEnabledToggle)
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO_VISIT_SITE)).thenReturn(true)

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -107,7 +107,7 @@ class CtaViewModel @Inject constructor(
             }
 
     private suspend fun requiredDaxOnboardingCtas(): Array<CtaId> {
-        val shouldShowPrivacyProCta = subscriptions.isEligible()
+        val shouldShowPrivacyProCta = subscriptions.isEligible() && extendedOnboardingFeatureToggles.privacyProCta().isEnabled()
         return if (shouldShowPrivacyProCta) {
             arrayOf(
                 CtaId.DAX_INTRO,
@@ -365,7 +365,7 @@ class CtaViewModel @Inject constructor(
 
     private suspend fun canShowPrivacyProCta(): Boolean {
         return daxOnboardingActive() && !hideTips() && !daxDialogPrivacyProShown() &&
-            subscriptions.isEligible()
+            subscriptions.isEligible() && extendedOnboardingFeatureToggles.privacyProCta().isEnabled()
     }
 
     @WorkerThread


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208833556472473/f

### Description
Add privacy pro onboarding dialog under a disabled feature flag

### Steps to test this PR

_FF disabled (default)_
- [ ] Make sure you are privacy pro eligible
- [ ] Fresh install
- [ ] Go through onboarding until end dialog appears in a new tab
- [ ] When dismiss End dialog, make sure privacy pro doesn't appear

_FF enabled_
- [ ] Make sure you are privacy pro eligible
- [ ] Fresh install
- [ ] In Settings > Feature Flag inventory, filter by `privacyProCta` and enable it
- [ ] Go through onboarding until end dialog appears in a new tab
- [ ] When dismiss End dialog, make sure privacy pro appears

### No UI changes
