### PR TITLE
Reduce the high-count buckets

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/tabs/store/TabStatsBucketing.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/store/TabStatsBucketing.kt
@@ -46,12 +46,7 @@ interface TabStatsBucketing {
             21..40,
             41..60,
             61..80,
-            81..100,
-            101..125,
-            126..150,
-            151..250,
-            251..500,
-            501..Int.MAX_VALUE,
+            81..Int.MAX_VALUE,
         )
 
         val ACTIVITY_BUCKETS = listOf(

--- a/app/src/test/java/com/duckduckgo/app/tabs/store/TabStatsBucketingTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/store/TabStatsBucketingTest.kt
@@ -94,42 +94,42 @@ class DefaultTabStatsBucketingTest {
     fun testGetNumberOfOpenTabs81To100() = runTest {
         whenever(tabRepository.getOpenTabCount()).thenReturn(90)
         val result = defaultTabStatsBucketing.getNumberOfOpenTabs()
-        assertEquals("81-100", result)
+        assertEquals("81+", result)
     }
 
     @Test
     fun testGetNumberOfOpenTabs101To125() = runTest {
         whenever(tabRepository.getOpenTabCount()).thenReturn(110)
         val result = defaultTabStatsBucketing.getNumberOfOpenTabs()
-        assertEquals("101-125", result)
+        assertEquals("81+", result)
     }
 
     @Test
     fun testGetNumberOfOpenTabs126To150() = runTest {
         whenever(tabRepository.getOpenTabCount()).thenReturn(130)
         val result = defaultTabStatsBucketing.getNumberOfOpenTabs()
-        assertEquals("126-150", result)
+        assertEquals("81+", result)
     }
 
     @Test
     fun testGetNumberOfOpenTabs151To250() = runTest {
         whenever(tabRepository.getOpenTabCount()).thenReturn(200)
         val result = defaultTabStatsBucketing.getNumberOfOpenTabs()
-        assertEquals("151-250", result)
+        assertEquals("81+", result)
     }
 
     @Test
     fun testGetNumberOfOpenTabs251To500() = runTest {
         whenever(tabRepository.getOpenTabCount()).thenReturn(300)
         val result = defaultTabStatsBucketing.getNumberOfOpenTabs()
-        assertEquals("251-500", result)
+        assertEquals("81+", result)
     }
 
     @Test
     fun testGetNumberOfOpenTabsMaxValue() = runTest {
         whenever(tabRepository.getOpenTabCount()).thenReturn(600)
         val result = defaultTabStatsBucketing.getNumberOfOpenTabs()
-        assertEquals("501+", result)
+        assertEquals("81+", result)
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207418217763355/1208798050088814/f

### Description

This PR removes the temporary high-count buckets from a tab-count pixel so that the highest one is 81+, as agreed in the privacy review.
