### PR TITLE
Update content scope scripts to version 7.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^12.6.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.1.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.6.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.7.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#7.3.1",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1734514764"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#7958ddab724c26326333cae13fe81478290607fa",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#0ac30560ec969a321caea321f95537120416c323",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -669,18 +669,18 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.72",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.72.tgz",
-      "integrity": "sha512-FW3H9aCaGTJ8l8RVCR3EX8GxsxDbQXuwetwwgXA2chYdsX+NY1ytCBl61narjjehWmCw92tc1AxlcY3668CU8g==",
+      "version": "6.1.73",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.73.tgz",
+      "integrity": "sha512-k1g5eX87vxu3g//6XMn62y4qjayu4cYby/PF7Ksnh4F4uUK1Z1ze/mJ4a+y5OjdJ+cXRp+YTInZhH+FGdUWy1w==",
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "6.1.72",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.72.tgz",
-      "integrity": "sha512-mfPL+Pzn3nJ0JeI9AHuO4l0NbxldZhpWUYokb8HdK8gbZ2k0/qEqs5E/FqcOjVr4vzTZpbRtiwMPXv77VwXpyQ==",
+      "version": "6.1.73",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.73.tgz",
+      "integrity": "sha512-5rljzPNMgdbjGs3WGvQIUi9oV93JaMsZKSslCe6qK62RGqRv+DIuiCkKsj8n+tw9v8Q9bSgRbB4iNwa1/yfd3g==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^6.1.72"
+        "tldts-core": "^6.1.73"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^12.6.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.1.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.6.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.7.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#7.3.1",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1734514764"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [x] All tests must pass