### PR TITLE
Wrap maestro UI tests inside a retry command

### DIFF
--- a/.github/workflows/end-to-end-robintest.yml
+++ b/.github/workflows/end-to-end-robintest.yml
@@ -116,3 +116,14 @@ jobs:
           app-file: apk/release.apk
           android-api-level: 33
           workspace: .maestro/notifications_permissions_android13_plus
+
+      - name: Create Asana task when workflow failed
+        if: ${{ failure() }}
+        uses: honeycombio/gha-create-asana-task@main
+        with:
+          asana-secret: ${{ secrets.GH_ASANA_SECRET }}
+          asana-workspace-id: ${{ secrets.GH_ASANA_WORKSPACE_ID }}
+          asana-project-id: ${{ secrets.GH_ASANA_AOR_PROJECT_ID }}
+          asana-section-id: ${{ secrets.GH_ASANA_INCOMING_ID }}
+          asana-task-name: GH Workflow Failure - End to end tests (Robin)
+          asana-task-description: The end to end workflow has failed. See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}

--- a/.maestro/ad_click_detection_flows/10_-_m.js_bing-provided_ad_domain_provided_but_incorrect_dsl_not_needed.yaml
+++ b/.maestro/ad_click_detection_flows/10_-_m.js_bing-provided_ad_domain_provided_but_incorrect_dsl_not_needed.yaml
@@ -2,49 +2,52 @@ appId: com.duckduckgo.mobile.android
 tags:
   - adClickTest
 ---
-- launchApp:
-    clearState: true
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
 
-- runFlow: ../shared/onboarding.yaml
+      - runFlow: ../shared/onboarding.yaml
 
-- inputText: "https://www.search-company.site/#ad-id-10"
-- pressKey: Enter
-- assertVisible:
-    text: ".*Got It.*"
-- tapOn:
-    text: "Got It"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/fireIconMenu"
-- tapOn:
-    text: "Cancel"
-- assertVisible:
-    id: "ad-id-10"
-- tapOn:
-    id: "ad-id-10"
-- assertVisible:
-    text: "Publisher site"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "We did not identify any requests from third-party domains."
-- assertVisible:
-    text: "About our Web Tracking Protections"
+      - inputText: "https://www.search-company.site/#ad-id-10"
+      - pressKey: Enter
+      - assertVisible:
+          text: ".*Got It.*"
+      - tapOn:
+          text: "Got It"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/fireIconMenu"
+      - tapOn:
+          text: "Cancel"
+      - assertVisible:
+          id: "ad-id-10"
+      - tapOn:
+          id: "ad-id-10"
+      - assertVisible:
+          text: "Publisher site"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+      - assertVisible:
+          text: "View Tracker Companies"
+      - tapOn:
+          text: "View Tracker Companies"
+      - assertVisible:
+          text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+      - assertVisible:
+          text: "About our Web Tracking Protections"
+      - assertVisible:
+          text: ".*Ad Company"
+      - assertVisible:
+          text: "convert.ad-company.site"
+      - assertVisible:
+          text: "ad-company.site"
+      - action: back
+      - assertVisible:
+          text: "View Non-Tracker Companies"
+      - tapOn:
+          text: "View Non-Tracker Companies"
+      - assertVisible:
+          text: "We did not identify any requests from third-party domains."
+      - assertVisible:
+          text: "About our Web Tracking Protections"

--- a/.maestro/ad_click_detection_flows/11_-_y.js_bing-provided_ad_domain_provided_but_it's_not_a_domain_i.e.,_abcedf_u3_not_needed.yaml
+++ b/.maestro/ad_click_detection_flows/11_-_y.js_bing-provided_ad_domain_provided_but_it's_not_a_domain_i.e.,_abcedf_u3_not_needed.yaml
@@ -2,55 +2,58 @@ appId: com.duckduckgo.mobile.android
 tags:
   - adClickTest
 ---
-- launchApp:
-    clearState: true
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
 
-- runFlow: ../shared/onboarding.yaml
+      - runFlow: ../shared/onboarding.yaml
 
-- inputText: "https://www.search-company.site/#ad-id-11"
-- pressKey: Enter
-- assertVisible:
-    text: ".*Got It.*"
-- tapOn:
-    text: "Got It"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/fireIconMenu"
-- tapOn:
-    text: "Cancel"
-- assertVisible:
-    id: "ad-id-11"
-- tapOn:
-    id: "ad-id-11"
-- assertVisible:
-    text: "Publisher site"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
-- assertVisible:
-    text: "How our search ads impact our protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
+      - inputText: "https://www.search-company.site/#ad-id-11"
+      - pressKey: Enter
+      - assertVisible:
+          text: ".*Got It.*"
+      - tapOn:
+          text: "Got It"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/fireIconMenu"
+      - tapOn:
+          text: "Cancel"
+      - assertVisible:
+          id: "ad-id-11"
+      - tapOn:
+          id: "ad-id-11"
+      - assertVisible:
+          text: "Publisher site"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+      - assertVisible:
+          text: "View Tracker Companies"
+      - tapOn:
+          text: "View Tracker Companies"
+      - assertVisible:
+          text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+      - assertVisible:
+          text: "About our Web Tracking Protections"
+      - assertVisible:
+          text: ".*Ad Company"
+      - assertVisible:
+          text: "ad-company.site"
+      - action: back
+      - assertVisible:
+          text: "View Non-Tracker Companies"
+      - tapOn:
+          text: "View Non-Tracker Companies"
+      - assertVisible:
+          text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
+      - assertVisible:
+          text: "About our Web Tracking Protections"
+      - assertVisible:
+          text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
+      - assertVisible:
+          text: "How our search ads impact our protections"
+      - assertVisible:
+          text: ".*Ad Company"
+      - assertVisible:
+          text: "convert.ad-company.site"

--- a/.maestro/ad_click_detection_flows/12_-_m.js_bing-provided_ad_domain_provided_but_it's_not_a_domain_i.e.,_abcedf__dsl_not_needed.yaml
+++ b/.maestro/ad_click_detection_flows/12_-_m.js_bing-provided_ad_domain_provided_but_it's_not_a_domain_i.e.,_abcedf__dsl_not_needed.yaml
@@ -2,55 +2,58 @@ appId: com.duckduckgo.mobile.android
 tags:
   - adClickTest
 ---
-- launchApp:
-    clearState: true
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
 
-- runFlow: ../shared/onboarding.yaml
+      - runFlow: ../shared/onboarding.yaml
 
-- inputText: "https://www.search-company.site/#ad-id-12"
-- pressKey: Enter
-- assertVisible:
-    text: ".*Got It.*"
-- tapOn:
-    text: "Got It"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/fireIconMenu"
-- tapOn:
-    text: "Cancel"
-- assertVisible:
-    id: "ad-id-12"
-- tapOn:
-    id: "ad-id-12"
-- assertVisible:
-    text: "Publisher site"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
-- assertVisible:
-    text: "How our search ads impact our protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
+      - inputText: "https://www.search-company.site/#ad-id-12"
+      - pressKey: Enter
+      - assertVisible:
+          text: ".*Got It.*"
+      - tapOn:
+          text: "Got It"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/fireIconMenu"
+      - tapOn:
+          text: "Cancel"
+      - assertVisible:
+          id: "ad-id-12"
+      - tapOn:
+          id: "ad-id-12"
+      - assertVisible:
+          text: "Publisher site"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+      - assertVisible:
+          text: "View Tracker Companies"
+      - tapOn:
+          text: "View Tracker Companies"
+      - assertVisible:
+          text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+      - assertVisible:
+          text: "About our Web Tracking Protections"
+      - assertVisible:
+          text: ".*Ad Company"
+      - assertVisible:
+          text: "ad-company.site"
+      - action: back
+      - assertVisible:
+          text: "View Non-Tracker Companies"
+      - tapOn:
+          text: "View Non-Tracker Companies"
+      - assertVisible:
+          text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
+      - assertVisible:
+          text: "About our Web Tracking Protections"
+      - assertVisible:
+          text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
+      - assertVisible:
+          text: "How our search ads impact our protections"
+      - assertVisible:
+          text: ".*Ad Company"
+      - assertVisible:
+          text: "convert.ad-company.site"

--- a/.maestro/ad_click_detection_flows/13_-_y.js_bing-provided_ad_domain_provided_but_it's_a_subdomain_of_advertiser_i.e.,_foo.www.search-company-site_u3_not_needed.yaml
+++ b/.maestro/ad_click_detection_flows/13_-_y.js_bing-provided_ad_domain_provided_but_it's_a_subdomain_of_advertiser_i.e.,_foo.www.search-company-site_u3_not_needed.yaml
@@ -2,55 +2,58 @@ appId: com.duckduckgo.mobile.android
 tags:
   - adClickTest
 ---
-- launchApp:
-    clearState: true
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
 
-- runFlow: ../shared/onboarding.yaml
+      - runFlow: ../shared/onboarding.yaml
 
-- inputText: "https://www.search-company.site/#ad-id-13"
-- pressKey: Enter
-- assertVisible:
-    text: ".*Got It.*"
-- tapOn:
-    text: "Got It"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/fireIconMenu"
-- tapOn:
-    text: "Cancel"
-- assertVisible:
-    id: "ad-id-13"
-- tapOn:
-    id: "ad-id-13"
-- assertVisible:
-    text: "Publisher site"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
-- assertVisible:
-    text: "How our search ads impact our protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
+      - inputText: "https://www.search-company.site/#ad-id-13"
+      - pressKey: Enter
+      - assertVisible:
+          text: ".*Got It.*"
+      - tapOn:
+          text: "Got It"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/fireIconMenu"
+      - tapOn:
+          text: "Cancel"
+      - assertVisible:
+          id: "ad-id-13"
+      - tapOn:
+          id: "ad-id-13"
+      - assertVisible:
+          text: "Publisher site"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+      - assertVisible:
+          text: "View Tracker Companies"
+      - tapOn:
+          text: "View Tracker Companies"
+      - assertVisible:
+          text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+      - assertVisible:
+          text: "About our Web Tracking Protections"
+      - assertVisible:
+          text: ".*Ad Company"
+      - assertVisible:
+          text: "ad-company.site"
+      - action: back
+      - assertVisible:
+          text: "View Non-Tracker Companies"
+      - tapOn:
+          text: "View Non-Tracker Companies"
+      - assertVisible:
+          text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
+      - assertVisible:
+          text: "About our Web Tracking Protections"
+      - assertVisible:
+          text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
+      - assertVisible:
+          text: "How our search ads impact our protections"
+      - assertVisible:
+          text: ".*Ad Company"
+      - assertVisible:
+          text: "convert.ad-company.site"

--- a/.maestro/ad_click_detection_flows/14_-_m.js_bing-provided_ad_domain_provided_but_it's_a_subdomain_of_advertiser_i.e.,_foo.www.search-company-site__dsl_not_needed.yaml
+++ b/.maestro/ad_click_detection_flows/14_-_m.js_bing-provided_ad_domain_provided_but_it's_a_subdomain_of_advertiser_i.e.,_foo.www.search-company-site__dsl_not_needed.yaml
@@ -2,55 +2,58 @@ appId: com.duckduckgo.mobile.android
 tags:
   - adClickTest
 ---
-- launchApp:
-    clearState: true
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
 
-- runFlow: ../shared/onboarding.yaml
+      - runFlow: ../shared/onboarding.yaml
 
-- inputText: "https://www.search-company.site/#ad-id-14"
-- pressKey: Enter
-- assertVisible:
-    text: ".*Got It.*"
-- tapOn:
-    text: "Got It"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/fireIconMenu"
-- tapOn:
-    text: "Cancel"
-- assertVisible:
-    id: "ad-id-14"
-- tapOn:
-    id: "ad-id-14"
-- assertVisible:
-    text: "Publisher site"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
-- assertVisible:
-    text: "How our search ads impact our protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
+      - inputText: "https://www.search-company.site/#ad-id-14"
+      - pressKey: Enter
+      - assertVisible:
+          text: ".*Got It.*"
+      - tapOn:
+          text: "Got It"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/fireIconMenu"
+      - tapOn:
+          text: "Cancel"
+      - assertVisible:
+          id: "ad-id-14"
+      - tapOn:
+          id: "ad-id-14"
+      - assertVisible:
+          text: "Publisher site"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+      - assertVisible:
+          text: "View Tracker Companies"
+      - tapOn:
+          text: "View Tracker Companies"
+      - assertVisible:
+          text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+      - assertVisible:
+          text: "About our Web Tracking Protections"
+      - assertVisible:
+          text: ".*Ad Company"
+      - assertVisible:
+          text: "ad-company.site"
+      - action: back
+      - assertVisible:
+          text: "View Non-Tracker Companies"
+      - tapOn:
+          text: "View Non-Tracker Companies"
+      - assertVisible:
+          text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
+      - assertVisible:
+          text: "About our Web Tracking Protections"
+      - assertVisible:
+          text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
+      - assertVisible:
+          text: "How our search ads impact our protections"
+      - assertVisible:
+          text: ".*Ad Company"
+      - assertVisible:
+          text: "convert.ad-company.site"

--- a/.maestro/ad_click_detection_flows/1_-_y.js_heuristic_no_ad_domain_param_u3_param_included_1_1_1.yaml
+++ b/.maestro/ad_click_detection_flows/1_-_y.js_heuristic_no_ad_domain_param_u3_param_included_1_1_1.yaml
@@ -2,49 +2,52 @@ appId: com.duckduckgo.mobile.android
 tags:
   - adClickTest
 ---
-- launchApp:
-    clearState: true
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
 
-- runFlow: ../shared/onboarding.yaml
+      - runFlow: ../shared/onboarding.yaml
 
-- inputText: "https://www.search-company.site/#ad-id-1"
-- pressKey: Enter
-- assertVisible:
-    text: ".*Got It.*"
-- tapOn:
-    text: "Got It"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/fireIconMenu"
-- tapOn:
-    text: "Cancel"
-- assertVisible:
-    id: "ad-id-1"
-- tapOn:
-    id: "ad-id-1"
-- assertVisible:
-    text: "Publisher site"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "We did not identify any requests from third-party domains."
-- assertVisible:
-    text: "About our Web Tracking Protections"
+      - inputText: "https://www.search-company.site/#ad-id-1"
+      - pressKey: Enter
+      - assertVisible:
+          text: ".*Got It.*"
+      - tapOn:
+          text: "Got It"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/fireIconMenu"
+      - tapOn:
+          text: "Cancel"
+      - assertVisible:
+          id: "ad-id-1"
+      - tapOn:
+          id: "ad-id-1"
+      - assertVisible:
+          text: "Publisher site"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+      - assertVisible:
+          text: "View Tracker Companies"
+      - tapOn:
+          text: "View Tracker Companies"
+      - assertVisible:
+          text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+      - assertVisible:
+          text: "About our Web Tracking Protections"
+      - assertVisible:
+          text: ".*Ad Company"
+      - assertVisible:
+          text: "convert.ad-company.site"
+      - assertVisible:
+          text: "ad-company.site"
+      - action: back
+      - assertVisible:
+          text: "View Non-Tracker Companies"
+      - tapOn:
+          text: "View Non-Tracker Companies"
+      - assertVisible:
+          text: "We did not identify any requests from third-party domains."
+      - assertVisible:
+          text: "About our Web Tracking Protections"

--- a/.maestro/ad_click_detection_flows/2_-_m.js_heuristic_no_ad_domain_param_dsl_param_included_1_1.yaml
+++ b/.maestro/ad_click_detection_flows/2_-_m.js_heuristic_no_ad_domain_param_dsl_param_included_1_1.yaml
@@ -2,49 +2,52 @@ appId: com.duckduckgo.mobile.android
 tags:
   - adClickTest
 ---
-- launchApp:
-    clearState: true
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
 
-- runFlow: ../shared/onboarding.yaml
+      - runFlow: ../shared/onboarding.yaml
 
-- inputText: "https://www.search-company.site/#ad-id-2"
-- pressKey: Enter
-- assertVisible:
-    text: ".*Got It.*"
-- tapOn:
-    text: "Got It"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/fireIconMenu"
-- tapOn:
-    text: "Cancel"
-- assertVisible:
-    id: "ad-id-2"
-- tapOn:
-    id: "ad-id-2"
-- assertVisible:
-    text: "Publisher site"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "We did not identify any requests from third-party domains."
-- assertVisible:
-    text: "About our Web Tracking Protections"
+      - inputText: "https://www.search-company.site/#ad-id-2"
+      - pressKey: Enter
+      - assertVisible:
+          text: ".*Got It.*"
+      - tapOn:
+          text: "Got It"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/fireIconMenu"
+      - tapOn:
+          text: "Cancel"
+      - assertVisible:
+          id: "ad-id-2"
+      - tapOn:
+          id: "ad-id-2"
+      - assertVisible:
+          text: "Publisher site"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+      - assertVisible:
+          text: "View Tracker Companies"
+      - tapOn:
+          text: "View Tracker Companies"
+      - assertVisible:
+          text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+      - assertVisible:
+          text: "About our Web Tracking Protections"
+      - assertVisible:
+          text: ".*Ad Company"
+      - assertVisible:
+          text: "convert.ad-company.site"
+      - assertVisible:
+          text: "ad-company.site"
+      - action: back
+      - assertVisible:
+          text: "View Non-Tracker Companies"
+      - tapOn:
+          text: "View Non-Tracker Companies"
+      - assertVisible:
+          text: "We did not identify any requests from third-party domains."
+      - assertVisible:
+          text: "About our Web Tracking Protections"

--- a/.maestro/ad_click_detection_flows/3_-_y.js_heuristic_no_ad_domain_param,_but_missing_u3_param_1_1.yaml
+++ b/.maestro/ad_click_detection_flows/3_-_y.js_heuristic_no_ad_domain_param,_but_missing_u3_param_1_1.yaml
@@ -2,49 +2,52 @@ appId: com.duckduckgo.mobile.android
 tags:
   - adClickTest
 ---
-- launchApp:
-    clearState: true
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
 
-- runFlow: ../shared/onboarding.yaml
+      - runFlow: ../shared/onboarding.yaml
 
