### PR TITLE
Remove temporary pixel when not showing trackers network dialog

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -44,10 +44,8 @@ import com.duckduckgo.app.privacy.model.TestEntity
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
-import com.duckduckgo.app.trackerdetection.blocklist.BlockList.Cohorts.CONTROL
 import com.duckduckgo.app.trackerdetection.model.Entity
 import com.duckduckgo.app.trackerdetection.model.TrackerStatus
 import com.duckduckgo.app.trackerdetection.model.TrackerType
@@ -794,7 +792,6 @@ class CtaViewModelTest {
         val site = site(url = privacyProUrl)
 
         val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true, site = site)
-        verify(mockPixel, never()).fire(eq(ONBOARDING_SKIP_MAJOR_NETWORK_UNIQUE), any(), any(), eq(Unique()))
         assertNull(value)
     }
 
@@ -811,36 +808,6 @@ class CtaViewModelTest {
 
         val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true, site = site)
         assertNull(value)
-    }
-
-    @Test
-    fun givenDuckPlayerSiteWhenRefreshCtaWhileBrowsingThenFireSkipMajorNetworkPixel() = runTest {
-        givenDaxOnboardingActive()
-        val site = site(url = "duck://player/12345", entity = TestEntity("Google", "Google", 9.0))
-
-        whenever(mockDuckPlayer.isDuckPlayerUri(any())).thenReturn(true)
-        whenever(mockDuckPlayer.getDuckPlayerState()).thenReturn(ENABLED)
-        whenever(mockDuckPlayer.getUserPreferences()).thenReturn(UserPreferences(false, AlwaysAsk))
-        whenever(mockDuckPlayer.isYouTubeUrl(any())).thenReturn(false)
-        whenever(mockDuckPlayer.isSimulatedYoutubeNoCookie(any())).thenReturn(false)
-
-        testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true, site = site)
-        verify(mockPixel).fire(eq(ONBOARDING_SKIP_MAJOR_NETWORK_UNIQUE), any(), any(), eq(Unique()))
-    }
-
-    @Test
-    fun givenDuckPlayerSiteWhenRefreshCtaWhileBrowsingAndTrackersDialogAlreadyShownThenDontSentSkipMajorNetworkPixel() = runTest {
-        givenDaxOnboardingActive()
-        val site = site(url = "duck://player/12345", entity = TestEntity("Google", "Google", 9.0))
-
-        whenever(mockDuckPlayer.isDuckPlayerUri(any())).thenReturn(true)
-        whenever(mockDuckPlayer.getDuckPlayerState()).thenReturn(ENABLED)
-        whenever(mockDuckPlayer.getUserPreferences()).thenReturn(UserPreferences(false, AlwaysAsk))
-        whenever(mockDuckPlayer.isYouTubeUrl(any())).thenReturn(false)
-        whenever(mockDuckPlayer.isSimulatedYoutubeNoCookie(any())).thenReturn(false)
-
-        testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = true, site = site)
-        verify(mockPixel).fire(eq(ONBOARDING_SKIP_MAJOR_NETWORK_UNIQUE), any(), any(), eq(Unique()))
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -42,11 +42,9 @@ import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.testPrivacyProOn
 import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.testPrivacyProOnboardingSecondaryButtonMetricPixel
 import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.testPrivacyProOnboardingShownMetricPixel
 import com.duckduckgo.app.pixels.AppPixelName
-import com.duckduckgo.app.pixels.AppPixelName.ONBOARDING_SKIP_MAJOR_NETWORK_UNIQUE
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.widget.ui.WidgetCapabilities
 import com.duckduckgo.brokensite.api.BrokenSitePrompt
@@ -485,15 +483,6 @@ class CtaViewModel @Inject constructor(
                     (duckPlayer.getUserPreferences().privatePlayerMode == AlwaysAsk && duckPlayer.isYouTubeUrl(uri)) ||
                         duckPlayer.isDuckPlayerUri(site.url) || duckPlayer.isSimulatedYoutubeNoCookie(uri)
                     )
-
-        if (isDuckPlayerUrl) { // temporary pixel
-            val isMayorNetwork = !daxDialogNetworkShown() && !daxDialogTrackersFoundShown() && OnboardingDaxDialogCta.mainTrackerNetworks.any {
-                site.entity?.displayName?.contains(it) ?: false
-            }
-            if (isMayorNetwork) {
-                pixel.fire(pixel = ONBOARDING_SKIP_MAJOR_NETWORK_UNIQUE, type = Unique())
-            }
-        }
 
         return isDuckPlayerUrl
     }

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -49,7 +49,6 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     ONBOARDING_DAX_ALL_CTA_HIDDEN("m_odc_h"),
     ONBOARDING_DAX_CTA_OK_BUTTON("m_odc_ok"),
     ONBOARDING_DAX_CTA_CANCEL_BUTTON("m_onboarding_dax_cta_cancel"),
-    ONBOARDING_SKIP_MAJOR_NETWORK_UNIQUE("m_onboarding_skip_major_network_unique"),
     ONBOARDING_VISIT_SITE_CTA_SHOWN("onboarding_visit_site_cta_shown"),
 
     BROWSER_MENU_ALLOWLIST_ADD("mb_wla"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205278999335242/1208163185498327/f

### Description
Remove temporary pixel when skipping major network onboarding dialog when Duck Player dialog is shown

### Steps to test this PR

_Pixel removed_
- [x] Fresh install
- [x] Go to any youtube URL
- [x] Check pixel `m_onboarding_skip_major_network_unique` is not sent and it works as expected

### No UI changes
