### PR TITLE
Additional "default browser" prompts: variant 2

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/store/DefaultBrowserPromptsPrefsDataStoreImplTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/store/DefaultBrowserPromptsPrefsDataStoreImplTest.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.defaultbrowsing.prompts.store
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.store.DefaultBrowserPromptsDataStore.ExperimentStage
+import com.duckduckgo.common.test.CoroutineTestRule
+import java.io.File
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+private const val DATA_STORE_NAME: String = "default_browser_prompts_test_data_store"
+
+@RunWith(AndroidJUnit4::class)
+class DefaultBrowserPromptsPrefsDataStoreImplTest {
+
+    @get:Rule
+    var coroutinesTestRule = CoroutineTestRule()
+
+    private lateinit var testDataStoreFile: File
+    private lateinit var testDataStore: DataStore<Preferences>
+
+    @Before
+    fun setUp() {
+        testDataStoreFile = File.createTempFile(DATA_STORE_NAME, ".preferences_pb")
+        testDataStore = PreferenceDataStoreFactory.create(
+            scope = coroutinesTestRule.testScope,
+            produceFile = { testDataStoreFile },
+        )
+    }
+
+    @After
+    fun tearDown() {
+        testDataStoreFile.delete()
+    }
+
+    @Test
+    fun whenExperimentInitializedThenDefaultValueIsNotEnrolled() = runTest {
+        val testee = DefaultBrowserPromptsPrefsDataStoreImpl(testDataStore, coroutinesTestRule.testDispatcherProvider)
+
+        assertEquals(testee.experimentStage.first(), ExperimentStage.NOT_ENROLLED)
+    }
+
+    @Test
+    fun whenExperimentStageIsUpdatedThenValueIsPropagated() = runTest {
+        val testee = DefaultBrowserPromptsPrefsDataStoreImpl(testDataStore, coroutinesTestRule.testDispatcherProvider)
+        val expectedUpdates = listOf(
+            ExperimentStage.NOT_ENROLLED,
+            ExperimentStage.STAGE_1,
+        )
+        val actualUpdates = mutableListOf<ExperimentStage>()
+        coroutinesTestRule.testScope.launch {
+            testee.experimentStage.toList(actualUpdates)
+        }
+
+        testee.storeExperimentStage(ExperimentStage.STAGE_1)
+
+        assertEquals(expectedUpdates, actualUpdates)
+    }
+
+    @Test
+    fun whenExperimentInitializedThenShowPopupMenuItemIsDisabled() = runTest {
+        val testee = DefaultBrowserPromptsPrefsDataStoreImpl(testDataStore, coroutinesTestRule.testDispatcherProvider)
+
+        assertFalse(testee.showSetAsDefaultPopupMenuItem.first())
+    }
+
+    @Test
+    fun whenShowPopupMenuItemIsUpdatedThenValueIsPropagated() = runTest {
+        val testee = DefaultBrowserPromptsPrefsDataStoreImpl(testDataStore, coroutinesTestRule.testDispatcherProvider)
+        val expectedUpdates = listOf(
+            false, // initial value
+            true,
+        )
+        val actualUpdates = mutableListOf<Boolean>()
+        coroutinesTestRule.testScope.launch {
+            testee.showSetAsDefaultPopupMenuItem.toList(actualUpdates)
+        }
+
+        testee.storeShowSetAsDefaultPopupMenuItemState(show = true)
+
+        assertEquals(expectedUpdates, actualUpdates)
+    }
+
+    @Test
+    fun whenExperimentInitializedThenHighlightPopupMenuIconIsDisabled() = runTest {
+        val testee = DefaultBrowserPromptsPrefsDataStoreImpl(testDataStore, coroutinesTestRule.testDispatcherProvider)
+
+        assertFalse(testee.highlightPopupMenu.first())
+    }
+
+    @Test
+    fun whenHighlightPopupMenuIconIsUpdatedThenValueIsPropagated() = runTest {
+        val testee = DefaultBrowserPromptsPrefsDataStoreImpl(testDataStore, coroutinesTestRule.testDispatcherProvider)
+        val expectedUpdates = listOf(
+            false, // initial value
+            true,
+        )
+        val actualUpdates = mutableListOf<Boolean>()
+        coroutinesTestRule.testScope.launch {
+            testee.highlightPopupMenu.toList(actualUpdates)
+        }
+
+        testee.storeHighlightPopupMenuState(highlight = true)
+
+        assertEquals(expectedUpdates, actualUpdates)
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -38,8 +38,12 @@ import androidx.webkit.WebViewFeature
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.browser.BrowserViewModel.Command
 import com.duckduckgo.app.browser.BrowserViewModel.Command.Query
+import com.duckduckgo.app.browser.BrowserViewModel.Command.ShowSystemDefaultAppsActivity
+import com.duckduckgo.app.browser.BrowserViewModel.Command.ShowSystemDefaultBrowserDialog
 import com.duckduckgo.app.browser.databinding.ActivityBrowserBinding
 import com.duckduckgo.app.browser.databinding.IncludeOmnibarToolbarMockupBinding
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.ui.DefaultBrowserBottomSheetDialog
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.ui.DefaultBrowserBottomSheetDialog.EventListener
 import com.duckduckgo.app.browser.omnibar.model.OmnibarPosition.BOTTOM
 import com.duckduckgo.app.browser.omnibar.model.OmnibarPosition.TOP
 import com.duckduckgo.app.browser.shortcut.ShortcutBuilder
@@ -50,9 +54,11 @@ import com.duckduckgo.app.feedback.ui.common.FeedbackActivity
 import com.duckduckgo.app.fire.DataClearer
 import com.duckduckgo.app.fire.DataClearerForegroundAppRestartPixel
 import com.duckduckgo.app.firebutton.FireButtonStore
-import com.duckduckgo.app.global.*
+import com.duckduckgo.app.global.ApplicationClearDataState
 import com.duckduckgo.app.global.events.db.UserEventsStore
+import com.duckduckgo.app.global.intentText
 import com.duckduckgo.app.global.rating.PromptCount
+import com.duckduckgo.app.global.sanitize
 import com.duckduckgo.app.global.view.ClearDataAction
 import com.duckduckgo.app.global.view.FireDialog
 import com.duckduckgo.app.global.view.renderIfChanged
@@ -162,6 +168,22 @@ open class BrowserActivity : DuckDuckGoActivity() {
             }
         }
 
+    private val startDefaultBrowserSystemDialogForResult =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result: ActivityResult ->
+            if (result.resultCode == RESULT_OK) {
+                viewModel.onSystemDefaultBrowserDialogSuccess()
+            } else {
+                viewModel.onSystemDefaultBrowserDialogCanceled()
+            }
+        }
+
+    private val startDefaultAppsSystemActivityForResult =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+            viewModel.onSystemDefaultAppsActivityClosed()
+        }
+
+    private var setAsDefaultBrowserDialog: DefaultBrowserBottomSheetDialog? = null
+
     @SuppressLint("MissingSuperCall")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.daggerInject()
@@ -179,6 +201,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
                 binding.bottomMockupToolbar.appBarLayoutMockup.gone()
                 binding.topMockupToolbar
             }
