### PR TITLE
Update content scope scripts to version 6.41.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^12.0.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#15.1.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.40.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.41.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#7.0.2",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1724449523"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#e51efbca45d2178c43dd3b0fe4d18d19b34c54e3",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#c4bb146afdf0c7a93fb9a7d95b1cb255708a470d",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -282,9 +282,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.10.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.0.tgz",
-      "integrity": "sha512-XC70cRZVElFHfIUB40FgZOBbgJYFKKMa5nb9lxcwYstFG/Mi+/Y0bGS+rs6Dmhmkpq4pnNiLiuZAbc02YCOnmA==",
+      "version": "22.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.1.tgz",
+      "integrity": "sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^12.0.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#15.1.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.40.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.41.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#7.0.2",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1724449523"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208868850993344/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass