### PR TITLE
Update content scope scripts to version 6.40.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/README.md
+++ b/node_modules/@duckduckgo/content-scope-scripts/README.md
@@ -32,7 +32,20 @@ Utilities to automatically generate TypeScript types from JSON Schema files.
 
 ## NPM commands
 
+Consider using [nvm](https://github.com/nvm-sh/nvm) to manage node versions, after installing in the project directory run:
+
+```
+nvm use
+```
+
 From the top-level root folder of this npm workspace, you can run the following npm commands:
+
+**Install dependencies**:
+
+Will install all the dependencies we need to build and run the project:
+```
+npm install
+```
 
 **Build all workspaces**:
 

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/js/index.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/js/index.js
@@ -2221,8 +2221,8 @@
   };
 
   // shared/components/Fallback/Fallback.jsx
-  function Fallback({ showDetails }) {
-    return /* @__PURE__ */ _("div", { class: Fallback_default.fallback }, /* @__PURE__ */ _("div", null, /* @__PURE__ */ _("p", null, "Something went wrong!"), showDetails && /* @__PURE__ */ _("p", null, "Please check logs for a message called ", /* @__PURE__ */ _("code", null, "reportPageException"))));
+  function Fallback({ showDetails, children }) {
+    return /* @__PURE__ */ _("div", { class: Fallback_default.fallback }, /* @__PURE__ */ _("div", null, /* @__PURE__ */ _("p", null, "Something went wrong!"), children, showDetails && /* @__PURE__ */ _("p", null, "Please check logs for a message called ", /* @__PURE__ */ _("code", null, "reportPageException"))));
   }
 
   // pages/duckplayer/app/components/Components.module.css

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^12.0.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#15.1.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.39.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.40.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#7.0.2",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1724449523"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#dfef00ef77f5181d1d8a4f7cc88f7b7c0514dd34",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#e51efbca45d2178c43dd3b0fe4d18d19b34c54e3",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -282,13 +282,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.1.tgz",
-      "integrity": "sha512-p8Yy/8sw1caA8CdRIQBG5tiLHmxtQKObCijiAa9Ez+d4+PRffM4054xbju0msf+cvhJpnFEeNjxmVT/0ipktrg==",
+      "version": "22.10.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.0.tgz",
+      "integrity": "sha512-XC70cRZVElFHfIUB40FgZOBbgJYFKKMa5nb9lxcwYstFG/Mi+/Y0bGS+rs6Dmhmkpq4pnNiLiuZAbc02YCOnmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.8"
+        "undici-types": "~6.20.0"
       }
     },
     "node_modules/@types/resolve": {
@@ -666,24 +666,24 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.63",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.63.tgz",
-      "integrity": "sha512-H1XCt54xY+QPbwhTgmxLkepX0MVHu3USfMmejiCOdkMbRcP22Pn2FVF127r/GWXVDmXTRezyF3Ckvhn4Fs6j7Q==",
+      "version": "6.1.64",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.64.tgz",
+      "integrity": "sha512-uqnl8vGV16KsyflHOzqrYjjArjfXaU6rMPXYy2/ZWoRKCkXtghgB4VwTDXUG+t0OTGeSewNAG31/x1gCTfLt+Q==",
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "6.1.63",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.63.tgz",
-      "integrity": "sha512-Xqxv4UvuTwC/sslspSbkw/52vvYCeZdEJwnv7VFlQEfYvK8fNuIpz5hoOvO7XuzfjqexMRRnVDYUyjqesTYESg==",
+      "version": "6.1.64",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.64.tgz",
+      "integrity": "sha512-Lm6dwThCCmUecyvOJwTfZgYRP9JB6UDam//96OSvZffBtBA3GuwucIiycLT5yO5nz0ZAGV37FF1hef2HE0K8BQ==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^6.1.63"
+        "tldts-core": "^6.1.64"
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
       "dev": true,
       "license": "MIT"
     }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^12.0.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#15.1.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.39.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.40.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#7.0.2",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1724449523"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass