### PR TITLE
In maestro tests, use the press enter command instead of using soft keyboard

### DIFF
--- a/.maestro/bookmarks/ensure_bookmarks_can_be_added_and_deleted.yaml
+++ b/.maestro/bookmarks/ensure_bookmarks_can_be_added_and_deleted.yaml
@@ -12,8 +12,7 @@ tags:
 - tapOn:
     text: "search or type URL"
 - inputText: "https://privacy-test-pages.site"
-- tapOn:
-    id: "com.google.android.inputmethod.latin:id/key_pos_ime_action"
+- pressKey: Enter
 - assertVisible:
     text: ".*keep browsing.*"
 - tapOn:

--- a/.maestro/bookmarks/open_bookmark_and_navigate_back.yaml
+++ b/.maestro/bookmarks/open_bookmark_and_navigate_back.yaml
@@ -12,8 +12,7 @@ tags:
 - tapOn:
       text: "search or type URL"
 - inputText: "https://www.search-company.site/"
-- tapOn:
-      id: "com.google.android.inputmethod.latin:id/key_pos_ime_action"
+- pressKey: Enter
 - assertVisible:
       text: ".*keep browsing.*"
 - tapOn:
@@ -23,8 +22,7 @@ tags:
 - tapOn:
       text: "https://www.search-company.site/"
 - inputText: "https://privacy-test-pages.site"
-- tapOn:
-      id: "com.google.android.inputmethod.latin:id/key_pos_ime_action"
+- pressKey: Enter
 - assertVisible:
       text: "Privacy Test Pages"
 - tapOn:

--- a/.maestro/bookmarks/open_bookmark_in_folder_and_navigate_back.yaml
+++ b/.maestro/bookmarks/open_bookmark_in_folder_and_navigate_back.yaml
@@ -12,8 +12,7 @@ tags:
 - tapOn:
       text: "search or type URL"
 - inputText: "https://privacy-test-pages.site/"
-- tapOn:
-      id: "com.google.android.inputmethod.latin:id/key_pos_ime_action"
+- pressKey: Enter
 - assertVisible:
       text: ".*keep browsing.*"
 - tapOn:
@@ -29,8 +28,7 @@ tags:
 - tapOn:
       text: "https://privacy-test-pages.site/"
 - inputText: "https://www.search-company.site/"
-- tapOn:
-    id: "com.google.android.inputmethod.latin:id/key_pos_ime_action"
+- pressKey: Enter
 - assertVisible:
     text: "Search engine"
 - tapOn:

--- a/.maestro/browsing/visit_site.yaml
+++ b/.maestro/browsing/visit_site.yaml
@@ -12,8 +12,7 @@ tags:
 - tapOn:
     text: "search or type URL"
 - inputText: "https://privacy-test-pages.site"
-- tapOn:
-    id: "com.google.android.inputmethod.latin:id/key_pos_ime_action"
+- pressKey: Enter
 - assertVisible:
     text: ".*keep browsing.*"
 - tapOn:

--- a/.maestro/favorites/favorites_bookmarks_add.yaml
+++ b/.maestro/favorites/favorites_bookmarks_add.yaml
@@ -12,8 +12,7 @@ tags:
 - tapOn:
     text: "search or type URL"
 - inputText: "https://privacy-test-pages.site"
-- tapOn:
-    id: "com.google.android.inputmethod.latin:id/key_pos_ime_action"
+- pressKey: Enter
 - assertVisible:
     text: ".*keep browsing.*"
 - tapOn:

--- a/.maestro/favorites/favorites_bookmarks_delete.yaml
+++ b/.maestro/favorites/favorites_bookmarks_delete.yaml
@@ -12,8 +12,7 @@ tags:
 - tapOn:
     text: "search or type URL"
 - inputText: "https://privacy-test-pages.site"
-- tapOn:
-    id: "com.google.android.inputmethod.latin:id/key_pos_ime_action"
+- pressKey: Enter
 - assertVisible:
     text: ".*keep browsing.*"
 - tapOn:

--- a/.maestro/fire_button/fire_during_onboarding.yaml
+++ b/.maestro/fire_button/fire_during_onboarding.yaml
@@ -12,8 +12,7 @@ tags:
 - tapOn:
     text: "search or type URL"
 - inputText: "https://privacy-test-pages.site"
-- tapOn:
-    id: "com.google.android.inputmethod.latin:id/key_pos_ime_action"
+- pressKey: Enter
 - assertVisible:
     text: ".*keep browsing.*"
 - tapOn:

--- a/.maestro/tabs/open_multiple_tabs.yaml
+++ b/.maestro/tabs/open_multiple_tabs.yaml
@@ -12,8 +12,7 @@ tags:
 - tapOn:
     text: "search or type URL"
 - inputText: "https://privacy-test-pages.site"
-- tapOn:
-    id: "com.google.android.inputmethod.latin:id/key_pos_ime_action"
+- pressKey: Enter
 - assertVisible:
     text: ".*keep browsing.*"
 - tapOn:
@@ -26,8 +25,7 @@ tags:
 - assertVisible:
     text: "Search or type URL"
 - inputText: "https://www.search-company.site"
-- tapOn:
-    id: "com.google.android.inputmethod.latin:id/key_pos_ime_action"
+- pressKey: Enter
 - assertVisible:
     text: "Search engine"
 - tapOn:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208921164205364/f 

### Description
Replace the instances where we look for a soft keyboard button with a specific ID and directly press enter key

**Before**
```
tapOn:
     id: "com.google.android.inputmethod.latin:id/key_pos_ime_action"
```

**After**
```
- pressKey: Enter
```

### Steps to test this PR

- QA optional as long as https://github.com/duckduckgo/Android/actions/runs/12197659365 passes
- If you want to test, run one or more of the changed test files