### PR TITLE
Fix flakey release test for AppTP, banner won't always show

### DIFF
--- a/.maestro/app_tp/app_tp_onboarding.yaml
+++ b/.maestro/app_tp/app_tp_onboarding.yaml
@@ -36,7 +36,9 @@ tags:
       text: "Good news! App Tracking Protection is now enabled.*"
 - assertVisible: "Got it!"
 - tapOn: "Got it!"
-- assertVisible: "Protection for some apps is automatically disabled. View apps"
+- assertVisible:
+    text: "Protection for some apps is automatically disabled. View apps"
+    optional: true
 - assertVisible: "Blocked tracking attempts will appear here"
 - assertVisible:
     id: "com.duckduckgo.mobile.android:id/activity_apps"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208918464533042/f 

### Description
Change maestro release test for AppTP to handle when banner might not show

### Steps to test this PR
-  QA optional
- [ ] [optional] Run `maestro test .maestro/app_tp/app_tp_onboarding.yaml`