### PR TITLE
Set report flow to form when launchiung hybrid site from the prompt

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -225,6 +225,7 @@ import com.duckduckgo.autofill.api.domain.app.LoginTriggerType
 import com.duckduckgo.autofill.api.emailprotection.EmailInjector
 import com.duckduckgo.browser.api.WebViewVersionProvider
 import com.duckduckgo.browser.api.brokensite.BrokenSiteData
+import com.duckduckgo.browser.api.brokensite.BrokenSiteData.ReportFlow.PROMPT
 import com.duckduckgo.common.ui.DuckDuckGoFragment
 import com.duckduckgo.common.ui.store.BrowserAppTheme
 import com.duckduckgo.common.ui.view.DaxDialog
@@ -272,6 +273,7 @@ import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.navigation.api.GlobalActivityStarter.DeeplinkActivityParams
 import com.duckduckgo.privacy.dashboard.api.ui.PrivacyDashboardHybridScreenParams
 import com.duckduckgo.privacy.dashboard.api.ui.PrivacyDashboardHybridScreenParams.BrokenSiteForm
+import com.duckduckgo.privacy.dashboard.api.ui.PrivacyDashboardHybridScreenParams.BrokenSiteForm.BrokenSiteFormReportFlow
 import com.duckduckgo.privacy.dashboard.api.ui.WebBrokenSiteForm
 import com.duckduckgo.privacyprotectionspopup.api.PrivacyProtectionsPopup
 import com.duckduckgo.privacyprotectionspopup.api.PrivacyProtectionsPopupFactory
@@ -1906,7 +1908,11 @@ class BrowserTabFragment :
         val context = context ?: return
 
         if (webBrokenSiteForm.shouldUseWebBrokenSiteForm()) {
-            globalActivityStarter.startIntent(context, BrokenSiteForm(tabId))
+            val reportFlow = when (data.reportFlow) {
+                PROMPT -> BrokenSiteFormReportFlow.PROMPT
+                else -> BrokenSiteFormReportFlow.MENU
+            }
+            globalActivityStarter.startIntent(context, BrokenSiteForm(tabId, reportFlow))
                 ?.let { startActivity(it) }
         } else {
             val options = ActivityOptions.makeSceneTransitionAnimation(browserActivity).toBundle()

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -363,10 +363,10 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
 
     REFRESH_ACTION_DAILY_PIXEL("m_refresh_action_daily"),
     RELOAD_TWICE_WITHIN_12_SECONDS("m_reload_twice_within_12_seconds"),
-    RELOAD_THREE_TIMES_WITHIN_20_SECONDS("m_reload_three_times_within_20_seconds"),
+    RELOAD_THREE_TIMES_WITHIN_20_SECONDS("m_reload-three-times-within-20-seconds"),
 
-    SITE_NOT_WORKING_WEBSITE_BROKEN("site_not_working_website_is_broken"),
-    SITE_NOT_WORKING_SHOWN("site_not_working_shown"),
+    SITE_NOT_WORKING_WEBSITE_BROKEN("m_site-not-working_website-is-broken"),
+    SITE_NOT_WORKING_SHOWN("m_site-not-working_shown"),
 
     URI_LOADED("m_uri_loaded"),
 

--- a/privacy-dashboard/privacy-dashboard-api/src/main/java/com/duckduckgo/privacy/dashboard/api/ui/PrivacyDashboardHybridScreenParams.kt
+++ b/privacy-dashboard/privacy-dashboard-api/src/main/java/com/duckduckgo/privacy/dashboard/api/ui/PrivacyDashboardHybridScreenParams.kt
@@ -32,5 +32,10 @@ sealed class PrivacyDashboardHybridScreenParams : GlobalActivityStarter.Activity
      * Use this parameter to launch the site breakage reporting form.
      * @param tabId The tab ID
      */
-    data class BrokenSiteForm(override val tabId: String) : PrivacyDashboardHybridScreenParams()
+    data class BrokenSiteForm(override val tabId: String, val reportFlow: BrokenSiteFormReportFlow) : PrivacyDashboardHybridScreenParams() {
+        enum class BrokenSiteFormReportFlow {
+            MENU,
+            PROMPT,
+        }
+    }
 }

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridActivity.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridActivity.kt
@@ -94,13 +94,12 @@ class PrivacyDashboardHybridActivity : DuckDuckGoActivity() {
                 onBrokenSiteClicked = { viewModel.onReportBrokenSiteSelected() },
                 onClose = { this@PrivacyDashboardHybridActivity.finish() },
                 onSubmitBrokenSiteReport = { payload ->
-                    val reportFlow = when (params) {
+                    val reportFlow = when (val params = params) {
                         is PrivacyDashboardPrimaryScreen, null -> ReportFlow.DASHBOARD
                         is BrokenSiteForm -> {
-                            if ((params as BrokenSiteForm).reportFlow == BrokenSiteForm.BrokenSiteFormReportFlow.MENU) {
-                                ReportFlow.MENU
-                            } else {
-                                ReportFlow.PROMPT
+                            when (params.reportFlow) {
+                                BrokenSiteForm.BrokenSiteFormReportFlow.MENU -> ReportFlow.MENU
+                                BrokenSiteForm.BrokenSiteFormReportFlow.PROMPT -> ReportFlow.PROMPT
                             }
                         }
                     }

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridActivity.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridActivity.kt
@@ -96,7 +96,13 @@ class PrivacyDashboardHybridActivity : DuckDuckGoActivity() {
                 onSubmitBrokenSiteReport = { payload ->
                     val reportFlow = when (params) {
                         is PrivacyDashboardPrimaryScreen, null -> ReportFlow.DASHBOARD
-                        is BrokenSiteForm -> ReportFlow.MENU
+                        is BrokenSiteForm -> {
+                            if ((params as BrokenSiteForm).reportFlow == BrokenSiteForm.BrokenSiteFormReportFlow.MENU) {
+                                ReportFlow.MENU
+                            } else {
+                                ReportFlow.PROMPT
+                            }
+                        }
                     }
                     viewModel.onSubmitBrokenSiteReport(payload, reportFlow)
                 },


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1163321984198618/1208852264436742/f 

### Description
Set report flow to form (not menu) when launching hybrid site from the prompt
Rename pixels according to spec

### Steps to test this PR

_Feature 1_
- [x] Fresh install, complete onboarding
- [x] Load a site and refresh 3 times
- [x] Check on the button to report broken site
- [x] Submit a report
- [x] Check the `reportFlow` parameter on `epbf` pixel is `prompt` instead of `menu`

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
