### PR TITLE
Fix missing NETP_DEBUG_SERVER_TOKEN for internal builds

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -100,6 +100,8 @@ jobs:
           gradle clean          
 
       - name: Assemble the bundle
+        env:
+          NETP_DEBUG_SERVER_TOKEN: ${{ secrets.NETP_DEBUG_SERVER_TOKEN }}
         if: steps.check_for_changes.outputs.has_changes == 'true'
         run: gradle bundleInternalRelease -PversionNameSuffix=-nightly -PuseUploadSigning -PlatestTag=${{ steps.get_latest_tag.outputs.latest_tag }} -Pbuild-date-time
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1209187729140301/f

### Description
When we migrated to GHA, the `NETP_DEBUG_SERVER_TOKEN` was no longer passed as env variable, breaking VPN internal settings

### Steps to test this PR

- [ ] Build internal build and verify `VPN server` option in NetP dev settings works as expected
