### PR TITLE
duckplayer: revert landscape impression pixel

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -152,7 +152,6 @@ import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.ExtendedOnboardi
 import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.HighlightsOnboardingExperimentManager
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.pixels.AppPixelName.AUTOCOMPLETE_BANNER_SHOWN
-import com.duckduckgo.app.pixels.AppPixelName.DUCK_PLAYER_LANDSCAPE_LAYOUT_IMPRESSIONS
 import com.duckduckgo.app.pixels.AppPixelName.DUCK_PLAYER_SETTING_ALWAYS_DUCK_PLAYER
 import com.duckduckgo.app.pixels.AppPixelName.DUCK_PLAYER_SETTING_ALWAYS_OVERLAY_YOUTUBE
 import com.duckduckgo.app.pixels.AppPixelName.DUCK_PLAYER_SETTING_NEVER_OVERLAY_YOUTUBE
@@ -4678,21 +4677,6 @@ class BrowserTabViewModelTest {
             false,
         ) { "someUrl" }
         assertCommandNotIssued<Navigate>()
-    }
-
-    @Test
-    fun whenProcessJsCallbackMessageTelemetryEventThenFirePixel() = runTest {
-        whenever(mockEnabledToggle.isEnabled()).thenReturn(true)
-        whenever(mockDuckPlayer.getUserPreferences()).thenReturn(UserPreferences(overlayInteracted = true, privatePlayerMode = AlwaysAsk))
-        testee.processJsCallbackMessage(
-            DUCK_PLAYER_PAGE_FEATURE_NAME,
-            "telemetryEvent",
-            "id",
-            JSONObject("""{"attributes": {"name": "impression", "value": "landscape-layout"}}"""),
-            false,
-            { "someUrl" },
-        )
-        verify(mockPixel).fire(DUCK_PLAYER_LANDSCAPE_LAYOUT_IMPRESSIONS)
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/browser/duckplayer/DuckPlayerJSHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/duckplayer/DuckPlayerJSHelper.kt
@@ -26,7 +26,6 @@ import com.duckduckgo.app.browser.commands.Command.SendResponseToDuckPlayer
 import com.duckduckgo.app.browser.commands.Command.SendResponseToJs
 import com.duckduckgo.app.browser.commands.Command.SendSubscriptions
 import com.duckduckgo.app.browser.commands.NavigationCommand.Navigate
-import com.duckduckgo.app.pixels.AppPixelName.DUCK_PLAYER_LANDSCAPE_LAYOUT_IMPRESSIONS
 import com.duckduckgo.app.pixels.AppPixelName.DUCK_PLAYER_SETTING_ALWAYS_DUCK_PLAYER
 import com.duckduckgo.app.pixels.AppPixelName.DUCK_PLAYER_SETTING_ALWAYS_OVERLAY_YOUTUBE
 import com.duckduckgo.app.pixels.AppPixelName.DUCK_PLAYER_SETTING_ALWAYS_SERP
@@ -237,34 +236,6 @@ class DuckPlayerJSHelper @Inject constructor(
             }
             "reportPageException", "reportInitException" -> {
                 Timber.tag(method).d(data.toString())
-            }
-            "telemetryEvent" -> {
-                val attributes = data?.getJSONObject("attributes")
-
-                if (attributes?.getString("name") == "impression" && attributes.getString("value") == "landscape-layout") {
-                    pixel.fire(DUCK_PLAYER_LANDSCAPE_LAYOUT_IMPRESSIONS)
-                }
-
-                /* TODO (cbarreiro) Abstract this to provide better support for telemetry events
-                  * https://app.asana.com/0/1202552961248957/1208690124356904/f */
-                /**
-                 * incoming data looks like this, where `name` is used to discriminate,
-                 * and 'value' is linked to it (but is optional)
-                 *
-                 * {
-                 *   "attributes": {
-                 *     "name": "impression",
-                 *     "value": "landscape-layout"
-                 *   }
-                 * }
-                 *
-                 * Another event might look like this in the future: (note: no 'value' field)
-                 * {
-                 *   "attributes": {
-                 *     "name": "page-view"
-                 *   }
-                 * }
-                 */
             }
             "openSettings" -> {
                 return OpenDuckPlayerSettings

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -361,7 +361,6 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     DUCK_PLAYER_SETTING_NEVER_SERP("duckplayer_setting_never_overlay_serp"),
     DUCK_PLAYER_SETTING_NEVER_OVERLAY_YOUTUBE("duckplayer_setting_never_overlay_youtube"),
     DUCK_PLAYER_SETTING_ALWAYS_DUCK_PLAYER("duckplayer_setting_always_duck-player"),
-    DUCK_PLAYER_LANDSCAPE_LAYOUT_IMPRESSIONS("duckplayer_landscape_layout_impressions"),
 
     ADD_BOOKMARK_CONFIRM_EDITED("m_add_bookmark_confirm_edit"),
 

--- a/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerScriptsJsMessaging.kt
+++ b/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerScriptsJsMessaging.kt
@@ -131,7 +131,6 @@ class DuckPlayerScriptsJsMessaging @Inject constructor(
             "setUserValues",
             "reportPageException",
             "reportInitException",
-            "telemetryEvent",
         )
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201141132935289/1209187970943576/f

### Description

Removal of temporary pixel.

### Steps to test this PR

The FE will still send an event, but it will no-op now, as designed :)

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
