### PR TITLE
Fix date format localization in subscription settings

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionSettingsViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionSettingsViewModel.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.subscriptions.impl.ui
 
 import android.annotation.SuppressLint
+import android.icu.text.DateFormat
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModel
@@ -37,7 +38,6 @@ import com.duckduckgo.subscriptions.impl.ui.SubscriptionSettingsViewModel.Comman
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionSettingsViewModel.SubscriptionDuration.Monthly
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionSettingsViewModel.SubscriptionDuration.Yearly
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionSettingsViewModel.ViewState.Ready
-import java.text.SimpleDateFormat
 import java.util.*
 import javax.inject.Inject
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
@@ -83,7 +83,7 @@ class SubscriptionSettingsViewModel @Inject constructor(
         val account = subscriptionsManager.getAccount() ?: return
         val subscription = subscriptionsManager.getSubscription() ?: return
 
-        val formatter = SimpleDateFormat("MMMM dd, yyyy", Locale.getDefault())
+        val formatter = DateFormat.getInstanceForSkeleton("ddMMMMyyyy")
         val date = formatter.format(Date(subscription.expiresOrRenewsAt))
         val type = when (subscription.productId) {
             MONTHLY_PLAN_US, MONTHLY_PLAN_ROW -> Monthly

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionSettingsViewModelTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionSettingsViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.duckduckgo.subscriptions.impl.ui
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.subscriptions.api.PrivacyProUnifiedFeedback
@@ -24,11 +25,13 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
+@RunWith(AndroidJUnit4::class)
 class SubscriptionSettingsViewModelTest {
 
     @get:Rule


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205648422731273/1208993054177524/f

### Description

In subscription settings, we display a date when subscription expires or renews. It is currently using fixed pattern `MMMM dd, yyyy`, which is correct in USA, but potentially confusing or grammatically incorrect in other parts of the world.

### Steps to test this PR

QA-optional

### UI changes
| Before  | After |
| ------ | ----- |
|![subs-active-date-format-broken](https://github.com/user-attachments/assets/afcc3342-d236-4a92-bc13-2dbf08a4b791)|![subs-active-date-format-fixed](https://github.com/user-attachments/assets/94e64c68-9179-4970-8240-7a29a38532d5)|
|![subs-expired-date-format-broken](https://github.com/user-attachments/assets/57c2f37a-599e-415e-a6c4-1683ea2d22c6)|![subs-expired-date-format-fixed](https://github.com/user-attachments/assets/8b2f0f60-8f72-467c-b551-f16b63ebc12e)|