### PR TITLE
Update content scope scripts to version 7.2.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.css
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.css
@@ -129,10 +129,10 @@ body[data-display=app] {
   line-height: 32px;
   font-size: 13px;
   font-weight: 600;
-  .Button_icon {
-    width: 16px;
-    height: 16px;
-  }
+}
+.Button_desktop .Button_icon {
+  width: 16px;
+  height: 16px;
 }
 .Button_iconOnly {
   width: 44px;
@@ -220,13 +220,13 @@ body[data-display=app] {
   height: 44px;
   position: relative;
   width: 100%;
-  > * {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-  }
+}
+.SwitchBarMobile_placeholder > * {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
 }
 
 /* pages/duckplayer/app/components/Switch.module.css */
@@ -320,18 +320,18 @@ body[data-display=app] {
   padding: 0;
   margin: 0;
   position: relative;
-  &:focus-visible {
-    outline: none;
-  }
-  &:focus-visible[aria-expanded=true] {
-    outline: 1px solid white;
-    outline-offset: 2px;
-    border-radius: 50%;
-  }
-  img {
-    display: block;
-    width: 100%;
-  }
+}
+.InfoBar_info:focus-visible {
+  outline: none;
+}
+.InfoBar_info:focus-visible[aria-expanded=true] {
+  outline: 1px solid white;
+  outline-offset: 2px;
+  border-radius: 50%;
+}
+.InfoBar_info img {
+  display: block;
+  width: 100%;
 }
 .InfoBar_lhs {
   display: flex;
@@ -396,18 +396,18 @@ body[data-display=app] {
 }
 .SwitchBarDesktop_input {
   display: block;
-  &:focus-visible {
-    outline: 1px solid white;
-    outline-offset: 2px;
-  }
+}
+.SwitchBarDesktop_input:focus-visible {
+  outline: 1px solid white;
+  outline-offset: 2px;
 }
 .SwitchBarDesktop_input[disabled] {
 }
 .SwitchBarDesktop_text {
   line-height: 1;
-  &:hover {
-    cursor: pointer;
-  }
+}
+.SwitchBarDesktop_text:hover {
+  cursor: pointer;
 }
 
 /* pages/duckplayer/app/components/Tooltip.module.css */
@@ -422,6 +422,7 @@ body[data-display=app] {
   background-blend-mode: normal, luminosity;
   box-shadow: inset 0px 0px 1px #ffffff;
   filter: drop-shadow(0px 0px 1px #000000) drop-shadow(0px 0px 1px #000000) drop-shadow(0px 0px 1px #000000) drop-shadow(0px 8px 16px rgba(0, 0, 0, 0.2));
+  -webkit-backdrop-filter: blur(76px);
   backdrop-filter: blur(76px);
   border-radius: 10px;
   width: 300px;
@@ -546,7 +547,10 @@ body[data-display=app] {
 .Background_bg::before {
   content: "";
   position: absolute;
-  inset: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
   height: 100%;
   background:
     linear-gradient(
@@ -559,7 +563,10 @@ body[data-display=app] {
 .Background_bg::after {
   content: "";
   position: absolute;
-  inset: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
   height: 100%;
   background:
     linear-gradient(
@@ -903,7 +910,9 @@ body:has([data-state=completed] [aria-checked=true]) .MobileApp_switch {
   background: rgba(0, 0, 0, 0.3);
   border-radius: var(--outer-radius);
   padding: 8px;
-  @media screen and (max-width: 700px) {
+}
+@media screen and (max-width: 700px) {
+  .DesktopApp_landscape .DesktopApp_wrapper {
     grid-template-columns: 50% 1fr;
   }
 }
@@ -929,7 +938,9 @@ body:has([data-state=completed] [aria-checked=true]) .MobileApp_switch {
 .DesktopApp_header {
   grid-area: header;
   padding-top: 48px;
-  @media screen and (max-height: 500px) {
+}
+@media screen and (max-height: 500px) {
+  .DesktopApp_header {
     padding-top: 32px;
   }
 }

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
@@ -6,6 +6,7 @@
   var __getOwnPropNames = Object.getOwnPropertyNames;
   var __getProtoOf = Object.getPrototypeOf;
   var __hasOwnProp = Object.prototype.hasOwnProperty;
+  var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
   var __commonJS = (cb, mod) => function __require() {
     return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
   };
@@ -25,6 +26,7 @@
     isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
     mod
   ));
+  var __publicField = (obj, key, value) => __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
 
   // ../node_modules/classnames/index.js
   var require_classnames = __commonJS({
@@ -2771,7 +2773,7 @@
   };
 
   // ../injected/src/features/duckplayer/util.js
-  var VideoParams = class _VideoParams {
+  var _VideoParams = class _VideoParams {
     /**
      * @param {string} id - the YouTube video ID
      * @param {string|null|undefined} time - an optional time
@@ -2780,8 +2782,6 @@
       this.id = id;
       this.time = time;
     }
-    static validVideoId = /^[a-zA-Z0-9-_]+$/;
-    static validTimestamp = /^[0-9hms]+$/;
     /**
      * @returns {string}
      */
@@ -2857,6 +2857,9 @@
       return new _VideoParams(id, time);
     }
   };
+  __publicField(_VideoParams, "validVideoId", /^[a-zA-Z0-9-_]+$/);
+  __publicField(_VideoParams, "validTimestamp", /^[0-9hms]+$/);
+  var VideoParams = _VideoParams;
 
   // pages/duckplayer/src/utils.js
   function createYoutubeURLForError(href, urlBase) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^12.4.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.1.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.1.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.2.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#7.3.1",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1734514764"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#a539758027d9fd37d9d26213399ac156ca9fb81c",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#3cc892f9acd53e3cb189a32845be348ae077aa22",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^12.4.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.1.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.1.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.2.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#7.3.1",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1734514764"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1209113171823443/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass