### PR TITLE
Improve german translation of runningInDdgMenuItemTitle string

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -708,7 +708,7 @@
 
     <!-- Custom Tab -->
     <string name="openInDdgMenuItemTitle">In DuckDuckGo öffnen</string>
-    <string name="runningInDdgMenuItemTitle">Laufen in DuckDuckGo</string>
+    <string name="runningInDdgMenuItemTitle">Läuft in DuckDuckGo</string>
 
     <!-- SSL Error -->
     <string name="sslErrorTitle">Warnung: Diese Website ist möglicherweise unsicher</string>


### PR DESCRIPTION
### Description
The German translation of runningInDdgMenuItemTitle string in the Android browser is incorrect. You want to say "This website is 'running in DuckDuckGo'" (singular) - but the current translation is "Laufen in DuckDuckGo" (plural), which is not valid German. I have updated the translation to "Läuft in DuckDuckGo" (singular), which is more accurate here.

![image](https://github.com/user-attachments/assets/19714da0-3a5e-4b5f-a78e-fe51e932cc25)