-- inputText: "https://www.search-company.site/#ad-id-3"
-- pressKey: Enter
-- assertVisible:
-    text: ".*Got It.*"
-- tapOn:
-    text: "Got It"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/fireIconMenu"
-- tapOn:
-    text: "Cancel"
-- assertVisible:
-    id: "ad-id-3"
-- tapOn:
-    id: "ad-id-3"
-- assertVisible:
-    text: "Publisher site"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "We did not identify any requests from third-party domains."
-- assertVisible:
-    text: "About our Web Tracking Protections"
+      - inputText: "https://www.search-company.site/#ad-id-3"
+      - pressKey: Enter
+      - assertVisible:
+          text: ".*Got It.*"
+      - tapOn:
+          text: "Got It"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/fireIconMenu"
+      - tapOn:
+          text: "Cancel"
+      - assertVisible:
+          id: "ad-id-3"
+      - tapOn:
+          id: "ad-id-3"
+      - assertVisible:
+          text: "Publisher site"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+      - assertVisible:
+          text: "View Tracker Companies"
+      - tapOn:
+          text: "View Tracker Companies"
+      - assertVisible:
+          text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+      - assertVisible:
+          text: "About our Web Tracking Protections"
+      - assertVisible:
+          text: ".*Ad Company"
+      - assertVisible:
+          text: "convert.ad-company.site"
+      - assertVisible:
+          text: "ad-company.site"
+      - action: back
+      - assertVisible:
+          text: "View Non-Tracker Companies"
+      - tapOn:
+          text: "View Non-Tracker Companies"
+      - assertVisible:
+          text: "We did not identify any requests from third-party domains."
+      - assertVisible:
+          text: "About our Web Tracking Protections"

--- a/.maestro/ad_click_detection_flows/4_-_m.js_heuristic_no_ad_domain_param,_but_missing_dsl_param_1_1.yaml
+++ b/.maestro/ad_click_detection_flows/4_-_m.js_heuristic_no_ad_domain_param,_but_missing_dsl_param_1_1.yaml
@@ -2,49 +2,52 @@ appId: com.duckduckgo.mobile.android
 tags:
   - adClickTest
 ---
-- launchApp:
-    clearState: true
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
 
-- runFlow: ../shared/onboarding.yaml
+      - runFlow: ../shared/onboarding.yaml
 
-- inputText: "https://www.search-company.site/#ad-id-4"
-- pressKey: Enter
-- assertVisible:
-    text: ".*Got It.*"
-- tapOn:
-    text: "Got It"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/fireIconMenu"
-- tapOn:
-    text: "Cancel"
-- assertVisible:
-    id: "ad-id-4"
-- tapOn:
-    id: "ad-id-4"
-- assertVisible:
-    text: "Publisher site"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "We did not identify any requests from third-party domains."
-- assertVisible:
-    text: "About our Web Tracking Protections"
+      - inputText: "https://www.search-company.site/#ad-id-4"
+      - pressKey: Enter
+      - assertVisible:
+          text: ".*Got It.*"
+      - tapOn:
+          text: "Got It"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/fireIconMenu"
+      - tapOn:
+          text: "Cancel"
+      - assertVisible:
+          id: "ad-id-4"
+      - tapOn:
+          id: "ad-id-4"
+      - assertVisible:
+          text: "Publisher site"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+      - assertVisible:
+          text: "View Tracker Companies"
+      - tapOn:
+          text: "View Tracker Companies"
+      - assertVisible:
+          text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+      - assertVisible:
+          text: "About our Web Tracking Protections"
+      - assertVisible:
+          text: ".*Ad Company"
+      - assertVisible:
+          text: "convert.ad-company.site"
+      - assertVisible:
+          text: "ad-company.site"
+      - action: back
+      - assertVisible:
+          text: "View Non-Tracker Companies"
+      - tapOn:
+          text: "View Non-Tracker Companies"
+      - assertVisible:
+          text: "We did not identify any requests from third-party domains."
+      - assertVisible:
+          text: "About our Web Tracking Protections"

--- a/.maestro/ad_click_detection_flows/5_-_y.js_heuristic_ad_domain_provided,_but_empty_u3_not_needed.yaml
+++ b/.maestro/ad_click_detection_flows/5_-_y.js_heuristic_ad_domain_provided,_but_empty_u3_not_needed.yaml
@@ -2,55 +2,58 @@ appId: com.duckduckgo.mobile.android
 tags:
   - adClickTest
 ---
-- launchApp:
-    clearState: true
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
 
-- runFlow: ../shared/onboarding.yaml
+      - runFlow: ../shared/onboarding.yaml
 
-- inputText: "https://www.search-company.site/#ad-id-5"
-- pressKey: Enter
-- assertVisible:
-    text: ".*Got It.*"
-- tapOn:
-    text: "Got It"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/fireIconMenu"
-- tapOn:
-    text: "Cancel"
-- assertVisible:
-    id: "ad-id-5"
-- tapOn:
-    id: "ad-id-5"
-- assertVisible:
-    text: "Publisher site"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
-- assertVisible:
-    text: "How our search ads impact our protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
+      - inputText: "https://www.search-company.site/#ad-id-5"
+      - pressKey: Enter
+      - assertVisible:
+          text: ".*Got It.*"
+      - tapOn:
+          text: "Got It"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/fireIconMenu"
+      - tapOn:
+          text: "Cancel"
+      - assertVisible:
+          id: "ad-id-5"
+      - tapOn:
+          id: "ad-id-5"
+      - assertVisible:
+          text: "Publisher site"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+      - assertVisible:
+          text: "View Tracker Companies"
+      - tapOn:
+          text: "View Tracker Companies"
+      - assertVisible:
+          text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+      - assertVisible:
+          text: "About our Web Tracking Protections"
+      - assertVisible:
+          text: ".*Ad Company"
+      - assertVisible:
+          text: "ad-company.site"
+      - action: back
+      - assertVisible:
+          text: "View Non-Tracker Companies"
+      - tapOn:
+          text: "View Non-Tracker Companies"
+      - assertVisible:
+          text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
+      - assertVisible:
+          text: "About our Web Tracking Protections"
+      - assertVisible:
+          text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
+      - assertVisible:
+          text: "How our search ads impact our protections"
+      - assertVisible:
+          text: ".*Ad Company"
+      - assertVisible:
+          text: "convert.ad-company.site"

--- a/.maestro/ad_click_detection_flows/6_-_m.js_heuristic_ad_domain_provided,_but_empty_dsl_not_needed.yaml
+++ b/.maestro/ad_click_detection_flows/6_-_m.js_heuristic_ad_domain_provided,_but_empty_dsl_not_needed.yaml
@@ -2,49 +2,52 @@ appId: com.duckduckgo.mobile.android
 tags:
   - adClickTest
 ---
-- launchApp:
-    clearState: true
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
 
-- runFlow: ../shared/onboarding.yaml
+      - runFlow: ../shared/onboarding.yaml
 
-- inputText: "https://www.search-company.site/#ad-id-6"
-- pressKey: Enter
-- assertVisible:
-    text: ".*Got It.*"
-- assertVisible:
-    id: "ad-id-6"
-- tapOn:
-    id: "ad-id-6"
-- assertVisible:
-    text: "Publisher site"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
-- assertVisible:
-    text: "How our search ads impact our protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
+      - inputText: "https://www.search-company.site/#ad-id-6"
+      - pressKey: Enter
+      - assertVisible:
+          text: ".*Got It.*"
+      - assertVisible:
+          id: "ad-id-6"
+      - tapOn:
+          id: "ad-id-6"
+      - assertVisible:
+          text: "Publisher site"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+      - assertVisible:
+          text: "View Tracker Companies"
+      - tapOn:
+          text: "View Tracker Companies"
+      - assertVisible:
+          text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+      - assertVisible:
+          text: "About our Web Tracking Protections"
+      - assertVisible:
+          text: ".*Ad Company"
+      - assertVisible:
+          text: "ad-company.site"
+      - action: back
+      - assertVisible:
+          text: "View Non-Tracker Companies"
+      - tapOn:
+          text: "View Non-Tracker Companies"
+      - assertVisible:
+          text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
+      - assertVisible:
+          text: "About our Web Tracking Protections"
+      - assertVisible:
+          text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
+      - assertVisible:
+          text: "How our search ads impact our protections"
+      - assertVisible:
+          text: ".*Ad Company"
+      - assertVisible:
+          text: "convert.ad-company.site"

--- a/.maestro/ad_click_detection_flows/7_-_y.js_bing-provided_ad_domain_provided_u3_not_needed.yaml
+++ b/.maestro/ad_click_detection_flows/7_-_y.js_bing-provided_ad_domain_provided_u3_not_needed.yaml
@@ -2,55 +2,58 @@ appId: com.duckduckgo.mobile.android
 tags:
   - adClickTest
 ---
-- launchApp:
-    clearState: true
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
 
-- runFlow: ../shared/onboarding.yaml
+      - runFlow: ../shared/onboarding.yaml
 
-- inputText: "https://www.search-company.site/#ad-id-6" # scroll until the ad-id-6 instead of ad-id-7 (context: https://app.asana.com/0/0/1204397066248823/1204415854211764/f)
-- pressKey: Enter
-- assertVisible:
-    text: ".*Got It.*"
-- tapOn:
-    text: "Got It"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/fireIconMenu"
-- tapOn:
-    text: "Cancel"
-- assertVisible:
-    id: "ad-id-7"
-- tapOn:
-    id: "ad-id-7"
-- assertVisible:
-    text: "Publisher site"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
-- assertVisible:
-    text: "How our search ads impact our protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
+      - inputText: "https://www.search-company.site/#ad-id-6" # scroll until the ad-id-6 instead of ad-id-7 (context: https://app.asana.com/0/0/1204397066248823/1204415854211764/f)
+      - pressKey: Enter
+      - assertVisible:
+          text: ".*Got It.*"
+      - tapOn:
+          text: "Got It"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/fireIconMenu"
+      - tapOn:
+          text: "Cancel"
+      - assertVisible:
+          id: "ad-id-7"
+      - tapOn:
+          id: "ad-id-7"
+      - assertVisible:
+          text: "Publisher site"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+      - assertVisible:
+          text: "View Tracker Companies"
+      - tapOn:
+          text: "View Tracker Companies"
+      - assertVisible:
+          text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+      - assertVisible:
+          text: "About our Web Tracking Protections"
+      - assertVisible:
+          text: ".*Ad Company"
+      - assertVisible:
+          text: "ad-company.site"
+      - action: back
+      - assertVisible:
+          text: "View Non-Tracker Companies"
+      - tapOn:
+          text: "View Non-Tracker Companies"
+      - assertVisible:
+          text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
+      - assertVisible:
+          text: "About our Web Tracking Protections"
+      - assertVisible:
+          text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
+      - assertVisible:
+          text: "How our search ads impact our protections"
+      - assertVisible:
+          text: ".*Ad Company"
+      - assertVisible:
+          text: "convert.ad-company.site"

--- a/.maestro/ad_click_detection_flows/8_-_m.js_bing-provided_ad_domain_provided_dsl_not_needed.yaml
+++ b/.maestro/ad_click_detection_flows/8_-_m.js_bing-provided_ad_domain_provided_dsl_not_needed.yaml
@@ -2,55 +2,58 @@ appId: com.duckduckgo.mobile.android
 tags:
   - adClickTest
 ---
-- launchApp:
-    clearState: true
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
 
-- runFlow: ../shared/onboarding.yaml
+      - runFlow: ../shared/onboarding.yaml
 
-- inputText: "https://www.search-company.site/#ad-id-8"
-- pressKey: Enter
-- assertVisible:
-    text: ".*Got It.*"
-- tapOn:
-    text: "Got It"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/fireIconMenu"
-- tapOn:
-    text: "Cancel"
-- assertVisible:
-    id: "ad-id-8"
-- tapOn:
-    id: "ad-id-8"
-- assertVisible:
-    text: "Publisher site"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
-- assertVisible:
-    text: "How our search ads impact our protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
+      - inputText: "https://www.search-company.site/#ad-id-8"
+      - pressKey: Enter
+      - assertVisible:
+          text: ".*Got It.*"
+      - tapOn:
+          text: "Got It"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/fireIconMenu"
+      - tapOn:
+          text: "Cancel"
+      - assertVisible:
+          id: "ad-id-8"
+      - tapOn:
+          id: "ad-id-8"
+      - assertVisible:
+          text: "Publisher site"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+      - assertVisible:
+          text: "View Tracker Companies"
+      - tapOn:
+          text: "View Tracker Companies"
+      - assertVisible:
+          text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+      - assertVisible:
+          text: "About our Web Tracking Protections"
+      - assertVisible:
+          text: ".*Ad Company"
+      - assertVisible:
+          text: "ad-company.site"
+      - action: back
+      - assertVisible:
+          text: "View Non-Tracker Companies"
+      - tapOn:
+          text: "View Non-Tracker Companies"
+      - assertVisible:
+          text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
+      - assertVisible:
+          text: "About our Web Tracking Protections"
+      - assertVisible:
+          text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
+      - assertVisible:
+          text: "How our search ads impact our protections"
+      - assertVisible:
+          text: ".*Ad Company"
+      - assertVisible:
+          text: "convert.ad-company.site"

--- a/.maestro/ad_click_detection_flows/9_-_y.js_bing-provided_ad_domain_provided_but_incorrect_u3_not_needed.yaml
+++ b/.maestro/ad_click_detection_flows/9_-_y.js_bing-provided_ad_domain_provided_but_incorrect_u3_not_needed.yaml
@@ -2,49 +2,52 @@ appId: com.duckduckgo.mobile.android
 tags:
   - adClickTest
 ---
-- launchApp:
-    clearState: true
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
 
-- runFlow: ../shared/onboarding.yaml
+      - runFlow: ../shared/onboarding.yaml
 
-- inputText: "https://www.search-company.site/#ad-id-9"
-- pressKey: Enter
-- assertVisible:
-    text: ".*Got It.*"
-- tapOn:
-    text: "Got It"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/fireIconMenu"
-- tapOn:
-    text: "Cancel"
-- assertVisible:
-    id: "ad-id-9"
-- tapOn:
-    id: "ad-id-9"
-- assertVisible:
-    text: "Publisher site"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "We did not identify any requests from third-party domains."
-- assertVisible:
-    text: "About our Web Tracking Protections"
+      - inputText: "https://www.search-company.site/#ad-id-9"
+      - pressKey: Enter
+      - assertVisible:
+          text: ".*Got It.*"
+      - tapOn:
+          text: "Got It"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/fireIconMenu"
+      - tapOn:
+          text: "Cancel"
+      - assertVisible:
+          id: "ad-id-9"
+      - tapOn:
+          id: "ad-id-9"
+      - assertVisible:
+          text: "Publisher site"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+      - assertVisible:
+          text: "View Tracker Companies"
+      - tapOn:
+          text: "View Tracker Companies"
+      - assertVisible:
+          text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+      - assertVisible:
+          text: "About our Web Tracking Protections"
+      - assertVisible:
+          text: ".*Ad Company"
+      - assertVisible:
+          text: "convert.ad-company.site"
+      - assertVisible:
+          text: "ad-company.site"
+      - action: back
+      - assertVisible:
+          text: "View Non-Tracker Companies"
+      - tapOn:
+          text: "View Non-Tracker Companies"
+      - assertVisible:
+          text: "We did not identify any requests from third-party domains."
+      - assertVisible:
+          text: "About our Web Tracking Protections"

--- a/.maestro/ads_preview_flows/1-_design-system-components.yaml
+++ b/.maestro/ads_preview_flows/1-_design-system-components.yaml
@@ -2,114 +2,117 @@ appId: com.duckduckgo.mobile.android
 tags:
     - androidDesignSystemTest
 ---
-- launchApp:
-    clearState: true
-    stopApp: true
+- retry:
+      maxRetries: 3
+      commands:
+        - launchApp:
+            clearState: true
+            stopApp: true
 
