### PR TITLE
Additional "default browser" prompts: variant 3

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/DefaultBrowserPromptsExperimentVariants.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/DefaultBrowserPromptsExperimentVariants.kt
@@ -76,4 +76,33 @@ interface DefaultBrowserPromptsExperimentStageEvaluator {
                 CONVERTED -> DefaultBrowserPromptsExperimentStageAction.disableAll
             }
     }
+
+    @ContributesMultibinding(scope = AppScope::class)
+    class Variant3 @Inject constructor() : DefaultBrowserPromptsExperimentStageEvaluator {
+
+        override val targetCohort = AdditionalPromptsCohortName.VARIANT_3
+
+        override suspend fun evaluate(newStage: ExperimentStage): DefaultBrowserPromptsExperimentStageAction =
+            when (newStage) {
+                NOT_ENROLLED -> DefaultBrowserPromptsExperimentStageAction.disableAll
+
+                ENROLLED -> DefaultBrowserPromptsExperimentStageAction.disableAll
+
+                STAGE_1 -> DefaultBrowserPromptsExperimentStageAction(
+                    showMessageDialog = true,
+                    showSetAsDefaultPopupMenuItem = true,
+                    highlightPopupMenu = true,
+                )
+
+                STAGE_2 -> DefaultBrowserPromptsExperimentStageAction(
+                    showMessageDialog = true,
+                    showSetAsDefaultPopupMenuItem = true,
+                    highlightPopupMenu = true,
+                )
+
+                STOPPED -> DefaultBrowserPromptsExperimentStageAction.disableAll
+
+                CONVERTED -> DefaultBrowserPromptsExperimentStageAction.disableAll
+            }
+    }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/DefaultBrowserPromptsFeatureToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/DefaultBrowserPromptsFeatureToggles.kt
@@ -35,5 +35,6 @@ interface DefaultBrowserPromptsFeatureToggles {
 
     enum class AdditionalPromptsCohortName(override val cohortName: String) : CohortName {
         VARIANT_2("variant_2"),
+        VARIANT_3("variant_3"),
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1208944504536349/f

### Description
Builds on top of https://github.com/duckduckgo/Android/pull/5476 and adds variant 3.

### Steps to test this PR

This PR relies on the new A/B/N framework for rollout, so to test you'll need a custom privacy config which includes the feature definition, for example:
```json
"defaultBrowserPrompts": {
  "state": "enabled",
  "exceptions": [],
  "features": {
    "additionalPrompts": {
      "state": "enabled",
      "rollout": {
        "steps": [
          {
            "percent": 100
          }
        ]
      },
      "settings": {
        "activeDaysUntilStage1": 1,
        "activeDaysUntilStage2": 3,
        "activeDaysUntilStop": 5
      },
      "cohorts": [
        {
          "name": "control",
          "weight": 0
        },
        {
          "name": "variant_1",
          "weight": 0
        },
        {
          "name": "variant_2",
          "weight": 0
        },
        {
          "name": "variant_3",
          "weight": 1
        }
      ]
    }
  },
}
```

or you can apply this JSON Blob:
```diff
diff --git a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
index ca0870311..5a904f76b 100644
--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
@@ -27,4 +27,5 @@ enum class PrivacyFeatureName(val value: String) {
     TrackingParametersFeatureName("trackingParameters"),
 }
 
-const val PRIVACY_REMOTE_CONFIG_URL = "https://staticcdn.duckduckgo.com/trackerblocking/config/v4/android-config.json"
+// const val PRIVACY_REMOTE_CONFIG_URL = "https://staticcdn.duckduckgo.com/trackerblocking/config/v4/android-config.json"
+const val PRIVACY_REMOTE_CONFIG_URL = "https://www.jsonblob.com/api/1329809981419216896"
```

Once built with the right config, ensure that you **don't have DDG app set as a default browser**, only then you'll be assigned to the experiment.

Given the example config above:
- after one active day you'll see a dialog pop up, a highlighted menu icon, and a new menu button
- after additional 2 active days you'll see another dialog pop up, and a refreshed highlight on the menu icon
- after additional 2 days, the menu button will disappear


If you convert at any point and set DDG app as default browser, the experiment will permanently stop.

[Screen_recording_20250117_150401.webm](https://github.com/user-attachments/assets/e722be8f-a890-456a-ba2c-653ba66e78bf)

In the video I'm using the [ADB commands to change the date](https://app.asana.com/0/1208671518894266/1209150522527594/f), but any mechanism of date change will be enough :)
