### PR TITLE
Update content scope scripts to version 7.6.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -7285,6 +7285,10 @@
             if (this.getFeatureSettingEnabled('modifyLocalStorage')) {
                 this.modifyLocalStorage();
             }
+
+            if (this.getFeatureSettingEnabled('modifyCookies')) {
+                this.modifyCookies();
+            }
         }
 
         /** Shim Web Share API in Android WebView */
@@ -7742,6 +7746,24 @@
             settings.changes.forEach((change) => {
                 if (change.action === 'delete') {
                     localStorage.removeItem(change.key);
+                }
+            });
+        }
+
+        /**
+         * Support for modifying cookies
+         */
+        modifyCookies() {
+            /** @type {import('@duckduckgo/privacy-configuration/schema/features/webcompat').WebCompatSettings['modifyCookies']} */
+            const settings = this.getFeatureSetting('modifyCookies');
+
+            if (!settings || !settings.changes) return;
+
+            settings.changes.forEach((change) => {
+                if (change.action === 'delete') {
+                    const pathValue = change.path ? `; path=${change.path}` : '';
+                    const domainValue = change.domain ? `; domain=${change.domain}` : '';
+                    document.cookie = `${change.key}=; expires=Thu, 01 Jan 1970 00:00:00 GMT${pathValue}${domainValue}`;
                 }
             });
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^12.5.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.1.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.5.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.6.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#7.3.1",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1734514764"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#0502ed7de4130bd8705daebaca9aeb20d3e62d15",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#7958ddab724c26326333cae13fe81478290607fa",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -282,9 +282,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.10.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.6.tgz",
-      "integrity": "sha512-qNiuwC4ZDAUNcY47xgaSuS92cjf8JbSUoaKS77bmLG1rU7MlATVSiw/IlrjtIyyskXBZ8KkNfjK/P5na7rgXbQ==",
+      "version": "22.10.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.7.tgz",
+      "integrity": "sha512-V09KvXxFiutGp6B7XkpaDXlNadZxrzajcY50EuoLIpQ6WWYCSvf19lVIazzfIzQvhUN2HjX12spLojTnhuKlGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -669,18 +669,18 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.71",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.71.tgz",
-      "integrity": "sha512-LRbChn2YRpic1KxY+ldL1pGXN/oVvKfCVufwfVzEQdFYNo39uF7AJa/WXdo+gYO7PTvdfkCPCed6Hkvz/kR7jg==",
+      "version": "6.1.72",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.72.tgz",
+      "integrity": "sha512-FW3H9aCaGTJ8l8RVCR3EX8GxsxDbQXuwetwwgXA2chYdsX+NY1ytCBl61narjjehWmCw92tc1AxlcY3668CU8g==",
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "6.1.71",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.71.tgz",
-      "integrity": "sha512-78lfP/3fRJ3HoCT5JSLOLj5ElHiWCAyglYNzjkFqBO7ykLZYst2u2jM1igSHWV0J2GFfOplApeDsfTF+XACrlA==",
+      "version": "6.1.72",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.72.tgz",
+      "integrity": "sha512-mfPL+Pzn3nJ0JeI9AHuO4l0NbxldZhpWUYokb8HdK8gbZ2k0/qEqs5E/FqcOjVr4vzTZpbRtiwMPXv77VwXpyQ==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^6.1.71"
+        "tldts-core": "^6.1.72"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^12.5.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.1.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.5.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.6.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#7.3.1",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1734514764"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass