### PR TITLE
Update autoconsent to v12.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ddg-android",
       "version": "1.0.0",
       "dependencies": {
-        "@duckduckgo/autoconsent": "^12.1.0",
+        "@duckduckgo/autoconsent": "^12.2.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#15.1.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.41.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#7.0.2",
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-12.1.0.tgz",
-      "integrity": "sha512-tWWYDYyzNKR2L1eah2FdIvytd5+4ymAWBwdAsd3WL22txfZ3iqsQgSZGMkFZSC1NMtamVjFudadyTCi/MqWHbA==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-12.2.0.tgz",
+      "integrity": "sha512-KhvkdhqTHqVxMxxmadWcW9E1WoGV06YIwVC2m8RIeJYk6AD2wIyO5MjP24moRG5OIvWohEhge8TU0OHeY0P6Tw==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "rollup-plugin-terser": "^7.0.2"
   },
   "dependencies": {
-    "@duckduckgo/autoconsent": "^12.1.0",
+    "@duckduckgo/autoconsent": "^12.2.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#15.1.0",
     "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.41.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#7.0.2",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1208921166781775/1208921166781775
Autoconsent Release: https://github.com/duckduckgo/autoconsent/releases/tag/v12.2.0


## Description
Updates Autoconsent to version [v12.2.0](https://github.com/duckduckgo/autoconsent/releases/tag/v12.2.0).

### Autoconsent v12.2.0 release notes
See release notes [here](https://github.com/duckduckgo/autoconsent/blob/v12.2.0/CHANGELOG.md)

## Steps to test
This release has been tested during Autoconsent development. You can check the release notes for more information.
1. Make sure that there's no unexpected failures in CI checks
2. (optional) smoke test some of the sites mentioned in the release notes
3. If there are problems, reach out to a CPM DRI