-- runFlow: ../shared/onboarding.yaml
+        - runFlow: ../shared/onboarding.yaml
 
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
-- tapOn:
-    text: "Settings"
-    index: 0
-- scrollUntilVisible:
-    element:
-      text: "Set of components designed following our Design System"
-    direction: DOWN
-- assertVisible: "Set of components designed following our Design System"
-- tapOn: "Android Design System Preview"
-- assertVisible: "COLOR PALETTE"
-- tapOn: "TYPOGRAPHY"
-- scrollUntilVisible:
-    element:
-      text: "Text Appearance Caption"
-    direction: DOWN
-- tapOn: "BUTTONS"
-- tapOn: "Primary Large"
-- tapOn: "Secondary Small"
-- tapOn: "Destructive Small"
-- tapOn: "TEXT INPUT"
-- tapOn: "DIALOGS"
-- tapOn: "Text Alert Dialog With Image"
-- assertVisible: "Keep Using"
-- tapOn: "Keep Using"
-- tapOn: "Stacked Text Alert Dialog With 4 buttons"
-- assertVisible: "Keep Using"
-- tapOn: "Keep Using"
-- scrollUntilVisible:
-    element:
-      text: "Promo Bottom Sheet with image"
-    direction: DOWN
-- tapOn: "Action Bottom Sheet"
-- assertVisible: "Primary Item"
-- tapOn: "Primary Item"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/actionBottomSheetButtonWithTitle"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/item_container"
-    index: 0
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/promoBottomSheetButtonWithTitle"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/bottomSheetPromoPrimaryButton"
-- scrollUntilVisible:
-    element:
-      text: "Cookie Consent dialog with animation"
-    direction: DOWN
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/animated_button"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/primaryCta"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/no_hide_button"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/primaryCta"
-- tapOn: "LAYOUTS"
-- assertVisible: "Expandable Layout"
-- tapOn: "INTERACTIVE"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/dax_switch_one"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/radio_button_two"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/checkbox_one"
-- tapOn:
-    point: "50%,75%"
-- tapOn: "MESSAGING"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/close"
-    index: 0
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/close"
-    index: 0
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/close"
-    index: 0
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/secondaryActionButton"
-    index: 0
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/primaryActionButton"
-    index: 0
-- tapOn: "LIST ITEMS"
-- scrollUntilVisible:
-    element:
-      text: "With Beta Pill and Switch"
-    direction: DOWN
-- tapOn: "Others"
-- scrollUntilVisible:
-    element:
-      text: "Enable Dark Theme"
-    direction: UP
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/trailingSwitch"
-- tapOn: "Typography"
-- tapOn: "BUTTONS"
-- tapOn: "TEXT INPUT"
-- tapOn: "DIALOGS"
-- tapOn: "LAYOUTS"
-- tapOn: "INTERACTIVE"
-- tapOn: "MESSAGING"
-- tapOn: "LIST ITEMS"
-- tapOn: "OTHERS"
+        - tapOn:
+            id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+        - tapOn:
+            text: "Settings"
+            index: 0
+        - scrollUntilVisible:
+            element:
+              text: "Set of components designed following our Design System"
+            direction: DOWN
+        - assertVisible: "Set of components designed following our Design System"
+        - tapOn: "Android Design System Preview"
+        - assertVisible: "COLOR PALETTE"
+        - tapOn: "TYPOGRAPHY"
+        - scrollUntilVisible:
+            element:
+              text: "Text Appearance Caption"
+            direction: DOWN
+        - tapOn: "BUTTONS"
+        - tapOn: "Primary Large"
+        - tapOn: "Secondary Small"
+        - tapOn: "Destructive Small"
+        - tapOn: "TEXT INPUT"
+        - tapOn: "DIALOGS"
+        - tapOn: "Text Alert Dialog With Image"
+        - assertVisible: "Keep Using"
+        - tapOn: "Keep Using"
+        - tapOn: "Stacked Text Alert Dialog With 4 buttons"
+        - assertVisible: "Keep Using"
+        - tapOn: "Keep Using"
+        - scrollUntilVisible:
+            element:
+              text: "Promo Bottom Sheet with image"
+            direction: DOWN
+        - tapOn: "Action Bottom Sheet"
+        - assertVisible: "Primary Item"
+        - tapOn: "Primary Item"
+        - tapOn:
+            id: "com.duckduckgo.mobile.android:id/actionBottomSheetButtonWithTitle"
+        - tapOn:
+            id: "com.duckduckgo.mobile.android:id/item_container"
+            index: 0
+        - tapOn:
+            id: "com.duckduckgo.mobile.android:id/promoBottomSheetButtonWithTitle"
+        - tapOn:
+            id: "com.duckduckgo.mobile.android:id/bottomSheetPromoPrimaryButton"
+        - scrollUntilVisible:
+            element:
+              text: "Cookie Consent dialog with animation"
+            direction: DOWN
+        - tapOn:
+            id: "com.duckduckgo.mobile.android:id/animated_button"
+        - tapOn:
+            id: "com.duckduckgo.mobile.android:id/primaryCta"
+        - tapOn:
+            id: "com.duckduckgo.mobile.android:id/no_hide_button"
+        - tapOn:
+            id: "com.duckduckgo.mobile.android:id/primaryCta"
+        - tapOn: "LAYOUTS"
+        - assertVisible: "Expandable Layout"
+        - tapOn: "INTERACTIVE"
+        - tapOn:
+            id: "com.duckduckgo.mobile.android:id/dax_switch_one"
+        - tapOn:
+            id: "com.duckduckgo.mobile.android:id/radio_button_two"
+        - tapOn:
+            id: "com.duckduckgo.mobile.android:id/checkbox_one"
+        - tapOn:
+            point: "50%,75%"
+        - tapOn: "MESSAGING"
+        - tapOn:
+            id: "com.duckduckgo.mobile.android:id/close"
+            index: 0
+        - tapOn:
+            id: "com.duckduckgo.mobile.android:id/close"
+            index: 0
+        - tapOn:
+            id: "com.duckduckgo.mobile.android:id/close"
+            index: 0
+        - tapOn:
+            id: "com.duckduckgo.mobile.android:id/secondaryActionButton"
+            index: 0
+        - tapOn:
+            id: "com.duckduckgo.mobile.android:id/primaryActionButton"
+            index: 0
+        - tapOn: "LIST ITEMS"
+        - scrollUntilVisible:
+            element:
+              text: "With Beta Pill and Switch"
+            direction: DOWN
+        - tapOn: "Others"
+        - scrollUntilVisible:
+            element:
+              text: "Enable Dark Theme"
+            direction: UP
+        - tapOn:
+            id: "com.duckduckgo.mobile.android:id/trailingSwitch"
+        - tapOn: "Typography"
+        - tapOn: "BUTTONS"
+        - tapOn: "TEXT INPUT"
+        - tapOn: "DIALOGS"
+        - tapOn: "LAYOUTS"
+        - tapOn: "INTERACTIVE"
+        - tapOn: "MESSAGING"
+        - tapOn: "LIST ITEMS"
+        - tapOn: "OTHERS"

--- a/.maestro/app_tp/app_tp_onboarding.yaml
+++ b/.maestro/app_tp/app_tp_onboarding.yaml
@@ -3,54 +3,57 @@ name: "ReleaseTest: AppTP onboarding"
 tags:
     - releaseTest
 ---
-- launchApp:
-      clearState: true
-      stopApp: true
+- retry:
+      maxRetries: 3
+      commands:
+        - launchApp:
+              clearState: true
+              stopApp: true
 
-- runFlow: ../shared/onboarding.yaml
+        - runFlow: ../shared/onboarding.yaml
 
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
-- tapOn:
-    text: "Settings"
-    index: 0
-- assertVisible: "Block app trackers on your device"
-- tapOn: "App Tracking Protection"
-- assertVisible: "One easy step for better app privacy!"
-- assertVisible: "Continue"
-- tapOn: "Continue"
-- assertVisible: "How does it work?"
-- assertVisible: "Continue"
-- tapOn: "Continue"
-- assertVisible: "Who sees your data?"
-- assertVisible:
-    text: "Enable App Tracking Protection"
-    index: 1
-- tapOn:
-    text: "Enable App Tracking Protection"
-    index: 1
-- tapOn:
-    text: "OK"
-    optional: true
-- assertVisible:
-      text: "Good news! App Tracking Protection is now enabled.*"
-- assertVisible: "Got it!"
-- tapOn: "Got it!"
-- assertVisible:
-    text: "Protection for some apps is automatically disabled. View apps"
-    optional: true
-- assertVisible: "Blocked tracking attempts will appear here"
-- assertVisible:
-    id: "com.duckduckgo.mobile.android:id/activity_apps"
-    index: 0
-- assertVisible:
-    id: "com.duckduckgo.mobile.android:id/activity_apps"
-    index: 1
-- scroll
-- assertVisible: "ABOUT"
-- assertVisible: "What are app trackers?"
-- assertVisible: "App Tracking Protection FAQ"
-- assertVisible: "MANAGE"
-- assertVisible: "Having Issues?"
-- assertVisible: "View Apps"
-- assertVisible: "Disable and Delete Data"
+        - tapOn:
+            id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+        - tapOn:
+            text: "Settings"
+            index: 0
+        - assertVisible: "Block app trackers on your device"
+        - tapOn: "App Tracking Protection"
+        - assertVisible: "One easy step for better app privacy!"
+        - assertVisible: "Continue"
+        - tapOn: "Continue"
+        - assertVisible: "How does it work?"
+        - assertVisible: "Continue"
+        - tapOn: "Continue"
+        - assertVisible: "Who sees your data?"
+        - assertVisible:
+            text: "Enable App Tracking Protection"
+            index: 1
+        - tapOn:
+            text: "Enable App Tracking Protection"
+            index: 1
+        - tapOn:
+            text: "OK"
+            optional: true
+        - assertVisible:
+              text: "Good news! App Tracking Protection is now enabled.*"
+        - assertVisible: "Got it!"
+        - tapOn: "Got it!"
+        - assertVisible:
+            text: "Protection for some apps is automatically disabled. View apps"
+            optional: true
+        - assertVisible: "Blocked tracking attempts will appear here"
+        - assertVisible:
+            id: "com.duckduckgo.mobile.android:id/activity_apps"
+            index: 0
+        - assertVisible:
+            id: "com.duckduckgo.mobile.android:id/activity_apps"
+            index: 1
+        - scroll
+        - assertVisible: "ABOUT"
+        - assertVisible: "What are app trackers?"
+        - assertVisible: "App Tracking Protection FAQ"
+        - assertVisible: "MANAGE"
+        - assertVisible: "Having Issues?"
+        - assertVisible: "View Apps"
+        - assertVisible: "Disable and Delete Data"

--- a/.maestro/autofill/0_all.yaml
+++ b/.maestro/autofill/0_all.yaml
@@ -6,7 +6,6 @@ name: "Autofill: Run all tests"
 
 - launchApp:
     clearState: true
-- runFlow: ../shared/onboarding.yaml
 - runFlow: 1_autofill_shown_in_overflow.yaml
 - runFlow: 2_autofill_add_search_update_delete_creds.yaml
 - runFlow: 3_autofill_prompted_to_save_creds_on_form.yaml

--- a/.maestro/autofill/1_autofill_shown_in_overflow.yaml
+++ b/.maestro/autofill/1_autofill_shown_in_overflow.yaml
@@ -5,7 +5,10 @@ tags:
 ---
 # Pre-requisite: None (can be run whether auth is required or not)
 
-- launchApp:
-      clearState: true
-- runFlow: ../shared/onboarding.yaml
-- runFlow: steps/access_passwords_screen.yaml
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+            clearState: true
+      - runFlow: ../shared/onboarding.yaml
+      - runFlow: steps/access_passwords_screen.yaml

--- a/.maestro/autofill/2_autofill_add_search_update_delete_creds.yaml
+++ b/.maestro/autofill/2_autofill_add_search_update_delete_creds.yaml
@@ -4,101 +4,103 @@ tags:
   - autofillNoAuthTests
 ---
 # Pre-requisite: on an autofill-eligible device
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
+      - runFlow: ../shared/onboarding.yaml
+      - runFlow: steps/access_passwords_screen.yaml
 
-- launchApp:
-    clearState: true
-- runFlow: ../shared/onboarding.yaml
-- runFlow: steps/access_passwords_screen.yaml
+      - assertVisible:
+          text: "No passwords saved yet"
+      - assertNotVisible:
+          id: searchLogins
 
-- assertVisible:
-    text: "No passwords saved yet"
-- assertNotVisible:
-    id: searchLogins
+      - runScript: steps/2_script.js
 
-- runScript: steps/2_script.js
+      - repeat:
+            while:
+                true: ${output.addLogins.counter < output.addLogins.domains.length}
+            commands:
+                - tapOn:
+                        id: addLoginManually
+                - assertVisible:
+                        text: Add Password
+                - assertNotVisible:
+                        id: view_menu_save
 
-- repeat:
-      while:
-          true: ${output.addLogins.counter < output.addLogins.domains.length}
-      commands:
-          - tapOn:
-                  id: addLoginManually
-          - assertVisible:
-                  text: Add Password
-          - assertNotVisible:
-                  id: view_menu_save
+                - scrollUntilVisible:
+                    element:
+                      id: usernameEditText
+                - tapOn:
+                      id: usernameEditText
+                - inputText: "user"
 
-          - scrollUntilVisible:
-              element:
-                id: usernameEditText
-          - tapOn:
-                id: usernameEditText
-          - inputText: "user"
+                - assertVisible:
+                      id: view_menu_save
 
-          - assertVisible:
-                id: view_menu_save
+                - scrollUntilVisible:
+                    element:
+                      id: passwordEditText
+                - tapOn:
+                      id: passwordEditText
+                - inputText: "123"
 
-          - scrollUntilVisible:
-              element:
-                id: passwordEditText
-          - tapOn:
-                id: passwordEditText
-          - inputText: "123"
+                - scrollUntilVisible:
+                    element:
+                      id: domainEditText
+                - tapOn:
+                      id: domainEditText
+                - inputText: "${output.addLogins.domains[output.addLogins.counter]}"
 
-          - scrollUntilVisible:
-              element:
-                id: domainEditText
-          - tapOn:
-                id: domainEditText
-          - inputText: "${output.addLogins.domains[output.addLogins.counter]}"
+                - scrollUntilVisible:
+                    element:
+                      id: notesEditText
+                - tapOn:
+                      id: notesEditText
+                - inputText: "a note"
 
-          - scrollUntilVisible:
-              element:
-                id: notesEditText
-          - tapOn:
-                id: notesEditText
-          - inputText: "a note"
+                - tapOn:
+                      id: view_menu_save
+                      retryTapIfNoChange: false
 
-          - tapOn:
-                id: view_menu_save
-                retryTapIfNoChange: false
+                - scrollUntilVisible:
+                   element:
+                      text: "Last updated.*"
+                - assertVisible: "Last updated.*"
 
-          - scrollUntilVisible:
-             element:
-                text: "Last updated.*"
-          - assertVisible: "Last updated.*"
+                - tapOn: "Navigate up"
 
-          - tapOn: "Navigate up"
+                - assertVisible:
+                      text: "Save and autofill passwords"
+                - evalScript: ${output.addLogins.counter++}
 
-          - assertVisible:
-                text: "Save and autofill passwords"
-          - evalScript: ${output.addLogins.counter++}
+      - scrollUntilVisible:
+          element:
+            text: "#"
+      - assertVisible:
+          text: "#"
 
-- scrollUntilVisible:
-    element:
-      text: "#"
-- assertVisible:
-    text: "#"
+      - scrollUntilVisible:
+          element:
+            text: "a.example.com"
+      - assertVisible:
+          text: "a.example.com"
 
-- scrollUntilVisible:
-    element:
-      text: "a.example.com"
-- assertVisible:
-    text: "a.example.com"
+      - assertNotVisible:
+          text: "https://a.example.com"
 
-- assertNotVisible:
-    text: "https://a.example.com"
+      - scrollUntilVisible:
+          element:
+            text: "fill.dev"
+      - assertVisible:
+          text: "fill.dev"
 
-- scrollUntilVisible:
-    element:
-      text: "fill.dev"
-- assertVisible:
-    text: "fill.dev"
-
-- assertNotVisible:
-    text: "fill.dev/example"
+      - assertNotVisible:
+          text: "fill.dev/example"
 
 
-- runFlow: steps/search_logins.yaml
-- runFlow: steps/manual_update.yaml
-- runFlow: steps/delete_logins.yaml
+      - runFlow: steps/search_logins.yaml
+      - runFlow: steps/manual_update.yaml
+      - runFlow: steps/delete_logins.yaml

--- a/.maestro/autofill/3_autofill_prompted_to_save_creds_on_form.yaml
+++ b/.maestro/autofill/3_autofill_prompted_to_save_creds_on_form.yaml
@@ -4,44 +4,46 @@ tags:
     - autofillNoAuthTestsModernWebView
 ---
 # Pre-requisite: on an autofill-eligible device, including having a modern WebView
+- retry:
+      maxRetries: 3
+      commands:
+        - launchApp:
+              clearState: true
+        - runFlow: ../shared/onboarding.yaml
 
-- launchApp:
-      clearState: true
-- runFlow: ../shared/onboarding.yaml
+        - tapOn:
+            id: "omnibarTextInput"
+        - eraseText
+        - inputText: "fill.dev/form/login-simple"
+        - pressKey: enter
 
-- tapOn:
-    id: "omnibarTextInput"
-- eraseText
-- inputText: "fill.dev/form/login-simple"
-- pressKey: enter
+        - tapOn:
+            text: "Got it"
+            optional: true
 
-- tapOn:
-    text: "Got it"
-    optional: true
+        - tapOn:
+            id: "username"
+        - inputText: "user"
+        - tapOn:
+            id: "password"
+        - inputText: "password1"
+        - tapOn:
+            text: "Login"
+        - assertVisible: "Save Password"
+        - tapOn: "Save Password"
+        - pressKey: back
+        - tapOn: "Close Autofill Dialog"
+        - tapOn:
+            id: "password"
+        - inputText: "password2"
+        - tapOn:
+            text: "Login"
+        - assertVisible: "Update Password"
+        - tapOn: "Update Password"
 
-- tapOn:
-    id: "username"
-- inputText: "user"
-- tapOn:
-    id: "password"
-- inputText: "password1"
-- tapOn:
-    text: "Login"
-- assertVisible: "Save Password"
-- tapOn: "Save Password"
-- pressKey: back
-- tapOn: "Close Autofill Dialog"
-- tapOn:
-    id: "password"
-- inputText: "password2"
-- tapOn:
-    text: "Login"
-- assertVisible: "Update Password"
-- tapOn: "Update Password"
+        - runFlow: steps/access_passwords_screen.yaml
 
-- runFlow: steps/access_passwords_screen.yaml
-
-- tapOn: "user"
-- tapOn:
-    id: "internal_password_icon"
-- assertVisible: "password2"
+        - tapOn: "user"
+        - tapOn:
+            id: "internal_password_icon"
+        - assertVisible: "password2"

--- a/.maestro/autofill/smoke.yaml
+++ b/.maestro/autofill/smoke.yaml
@@ -3,7 +3,9 @@ name: "ReleaseTest: Autofill screen is reachable from overflow menu"
 tags:
     - releaseTest
 ---
-- launchApp:
-    clearState: true
-- runFlow: ../shared/onboarding.yaml
-- runFlow: 1_autofill_shown_in_overflow.yaml
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
+      - runFlow: 1_autofill_shown_in_overflow.yaml

--- a/.maestro/bookmarks/ensure_bookmarks_can_be_added_and_deleted.yaml
+++ b/.maestro/bookmarks/ensure_bookmarks_can_be_added_and_deleted.yaml
@@ -3,41 +3,44 @@ name: "ReleaseTest: Bookmarks can be added and deleted"
 tags:
   - releaseTest
 ---
-- launchApp:
-    clearState: true
-    stopApp: true
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
+          stopApp: true
 
-- runFlow: ../shared/onboarding.yaml
+      - runFlow: ../shared/onboarding.yaml
 
-- tapOn:
-    text: "search or type URL"
-- inputText: "https://privacy-test-pages.site"
-- pressKey: Enter
-- assertVisible:
-    text: ".*keep browsing.*"
-- tapOn:
-    text: "got it"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
-- assertVisible:
-    text: "add bookmark"
-- tapOn:
-    text: "add bookmark"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
-- assertVisible:
-    text: "bookmarks"
-- tapOn:
-    text: "bookmarks"
-- assertVisible:
-    text: "Privacy Test Pages - Home"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/trailingIcon"
-- assertVisible:
-    text: "Delete"
-- tapOn:
-    text: "delete"
-- assertNotVisible:
-    text: "Privacy Test Pages - Home"
-- assertVisible:
-    text: "No bookmarks added yet"
+      - tapOn:
+          text: "search or type URL"
+      - inputText: "https://privacy-test-pages.site"
+      - pressKey: Enter
+      - assertVisible:
+          text: ".*keep browsing.*"
+      - tapOn:
+          text: "got it"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+      - assertVisible:
+          text: "add bookmark"
+      - tapOn:
+          text: "add bookmark"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+      - assertVisible:
+          text: "bookmarks"
+      - tapOn:
+          text: "bookmarks"
+      - assertVisible:
+          text: "Privacy Test Pages - Home"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/trailingIcon"
+      - assertVisible:
+          text: "Delete"
+      - tapOn:
+          text: "delete"
+      - assertNotVisible:
+          text: "Privacy Test Pages - Home"
+      - assertVisible:
+          text: "No bookmarks added yet"

