### PR TITLE
Update content scope scripts to version 7.1.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -59,7 +59,6 @@
     });
 
     /* eslint-disable no-redeclare, no-global-assign */
-    /* global cloneInto, exportFunction, false */
 
     // Only use globalThis for testing this breaks window.wrappedJSObject code in Firefox
 
@@ -87,11 +86,8 @@
      * @returns {HTMLLinkElement | HTMLStyleElement}
      */
     function createStyleElement(css) {
-        let style;
-        {
-            style = document.createElement('style');
-            style.innerText = css;
-        }
+        const style = document.createElement('style');
+        style.innerText = css;
         return style;
     }
 
@@ -416,7 +412,7 @@
                 }
                 // The normal return value
                 if (isExempt) {
-                    return DDGReflect.apply(...args);
+                    return DDGReflect.apply(args[0], args[1], args[2]);
                 }
                 return proxyObject.apply(...args);
             };
@@ -432,20 +428,16 @@
                 }
                 return DDGReflect.get(target, prop, receiver);
             };
-            {
-                this._native = objectScope[property];
-                const handler = {};
-                handler.apply = outputHandler;
-                handler.get = getMethod;
-                this.internal = new globalObj.Proxy(objectScope[property], handler);
-            }
+            this._native = objectScope[property];
+            const handler = {};
+            handler.apply = outputHandler;
+            handler.get = getMethod;
+            this.internal = new globalObj.Proxy(objectScope[property], handler);
         }
 
         // Actually apply the proxy to the native property
         overload() {
-            {
-                this.objectScope[this.property] = this.internal;
-            }
+            this.objectScope[this.property] = this.internal;
         }
 
         overloadDescriptor() {
@@ -488,14 +480,8 @@
         });
     }
 
-    let DDGReflect;
-    let DDGPromise;
-
-    // Exports for usage where we have to cross the xray boundary: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Sharing_objects_with_page_scripts
-    {
-        DDGPromise = globalObj.Promise;
-        DDGReflect = globalObj.Reflect;
-    }
+    const DDGPromise = globalObj.Promise;
+    const DDGReflect = globalObj.Reflect;
 
     /**
      * @param {string | null} topLevelHostname
@@ -709,7 +695,6 @@
     }
 
     function createCustomEvent(eventName, eventDetail) {
-
         // @ts-expect-error - possibly null
         return new OriginalCustomEvent(eventName, eventDetail);
     }
@@ -719,7 +704,9 @@
         // FF & Chrome
         return (
             originalWindowDispatchEvent &&
-            originalWindowDispatchEvent(createCustomEvent('sendMessageProxy' + messageSecret, { detail: { messageType, options } }))
+            originalWindowDispatchEvent(
+                createCustomEvent('sendMessageProxy' + messageSecret, { detail: JSON.stringify({ messageType, options }) }),
+            )
         );
         // TBD other platforms
     }
@@ -1996,19 +1983,15 @@
       return parseJSONPointer(fromPointer);
     }
 
-    /* global false, cloneInto, exportFunction */
-
-
     /**
+     * FIXME: this function is not needed anymore after FF xray removal
      * Like Object.defineProperty, but with support for Firefox's mozProxies.
      * @param {any} object - object whose property we are wrapping (most commonly a prototype, e.g. globalThis.BatteryManager.prototype)
      * @param {string} propertyName
      * @param {import('./wrapper-utils').StrictPropertyDescriptor} descriptor - requires all descriptor options to be defined because we can't validate correctness based on TS types
      */
     function defineProperty(object, propertyName, descriptor) {
-        {
-            objectDefineProperty(object, propertyName, descriptor);
-        }
+        objectDefineProperty(object, propertyName, descriptor);
     }
 
     /**

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
@@ -1727,9 +1727,6 @@
 
   // shared/components/ErrorBoundary.js
   var ErrorBoundary = class extends k {
-    /**
-     * @param {{didCatch: (params: {error: Error; info: any}) => void}} props
-     */
     constructor(props) {
       super(props);
       this.state = { hasError: false };
@@ -1740,7 +1737,10 @@
     componentDidCatch(error, info) {
       console.error(error);
       console.log(info);
-      this.props.didCatch({ error, info });
+      let message = error.message;
+      if (typeof message !== "string") message = "unknown";
+      const composed = this.props.context ? [this.props.context, message].join(" ") : message;
+      this.props.didCatch({ error, message: composed, info });
     }
     render() {
       if (this.state.hasError) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^12.4.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.1.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.44.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.1.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#7.3.1",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1734514764"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#09b457c0337dfb56e387576d36849c55518d9f16",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#a539758027d9fd37d9d26213399ac156ca9fb81c",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^12.4.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.1.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#6.44.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.1.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#7.3.1",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1734514764"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass