### PR TITLE
Record malware blocks

### DIFF
--- a/network-protection/network-protection-impl/src/main/java/com/wireguard/android/backend/GoBackend.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/wireguard/android/backend/GoBackend.kt
@@ -109,6 +109,12 @@ class GoBackend @Inject constructor(
         return shouldAllowDomain(sni, uid)
     }
 
+    // Called from native code
+    @Suppress("unused")
+    fun recordMalwareBlock(domain: String) {
+        logcat { "Malware blocked in $domain" }
+    }
+
     private fun shouldAllowDomain(
         name: String,
         uid: Int,

--- a/versions.properties
+++ b/versions.properties
@@ -77,7 +77,7 @@ version.com.airbnb.android..lottie=5.2.0
 
 version.com.android.installreferrer..installreferrer=2.2
 
-version.com.duckduckgo.netguard..netguard-android=1.6.12
+version.com.duckduckgo.netguard..netguard-android=1.7.0
 
 version.com.duckduckgo.synccrypto..sync-crypto-android=0.3.0
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1142021229838617/1208368538104397/f

### Description
This PR bumps the our netguard (vpn) library to 1.7.0
Also adds the `recordMalwareBlock` callback, called from native when malware is blocked.

### Steps to test this PR

_Test_
- [x] Install from this branch and go through onboarding
- [x] Enabled VPN
- [x] filter logcat by "package:mine tag:GoBackend Malware blocked"
- [x] open tab and go to `vpn-malware.goduckgo.com`
- [x] verify "Malware blocked in vpn-malware.goduckgo.com" shows
- [x] Smoke test browser and VPN
