### PR TITLE
Allow scrolling all of the password management list mode screen

### DIFF
--- a/autofill/autofill-impl/src/main/res/layout/fragment_autofill_management_list_mode.xml
+++ b/autofill/autofill-impl/src/main/res/layout/fragment_autofill_management_list_mode.xml
@@ -78,9 +78,8 @@
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/logins"
             android:layout_width="0dp"
-            android:layout_height="0dp"
+            android:layout_height="wrap_content"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/topDivider" />


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208758825735780/f 

### Description
This PR tweaks the layout params for the password recycler view so that the whole view content, already encapsulated in a `NestedScrollView`, is scrollable.

- Before, you had to scroll on the list view directly, and then only the passwords list would scroll while the rest of the views above were fixed. 
- Now, the entire view (including the toggle) is scrollable

### Steps to test this PR

- [ ] Visit password management view when you have 0 passwords; verify it looks fine and unchanged from before
- [ ] Add a single password; verify the password appears immediately below the horizontal divider
- [ ] Add enough passwords that they appear down below the screen. 
- [ ] Verify that scrolling scrolls the whole content, and not just the password list itself
- [ ] Verify you can scroll on the list, or scroll on the sync panel, or the text etc… and the whole page scrolls the same way


## Screenshots

### Current behavior
![current](https://github.com/user-attachments/assets/633dbba3-548f-47f7-b1e7-0065ecacb5a5)

### New behavior
![after](https://github.com/user-attachments/assets/c5456d1a-8256-49fc-9632-3313ec6de25a)