--- a/.maestro/bookmarks/open_bookmark_and_navigate_back.yaml
+++ b/.maestro/bookmarks/open_bookmark_and_navigate_back.yaml
@@ -3,46 +3,49 @@ name: "ReleaseTest: Bookmark open and back navigation"
 tags:
     - releaseTest
 ---
-- launchApp:
-      clearState: true
-      stopApp: true
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+            clearState: true
+            stopApp: true
 
-- runFlow: ../shared/onboarding.yaml
+      - runFlow: ../shared/onboarding.yaml
 
-- tapOn:
-      text: "search or type URL"
-- inputText: "https://www.search-company.site/"
-- pressKey: Enter
-- assertVisible:
-      text: ".*keep browsing.*"
-- tapOn:
-      text: "got it"
-- assertVisible:
-      text: "Search engine"
-- tapOn:
-      text: "https://www.search-company.site/"
-- inputText: "https://privacy-test-pages.site"
-- pressKey: Enter
-- assertVisible:
-      text: "Privacy Test Pages"
-- tapOn:
-      id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
-- assertVisible:
-      text: "add bookmark"
-- tapOn:
-      text: "add bookmark"
-- tapOn:
-      id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
-- assertVisible:
-      text: "bookmarks"
-- tapOn:
-      text: "bookmarks"
-- assertVisible:
-      text: "Privacy Test Pages - Home"
-- tapOn:
-      text: "Privacy Test Pages - Home"
-- assertVisible:
-      text: "Privacy Test Pages"
-- action: back
-- assertVisible:
-      text: "Search engine"
+      - tapOn:
+            text: "search or type URL"
+      - inputText: "https://www.search-company.site/"
+      - pressKey: Enter
+      - assertVisible:
+            text: ".*keep browsing.*"
+      - tapOn:
+            text: "got it"
+      - assertVisible:
+            text: "Search engine"
+      - tapOn:
+            text: "https://www.search-company.site/"
+      - inputText: "https://privacy-test-pages.site"
+      - pressKey: Enter
+      - assertVisible:
+            text: "Privacy Test Pages"
+      - tapOn:
+            id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+      - assertVisible:
+            text: "add bookmark"
+      - tapOn:
+            text: "add bookmark"
+      - tapOn:
+            id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+      - assertVisible:
+            text: "bookmarks"
+      - tapOn:
+            text: "bookmarks"
+      - assertVisible:
+            text: "Privacy Test Pages - Home"
+      - tapOn:
+            text: "Privacy Test Pages - Home"
+      - assertVisible:
+            text: "Privacy Test Pages"
+      - action: back
+      - assertVisible:
+            text: "Search engine"

--- a/.maestro/bookmarks/open_bookmark_in_folder_and_navigate_back.yaml
+++ b/.maestro/bookmarks/open_bookmark_in_folder_and_navigate_back.yaml
@@ -3,158 +3,161 @@ name: "ReleaseTest: Bookmark open in folder and back navigation"
 tags:
     - releaseTest
 ---
-- launchApp:
-      clearState: true
-      stopApp: true
+- retry:
+      maxRetries: 3
+      commands:
+            - launchApp:
+                  clearState: true
+                  stopApp: true
 
-- runFlow: ../shared/onboarding.yaml
+            - runFlow: ../shared/onboarding.yaml
 
-- tapOn:
-      text: "search or type URL"
-- inputText: "https://privacy-test-pages.site/"
-- pressKey: Enter
-- assertVisible:
-      text: ".*keep browsing.*"
-- tapOn:
-      text: "got it"
-- assertVisible:
-      text: "Privacy Test Pages"
-- tapOn:
-      id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
-- assertVisible:
-      text: "add bookmark"
-- tapOn:
-      text: "add bookmark"
-- tapOn:
-      text: "https://privacy-test-pages.site/"
-- inputText: "https://www.search-company.site/"
-- pressKey: Enter
-- assertVisible:
-    text: "Search engine"
-- tapOn:
-      id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
-- assertVisible:
-      text: "bookmarks"
-- tapOn:
-      text: "bookmarks"
-- assertVisible:
-      text: "Privacy Test Pages - Home"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/trailingIcon"
-- assertVisible:
-    text: "Edit"
-- tapOn:
-    text: "edit"
-- assertVisible:
-    text: "Location"
-- assertVisible:
-    text: "Bookmarks"
-- tapOn:
-    text: "bookmarks"
-- assertVisible:
-    text: "Select Location"
-- assertVisible:
-    text: "Bookmarks"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/action_add_folder"
-- assertVisible:
-    text: "Add Folder"
-- assertVisible:
-    text: "Bookmarks"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/titleInput"
-- inputText: "Folder1"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/action_confirm_changes"
-- assertVisible:
-    text: "Select Location"
-- assertVisible:
-    text: "Bookmarks"
-- assertVisible:
-    text: "Folder1"
-- tapOn:
-    text: "Folder1"
-- assertVisible:
-    text: "Edit Bookmark"
-- assertVisible:
-    text: "Folder1"
-- tapOn:
-    text: "Folder1"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/action_add_folder"
-- assertVisible:
-    text: "Add Folder"
-- assertVisible:
-    text: "Bookmarks"
-- inputText: "Folder2"
-- tapOn:
-    text: "Bookmarks"
-- assertVisible:
-    text: "Select Location"
-- assertVisible:
-    text: "Bookmarks"
-- assertVisible:
-    text: "Folder1"
-- tapOn:
-    text: "Folder1"
-- assertVisible:
-    text: "Add Folder"
-- assertVisible:
-    text: "Folder2"
-- assertVisible:
-    text: "Folder1"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/action_confirm_changes"
-- assertVisible:
-    text: "Select Location"
-- assertVisible:
-    text: "Bookmarks"
-- assertVisible:
-    text: "Folder1"
-- tapOn:
-    text: "Folder1"
-- assertVisible:
-    text: "Edit Bookmark"
-- assertVisible:
-    text: "Folder1"
-- tapOn:
-    text: "Folder1"
-- assertVisible:
-    text: "Select Location"
-- assertVisible:
-    text: "Folder1"
-- assertVisible:
-    text: "Folder2"
-- tapOn:
-    text: "Folder2"
-- assertVisible:
-    text: "Edit Bookmark"
-- assertVisible:
-    text: "Folder2"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/action_confirm_changes"
-- assertVisible:
-    text: "Bookmarks"
-- assertVisible:
-    text: "Folder1"
-- assertNotVisible:
-    text: "Privacy Test Pages - Home"
-- tapOn:
-    text: "Folder1"
-- assertVisible:
-    text: "Folder2"
-- tapOn:
-    text: "Folder1"
-- assertVisible:
-    text: "Folder2"
-- tapOn:
-    text: "Folder2"
-- assertVisible:
-    text: "Privacy Test Pages - Home"
-- tapOn:
-    text: "Privacy Test Pages - Home"
-- assertVisible:
-    text: "Privacy Test Pages"
-- action: back
-- assertVisible:
-    text: "Search engine"
+            - tapOn:
+                  text: "search or type URL"
+            - inputText: "https://privacy-test-pages.site/"
+            - pressKey: Enter
+            - assertVisible:
+                  text: ".*keep browsing.*"
+            - tapOn:
+                  text: "got it"
+            - assertVisible:
+                  text: "Privacy Test Pages"
+            - tapOn:
+                  id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+            - assertVisible:
+                  text: "add bookmark"
+            - tapOn:
+                  text: "add bookmark"
+            - tapOn:
+                  text: "https://privacy-test-pages.site/"
+            - inputText: "https://www.search-company.site/"
+            - pressKey: Enter
+            - assertVisible:
+                text: "Search engine"
+            - tapOn:
+                  id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+            - assertVisible:
+                  text: "bookmarks"
+            - tapOn:
+                  text: "bookmarks"
+            - assertVisible:
+                  text: "Privacy Test Pages - Home"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/trailingIcon"
+            - assertVisible:
+                text: "Edit"
+            - tapOn:
+                text: "edit"
+            - assertVisible:
+                text: "Location"
+            - assertVisible:
+                text: "Bookmarks"
+            - tapOn:
+                text: "bookmarks"
+            - assertVisible:
+                text: "Select Location"
+            - assertVisible:
+                text: "Bookmarks"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/action_add_folder"
+            - assertVisible:
+                text: "Add Folder"
+            - assertVisible:
+                text: "Bookmarks"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/titleInput"
+            - inputText: "Folder1"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/action_confirm_changes"
+            - assertVisible:
+                text: "Select Location"
+            - assertVisible:
+                text: "Bookmarks"
+            - assertVisible:
+                text: "Folder1"
+            - tapOn:
+                text: "Folder1"
+            - assertVisible:
+                text: "Edit Bookmark"
+            - assertVisible:
+                text: "Folder1"
+            - tapOn:
+                text: "Folder1"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/action_add_folder"
+            - assertVisible:
+                text: "Add Folder"
+            - assertVisible:
+                text: "Bookmarks"
+            - inputText: "Folder2"
+            - tapOn:
+                text: "Bookmarks"
+            - assertVisible:
+                text: "Select Location"
+            - assertVisible:
+                text: "Bookmarks"
+            - assertVisible:
+                text: "Folder1"
+            - tapOn:
+                text: "Folder1"
+            - assertVisible:
+                text: "Add Folder"
+            - assertVisible:
+                text: "Folder2"
+            - assertVisible:
+                text: "Folder1"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/action_confirm_changes"
+            - assertVisible:
+                text: "Select Location"
+            - assertVisible:
+                text: "Bookmarks"
+            - assertVisible:
+                text: "Folder1"
+            - tapOn:
+                text: "Folder1"
+            - assertVisible:
+                text: "Edit Bookmark"
+            - assertVisible:
+                text: "Folder1"
+            - tapOn:
+                text: "Folder1"
+            - assertVisible:
+                text: "Select Location"
+            - assertVisible:
+                text: "Folder1"
+            - assertVisible:
+                text: "Folder2"
+            - tapOn:
+                text: "Folder2"
+            - assertVisible:
+                text: "Edit Bookmark"
+            - assertVisible:
+                text: "Folder2"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/action_confirm_changes"
+            - assertVisible:
+                text: "Bookmarks"
+            - assertVisible:
+                text: "Folder1"
+            - assertNotVisible:
+                text: "Privacy Test Pages - Home"
+            - tapOn:
+                text: "Folder1"
+            - assertVisible:
+                text: "Folder2"
+            - tapOn:
+                text: "Folder1"
+            - assertVisible:
+                text: "Folder2"
+            - tapOn:
+                text: "Folder2"
+            - assertVisible:
+                text: "Privacy Test Pages - Home"
+            - tapOn:
+                text: "Privacy Test Pages - Home"
+            - assertVisible:
+                text: "Privacy Test Pages"
+            - action: back
+            - assertVisible:
+                text: "Search engine"

--- a/.maestro/browsing/visit_site.yaml
+++ b/.maestro/browsing/visit_site.yaml
@@ -3,19 +3,22 @@ name: "ReleaseTest: General website browsing works"
 tags:
   - releaseTest
 ---
-- launchApp:
-    clearState: true
-    stopApp: true
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
+          stopApp: true
 
-- runFlow: ../shared/onboarding.yaml
+      - runFlow: ../shared/onboarding.yaml
 
-- tapOn:
-    text: "search or type URL"
-- inputText: "https://privacy-test-pages.site"
-- pressKey: Enter
-- assertVisible:
-    text: ".*keep browsing.*"
-- tapOn:
-    text: "got it"
-- assertVisible:
-    text: ".*Privacy Test Pages.*"
+      - tapOn:
+          text: "search or type URL"
+      - inputText: "https://privacy-test-pages.site"
+      - pressKey: Enter
+      - assertVisible:
+          text: ".*keep browsing.*"
+      - tapOn:
+          text: "got it"
+      - assertVisible:
+          text: ".*Privacy Test Pages.*"

--- a/.maestro/custom_tabs/custom_tabs_navigation.yaml
+++ b/.maestro/custom_tabs/custom_tabs_navigation.yaml
@@ -3,66 +3,69 @@ name: "Custom Tabs navigation"
 tags:
   - customTabsTest
 ---
-- launchApp:
-    clearState: true
-    stopApp: true
-
-- assertVisible:
-    text: ".*Ready for a better, more private internet?.*"
-- tapOn: "let's do it!"
-- assertVisible:
-    text: ".*Privacy protections activated.*"
-- tapOn: "choose your browser"
-- runFlow:
-    when:
-      visible: "set as default"
+- retry:
+    maxRetries: 3
     commands:
-      - tapOn: "duckduckgo"
-      - tapOn: "set as default"
-      - assertVisible:
-          text: ".*Awesome! Welcome to the duck side.*"
-      - tapOn: "start browsing"
+      - launchApp:
+          clearState: true
+          stopApp: true
 
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
-- tapOn:
-    text: "settings"
-- scrollUntilVisible:
-    element:
-      text: "developer settings"
-    direction: DOWN
-- tapOn:
-    text: "developer settings"
-- scrollUntilVisible:
-    element:
-      text: "custom tabs"
-    direction: DOWN
-- tapOn:
-    text: "custom tabs"
-- tapOn:
-    text: "add your url here"
-- inputText: "https://www.search-company.site"
-- tapOn:
-    text: "load custom tab"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
-- assertVisible:
-    text: "running in duckduckgo"
-- action: back
-- tapOn:
-    text: "[Ad 1] SERP Ad (heuristic)"
-- action: back
-- tapOn:
-    text: "[Ad 1] SERP Ad (heuristic)"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/backMenuItem"
-- assertVisible:
-    text: "Search engine"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/forwardMenuItem"
-- assertVisible:
-    text: "Publisher site"
+      - assertVisible:
+          text: ".*Ready for a better, more private internet?.*"
+      - tapOn: "let's do it!"
+      - assertVisible:
+          text: ".*Privacy protections activated.*"
+      - tapOn: "choose your browser"
+      - runFlow:
+          when:
+            visible: "set as default"
+          commands:
+            - tapOn: "duckduckgo"
+            - tapOn: "set as default"
+            - assertVisible:
+                text: ".*Awesome! Welcome to the duck side.*"
+            - tapOn: "start browsing"
+
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+      - tapOn:
+          text: "settings"
+      - scrollUntilVisible:
+          element:
+            text: "developer settings"
+          direction: DOWN
+      - tapOn:
+          text: "developer settings"
+      - scrollUntilVisible:
+          element:
+            text: "custom tabs"
+          direction: DOWN
+      - tapOn:
+          text: "custom tabs"
+      - tapOn:
+          text: "add your url here"
+      - inputText: "https://www.search-company.site"
+      - tapOn:
+          text: "load custom tab"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+      - assertVisible:
+          text: "running in duckduckgo"
+      - action: back
+      - tapOn:
+          text: "[Ad 1] SERP Ad (heuristic)"
+      - action: back
+      - tapOn:
+          text: "[Ad 1] SERP Ad (heuristic)"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/backMenuItem"
+      - assertVisible:
+          text: "Search engine"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/forwardMenuItem"
+      - assertVisible:
+          text: "Publisher site"

--- a/.maestro/custom_tabs/custom_tabs_navigation_new_tab.yaml
+++ b/.maestro/custom_tabs/custom_tabs_navigation_new_tab.yaml
@@ -3,72 +3,75 @@ name: "Custom Tabs navigation in new tab"
 tags:
   - customTabsTest
 ---
-- launchApp:
-    clearState: true
-    stopApp: true
-
-- assertVisible:
-    text: ".*Ready for a better, more private internet?.*"
-- tapOn: "let's do it!"
-- assertVisible:
-    text: ".*Privacy protections activated.*"
-- tapOn: "choose your browser"
-- runFlow:
-    when:
-      visible: "set as default"
+- retry:
+    maxRetries: 3
     commands:
-      - tapOn: "duckduckgo"
-      - tapOn: "set as default"
-      - assertVisible:
-          text: ".*Awesome! Welcome to the duck side.*"
-      - tapOn: "start browsing"
+      - launchApp:
+          clearState: true
+          stopApp: true
 
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
-- tapOn:
-    text: "settings"
-- scrollUntilVisible:
-    element:
-      text: "developer settings"
-    direction: DOWN
-- tapOn:
-    text: "developer settings"
-- scrollUntilVisible:
-    element:
-      text: "custom tabs"
-    direction: DOWN
-- tapOn:
-    text: "custom tabs"
-- tapOn:
-    text: "add your url here"
-- inputText: "https://www.search-company.site"
-- tapOn:
-    text: "load custom tab"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
-- assertVisible:
-    text: "running in duckduckgo"
-- action: back
-- tapOn:
-    text: "[Ad 2] Shopping Tab Ad (heuristic)"
-- assertVisible:
-    text: "Publisher site"
-- action: back
-- tapOn:
-    text: "[Ad 2] Shopping Tab Ad (heuristic)"
-- tapOn:
-    text: "Red shoes"
-- assertVisible:
-    text: "Checkout"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/backMenuItem"
-- assertVisible:
-    text: "Red shoes"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/forwardMenuItem"
-- assertVisible:
-    text: "Checkout"
+      - assertVisible:
+          text: ".*Ready for a better, more private internet?.*"
+      - tapOn: "let's do it!"
+      - assertVisible:
+          text: ".*Privacy protections activated.*"
+      - tapOn: "choose your browser"
+      - runFlow:
+          when:
+            visible: "set as default"
+          commands:
+            - tapOn: "duckduckgo"
+            - tapOn: "set as default"
+            - assertVisible:
+                text: ".*Awesome! Welcome to the duck side.*"
+            - tapOn: "start browsing"
+
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+      - tapOn:
+          text: "settings"
+      - scrollUntilVisible:
+          element:
+            text: "developer settings"
+          direction: DOWN
+      - tapOn:
+          text: "developer settings"
+      - scrollUntilVisible:
+          element:
+            text: "custom tabs"
+          direction: DOWN
+      - tapOn:
+          text: "custom tabs"
+      - tapOn:
+          text: "add your url here"
+      - inputText: "https://www.search-company.site"
+      - tapOn:
+          text: "load custom tab"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+      - assertVisible:
+          text: "running in duckduckgo"
+      - action: back
+      - tapOn:
+          text: "[Ad 2] Shopping Tab Ad (heuristic)"
+      - assertVisible:
+          text: "Publisher site"
+      - action: back
+      - tapOn:
+          text: "[Ad 2] Shopping Tab Ad (heuristic)"
+      - tapOn:
+          text: "Red shoes"
+      - assertVisible:
+          text: "Checkout"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/backMenuItem"
+      - assertVisible:
+          text: "Red shoes"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/forwardMenuItem"
+      - assertVisible:
+          text: "Checkout"

