### PR TITLE
Add option to change list item leading icon's background color

### DIFF
--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/listitem/BookmarksListItem.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/listitem/BookmarksListItem.kt
@@ -114,6 +114,10 @@ class BookmarksListItem @JvmOverloads constructor(
                 setLeadingIconSize(imageSize)
             }
 
+            if (hasValue(R.styleable.TwoLineListItem_leadingIconBackgroundColor)) {
+                setLeadingIconBackgroundColorStateList(getColorStateList(R.styleable.TwoLineListItem_leadingIconBackgroundColor))
+            }
+
             if (hasValue(R.styleable.TwoLineListItem_primaryTextColorOverlay)) {
                 setPrimaryTextColorStateList(getColorStateList(R.styleable.TwoLineListItem_primaryTextColorOverlay))
             }

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/listitem/DaxListItem.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/listitem/DaxListItem.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.common.ui.view.listitem
 
 import android.content.Context
 import android.content.res.ColorStateList
+import android.graphics.PorterDuff
 import android.graphics.drawable.Drawable
 import android.text.TextUtils.TruncateAt
 import android.util.AttributeSet
@@ -159,6 +160,18 @@ abstract class DaxListItem(
         leadingIconContainer.setBackgroundResource(ImageBackground.background(type))
         leadingIconContainer.layoutParams.width = backgroundSize
         leadingIconContainer.layoutParams.height = backgroundSize
+    }
+
+    fun setLeadingIconBackgroundColor(@ColorRes backgroundColorRes: Int) {
+        val stateList = ContextCompat.getColorStateList(context, backgroundColorRes)
+        setLeadingIconBackgroundColorStateList(stateList)
+    }
+
+    fun setLeadingIconBackgroundColorStateList(stateList: ColorStateList?) {
+        leadingIconContainer.background?.mutate()?.apply {
+            setTintMode(PorterDuff.Mode.SRC)
+            setTintList(stateList)
+        }
     }
 
     /** Returns the binding of the leading icon */

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/listitem/OneLineListItem.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/listitem/OneLineListItem.kt
@@ -101,6 +101,10 @@ class OneLineListItem @JvmOverloads constructor(
 
             setLeadingIconSize(leadingIconSize, leadingIconBackground)
 
+            if (hasValue(R.styleable.OneLineListItem_leadingIconBackgroundColor)) {
+                setLeadingIconBackgroundColorStateList(getColorStateList(R.styleable.OneLineListItem_leadingIconBackgroundColor))
+            }
+
             val showTrailingIcon = hasValue(R.styleable.OneLineListItem_trailingIcon)
             val showSwitch = getBoolean(R.styleable.OneLineListItem_showSwitch, false)
             when {

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/listitem/TwoLineListItem.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/listitem/TwoLineListItem.kt
@@ -107,6 +107,10 @@ class TwoLineListItem @JvmOverloads constructor(
 
             setLeadingIconSize(leadingIconSize, leadingIconBackground)
 
+            if (hasValue(R.styleable.TwoLineListItem_leadingIconBackgroundColor)) {
+                setLeadingIconBackgroundColorStateList(getColorStateList(R.styleable.TwoLineListItem_leadingIconBackgroundColor))
+            }
+
             if (hasValue(R.styleable.TwoLineListItem_primaryTextColorOverlay)) {
                 setPrimaryTextColorStateList(getColorStateList(R.styleable.TwoLineListItem_primaryTextColorOverlay))
             }

--- a/common/common-ui/src/main/res/values/attrs-lists.xml
+++ b/common/common-ui/src/main/res/values/attrs-lists.xml
@@ -44,6 +44,7 @@
         <!-- Rectangular shape, with optional rounded corners. -->
         <enum name="rounded" value="2" />
     </attr>
+    <attr name="leadingIconBackgroundColor" format="color"/>
     <attr name="leadingIconSize">
         <!-- Small 16dp -->
         <enum name="small" value="0" />
@@ -70,6 +71,7 @@
         <attr name="primaryTextTruncated"/>
         <attr name="leadingIcon"/>
         <attr name="leadingIconBackground"/>
+        <attr name="leadingIconBackgroundColor"/>
         <attr name="leadingIconSize"/>
         <attr name="trailingIcon"/>
         <attr name="showSwitch"/>
@@ -85,6 +87,7 @@
         <attr name="secondaryTextColorOverlay"/>
         <attr name="leadingIcon"/>
         <attr name="leadingIconBackground"/>
+        <attr name="leadingIconBackgroundColor"/>
         <attr name="leadingIconSize"/>
         <attr name="trailingIcon"/>
         <attr name="showBetaPill"/>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202857801505092/1208848663479871

### Description
Introduces an option to set a color for the list item leading icon's background. All leading icon backgrounds by default use a default grey-ish colors (depending on light/dark mode) with no option to change them. A new design for the Privacy Pro subscription activation screen requires the background for one of the list items to be specifically yellow.

I opted to provide this functionality by tinting the existing background drawable. This ensures that tinted background will still use the same shape as all the other list items, which cuts any additional maintenance if the background shapes/sizes get updated.

### Steps to test this PR

You can try this out by applying below diff and navigating to Settings -> Sync & Backup:
```diff
diff --git a/sync/sync-impl/src/main/res/layout/view_sync_disabled.xml b/sync/sync-impl/src/main/res/layout/view_sync_disabled.xml
index d39d01829..0e0894019 100644
--- a/sync/sync-impl/src/main/res/layout/view_sync_disabled.xml
+++ b/sync/sync-impl/src/main/res/layout/view_sync_disabled.xml
@@ -36,6 +36,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:leadingIconBackground="circular"
+        app:leadingIconBackgroundColor="@color/yellow10"
         app:leadingIcon="@drawable/ic_sync_device_all_24"
         app:primaryText="@string/sync_setup_with_another_device_cta_title"
         app:secondaryText="@string/sync_setup_with_another_device_cta_subtitle"/>
```


| Before  | After |
| ------ | ----- |
![Screenshot_20241126_122237](https://github.com/user-attachments/assets/0f3ffc17-372c-4797-aafd-847fe7474c99) | ![Screenshot_20241126_122425](https://github.com/user-attachments/assets/ee7317d5-c664-4548-a3c8-99bedadcc315) |

### UI changes

No changes to existing views.
