### PR TITLE
Guard against crashes in NetpDataVolumeStore

### DIFF
--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/volume/NetpDataVolumeStore.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/volume/NetpDataVolumeStore.kt
@@ -35,13 +35,19 @@ class RealNetpDataVolumeStore @Inject constructor(
     private val networkProtectionPrefs: NetworkProtectionPrefs,
 ) : NetpDataVolumeStore {
     override var dataVolume: DataVolume
-        get() = DataVolume(
-            receivedBytes = networkProtectionPrefs.getLong(KEY_RECEIVED_BYTES, 0L),
-            transmittedBytes = networkProtectionPrefs.getLong(KEY_TRANSMITTED_BYTES, 0L),
-        )
+        get() {
+            return kotlin.runCatching {
+                DataVolume(
+                    receivedBytes = networkProtectionPrefs.getLong(KEY_RECEIVED_BYTES, 0L),
+                    transmittedBytes = networkProtectionPrefs.getLong(KEY_TRANSMITTED_BYTES, 0L),
+                )
+            }.getOrDefault(DataVolume())
+        }
         set(value) {
-            networkProtectionPrefs.putLong(KEY_RECEIVED_BYTES, value.receivedBytes)
-            networkProtectionPrefs.putLong(KEY_TRANSMITTED_BYTES, value.transmittedBytes)
+            kotlin.runCatching {
+                networkProtectionPrefs.putLong(KEY_RECEIVED_BYTES, value.receivedBytes)
+                networkProtectionPrefs.putLong(KEY_TRANSMITTED_BYTES, value.transmittedBytes)
+            }
         }
 
     companion object {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1198194956794324/1208858014826586/f

### Description
Guard against possible crashes on NetpDataVolumeStore (we've seen single user spikes)

### Steps to test this PR
NA, smoke test vpn data volume