--- a/.maestro/favorites/favorites_bookmarks_add.yaml
+++ b/.maestro/favorites/favorites_bookmarks_add.yaml
@@ -3,34 +3,37 @@ name: "ReleaseTest: Can add favorite from bookmark screen"
 tags:
   - releaseTest
 ---
-- launchApp:
-    clearState: true
-    stopApp: true
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
+          stopApp: true
 
-- runFlow: ../shared/onboarding.yaml
+      - runFlow: ../shared/onboarding.yaml
 
-- tapOn:
-    text: "search or type URL"
-- inputText: "https://privacy-test-pages.site"
-- pressKey: Enter
-- assertVisible:
-    text: ".*keep browsing.*"
-- tapOn:
-    text: "got it"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
-- tapOn:
-    text: "add bookmark"
-# Navigate to bookmarks screen
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
-- tapOn:
-    text: "bookmarks"
-# Add favorite from bookmarks screen
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/trailingIcon"
-    index: 0
-- tapOn:
-    text: "add to favorites"
-- assertVisible:
-    id: "com.duckduckgo.mobile.android:id/favoriteStar"
+      - tapOn:
+          text: "search or type URL"
+      - inputText: "https://privacy-test-pages.site"
+      - pressKey: Enter
+      - assertVisible:
+          text: ".*keep browsing.*"
+      - tapOn:
+          text: "got it"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+      - tapOn:
+          text: "add bookmark"
+      # Navigate to bookmarks screen
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+      - tapOn:
+          text: "bookmarks"
+      # Add favorite from bookmarks screen
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/trailingIcon"
+          index: 0
+      - tapOn:
+          text: "add to favorites"
+      - assertVisible:
+          id: "com.duckduckgo.mobile.android:id/favoriteStar"

--- a/.maestro/favorites/favorites_bookmarks_delete.yaml
+++ b/.maestro/favorites/favorites_bookmarks_delete.yaml
@@ -3,53 +3,56 @@ name: "ReleaseTest: Deleting a favorite does not delete bookmark"
 tags:
   - releaseTest
 ---
-- launchApp:
-    clearState: true
-    stopApp: true
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
+          stopApp: true
 
-- runFlow: ../shared/onboarding.yaml
+      - runFlow: ../shared/onboarding.yaml
 
-- tapOn:
-    text: "search or type URL"
-- inputText: "https://privacy-test-pages.site"
-- pressKey: Enter
-- assertVisible:
-    text: ".*keep browsing.*"
-- tapOn:
-    text: "got it"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
-- assertVisible:
-    text: "add bookmark"
-- tapOn:
-    text: "add bookmark"
-# Add favorite from edit saved site
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
-- assertVisible:
-    text: "edit bookmark"
-- tapOn:
-    text: "edit bookmark"
-- assertVisible:
-    text: "add to favorites"
-- tapOn:
-    text: "add to favorites"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/action_confirm_changes"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
-- assertVisible:
-    text: "bookmarks"
-- tapOn:
-    text: "bookmarks"
-# Remove favorite from bookmarks screen
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/trailingIcon"
-    index: 0
-- assertVisible:
-    text: "remove from favorites"
-- tapOn:
-    text: "remove from favorites"
-# When a favorite is removed, it still stays as Bookmark
-- assertVisible:
-    text: "Privacy Test Pages - Home"
+      - tapOn:
+          text: "search or type URL"
+      - inputText: "https://privacy-test-pages.site"
+      - pressKey: Enter
+      - assertVisible:
+          text: ".*keep browsing.*"
+      - tapOn:
+          text: "got it"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+      - assertVisible:
+          text: "add bookmark"
+      - tapOn:
+          text: "add bookmark"
+      # Add favorite from edit saved site
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+      - assertVisible:
+          text: "edit bookmark"
+      - tapOn:
+          text: "edit bookmark"
+      - assertVisible:
+          text: "add to favorites"
+      - tapOn:
+          text: "add to favorites"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/action_confirm_changes"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+      - assertVisible:
+          text: "bookmarks"
+      - tapOn:
+          text: "bookmarks"
+      # Remove favorite from bookmarks screen
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/trailingIcon"
+          index: 0
+      - assertVisible:
+          text: "remove from favorites"
+      - tapOn:
+          text: "remove from favorites"
+      # When a favorite is removed, it still stays as Bookmark
+      - assertVisible:
+          text: "Privacy Test Pages - Home"

--- a/.maestro/fire_button/fire_during_onboarding.yaml
+++ b/.maestro/fire_button/fire_during_onboarding.yaml
@@ -3,27 +3,30 @@ name: "ReleaseTest: Fire button is working"
 tags:
     - releaseTest
 ---
-- launchApp:
-    clearState: true
-    stopApp: true
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
+          stopApp: true
 
-- runFlow: ../shared/onboarding.yaml
+      - runFlow: ../shared/onboarding.yaml
 
-- tapOn:
-    text: "search or type URL"
-- inputText: "https://privacy-test-pages.site"
-- pressKey: Enter
-- assertVisible:
-    text: ".*keep browsing.*"
-- tapOn:
-    text: "got it"
-- assertVisible:
-      text: ".*browsing activity with the fire button.*"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/fireIconImageView"
-- tapOn: "Cancel"
-- assertNotVisible: ".*browsing activity with the Fire Button.*"
-- tapOn:
-      id: "com.duckduckgo.mobile.android:id/fireIconImageView"
-- tapOn: "Clear All Tabs And Data"
-- assertVisible: "You've got this!.*"
+      - tapOn:
+          text: "search or type URL"
+      - inputText: "https://privacy-test-pages.site"
+      - pressKey: Enter
+      - assertVisible:
+          text: ".*keep browsing.*"
+      - tapOn:
+          text: "got it"
+      - assertVisible:
+            text: ".*browsing activity with the fire button.*"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/fireIconImageView"
+      - tapOn: "Cancel"
+      - assertNotVisible: ".*browsing activity with the Fire Button.*"
+      - tapOn:
+            id: "com.duckduckgo.mobile.android:id/fireIconImageView"
+      - tapOn: "Clear All Tabs And Data"
+      - assertVisible: "You've got this!.*"

--- a/.maestro/notifications_permissions_android13_plus/1_-_permissions_allowed.yaml
+++ b/.maestro/notifications_permissions_android13_plus/1_-_permissions_allowed.yaml
@@ -1,33 +1,36 @@
 appId: com.duckduckgo.mobile.android
 ---
-- launchApp:
-    clearState: true
-    stopApp: true
-    permissions: { all: unset }
-- assertVisible:
-    text: ".*Allow DuckDuckGo to send you notifications.*"
-- tapOn: "Allow"
-- assertVisible:
-    text: ".*Welcome to DuckDuckGo!.*"
-    optional: true
-- assertVisible:
-    text: ".*Ready for a better, more private internet?.*"
-- tapOn: "let's do it!"
-- assertVisible:
-    text: ".*Privacy protections activated.*"
-- tapOn: "choose your browser"
-- tapOn: "cancel"
-- assertVisible:
-    text: ".*Try a search!.*"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
-- tapOn:
-    text: "Downloads"
-- assertVisible:
-    text: ".*No files downloaded yet.*"
-- assertNotVisible:
-    text: ".*Find out when downloads are ready.*"
-- assertNotVisible:
-    text: ".*Get a notification when downloads complete.*"
-- assertNotVisible:
-    text: ".*Notify Me.*"
+- retry:
+      maxRetries: 3
+      commands:
+            - launchApp:
+                clearState: true
+                stopApp: true
+                permissions: { all: unset }
+            - assertVisible:
+                text: ".*Allow DuckDuckGo to send you notifications.*"
+            - tapOn: "Allow"
+            - assertVisible:
+                text: ".*Welcome to DuckDuckGo!.*"
+                optional: true
+            - assertVisible:
+                text: ".*Ready for a better, more private internet?.*"
+            - tapOn: "let's do it!"
+            - assertVisible:
+                text: ".*Privacy protections activated.*"
+            - tapOn: "choose your browser"
+            - tapOn: "cancel"
+            - assertVisible:
+                text: ".*Try a search!.*"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+            - tapOn:
+                text: "Downloads"
+            - assertVisible:
+                text: ".*No files downloaded yet.*"
+            - assertNotVisible:
+                text: ".*Find out when downloads are ready.*"
+            - assertNotVisible:
+                text: ".*Get a notification when downloads complete.*"
+            - assertNotVisible:
+                text: ".*Notify Me.*"

--- a/.maestro/notifications_permissions_android13_plus/2_-_permissions_denied.yaml
+++ b/.maestro/notifications_permissions_android13_plus/2_-_permissions_denied.yaml
@@ -1,33 +1,36 @@
 appId: com.duckduckgo.mobile.android
 ---
-- launchApp:
-    clearState: true
-    stopApp: true
-    permissions: { all: unset }
-- assertVisible:
-    text: ".*Allow DuckDuckGo to send you notifications.*"
-- tapOn: "Don’t allow"
-- assertVisible:
-    text: ".*Welcome to DuckDuckGo!.*"
-    optional: true
-- assertVisible:
-    text: ".*Ready for a better, more private internet?.*"
-- tapOn: "let's do it!"
-- assertVisible:
-    text: ".*Privacy protections activated.*"
-- tapOn: "choose your browser"
-- tapOn: "cancel"
-- assertVisible:
-    text: ".*Try a search!.*"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
-- tapOn:
-    text: "Downloads"
-- assertVisible:
-    text: ".*Find out when downloads are ready.*"
-- assertVisible:
-    text: ".*Get a notification when downloads complete.*"
-- assertVisible:
-    text: ".*Notify Me.*"
-- assertVisible:
-    text: ".*No files downloaded yet.*"
+- retry:
+      maxRetries: 3
+      commands:
+            - launchApp:
+                clearState: true
+                stopApp: true
+                permissions: { all: unset }
+            - assertVisible:
+                text: ".*Allow DuckDuckGo to send you notifications.*"
+            - tapOn: "Don’t allow"
+            - assertVisible:
+                text: ".*Welcome to DuckDuckGo!.*"
+                optional: true
+            - assertVisible:
+                text: ".*Ready for a better, more private internet?.*"
+            - tapOn: "let's do it!"
+            - assertVisible:
+                text: ".*Privacy protections activated.*"
+            - tapOn: "choose your browser"
+            - tapOn: "cancel"
+            - assertVisible:
+                text: ".*Try a search!.*"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+            - tapOn:
+                text: "Downloads"
+            - assertVisible:
+                text: ".*Find out when downloads are ready.*"
+            - assertVisible:
+                text: ".*Get a notification when downloads complete.*"
+            - assertVisible:
+                text: ".*Notify Me.*"
+            - assertVisible:
+                text: ".*No files downloaded yet.*"

--- a/.maestro/privacy_tests/10_-_Query_Parameters,_utm_source_and_1_standard_parameter.yaml
+++ b/.maestro/privacy_tests/10_-_Query_Parameters,_utm_source_and_1_standard_parameter.yaml
@@ -2,18 +2,21 @@ appId: com.duckduckgo.mobile.android
 tags:
     - privacyTest
 ---
-- launchApp:
-    clearState: true
-- runFlow: ../shared/onboarding.yaml
-- inputText: "https://privacy-test-pages.site/privacy-protections/query-parameters/"
-- pressKey: Enter
-- assertVisible:
-    text: ".*Got It.*"
-- assertVisible:
-    text: "Link with utm_source and 1 standard parameter"
-- tapOn:
-    text: "Link with utm_source and 1 standard parameter"
-- assertNotVisible:
-    text: "utm_source=something&q=other"
-- assertVisible:
-    text: "q=other"
+- retry:
+      maxRetries: 3
+      commands:
+            - launchApp:
+                clearState: true
+            - runFlow: ../shared/onboarding.yaml
+            - inputText: "https://privacy-test-pages.site/privacy-protections/query-parameters/"
+            - pressKey: Enter
+            - assertVisible:
+                text: ".*Got It.*"
+            - assertVisible:
+                text: "Link with utm_source and 1 standard parameter"
+            - tapOn:
+                text: "Link with utm_source and 1 standard parameter"
+            - assertNotVisible:
+                text: "utm_source=something&q=other"
+            - assertVisible:
+                text: "q=other"

--- a/.maestro/privacy_tests/11_-_Query_Parameters,_utm_source_and_utm_medium.yaml
+++ b/.maestro/privacy_tests/11_-_Query_Parameters,_utm_source_and_utm_medium.yaml
@@ -2,18 +2,21 @@ appId: com.duckduckgo.mobile.android
 tags:
     - privacyTest
 ---
-- launchApp:
-    clearState: true
-- runFlow: ../shared/onboarding.yaml
-- inputText: "https://privacy-test-pages.site/privacy-protections/query-parameters/"
-- pressKey: Enter
-- assertVisible:
-    text: ".*Got It.*"
-- assertVisible:
-    text: "Link with utm_source and utm_medium"
-- tapOn:
-    text: "Link with utm_source and utm_medium"
-- assertNotVisible:
-    text: "utm_source=something&utm_medium=somethingelse"
-- assertVisible:
-    text: ""
+- retry:
+      maxRetries: 3
+      commands:
+            - launchApp:
+                clearState: true
+            - runFlow: ../shared/onboarding.yaml
+            - inputText: "https://privacy-test-pages.site/privacy-protections/query-parameters/"
+            - pressKey: Enter
+            - assertVisible:
+                text: ".*Got It.*"
+            - assertVisible:
+                text: "Link with utm_source and utm_medium"
+            - tapOn:
+                text: "Link with utm_source and utm_medium"
+            - assertNotVisible:
+                text: "utm_source=something&utm_medium=somethingelse"
+            - assertVisible:
+                text: ""

--- a/.maestro/privacy_tests/12_-_Query_Parameters,_fbclid,_fb_source_and_1_standard_parameter.yaml
+++ b/.maestro/privacy_tests/12_-_Query_Parameters,_fbclid,_fb_source_and_1_standard_parameter.yaml
@@ -2,18 +2,21 @@ appId: com.duckduckgo.mobile.android
 tags:
     - privacyTest
 ---
-- launchApp:
-    clearState: true
-- runFlow: ../shared/onboarding.yaml
-- inputText: "https://privacy-test-pages.site/privacy-protections/query-parameters/"
-- pressKey: Enter
-- assertVisible:
-    text: ".*Got It.*"
-- assertVisible:
-    text: "Link with fbclid, fb_source and 1 standard parameter"
-- tapOn:
-    text: "Link with fbclid, fb_source and 1 standard parameter"
-- assertNotVisible:
-    text: "fbclid=12345&fb_source=someting&u=14"
-- assertVisible:
-    text: "u=14"
+- retry:
+      maxRetries: 3
+      commands:
+            - launchApp:
+                clearState: true
+            - runFlow: ../shared/onboarding.yaml
+            - inputText: "https://privacy-test-pages.site/privacy-protections/query-parameters/"
+            - pressKey: Enter
+            - assertVisible:
+                text: ".*Got It.*"
+            - assertVisible:
+                text: "Link with fbclid, fb_source and 1 standard parameter"
+            - tapOn:
+                text: "Link with fbclid, fb_source and 1 standard parameter"
+            - assertNotVisible:
+                text: "fbclid=12345&fb_source=someting&u=14"
+            - assertVisible:
+                text: "u=14"

--- a/.maestro/privacy_tests/13_-_Query_Parameters,_link_which_should_not_be_rewritten.yaml
+++ b/.maestro/privacy_tests/13_-_Query_Parameters,_link_which_should_not_be_rewritten.yaml
@@ -2,16 +2,19 @@ appId: com.duckduckgo.mobile.android
 tags:
     - privacyTest
 ---
-- launchApp:
-    clearState: true
-- runFlow: ../shared/onboarding.yaml
-- inputText: "https://privacy-test-pages.site/privacy-protections/query-parameters/"
-- pressKey: Enter
-- assertVisible:
-    text: ".*Got It.*"
-- assertVisible:
-    text: "Link which should not be rewritten"
-- tapOn:
-    text: "Link which should not be rewritten"
-- assertVisible:
-    text: "q=something&id=1234"
+- retry:
+      maxRetries: 3
+      commands:
+            - launchApp:
+                clearState: true
+            - runFlow: ../shared/onboarding.yaml
+            - inputText: "https://privacy-test-pages.site/privacy-protections/query-parameters/"
+            - pressKey: Enter
+            - assertVisible:
+                text: ".*Got It.*"
+            - assertVisible:
+                text: "Link which should not be rewritten"
+            - tapOn:
+                text: "Link which should not be rewritten"
+            - assertVisible:
+                text: "q=something&id=1234"

--- a/.maestro/privacy_tests/1_-_Single-site,_single-tab,_session.yaml
+++ b/.maestro/privacy_tests/1_-_Single-site,_single-tab,_session.yaml
@@ -2,130 +2,133 @@ appId: com.duckduckgo.mobile.android
 tags:
     - privacyTest
 ---
