### PR TITLE
Enable nightly builds for execution in robin

### DIFF
--- a/.github/workflows/end-to-end-robintest.yml
+++ b/.github/workflows/end-to-end-robintest.yml
@@ -1,0 +1,118 @@
+name: End-to-End tests (Robin)
+
+on:
+  schedule:
+    - cron: '0 3 * * *' # run at 3 AM UTC
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  instrumentation_tests:
+    runs-on: ubuntu-latest
+    name: End-to-End tests
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+
+      - name: Create folder
+        if: always()
+        run: mkdir apk
+
+      - name: Decode keys
+        uses: davidSchuppa/base64Secret-toFile-action@v2
+        with:
+          secret: ${{ secrets.FAKE_RELEASE_PROPERTIES }}
+          fileName: ddg_android_build.properties
+          destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
+
+      - name: Decode key file
+        uses: davidSchuppa/base64Secret-toFile-action@v2
+        with:
+          secret: ${{ secrets.FAKE_RELEASE_KEY }}
+          fileName: android
+          destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Assemble release APK
+        run: ./gradlew assemblePlayRelease -Pforce-default-variant
+
+      - name: Move APK to new folder
+        if: always()
+        run: find . -name "*.apk"  -exec mv '{}' apk/release.apk \;
+
+      - name: Ad click detection flows
+        uses: mobile-dev-inc/action-maestro-cloud@v1.9.7
+        with:
+          api-key: ${{ secrets.ROBIN_API_KEY }}
+          project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
+          name: adClickTest_${{ github.sha }}
+          timeout: 120
+          app-file: apk/release.apk
+          android-api-level: 30
+          workspace: .maestro
+          include-tags: adClickTest
+
+      - name: Privacy Tests
+        if: always()
+        uses: mobile-dev-inc/action-maestro-cloud@v1.9.7
+        with:
+          api-key: ${{ secrets.ROBIN_API_KEY }}
+          project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
+          name: privacyTest_${{ github.sha }}
+          timeout: 120
+          app-file: apk/release.apk
+          android-api-level: 30
+          workspace: .maestro
+          include-tags: privacyTest
+
+      - name: Security Tests
+        if: always()
+        uses: mobile-dev-inc/action-maestro-cloud@v1.9.7
+        with:
+          api-key: ${{ secrets.ROBIN_API_KEY }}
+          project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
+          name: securityTest_${{ github.sha }}
+          timeout: 120
+          app-file: apk/release.apk
+          android-api-level: 30
+          workspace: .maestro
+          include-tags: securityTest
+
+      - name: Release Tests
+        if: always()
+        uses: mobile-dev-inc/action-maestro-cloud@v1.9.7
+        with:
+          api-key: ${{ secrets.ROBIN_API_KEY }}
+          project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
+          name: releaseTest_${{ github.sha }}
+          timeout: 120
+          app-file: apk/release.apk
+          android-api-level: 30
+          workspace: .maestro
+          include-tags: releaseTest
+
+      - name: Notifications permissions Android 13+
+        if: always()
+        uses: mobile-dev-inc/action-maestro-cloud@v1.9.7
+        with:
+          api-key: ${{ secrets.ROBIN_API_KEY }}
+          project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
+          name: notificationPermissionTest_${{ github.sha }}
+          timeout: 120
+          app-file: apk/release.apk
+          android-api-level: 33
+          workspace: .maestro/notifications_permissions_android13_plus


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1208926527656098/f 

### Description
Enables nightly UI builds to execute in Robin. These are going to run in parallel to the nightly UI builds in Maestro Cloud for some time (probably a number of weeks).
- tests are pretty close to being all-green, but with a small amount of flakiness 
- waiting for `retry` functionality to become available which will help them to be reliably green
- failure alerting is deliberately disabled for now (until `retry` functionality available)

Can see an example of it running successfully here: https://github.com/duckduckgo/Android/actions/runs/12236736123

### Steps to test this PR
- [ ] Check the new workflow and make sure it makes sense