### PR TITLE
Fix Show on App Launch opening after opening a website shortcut

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -364,11 +364,9 @@ open class BrowserActivity : DuckDuckGoActivity() {
             if (intent.getBooleanExtra(ShortcutBuilder.SHORTCUT_EXTRA_ARG, false)) {
                 Timber.d("Shortcut opened with url $sharedText")
                 lifecycleScope.launch { viewModel.onOpenShortcut(sharedText) }
-                return
             } else if (intent.getBooleanExtra(LAUNCH_FROM_FAVORITES_WIDGET, false)) {
                 Timber.d("Favorite clicked from widget $sharedText")
                 lifecycleScope.launch { viewModel.onOpenFavoriteFromWidget(query = sharedText) }
-                return
             } else if (intent.getBooleanExtra(OPEN_IN_CURRENT_TAB_EXTRA, false)) {
                 Timber.w("open in current tab requested")
                 if (currentTab != null) {
@@ -377,7 +375,6 @@ open class BrowserActivity : DuckDuckGoActivity() {
                     Timber.w("can't use current tab, opening in new tab instead")
                     lifecycleScope.launch { viewModel.onOpenInNewTabRequested(query = sharedText, skipHome = true) }
                 }
-                return
             } else {
                 val isExternal = intent.getBooleanExtra(LAUNCH_FROM_EXTERNAL_EXTRA, false)
                 val interstitialScreen = intent.getBooleanExtra(LAUNCH_FROM_INTERSTITIAL_EXTRA, false)
@@ -390,15 +387,12 @@ open class BrowserActivity : DuckDuckGoActivity() {
                 val sourceTabId = if (selectedText) currentTab?.tabId else null
                 val skipHome = !selectedText
                 lifecycleScope.launch { viewModel.onOpenInNewTabRequested(sourceTabId = sourceTabId, query = sharedText, skipHome = skipHome) }
-
-                return
             }
         } else {
-            Timber.i("shared text empty, opening last tab")
-        }
-
-        if (!intent.getBooleanExtra(LAUNCH_FROM_CLEAR_DATA_ACTION, false)) {
-            viewModel.handleShowOnAppLaunchOption()
+            Timber.i("shared text empty, defaulting to show on app launch option")
+            if (!intent.getBooleanExtra(LAUNCH_FROM_CLEAR_DATA_ACTION, false)) {
+                viewModel.handleShowOnAppLaunchOption()
+            }
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -364,6 +364,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
             if (intent.getBooleanExtra(ShortcutBuilder.SHORTCUT_EXTRA_ARG, false)) {
                 Timber.d("Shortcut opened with url $sharedText")
                 lifecycleScope.launch { viewModel.onOpenShortcut(sharedText) }
+                return
             } else if (intent.getBooleanExtra(LAUNCH_FROM_FAVORITES_WIDGET, false)) {
                 Timber.d("Favorite clicked from widget $sharedText")
                 lifecycleScope.launch { viewModel.onOpenFavoriteFromWidget(query = sharedText) }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202552961248957/1208930104860728/f

### Description
Added a return statement after handling shortcut URLs to prevent unintended processing of the same URL through multiple paths.

### Steps to test this PR

_Shortcut Handling_
- [ ] Set Show on App Launch to New Tab Page or Specific Page: Settings -> General -> Show on App Launch
- [ ] Open a website and add it as a shortcut
- [ ] Force close the app
- [ ] Open the shortcut you made earlier
- [ ] The New Tab Page or Specific Page you set earlier should **not** open

### UI changes
No UI changes