-- launchApp:
-    clearState: true
-- runFlow: ../shared/onboarding.yaml
-- inputText: "https://www.search-company.site/#ad-id-5"
-- pressKey: Enter
-- assertVisible:
-    text: ".*Got It.*"
-- assertVisible:
-    id: "ad-id-5"
-- tapOn:
-    id: "ad-id-5"
-- assertVisible:
-    text: "Publisher site"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
-- assertVisible:
-    text: "How our search ads impact our protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
-- action: back
-- action: back
-- assertVisible:
-    text: "Buy now"
-- assertVisible:
-    id: "buy-now"
-- tapOn:
-    id: "buy-now"
-- assertVisible:
-    text: "Checkout"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
-- assertVisible:
-    text: "How our search ads impact our protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
-- action: back
-- action: back
-- assertVisible:
-    id: "pay-button"
-- tapOn:
-    id: "pay-button"
-- assertVisible:
-    text: ".*Order complete.*"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
-- assertVisible:
-    text: "How our search ads impact our protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
+- retry:
+      maxRetries: 3
+      commands:
+            - launchApp:
+                clearState: true
+            - runFlow: ../shared/onboarding.yaml
+            - inputText: "https://www.search-company.site/#ad-id-5"
+            - pressKey: Enter
+            - assertVisible:
+                text: ".*Got It.*"
+            - assertVisible:
+                id: "ad-id-5"
+            - tapOn:
+                id: "ad-id-5"
+            - assertVisible:
+                text: "Publisher site"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - assertVisible:
+                text: "View Tracker Companies"
+            - tapOn:
+                text: "View Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "ad-company.site"
+            - action: back
+            - assertVisible:
+                text: "View Non-Tracker Companies"
+            - tapOn:
+                text: "View Non-Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
+            - assertVisible:
+                text: "How our search ads impact our protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "convert.ad-company.site"
+            - action: back
+            - action: back
+            - assertVisible:
+                text: "Buy now"
+            - assertVisible:
+                id: "buy-now"
+            - tapOn:
+                id: "buy-now"
+            - assertVisible:
+                text: "Checkout"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - assertVisible:
+                text: "View Tracker Companies"
+            - tapOn:
+                text: "View Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "ad-company.site"
+            - action: back
+            - assertVisible:
+                text: "View Non-Tracker Companies"
+            - tapOn:
+                text: "View Non-Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
+            - assertVisible:
+                text: "How our search ads impact our protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "convert.ad-company.site"
+            - action: back
+            - action: back
+            - assertVisible:
+                id: "pay-button"
+            - tapOn:
+                id: "pay-button"
+            - assertVisible:
+                text: ".*Order complete.*"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - assertVisible:
+                text: "View Tracker Companies"
+            - tapOn:
+                text: "View Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "ad-company.site"
+            - action: back
+            - assertVisible:
+                text: "View Non-Tracker Companies"
+            - tapOn:
+                text: "View Non-Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
+            - assertVisible:
+                text: "How our search ads impact our protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "convert.ad-company.site"
 
-    
+
 

--- a/.maestro/privacy_tests/2_-_Single-site,_new-tab,_session.yaml
+++ b/.maestro/privacy_tests/2_-_Single-site,_new-tab,_session.yaml
@@ -2,134 +2,137 @@ appId: com.duckduckgo.mobile.android
 tags:
     - privacyTest
 ---
-- launchApp:
-    clearState: true
-- runFlow: ../shared/onboarding.yaml
-- inputText: "https://www.search-company.site/#ad-id-5"
-- pressKey: Enter
-- assertVisible:
-    text: ".*Got It.*"
-- assertVisible:
-    id: "ad-id-5"
-- longPressOn:
-    id: "ad-id-5"
-- assertVisible:
-    text: "Open in New Tab"
-- tapOn:
-    text: "Open in New Tab"
-- assertVisible:
-    text: "Publisher site"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
-- assertVisible:
-    text: "How our search ads impact our protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
-- action: back
-- action: back
-- assertVisible:
-    text: "Buy now"
-- assertVisible:
-    id: "buy-now"
-- tapOn:
-    id: "buy-now"
-- assertVisible:
-    text: "Checkout"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
-- assertVisible:
-    text: "How our search ads impact our protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
-- action: back
-- action: back
-- assertVisible:
-    id: "pay-button"
-- tapOn:
-    id: "pay-button"
-- assertVisible:
-    text: ".*Order complete.*"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
-- assertVisible:
-    text: "How our search ads impact our protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
+- retry:
+      maxRetries: 3
+      commands:
+            - launchApp:
+                clearState: true
+            - runFlow: ../shared/onboarding.yaml
+            - inputText: "https://www.search-company.site/#ad-id-5"
+            - pressKey: Enter
+            - assertVisible:
+                text: ".*Got It.*"
+            - assertVisible:
+                id: "ad-id-5"
+            - longPressOn:
+                id: "ad-id-5"
+            - assertVisible:
+                text: "Open in New Tab"
+            - tapOn:
+                text: "Open in New Tab"
+            - assertVisible:
+                text: "Publisher site"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - assertVisible:
+                text: "View Tracker Companies"
+            - tapOn:
+                text: "View Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "ad-company.site"
+            - action: back
+            - assertVisible:
+                text: "View Non-Tracker Companies"
+            - tapOn:
+                text: "View Non-Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
+            - assertVisible:
+                text: "How our search ads impact our protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "convert.ad-company.site"
+            - action: back
+            - action: back
+            - assertVisible:
+                text: "Buy now"
+            - assertVisible:
+                id: "buy-now"
+            - tapOn:
+                id: "buy-now"
+            - assertVisible:
+                text: "Checkout"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - assertVisible:
+                text: "View Tracker Companies"
+            - tapOn:
+                text: "View Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "ad-company.site"
+            - action: back
+            - assertVisible:
+                text: "View Non-Tracker Companies"
+            - tapOn:
+                text: "View Non-Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
+            - assertVisible:
+                text: "How our search ads impact our protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "convert.ad-company.site"
+            - action: back
+            - action: back
+            - assertVisible:
+                id: "pay-button"
+            - tapOn:
+                id: "pay-button"
+            - assertVisible:
+                text: ".*Order complete.*"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - assertVisible:
+                text: "View Tracker Companies"
+            - tapOn:
+                text: "View Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "ad-company.site"
+            - action: back
+            - assertVisible:
+                text: "View Non-Tracker Companies"
+            - tapOn:
+                text: "View Non-Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
+            - assertVisible:
+                text: "How our search ads impact our protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "convert.ad-company.site"
 
-    
+
 

--- a/.maestro/privacy_tests/3_-_Single-site,_new-tab,_session_variant_two.yaml
+++ b/.maestro/privacy_tests/3_-_Single-site,_new-tab,_session_variant_two.yaml
@@ -2,134 +2,137 @@ appId: com.duckduckgo.mobile.android
 tags:
     - privacyTest
 ---
-- launchApp:
-    clearState: true
-- runFlow: ../shared/onboarding.yaml
-- inputText: "https://www.search-company.site/#ad-id-5"
-- pressKey: Enter
-- assertVisible:
-    text: ".*Got It.*"
-- assertVisible:
-    id: "ad-id-5"
-- tapOn:
-    id: "ad-id-5"
-- assertVisible:
-    text: "Publisher site"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
-- assertVisible:
-    text: "How our search ads impact our protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
-- action: back
-- action: back
-- assertVisible:
-    text: "Buy now"
-- assertVisible:
-    id: "buy-now"
-- longPressOn:
-    id: "buy-now"
-- assertVisible:
-    text: "Open in New Tab"
-- tapOn:
-    text: "Open in New Tab"
-- assertVisible:
-    text: "Checkout"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
-- assertVisible:
-    text: "How our search ads impact our protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
-- action: back
-- action: back
-- assertVisible:
-    id: "pay-button"
-- tapOn:
-    id: "pay-button"
-- assertVisible:
-    text: ".*Order complete.*"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
-- assertVisible:
-    text: "How our search ads impact our protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
+- retry:
+      maxRetries: 3
+      commands:
+            - launchApp:
+                clearState: true
+            - runFlow: ../shared/onboarding.yaml
+            - inputText: "https://www.search-company.site/#ad-id-5"
+            - pressKey: Enter
+            - assertVisible:
+                text: ".*Got It.*"
+            - assertVisible:
+                id: "ad-id-5"
+            - tapOn:
+                id: "ad-id-5"
+            - assertVisible:
+                text: "Publisher site"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - assertVisible:
+                text: "View Tracker Companies"
+            - tapOn:
+                text: "View Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "ad-company.site"
+            - action: back
+            - assertVisible:
+                text: "View Non-Tracker Companies"
+            - tapOn:
+                text: "View Non-Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
+            - assertVisible:
+                text: "How our search ads impact our protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "convert.ad-company.site"
+            - action: back
+            - action: back
+            - assertVisible:
+                text: "Buy now"
+            - assertVisible:
+                id: "buy-now"
+            - longPressOn:
+                id: "buy-now"
+            - assertVisible:
+                text: "Open in New Tab"
+            - tapOn:
+                text: "Open in New Tab"
+            - assertVisible:
+                text: "Checkout"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - assertVisible:
+                text: "View Tracker Companies"
+            - tapOn:
+                text: "View Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "ad-company.site"
+            - action: back
+            - assertVisible:
+                text: "View Non-Tracker Companies"
+            - tapOn:
+                text: "View Non-Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
+            - assertVisible:
+                text: "How our search ads impact our protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "convert.ad-company.site"
+            - action: back
+            - action: back
+            - assertVisible:
+                id: "pay-button"
+            - tapOn:
+                id: "pay-button"
+            - assertVisible:
+                text: ".*Order complete.*"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - assertVisible:
+                text: "View Tracker Companies"
+            - tapOn:
+                text: "View Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "ad-company.site"
+            - action: back
+            - assertVisible:
+                text: "View Non-Tracker Companies"
+            - tapOn:
+                text: "View Non-Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
+            - assertVisible:
+                text: "How our search ads impact our protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "convert.ad-company.site"
 
-    
+
 

--- a/.maestro/privacy_tests/4_-_Single-site,_multi-tab_session.yaml
+++ b/.maestro/privacy_tests/4_-_Single-site,_multi-tab_session.yaml
@@ -2,107 +2,110 @@ appId: com.duckduckgo.mobile.android
 tags:
     - privacyTest
 ---
-- launchApp:
-    clearState: true
-- runFlow: ../shared/onboarding.yaml
-- inputText: "https://www.search-company.site/#ad-id-5"
-- pressKey: Enter
-- assertVisible:
-    text: ".*Got It.*"
-- assertVisible:
-    id: "ad-id-5"
-- tapOn:
-    id: "ad-id-5"
-- assertVisible:
-    text: "Publisher site"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
-- assertVisible:
-    text: "How our search ads impact our protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
-- action: back
-- action: back
-- assertVisible:
-    text: "Publisher site"
-- tapOn:
-    text: "Publisher site"
-- assertVisible:
-    text: "Green T-shirt"
-- assertVisible:
-    id: "product-link-1"
-- tapOn:
-    id: "product-link-1"
-- assertVisible:
-    text: "Buy now"
-- assertVisible:
-    id: "buy-now"
-- tapOn:
-    id: "buy-now"
-- assertVisible:
-    text: "Pay"
-- assertVisible:
-    id: "pay-button"
-- tapOn:
-    id: "pay-button"
-- assertVisible:
-    text: ".*Order complete.*"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
-- assertVisible:
-    text: "How our search ads impact our protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
+- retry:
+      maxRetries: 3
+      commands:
+            - launchApp:
+                clearState: true
+            - runFlow: ../shared/onboarding.yaml
+            - inputText: "https://www.search-company.site/#ad-id-5"
+            - pressKey: Enter
+            - assertVisible:
+                text: ".*Got It.*"
+            - assertVisible:
+                id: "ad-id-5"
+            - tapOn:
+                id: "ad-id-5"
+            - assertVisible:
+                text: "Publisher site"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - assertVisible:
+                text: "View Tracker Companies"
+            - tapOn:
+                text: "View Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "ad-company.site"
+            - action: back
+            - assertVisible:
+                text: "View Non-Tracker Companies"
+            - tapOn:
+                text: "View Non-Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
+            - assertVisible:
+                text: "How our search ads impact our protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "convert.ad-company.site"
+            - action: back
+            - action: back
+            - assertVisible:
+                text: "Publisher site"
+            - tapOn:
+                text: "Publisher site"
+            - assertVisible:
+                text: "Green T-shirt"
+            - assertVisible:
+                id: "product-link-1"
+            - tapOn:
+                id: "product-link-1"
+            - assertVisible:
+                text: "Buy now"
+            - assertVisible:
+                id: "buy-now"
+            - tapOn:
+                id: "buy-now"
+            - assertVisible:
+                text: "Pay"
+            - assertVisible:
+                id: "pay-button"
+            - tapOn:
+                id: "pay-button"
+            - assertVisible:
+                text: ".*Order complete.*"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - assertVisible:
+                text: "View Tracker Companies"
+            - tapOn:
+                text: "View Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "ad-company.site"
+            - action: back
+            - assertVisible:
+                text: "View Non-Tracker Companies"
+            - tapOn:
+                text: "View Non-Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
+            - assertVisible:
+                text: "How our search ads impact our protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "convert.ad-company.site"
 
-    
+
 

--- a/.maestro/privacy_tests/5_-_Multi-site,_single-tab,_session.yaml
+++ b/.maestro/privacy_tests/5_-_Multi-site,_single-tab,_session.yaml
@@ -2,142 +2,145 @@ appId: com.duckduckgo.mobile.android
 tags:
     - privacyTest
 ---
-- launchApp:
-    clearState: true
-- runFlow: ../shared/onboarding.yaml
-- inputText: "https://www.search-company.site/#ad-id-5"
-- pressKey: Enter
-- assertVisible:
-    text: ".*Got It.*"
-- assertVisible:
-    id: "ad-id-5"
-- tapOn:
-    id: "ad-id-5"
-- assertVisible:
-    text: "Publisher site"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
-- assertVisible:
-    text: "How our search ads impact our protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
-- action: back
-- action: back
-- assertVisible:
-    text: "Publisher site"
-- tapOn:
-    text: "Publisher site"
-- assertVisible:
-    text: "Green T-shirt"
-- assertVisible:
-    id: "product-link-1"
-- tapOn:
-    id: "product-link-1"
-- assertVisible:
-    text: "Buy now"
-- assertVisible:
-    id: "buy-now"
-- tapOn:
-    id: "buy-now"
-- assertVisible:
-    text: "Pay with payment-company!"
-- assertVisible:
-    id: "payment-company"
-- tapOn:
-    id: "payment-company"
-- assertVisible:
-    text: "Pay First Party"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "ad-company.site"
-- assertVisible:
-    text: "convert.ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "We did not identify any requests from third-party domains."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- action: back
-- action: back    
-- assertVisible:
-    text: "Pay"
-- assertVisible:
-    id: "pay-button"
-- tapOn:
-    id: "pay-button"
-- assertVisible:
-    text: "Order complete.*"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
-- assertVisible:
-    text: "How our search ads impact our protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
+- retry:
+      maxRetries: 3
+      commands:
+            - launchApp:
+                clearState: true
+            - runFlow: ../shared/onboarding.yaml
+            - inputText: "https://www.search-company.site/#ad-id-5"
+            - pressKey: Enter
+            - assertVisible:
+                text: ".*Got It.*"
+            - assertVisible:
+                id: "ad-id-5"
+            - tapOn:
+                id: "ad-id-5"
+            - assertVisible:
+                text: "Publisher site"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - assertVisible:
+                text: "View Tracker Companies"
+            - tapOn:
+                text: "View Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "ad-company.site"
+            - action: back
+            - assertVisible:
+                text: "View Non-Tracker Companies"
+            - tapOn:
+                text: "View Non-Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
+            - assertVisible:
+                text: "How our search ads impact our protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "convert.ad-company.site"
+            - action: back
+            - action: back
+            - assertVisible:
+                text: "Publisher site"
+            - tapOn:
+                text: "Publisher site"
+            - assertVisible:
+                text: "Green T-shirt"
+            - assertVisible:
+                id: "product-link-1"
+            - tapOn:
+                id: "product-link-1"
+            - assertVisible:
+                text: "Buy now"
+            - assertVisible:
+                id: "buy-now"
+            - tapOn:
+                id: "buy-now"
+            - assertVisible:
+                text: "Pay with payment-company!"
+            - assertVisible:
+                id: "payment-company"
+            - tapOn:
+                id: "payment-company"
+            - assertVisible:
+                text: "Pay First Party"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - assertVisible:
+                text: "View Tracker Companies"
+            - tapOn:
+                text: "View Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "ad-company.site"
+            - assertVisible:
+                text: "convert.ad-company.site"
+            - action: back
+            - assertVisible:
+                text: "View Non-Tracker Companies"
+            - tapOn:
+                text: "View Non-Tracker Companies"
+            - assertVisible:
+                text: "We did not identify any requests from third-party domains."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - action: back
+            - action: back
+            - assertVisible:
+                text: "Pay"
+            - assertVisible:
+                id: "pay-button"
+            - tapOn:
+                id: "pay-button"
+            - assertVisible:
+                text: "Order complete.*"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - assertVisible:
+                text: "View Tracker Companies"
+            - tapOn:
+                text: "View Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "ad-company.site"
+            - action: back
+            - assertVisible:
+                text: "View Non-Tracker Companies"
+            - tapOn:
+                text: "View Non-Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
+            - assertVisible:
+                text: "How our search ads impact our protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "convert.ad-company.site"
 
-    
+
 

--- a/.maestro/privacy_tests/6_-_Multi-tab.yaml
+++ b/.maestro/privacy_tests/6_-_Multi-tab.yaml
@@ -2,113 +2,116 @@ appId: com.duckduckgo.mobile.android
 tags:
     - privacyTest
 ---
