### PR TITLE
Tab Manager: Origin pixels

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -5845,6 +5845,7 @@ class BrowserTabViewModelTest {
     @Test
     fun whenTabSwitcherPressedAndUserOnSiteThenPixelIsSent() = runTest {
         givenTabManagerData()
+        setBrowserShowing(true)
         val domain = "https://www.example.com"
         givenCurrentSite(domain)
 
@@ -5866,6 +5867,7 @@ class BrowserTabViewModelTest {
     @Test
     fun whenTabSwitcherPressedAndUserOnNewTabThenPixelIsSent() = runTest {
         givenTabManagerData()
+        setBrowserShowing(true)
         whenever(mockDuckDuckGoUrlDetector.isDuckDuckGoUrl(any())).thenReturn(true)
         val domain = "https://duckduckgo.com/?q=test&atb=v395-1-wb&ia=web"
         givenCurrentSite(domain)

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -5843,33 +5843,50 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenNewTabPressedAndUserOnSiteThenPixelIsSent() = runTest {
+    fun whenTabSwitcherPressedAndUserOnSiteThenPixelIsSent() = runTest {
+        givenTabManagerData()
         val domain = "https://www.example.com"
         givenCurrentSite(domain)
 
-        testee.userRequestedOpeningNewTab()
+        testee.userLaunchingTabSwitcher()
 
         verify(mockPixel).fire(AppPixelName.TAB_MANAGER_OPENED_FROM_SITE)
     }
 
     @Test
-    fun whenNewTabPressedAndUserOnSerpThenPixelIsSent() = runTest {
+    fun whenTabSwitcherPressedAndUserOnSerpThenPixelIsSent() = runTest {
+        givenTabManagerData()
         setBrowserShowing(false)
 
-        testee.userRequestedOpeningNewTab()
+        testee.userLaunchingTabSwitcher()
 
         verify(mockPixel).fire(AppPixelName.TAB_MANAGER_OPENED_FROM_NEW_TAB)
     }
 
     @Test
-    fun whenNewTabPressedAndUserOnNewTabThenPixelIsSent() = runTest {
+    fun whenTabSwitcherPressedAndUserOnNewTabThenPixelIsSent() = runTest {
+        givenTabManagerData()
         whenever(mockDuckDuckGoUrlDetector.isDuckDuckGoUrl(any())).thenReturn(true)
         val domain = "https://duckduckgo.com/?q=test&atb=v395-1-wb&ia=web"
         givenCurrentSite(domain)
 
-        testee.userRequestedOpeningNewTab()
+        testee.userLaunchingTabSwitcher()
 
         verify(mockPixel).fire(AppPixelName.TAB_MANAGER_OPENED_FROM_SERP)
+    }
+
+    private fun givenTabManagerData() = runTest {
+        val tabCount = "61-80"
+        val active7d = "21+"
+        val inactive1w = "11-20"
+        val inactive2w = "6-10"
+        val inactive3w = "0"
+
+        whenever(mockTabStatsBucketing.getNumberOfOpenTabs()).thenReturn(tabCount)
+        whenever(mockTabStatsBucketing.getTabsActiveLastWeek()).thenReturn(active7d)
+        whenever(mockTabStatsBucketing.getTabsActiveOneWeekAgo()).thenReturn(inactive1w)
+        whenever(mockTabStatsBucketing.getTabsActiveTwoWeeksAgo()).thenReturn(inactive2w)
+        whenever(mockTabStatsBucketing.getTabsActiveMoreThanThreeWeeksAgo()).thenReturn(inactive3w)
     }
 
     private fun aCredential(): LoginCredentials {

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -5842,6 +5842,36 @@ class BrowserTabViewModelTest {
         verify(mockShowOnAppLaunchHandler).handleResolvedUrlStorage(eq("https://example.com"), any(), any())
     }
 
+    @Test
+    fun whenNewTabPressedAndUserOnSiteThenPixelIsSent() = runTest {
+        val domain = "https://www.example.com"
+        givenCurrentSite(domain)
+
+        testee.userRequestedOpeningNewTab()
+
+        verify(mockPixel).fire(AppPixelName.TAB_MANAGER_OPENED_FROM_SITE)
+    }
+
+    @Test
+    fun whenNewTabPressedAndUserOnSerpThenPixelIsSent() = runTest {
+        setBrowserShowing(false)
+
+        testee.userRequestedOpeningNewTab()
+
+        verify(mockPixel).fire(AppPixelName.TAB_MANAGER_OPENED_FROM_NEW_TAB)
+    }
+
+    @Test
+    fun whenNewTabPressedAndUserOnNewTabThenPixelIsSent() = runTest {
+        whenever(mockDuckDuckGoUrlDetector.isDuckDuckGoUrl(any())).thenReturn(true)
+        val domain = "https://duckduckgo.com/?q=test&atb=v395-1-wb&ia=web"
+        givenCurrentSite(domain)
+
+        testee.userRequestedOpeningNewTab()
+
+        verify(mockPixel).fire(AppPixelName.TAB_MANAGER_OPENED_FROM_SERP)
+    }
+
     private fun aCredential(): LoginCredentials {
         return LoginCredentials(domain = null, username = null, password = null)
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -907,7 +907,6 @@ class BrowserTabFragment :
 
     private fun onOmnibarNewTabRequested() {
         viewModel.userRequestedOpeningNewTab()
-        pixel.fire(AppPixelName.MENU_ACTION_NEW_TAB_PRESSED.pixelName)
     }
 
     private fun onOmnibarCustomTabClosed() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2642,22 +2642,6 @@ class BrowserTabViewModel @Inject constructor(
             pixel.fire(AppPixelName.TAB_MANAGER_NEW_TAB_LONG_PRESSED)
         }
 
-        pixel.fire(AppPixelName.TAB_MANAGER_OPENED)
-        pixel.fire(AppPixelName.TAB_MANAGER_OPENED_DAILY, type = Daily())
-
-        if (!currentBrowserViewState().browserShowing) {
-            pixel.fire(AppPixelName.TAB_MANAGER_OPENED_FROM_NEW_TAB)
-        } else {
-            val url = site?.url
-            if (url != null) {
-                if (duckDuckGoUrlDetector.isDuckDuckGoUrl(url)) {
-                    pixel.fire(AppPixelName.TAB_MANAGER_OPENED_FROM_SERP)
-                } else {
-                    pixel.fire(AppPixelName.TAB_MANAGER_OPENED_FROM_SITE)
-                }
-            }
-        }
-
         onUserDismissedCta(ctaViewState.value?.cta)
     }
 
@@ -2871,6 +2855,20 @@ class BrowserTabViewModel @Inject constructor(
         command.value = LaunchTabSwitcher
         pixel.fire(AppPixelName.TAB_MANAGER_CLICKED)
         fireDailyLaunchPixel()
+
+        if (!currentBrowserViewState().browserShowing) {
+            pixel.fire(AppPixelName.TAB_MANAGER_OPENED_FROM_NEW_TAB)
+        } else {
+            val url = site?.url
+            if (url != null) {
+                if (duckDuckGoUrlDetector.isDuckDuckGoUrl(url)) {
+                    pixel.fire(AppPixelName.TAB_MANAGER_OPENED_FROM_SERP)
+                } else {
+                    pixel.fire(AppPixelName.TAB_MANAGER_OPENED_FROM_SITE)
+                }
+            }
+        }
+
         onUserDismissedCta(ctaViewState.value?.cta)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2633,12 +2633,28 @@ class BrowserTabViewModel @Inject constructor(
         }
     }
 
-    fun userRequestedOpeningNewTab(longPress: Boolean = false) {
+    fun userRequestedOpeningNewTab(
+        longPress: Boolean = false,
+        url: String,
+        inNewTabPage: Boolean,
+    ) {
         command.value = GenerateWebViewPreviewImage
         command.value = LaunchNewTab
         if (longPress) {
             pixel.fire(AppPixelName.TAB_MANAGER_NEW_TAB_LONG_PRESSED)
         }
+
+        pixel.fire(AppPixelName.TAB_MANAGER_OPENED)
+        pixel.fire(AppPixelName.TAB_MANAGER_OPENED_DAILY, type = Daily())
+
+        if (inNewTabPage) {
+            pixel.fire(AppPixelName.TAB_MANAGER_OPENED_FROM_NEW_TAB)
+        } else if (duckDuckGoUrlDetector.isDuckDuckGoUrl(url)) {
+            pixel.fire(AppPixelName.TAB_MANAGER_OPENED_FROM_SERP)
+        } else {
+            pixel.fire(AppPixelName.TAB_MANAGER_OPENED_FROM_SITE)
+        }
+
         onUserDismissedCta(ctaViewState.value?.cta)
     }
 
@@ -3539,6 +3555,7 @@ class BrowserTabViewModel @Inject constructor(
                     "https://duckduckgo.com/pro?origin=funnel_pro_android_onboarding$cohortOrigin".toUri(),
                 )
             }
+
             is DaxBubbleCta.DaxEndCta, is DaxBubbleCta.DaxExperimentEndCta -> {
                 viewModelScope.launch {
                     val updatedCta = refreshCta()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2635,8 +2635,6 @@ class BrowserTabViewModel @Inject constructor(
 
     fun userRequestedOpeningNewTab(
         longPress: Boolean = false,
-        url: String,
-        inNewTabPage: Boolean,
     ) {
         command.value = GenerateWebViewPreviewImage
         command.value = LaunchNewTab
@@ -2647,12 +2645,17 @@ class BrowserTabViewModel @Inject constructor(
         pixel.fire(AppPixelName.TAB_MANAGER_OPENED)
         pixel.fire(AppPixelName.TAB_MANAGER_OPENED_DAILY, type = Daily())
 
-        if (inNewTabPage) {
+        if (!currentBrowserViewState().browserShowing) {
             pixel.fire(AppPixelName.TAB_MANAGER_OPENED_FROM_NEW_TAB)
-        } else if (duckDuckGoUrlDetector.isDuckDuckGoUrl(url)) {
-            pixel.fire(AppPixelName.TAB_MANAGER_OPENED_FROM_SERP)
         } else {
-            pixel.fire(AppPixelName.TAB_MANAGER_OPENED_FROM_SITE)
+            val url = site?.url
+            if (url != null) {
+                if (duckDuckGoUrlDetector.isDuckDuckGoUrl(url)) {
+                    pixel.fire(AppPixelName.TAB_MANAGER_OPENED_FROM_SERP)
+                } else {
+                    pixel.fire(AppPixelName.TAB_MANAGER_OPENED_FROM_SITE)
+                }
+            }
         }
 
         onUserDismissedCta(ctaViewState.value?.cta)

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -351,6 +351,11 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     TAB_MANAGER_REARRANGE_TABS_DAILY("m_tab_manager_rearrange_tabs_daily"),
     TAB_MANAGER_GRID_VIEW_BUTTON_CLICKED("m_tab_manager_grid_view_button_clicked"),
     TAB_MANAGER_LIST_VIEW_BUTTON_CLICKED("m_tab_manager_list_view_button_clicked"),
+    TAB_MANAGER_OPENED("m_tab_manager_opened"),
+    TAB_MANAGER_OPENED_DAILY("m_tab_manager_opened_daily"),
+    TAB_MANAGER_OPENED_FROM_SERP("m_tab_manager_open_from_serp"),
+    TAB_MANAGER_OPENED_FROM_SITE("m_tab_manager_open_from_website"),
+    TAB_MANAGER_OPENED_FROM_NEW_TAB("m_tab_manager_open_from_newtabpage"),
 
     DUCK_PLAYER_SETTING_ALWAYS_OVERLAY_YOUTUBE("duckplayer_setting_always_overlay_youtube"),
     DUCK_PLAYER_SETTING_ALWAYS_SERP("duckplayer_setting_always_overlay_serp"),

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -351,8 +351,6 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     TAB_MANAGER_REARRANGE_TABS_DAILY("m_tab_manager_rearrange_tabs_daily"),
     TAB_MANAGER_GRID_VIEW_BUTTON_CLICKED("m_tab_manager_grid_view_button_clicked"),
     TAB_MANAGER_LIST_VIEW_BUTTON_CLICKED("m_tab_manager_list_view_button_clicked"),
-    TAB_MANAGER_OPENED("m_tab_manager_opened"),
-    TAB_MANAGER_OPENED_DAILY("m_tab_manager_opened_daily"),
     TAB_MANAGER_OPENED_FROM_SERP("m_tab_manager_open_from_serp"),
     TAB_MANAGER_OPENED_FROM_SITE("m_tab_manager_open_from_website"),
     TAB_MANAGER_OPENED_FROM_NEW_TAB("m_tab_manager_open_from_newtabpage"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1174433894299346/1208763092216879/f

### Description
This PR adds an origin to the pixels sent when the tab manage is open

### Steps to test this PR

_From SERP_
- [x] Open and and make any search
- [x] Open Tab Manager 
- [x] Verify `m_tab_manager_open_from_serp` is fired

_From any site_
- [x] Open and and visit any site
- [x] Open Tab Manager 
- [x] Verify `m_tab_manager_open_from_website` is fired

_From new tab_
- [x] Open New Tab
- [x] Open Tab Manager 
- [ ] Verify `m_tab_manager_open_from_newtabpage` is fired