### PR TITLE
Ensure LevelDB Iterator is closed

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/weblocalstorage/WebLocalStorageManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/weblocalstorage/WebLocalStorageManager.kt
@@ -59,16 +59,17 @@ class DuckDuckGoWebLocalStorageManager @Inject constructor(
         Timber.d("WebLocalStorageManager: Matching regex: $matchingRegex")
 
         databaseProvider.get().use { db ->
-            val iterator = db.iterator()
-            iterator.seekToFirst()
+            db.iterator().use { iterator ->
+                iterator.seekToFirst()
 
-            while (iterator.hasNext()) {
-                val entry = iterator.next()
-                val key = String(entry.key, StandardCharsets.UTF_8)
+                while (iterator.hasNext()) {
+                    val entry = iterator.next()
+                    val key = String(entry.key, StandardCharsets.UTF_8)
 
-                if (!isAllowedKey(key)) {
-                    db.delete(entry.key)
-                    Timber.d("WebLocalStorageManager: Deleted key: $key")
+                    if (!isAllowedKey(key)) {
+                        db.delete(entry.key)
+                        Timber.d("WebLocalStorageManager: Deleted key: $key")
+                    }
                 }
             }
         }

--- a/app/src/test/java/com/duckduckgo/app/browser/DuckDuckGoWebLocalStorageManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/DuckDuckGoWebLocalStorageManagerTest.kt
@@ -23,7 +23,7 @@ import com.duckduckgo.app.browser.weblocalstorage.WebLocalStorageSettings
 import com.duckduckgo.app.browser.weblocalstorage.WebLocalStorageSettingsJsonParser
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.feature.toggles.api.Toggle
-import javax.inject.Provider
+import dagger.Lazy
 import kotlinx.coroutines.test.runTest
 import org.iq80.leveldb.DB
 import org.iq80.leveldb.DBIterator
@@ -39,7 +39,7 @@ class DuckDuckGoWebLocalStorageManagerTest {
 
     private val mockDB: DB = mock()
     private val mockIterator: DBIterator = mock()
-    private val mockDatabaseProvider: Provider<DB> = mock()
+    private val mockDatabaseProvider: Lazy<DB> = mock()
     private val mockWebLocalStorageSettingsJsonParser: WebLocalStorageSettingsJsonParser = mock()
     private val mockAndroidBrowserConfigFeature: AndroidBrowserConfigFeature = mock()
     private val mockToggle: Toggle = mock()
@@ -152,13 +152,12 @@ class DuckDuckGoWebLocalStorageManagerTest {
     }
 
     @Test
-    fun whenClearWebLocalStorageThenDBAndIteratorIsClosed() {
+    fun whenClearWebLocalStorageThenIteratorIsClosed() {
         whenever(mockDB.iterator()).thenReturn(mockIterator)
         whenever(mockIterator.hasNext()).thenReturn(false)
 
         testee.clearWebLocalStorage()
 
-        verify(mockDB).close()
         verify(mockIterator).close()
     }
 

--- a/app/src/test/java/com/duckduckgo/app/browser/DuckDuckGoWebLocalStorageManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/DuckDuckGoWebLocalStorageManagerTest.kt
@@ -152,13 +152,14 @@ class DuckDuckGoWebLocalStorageManagerTest {
     }
 
     @Test
-    fun whenClearWebLocalStorageThenDBIsClosed() {
+    fun whenClearWebLocalStorageThenDBAndIteratorIsClosed() {
         whenever(mockDB.iterator()).thenReturn(mockIterator)
         whenever(mockIterator.hasNext()).thenReturn(false)
 
         testee.clearWebLocalStorage()
 
         verify(mockDB).close()
+        verify(mockIterator).close()
     }
 
     private fun createMockDBEntry(key: ByteArray): MutableMap.MutableEntry<ByteArray, ByteArray> {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1200204095367872/1209128100809324/f

### Description

- Closes the `DBIterator` after local storage has been cleared.
- Also keeps the DB open and updates the DB initialization to be `Lazy`.

### Steps to test this PR

_Filter logcat by WebLocalStorageManager_
- [x] Visit cnn.com
- [x] Use the fire button
- [x] Verify that cnn.com entries are deleted