-- launchApp:
-    clearState: true
-- runFlow: ../shared/onboarding.yaml
-- inputText: "https://www.search-company.site/#ad-id-5"
-- pressKey: Enter
-- assertVisible:
-    text: ".*Got It.*"
-- assertVisible:
-    id: "ad-id-5"
-- tapOn:
-    id: "ad-id-5"
-- assertVisible:
-    text: "Publisher site"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
-- assertVisible:
-    text: "How our search ads impact our protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
-- action: back
-- action: back
-- assertVisible:
-    text: "Publisher site"
-- assertVisible:
-    id: "com.duckduckgo.mobile.android:id/tabsMenu"
-- tapOn: 
-    id: "com.duckduckgo.mobile.android:id/tabsMenu"    
-- assertVisible:
-    id: "com.duckduckgo.mobile.android:id/close"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/close"
-- assertVisible:
-    id: "com.duckduckgo.mobile.android:id/newTab"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/newTab"
-- assertVisible:
-    id: "com.duckduckgo.mobile.android:id/omnibarTextInput"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarTextInput"
-- inputText: "https://www.publisher-company.site/product.html?p=200"
-- pressKey: Enter
-- assertVisible:
-    text: "Red shoes"
-- assertVisible:
-    text: "Buy now"
-- assertVisible:
-    id: "buy-now"
-- tapOn:
-    id: "buy-now"
-- assertVisible:
-    text: "Pay"
-- assertVisible:
-    id: "pay-button"
-- tapOn:
-    id: "pay-button"
-- assertVisible:
-    text: ".*Order complete.*"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "ad-company.site"
-- assertVisible:
-    text: "convert.ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "We did not identify any requests from third-party domains."
-- assertVisible:
-    text: "About our Web Tracking Protections"
+- retry:
+      maxRetries: 3
+      commands:
+            - launchApp:
+                clearState: true
+            - runFlow: ../shared/onboarding.yaml
+            - inputText: "https://www.search-company.site/#ad-id-5"
+            - pressKey: Enter
+            - assertVisible:
+                text: ".*Got It.*"
+            - assertVisible:
+                id: "ad-id-5"
+            - tapOn:
+                id: "ad-id-5"
+            - assertVisible:
+                text: "Publisher site"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - assertVisible:
+                text: "View Tracker Companies"
+            - tapOn:
+                text: "View Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "ad-company.site"
+            - action: back
+            - assertVisible:
+                text: "View Non-Tracker Companies"
+            - tapOn:
+                text: "View Non-Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
+            - assertVisible:
+                text: "How our search ads impact our protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "convert.ad-company.site"
+            - action: back
+            - action: back
+            - assertVisible:
+                text: "Publisher site"
+            - assertVisible:
+                id: "com.duckduckgo.mobile.android:id/tabsMenu"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/tabsMenu"
+            - assertVisible:
+                id: "com.duckduckgo.mobile.android:id/close"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/close"
+            - assertVisible:
+                id: "com.duckduckgo.mobile.android:id/newTab"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/newTab"
+            - assertVisible:
+                id: "com.duckduckgo.mobile.android:id/omnibarTextInput"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/omnibarTextInput"
+            - inputText: "https://www.publisher-company.site/product.html?p=200"
+            - pressKey: Enter
+            - assertVisible:
+                text: "Red shoes"
+            - assertVisible:
+                text: "Buy now"
+            - assertVisible:
+                id: "buy-now"
+            - tapOn:
+                id: "buy-now"
+            - assertVisible:
+                text: "Pay"
+            - assertVisible:
+                id: "pay-button"
+            - tapOn:
+                id: "pay-button"
+            - assertVisible:
+                text: ".*Order complete.*"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - assertVisible:
+                text: "View Tracker Companies"
+            - tapOn:
+                text: "View Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "ad-company.site"
+            - assertVisible:
+                text: "convert.ad-company.site"
+            - action: back
+            - assertVisible:
+                text: "View Non-Tracker Companies"
+            - tapOn:
+                text: "View Non-Tracker Companies"
+            - assertVisible:
+                text: "We did not identify any requests from third-party domains."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
 
-    
+
 

--- a/.maestro/privacy_tests/7_-_Browser_restart_mid-session.yaml
+++ b/.maestro/privacy_tests/7_-_Browser_restart_mid-session.yaml
@@ -2,136 +2,139 @@ appId: com.duckduckgo.mobile.android
 tags:
     - privacyTest
 ---
-- launchApp:
-    clearState: true
-- runFlow: ../shared/onboarding.yaml
-- inputText: "https://www.search-company.site/#ad-id-5"
-- pressKey: Enter
-- assertVisible:
-    text: ".*Got It.*"
-- assertVisible:
-    id: "ad-id-5"
-- tapOn:
-    id: "ad-id-5"
-- assertVisible:
-    text: "Publisher site"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
-- assertVisible:
-    text: "How our search ads impact our protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
-- action: back
-- action: back
-- assertVisible:
-    text: "Publisher site"
-- assertVisible:
-    text: "Buy now"
-- assertVisible:
-    id: "buy-now"
-- tapOn:
-    id: "buy-now"
-- assertVisible:
-    text: "Pay"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
-- assertVisible:
-    text: "How our search ads impact our protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
-- action: back
-- action: back
-- killApp
-- launchApp:
-    clearState: false
-- assertVisible:
-    text: "Pay"    
-- assertVisible:
-    id: "pay-button"
-- tapOn:
-    id: "pay-button"
-- assertVisible:
-    text: ".*Order complete.*"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
-- assertVisible:
-    text: "How our search ads impact our protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
-    
+- retry:
+      maxRetries: 3
+      commands:
+            - launchApp:
+                clearState: true
+            - runFlow: ../shared/onboarding.yaml
+            - inputText: "https://www.search-company.site/#ad-id-5"
+            - pressKey: Enter
+            - assertVisible:
+                text: ".*Got It.*"
+            - assertVisible:
+                id: "ad-id-5"
+            - tapOn:
+                id: "ad-id-5"
+            - assertVisible:
+                text: "Publisher site"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - assertVisible:
+                text: "View Tracker Companies"
+            - tapOn:
+                text: "View Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "ad-company.site"
+            - action: back
+            - assertVisible:
+                text: "View Non-Tracker Companies"
+            - tapOn:
+                text: "View Non-Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
+            - assertVisible:
+                text: "How our search ads impact our protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "convert.ad-company.site"
+            - action: back
+            - action: back
+            - assertVisible:
+                text: "Publisher site"
+            - assertVisible:
+                text: "Buy now"
+            - assertVisible:
+                id: "buy-now"
+            - tapOn:
+                id: "buy-now"
+            - assertVisible:
+                text: "Pay"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - assertVisible:
+                text: "View Tracker Companies"
+            - tapOn:
+                text: "View Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "ad-company.site"
+            - action: back
+            - assertVisible:
+                text: "View Non-Tracker Companies"
+            - tapOn:
+                text: "View Non-Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
+            - assertVisible:
+                text: "How our search ads impact our protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "convert.ad-company.site"
+            - action: back
+            - action: back
+            - killApp
+            - launchApp:
+                clearState: false
+            - assertVisible:
+                text: "Pay"
+            - assertVisible:
+                id: "pay-button"
+            - tapOn:
+                id: "pay-button"
+            - assertVisible:
+                text: ".*Order complete.*"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - assertVisible:
+                text: "View Tracker Companies"
+            - tapOn:
+                text: "View Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "ad-company.site"
+            - action: back
+            - assertVisible:
+                text: "View Non-Tracker Companies"
+            - tapOn:
+                text: "View Non-Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
+            - assertVisible:
+                text: "How our search ads impact our protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "convert.ad-company.site"
+
 

--- a/.maestro/privacy_tests/8_-_Navigation_with_back_forward.yaml
+++ b/.maestro/privacy_tests/8_-_Navigation_with_back_forward.yaml
@@ -2,169 +2,172 @@ appId: com.duckduckgo.mobile.android
 tags:
     - privacyTest
 ---
-- launchApp:
-    clearState: true
-- runFlow: ../shared/onboarding.yaml
-- inputText: "https://www.search-company.site/#ad-id-5"
-- pressKey: Enter
-- assertVisible:
-    text: ".*Got It.*"
-- assertVisible:
-    id: "ad-id-5"
-- tapOn:
-    id: "ad-id-5"
-- assertVisible:
-    text: "Publisher site"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
-- assertVisible:
-    text: "How our search ads impact our protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
-- action: back
-- action: back    
-- assertVisible:
-    text: "Publisher site"
-- tapOn:
-    text: "Publisher site"
-- assertVisible:
-    text: "Green T-shirt"
-- assertVisible:
-    id: "product-link-1"
-- tapOn:
-    id: "product-link-1"
-- assertVisible:
-    text: "Buy now"
-- assertVisible:
-    id: "buy-now"
-- tapOn:
-    id: "buy-now" 
-- assertVisible:
-    text: "Pay with payment-company!"
-- assertVisible:
-    id: "payment-company"
-- tapOn:
-    id: "payment-company"
-- assertVisible:
-    text: "Pay First Party"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "ad-company.site"
-- assertVisible:
-    text: "convert.ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "We did not identify any requests from third-party domains."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- action: back
-- action: back
-- assertVisible:
-    id: "com.duckduckgo.mobile.android:id/browserMenu"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/browserMenu"    
-- assertVisible:
-    id: "com.duckduckgo.mobile.android:id/backMenuItem"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/backMenuItem"
-- assertVisible:
-    id: "com.duckduckgo.mobile.android:id/browserMenu"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/browserMenu"    
-- assertVisible:
-    id: "com.duckduckgo.mobile.android:id/backMenuItem"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/backMenuItem"
-- assertVisible:
-    id: "com.duckduckgo.mobile.android:id/browserMenu"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/browserMenu"    
-- assertVisible:
-    id: "com.duckduckgo.mobile.android:id/forwardMenuItem"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/forwardMenuItem"
-- assertVisible:
-    id: "com.duckduckgo.mobile.android:id/browserMenu"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/browserMenu"    
-- assertVisible:
-    id: "com.duckduckgo.mobile.android:id/forwardMenuItem"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/forwardMenuItem"
-- assertVisible:
-    text: "Pay"
-- assertVisible:
-    id: "pay-button"
-- tapOn:
-    id: "pay-button"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
-- assertVisible:
-    text: "How our search ads impact our protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
+- retry:
+      maxRetries: 3
+      commands:
+            - launchApp:
+                clearState: true
+            - runFlow: ../shared/onboarding.yaml
+            - inputText: "https://www.search-company.site/#ad-id-5"
+            - pressKey: Enter
+            - assertVisible:
+                text: ".*Got It.*"
+            - assertVisible:
+                id: "ad-id-5"
+            - tapOn:
+                id: "ad-id-5"
+            - assertVisible:
+                text: "Publisher site"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - assertVisible:
+                text: "View Tracker Companies"
+            - tapOn:
+                text: "View Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "ad-company.site"
+            - action: back
+            - assertVisible:
+                text: "View Non-Tracker Companies"
+            - tapOn:
+                text: "View Non-Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
+            - assertVisible:
+                text: "How our search ads impact our protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "convert.ad-company.site"
+            - action: back
+            - action: back
+            - assertVisible:
+                text: "Publisher site"
+            - tapOn:
+                text: "Publisher site"
+            - assertVisible:
+                text: "Green T-shirt"
+            - assertVisible:
+                id: "product-link-1"
+            - tapOn:
+                id: "product-link-1"
+            - assertVisible:
+                text: "Buy now"
+            - assertVisible:
+                id: "buy-now"
+            - tapOn:
+                id: "buy-now"
+            - assertVisible:
+                text: "Pay with payment-company!"
+            - assertVisible:
+                id: "payment-company"
+            - tapOn:
+                id: "payment-company"
+            - assertVisible:
+                text: "Pay First Party"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - assertVisible:
+                text: "View Tracker Companies"
+            - tapOn:
+                text: "View Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "ad-company.site"
+            - assertVisible:
+                text: "convert.ad-company.site"
+            - action: back
+            - assertVisible:
+                text: "View Non-Tracker Companies"
+            - tapOn:
+                text: "View Non-Tracker Companies"
+            - assertVisible:
+                text: "We did not identify any requests from third-party domains."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - action: back
+            - action: back
+            - assertVisible:
+                id: "com.duckduckgo.mobile.android:id/browserMenu"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/browserMenu"
+            - assertVisible:
+                id: "com.duckduckgo.mobile.android:id/backMenuItem"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/backMenuItem"
+            - assertVisible:
+                id: "com.duckduckgo.mobile.android:id/browserMenu"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/browserMenu"
+            - assertVisible:
+                id: "com.duckduckgo.mobile.android:id/backMenuItem"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/backMenuItem"
+            - assertVisible:
+                id: "com.duckduckgo.mobile.android:id/browserMenu"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/browserMenu"
+            - assertVisible:
+                id: "com.duckduckgo.mobile.android:id/forwardMenuItem"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/forwardMenuItem"
+            - assertVisible:
+                id: "com.duckduckgo.mobile.android:id/browserMenu"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/browserMenu"
+            - assertVisible:
+                id: "com.duckduckgo.mobile.android:id/forwardMenuItem"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/forwardMenuItem"
+            - assertVisible:
+                text: "Pay"
+            - assertVisible:
+                id: "pay-button"
+            - tapOn:
+                id: "pay-button"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - assertVisible:
+                text: "View Tracker Companies"
+            - tapOn:
+                text: "View Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "ad-company.site"
+            - action: back
+            - assertVisible:
+                text: "View Non-Tracker Companies"
+            - tapOn:
+                text: "View Non-Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
+            - assertVisible:
+                text: "How our search ads impact our protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "convert.ad-company.site"

--- a/.maestro/privacy_tests/9_-_Navigation_with_refresh.yaml
+++ b/.maestro/privacy_tests/9_-_Navigation_with_refresh.yaml
@@ -2,145 +2,148 @@ appId: com.duckduckgo.mobile.android
 tags:
     - privacyTest
 ---
-- launchApp:
-    clearState: true
-- runFlow: ../shared/onboarding.yaml
-- inputText: "https://www.search-company.site/#ad-id-5"
-- pressKey: Enter
-- assertVisible:
-    text: ".*Got It.*"
-- assertVisible:
-    id: "ad-id-5"
-- tapOn:
-    id: "ad-id-5"
-- assertVisible:
-    text: "Publisher site"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
-- assertVisible:
-    text: "How our search ads impact our protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
-- action: back
-- action: back    
-- assertVisible:
-    text: "Publisher site"
-- tapOn:
-    text: "Publisher site"
-- assertVisible:
-    text: "Green T-shirt"
-- assertVisible:
-    id: "product-link-1"
-- tapOn:
-    id: "product-link-1"
-- assertVisible:
-    text: "Buy now"
-- assertVisible:
-    id: "buy-now"
-- tapOn:
-    id: "buy-now" 
-- assertVisible:
-    text: "Pay with payment-company!"
-- assertVisible:
-    id: "payment-company"
-- tapOn:
-    id: "payment-company"
-- assertVisible:
-    text: "Pay First Party"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "ad-company.site"
-- assertVisible:
-    text: "convert.ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "We did not identify any requests from third-party domains."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- action: back
-- action: back
-- assertVisible:
-    id: "com.duckduckgo.mobile.android:id/browserMenu"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/browserMenu"    
-- assertVisible:
-    id: "com.duckduckgo.mobile.android:id/refreshMenuItem"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/refreshMenuItem"
-- assertVisible:
-    text: "Pay"
-- assertVisible:
-    id: "pay-button"
-- tapOn:
-    id: "pay-button"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-- assertVisible:
-    text: "View Tracker Companies"
-- tapOn:
-    text: "View Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "ad-company.site"
-- action: back
-- assertVisible:
-    text: "View Non-Tracker Companies"
-- tapOn:
-    text: "View Non-Tracker Companies"
-- assertVisible:
-    text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
-- assertVisible:
-    text: "About our Web Tracking Protections"
-- assertVisible:
-    text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
-- assertVisible:
-    text: "How our search ads impact our protections"
-- assertVisible:
-    text: ".*Ad Company"
-- assertVisible:
-    text: "convert.ad-company.site"
+- retry:
+      maxRetries: 3
+      commands:
+            - launchApp:
+                clearState: true
+            - runFlow: ../shared/onboarding.yaml
+            - inputText: "https://www.search-company.site/#ad-id-5"
+            - pressKey: Enter
+            - assertVisible:
+                text: ".*Got It.*"
+            - assertVisible:
+                id: "ad-id-5"
+            - tapOn:
+                id: "ad-id-5"
+            - assertVisible:
+                text: "Publisher site"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - assertVisible:
+                text: "View Tracker Companies"
+            - tapOn:
+                text: "View Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "ad-company.site"
+            - action: back
+            - assertVisible:
+                text: "View Non-Tracker Companies"
+            - tapOn:
+                text: "View Non-Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
+            - assertVisible:
+                text: "How our search ads impact our protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "convert.ad-company.site"
+            - action: back
+            - action: back
+            - assertVisible:
+                text: "Publisher site"
+            - tapOn:
+                text: "Publisher site"
+            - assertVisible:
+                text: "Green T-shirt"
+            - assertVisible:
+                id: "product-link-1"
+            - tapOn:
+                id: "product-link-1"
+            - assertVisible:
+                text: "Buy now"
+            - assertVisible:
+                id: "buy-now"
+            - tapOn:
+                id: "buy-now"
+            - assertVisible:
+                text: "Pay with payment-company!"
+            - assertVisible:
+                id: "payment-company"
+            - tapOn:
+                id: "payment-company"
+            - assertVisible:
+                text: "Pay First Party"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - assertVisible:
+                text: "View Tracker Companies"
+            - tapOn:
+                text: "View Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "ad-company.site"
+            - assertVisible:
+                text: "convert.ad-company.site"
+            - action: back
+            - assertVisible:
+                text: "View Non-Tracker Companies"
+            - tapOn:
+                text: "View Non-Tracker Companies"
+            - assertVisible:
+                text: "We did not identify any requests from third-party domains."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - action: back
+            - action: back
+            - assertVisible:
+                id: "com.duckduckgo.mobile.android:id/browserMenu"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/browserMenu"
+            - assertVisible:
+                id: "com.duckduckgo.mobile.android:id/refreshMenuItem"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/refreshMenuItem"
+            - assertVisible:
+                text: "Pay"
+            - assertVisible:
+                id: "pay-button"
+            - tapOn:
+                id: "pay-button"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - assertVisible:
+                text: "View Tracker Companies"
+            - tapOn:
+                text: "View Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were blocked from loading because they were identified as tracking requests. If a company's requests are loaded, it can allow them to profile you."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "ad-company.site"
+            - action: back
+            - assertVisible:
+                text: "View Non-Tracker Companies"
+            - tapOn:
+                text: "View Non-Tracker Companies"
+            - assertVisible:
+                text: "The following third-party domains’ requests were loaded. If a company's requests are loaded, it can allow them to profile you, though our other web tracking protections still apply."
+            - assertVisible:
+                text: "About our Web Tracking Protections"
+            - assertVisible:
+                text: "The following domain’s requests were loaded because a publisher-company.site ad on DuckDuckGo was recently clicked. These requests help evaluate ad effectiveness. All ads on DuckDuckGo are non-profiling."
+            - assertVisible:
+                text: "How our search ads impact our protections"
+            - assertVisible:
+                text: ".*Ad Company"
+            - assertVisible:
+                text: "convert.ad-company.site"

