### PR TITLE
Privacy Pro Subscriptions: Update some internal models and methods

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -77,7 +77,7 @@ class RealSubscriptions @Inject constructor(
     override suspend fun isEligible(): Boolean {
         val supportsEncryption = subscriptionsManager.canSupportEncryption()
         val isActive = subscriptionsManager.subscriptionStatus().isActiveOrWaiting()
-        val isEligible = subscriptionsManager.getSubscriptionOffer() != null
+        val isEligible = subscriptionsManager.getSubscriptionOffer().isNotEmpty()
         return isActive || (isEligible && supportsEncryption)
     }
 

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsConstants.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsConstants.kt
@@ -32,6 +32,7 @@ object SubscriptionsConstants {
     const val MONTHLY_PLAN_US = "ddg-privacy-pro-monthly-renews-us"
     const val YEARLY_PLAN_ROW = "ddg-privacy-pro-yearly-renews-row"
     const val MONTHLY_PLAN_ROW = "ddg-privacy-pro-monthly-renews-row"
+    val privacyProActivePlans = listOf(YEARLY_PLAN_US, MONTHLY_PLAN_US, YEARLY_PLAN_ROW, MONTHLY_PLAN_ROW)
 
     // List of features
     const val LEGACY_FE_NETP = "vpn"

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsConstants.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsConstants.kt
@@ -32,7 +32,6 @@ object SubscriptionsConstants {
     const val MONTHLY_PLAN_US = "ddg-privacy-pro-monthly-renews-us"
     const val YEARLY_PLAN_ROW = "ddg-privacy-pro-yearly-renews-row"
     const val MONTHLY_PLAN_ROW = "ddg-privacy-pro-monthly-renews-row"
-    val privacyProActivePlans = listOf(YEARLY_PLAN_US, MONTHLY_PLAN_US, YEARLY_PLAN_ROW, MONTHLY_PLAN_ROW)
 
     // List of features
     const val LEGACY_FE_NETP = "vpn"

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsConstants.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsConstants.kt
@@ -33,6 +33,10 @@ object SubscriptionsConstants {
     const val YEARLY_PLAN_ROW = "ddg-privacy-pro-yearly-renews-row"
     const val MONTHLY_PLAN_ROW = "ddg-privacy-pro-monthly-renews-row"
 
+    // List of offers
+    const val MONTHLY_FREE_TRIAL_OFFER_US = "ddg-privacy-pro-sandbox-freetrial-monthly-renews-us"
+    const val YEARLY_FREE_TRIAL_OFFER_US = "ddg-privacy-pro-sandbox-freetrial-yearly-renews-us"
+
     // List of features
     const val LEGACY_FE_NETP = "vpn"
     const val LEGACY_FE_ITR = "identity-theft-restoration"

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
@@ -665,10 +665,7 @@ class RealSubscriptionsManager @Inject constructor(
             .let { availablePlans ->
                 availablePlans.map { offer ->
                     val pricingPhases = offer.pricingPhases.pricingPhaseList.map { phase ->
-                        PricingPhase(
-                            formattedPrice = phase.formattedPrice,
-                            billingPeriod = phase.billingPeriod,
-                        )
+                        PricingPhase(formattedPrice = phase.formattedPrice)
                     }
 
                     val features = if (privacyProFeature.get().featuresApi().isEnabled()) {
@@ -957,7 +954,6 @@ data class SubscriptionOfferDetails(
 
 data class PricingPhase(
     val formattedPrice: String,
-    val billingPeriod: String,
 )
 
 data class ValidatedTokenPair(

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/settings/views/LegacyProSettingViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/settings/views/LegacyProSettingViewModel.kt
@@ -88,7 +88,8 @@ class LegacyProSettingViewModel @Inject constructor(
         subscriptionsManager.subscriptionStatus
             .distinctUntilChanged()
             .onEach { subscriptionStatus ->
-                val region = when (subscriptionsManager.getSubscriptionOffer()?.monthlyPlanId) {
+                val offer = subscriptionsManager.getSubscriptionOffer().firstOrNull()
+                val region = when (offer?.planId) {
                     MONTHLY_PLAN_ROW -> SubscriptionRegion.ROW
                     MONTHLY_PLAN_US -> SubscriptionRegion.US
                     else -> null

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/settings/views/LegacyProSettingViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/settings/views/LegacyProSettingViewModel.kt
@@ -27,6 +27,8 @@ import com.duckduckgo.subscriptions.api.SubscriptionStatus
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.UNKNOWN
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.MONTHLY_PLAN_ROW
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.MONTHLY_PLAN_US
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.YEARLY_PLAN_ROW
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.YEARLY_PLAN_US
 import com.duckduckgo.subscriptions.impl.SubscriptionsManager
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixelSender
 import com.duckduckgo.subscriptions.impl.settings.views.LegacyProSettingViewModel.Command.OpenBuyScreen
@@ -90,8 +92,8 @@ class LegacyProSettingViewModel @Inject constructor(
             .onEach { subscriptionStatus ->
                 val offer = subscriptionsManager.getSubscriptionOffer().firstOrNull()
                 val region = when (offer?.planId) {
-                    MONTHLY_PLAN_ROW -> SubscriptionRegion.ROW
-                    MONTHLY_PLAN_US -> SubscriptionRegion.US
+                    MONTHLY_PLAN_ROW, YEARLY_PLAN_ROW -> SubscriptionRegion.ROW
+                    MONTHLY_PLAN_US, YEARLY_PLAN_US -> SubscriptionRegion.US
                     else -> null
                 }
                 _viewState.emit(viewState.value.copy(status = subscriptionStatus, region = region))

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/settings/views/ProSettingViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/settings/views/ProSettingViewModel.kt
@@ -88,7 +88,8 @@ class ProSettingViewModel @Inject constructor(
         subscriptionsManager.subscriptionStatus
             .distinctUntilChanged()
             .onEach { subscriptionStatus ->
-                val region = when (subscriptionsManager.getSubscriptionOffer()?.monthlyPlanId) {
+                val offer = subscriptionsManager.getSubscriptionOffer().firstOrNull()
+                val region = when (offer?.planId) {
                     MONTHLY_PLAN_ROW -> SubscriptionRegion.ROW
                     MONTHLY_PLAN_US -> SubscriptionRegion.US
                     else -> null

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/settings/views/ProSettingViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/settings/views/ProSettingViewModel.kt
@@ -27,6 +27,8 @@ import com.duckduckgo.subscriptions.api.SubscriptionStatus
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.UNKNOWN
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.MONTHLY_PLAN_ROW
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.MONTHLY_PLAN_US
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.YEARLY_PLAN_ROW
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.YEARLY_PLAN_US
 import com.duckduckgo.subscriptions.impl.SubscriptionsManager
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixelSender
 import com.duckduckgo.subscriptions.impl.settings.views.ProSettingViewModel.Command.OpenBuyScreen
@@ -90,8 +92,8 @@ class ProSettingViewModel @Inject constructor(
             .onEach { subscriptionStatus ->
                 val offer = subscriptionsManager.getSubscriptionOffer().firstOrNull()
                 val region = when (offer?.planId) {
-                    MONTHLY_PLAN_ROW -> SubscriptionRegion.ROW
-                    MONTHLY_PLAN_US -> SubscriptionRegion.US
+                    MONTHLY_PLAN_ROW, YEARLY_PLAN_ROW -> SubscriptionRegion.ROW
+                    MONTHLY_PLAN_US, YEARLY_PLAN_US -> SubscriptionRegion.US
                     else -> null
                 }
                 _viewState.emit(viewState.value.copy(status = subscriptionStatus, region = region))

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
@@ -37,6 +37,7 @@ import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.LEGACY_FE_ITR
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.LEGACY_FE_NETP
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.LEGACY_FE_PIR
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.MONTHLY
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.MONTHLY_FREE_TRIAL_OFFER_US
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.MONTHLY_PLAN_ROW
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.MONTHLY_PLAN_US
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.NETP
@@ -44,6 +45,7 @@ import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.PIR
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.PLATFORM
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.ROW_ITR
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.YEARLY
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.YEARLY_FREE_TRIAL_OFFER_US
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.YEARLY_PLAN_ROW
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.YEARLY_PLAN_US
 import com.duckduckgo.subscriptions.impl.SubscriptionsManager
@@ -297,17 +299,16 @@ class SubscriptionWebViewViewModel @Inject constructor(
 
         return OptionsJson(
             id = offer.planId,
-            cost = CostJson(displayPrice = offer.pricingPhases.first().formattedPrice, recurrence = recurrence),
+            cost = CostJson(displayPrice = offerDisplayPrice, recurrence = recurrence),
             offer = getOfferJson(offer),
         )
     }
 
     private fun getOfferJson(offer: SubscriptionOffer): OfferJson? {
         return offer.offerId?.let {
-            val offerType = if (offer.pricingPhases.first().formattedPrice == "Free") {
-                OfferType.FREE_TRIAL
-            } else {
-                OfferType.UNKNOWN
+            val offerType = when (offer.offerId) {
+                MONTHLY_FREE_TRIAL_OFFER_US, YEARLY_FREE_TRIAL_OFFER_US -> OfferType.FREE_TRIAL
+                else -> OfferType.UNKNOWN
             }
 
             OfferJson(

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
@@ -312,7 +312,7 @@ class SubscriptionWebViewViewModel @Inject constructor(
             }
 
             OfferJson(
-                type = offerType,
+                type = offerType.type,
                 id = it,
                 durationInDays = offer.pricingPhases.first().getBillingPeriodInDays(),
                 isUserEligible = true, // TODO Noelia: Need to check if they already had a free trial before to return false
@@ -358,7 +358,7 @@ class SubscriptionWebViewViewModel @Inject constructor(
     )
 
     data class OfferJson(
-        val type: OfferType,
+        val type: String,
         val id: String,
         val durationInDays: Int?,
         val isUserEligible: Boolean,

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
@@ -247,8 +247,7 @@ class SubscriptionWebViewViewModel @Inject constructor(
                             subscriptionOffers.getValue(MONTHLY_PLAN_US) to subscriptionOffers.getValue(YEARLY_PLAN_US)
                         }
 
-                        subscriptionOffers.keys.containsAll(listOf(MONTHLY_PLAN_ROW, YEARLY_PLAN_ROW)) &&
-                            privacyProFeature.isLaunchedROW().isEnabled() -> {
+                        subscriptionOffers.keys.containsAll(listOf(MONTHLY_PLAN_ROW, YEARLY_PLAN_ROW)) -> {
                             subscriptionOffers.getValue(MONTHLY_PLAN_ROW) to subscriptionOffers.getValue(YEARLY_PLAN_ROW)
                         }
 

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
@@ -314,7 +314,6 @@ class SubscriptionWebViewViewModel @Inject constructor(
             OfferJson(
                 type = offerType,
                 id = it,
-                displayPrice = offer.pricingPhases.first().formattedPrice,
                 durationInDays = offer.pricingPhases.first().getBillingPeriodInDays(),
                 isUserEligible = true, // TODO Noelia: Need to check if they already had a free trial before to return false
             )
@@ -361,7 +360,6 @@ class SubscriptionWebViewViewModel @Inject constructor(
     data class OfferJson(
         val type: OfferType,
         val id: String,
-        val displayPrice: String,
         val durationInDays: Int?,
         val isUserEligible: Boolean,
     )

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
@@ -79,6 +79,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -1159,7 +1160,6 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
     @Test
     fun whenGetSubscriptionOfferAndRowPlansAvailableThenReturnValue() = runTest {
         authRepository.setFeatures(MONTHLY_PLAN_ROW, setOf(NETP))
-        authRepository.setFeatures(YEARLY_PLAN_ROW, setOf(NETP))
         givenPlansAvailable(MONTHLY_PLAN_ROW, YEARLY_PLAN_ROW)
         givenIsLaunchedRow(true)
 
@@ -1526,9 +1526,12 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         val productDetails: ProductDetails = mock { productDetails ->
             whenever(productDetails.productId).thenReturn(SubscriptionsConstants.BASIC_SUBSCRIPTION)
 
-            val pricingPhaseList: List<PricingPhase> = listOf(
-                mock { pricingPhase -> whenever(pricingPhase.formattedPrice).thenReturn("1$") },
-            )
+            val mockPricingPhase: PricingPhase = mock {
+                on { formattedPrice } doReturn "1$"
+                on { billingPeriod } doReturn "P1M"
+            }
+
+            val pricingPhaseList: List<PricingPhase> = listOf(mockPricingPhase)
 
             val pricingPhases: PricingPhases = mock { pricingPhases ->
                 whenever(pricingPhases.pricingPhaseList).thenReturn(pricingPhaseList)
@@ -1536,6 +1539,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
 
             val offers = basePlanIds.map { basePlanId ->
                 mock<SubscriptionOfferDetails> { offer ->
+                    whenever(offer.basePlanId).thenReturn(basePlanId)
                     whenever(offer.basePlanId).thenReturn(basePlanId)
                     whenever(offer.pricingPhases).thenReturn(pricingPhases)
                 }

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
@@ -1160,6 +1160,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
     @Test
     fun whenGetSubscriptionOfferAndRowPlansAvailableThenReturnValue() = runTest {
         authRepository.setFeatures(MONTHLY_PLAN_ROW, setOf(NETP))
+        authRepository.setFeatures(YEARLY_PLAN_ROW, setOf(NETP))
         givenPlansAvailable(MONTHLY_PLAN_ROW, YEARLY_PLAN_ROW)
         givenIsLaunchedRow(true)
 

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
@@ -1133,6 +1133,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
     @Test
     fun whenGetSubscriptionOfferThenReturnValue() = runTest {
         authRepository.setFeatures(MONTHLY_PLAN_US, setOf(NETP))
+        authRepository.setFeatures(YEARLY_PLAN_US, setOf(NETP))
         givenPlansAvailable(MONTHLY_PLAN_US, YEARLY_PLAN_US)
 
         val subscriptionOffers = subscriptionsManager.getSubscriptionOffer()
@@ -1147,16 +1148,18 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
     }
 
     @Test
-    fun whenGetSubscriptionOfferAndNoFeaturesThenReturnNull() = runTest {
+    fun whenGetSubscriptionOfferAndNoFeaturesThenReturnEmptyList() = runTest {
         authRepository.setFeatures(MONTHLY_PLAN_US, emptySet())
+        authRepository.setFeatures(YEARLY_PLAN_US, emptySet())
         givenPlansAvailable(MONTHLY_PLAN_US, YEARLY_PLAN_US)
 
-        assertNull(subscriptionsManager.getSubscriptionOffer())
+        assertEquals(emptyList<SubscriptionOfferDetails>(), subscriptionsManager.getSubscriptionOffer())
     }
 
     @Test
     fun whenGetSubscriptionOfferAndRowPlansAvailableThenReturnValue() = runTest {
         authRepository.setFeatures(MONTHLY_PLAN_ROW, setOf(NETP))
+        authRepository.setFeatures(YEARLY_PLAN_ROW, setOf(NETP))
         givenPlansAvailable(MONTHLY_PLAN_ROW, YEARLY_PLAN_ROW)
         givenIsLaunchedRow(true)
 
@@ -1172,12 +1175,13 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
     }
 
     @Test
-    fun whenGetSubscriptionAndRowPlansAvailableAndFeatureDisabledThenReturnNull() = runTest {
-        authRepository.setFeatures(MONTHLY_PLAN_US, emptySet())
+    fun whenGetSubscriptionAndRowPlansAvailableAndFeatureDisabledThenReturnEmptyList() = runTest {
+        authRepository.setFeatures(MONTHLY_PLAN_ROW, setOf(NETP))
+        authRepository.setFeatures(YEARLY_PLAN_ROW, setOf(NETP))
         givenPlansAvailable(MONTHLY_PLAN_ROW, YEARLY_PLAN_ROW)
         givenIsLaunchedRow(false)
 
-        assertNull(subscriptionsManager.getSubscriptionOffer())
+        assertEquals(emptyList<SubscriptionOfferDetails>(), subscriptionsManager.getSubscriptionOffer())
     }
 
     @Test

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
@@ -1541,7 +1541,6 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
             val offers = basePlanIds.map { basePlanId ->
                 mock<SubscriptionOfferDetails> { offer ->
                     whenever(offer.basePlanId).thenReturn(basePlanId)
-                    whenever(offer.basePlanId).thenReturn(basePlanId)
                     whenever(offer.pricingPhases).thenReturn(pricingPhases)
                 }
             }

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsTest.kt
@@ -64,7 +64,7 @@ class RealSubscriptionsTest {
     private lateinit var subscriptions: RealSubscriptions
 
     private val testSubscriptionOfferList = listOf(
-        SubscriptionOfferDetails(
+        SubscriptionOffer(
             planId = "test",
             offerId = null,
             pricingPhases = emptyList(),

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsTest.kt
@@ -34,7 +34,10 @@ import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixelSender
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionsWebViewActivityWithParams
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -60,9 +63,19 @@ class RealSubscriptionsTest {
     private val pixel: SubscriptionPixelSender = mock()
     private lateinit var subscriptions: RealSubscriptions
 
+    private val testSubscriptionOfferList = listOf(
+        SubscriptionOfferDetails(
+            planId = "test",
+            offerId = null,
+            pricingPhases = emptyList(),
+            features = setOf(SubscriptionsConstants.NETP),
+        ),
+    )
+
     @Before
     fun before() = runTest {
         whenever(mockSubscriptionsManager.canSupportEncryption()).thenReturn(true)
+        whenever(mockSubscriptionsManager.getSubscriptionOffer()).thenReturn(emptyList())
         subscriptions = RealSubscriptions(mockSubscriptionsManager, globalActivityStarter, pixel)
     }
 
@@ -104,36 +117,25 @@ class RealSubscriptionsTest {
     @Test
     fun whenIsEligibleIfOffersReturnedThenReturnTrueRegardlessOfStatus() = runTest {
         whenever(mockSubscriptionsManager.subscriptionStatus()).thenReturn(UNKNOWN)
-        whenever(mockSubscriptionsManager.getSubscriptionOffer()).thenReturn(
-            SubscriptionOffer(
-                monthlyPlanId = "test",
-                yearlyFormattedPrice = "test",
-                yearlyPlanId = "test",
-                monthlyFormattedPrice = "test",
-                features = setOf(SubscriptionsConstants.NETP),
-            ),
-        )
+        whenever(mockSubscriptionsManager.getSubscriptionOffer()).thenReturn(testSubscriptionOfferList)
         assertTrue(subscriptions.isEligible())
     }
 
     @Test
     fun whenIsEligibleIfNotOffersReturnedThenReturnFalseIfNotActiveOrWaiting() = runTest {
         whenever(mockSubscriptionsManager.subscriptionStatus()).thenReturn(UNKNOWN)
-        whenever(mockSubscriptionsManager.getSubscriptionOffer()).thenReturn(null)
         assertFalse(subscriptions.isEligible())
     }
 
     @Test
     fun whenIsEligibleIfNotOffersReturnedThenReturnTrueIfWaiting() = runTest {
         whenever(mockSubscriptionsManager.subscriptionStatus()).thenReturn(WAITING)
-        whenever(mockSubscriptionsManager.getSubscriptionOffer()).thenReturn(null)
         assertTrue(subscriptions.isEligible())
     }
 
     @Test
     fun whenIsEligibleIfNotOffersReturnedThenReturnTrueIfActive() = runTest {
         whenever(mockSubscriptionsManager.subscriptionStatus()).thenReturn(AUTO_RENEWABLE)
-        whenever(mockSubscriptionsManager.getSubscriptionOffer()).thenReturn(null)
         assertTrue(subscriptions.isEligible())
     }
 
@@ -141,15 +143,7 @@ class RealSubscriptionsTest {
     fun whenIsEligibleIfNotEncryptionThenReturnTrueIfActive() = runTest {
         whenever(mockSubscriptionsManager.canSupportEncryption()).thenReturn(false)
         whenever(mockSubscriptionsManager.subscriptionStatus()).thenReturn(AUTO_RENEWABLE)
-        whenever(mockSubscriptionsManager.getSubscriptionOffer()).thenReturn(
-            SubscriptionOffer(
-                monthlyPlanId = "test",
-                yearlyFormattedPrice = "test",
-                yearlyPlanId = "test",
-                monthlyFormattedPrice = "test",
-                features = setOf(SubscriptionsConstants.NETP),
-            ),
-        )
+        whenever(mockSubscriptionsManager.getSubscriptionOffer()).thenReturn(testSubscriptionOfferList)
         assertTrue(subscriptions.isEligible())
     }
 
@@ -157,29 +151,13 @@ class RealSubscriptionsTest {
     fun whenIsEligibleIfNotEncryptionAndNotActiveThenReturnFalse() = runTest {
         whenever(mockSubscriptionsManager.canSupportEncryption()).thenReturn(false)
         whenever(mockSubscriptionsManager.subscriptionStatus()).thenReturn(UNKNOWN)
-        whenever(mockSubscriptionsManager.getSubscriptionOffer()).thenReturn(
-            SubscriptionOffer(
-                monthlyPlanId = "test",
-                yearlyFormattedPrice = "test",
-                yearlyPlanId = "test",
-                monthlyFormattedPrice = "test",
-                features = setOf(SubscriptionsConstants.NETP),
-            ),
-        )
+        whenever(mockSubscriptionsManager.getSubscriptionOffer()).thenReturn(testSubscriptionOfferList)
         assertFalse(subscriptions.isEligible())
     }
 
     @Test
     fun whenShouldLaunchPrivacyProForUrlThenReturnCorrectValue() = runTest {
-        whenever(mockSubscriptionsManager.getSubscriptionOffer()).thenReturn(
-            SubscriptionOffer(
-                monthlyPlanId = "test",
-                yearlyFormattedPrice = "test",
-                yearlyPlanId = "test",
-                monthlyFormattedPrice = "test",
-                features = setOf(SubscriptionsConstants.NETP),
-            ),
-        )
+        whenever(mockSubscriptionsManager.getSubscriptionOffer()).thenReturn(testSubscriptionOfferList)
         whenever(mockSubscriptionsManager.subscriptionStatus()).thenReturn(UNKNOWN)
 
         assertTrue(subscriptions.shouldLaunchPrivacyProForUrl("https://duckduckgo.com/pro"))
@@ -194,15 +172,7 @@ class RealSubscriptionsTest {
 
     @Test
     fun whenShouldLaunchPrivacyProForUrlThenReturnTrue() = runTest {
-        whenever(mockSubscriptionsManager.getSubscriptionOffer()).thenReturn(
-            SubscriptionOffer(
-                monthlyPlanId = "test",
-                yearlyFormattedPrice = "test",
-                yearlyPlanId = "test",
-                monthlyFormattedPrice = "test",
-                features = setOf(SubscriptionsConstants.NETP),
-            ),
-        )
+        whenever(mockSubscriptionsManager.getSubscriptionOffer()).thenReturn(testSubscriptionOfferList)
         whenever(mockSubscriptionsManager.subscriptionStatus()).thenReturn(UNKNOWN)
 
         assertTrue(subscriptions.shouldLaunchPrivacyProForUrl("https://duckduckgo.com/pro"))

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/settings/views/LegacyProSettingViewModelTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/settings/views/LegacyProSettingViewModelTest.kt
@@ -62,6 +62,7 @@ class LegacyProSettingViewModelTest {
     @Test
     fun whenOnResumeEmitViewState() = runTest {
         whenever(subscriptionsManager.subscriptionStatus).thenReturn(flowOf(SubscriptionStatus.EXPIRED))
+        whenever(subscriptionsManager.getSubscriptionOffer()).thenReturn(emptyList())
 
         viewModel.onCreate(mock())
         viewModel.viewState.test {

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/settings/views/ProSettingViewModelTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/settings/views/ProSettingViewModelTest.kt
@@ -62,6 +62,7 @@ class ProSettingViewModelTest {
     @Test
     fun whenOnResumeEmitViewState() = runTest {
         whenever(subscriptionsManager.subscriptionStatus).thenReturn(flowOf(SubscriptionStatus.EXPIRED))
+        whenever(subscriptionsManager.getSubscriptionOffer()).thenReturn(emptyList())
 
         viewModel.onCreate(mock())
         viewModel.viewState.test {

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModelTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModelTest.kt
@@ -17,7 +17,7 @@ import com.duckduckgo.subscriptions.impl.CurrentPurchase
 import com.duckduckgo.subscriptions.impl.JSONObjectAdapter
 import com.duckduckgo.subscriptions.impl.PricingPhase
 import com.duckduckgo.subscriptions.impl.PrivacyProFeature
-import com.duckduckgo.subscriptions.impl.SubscriptionOfferDetails
+import com.duckduckgo.subscriptions.impl.SubscriptionOffer
 import com.duckduckgo.subscriptions.impl.SubscriptionsChecker
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.MONTHLY_PLAN_US
@@ -200,16 +200,16 @@ class SubscriptionWebViewViewModelTest {
     @Test
     fun whenGetSubscriptionOptionsThenSendCommand() = runTest {
         val testSubscriptionOfferList = listOf(
-            SubscriptionOfferDetails(
+            SubscriptionOffer(
                 planId = MONTHLY_PLAN_US,
                 offerId = null,
-                pricingPhases = listOf(PricingPhase(formattedPrice = "$1")),
+                pricingPhases = listOf(PricingPhase(formattedPrice = "$1", billingPeriod = "P1M")),
                 features = setOf(SubscriptionsConstants.NETP),
             ),
-            SubscriptionOfferDetails(
+            SubscriptionOffer(
                 planId = YEARLY_PLAN_US,
                 offerId = null,
-                pricingPhases = listOf(PricingPhase(formattedPrice = "$10")),
+                pricingPhases = listOf(PricingPhase(formattedPrice = "$10", billingPeriod = "P1Y")),
                 features = setOf(SubscriptionsConstants.NETP),
             ),
         )
@@ -256,16 +256,16 @@ class SubscriptionWebViewViewModelTest {
     @Test
     fun whenGetSubscriptionsAndToggleOffThenSendCommandWithEmptyData() = runTest {
         val testSubscriptionOfferList = listOf(
-            SubscriptionOfferDetails(
+            SubscriptionOffer(
                 planId = MONTHLY_PLAN_US,
                 offerId = null,
-                pricingPhases = listOf(PricingPhase(formattedPrice = "$1")),
+                pricingPhases = listOf(PricingPhase(formattedPrice = "$1", billingPeriod = "P1M")),
                 features = setOf(SubscriptionsConstants.NETP),
             ),
-            SubscriptionOfferDetails(
+            SubscriptionOffer(
                 planId = YEARLY_PLAN_US,
                 offerId = null,
-                pricingPhases = listOf(PricingPhase(formattedPrice = "$10")),
+                pricingPhases = listOf(PricingPhase(formattedPrice = "$10", billingPeriod = "P1Y")),
                 features = setOf(SubscriptionsConstants.NETP),
             ),
         )

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModelTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModelTest.kt
@@ -234,6 +234,7 @@ class SubscriptionWebViewViewModelTest {
     @Test
     fun whenGetSubscriptionsAndNoSubscriptionOfferThenSendCommandWithEmptyData() = runTest {
         privacyProFeature.allowPurchase().setRawStoredState(Toggle.State(enable = true))
+        whenever(subscriptionsManager.getSubscriptionOffer()).thenReturn(emptyList())
 
         viewModel.commands().test {
             viewModel.processJsCallbackMessage("test", "getSubscriptionOptions", "id", JSONObject("{}"))

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModelTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModelTest.kt
@@ -15,8 +15,9 @@ import com.duckduckgo.subscriptions.api.SubscriptionStatus.INACTIVE
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.UNKNOWN
 import com.duckduckgo.subscriptions.impl.CurrentPurchase
 import com.duckduckgo.subscriptions.impl.JSONObjectAdapter
+import com.duckduckgo.subscriptions.impl.PricingPhase
 import com.duckduckgo.subscriptions.impl.PrivacyProFeature
-import com.duckduckgo.subscriptions.impl.SubscriptionOffer
+import com.duckduckgo.subscriptions.impl.SubscriptionOfferDetails
 import com.duckduckgo.subscriptions.impl.SubscriptionsChecker
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants
 import com.duckduckgo.subscriptions.impl.SubscriptionsManager
@@ -196,17 +197,22 @@ class SubscriptionWebViewViewModelTest {
 
     @Test
     fun whenGetSubscriptionOptionsThenSendCommand() = runTest {
-        privacyProFeature.allowPurchase().setRawStoredState(Toggle.State(enable = true))
-
-        whenever(subscriptionsManager.getSubscriptionOffer()).thenReturn(
-            SubscriptionOffer(
-                monthlyPlanId = "monthly",
-                monthlyFormattedPrice = "$1",
-                yearlyPlanId = "yearly",
-                yearlyFormattedPrice = "$10",
+        val testSubscriptionOfferList = listOf(
+            SubscriptionOfferDetails(
+                planId = "monthly",
+                offerId = null,
+                pricingPhases = listOf(PricingPhase(formattedPrice = "$1")),
+                features = setOf(SubscriptionsConstants.NETP),
+            ),
+            SubscriptionOfferDetails(
+                planId = "yearly",
+                offerId = null,
+                pricingPhases = listOf(PricingPhase(formattedPrice = "$10")),
                 features = setOf(SubscriptionsConstants.NETP),
             ),
         )
+        privacyProFeature.allowPurchase().setRawStoredState(Toggle.State(enable = true))
+        whenever(subscriptionsManager.getSubscriptionOffer()).thenReturn(testSubscriptionOfferList)
 
         viewModel.commands().test {
             viewModel.processJsCallbackMessage("test", "getSubscriptionOptions", "id", JSONObject("{}"))
@@ -246,16 +252,22 @@ class SubscriptionWebViewViewModelTest {
 
     @Test
     fun whenGetSubscriptionsAndToggleOffThenSendCommandWithEmptyData() = runTest {
-        privacyProFeature.allowPurchase().setRawStoredState(Toggle.State(enable = false))
-        whenever(subscriptionsManager.getSubscriptionOffer()).thenReturn(
-            SubscriptionOffer(
-                monthlyPlanId = "monthly",
-                monthlyFormattedPrice = "$1",
-                yearlyPlanId = "yearly",
-                yearlyFormattedPrice = "$10",
+        val testSubscriptionOfferList = listOf(
+            SubscriptionOfferDetails(
+                planId = "monthly",
+                offerId = null,
+                pricingPhases = listOf(PricingPhase(formattedPrice = "$1")),
+                features = setOf(SubscriptionsConstants.NETP),
+            ),
+            SubscriptionOfferDetails(
+                planId = "yearly",
+                offerId = null,
+                pricingPhases = listOf(PricingPhase(formattedPrice = "$10")),
                 features = setOf(SubscriptionsConstants.NETP),
             ),
         )
+        privacyProFeature.allowPurchase().setRawStoredState(Toggle.State(enable = false))
+        whenever(subscriptionsManager.getSubscriptionOffer()).thenReturn(testSubscriptionOfferList)
 
         viewModel.commands().test {
             viewModel.processJsCallbackMessage("test", "getSubscriptionOptions", "id", JSONObject("{}"))

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModelTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModelTest.kt
@@ -20,6 +20,8 @@ import com.duckduckgo.subscriptions.impl.PrivacyProFeature
 import com.duckduckgo.subscriptions.impl.SubscriptionOfferDetails
 import com.duckduckgo.subscriptions.impl.SubscriptionsChecker
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.MONTHLY_PLAN_US
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.YEARLY_PLAN_US
 import com.duckduckgo.subscriptions.impl.SubscriptionsManager
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixelSender
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command
@@ -199,20 +201,20 @@ class SubscriptionWebViewViewModelTest {
     fun whenGetSubscriptionOptionsThenSendCommand() = runTest {
         val testSubscriptionOfferList = listOf(
             SubscriptionOfferDetails(
-                planId = "monthly",
+                planId = MONTHLY_PLAN_US,
                 offerId = null,
                 pricingPhases = listOf(PricingPhase(formattedPrice = "$1")),
                 features = setOf(SubscriptionsConstants.NETP),
             ),
             SubscriptionOfferDetails(
-                planId = "yearly",
+                planId = YEARLY_PLAN_US,
                 offerId = null,
                 pricingPhases = listOf(PricingPhase(formattedPrice = "$10")),
                 features = setOf(SubscriptionsConstants.NETP),
             ),
         )
-        privacyProFeature.allowPurchase().setRawStoredState(Toggle.State(enable = true))
         whenever(subscriptionsManager.getSubscriptionOffer()).thenReturn(testSubscriptionOfferList)
+        privacyProFeature.allowPurchase().setRawStoredState(Toggle.State(enable = true))
 
         viewModel.commands().test {
             viewModel.processJsCallbackMessage("test", "getSubscriptionOptions", "id", JSONObject("{}"))
@@ -224,8 +226,8 @@ class SubscriptionWebViewViewModelTest {
             assertEquals("id", response.id)
             assertEquals("test", response.featureName)
             assertEquals("getSubscriptionOptions", response.method)
-            assertEquals("yearly", params?.options?.first()?.id)
-            assertEquals("monthly", params?.options?.last()?.id)
+            assertEquals(YEARLY_PLAN_US, params?.options?.first()?.id)
+            assertEquals(MONTHLY_PLAN_US, params?.options?.last()?.id)
         }
     }
 
@@ -254,13 +256,13 @@ class SubscriptionWebViewViewModelTest {
     fun whenGetSubscriptionsAndToggleOffThenSendCommandWithEmptyData() = runTest {
         val testSubscriptionOfferList = listOf(
             SubscriptionOfferDetails(
-                planId = "monthly",
+                planId = MONTHLY_PLAN_US,
                 offerId = null,
                 pricingPhases = listOf(PricingPhase(formattedPrice = "$1")),
                 features = setOf(SubscriptionsConstants.NETP),
             ),
             SubscriptionOfferDetails(
-                planId = "yearly",
+                planId = YEARLY_PLAN_US,
                 offerId = null,
                 pricingPhases = listOf(PricingPhase(formattedPrice = "$10")),
                 features = setOf(SubscriptionsConstants.NETP),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201807753394693/1209007672205184/f

### Description
Update some subscriptions models in order to support free trials on mobile:

- `SubscriptionOffer` model
- `OptionsJson` model
- `getSubscriptionOffer()` method

### Steps to test this PR
_Pre steps_
- [x] Apply patch to being able to test subscriptions in staging

_Privacy Pro Eligible US_
- [x] Make sure you are US eligible
- [x] Install form branch
- [x] Check browser works as expected
- [x] Go to Settings
- [x] Check you can see Privacy Pro option
- [x] Tap on that option
- [x] Check Subscription page looks as expected
- [x] Purchase any of the options and check it works well
- [x] Go to Subscription Settings
- [x] Check everything works as expected

_Privacy Pro Eligible ROW (Optional)_
- [x] Make sure you are ROW eligible
- [x] Install form branch
- [x] Check browser works as expected
- [x] Go to Settings
- [x] Check you can see Privacy Pro option
- [x] Tap on that option
- [x] Check Subscription page looks as expected
- [x] Purchase any of the options and check it works well
- [x] Go to Subscription Settings
- [x] Check everything works as expected

_Privacy Pro No Eligible_
- [x] Install form branch
- [x] Check browser works as expected
- [x] Go to Settings
- [x] Check you can't see Privacy Pro option

### No UI changes
