### PR TITLE
Fix subscription purchase error after cancelling purchase flow

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
@@ -701,7 +701,16 @@ class RealSubscriptionsManager @Inject constructor(
 
             // refresh any existing account / subscription data
             when {
-                isSignedInV2() -> refreshSubscriptionData()
+                isSignedInV2() -> try {
+                    refreshSubscriptionData()
+                } catch (e: HttpException) {
+                    if (e.code() == 400) {
+                        // expected if this is a first ever purchase using this account - ignore
+                    } else {
+                        throw e
+                    }
+                }
+
                 isSignedInV1() -> fetchAndStoreAllData()
             }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205648422731273/1208929009317918/f

### Description

This PR fixes an issue where with auth v2 enabled, users may see an error popup instead of the payment method selection if they cancel and retry a subscription purchase. 

### Steps to test this PR

QA-optional

### No UI changes