+
             BOTTOM -> {
                 binding.topMockupToolbar.appBarLayoutMockup.gone()
                 binding.bottomMockupToolbar
@@ -300,7 +323,10 @@ open class BrowserActivity : DuckDuckGoActivity() {
         transaction.commit()
     }
 
-    override fun onKeyLongPress(keyCode: Int, event: KeyEvent?): Boolean {
+    override fun onKeyLongPress(
+        keyCode: Int,
+        event: KeyEvent?,
+    ): Boolean {
         return if (keyCode == KeyEvent.KEYCODE_BACK) {
             currentTab?.onLongPressBackButton()
             true
@@ -459,6 +485,10 @@ open class BrowserActivity : DuckDuckGoActivity() {
             is Command.ShowAppFeedbackPrompt -> showGiveFeedbackDialog(command.promptCount)
             is Command.LaunchFeedbackView -> startActivity(FeedbackActivity.intent(this))
             is Command.OpenSavedSite -> currentTab?.submitQuery(command.url)
+            is Command.ShowSetAsDefaultBrowserDialog -> showSetAsDefaultBrowserDialog()
+            is Command.HideSetAsDefaultBrowserDialog -> hideSetAsDefaultBrowserDialog()
+            is ShowSystemDefaultAppsActivity -> showSystemDefaultAppsActivity(command.intent)
+            is ShowSystemDefaultBrowserDialog -> showSystemDefaultBrowserDialog(command.intent)
         }
     }
 
@@ -706,6 +736,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
                     override fun onDialogShown() {
                         viewModel.onAppRatingDialogShown(promptCount)
                     }
+
                     override fun onDialogCancelled() {
                         viewModel.onUserCancelledRateAppDialog(promptCount)
                     }
@@ -757,6 +788,52 @@ open class BrowserActivity : DuckDuckGoActivity() {
         val originalInstanceState: Bundle?,
         val newInstanceState: Bundle?,
     )
+
+    private fun showSetAsDefaultBrowserDialog() {
+        val dialog = DefaultBrowserBottomSheetDialog(context = this)
+        dialog.eventListener = object : EventListener {
+            override fun onShown() {
+                viewModel.onSetDefaultBrowserDialogShown()
+            }
+
+            override fun onDismissed() {
+                viewModel.onSetDefaultBrowserDismissed()
+            }
+
+            override fun onSetBrowserButtonClicked() {
+                viewModel.onSetDefaultBrowserConfirmationButtonClicked()
+            }
+
+            override fun onNotNowButtonClicked() {
+                viewModel.onSetDefaultBrowserNotNowButtonClicked()
+            }
+        }
+        dialog.show()
+        setAsDefaultBrowserDialog = dialog
+    }
+
+    private fun hideSetAsDefaultBrowserDialog() {
+        setAsDefaultBrowserDialog?.dismiss()
+        setAsDefaultBrowserDialog = null
+    }
+
+    private fun showSystemDefaultAppsActivity(intent: Intent) {
+        try {
+            startDefaultAppsSystemActivityForResult.launch(intent)
+            viewModel.onSystemDefaultAppsActivityOpened()
+        } catch (ex: Exception) {
+            Timber.e(ex)
+        }
+    }
+
+    private fun showSystemDefaultBrowserDialog(intent: Intent) {
+        try {
+            startDefaultBrowserSystemDialogForResult.launch(intent)
+            viewModel.onSystemDefaultBrowserDialogShown()
+        } catch (ex: Exception) {
+            Timber.e(ex)
+        }
+    }
 }
 
 // Temporary class to keep track of latest visited tabs, keeping unique ids.

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1064,6 +1064,7 @@ class BrowserTabFragment :
         binding.rootView.postDelayed(POPUP_MENU_DELAY) {
             if (isAdded) {
                 popupMenu.show(binding.rootView, omnibar.toolbar)
+                viewModel.onPopupMenuLaunched()
                 if (isActiveCustomTab()) {
                     pixel.fire(CustomTabPixelNames.CUSTOM_TABS_MENU_OPENED)
                 } else {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.app.browser
 
+import android.content.Intent
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
@@ -23,7 +24,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.app.browser.BrowserViewModel.Command.HideSetAsDefaultBrowserDialog
 import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.DefaultBrowserPromptsExperiment
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.DefaultBrowserPromptsExperiment.Command.OpenMessageDialog
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.DefaultBrowserPromptsExperiment.Command.OpenSystemDefaultAppsActivity
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.DefaultBrowserPromptsExperiment.Command.OpenSystemDefaultBrowserDialog
 import com.duckduckgo.app.browser.omnibar.OmnibarEntryConverter
 import com.duckduckgo.app.fire.DataClearer
 import com.duckduckgo.app.generalsettings.showonapplaunch.ShowOnAppLaunchFeature
@@ -74,6 +80,7 @@ class BrowserViewModel @Inject constructor(
     private val skipUrlConversionOnNewTabFeature: SkipUrlConversionOnNewTabFeature,
     private val showOnAppLaunchFeature: ShowOnAppLaunchFeature,
     private val showOnAppLaunchOptionHandler: ShowOnAppLaunchOptionHandler,
+    private val defaultBrowserPromptsExperiment: DefaultBrowserPromptsExperiment,
 ) : ViewModel(),
     CoroutineScope {
 
@@ -92,6 +99,10 @@ class BrowserViewModel @Inject constructor(
         data class ShowAppRatingPrompt(val promptCount: PromptCount) : Command()
         data class ShowAppFeedbackPrompt(val promptCount: PromptCount) : Command()
         data class OpenSavedSite(val url: String) : Command()
+        data object ShowSetAsDefaultBrowserDialog : Command()
+        data object HideSetAsDefaultBrowserDialog : Command()
+        data class ShowSystemDefaultBrowserDialog(val intent: Intent) : Command()
+        data class ShowSystemDefaultAppsActivity(val intent: Intent) : Command()
     }
 
     var viewState: MutableLiveData<ViewState> = MutableLiveData<ViewState>().also {
@@ -139,6 +150,23 @@ class BrowserViewModel @Inject constructor(
 
     init {
         appEnjoymentPromptEmitter.promptType.observeForever(appEnjoymentObserver)
+        viewModelScope.launch {
+            defaultBrowserPromptsExperiment.commands.collect {
+                when (it) {
+                    OpenMessageDialog -> {
+                        command.value = Command.ShowSetAsDefaultBrowserDialog
+                    }
+
+                    is OpenSystemDefaultAppsActivity -> {
+                        command.value = Command.ShowSystemDefaultAppsActivity(it.intent)
+                    }
+
+                    is OpenSystemDefaultBrowserDialog -> {
+                        command.value = Command.ShowSystemDefaultBrowserDialog(it.intent)
+                    }
+                }
+            }
+        }
     }
 
     suspend fun onNewTabRequested(sourceTabId: String? = null): String {
@@ -308,6 +336,44 @@ class BrowserViewModel @Inject constructor(
         viewModelScope.launch(dispatchers.io()) {
             tabRepository.updateTabLastAccess(tabId)
         }
+    }
+
+    fun onSetDefaultBrowserDialogShown() {
+        defaultBrowserPromptsExperiment.onMessageDialogShown()
+    }
+
+    fun onSetDefaultBrowserDismissed() {
+        defaultBrowserPromptsExperiment.onMessageDialogDismissed()
+    }
+
+    fun onSetDefaultBrowserConfirmationButtonClicked() {
+        command.value = HideSetAsDefaultBrowserDialog
+        defaultBrowserPromptsExperiment.onMessageDialogConfirmationButtonClicked()
+    }
+
+    fun onSetDefaultBrowserNotNowButtonClicked() {
+        command.value = HideSetAsDefaultBrowserDialog
+        defaultBrowserPromptsExperiment.onMessageDialogNotNowButtonClicked()
+    }
+
+    fun onSystemDefaultBrowserDialogShown() {
+        defaultBrowserPromptsExperiment.onSystemDefaultBrowserDialogShown()
+    }
+
+    fun onSystemDefaultBrowserDialogSuccess() {
+        defaultBrowserPromptsExperiment.onSystemDefaultBrowserDialogSuccess()
+    }
+
+    fun onSystemDefaultBrowserDialogCanceled() {
+        defaultBrowserPromptsExperiment.onSystemDefaultBrowserDialogCanceled()
+    }
+
+    fun onSystemDefaultAppsActivityOpened() {
+        defaultBrowserPromptsExperiment.onSystemDefaultAppsActivityOpened()
+    }
+
+    fun onSystemDefaultAppsActivityClosed() {
+        defaultBrowserPromptsExperiment.onSystemDefaultAppsActivityClosed()
     }
 }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/DefaultBrowserPromptsExperiment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/DefaultBrowserPromptsExperiment.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.defaultbrowsing.prompts
+
+import android.content.Intent
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+
+interface DefaultBrowserPromptsExperiment {
+
+    val highlightPopupMenu: StateFlow<Boolean>
+    val showSetAsDefaultPopupMenuItem: StateFlow<Boolean>
+    val commands: Flow<Command>
+
+    fun onPopupMenuLaunched()
+    fun onSetAsDefaultPopupMenuItemSelected()
+
+    fun onMessageDialogShown()
+    fun onMessageDialogDismissed()
+    fun onMessageDialogConfirmationButtonClicked()
+    fun onMessageDialogNotNowButtonClicked()
+
+    fun onSystemDefaultBrowserDialogShown()
+    fun onSystemDefaultBrowserDialogSuccess()
+    fun onSystemDefaultBrowserDialogCanceled()
+
+    fun onSystemDefaultAppsActivityOpened()
+    fun onSystemDefaultAppsActivityClosed()
+
+    sealed class Command {
+        data object OpenMessageDialog : Command()
+        data class OpenSystemDefaultBrowserDialog(val intent: Intent) : Command()
+        data class OpenSystemDefaultAppsActivity(val intent: Intent) : Command()
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/DefaultBrowserPromptsExperimentImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/DefaultBrowserPromptsExperimentImpl.kt
@@ -1,0 +1,339 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.defaultbrowsing.prompts
+
+import android.content.Context
+import androidx.annotation.VisibleForTesting
+import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
+import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserSystemSettings
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.DefaultBrowserPromptsExperiment.Command
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.DefaultBrowserPromptsExperiment.Command.OpenMessageDialog
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.DefaultBrowserPromptsFeatureToggles.AdditionalPromptsCohortName
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.store.DefaultBrowserPromptsDataStore
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.store.DefaultBrowserPromptsDataStore.ExperimentStage.CONVERTED
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.store.DefaultBrowserPromptsDataStore.ExperimentStage.ENROLLED
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.store.DefaultBrowserPromptsDataStore.ExperimentStage.NOT_ENROLLED
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.store.DefaultBrowserPromptsDataStore.ExperimentStage.STAGE_1
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.store.DefaultBrowserPromptsDataStore.ExperimentStage.STAGE_2
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.store.DefaultBrowserPromptsDataStore.ExperimentStage.STOPPED
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.global.DefaultRoleBrowserDialog
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.app.usage.app.AppDaysUsedRepository
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.plugins.PluginPoint
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.anvil.annotations.ContributesMultibinding
+import com.squareup.moshi.Moshi
+import dagger.SingleInstanceIn
+import java.time.ZonedDateTime
+import java.util.Date
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+
+/**
+ * Introduced by [this Asana task](https://app.asana.com/0/1208671518894266/1207295380941379/f).
+ *
+ * For more information refer to the diagrams in [com.duckduckgo.app.browser.defaultbrowsing.prompts.diagrams].
+ */
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = MainProcessLifecycleObserver::class,
+)
+@ContributesMultibinding(
+    AppScope::class,
+    boundType = PrivacyConfigCallbackPlugin::class,
+)
+@ContributesBinding(
+    scope = AppScope::class,
+    boundType = DefaultBrowserPromptsExperiment::class,
+)
+@SingleInstanceIn(scope = AppScope::class)
+class DefaultBrowserPromptsExperimentImpl @Inject constructor(
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val dispatchers: DispatcherProvider,
+    private val applicationContext: Context,
+    private val defaultBrowserPromptsFeatureToggles: DefaultBrowserPromptsFeatureToggles,
+    private val defaultBrowserDetector: DefaultBrowserDetector,
+    private val defaultRoleBrowserDialog: DefaultRoleBrowserDialog,
+    private val appDaysUsedRepository: AppDaysUsedRepository,
+    private val defaultBrowserPromptsDataStore: DefaultBrowserPromptsDataStore,
+    private val experimentStageEvaluatorPluginPoint: PluginPoint<DefaultBrowserPromptsExperimentStageEvaluator>,
+    moshi: Moshi,
+) : DefaultBrowserPromptsExperiment, MainProcessLifecycleObserver, PrivacyConfigCallbackPlugin {
+
+    private val evaluationMutex = Mutex()
+
+    private val _commands = Channel<Command>(capacity = Channel.CONFLATED)
+    override val commands: Flow<Command> = _commands.receiveAsFlow()
+
+    override val showSetAsDefaultPopupMenuItem: StateFlow<Boolean> = defaultBrowserPromptsDataStore.showSetAsDefaultPopupMenuItem.stateIn(
+        scope = appCoroutineScope,
+        started = SharingStarted.Lazily,
+        initialValue = false,
+    )
+
+    override val highlightPopupMenu: StateFlow<Boolean> = defaultBrowserPromptsDataStore.highlightPopupMenu.stateIn(
+        scope = appCoroutineScope,
+        started = SharingStarted.Lazily,
+        initialValue = false,
+    )
+
+    @VisibleForTesting
+    data class FeatureSettings(
+        val activeDaysUntilStage1: Int,
+        val activeDaysUntilStage2: Int,
+        val activeDaysUntilStop: Int,
+    )
+
+    private val featureSettingsJsonAdapter = moshi.adapter(FeatureSettings::class.java)
+
+    /**
+     * Caches deserialized [Toggle.getSettings] for [DefaultBrowserPromptsFeatureToggles.defaultBrowserAdditionalPrompts202501].
+     *
+     * Since we're re-evaluating the experiment on every process' resume,
+     * this allows us to avoid constantly deserializing the same value.
+     *
+     * The value is recomputed on first launch, and on each subsequent privacy config change via [onPrivacyConfigDownloaded].
+     */
+    private var featureSettings: FeatureSettings? = null
+
+    /**
+     * Provides a workaround for cases where the default system browser selection dialog is not available.
+     *
+     * If this [Deferred] is active when [onSystemDefaultBrowserDialogCanceled] is called,
+     * then it means that we should fallback to opening the default apps activity instead.
+     *
+     * If this [Deferred] is complete or cancelled, it means that we should ignore the dialog cancellation as it was likely intentional by the user.
+     *
+     * More context in [this Asana task](https://app.asana.com/0/0/1208996977455495/f).
+     */
+    private var browserSelectionWindowFallbackDeferred: Deferred<Unit>? = null
+
+    override fun onResume(owner: LifecycleOwner) {
+        super.onResume(owner)
+        appCoroutineScope.launch {
+            evaluate()
+        }
+    }
+
+    override fun onPrivacyConfigDownloaded() {
+        appCoroutineScope.launch {
+            featureSettings = defaultBrowserPromptsFeatureToggles.parseFeatureSettings()
+            evaluate()
+        }
+    }
+
+    private suspend fun evaluate() = evaluationMutex.withLock {
+        val isEnrolled = defaultBrowserPromptsFeatureToggles.defaultBrowserAdditionalPrompts202501().getCohort() != null
+        val isDefaultBrowser = defaultBrowserDetector.isDefaultBrowser()
+        val isEligible = isEnrolled || !isDefaultBrowser
+        if (!isEligible) {
+            return
+        }
+
+        val hasConvertedBefore = defaultBrowserPromptsDataStore.experimentStage.first() == CONVERTED
+        val isStopped = defaultBrowserPromptsDataStore.experimentStage.first() == STOPPED
+        if (hasConvertedBefore || isStopped) {
+            return
+        }
+
+        val activeCohortName = defaultBrowserPromptsFeatureToggles.getOrAssignCohort()
+        val currentExperimentStage = defaultBrowserPromptsDataStore.experimentStage.first()
+        if (activeCohortName == null && currentExperimentStage == NOT_ENROLLED) {
+            // The user wasn't enrolled before and wasn't enrolled now either.
+            return
+        }
+
+        val newExperimentStage = if (activeCohortName == null) {
+            // If experiment was underway but we lost the cohort name, it means that the experiment was remotely disabled.
+            STOPPED
+        } else if (isDefaultBrowser) {
+            CONVERTED
+        } else {
+            /**
+             * The [appDaysUsedRepository] expects a [Date] but the experiment framework stores the enrollment date as [ZonedDateTime],
+             * so we're doing a conversion here.
+             */
+            val enrollmentDateGMT = defaultBrowserPromptsFeatureToggles.getEnrollmentDate() ?: run {
+                Timber.e("Missing enrollment date even though cohort is assigned.")
+                return
+            }
+
+            val configSettings = featureSettings ?: run {
+                // If feature settings weren't cached before, deserialize and cache them now.
+                val parsedSettings = defaultBrowserPromptsFeatureToggles.parseFeatureSettings()
+                featureSettings = parsedSettings
+                parsedSettings
+            } ?: run {
+                Timber.e("Failed to obtain feature settings.")
+                return
+            }
+
+            when (currentExperimentStage) {
+                NOT_ENROLLED -> ENROLLED
+
+                ENROLLED -> {
+                    if (appDaysUsedRepository.getNumberOfDaysAppUsedSinceDate(enrollmentDateGMT) >= configSettings.activeDaysUntilStage1) {
+                        STAGE_1
+                    } else {
+                        null
+                    }
+                }
+
+                STAGE_1 -> {
+                    if (appDaysUsedRepository.getNumberOfDaysAppUsedSinceDate(enrollmentDateGMT) >= configSettings.activeDaysUntilStage2) {
+                        STAGE_2
+                    } else {
+                        null
+                    }
+                }
+
+                STAGE_2 -> {
+                    if (appDaysUsedRepository.getNumberOfDaysAppUsedSinceDate(enrollmentDateGMT) >= configSettings.activeDaysUntilStop) {
+                        STOPPED
+                    } else {
+                        null
+                    }
+                }
+
+                STOPPED, CONVERTED -> null
+            }
+        }
+
+        if (newExperimentStage != null) {
+            defaultBrowserPromptsDataStore.storeExperimentStage(newExperimentStage)
+
+            val action = experimentStageEvaluatorPluginPoint.getPlugins().first { it.targetCohort == activeCohortName }.evaluate(newExperimentStage)
+            if (action.showMessageDialog) {
+                _commands.send(OpenMessageDialog)
+            }
+            defaultBrowserPromptsDataStore.storeShowSetAsDefaultPopupMenuItemState(action.showSetAsDefaultPopupMenuItem)
+            defaultBrowserPromptsDataStore.storeHighlightPopupMenuState(action.highlightPopupMenu)
+        }
+    }
+
+    override fun onPopupMenuLaunched() {
+        appCoroutineScope.launch {
+            defaultBrowserPromptsDataStore.storeHighlightPopupMenuState(highlight = false)
+        }
+    }
+
+    override fun onSetAsDefaultPopupMenuItemSelected() {
+        launchBestSelectionWindow()
+    }
+
+    override fun onMessageDialogShown() {
+    }
+
+    override fun onMessageDialogDismissed() {
+    }
+
+    override fun onMessageDialogConfirmationButtonClicked() {
+        launchBestSelectionWindow()
+    }
+
+    override fun onMessageDialogNotNowButtonClicked() {
+    }
+
+    override fun onSystemDefaultBrowserDialogShown() {
+        browserSelectionWindowFallbackDeferred = appCoroutineScope.async {
+            delay(FALLBACK_TO_DEFAULT_APPS_SCREEN_THRESHOLD_MILLIS)
+        }
+    }
+
+    override fun onSystemDefaultBrowserDialogSuccess() {
+    }
+
+    override fun onSystemDefaultBrowserDialogCanceled() {
+        if (browserSelectionWindowFallbackDeferred?.isActive == true) {
+            browserSelectionWindowFallbackDeferred?.cancel()
+            launchSystemDefaultAppsActivity()
+        }
+    }
+
+    override fun onSystemDefaultAppsActivityOpened() {
+    }
+
+    override fun onSystemDefaultAppsActivityClosed() {
+    }
+
+    private fun launchBestSelectionWindow() {
+        val command = defaultRoleBrowserDialog.createIntent(applicationContext)?.let {
+            Command.OpenSystemDefaultBrowserDialog(intent = it)
+        }
+        if (command != null) {
+            _commands.trySend(command)
+        } else {
+            launchSystemDefaultAppsActivity()
+        }
+    }
+
+    private fun launchSystemDefaultAppsActivity() {
+        val command = Command.OpenSystemDefaultAppsActivity(DefaultBrowserSystemSettings.intent())
+        _commands.trySend(command)
+    }
+
+    private suspend fun DefaultBrowserPromptsFeatureToggles.parseFeatureSettings(): FeatureSettings? = withContext(dispatchers.io()) {
+        defaultBrowserAdditionalPrompts202501().getSettings()?.let { settings ->
+            try {
+                featureSettingsJsonAdapter.fromJson(settings)
+            } catch (e: Exception) {
+                Timber.e(e)
+                null
+            }
+        }
+    }
+
+    private fun DefaultBrowserPromptsFeatureToggles.getEnrollmentDate(): Date? =
+        defaultBrowserAdditionalPrompts202501().getCohort()?.enrollmentDateET?.let { enrollmentZonedDateET ->
+            val instant = ZonedDateTime.parse(enrollmentZonedDateET).toInstant()
+            return Date.from(instant)
+        }
+
+    private fun DefaultBrowserPromptsFeatureToggles.getOrAssignCohort(): AdditionalPromptsCohortName? {
+        for (cohort in AdditionalPromptsCohortName.entries) {
+            if (defaultBrowserAdditionalPrompts202501().isEnabled(cohort)) {
+                return cohort
+            }
+        }
+        return null
+    }
+
+    companion object {
+        const val FALLBACK_TO_DEFAULT_APPS_SCREEN_THRESHOLD_MILLIS = 500L
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/DefaultBrowserPromptsExperimentVariants.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/DefaultBrowserPromptsExperimentVariants.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.defaultbrowsing.prompts
+
+import com.duckduckgo.anvil.annotations.ContributesPluginPoint
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.DefaultBrowserPromptsFeatureToggles.AdditionalPromptsCohortName
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.store.DefaultBrowserPromptsDataStore.ExperimentStage
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.store.DefaultBrowserPromptsDataStore.ExperimentStage.CONVERTED
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.store.DefaultBrowserPromptsDataStore.ExperimentStage.ENROLLED
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.store.DefaultBrowserPromptsDataStore.ExperimentStage.NOT_ENROLLED
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.store.DefaultBrowserPromptsDataStore.ExperimentStage.STAGE_1
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.store.DefaultBrowserPromptsDataStore.ExperimentStage.STAGE_2
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.store.DefaultBrowserPromptsDataStore.ExperimentStage.STOPPED
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+data class DefaultBrowserPromptsExperimentStageAction(
+    val showMessageDialog: Boolean,
+    val showSetAsDefaultPopupMenuItem: Boolean,
+    val highlightPopupMenu: Boolean,
+) {
+    companion object {
+        val disableAll = DefaultBrowserPromptsExperimentStageAction(
+            showMessageDialog = false,
+            showSetAsDefaultPopupMenuItem = false,
+            highlightPopupMenu = false,
+        )
+    }
+}
+
+@ContributesPluginPoint(scope = AppScope::class)
+interface DefaultBrowserPromptsExperimentStageEvaluator {
+    val targetCohort: AdditionalPromptsCohortName
+    suspend fun evaluate(newStage: ExperimentStage): DefaultBrowserPromptsExperimentStageAction
+
+    @ContributesMultibinding(scope = AppScope::class)
+    class Variant2 @Inject constructor() : DefaultBrowserPromptsExperimentStageEvaluator {
+
+        override val targetCohort = AdditionalPromptsCohortName.VARIANT_2
+
+        override suspend fun evaluate(newStage: ExperimentStage): DefaultBrowserPromptsExperimentStageAction =
+            when (newStage) {
+                NOT_ENROLLED -> DefaultBrowserPromptsExperimentStageAction.disableAll
+
+                ENROLLED -> DefaultBrowserPromptsExperimentStageAction.disableAll
+
+                STAGE_1 -> DefaultBrowserPromptsExperimentStageAction(
+                    showMessageDialog = true,
+                    showSetAsDefaultPopupMenuItem = false,
+                    highlightPopupMenu = false,
+                )
+
+                STAGE_2 -> DefaultBrowserPromptsExperimentStageAction(
+                    showMessageDialog = false,
+                    showSetAsDefaultPopupMenuItem = true,
+                    highlightPopupMenu = true,
+                )
+
+                STOPPED -> DefaultBrowserPromptsExperimentStageAction.disableAll
+
+                CONVERTED -> DefaultBrowserPromptsExperimentStageAction.disableAll
+            }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/DefaultBrowserPromptsFeatureToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/DefaultBrowserPromptsFeatureToggles.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.defaultbrowsing.prompts
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.State.CohortName
+
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "defaultBrowserPrompts",
+)
+interface DefaultBrowserPromptsFeatureToggles {
+
+    @Toggle.DefaultValue(false)
+    fun self(): Toggle
+
+    @Toggle.DefaultValue(false)
+    fun defaultBrowserAdditionalPrompts202501(): Toggle
+
+    enum class AdditionalPromptsCohortName(override val cohortName: String) : CohortName {
+        VARIANT_2("variant_2"),
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/di/DefaultBrowserPromptsDataStoreModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/di/DefaultBrowserPromptsDataStoreModule.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.defaultbrowsing.prompts.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesTo
+import dagger.Module
+import dagger.Provides
+import javax.inject.Qualifier
+
+@ContributesTo(AppScope::class)
+@Module
+object DefaultBrowserPromptsDataStoreModule {
+
+    private val Context.defaultBrowserPromptsDataStore: DataStore<Preferences> by preferencesDataStore(
+        name = "default_browser_prompts",
+    )
+
+    @Provides
+    @DefaultBrowserPrompts
+    fun defaultBrowserPromptsDataStore(context: Context): DataStore<Preferences> = context.defaultBrowserPromptsDataStore
+}
+
+@Qualifier
+annotation class DefaultBrowserPrompts

--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/diagrams/default_browser_prompts_experiment_class_diagram.puml
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/diagrams/default_browser_prompts_experiment_class_diagram.puml
@@ -1,0 +1,219 @@
+@startuml
+allowmixing
+
+component MainProcessLifecycleObserver
+note top of MainProcessLifecycleObserver
+  The implementation class is the process observer so that it can check
+  whether DDG is the default browser app whenever the process resumes.
+  This allows us to check the state on app launch,
+  but also when app is already running and user changed the default
+  either via the system dialog or manually in system settings.
+end note
+
+abstract class DefaultBrowserPromptsExperimentCommand as "(sealed class) DefaultBrowserPromptsExperiment.Command"
+
+class OpenMessageDialog as "(data object) OpenMessageDialog"
+
+class OpenSystemDefaultBrowserDialog as "(data class) OpenSystemDefaultBrowserDialog" {
+  + intent: Intent
+}
+
+class OpenSystemDefaultAppsActivity as "(data class) OpenSystemDefaultAppsActivity" {
+  + intent: Intent
+}
+
+DefaultBrowserPromptsExperimentCommand <|-- OpenMessageDialog : extends
+DefaultBrowserPromptsExperimentCommand <|-- OpenSystemDefaultBrowserDialog : extends
+DefaultBrowserPromptsExperimentCommand <|-- OpenSystemDefaultAppsActivity : extends
+
+interface DefaultBrowserPromptsExperiment {
+  + val highlightPopupMenu: StateFlow<Boolean>
+  + val showSetAsDefaultPopupMenuItem: StateFlow<Boolean>
+  + val commands: Flow<DefaultBrowserPromptsExperiment.Command>
+
+  + fun onPopupMenuLaunched()
+  + fun onSetAsDefaultPopupMenuItemSelected()
+
+  + fun onMessageDialogShown()
+  + fun onMessageDialogDismissed()
+  + fun onMessageDialogConfirmationButtonClicked()
+  + fun onMessageDialogNotNowButtonClicked()
+
+  + fun onSystemDefaultBrowserDialogShown()
+  + fun onSystemDefaultBrowserDialogSuccess()
+  + fun onSystemDefaultBrowserDialogCanceled()
+
+  + fun onSystemDefaultAppsActivityOpened()
+  + fun onSystemDefaultAppsActivityClosed()
+}
+
+DefaultBrowserPromptsExperiment::commands -> DefaultBrowserPromptsExperimentCommand : uses
+
+note left of DefaultBrowserPromptsExperiment::commands
+  Backed by a //Conflated Channel// so that the experiment
+  can prepare an intent to be launched without being coupled
+  with Activity/Fragment's lifecycle.
+
+  The Activity/Fragment will pick up and execute the intent whenever its ready to do so.
+end note
+
+enum AdditionalPromptsCohortName {
+  + CONTROL("control")
+  + VARIANT_1("variant_1")
+  + VARIANT_2("variant_2")
+  + VARIANT_3("variant_3")
+}
+
+interface DefaultBrowserPromptsFeatureToggles {
+  + additionalPrompts(): Toggle
+}
+
+DefaultBrowserPromptsFeatureToggles -> AdditionalPromptsCohortName : uses
+
+enum ExperimentStage {
+  + NOT_ENROLLED
+  + ENROLLED
+  + STAGE_1
+  + STAGE_2
+  + STOPPED
+  + CONVERTED
+}
+
+interface DefaultBrowserPromptsDataStore {
+  + val experimentStage: Flow<ExperimentStage>
+  + val showSetAsDefaultPopupMenuItem: Flow<Boolean>
+  + val highlightPopupMenuIcon: Flow<Boolean>
+  + suspend fun storeExperimentStage(stage: ExperimentStage)
+  + suspend fun storeShowSetAsDefaultPopupMenuItemState(show: Boolean)
+  + suspend fun storeHighlightPopupMenuState(highlight: Boolean)
+}
+
+note right of ExperimentStage::CONVERTED
+  Notes if the user has already set the DDG browser as default while enrolled.
+  Prevents counting users that keep changing the default browser multiple times.
+  If a user converts, the experiment permanently stops for them.
+end note
+
+DefaultBrowserPromptsDataStore::experimentStage -> ExperimentStage : returns
+
+class DefaultBrowserPromptsDataStoreImpl {
+  - val dataStore: DataStore<Preferences>
+  - val dispatchers: DispatcherProvider
+}
+
+DefaultBrowserPromptsDataStore <|-- DefaultBrowserPromptsDataStoreImpl : implements
+
+class DefaultBrowserPromptsExperimentStageAction as "(data class) DefaultBrowserPromptsExperimentStageAction" {
+  + val showMessageDialog: Boolean
+  + val showSetAsDefaultPopupMenuItem: Boolean
+  + val highlightPopupMenu: Boolean
+}
+
+interface DefaultBrowserPromptsExperimentStageEvaluator {
+  + val targetCohort: AdditionalPromptsCohortName
+  + suspend fun evaluate(newStage: ExperimentStage): DefaultBrowserPromptsExperimentStageAction
+}
+
+DefaultBrowserPromptsExperimentStageEvaluator::targetCohort --> AdditionalPromptsCohortName : uses
+DefaultBrowserPromptsExperimentStageEvaluator::evaluate --> ExperimentStage : accepts
+DefaultBrowserPromptsExperimentStageEvaluator::evaluate --> DefaultBrowserPromptsExperimentStageAction : returns
+
+note top of DefaultBrowserPromptsExperimentStageEvaluator
+  For a given target cohort, the evaluator implementation returns actions that the experiment implementation should take next.
+  These actions include showing dialogs, adding elements to the menu, etc.
+  Evaluation only happens once per stage change, so it's up to the experiment impl to persist the state for actions like menu buttons/highlights,
+  for example when a button should be present in the menu for as long as a given stage is active, including across app launches.
+end note
+
+class Variant2
+
+DefaultBrowserPromptsExperimentStageEvaluator <|--- Variant2 : implements
+
+note left of Variant2
+  Stage 1: show a pop-up dialog.
+  Stage 2: add an popup menu button and highlight the menu itself with a blue dot.
+end note
+
+class DefaultBrowserPromptsExperimentImpl {
+  - val appCoroutineScope: CoroutineScope
+  - val dispatchers: DispatcherProvider
+  - val applicationContext: Context
+  - val defaultBrowserPromptsFeatureToggles: DefaultBrowserPromptsFeatureToggles
+  - val defaultBrowserDetector: DefaultBrowserDetector
+  - val defaultRoleBrowserDialog: DefaultRoleBrowserDialog
+  - val appDaysUsedRepository: AppDaysUsedRepository
+  - val defaultBrowserPromptsDataStore: DefaultBrowserPromptsDataStore
+  - val experimentStageEvaluatorPluginPoint: PluginPoint<DefaultBrowserPromptsExperimentStageEvaluator>
+  - val pixelSender: PixelSender
+  - val moshi: Moshi
+}
+
+MainProcessLifecycleObserver <|--- DefaultBrowserPromptsExperimentImpl : implements
+
+DefaultBrowserPromptsExperiment <|-- DefaultBrowserPromptsExperimentImpl : implements
+
+DefaultBrowserPromptsExperimentImpl::defaultBrowserPromptsDataStore --> DefaultBrowserPromptsDataStore : uses
+
+DefaultBrowserPromptsExperimentImpl::defaultBrowserPromptsFeatureToggles --> DefaultBrowserPromptsFeatureToggles : uses
+
+DefaultBrowserPromptsExperimentImpl::experimentStageEvaluatorPluginPoint ---> DefaultBrowserPromptsExperimentStageEvaluator : uses
+
+note left of DefaultBrowserPromptsExperimentImpl::applicationContext
+  Used to create intents.
+end note
+
+note left of DefaultBrowserPromptsExperimentImpl::defaultBrowserPromptsFeatureToggles
+  Used to manage cohorts and enrolment.
+end note
+
+note left of DefaultBrowserPromptsExperimentImpl::defaultBrowserDetector
+  Used to check if the browser is set as default.
+end note
+
+note left of DefaultBrowserPromptsExperimentImpl::defaultRoleBrowserDialog
+  Used to generate the intent to open the system's
+  default browser dialog.
+end note
+
+note left of DefaultBrowserPromptsExperimentImpl::appDaysUsedRepository
+  Used to monitor the active use days.
+end note
+
+note left of DefaultBrowserPromptsExperimentImpl::defaultBrowserPromptsDataStore
+  Used to persist the stage of the experiment.
+end note
+
+note left of DefaultBrowserPromptsExperimentImpl::experimentStageEvaluatorPluginPoint
+  Used to inject the definitions of what each variant should do given the experiment's stage.
+end note
+
+note left of DefaultBrowserPromptsExperimentImpl::PixelSender
+  Used to send pixels defined in [[https://app.asana.com/0/1208671518894266/1208774988133227/f this Asana task]].
+end note
+
+note left of DefaultBrowserPromptsExperimentImpl::moshi
+  Used to parse feature settings from remote config.
+end note
+
+component BrowserViewModel
+BrowserViewModel --> DefaultBrowserPromptsExperiment : uses
+note top of BrowserViewModel
+  Monitors the experiment to open the message dialog
+  that encourages users to set the DDG app as default browser.
+end note
+
+component OmnibarLayoutViewModel
+OmnibarLayoutViewModel --> DefaultBrowserPromptsExperiment : uses
+note top of OmnibarLayoutViewModel
+  Monitors the experiment to show
+  a blue highlight dot next to popup menu's three-dots.
+end note
+
+component BrowserTabViewModel
+BrowserTabViewModel --> DefaultBrowserPromptsExperiment : uses
+note top of BrowserTabViewModel
+  Monitors the experiment to add
+  a popup menu item to set browser as default.
+end note
+
+@enduml

--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/diagrams/default_browser_prompts_experiment_variant_2_flow_diagram.puml
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/diagrams/default_browser_prompts_experiment_variant_2_flow_diagram.puml
@@ -1,0 +1,94 @@
+@startuml
+start
+note
+  Flow run each time when user opens or comes back to the app.
+end note
+:App process resumed or remote config loaded;
+if (Is enrolled OR does not have DDG set as default browser) then (yes)
+  if (Has user converted already?) then (no)
+    if (Is user in the `variant_2` cohort?) then (yes)
+      note
+         Also enrolls and assigns the cohort, if needed.
+      end note
+      if (Is DDG the default browser app) then (no)
+        switch (Experiment stage)
+        case (NOT_ENROLLED)
+          :Enroll and assign a cohort;
+          :Move stage to ENROLLED;
+        case (ENROLLED)
+          if (App active use days since enrollment >= 1?) then (yes)
+            :Move stage to STAGE_1;
+            :Show message dialog;
+          else (no)
+          endif
+        case (STAGE_1)
+          if (App active use days since enrollment >= 20?) then (yes)
+            :Move stage to STAGE_2;
+            :Show popup menu highlight;
+              :Show popup menu item;
+          else (no)
+          endif
+        case (STAGE_2)
+          if (App active use days since enrollment >= 30?) then (yes)
+            :Move stage to STOPPED;
+            :Remove popup menu highlight;
+            :Remove popup menu item;
+          else (no)
+          endif
+        case (STOPPED)
+          :noop;
+        case (CONVERTED)
+          :noop;
+        endswitch
+        stop
+      else (yes)
+        if (Is STOPPED) is (yes) then
+        else (no)
+          :Move stage to CONVERTED;
+          :Send conversion pixel;
+        endif
+      endif
+    else (no)
+      note right
+        If experiment was underway but we lost the cohort name,
+        it means that the experiment was remotely disabled.
+      end note
+      if (Was enrolled already?) is (yes) then
+        :Move stage to STOPPED;
+        :Remove popup menu highlight;
+        :Remove popup menu item;
+      else (no)
+      endif
+    endif
+  else (yes)
+    endif
+else (false)
+endif
+stop
+
+start
+note
+  Flow run each time user clicks the popup menu button.
+end note
+:Popup menu opened;
+:Remove popup menu highlight;
+stop
+
+start
+note
+  Flow run each time user clicks "Set As Default Browser" in the message dialog,
+  or when "Set As Default Browser" button in the popup menu is clicked.
+end note
+:Message dialog's call-to-action accepted (primary button clicked);
+:Open system's default browser selection dialog;
+if (System's default browser selection dialog canceled in less than 500 ms?) then (yes)
+  :Open system's default apps settings activity;
+  note
+    Workaround in case user selected "Don't ask again" in the system dialog.
+    Details in [[https://app.asana.com/0/0/1208996977455495/f this Asana task]].
+  end note
+else (no)
+endif
+stop
+
+@enduml

--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/store/DefaultBrowserPromptsDataStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/store/DefaultBrowserPromptsDataStore.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.defaultbrowsing.prompts.store
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.di.DefaultBrowserPrompts
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.store.DefaultBrowserPromptsDataStore.ExperimentStage
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.store.DefaultBrowserPromptsDataStore.ExperimentStage.NOT_ENROLLED
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+
+interface DefaultBrowserPromptsDataStore {
+    val experimentStage: Flow<ExperimentStage>
+    val showSetAsDefaultPopupMenuItem: Flow<Boolean>
+    val highlightPopupMenu: Flow<Boolean>
+
+    suspend fun storeExperimentStage(stage: ExperimentStage)
+    suspend fun storeShowSetAsDefaultPopupMenuItemState(show: Boolean)
+    suspend fun storeHighlightPopupMenuState(highlight: Boolean)
+
+    enum class ExperimentStage {
+        NOT_ENROLLED,
+        ENROLLED,
+        STAGE_1,
+        STAGE_2,
+        STOPPED,
+        CONVERTED,
+    }
+}
+
+@ContributesBinding(AppScope::class)
+class DefaultBrowserPromptsPrefsDataStoreImpl @Inject constructor(
+    @DefaultBrowserPrompts private val store: DataStore<Preferences>,
+    private val dispatchers: DispatcherProvider,
+) : DefaultBrowserPromptsDataStore {
+    companion object {
+        private const val PREF_KEY_EXPERIMENT_STAGE_ID = "additional_default_browser_prompts_experiment_stage_id"
+        private const val PREF_KEY_SHOW_OVERFLOW_MENU_ITEM = "additional_default_browser_prompts_show_overflow_menu_item"
+        private const val PREF_KEY_HIGHLIGHT_OVERFLOW_MENU_ICON = "additional_default_browser_prompts_highlight_overflow_menu_icon"
+    }
+
+    override val experimentStage: Flow<ExperimentStage> = store.data.map { preferences ->
+        preferences[stringPreferencesKey(PREF_KEY_EXPERIMENT_STAGE_ID)]?.let { ExperimentStage.valueOf(it) } ?: NOT_ENROLLED
+    }
+
+    override val showSetAsDefaultPopupMenuItem: Flow<Boolean> = store.data.map { preferences ->
+        preferences[booleanPreferencesKey(PREF_KEY_SHOW_OVERFLOW_MENU_ITEM)] ?: false
+    }
+
+    override val highlightPopupMenu: Flow<Boolean> = store.data.map { preferences ->
+        preferences[booleanPreferencesKey(PREF_KEY_HIGHLIGHT_OVERFLOW_MENU_ICON)] ?: false
+    }
+
+    override suspend fun storeExperimentStage(stage: ExperimentStage) {
+        withContext(dispatchers.io()) {
+            store.edit { preferences ->
+                preferences[stringPreferencesKey(PREF_KEY_EXPERIMENT_STAGE_ID)] = stage.name
+            }
+        }
+    }
+
+    override suspend fun storeShowSetAsDefaultPopupMenuItemState(show: Boolean) {
+        withContext(dispatchers.io()) {
+            store.edit { preferences ->
+                preferences[booleanPreferencesKey(PREF_KEY_SHOW_OVERFLOW_MENU_ITEM)] = show
+            }
+        }
+    }
+
+    override suspend fun storeHighlightPopupMenuState(highlight: Boolean) {
+        withContext(dispatchers.io()) {
+            store.edit { preferences ->
+                preferences[booleanPreferencesKey(PREF_KEY_HIGHLIGHT_OVERFLOW_MENU_ICON)] = highlight
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/ui/DefaultBrowserBottomSheetDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/ui/DefaultBrowserBottomSheetDialog.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.browser.defaultbrowsing.prompts.ui
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.DialogInterface
 import android.view.LayoutInflater
 import android.widget.FrameLayout
 import com.duckduckgo.app.browser.databinding.BottomSheetDefaultBrowserBinding
@@ -33,31 +34,51 @@ class DefaultBrowserBottomSheetDialog(private val context: Context) : BottomShee
 
     private val binding: BottomSheetDefaultBrowserBinding = BottomSheetDefaultBrowserBinding.inflate(LayoutInflater.from(context))
 
+    var eventListener: EventListener? = null
+
     init {
         setContentView(binding.root)
         // We need the dialog to always be expanded and not draggable because the content takes up a lot of vertical space and requires a scroll view,
         // especially in landscape aspect-ratios. If the dialog started as collapsed, the drag would interfere with internal scroll.
         this.behavior.state = BottomSheetBehavior.STATE_EXPANDED
         this.behavior.isDraggable = false
-        roundCornersAlways(this)
+
+        setOnShowListener { dialogInterface ->
+            setRoundCorners(dialogInterface)
+            eventListener?.onShown()
+        }
+        setOnDismissListener {
+            eventListener?.onDismissed()
+        }
+        binding.defaultBrowserBottomSheetDialogPrimaryButton.setOnClickListener {
+            eventListener?.onSetBrowserButtonClicked()
+        }
+        binding.defaultBrowserBottomSheetDialogGhostButton.setOnClickListener {
+            eventListener?.onNotNowButtonClicked()
+        }
     }
 
     /**
      * By default, when bottom sheet dialog is expanded, the corners become squared.
      * This function ensures that the bottom sheet dialog will have rounded corners even when in an expanded state.
      */
-    private fun roundCornersAlways(dialog: BottomSheetDialog) {
-        dialog.setOnShowListener { dialogInterface ->
-            val bottomSheetDialog = dialogInterface as BottomSheetDialog
-            val bottomSheet = bottomSheetDialog.findViewById<FrameLayout>(R.id.design_bottom_sheet)
+    private fun setRoundCorners(dialogInterface: DialogInterface) {
+        val bottomSheetDialog = dialogInterface as BottomSheetDialog
+        val bottomSheet = bottomSheetDialog.findViewById<FrameLayout>(R.id.design_bottom_sheet)
 
-            val shapeDrawable = MaterialShapeDrawable.createWithElevationOverlay(context)
-            shapeDrawable.shapeAppearanceModel = shapeDrawable.shapeAppearanceModel
-                .toBuilder()
-                .setTopLeftCorner(CornerFamily.ROUNDED, context.resources.getDimension(CommonR.dimen.dialogBorderRadius))
-                .setTopRightCorner(CornerFamily.ROUNDED, context.resources.getDimension(CommonR.dimen.dialogBorderRadius))
-                .build()
-            bottomSheet?.background = shapeDrawable
-        }
+        val shapeDrawable = MaterialShapeDrawable.createWithElevationOverlay(context)
+        shapeDrawable.shapeAppearanceModel = shapeDrawable.shapeAppearanceModel
+            .toBuilder()
+            .setTopLeftCorner(CornerFamily.ROUNDED, context.resources.getDimension(CommonR.dimen.dialogBorderRadius))
+            .setTopRightCorner(CornerFamily.ROUNDED, context.resources.getDimension(CommonR.dimen.dialogBorderRadius))
+            .build()
+        bottomSheet?.background = shapeDrawable
+    }
+
+    interface EventListener {
+        fun onShown()
+        fun onDismissed()
+        fun onSetBrowserButtonClicked()
+        fun onNotNowButtonClicked()
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -152,6 +152,7 @@ class OmnibarLayout @JvmOverloads constructor(
     internal val tabsMenu: TabSwitcherButton by lazy { findViewById(R.id.tabsMenu) }
     internal val fireIconMenu: FrameLayout by lazy { findViewById(R.id.fireIconMenu) }
     internal val browserMenu: FrameLayout by lazy { findViewById(R.id.browserMenu) }
+    internal val browserMenuHighlight: View by lazy { findViewById(R.id.browserMenuHighlight) }
     internal val cookieDummyView: View by lazy { findViewById(R.id.cookieDummyView) }
     internal val cookieAnimation: LottieAnimationView by lazy { findViewById(R.id.cookieAnimation) }
     internal val sceneRoot: ViewGroup by lazy { findViewById(R.id.sceneRoot) }
@@ -469,6 +470,7 @@ class OmnibarLayout @JvmOverloads constructor(
         tabsMenu.isVisible = viewState.showTabsMenu
         fireIconMenu.isVisible = viewState.showFireIcon
         browserMenu.isVisible = viewState.showBrowserMenu
+        browserMenuHighlight.isVisible = viewState.showBrowserMenuHighlight
         spacer.isVisible = viewState.showVoiceSearch && viewState.showClearButton
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.browser.DuckDuckGoUrlDetector
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.DefaultBrowserPromptsExperiment
 import com.duckduckgo.app.browser.omnibar.Omnibar.ViewMode
 import com.duckduckgo.app.browser.omnibar.Omnibar.ViewMode.Browser
 import com.duckduckgo.app.browser.omnibar.Omnibar.ViewMode.CustomTab
@@ -79,6 +80,7 @@ class OmnibarLayoutViewModel @Inject constructor(
     private val pixel: Pixel,
     private val userBrowserProperties: UserBrowserProperties,
     private val dispatcherProvider: DispatcherProvider,
+    private val defaultBrowserPromptsExperiment: DefaultBrowserPromptsExperiment,
 ) : ViewModel() {
 
     private val _viewState = MutableStateFlow(ViewState())
@@ -107,6 +109,7 @@ class OmnibarLayoutViewModel @Inject constructor(
         val showTabsMenu: Boolean = true,
         val showFireIcon: Boolean = true,
         val showBrowserMenu: Boolean = true,
+        val showBrowserMenuHighlight: Boolean = false,
         val scrollingEnabled: Boolean = true,
         val isLoading: Boolean = false,
         val loadingProgress: Int = 0,
@@ -125,6 +128,16 @@ class OmnibarLayoutViewModel @Inject constructor(
         DAX,
         DUCK_PLAYER,
         GLOBE,
+    }
+
+    init {
+        viewModelScope.launch {
+            defaultBrowserPromptsExperiment.highlightPopupMenu.collect { highlightOverflowMenu ->
+                _viewState.update {
+                    it.copy(showBrowserMenuHighlight = highlightOverflowMenu)
+                }
+            }
+        }
     }
 
     fun onAttachedToWindow() {

--- a/app/src/main/res/drawable/ic_circle_7_accent_blue.xml
+++ b/app/src/main/res/drawable/ic_circle_7_accent_blue.xml
@@ -1,0 +1,7 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+  <size
+      android:width="7dp"
+      android:height="7dp" />
+  <solid android:color="?attr/daxColorAccentBlue" />
+</shape>

--- a/app/src/main/res/layout/view_new_omnibar.xml
+++ b/app/src/main/res/layout/view_new_omnibar.xml
@@ -311,6 +311,14 @@
                 android:contentDescription="@string/browserPopupMenu"
                 android:src="@drawable/ic_menu_vertical_24" />
 
+            <View
+                android:id="@+id/browserMenuHighlight"
+                android:layout_width="7dp"
+                android:layout_height="7dp"
+                android:layout_gravity="end"
+                android:background="@drawable/ic_circle_7_accent_blue"
+                android:visibility="gone" />
+
         </FrameLayout>
 
         <include

--- a/app/src/main/res/layout/view_new_omnibar_bottom.xml
+++ b/app/src/main/res/layout/view_new_omnibar_bottom.xml
@@ -311,6 +311,14 @@
                 android:contentDescription="@string/browserPopupMenu"
                 android:src="@drawable/ic_menu_vertical_24" />
 
+            <View
+                android:id="@+id/browserMenuHighlight"
+                android:layout_width="7dp"
+                android:layout_height="7dp"
+                android:layout_gravity="end"
+                android:background="@drawable/ic_circle_7_accent_blue"
+                android:visibility="gone" />
+
         </FrameLayout>
 
         <include

--- a/app/src/test/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/DefaultBrowserPromptsExperimentImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/DefaultBrowserPromptsExperimentImplTest.kt
@@ -1,0 +1,844 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.defaultbrowsing.prompts
+
+import android.content.Context
+import android.content.Intent
+import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
+import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserSystemSettings
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.DefaultBrowserPromptsExperiment.Command
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.DefaultBrowserPromptsExperimentImpl.Companion.FALLBACK_TO_DEFAULT_APPS_SCREEN_THRESHOLD_MILLIS
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.DefaultBrowserPromptsExperimentImpl.FeatureSettings
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.DefaultBrowserPromptsFeatureToggles.AdditionalPromptsCohortName
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.store.DefaultBrowserPromptsDataStore
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.store.DefaultBrowserPromptsDataStore.ExperimentStage
+import com.duckduckgo.app.global.DefaultRoleBrowserDialog
+import com.duckduckgo.app.usage.app.AppDaysUsedRepository
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.plugins.PluginPoint
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.State.Cohort
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import java.time.Instant
+import java.util.Date
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.mock
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DefaultBrowserPromptsExperimentImplTest {
+
+    @get:Rule
+    var coroutinesTestRule = CoroutineTestRule()
+
+    @Mock private lateinit var appContextMock: Context
+
+    @Mock private lateinit var lifecycleOwnerMock: LifecycleOwner
+
+    @Mock private lateinit var featureTogglesMock: DefaultBrowserPromptsFeatureToggles
+
+    @Mock private lateinit var additionalPromptsToggleMock: Toggle
+
+    private val additionalPromptsFeatureSettingsFake = "fake feature settings JSON"
+
+    @Mock private lateinit var defaultRoleBrowserDialogMock: DefaultRoleBrowserDialog
+
+    @Mock private lateinit var defaultBrowserDetectorMock: DefaultBrowserDetector
+
+    @Mock private lateinit var appDaysUsedRepositoryMock: AppDaysUsedRepository
+
+    @Mock private lateinit var experimentStageEvaluatorPluginPointMock: PluginPoint<DefaultBrowserPromptsExperimentStageEvaluator>
+
+    @Mock private lateinit var moshiMock: Moshi
+
+    @Mock private lateinit var featureSettingsJsonAdapterMock: JsonAdapter<FeatureSettings>
+
+    @Mock private lateinit var systemDefaultBrowserDialogIntentMock: Intent
+
+    private lateinit var dataStoreMock: DefaultBrowserPromptsDataStore
+
+    private val fakeEnrollmentDateETString = "2025-01-16T00:00-05:00[America/New_York]"
+    private val fakeEnrollmentDate = Date.from(Instant.ofEpochMilli(1737003600000))
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        dataStoreMock = createDataStoreFake()
+
+        whenever(featureTogglesMock.defaultBrowserAdditionalPrompts202501()).thenReturn(additionalPromptsToggleMock)
+        whenever(defaultRoleBrowserDialogMock.createIntent(appContextMock)).thenReturn(systemDefaultBrowserDialogIntentMock)
+        whenever(moshiMock.adapter<FeatureSettings>(any())).thenReturn(featureSettingsJsonAdapterMock)
+    }
+
+    @Test
+    fun `when initialized, then don't highlight popup menu`() = runTest {
+        val testee = createTestee()
+        assertFalse(testee.highlightPopupMenu.first())
+    }
+
+    @Test
+    fun `when initialized, then don't show popup menu item`() = runTest {
+        val testee = createTestee()
+        assertFalse(testee.showSetAsDefaultPopupMenuItem.first())
+    }
+
+    @Test
+    fun `when popup menu opened, then remove the highlight`() = runTest {
+        val dataStoreMock = createDataStoreFake(
+            initialHighlightPopupMenuIcon = true,
+        )
+        val testee = createTestee(
+            defaultBrowserPromptsDataStore = dataStoreMock,
+        )
+        val expectedUpdates = listOf(
+            false, // initial impl value
+            true, // initial data store value
+            false, // update
+        )
+        val actualUpdates = mutableListOf<Boolean>()
+        coroutinesTestRule.testScope.launch {
+            testee.highlightPopupMenu.toList(actualUpdates)
+        }
+        assertEquals(2, actualUpdates.size) // initial values expected immediately
+
+        testee.onPopupMenuLaunched()
+
+        assertEquals(expectedUpdates, actualUpdates)
+    }
+
+    @Test
+    fun `when popup menu item clicked, then launch browser selection system dialog`() = runTest {
+        val testee = createTestee()
+        val expectedUpdates = listOf<Command>(
+            Command.OpenSystemDefaultBrowserDialog(systemDefaultBrowserDialogIntentMock),
+        )
+        val actualUpdates = mutableListOf<Command>()
+        coroutinesTestRule.testScope.launch {
+            testee.commands.toList(actualUpdates)
+        }
+        assertTrue(actualUpdates.isEmpty())
+
+        testee.onSetAsDefaultPopupMenuItemSelected()
+
+        assertEquals(expectedUpdates, actualUpdates)
+    }
+
+    /**
+     * fixme to verify that the correct intent is passed,
+     *  we need to refactor [DefaultBrowserSystemSettings] to not use a companion object function,
+     *  or use a different test lib to mock the companion object function
+     */
+    @Test
+    fun `when popup menu item clicked and dialog fails, then launch default apps screen as fallback`() = runTest {
+        val testee = createTestee()
+        whenever(defaultRoleBrowserDialogMock.createIntent(appContextMock)).thenReturn(null)
+        val actualUpdates = mutableListOf<Command>()
+        coroutinesTestRule.testScope.launch {
+            testee.commands.toList(actualUpdates)
+        }
+        assertTrue(actualUpdates.isEmpty())
+
+        testee.onSetAsDefaultPopupMenuItemSelected()
+
+        assertEquals(1, actualUpdates.size)
+        assertTrue(actualUpdates[0] is Command.OpenSystemDefaultAppsActivity)
+    }
+
+    @Test
+    fun `when message dialog confirmation clicked, then launch browser selection system dialog`() = runTest {
+        val testee = createTestee()
+        val expectedUpdates = listOf<Command>(
+            Command.OpenSystemDefaultBrowserDialog(systemDefaultBrowserDialogIntentMock),
+        )
+        val actualUpdates = mutableListOf<Command>()
+        coroutinesTestRule.testScope.launch {
+            testee.commands.toList(actualUpdates)
+        }
+        assertTrue(actualUpdates.isEmpty())
+
+        testee.onMessageDialogConfirmationButtonClicked()
+
+        assertEquals(expectedUpdates, actualUpdates)
+    }
+
+    /**
+     * fixme to verify that the correct intent is passed,
+     *  we need to refactor [DefaultBrowserSystemSettings] to not use a companion object function,
+     *  or use a different test lib to mock the companion object function
+     */
+    @Test
+    fun `when message dialog confirmation clicked and dialog fails, then launch default apps screen as fallback`() = runTest {
+        val testee = createTestee()
+        whenever(defaultRoleBrowserDialogMock.createIntent(appContextMock)).thenReturn(null)
+        val actualUpdates = mutableListOf<Command>()
+        coroutinesTestRule.testScope.launch {
+            testee.commands.toList(actualUpdates)
+        }
+        assertTrue(actualUpdates.isEmpty())
+
+        testee.onMessageDialogConfirmationButtonClicked()
+
+        assertEquals(1, actualUpdates.size)
+        assertTrue(actualUpdates[0] is Command.OpenSystemDefaultAppsActivity)
+    }
+
+    /**
+     * Details in this [Asana task](https://app.asana.com/0/0/1208996977455495/f).
+     *
+     * fixme to verify that the correct intent is passed,
+     *  we need to refactor [DefaultBrowserSystemSettings] to not use a companion object function,
+     *  or use a different test lib to mock the companion object function
+     */
+    @Test
+    fun `when system default browser dialog canceled quickly, then open default apps screen instead`() = runTest {
+        val testee = createTestee()
+        val actualUpdates = mutableListOf<Command>()
+        coroutinesTestRule.testScope.launch {
+            testee.commands.toList(actualUpdates)
+        }
+        assertTrue(actualUpdates.isEmpty())
+
+        testee.onSystemDefaultBrowserDialogShown()
+        advanceTimeBy(FALLBACK_TO_DEFAULT_APPS_SCREEN_THRESHOLD_MILLIS - 1) // canceled before threshold
+        testee.onSystemDefaultBrowserDialogCanceled()
+        testee.onSystemDefaultBrowserDialogCanceled() // verifies that repeated cancellation won't keep opening new screens
+
+        assertEquals(1, actualUpdates.size)
+        assertTrue(actualUpdates[0] is Command.OpenSystemDefaultAppsActivity)
+    }
+
+    @Test
+    fun `when system default browser dialog is not canceled quickly, then do nothing`() = runTest {
+        val testee = createTestee()
+        val actualUpdates = mutableListOf<Command>()
+        coroutinesTestRule.testScope.launch {
+            testee.commands.toList(actualUpdates)
+        }
+        assertTrue(actualUpdates.isEmpty())
+
+        testee.onSystemDefaultBrowserDialogShown()
+        advanceTimeBy(FALLBACK_TO_DEFAULT_APPS_SCREEN_THRESHOLD_MILLIS + 1) // canceled after threshold
+        testee.onSystemDefaultBrowserDialogCanceled()
+
+        assertTrue(actualUpdates.isEmpty())
+    }
+
+    @Test
+    fun `evaluate - if not enrolled and browser already set as default, then don't enroll`() = runTest {
+        val testee = createTestee()
+        whenever(defaultBrowserDetectorMock.isDefaultBrowser()).thenReturn(true)
+        whenever(additionalPromptsToggleMock.getCohort()).thenReturn(null)
+
+        testee.onResume(lifecycleOwnerMock)
+
+        verify(dataStoreMock, never()).storeExperimentStage(any())
+        assertEquals(ExperimentStage.NOT_ENROLLED, dataStoreMock.experimentStage.first())
+    }
+
+    @Test
+    fun `evaluate - if not enrolled, browser not set as default, but no cohort assigned, then don't enroll`() = runTest {
+        val testee = createTestee()
+        whenever(defaultBrowserDetectorMock.isDefaultBrowser()).thenReturn(false)
+        whenever(additionalPromptsToggleMock.getCohort()).thenReturn(null)
+        whenever(additionalPromptsToggleMock.isEnabled(any())).thenReturn(false)
+
+        testee.onResume(lifecycleOwnerMock)
+
+        AdditionalPromptsCohortName.entries.forEach {
+            verify(additionalPromptsToggleMock).isEnabled(it)
+        }
+        verify(dataStoreMock, never()).storeExperimentStage(any())
+        assertEquals(ExperimentStage.NOT_ENROLLED, dataStoreMock.experimentStage.first())
+    }
+
+    @Test
+    fun `evaluate - if not enrolled, browser not set as default, and cohort assigned, then enroll`() = runTest {
+        val testee = createTestee()
+        whenever(defaultBrowserDetectorMock.isDefaultBrowser()).thenReturn(false)
+        mockActiveCohort(cohortName = AdditionalPromptsCohortName.VARIANT_2)
+        mockFeatureSettings(
+            activeDaysUntilStage1 = 1,
+            activeDaysUntilStage2 = 3,
+            activeDaysUntilStop = 5,
+        )
+        val evaluatorMock = mockStageEvaluator(
+            forNewStage = ExperimentStage.ENROLLED,
+            forCohortName = AdditionalPromptsCohortName.VARIANT_2,
+            returnsAction = DefaultBrowserPromptsExperimentStageAction(
+                showMessageDialog = false,
+                showSetAsDefaultPopupMenuItem = false,
+                highlightPopupMenu = false,
+            ),
+        )
+        whenever(experimentStageEvaluatorPluginPointMock.getPlugins()).thenReturn(setOf(evaluatorMock))
+
+        testee.onResume(lifecycleOwnerMock)
+
+        verify(dataStoreMock).storeExperimentStage(ExperimentStage.ENROLLED)
+        verify(evaluatorMock).evaluate(ExperimentStage.ENROLLED)
+    }
+
+    @Test
+    fun `evaluate - if enrolled, browser not set as default, and not enough active days until stage 1, then do nothing`() = runTest {
+        val dataStoreMock = createDataStoreFake(
+            initialExperimentStage = ExperimentStage.ENROLLED,
+        )
+        val testee = createTestee(
+            defaultBrowserPromptsDataStore = dataStoreMock,
+        )
+        whenever(defaultBrowserDetectorMock.isDefaultBrowser()).thenReturn(false)
+        mockActiveCohort(cohortName = AdditionalPromptsCohortName.VARIANT_2)
+        mockFeatureSettings(
+            activeDaysUntilStage1 = 1,
+            activeDaysUntilStage2 = 3,
+            activeDaysUntilStop = 5,
+        )
+        whenever(appDaysUsedRepositoryMock.getNumberOfDaysAppUsedSinceDate(fakeEnrollmentDate)).thenReturn(0)
+        val evaluatorMock = mockStageEvaluator(
+            forNewStage = ExperimentStage.ENROLLED,
+            forCohortName = AdditionalPromptsCohortName.VARIANT_2,
+            returnsAction = mock(),
+        )
+        whenever(experimentStageEvaluatorPluginPointMock.getPlugins()).thenReturn(setOf(evaluatorMock))
+
+        testee.onResume(lifecycleOwnerMock)
+
+        verify(dataStoreMock, never()).storeExperimentStage(any())
+        verify(evaluatorMock, never()).evaluate(any())
+    }
+
+    @Test
+    fun `evaluate - if enrolled, browser not set as default, and enough active days until stage 1, then move to stage 1`() = runTest {
+        val dataStoreMock = createDataStoreFake(
+            initialExperimentStage = ExperimentStage.ENROLLED,
+        )
+        val testee = createTestee(
+            defaultBrowserPromptsDataStore = dataStoreMock,
+        )
+        whenever(defaultBrowserDetectorMock.isDefaultBrowser()).thenReturn(false)
+        mockActiveCohort(cohortName = AdditionalPromptsCohortName.VARIANT_2)
+        mockFeatureSettings(
+            activeDaysUntilStage1 = 1,
+            activeDaysUntilStage2 = 3,
+            activeDaysUntilStop = 5,
+        )
+        whenever(appDaysUsedRepositoryMock.getNumberOfDaysAppUsedSinceDate(fakeEnrollmentDate)).thenReturn(1)
+        val evaluatorMock = mockStageEvaluator(
+            forNewStage = ExperimentStage.STAGE_1,
+            forCohortName = AdditionalPromptsCohortName.VARIANT_2,
+            returnsAction = DefaultBrowserPromptsExperimentStageAction(
+                showMessageDialog = true,
+                showSetAsDefaultPopupMenuItem = false,
+                highlightPopupMenu = false,
+            ),
+        )
+        whenever(experimentStageEvaluatorPluginPointMock.getPlugins()).thenReturn(setOf(evaluatorMock))
+
+        testee.onResume(lifecycleOwnerMock)
+
+        verify(dataStoreMock).storeExperimentStage(ExperimentStage.STAGE_1)
+        verify(evaluatorMock).evaluate(ExperimentStage.STAGE_1)
+    }
+
+    @Test
+    fun `evaluate - if enrolled, browser not set as default, and not enough active days until stage 2, then do nothing`() = runTest {
+        val dataStoreMock = createDataStoreFake(
+            initialExperimentStage = ExperimentStage.STAGE_1,
+        )
+        val testee = createTestee(
+            defaultBrowserPromptsDataStore = dataStoreMock,
+        )
+        whenever(defaultBrowserDetectorMock.isDefaultBrowser()).thenReturn(false)
+        mockActiveCohort(cohortName = AdditionalPromptsCohortName.VARIANT_2)
+        mockFeatureSettings(
+            activeDaysUntilStage1 = 1,
+            activeDaysUntilStage2 = 3,
+            activeDaysUntilStop = 5,
+        )
+        whenever(appDaysUsedRepositoryMock.getNumberOfDaysAppUsedSinceDate(fakeEnrollmentDate)).thenReturn(2)
+        val evaluatorMock = mockStageEvaluator(
+            forNewStage = ExperimentStage.STAGE_1,
+            forCohortName = AdditionalPromptsCohortName.VARIANT_2,
+            returnsAction = mock(),
+        )
+        whenever(experimentStageEvaluatorPluginPointMock.getPlugins()).thenReturn(setOf(evaluatorMock))
+
+        testee.onResume(lifecycleOwnerMock)
+
+        verify(dataStoreMock, never()).storeExperimentStage(any())
+        verify(evaluatorMock, never()).evaluate(any())
+    }
+
+    @Test
+    fun `evaluate - if enrolled, browser not set as default, and enough active days until stage 2, then move to stage 2`() = runTest {
+        val dataStoreMock = createDataStoreFake(
+            initialExperimentStage = ExperimentStage.STAGE_1,
+        )
+        val testee = createTestee(
+            defaultBrowserPromptsDataStore = dataStoreMock,
+        )
+        whenever(defaultBrowserDetectorMock.isDefaultBrowser()).thenReturn(false)
+        mockActiveCohort(cohortName = AdditionalPromptsCohortName.VARIANT_2)
+        mockFeatureSettings(
+            activeDaysUntilStage1 = 1,
+            activeDaysUntilStage2 = 3,
+            activeDaysUntilStop = 5,
+        )
+        whenever(appDaysUsedRepositoryMock.getNumberOfDaysAppUsedSinceDate(fakeEnrollmentDate)).thenReturn(3)
+        val evaluatorMock = mockStageEvaluator(
+            forNewStage = ExperimentStage.STAGE_2,
+            forCohortName = AdditionalPromptsCohortName.VARIANT_2,
+            returnsAction = DefaultBrowserPromptsExperimentStageAction(
+                showMessageDialog = true,
+                showSetAsDefaultPopupMenuItem = false,
+                highlightPopupMenu = false,
+            ),
+        )
+        whenever(experimentStageEvaluatorPluginPointMock.getPlugins()).thenReturn(setOf(evaluatorMock))
+
+        testee.onResume(lifecycleOwnerMock)
+
+        verify(dataStoreMock).storeExperimentStage(ExperimentStage.STAGE_2)
+        verify(evaluatorMock).evaluate(ExperimentStage.STAGE_2)
+    }
+
+    @Test
+    fun `evaluate - if enrolled, browser not set as default, and not enough active days until stop, then do nothing`() = runTest {
+        val dataStoreMock = createDataStoreFake(
+            initialExperimentStage = ExperimentStage.STAGE_2,
+        )
+        val testee = createTestee(
+            defaultBrowserPromptsDataStore = dataStoreMock,
+        )
+        whenever(defaultBrowserDetectorMock.isDefaultBrowser()).thenReturn(false)
+        mockActiveCohort(cohortName = AdditionalPromptsCohortName.VARIANT_2)
+        mockFeatureSettings(
+            activeDaysUntilStage1 = 1,
+            activeDaysUntilStage2 = 3,
+            activeDaysUntilStop = 5,
+        )
+        whenever(appDaysUsedRepositoryMock.getNumberOfDaysAppUsedSinceDate(fakeEnrollmentDate)).thenReturn(4)
+        val evaluatorMock = mockStageEvaluator(
+            forNewStage = ExperimentStage.STAGE_2,
+            forCohortName = AdditionalPromptsCohortName.VARIANT_2,
+            returnsAction = mock(),
+        )
+        whenever(experimentStageEvaluatorPluginPointMock.getPlugins()).thenReturn(setOf(evaluatorMock))
+
+        testee.onResume(lifecycleOwnerMock)
+
+        verify(dataStoreMock, never()).storeExperimentStage(any())
+        verify(evaluatorMock, never()).evaluate(any())
+    }
+
+    @Test
+    fun `evaluate - if enrolled, browser not set as default, and enough active days until stop, then move to stopped`() = runTest {
+        val dataStoreMock = createDataStoreFake(
+            initialExperimentStage = ExperimentStage.STAGE_2,
+        )
+        val testee = createTestee(
+            defaultBrowserPromptsDataStore = dataStoreMock,
+        )
+        whenever(defaultBrowserDetectorMock.isDefaultBrowser()).thenReturn(false)
+        mockActiveCohort(cohortName = AdditionalPromptsCohortName.VARIANT_2)
+        mockFeatureSettings(
+            activeDaysUntilStage1 = 1,
+            activeDaysUntilStage2 = 3,
+            activeDaysUntilStop = 5,
+        )
+        whenever(appDaysUsedRepositoryMock.getNumberOfDaysAppUsedSinceDate(fakeEnrollmentDate)).thenReturn(5)
+        val evaluatorMock = mockStageEvaluator(
+            forNewStage = ExperimentStage.STOPPED,
+            forCohortName = AdditionalPromptsCohortName.VARIANT_2,
+            returnsAction = DefaultBrowserPromptsExperimentStageAction(
+                showMessageDialog = true,
+                showSetAsDefaultPopupMenuItem = false,
+                highlightPopupMenu = false,
+            ),
+        )
+        whenever(experimentStageEvaluatorPluginPointMock.getPlugins()).thenReturn(setOf(evaluatorMock))
+
+        testee.onResume(lifecycleOwnerMock)
+
+        verify(dataStoreMock).storeExperimentStage(ExperimentStage.STOPPED)
+        verify(evaluatorMock).evaluate(ExperimentStage.STOPPED)
+    }
+
+    @Test
+    fun `evaluate - if enrolled and browser set as default, then convert`() = runTest {
+        val dataStoreMock = createDataStoreFake(
+            initialExperimentStage = ExperimentStage.ENROLLED,
+        )
+        val testee = createTestee(
+            defaultBrowserPromptsDataStore = dataStoreMock,
+        )
+        whenever(defaultBrowserDetectorMock.isDefaultBrowser()).thenReturn(true)
+        mockActiveCohort(cohortName = AdditionalPromptsCohortName.VARIANT_2)
+        val evaluatorMock = mockStageEvaluator(
+            forNewStage = ExperimentStage.CONVERTED,
+            forCohortName = AdditionalPromptsCohortName.VARIANT_2,
+            returnsAction = DefaultBrowserPromptsExperimentStageAction(
+                showMessageDialog = false,
+                showSetAsDefaultPopupMenuItem = false,
+                highlightPopupMenu = false,
+            ),
+        )
+        whenever(experimentStageEvaluatorPluginPointMock.getPlugins()).thenReturn(setOf(evaluatorMock))
+
+        testee.onResume(lifecycleOwnerMock)
+
+        verify(dataStoreMock).storeExperimentStage(ExperimentStage.CONVERTED)
+        verify(evaluatorMock).evaluate(ExperimentStage.CONVERTED)
+    }
+
+    @Test
+    fun `evaluate - if stage 1 and browser set as default, then convert`() = runTest {
+        val dataStoreMock = createDataStoreFake(
+            initialExperimentStage = ExperimentStage.STAGE_1,
+        )
+        val testee = createTestee(
+            defaultBrowserPromptsDataStore = dataStoreMock,
+        )
+        whenever(defaultBrowserDetectorMock.isDefaultBrowser()).thenReturn(true)
+        mockActiveCohort(cohortName = AdditionalPromptsCohortName.VARIANT_2)
+        val evaluatorMock = mockStageEvaluator(
+            forNewStage = ExperimentStage.CONVERTED,
+            forCohortName = AdditionalPromptsCohortName.VARIANT_2,
+            returnsAction = DefaultBrowserPromptsExperimentStageAction(
+                showMessageDialog = false,
+                showSetAsDefaultPopupMenuItem = false,
+                highlightPopupMenu = false,
+            ),
+        )
+        whenever(experimentStageEvaluatorPluginPointMock.getPlugins()).thenReturn(setOf(evaluatorMock))
+
+        testee.onResume(lifecycleOwnerMock)
+
+        verify(dataStoreMock).storeExperimentStage(ExperimentStage.CONVERTED)
+        verify(evaluatorMock).evaluate(ExperimentStage.CONVERTED)
+    }
+
+    @Test
+    fun `evaluate - if stage 2 and browser set as default, then convert`() = runTest {
+        val dataStoreMock = createDataStoreFake(
+            initialExperimentStage = ExperimentStage.STAGE_2,
+        )
+        val testee = createTestee(
+            defaultBrowserPromptsDataStore = dataStoreMock,
+        )
+        whenever(defaultBrowserDetectorMock.isDefaultBrowser()).thenReturn(true)
+        mockActiveCohort(cohortName = AdditionalPromptsCohortName.VARIANT_2)
+        val evaluatorMock = mockStageEvaluator(
+            forNewStage = ExperimentStage.CONVERTED,
+            forCohortName = AdditionalPromptsCohortName.VARIANT_2,
+            returnsAction = DefaultBrowserPromptsExperimentStageAction(
+                showMessageDialog = false,
+                showSetAsDefaultPopupMenuItem = false,
+                highlightPopupMenu = false,
+            ),
+        )
+        whenever(experimentStageEvaluatorPluginPointMock.getPlugins()).thenReturn(setOf(evaluatorMock))
+
+        testee.onResume(lifecycleOwnerMock)
+
+        verify(dataStoreMock).storeExperimentStage(ExperimentStage.CONVERTED)
+        verify(evaluatorMock).evaluate(ExperimentStage.CONVERTED)
+    }
+
+    @Test
+    fun `evaluate - if stopped and browser set as default, then don't convert`() = runTest {
+        val dataStoreMock = createDataStoreFake(
+            initialExperimentStage = ExperimentStage.STOPPED,
+        )
+        val testee = createTestee(
+            defaultBrowserPromptsDataStore = dataStoreMock,
+        )
+        whenever(defaultBrowserDetectorMock.isDefaultBrowser()).thenReturn(true)
+        mockActiveCohort(cohortName = AdditionalPromptsCohortName.VARIANT_2)
+        val evaluatorMock = mockStageEvaluator(
+            forNewStage = ExperimentStage.CONVERTED,
+            forCohortName = AdditionalPromptsCohortName.VARIANT_2,
+            returnsAction = DefaultBrowserPromptsExperimentStageAction(
+                showMessageDialog = false,
+                showSetAsDefaultPopupMenuItem = false,
+                highlightPopupMenu = false,
+            ),
+        )
+        whenever(experimentStageEvaluatorPluginPointMock.getPlugins()).thenReturn(setOf(evaluatorMock))
+
+        testee.onResume(lifecycleOwnerMock)
+
+        verify(dataStoreMock, never()).storeExperimentStage(any())
+        verify(evaluatorMock, never()).evaluate(any())
+    }
+
+    @Test
+    fun `evaluate - if converted and browser set as default, then don't convert again`() = runTest {
+        val dataStoreMock = createDataStoreFake(
+            initialExperimentStage = ExperimentStage.CONVERTED,
+        )
+        val testee = createTestee(
+            defaultBrowserPromptsDataStore = dataStoreMock,
+        )
+        whenever(defaultBrowserDetectorMock.isDefaultBrowser()).thenReturn(true)
+        mockActiveCohort(cohortName = AdditionalPromptsCohortName.VARIANT_2)
+        val evaluatorMock = mockStageEvaluator(
+            forNewStage = ExperimentStage.CONVERTED,
+            forCohortName = AdditionalPromptsCohortName.VARIANT_2,
+            returnsAction = DefaultBrowserPromptsExperimentStageAction(
+                showMessageDialog = false,
+                showSetAsDefaultPopupMenuItem = false,
+                highlightPopupMenu = false,
+            ),
+        )
+        whenever(experimentStageEvaluatorPluginPointMock.getPlugins()).thenReturn(setOf(evaluatorMock))
+
+        testee.onResume(lifecycleOwnerMock)
+
+        verify(dataStoreMock, never()).storeExperimentStage(any())
+        verify(evaluatorMock, never()).evaluate(any())
+    }
+
+    @Test
+    fun `evaluate - if stage changes and show dialog action produced, then propagate it`() = runTest {
+        val dataStoreMock = createDataStoreFake(
+            initialExperimentStage = ExperimentStage.ENROLLED,
+        )
+        val testee = createTestee(
+            defaultBrowserPromptsDataStore = dataStoreMock,
+        )
+        whenever(defaultBrowserDetectorMock.isDefaultBrowser()).thenReturn(false)
+        mockActiveCohort(cohortName = AdditionalPromptsCohortName.VARIANT_2)
+        mockFeatureSettings(
+            activeDaysUntilStage1 = 1,
+            activeDaysUntilStage2 = 3,
+            activeDaysUntilStop = 5,
+        )
+        whenever(appDaysUsedRepositoryMock.getNumberOfDaysAppUsedSinceDate(fakeEnrollmentDate)).thenReturn(1)
+        val evaluatorMock = mockStageEvaluator(
+            forNewStage = ExperimentStage.STAGE_1,
+            forCohortName = AdditionalPromptsCohortName.VARIANT_2,
+            returnsAction = DefaultBrowserPromptsExperimentStageAction(
+                showMessageDialog = true,
+                showSetAsDefaultPopupMenuItem = false,
+                highlightPopupMenu = false,
+            ),
+        )
+        whenever(experimentStageEvaluatorPluginPointMock.getPlugins()).thenReturn(setOf(evaluatorMock))
+
+        testee.onResume(lifecycleOwnerMock)
+        val command = testee.commands.first()
+
+        assertEquals(Command.OpenMessageDialog, command)
+    }
+
+    @Test
+    fun `evaluate - if stage changes and show menu item action produced, then propagate it`() = runTest {
+        val dataStoreMock = createDataStoreFake(
+            initialExperimentStage = ExperimentStage.STAGE_1,
+        )
+        val testee = createTestee(
+            defaultBrowserPromptsDataStore = dataStoreMock,
+        )
+        whenever(defaultBrowserDetectorMock.isDefaultBrowser()).thenReturn(false)
+        mockActiveCohort(cohortName = AdditionalPromptsCohortName.VARIANT_2)
+        mockFeatureSettings(
+            activeDaysUntilStage1 = 1,
+            activeDaysUntilStage2 = 3,
+            activeDaysUntilStop = 5,
+        )
+        whenever(appDaysUsedRepositoryMock.getNumberOfDaysAppUsedSinceDate(fakeEnrollmentDate)).thenReturn(3)
+        val evaluatorMock = mockStageEvaluator(
+            forNewStage = ExperimentStage.STAGE_2,
+            forCohortName = AdditionalPromptsCohortName.VARIANT_2,
+            returnsAction = DefaultBrowserPromptsExperimentStageAction(
+                showMessageDialog = false,
+                showSetAsDefaultPopupMenuItem = true,
+                highlightPopupMenu = false,
+            ),
+        )
+        whenever(experimentStageEvaluatorPluginPointMock.getPlugins()).thenReturn(setOf(evaluatorMock))
+
+        testee.onResume(lifecycleOwnerMock)
+        val result = testee.showSetAsDefaultPopupMenuItem.first()
+
+        assertTrue(result)
+        verify(dataStoreMock).storeShowSetAsDefaultPopupMenuItemState(show = true)
+    }
+
+    @Test
+    fun `evaluate - if stage changes and highlight menu action produced, then propagate it`() = runTest {
+        val dataStoreMock = createDataStoreFake(
+            initialExperimentStage = ExperimentStage.STAGE_1,
+        )
+        val testee = createTestee(
+            defaultBrowserPromptsDataStore = dataStoreMock,
+        )
+        whenever(defaultBrowserDetectorMock.isDefaultBrowser()).thenReturn(false)
+        mockActiveCohort(
+            cohortName = AdditionalPromptsCohortName.VARIANT_2,
+        )
+        mockFeatureSettings(
+            activeDaysUntilStage1 = 1,
+            activeDaysUntilStage2 = 3,
+            activeDaysUntilStop = 5,
+        )
+        whenever(appDaysUsedRepositoryMock.getNumberOfDaysAppUsedSinceDate(fakeEnrollmentDate)).thenReturn(3)
+        val evaluatorMock = mockStageEvaluator(
+            forNewStage = ExperimentStage.STAGE_2,
+            forCohortName = AdditionalPromptsCohortName.VARIANT_2,
+            returnsAction = DefaultBrowserPromptsExperimentStageAction(
+                showMessageDialog = false,
+                showSetAsDefaultPopupMenuItem = false,
+                highlightPopupMenu = true,
+            ),
+        )
+        whenever(experimentStageEvaluatorPluginPointMock.getPlugins()).thenReturn(setOf(evaluatorMock))
+
+        testee.onResume(lifecycleOwnerMock)
+        val result = testee.highlightPopupMenu.first()
+
+        assertTrue(result)
+        verify(dataStoreMock).storeHighlightPopupMenuState(highlight = true)
+    }
+
+    private fun createTestee(
+        appCoroutineScope: CoroutineScope = coroutinesTestRule.testScope,
+        dispatchers: DispatcherProvider = coroutinesTestRule.testDispatcherProvider,
+        applicationContext: Context = appContextMock,
+        defaultBrowserPromptsFeatureToggles: DefaultBrowserPromptsFeatureToggles = featureTogglesMock,
+        defaultBrowserDetector: DefaultBrowserDetector = defaultBrowserDetectorMock,
+        defaultRoleBrowserDialog: DefaultRoleBrowserDialog = defaultRoleBrowserDialogMock,
+        appDaysUsedRepository: AppDaysUsedRepository = appDaysUsedRepositoryMock,
+        defaultBrowserPromptsDataStore: DefaultBrowserPromptsDataStore = dataStoreMock,
+        experimentStageEvaluatorPluginPoint: PluginPoint<DefaultBrowserPromptsExperimentStageEvaluator> = experimentStageEvaluatorPluginPointMock,
+        moshi: Moshi = moshiMock,
+    ) = DefaultBrowserPromptsExperimentImpl(
+        appCoroutineScope = appCoroutineScope,
+        dispatchers = dispatchers,
+        applicationContext = applicationContext,
+        defaultBrowserPromptsFeatureToggles = defaultBrowserPromptsFeatureToggles,
+        defaultBrowserDetector = defaultBrowserDetector,
+        defaultRoleBrowserDialog = defaultRoleBrowserDialog,
+        appDaysUsedRepository = appDaysUsedRepository,
+        defaultBrowserPromptsDataStore = defaultBrowserPromptsDataStore,
+        experimentStageEvaluatorPluginPoint = experimentStageEvaluatorPluginPoint,
+        moshi = moshi,
+    )
+
+    private fun createDataStoreFake(
+        initialExperimentStage: ExperimentStage = ExperimentStage.NOT_ENROLLED,
+        initialShowPopupMenuItem: Boolean = false,
+        initialHighlightPopupMenuIcon: Boolean = false,
+    ) = spy(
+        DefaultBrowserPromptsDataStoreMock(
+            initialExperimentStage,
+            initialShowPopupMenuItem,
+            initialHighlightPopupMenuIcon,
+        ),
+    )
+
+    private fun mockActiveCohort(cohortName: AdditionalPromptsCohortName): Cohort {
+        val cohort = Cohort(
+            name = cohortName.name,
+            weight = 1,
+            enrollmentDateET = fakeEnrollmentDateETString,
+        )
+        whenever(additionalPromptsToggleMock.getCohort()).thenReturn(cohort)
+        whenever(additionalPromptsToggleMock.isEnabled(cohortName)).thenReturn(true)
+
+        return cohort
+    }
+
+    private fun mockFeatureSettings(
+        activeDaysUntilStage1: Int,
+        activeDaysUntilStage2: Int,
+        activeDaysUntilStop: Int,
+    ): FeatureSettings {
+        val settings = FeatureSettings(
+            activeDaysUntilStage1 = activeDaysUntilStage1,
+            activeDaysUntilStage2 = activeDaysUntilStage2,
+            activeDaysUntilStop = activeDaysUntilStop,
+        )
+        whenever(additionalPromptsToggleMock.getSettings()).thenReturn(additionalPromptsFeatureSettingsFake)
+        whenever(featureSettingsJsonAdapterMock.fromJson(additionalPromptsFeatureSettingsFake)).thenReturn(settings)
+        return settings
+    }
+
+    private suspend fun mockStageEvaluator(
+        forNewStage: ExperimentStage,
+        forCohortName: AdditionalPromptsCohortName,
+        returnsAction: DefaultBrowserPromptsExperimentStageAction,
+    ): DefaultBrowserPromptsExperimentStageEvaluator {
+        val evaluatorMock: DefaultBrowserPromptsExperimentStageEvaluator = mock()
+        whenever(evaluatorMock.targetCohort).thenReturn(forCohortName)
+        whenever(evaluatorMock.evaluate(forNewStage)).thenReturn(returnsAction)
+        return evaluatorMock
+    }
+}
+
+class DefaultBrowserPromptsDataStoreMock(
+    initialExperimentStage: ExperimentStage,
+    initialShowPopupMenuItem: Boolean,
+    initialHighlightPopupMenuIcon: Boolean,
+) : DefaultBrowserPromptsDataStore {
+
+    private val _experimentStage = MutableStateFlow(initialExperimentStage)
+    override val experimentStage: Flow<ExperimentStage> = _experimentStage.asStateFlow()
+
+    private val _showPopupMenuItem = MutableStateFlow(initialShowPopupMenuItem)
+    override val showSetAsDefaultPopupMenuItem: Flow<Boolean> = _showPopupMenuItem.asStateFlow()
+
+    private val _highlightPopupMenuIcon = MutableStateFlow(initialHighlightPopupMenuIcon)
+    override val highlightPopupMenu: Flow<Boolean> = _highlightPopupMenuIcon.asStateFlow()
+
+    override suspend fun storeExperimentStage(stage: ExperimentStage) {
+        _experimentStage.value = stage
+    }
+
+    override suspend fun storeShowSetAsDefaultPopupMenuItemState(show: Boolean) {
+        _showPopupMenuItem.value = show
+    }
+
+    override suspend fun storeHighlightPopupMenuState(highlight: Boolean) {
+        _highlightPopupMenuIcon.value = highlight
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -4,6 +4,7 @@ import android.view.MotionEvent
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import com.duckduckgo.app.browser.DuckDuckGoUrlDetectorImpl
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.DefaultBrowserPromptsExperiment
 import com.duckduckgo.app.browser.omnibar.Omnibar.ViewMode
 import com.duckduckgo.app.browser.omnibar.OmnibarLayout.Decoration
 import com.duckduckgo.app.browser.omnibar.OmnibarLayout.StateChange
@@ -31,6 +32,7 @@ import com.duckduckgo.privacy.dashboard.impl.pixels.PrivacyDashboardPixels
 import com.duckduckgo.voice.api.VoiceSearchAvailability
 import com.duckduckgo.voice.api.VoiceSearchAvailabilityPixelLogger
 import kotlin.reflect.KClass
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
@@ -58,6 +60,9 @@ class OmnibarLayoutViewModelTest {
     private val pixel: Pixel = mock()
     private val userBrowserProperties: UserBrowserProperties = mock()
 
+    private val defaultBrowserPromptsExperimentHighlightOverflowMenuFlow = MutableStateFlow(false)
+    private val defaultBrowserPromptsExperiment: DefaultBrowserPromptsExperiment = mock()
+
     private lateinit var testee: OmnibarLayoutViewModel
 
     private val EMPTY_URL = ""
@@ -68,6 +73,8 @@ class OmnibarLayoutViewModelTest {
 
     @Before
     fun before() {
+        whenever(defaultBrowserPromptsExperiment.highlightPopupMenu).thenReturn(defaultBrowserPromptsExperimentHighlightOverflowMenuFlow)
+
         testee = OmnibarLayoutViewModel(
             tabRepository = tabRepository,
             voiceSearchAvailability = voiceSearchAvailability,
@@ -77,6 +84,7 @@ class OmnibarLayoutViewModelTest {
             pixel = pixel,
             userBrowserProperties = userBrowserProperties,
             dispatcherProvider = coroutineTestRule.testDispatcherProvider,
+            defaultBrowserPromptsExperiment = defaultBrowserPromptsExperiment,
         )
 
         whenever(tabRepository.flowTabs).thenReturn(flowOf(emptyList()))
@@ -924,6 +932,16 @@ class OmnibarLayoutViewModelTest {
         testee.viewState.test {
             val viewState = awaitItem()
             assertTrue(viewState.omnibarText == RANDOM_URL)
+        }
+    }
+
+    @Test
+    fun `when default browser experiment updates browser menu highlight, then update the view state`() = runTest {
+        defaultBrowserPromptsExperimentHighlightOverflowMenuFlow.value = true
+
+        testee.viewState.test {
+            val viewState = awaitItem()
+            assertTrue(viewState.showBrowserMenuHighlight)
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1208671518894266/1208944504536347/f

### Description
Introduces variant 2 of the experiment that proposes new CTAs around setting DDG as a default browser. The PR also adds all of the experiment foundations and abstractions, so the remaining two variants will only be a small formality.

I'm going to follow up on pixels in a separate PR.

### Class diagram
![image](https://github.com/user-attachments/assets/8a8f5c84-0d73-4024-ac72-bd4650556ab0)

### Flow diagram
![image](https://github.com/user-attachments/assets/1846fe61-8acb-4a63-a297-cd4d9c907145)

### Steps to test this PR

This PR relies on the new A/B/N framework for rollout, so to test you'll need a custom privacy config which includes the feature definition, for example:
```json
"defaultBrowserPrompts": {
  "state": "enabled",
  "exceptions": [],
  "features": {
    "additionalPrompts": {
      "state": "enabled",
      "rollout": {
        "steps": [
          {
            "percent": 100
          }
        ]
      },
      "settings": {
        "activeDaysUntilStage1": 1,
        "activeDaysUntilStage2": 3,
        "activeDaysUntilStop": 5
      },
      "cohorts": [
        {
          "name": "control",
          "weight": 0
        },
        {
          "name": "variant_2",
          "weight": 1
        }
      ]
    }
  },
}
```

or you can apply this JSON Blob:
```diff
diff --git a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
index ca0870311..5a904f76b 100644
--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
@@ -27,4 +27,5 @@ enum class PrivacyFeatureName(val value: String) {
     TrackingParametersFeatureName("trackingParameters"),
 }
 
-const val PRIVACY_REMOTE_CONFIG_URL = "https://staticcdn.duckduckgo.com/trackerblocking/config/v4/android-config.json"
+// const val PRIVACY_REMOTE_CONFIG_URL = "https://staticcdn.duckduckgo.com/trackerblocking/config/v4/android-config.json"
+const val PRIVACY_REMOTE_CONFIG_URL = "https://www.jsonblob.com/api/1329040942036082688"
```

Once built with the right config, ensure that you **don't have DDG app set as a default browser**, only then you'll be assigned to the experiment.

Given the example config above:
- after one active day you'll see a dialog pop up
- after additional 2 active days you'll see a highlighted menu icon and a new menu button
- after additional 2 days, the menu button will disappear

If you convert at any point and set DDG app as default browser, the experiment will permanently stop.

[Screen_recording_20250115_173728.webm](https://github.com/user-attachments/assets/a63f243d-b21f-4dc5-9e69-53e6ee90524b)

In the video I'm using the [ADB commands to change the date](https://app.asana.com/0/1208671518894266/1209150522527594/f), but any mechanism of date change will be enough :)