### PR TITLE
Switch order of autofill banner dismissals in maestro test

### DIFF
--- a/.maestro/autofill/steps/search_logins.yaml
+++ b/.maestro/autofill/steps/search_logins.yaml
@@ -5,16 +5,16 @@ name: "Autofill: Search credentials"
 
 - runFlow:
     when:
-      visible: "Sync & Back Up Your Passwords"
-    commands:
-      - tapOn: "No thanks"
-
-- runFlow:
-    when:
       visible: "Help us improve!"
     commands:
       - tapOn:
           id: "com.duckduckgo.mobile.android:id/close"
+
+- runFlow:
+    when:
+      visible: "Sync & Back Up Your Passwords"
+    commands:
+      - tapOn: "No thanks"
 
 - tapOn:
     id: searchLogins


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208921295229158/f 

### Description
Change to UI maestro test steps: Change order of banner dismissal in password management screen to reflect the priority order they would be shown.

### Steps to test this PR
- [ ] Ensure https://github.com/duckduckgo/Android/actions/runs/12196900861 passed 🟢