### PR TITLE
Fix subscription activation using email when auth v2 is enabled

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
@@ -341,7 +341,15 @@ class RealSubscriptionsManager @Inject constructor(
 
     override suspend fun signInV1(authToken: String) {
         exchangeAuthToken(authToken)
-        fetchAndStoreAllData()
+        if (shouldUseAuthV2()) {
+            try {
+                refreshSubscriptionData()
+            } catch (e: Exception) {
+                logcat { "Subs: error when refreshing subscription on v1 sign in" }
+            }
+        } else {
+            fetchAndStoreAllData()
+        }
     }
 
     override suspend fun signOut() {

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
@@ -342,6 +342,7 @@ class RealSubscriptionsManager @Inject constructor(
     override suspend fun signInV1(authToken: String) {
         exchangeAuthToken(authToken)
         if (shouldUseAuthV2()) {
+            authRepository.purchaseToWaitingStatus()
             try {
                 refreshSubscriptionData()
             } catch (e: Exception) {

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionMessagingInterface.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionMessagingInterface.kt
@@ -203,8 +203,7 @@ class SubscriptionMessagingInterface @Inject constructor(
             try {
                 val token = jsMessage.params.getString("token")
                 appCoroutineScope.launch(dispatcherProvider.io()) {
-                    subscriptionsManager.exchangeAuthToken(token)
-                    subscriptionsManager.fetchAndStoreAllData()
+                    subscriptionsManager.signInV1(token)
                     subscriptionsChecker.runChecker()
                     pixelSender.reportRestoreUsingEmailSuccess()
                     pixelSender.reportSubscriptionActivated()

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
@@ -63,12 +63,14 @@ import java.time.LocalDateTime
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Assume.assumeFalse
@@ -1238,6 +1240,31 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
             val entitlements = expectMostRecentItem()
             assertTrue(entitlements.isEmpty())
         }
+    }
+
+    @Test
+    fun whenSignInV1ThenExchangesAuthTokenAndLoadsSubscription() = runTest {
+        givenAccessTokenSucceeds()
+        givenValidateTokenSucceedsWithEntitlements()
+        givenV1AccessTokenExchangeSuccess()
+        givenV2AccessTokenRefreshSucceeds()
+
+        whenever(subscriptionsService.subscription()).thenAnswer {
+            runBlocking { subscriptionsManager.getAccessToken() } // triggers v1 -> v2 migration if necessary
+
+            SubscriptionResponse(
+                productId = MONTHLY_PLAN_US,
+                startedAt = 1234,
+                expiresOrRenewsAt = 1234,
+                platform = "android",
+                status = "AUTO_RENEWABLE",
+            )
+        }
+
+        subscriptionsManager.signInV1("authToken")
+
+        assertTrue(subscriptionsManager.isSignedIn())
+        assertNotNull(subscriptionsManager.getSubscription())
     }
 
     private suspend fun givenUrlPortalSucceeds() {

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
@@ -1267,6 +1267,21 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         assertNotNull(subscriptionsManager.getSubscription())
     }
 
+    @Test
+    fun whenSignInV1AndLoadingSubscriptionFailsThenSetsStatusToWaiting() = runTest {
+        assumeTrue(authApiV2Enabled)
+        givenAccessTokenSucceeds()
+        givenV1AccessTokenExchangeSuccess()
+        givenV2AccessTokenRefreshSucceeds()
+        givenSubscriptionFails()
+
+        subscriptionsManager.signInV1("authToken")
+
+        assertTrue(subscriptionsManager.isSignedIn())
+        assertNull(subscriptionsManager.getSubscription())
+        assertEquals(WAITING, subscriptionsManager.subscriptionStatus())
+    }
+
     private suspend fun givenUrlPortalSucceeds() {
         whenever(subscriptionsService.portal()).thenReturn(PortalResponse("example.com"))
     }

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
@@ -113,7 +113,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
     private val authJwtValidator: AuthJwtValidator = mock()
     private val timeProvider = FakeTimeProvider()
     private val backgroundTokenRefresh: BackgroundTokenRefresh = mock()
-    private lateinit var subscriptionsManager: SubscriptionsManager
+    private lateinit var subscriptionsManager: RealSubscriptionsManager
 
     @Before
     fun before() = runTest {

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionMessagingInterfaceTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionMessagingInterfaceTest.kt
@@ -378,7 +378,7 @@ class SubscriptionMessagingInterfaceTest {
 
         messagingInterface.process(message, "duckduckgo-android-messaging-secret")
 
-        verify(subscriptionsManager).exchangeAuthToken("authToken")
+        verify(subscriptionsManager).signInV1("authToken")
         verify(pixelSender).reportRestoreUsingEmailSuccess()
         verify(pixelSender).reportSubscriptionActivated()
         assertEquals(0, callback.counter)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1209143210335480/f

### Description

This PR fixes an issue where subscription details aren't fetched from BE after activating subscription using email. The issue only occurs when auth v2 is enabled.

### Steps to test this PR

- [x] Ensure authApiV2 FF is enabled
- [x] Go to app settings -> "I Have a Subscription" -> "Add via Email"
- [x] Proceed with activating subscription using email until you see success confirmation ("Your Privacy Pro subscription has been added to this device!")
- [x] Tap "Done"
- [x] Verify that you land on subscription settings screen, and it shows correct expiration/renewal date.
- [x] Go Back / tap arrow in the toolbar
- [x] Verify that app settings show correct Privacy Pro state

### No UI changes
