### PR TITLE
Android Bug: Address Bar can be hidden on NTP by user and doesn't reappear until background/foreground

### DIFF
--- a/app/src/main/res/layout/fragment_browser_tab.xml
+++ b/app/src/main/res/layout/fragment_browser_tab.xml
@@ -58,6 +58,7 @@
         android:background="?attr/daxColorSurface"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        app:layout_scrollFlags="noScroll"
         app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
     <include


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/715106103902962/1209003862601172/f

### Description
Fixed scrolling issue on focused view.

### Steps to test this PR

See task description for video https://app.asana.com/0/715106103902962/1209003862601172/f

Steps to reproduce:
- [x] Install from develop.
- [x] Have Address Bar set to Top.
- [x] On NTP use finger to hold/slide the address bar to the top of the device.
- [x] Observe that you can not use any gesture to make the address bar reappear.

Steps to test the fix:
- [x] Install from this branch.
- [x] Have Address Bar set to Top.
- [x] On NTP use finger to hold/slide the address bar to the top of the device.
- [x] Notice the Address Bar does not scroll.

### NO UI changes

