### PR TITLE
Fix: Don't show the find-in-page bar if it's hidden

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2425,7 +2425,7 @@ class BrowserTabViewModel @Inject constructor(
 
     fun userFindingInPage(searchTerm: String) {
         val currentViewState = currentFindInPageViewState()
-        if (!currentViewState.visible) {
+        if (!currentViewState.visible && searchTerm.isEmpty()) {
             return
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2425,7 +2425,7 @@ class BrowserTabViewModel @Inject constructor(
 
     fun userFindingInPage(searchTerm: String) {
         val currentViewState = currentFindInPageViewState()
-        if (!currentViewState.visible && searchTerm.isEmpty()) {
+        if (!currentViewState.visible) {
             return
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
@@ -618,6 +618,7 @@ class Omnibar(
             binding.focusDummy.requestFocus()
             findInPage.findInPageContainer.gone()
             findInPage.findInPageInput.hideKeyboard()
+            findInPage.findInPageInput.text.clear()
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207418217763355/1205772199506591/f

### Description

This fix prevents showing the find-in-page bar when changing the omnibar position.

### Steps to test this PR

- [x] Go to any URL
- [x] Perform a find in page search for any text
- [x] Dismiss the find in page bar
- [x] Go into settings & switch omnibar to the opposite position
- [x] Notice the find in page toolbar is not visible
- [x] Switch the omnibar position again

