### PR TITLE
Additional "default browser" prompts: control

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/DefaultBrowserPromptsExperimentVariants.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/DefaultBrowserPromptsExperimentVariants.kt
@@ -49,6 +49,15 @@ interface DefaultBrowserPromptsExperimentStageEvaluator {
     suspend fun evaluate(newStage: ExperimentStage): DefaultBrowserPromptsExperimentStageAction
 
     @ContributesMultibinding(scope = AppScope::class)
+    class Control @Inject constructor() : DefaultBrowserPromptsExperimentStageEvaluator {
+
+        override val targetCohort = AdditionalPromptsCohortName.CONTROL
+
+        override suspend fun evaluate(newStage: ExperimentStage): DefaultBrowserPromptsExperimentStageAction =
+            DefaultBrowserPromptsExperimentStageAction.disableAll
+    }
+
+    @ContributesMultibinding(scope = AppScope::class)
     class Variant1 @Inject constructor() : DefaultBrowserPromptsExperimentStageEvaluator {
 
         override val targetCohort = AdditionalPromptsCohortName.VARIANT_1

--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/DefaultBrowserPromptsFeatureToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/DefaultBrowserPromptsFeatureToggles.kt
@@ -34,6 +34,7 @@ interface DefaultBrowserPromptsFeatureToggles {
     fun defaultBrowserAdditionalPrompts202501(): Toggle
 
     enum class AdditionalPromptsCohortName(override val cohortName: String) : CohortName {
+        CONTROL("control"),
         VARIANT_1("variant_1"),
         VARIANT_2("variant_2"),
         VARIANT_3("variant_3"),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1209176678727048/f

### Description
Builds on top of https://github.com/duckduckgo/Android/pull/5476 and adds control.

### Steps to test this PR

This PR relies on the new A/B/N framework for rollout, so to test you'll need a custom privacy config which includes the feature definition, for example:
```json
"defaultBrowserPrompts": {
  "state": "enabled",
  "exceptions": [],
  "features": {
    "additionalPrompts": {
      "state": "enabled",
      "rollout": {
        "steps": [
          {
            "percent": 100
          }
        ]
      },
      "settings": {
        "activeDaysUntilStage1": 1,
        "activeDaysUntilStage2": 3,
        "activeDaysUntilStop": 5
      },
      "cohorts": [
        {
          "name": "control",
          "weight": 1
        },
        {
          "name": "variant_1",
          "weight": 0
        },
        {
          "name": "variant_2",
          "weight": 0
        },
        {
          "name": "variant_3",
          "weight": 0
        }
      ]
    }
  },
}
```

or you can apply this JSON Blob:
```diff
diff --git a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
index ca0870311..5a904f76b 100644
--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
@@ -27,4 +27,5 @@ enum class PrivacyFeatureName(val value: String) {
     TrackingParametersFeatureName("trackingParameters"),
 }
 
-const val PRIVACY_REMOTE_CONFIG_URL = "https://staticcdn.duckduckgo.com/trackerblocking/config/v4/android-config.json"
+// const val PRIVACY_REMOTE_CONFIG_URL = "https://staticcdn.duckduckgo.com/trackerblocking/config/v4/android-config.json"
+const val PRIVACY_REMOTE_CONFIG_URL = "https://www.jsonblob.com/api/1329816455226777600"
```

Once built with the right config, ensure that you **don't have DDG app set as a default browser**, only then you'll be assigned to the experiment.

As this is control, during the experiment, you should see no dialogs, no highlights, and no new menu items.