### PR TITLE
Update Settings: Add new pixels

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -130,6 +130,7 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     SETTINGS_ADDRESS_BAR_POSITION_PRESSED("ms_address_bar_position_setting_pressed"),
     SETTINGS_ADDRESS_BAR_POSITION_SELECTED_TOP("ms_address_bar_position_setting_selected_top"),
     SETTINGS_ADDRESS_BAR_POSITION_SELECTED_BOTTOM("ms_address_bar_position_setting_selected_bottom"),
+    SETTINGS_NEXT_STEPS_ADDRESS_BAR("m_settings_next_steps_set_address_bar"),
     SETTINGS_MAC_APP_PRESSED("ms_mac_app_setting_pressed"),
     SETTINGS_WINDOWS_APP_PRESSED("ms_windows_app_setting_pressed"),
     SETTINGS_EMAIL_PROTECTION_PRESSED("ms_email_protection_setting_pressed"),

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -131,6 +131,7 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     SETTINGS_ADDRESS_BAR_POSITION_SELECTED_TOP("ms_address_bar_position_setting_selected_top"),
     SETTINGS_ADDRESS_BAR_POSITION_SELECTED_BOTTOM("ms_address_bar_position_setting_selected_bottom"),
     SETTINGS_NEXT_STEPS_ADDRESS_BAR("m_settings_next_steps_set_address_bar"),
+    SETTINGS_NEXT_STEPS_VOICE_SEARCH("m_settings_next_steps_enable_voice_search"),
     SETTINGS_MAC_APP_PRESSED("ms_mac_app_setting_pressed"),
     SETTINGS_WINDOWS_APP_PRESSED("ms_windows_app_setting_pressed"),
     SETTINGS_EMAIL_PROTECTION_PRESSED("ms_email_protection_setting_pressed"),

--- a/app/src/main/java/com/duckduckgo/app/settings/NewSettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/NewSettingsViewModel.kt
@@ -34,6 +34,7 @@ import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_DEFAULT_BROWSER_PRESSED
 import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_EMAIL_PROTECTION_PRESSED
 import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_FIRE_BUTTON_PRESSED
 import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_GENERAL_PRESSED
+import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_NEXT_STEPS_ADDRESS_BAR
 import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_OPENED
 import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_PERMISSIONS_PRESSED
 import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_PRIVATE_SEARCH_PRESSED
@@ -213,6 +214,7 @@ class NewSettingsViewModel @Inject constructor(
 
     fun onChangeAddressBarPositionClicked() {
         viewModelScope.launch { command.send(LaunchAppearanceScreen) }
+        pixel.fire(SETTINGS_NEXT_STEPS_ADDRESS_BAR)
     }
 
     fun onEnableVoiceSearchClicked() {

--- a/app/src/main/java/com/duckduckgo/app/settings/NewSettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/NewSettingsViewModel.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_EMAIL_PROTECTION_PRESSED
 import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_FIRE_BUTTON_PRESSED
 import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_GENERAL_PRESSED
 import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_NEXT_STEPS_ADDRESS_BAR
+import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_NEXT_STEPS_VOICE_SEARCH
 import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_OPENED
 import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_PERMISSIONS_PRESSED
 import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_PRIVATE_SEARCH_PRESSED
@@ -219,6 +220,7 @@ class NewSettingsViewModel @Inject constructor(
 
     fun onEnableVoiceSearchClicked() {
         viewModelScope.launch { command.send(LaunchAccessibilitySettings) }
+        pixel.fire(SETTINGS_NEXT_STEPS_VOICE_SEARCH)
     }
 
     fun onDefaultBrowserSettingClicked() {

--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/pixels/AutoConsentPixel.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/pixels/AutoConsentPixel.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autoconsent.impl.pixels
+
+import com.duckduckgo.app.statistics.pixels.Pixel
+
+enum class AutoConsentPixel(override val pixelName: String) : Pixel.PixelName {
+
+    SETTINGS_AUTOCONSENT_SHOWN("m_settings_autoconsent_shown"),
+    SETTINGS_AUTOCONSENT_ON("m_settings_autoconsent_on"),
+    SETTINGS_AUTOCONSENT_OFF("m_settings_autoconsent_off"),
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207908166761516/1208880593716452/f

### Description

Adds new pixels to Settings where we were missing some compared to iOS. See task for more details.

### Steps to test this PR

Prerequisite: Enable `newSettings` feature toggle

_Cookie Pop-Up Protection_
- [x] Open Cookie Pop-Up Protection screen
- [x] Check `m_settings_autoconsent_shown` Pixel is fired
- [x] Toggle pop-up protection off
- [x] Check `m_settings_autoconsent_off` Pixel is fired
- [x] Toggle pop-up protection on
- [x] Check `m_settings_autoconsent_on` Pixel is fired

_Next Steps: Address Bar Position_
- [x] From main Settings screen click "Set Your Address Bar Position" 
- [x] Check `m_settings_next_steps_set_address_bar` Pixel is fired

_Next Steps: Enable Voice Search_
- [x] Use a Pixel device
- [x] From main Settings screen click "Enable Voice Search" 
- [x] Check `m_settings_next_steps_enable_voice_search` Pixel is fired

### UI changes
N/A
