### PR TITLE
Revert "Allow scrolling all of the password management list mode screen"

### DIFF
--- a/autofill/autofill-impl/src/main/res/layout/fragment_autofill_management_list_mode.xml
+++ b/autofill/autofill-impl/src/main/res/layout/fragment_autofill_management_list_mode.xml
@@ -78,8 +78,9 @@
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/logins"
             android:layout_width="0dp"
-            android:layout_height="wrap_content"
+            android:layout_height="0dp"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/topDivider" />


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/608920331025315/1209106756565265/f 

### Description
Reverts changes made in https://github.com/duckduckgo/Android/pull/5377 as it introduces performance issues on the password management screen with larger password list sizes. Depending on the device / list size, it can be crippling performance.

### Steps to test this PR
- [x] install `internal` variant to make the next step easier
- [x] Add 500+ passwords (can be done in `Autofill Dev Settings` screen, using the **Add a lot of sample logins** button)
- [x] Visit password management screen and verify there isn’t a huge delay in rendering the password list

For contrast, if you try this on `develop` you will notice a large perf issue.