### PR TITLE
Add feature toggle around clearWebStorage

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewDataManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewDataManagerTest.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.app.global.file.FileDeleter
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.appbuildconfig.api.BuildFlavor.INTERNAL
+import com.duckduckgo.appbuildconfig.api.BuildFlavor.PLAY
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.cookies.api.DuckDuckGoCookieManager
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
@@ -131,16 +132,16 @@ class WebViewDataManagerTest {
 
     @SuppressLint("DenyListedApi")
     @Test
-    fun whenDataClearedAndThrowsExceptionAndNotInternalThenSendCrashPixelAndDeleteAllData() = runTest {
+    fun whenDataClearedAndThrowsExceptionAndNotInternalThenDonNotSendCrashPixelAndDeleteAllData() = runTest {
         withContext(Dispatchers.Main) {
             feature.webLocalStorage().setRawStoredState(State(enable = true))
             val exception = RuntimeException("test")
             val webView = TestWebView(context)
-            whenever(mockAppBuildConfig.flavor).thenReturn(INTERNAL)
+            whenever(mockAppBuildConfig.flavor).thenReturn(PLAY)
             whenever(mockWebLocalStorageManager.clearWebLocalStorage()).thenThrow(exception)
             testee.clearData(webView, mockStorage)
             verify(mockWebLocalStorageManager).clearWebLocalStorage()
-            verify(mockCrashLogger).logCrash(CrashLogger.Crash(shortName = "web_storage_on_clear_error", t = exception))
+            verifyNoInteractions(mockCrashLogger)
             verify(mockStorage).deleteAllData()
         }
     }

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewDataManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/WebViewDataManagerTest.kt
@@ -116,7 +116,7 @@ class WebViewDataManagerTest {
 
     @SuppressLint("DenyListedApi")
     @Test
-    fun whenDataClearedAndThrowsExceptionThenSendCrashPixelAndDeleteAllData() = runTest {
+    fun whenDataClearedAndThrowsExceptionAndInternalThenSendCrashPixelAndDeleteAllData() = runTest {
         withContext(Dispatchers.Main) {
             feature.webLocalStorage().setRawStoredState(State(enable = true))
             val exception = RuntimeException("test")
@@ -132,7 +132,7 @@ class WebViewDataManagerTest {
 
     @SuppressLint("DenyListedApi")
     @Test
-    fun whenDataClearedAndThrowsExceptionAndNotInternalThenDonNotSendCrashPixelAndDeleteAllData() = runTest {
+    fun whenDataClearedAndThrowsExceptionAndNotInternalThenDoNotSendCrashPixelAndDeleteAllData() = runTest {
         withContext(Dispatchers.Main) {
             feature.webLocalStorage().setRawStoredState(State(enable = true))
             val exception = RuntimeException("test")

--- a/app/src/main/java/com/duckduckgo/app/browser/WebDataManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebDataManager.kt
@@ -26,6 +26,8 @@ import com.duckduckgo.app.browser.weblocalstorage.WebLocalStorageManager
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.global.file.FileDeleter
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.appbuildconfig.api.isInternalBuild
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.cookies.api.DuckDuckGoCookieManager
 import com.duckduckgo.di.scopes.AppScope
@@ -61,6 +63,7 @@ class WebViewDataManager @Inject constructor(
     private val crashLogger: CrashLogger,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
+    private val appBuildConfig: AppBuildConfig,
 ) : WebDataManager {
 
     override suspend fun clearData(
@@ -92,7 +95,9 @@ class WebViewDataManager @Inject constructor(
                     continuation.resume(Unit)
                 }.onFailure { e ->
                     Timber.e(e, "WebDataManager: Could not selectively clear web storage")
-                    sendCrashPixel(e)
+                    if (appBuildConfig.isInternalBuild()) {
+                        sendCrashPixel(e)
+                    }
                     // fallback, if we crash we delete everything
                     webStorage.deleteAllData()
                     continuation.resume(Unit)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1200204095367872/1209144640221025/f

### Description
- Currently the `webLocalStorage` toggle only toggles `clearWebViewDirectories()`, it should also toggle `clearWebStorage()`.
- Also only sends the clearWebStorage crash pixel for internal builds.

### Steps to test this PR

_Filter by WebLocalStorageManager_
- [x] In the feature flag inventory, enable `webLocalStorage`
- [x] Visit cnn.com
- [x] Use the fire button
- [x] Verify that you see `WebLocalStorageManager: Deleted key…`
- [x] In the feature flag inventory, disable `webLocalStorage`
- [x] Visit cnn.com
- [x] Use the fire button
- [x] Verify that you **don't** see `WebLocalStorageManager: Deleted key…`
