### PR TITLE
Fix privacy tests which are currently getting interrupted with the privacy toggle check screen

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/RequestBlockingTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/RequestBlockingTest.kt
@@ -21,6 +21,7 @@ import androidx.test.core.app.*
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.IdlingRegistry
 import androidx.test.espresso.IdlingResource
+import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.espresso.web.model.Atoms.script
@@ -88,6 +89,9 @@ class RequestBlockingTest {
         onView(withId(R.id.browserMenu)).perform(click())
         onView(isRoot()).perform(waitForView(withId(R.id.privacyProtectionMenuItem)))
         onView(withId(R.id.privacyProtectionMenuItem)).perform(click())
+
+        // handle the privacy protection toggle check screen showing
+        onView(isRoot()).perform(ViewActions.pressBack())
 
         val idlingResourceForScript: IdlingResource = WebViewIdlingResource(webView!!)
         IdlingRegistry.getInstance().register(idlingResourceForScript)

--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/SurrogatesTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/SurrogatesTest.kt
@@ -97,6 +97,9 @@ class SurrogatesTest {
         onView(isRoot()).perform(waitForView(withId(R.id.privacyProtectionMenuItem)))
         onView(withId(R.id.privacyProtectionMenuItem)).perform(ViewActions.click())
 
+        // handle the privacy protection toggle check screen showing
+        onView(isRoot()).perform(ViewActions.pressBack())
+
         val idlingResourceForScript: IdlingResource = WebViewIdlingResource(webView!!)
         IdlingRegistry.getInstance().register(idlingResourceForScript)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208945103446235/f

### Description
Fixes the tests which are failing due to a new screen being presented when privacy protections are disabled. The fix is simply backing out of those screens as part of the test scripts.

### Steps to test this PR
- [x] Ensure privacy tests succeeded: https://github.com/duckduckgo/Android/actions/runs/12275448579