### PR TITLE
Ensure maestro test works with and without gesture navigation

### DIFF
--- a/.maestro/privacy_tests/7_-_Browser_restart_mid-session.yaml
+++ b/.maestro/privacy_tests/7_-_Browser_restart_mid-session.yaml
@@ -91,11 +91,7 @@ tags:
     text: "convert.ad-company.site"
 - action: back
 - action: back
-- tapOn:
-    id: "com.android.systemui:id/recent_apps"
-- swipe:
-    start: 100,500
-    end: 100,200
+- killApp
 - launchApp:
     clearState: false
 - assertVisible:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208915665635635/f 

### Description
Simplifies a UI test which currently kills the app by activating multi-tasking view and swiping the app away. Replaces with a method which also works with gesture navigation.

### Steps to test this PR
- qa optional
- [optional] run `.maestro/privacy_tests/7_-_Browser_restart_mid-session.yaml` where gesture navigation on and off (e.g., on emulators running API 30 and API 34 which have different nav behaviours by default)