--- a/.maestro/security_tests/1_-_AddressBarSpoof,_basicauth.yaml
+++ b/.maestro/security_tests/1_-_AddressBarSpoof,_basicauth.yaml
@@ -2,40 +2,43 @@ appId: com.duckduckgo.mobile.android
 tags:
     - securityTest
 ---
-- launchApp:
-    clearState: true
-- runFlow: ../shared/onboarding.yaml
-- doubleTapOn:
-    id: "omnibarTextInput"
-- pressKey: Backspace
-# Test 1 - using \u2028 character
-- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-basicauth-2028.html"
-- pressKey: Enter
-- tapOn: "Got It"
-- tapOn: "run"
-- assertVisible: "Example Domain"
-- copyTextFrom:
-    id: "omnibarTextInput"
-- assertTrue: ${maestro.copiedText.indexOf("https://www.google.com") != 0}
-- tapOn:
-    id: "omnibarTextInput"
-# Test 2 - using \u2029 character
-- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-basicauth-2029.html"
-- pressKey: Enter
-- tapOn: "run"
-- assertVisible: "Example Domain"
-- copyTextFrom:
-    id: "omnibarTextInput"
-- assertTrue: ${maestro.copiedText.indexOf("https://www.google.com") != 0}
-- tapOn:
-    id: "omnibarTextInput"
-# Test 3 - using repeated " " space character
-- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-basicauth-whitespace.html"
-- pressKey: Enter
-- tapOn: "run"
-- assertVisible: "Example Domain"
-- copyTextFrom:
-    id: "omnibarTextInput"
-- assertTrue: ${maestro.copiedText.indexOf("https://www.google.com") != 0}
-- tapOn:
-    id: "omnibarTextInput"
+- retry:
+      maxRetries: 3
+      commands:
+            - launchApp:
+                clearState: true
+            - runFlow: ../shared/onboarding.yaml
+            - doubleTapOn:
+                id: "omnibarTextInput"
+            - pressKey: Backspace
+            # Test 1 - using \u2028 character
+            - inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-basicauth-2028.html"
+            - pressKey: Enter
+            - tapOn: "Got It"
+            - tapOn: "run"
+            - assertVisible: "Example Domain"
+            - copyTextFrom:
+                id: "omnibarTextInput"
+            - assertTrue: ${maestro.copiedText.indexOf("https://www.google.com") != 0}
+            - tapOn:
+                id: "omnibarTextInput"
+            # Test 2 - using \u2029 character
+            - inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-basicauth-2029.html"
+            - pressKey: Enter
+            - tapOn: "run"
+            - assertVisible: "Example Domain"
+            - copyTextFrom:
+                id: "omnibarTextInput"
+            - assertTrue: ${maestro.copiedText.indexOf("https://www.google.com") != 0}
+            - tapOn:
+                id: "omnibarTextInput"
+            # Test 3 - using repeated " " space character
+            - inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-basicauth-whitespace.html"
+            - pressKey: Enter
+            - tapOn: "run"
+            - assertVisible: "Example Domain"
+            - copyTextFrom:
+                id: "omnibarTextInput"
+            - assertTrue: ${maestro.copiedText.indexOf("https://www.google.com") != 0}
+            - tapOn:
+                id: "omnibarTextInput"

--- a/.maestro/security_tests/2_-_AddressBarSpoof,_aboutblank.yaml
+++ b/.maestro/security_tests/2_-_AddressBarSpoof,_aboutblank.yaml
@@ -2,20 +2,23 @@ appId: com.duckduckgo.mobile.android
 tags:
     - securityTest
 ---
-- launchApp:
-    clearState: true
-- runFlow: ../shared/onboarding.yaml
-- doubleTapOn:
-    id: "omnibarTextInput"
-- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-about-blank-rewrite.html"
-- pressKey: Enter
-- tapOn: "Got It"
-- tapOn: "Start"
-# This test is expected to load "about:blank" then duckduckgo.com, not remain on the current page with spoofed content.
-- extendedWaitUntil:
-    notVisible: "Not DDG."  # Spoofed content not visible
-    timeout: 10000
-- tapOn: "Got it!"
-- copyTextFrom:
-    id: "omnibarTextInput"
-- assertTrue: ${maestro.copiedText == "about:blank" || maestro.copiedText == "https://duckduckgo.com/"}
+- retry:
+      maxRetries: 3
+      commands:
+            - launchApp:
+                clearState: true
+            - runFlow: ../shared/onboarding.yaml
+            - doubleTapOn:
+                id: "omnibarTextInput"
+            - inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-about-blank-rewrite.html"
+            - pressKey: Enter
+            - tapOn: "Got It"
+            - tapOn: "Start"
+            # This test is expected to load "about:blank" then duckduckgo.com, not remain on the current page with spoofed content.
+            - extendedWaitUntil:
+                notVisible: "Not DDG."  # Spoofed content not visible
+                timeout: 10000
+            - tapOn: "Got it!"
+            - copyTextFrom:
+                id: "omnibarTextInput"
+            - assertTrue: ${maestro.copiedText == "about:blank" || maestro.copiedText == "https://duckduckgo.com/"}

--- a/.maestro/security_tests/3_-_AddressBarSpoof,_appschemes.yaml
+++ b/.maestro/security_tests/3_-_AddressBarSpoof,_appschemes.yaml
@@ -2,27 +2,30 @@ appId: com.duckduckgo.mobile.android
 tags:
     - securityTest
 ---
-- launchApp:
-    clearState: true
-- runFlow: ../shared/onboarding.yaml
-# Test 1
-- doubleTapOn:
-    id: "omnibarTextInput"
-- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-application-scheme.html"
-- pressKey: Enter
-- tapOn: "Got It"
-- tapOn: "Start"
-# This test is expected to load spreadprivacy.com, not remain on the current page with spoofed content.
-- assertVisible: "Spread Privacy" # DuckDuckGo blog homepage
-- copyTextFrom:
-    id: "omnibarTextInput"
-- assertTrue: ${maestro.copiedText == "https://spreadprivacy.com/"} # DuckDuckGo blog home page
-- tapOn:
-    id: "omnibarTextInput"
-# Test 2
-- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-unsupported-scheme.html"
-- pressKey: Enter
-- tapOn: "Start"
-- copyTextFrom:
-    id: "omnibarTextInput"
-- assertTrue: ${maestro.copiedText == "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-unsupported-scheme.html"}
+- retry:
+      maxRetries: 3
+      commands:
+            - launchApp:
+                clearState: true
+            - runFlow: ../shared/onboarding.yaml
+            # Test 1
+            - doubleTapOn:
+                id: "omnibarTextInput"
+            - inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-application-scheme.html"
+            - pressKey: Enter
+            - tapOn: "Got It"
+            - tapOn: "Start"
+            # This test is expected to load spreadprivacy.com, not remain on the current page with spoofed content.
+            - assertVisible: "Spread Privacy" # DuckDuckGo blog homepage
+            - copyTextFrom:
+                id: "omnibarTextInput"
+            - assertTrue: ${maestro.copiedText == "https://spreadprivacy.com/"} # DuckDuckGo blog home page
+            - tapOn:
+                id: "omnibarTextInput"
+            # Test 2
+            - inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-unsupported-scheme.html"
+            - pressKey: Enter
+            - tapOn: "Start"
+            - copyTextFrom:
+                id: "omnibarTextInput"
+            - assertTrue: ${maestro.copiedText == "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-unsupported-scheme.html"}

--- a/.maestro/security_tests/4_-_AddressBarSpoof,_b64_html.yaml
+++ b/.maestro/security_tests/4_-_AddressBarSpoof,_b64_html.yaml
@@ -2,19 +2,22 @@ appId: com.duckduckgo.mobile.android
 tags:
     - securityTest
 ---
-- launchApp:
-    clearState: true
-- runFlow: ../shared/onboarding.yaml
-# Test 1
-- doubleTapOn:
-    id: "omnibarTextInput"
-- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-open-b64-html.html"
-- pressKey: Enter
-- tapOn: "Got It"
-- tapOn: "Start"
-# This test is expected to open a new tab with empty origin ("") and then prompt to open the link in another app
-- assertVisible: "Open in another app"
-- tapOn: "Cancel"
-- copyTextFrom:
-    id: "omnibarTextInput"
-- assertTrue: ${maestro.copiedText.indexOf("duckduckgo.com") == -1}
+- retry:
+      maxRetries: 3
+      commands:
+            - launchApp:
+                clearState: true
+            - runFlow: ../shared/onboarding.yaml
+            # Test 1
+            - doubleTapOn:
+                id: "omnibarTextInput"
+            - inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-open-b64-html.html"
+            - pressKey: Enter
+            - tapOn: "Got It"
+            - tapOn: "Start"
+            # This test is expected to open a new tab with empty origin ("") and then prompt to open the link in another app
+            - assertVisible: "Open in another app"
+            - tapOn: "Cancel"
+            - copyTextFrom:
+                id: "omnibarTextInput"
+            - assertTrue: ${maestro.copiedText.indexOf("duckduckgo.com") == -1}

--- a/.maestro/security_tests/5_-_AddressBarSpoof,_downloadpath.yaml
+++ b/.maestro/security_tests/5_-_AddressBarSpoof,_downloadpath.yaml
@@ -2,32 +2,35 @@ appId: com.duckduckgo.mobile.android
 tags:
     - securityTest
 ---
-- launchApp:
-    clearState: true
-- runFlow: ../shared/onboarding.yaml
-# Test 1
-- doubleTapOn:
-    id: "omnibarTextInput"
-- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-js-download-url.html"
-- pressKey: Enter
-- tapOn: "Got It"
-- tapOn: "Start"
-# Download Acceptance Flow:
-- extendedWaitUntil:
-    visible: "Save to Downloads"
-    timeout: 10000
-- tapOn: "Save to Downloads"
-- copyTextFrom:
-    id: "omnibarTextInput"
-- assertTrue: ${maestro.copiedText == "Search or type URL"} # Downloads should occur in empty origin.
-- pressKey: Back
-# Download Cancel Flow:
-- tapOn: "Start"
-- extendedWaitUntil:
-    visible: "Cancel"  
-    timeout: 10000
-- tapOn: "Cancel"
-# Should redirect back to the last page.
-- copyTextFrom:
-    id: "omnibarTextInput"
-- assertTrue: ${maestro.copiedText.indexOf("https://staticcdn.duckduckgo.com") == -1} 
+- retry:
+      maxRetries: 3
+      commands:
+            - launchApp:
+                clearState: true
+            - runFlow: ../shared/onboarding.yaml
+            # Test 1
+            - doubleTapOn:
+                id: "omnibarTextInput"
+            - inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-js-download-url.html"
+            - pressKey: Enter
+            - tapOn: "Got It"
+            - tapOn: "Start"
+            # Download Acceptance Flow:
+            - extendedWaitUntil:
+                visible: "Save to Downloads"
+                timeout: 10000
+            - tapOn: "Save to Downloads"
+            - copyTextFrom:
+                id: "omnibarTextInput"
+            - assertTrue: ${maestro.copiedText == "Search or type URL"} # Downloads should occur in empty origin.
+            - pressKey: Back
+            # Download Cancel Flow:
+            - tapOn: "Start"
+            - extendedWaitUntil:
+                visible: "Cancel"
+                timeout: 10000
+            - tapOn: "Cancel"
+            # Should redirect back to the last page.
+            - copyTextFrom:
+                id: "omnibarTextInput"
+            - assertTrue: ${maestro.copiedText.indexOf("https://staticcdn.duckduckgo.com") == -1}

--- a/.maestro/security_tests/6_-_AddressBarSpoof,_formaction.yaml
+++ b/.maestro/security_tests/6_-_AddressBarSpoof,_formaction.yaml
@@ -2,17 +2,20 @@ appId: com.duckduckgo.mobile.android
 tags:
     - securityTest
 ---
-- launchApp:
-    clearState: true
-- runFlow: ../shared/onboarding.yaml
-# Test 1
-- doubleTapOn:
-    id: "omnibarTextInput"
-- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-form-action.html"
-- pressKey: Enter
-- tapOn: "Got It"
-- tapOn: "run"
-# Should do nothing - the navigation should be prevented.
-- copyTextFrom:
-    id: "omnibarTextInput"
-- assertTrue: ${maestro.copiedText == "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-form-action.html"}
+- retry:
+      maxRetries: 3
+      commands:
+            - launchApp:
+                clearState: true
+            - runFlow: ../shared/onboarding.yaml
+            # Test 1
+            - doubleTapOn:
+                id: "omnibarTextInput"
+            - inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-form-action.html"
+            - pressKey: Enter
+            - tapOn: "Got It"
+            - tapOn: "run"
+            # Should do nothing - the navigation should be prevented.
+            - copyTextFrom:
+                id: "omnibarTextInput"
+            - assertTrue: ${maestro.copiedText == "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-form-action.html"}

--- a/.maestro/security_tests/7_-_AddressBarSpoof,_pagerewrite.yaml
+++ b/.maestro/security_tests/7_-_AddressBarSpoof,_pagerewrite.yaml
@@ -2,18 +2,21 @@ appId: com.duckduckgo.mobile.android
 tags:
     - securityTest
 ---
-- launchApp:
-    clearState: true
-- runFlow: ../shared/onboarding.yaml
-# Test 1
-- doubleTapOn:
-    id: "omnibarTextInput"
-- inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-js-page-rewrite.html"
-- pressKey: Enter
-- tapOn: "Got It"
-- tapOn: "Start"
-# Now check the address bar hasn't been updated too early resulting in spoofed content
-- copyTextFrom:
-    id: "omnibarTextInput"
-- assertTrue: ${maestro.copiedText == "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-js-page-rewrite.html"}
-- assertNotVisible: "DDG." 
+- retry:
+      maxRetries: 3
+      commands:
+            - launchApp:
+                clearState: true
+            - runFlow: ../shared/onboarding.yaml
+            # Test 1
+            - doubleTapOn:
+                id: "omnibarTextInput"
+            - inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-js-page-rewrite.html"
+            - pressKey: Enter
+            - tapOn: "Got It"
+            - tapOn: "Start"
+            # Now check the address bar hasn't been updated too early resulting in spoofed content
+            - copyTextFrom:
+                id: "omnibarTextInput"
+            - assertTrue: ${maestro.copiedText == "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-js-page-rewrite.html"}
+            - assertNotVisible: "DDG."

--- a/.maestro/tabs/open_multiple_tabs.yaml
+++ b/.maestro/tabs/open_multiple_tabs.yaml
@@ -3,49 +3,52 @@ name: "ReleaseTest: Multiple tabs can be opened"
 tags:
     - releaseTest
 ---
-- launchApp:
-      clearState: true
-      stopApp: true
+- retry:
+      maxRetries: 3
+      commands:
+            - launchApp:
+                  clearState: true
+                  stopApp: true
 
-- runFlow: ../shared/onboarding.yaml
+            - runFlow: ../shared/onboarding.yaml
 
-- tapOn:
-    text: "search or type URL"
-- inputText: "https://privacy-test-pages.site"
-- pressKey: Enter
-- assertVisible:
-    text: ".*keep browsing.*"
-- tapOn:
-    text: "got it"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/tabCount"
-- assertVisible:
-    text: "Privacy Test Pages - Home"
-- tapOn: "New Tab"
-- assertVisible:
-    text: "Search or type URL"
-- inputText: "https://www.search-company.site"
-- pressKey: Enter
-- assertVisible:
-    text: "Search engine"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/tabCount"
-- assertVisible:
-    text: "Ad Click Flow"
-- assertVisible:
-    text: "Privacy Test Pages - Home"
-- tapOn:
-    text: "Privacy Test Pages - Home"
-- assertNotVisible:
-    text: "Ad Click Flow"
-- assertVisible:
-    text: "Privacy Test Pages - Home"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/tabCount"
-- assertVisible:
-    text: "Ad Click Flow"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/close"
-    rightOf: "Ad Click Flow"
-- assertNotVisible:
-    text: "Ad Click Flow"
+            - tapOn:
+                text: "search or type URL"
+            - inputText: "https://privacy-test-pages.site"
+            - pressKey: Enter
+            - assertVisible:
+                text: ".*keep browsing.*"
+            - tapOn:
+                text: "got it"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/tabCount"
+            - assertVisible:
+                text: "Privacy Test Pages - Home"
+            - tapOn: "New Tab"
+            - assertVisible:
+                text: "Search or type URL"
+            - inputText: "https://www.search-company.site"
+            - pressKey: Enter
+            - assertVisible:
+                text: "Search engine"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/tabCount"
+            - assertVisible:
+                text: "Ad Click Flow"
+            - assertVisible:
+                text: "Privacy Test Pages - Home"
+            - tapOn:
+                text: "Privacy Test Pages - Home"
+            - assertNotVisible:
+                text: "Ad Click Flow"
+            - assertVisible:
+                text: "Privacy Test Pages - Home"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/tabCount"
+            - assertVisible:
+                text: "Ad Click Flow"
+            - tapOn:
+                id: "com.duckduckgo.mobile.android:id/close"
+                rightOf: "Ad Click Flow"
+            - assertNotVisible:
+                text: "Ad Click Flow"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1209000807402387/f 

### Description
Wraps Maestro UI tests in a `retry` wrapper to minimize any noise from occasionally flakey tests (either from the test themselves or from flakiness in the testing infrastructure). Where we do spot flakiness in our tests, we should fix them and having the `retry` isn’t a substitute for aiming for properly deterministic tests.

By default, all tests are being set with `maxRetries = 3` by default.

### 💡  Tip for reviewing the PR:
- each test suite has a `retry` block added, and then the rest of the test steps have been indented. there are, therefore, mostly whitespace-only changes
- if you want an easier time in the diff, **Hide whitespace:**
<img width="253" alt="Screenshot 2024-12-18 at 12 26 33" src="https://github.com/user-attachments/assets/3dfe4eff-4583-48a8-96ea-12b4c2953737" />


### Steps to test this PR



- QA optional
- [x] Ensure end-to-end CI job passed: https://github.com/duckduckgo/Android/actions/runs/12392897145