### PR TITLE
Native handing of ReportBrokenSiteShown message

### DIFF
--- a/node_modules/@duckduckgo/privacy-dashboard/build/app/public/js/base.js
+++ b/node_modules/@duckduckgo/privacy-dashboard/build/app/public/js/base.js
@@ -12776,6 +12776,8 @@
   };
   var ShowNativeFeedback = class extends Msg {
   };
+  var ReportBrokenSiteShown = class extends Msg {
+  };
   var TelemetrySpanMsg = class extends Msg {
     /**
      * @param {object} params
@@ -13109,6 +13111,7 @@
     privacyDashboardOpenSettings: () => privacyDashboardOpenSettings,
     privacyDashboardOpenUrlInNewTab: () => privacyDashboardOpenUrlInNewTab,
     privacyDashboardRejectToggleReport: () => privacyDashboardRejectToggleReport,
+    privacyDashboardReportBrokenSiteShown: () => privacyDashboardReportBrokenSiteShown,
     privacyDashboardSeeWhatIsSent: () => privacyDashboardSeeWhatIsSent,
     privacyDashboardSendToggleReport: () => privacyDashboardSendToggleReport,
     privacyDashboardSetPermission: () => privacyDashboardSetPermission,
@@ -14089,6 +14092,10 @@
     invariant(window.webkit?.messageHandlers, "webkit.messageHandlers required");
     window.webkit.messageHandlers.privacyDashboardSetPermission.postMessage(params);
   }
+  function privacyDashboardReportBrokenSiteShown(args) {
+    invariant(window.webkit?.messageHandlers, "webkit.messageHandlers required");
+    window.webkit.messageHandlers.privacyDashboardReportBrokenSiteShown.postMessage(args);
+  }
   function privacyDashboardGetToggleReportOptions() {
     return new Promise((resolve) => {
       invariant(window.webkit?.messageHandlers, "webkit.messageHandlers required");
@@ -14172,6 +14179,10 @@
     }
     if (message instanceof ShowNativeFeedback) {
       privacyDashboardShowNativeFeedback({});
+      return false;
+    }
+    if (message instanceof ReportBrokenSiteShown) {
+      privacyDashboardReportBrokenSiteShown({});
       return false;
     }
   }
@@ -14284,7 +14295,6 @@
   }
   async function fetch3(message) {
     if (message instanceof CheckBrokenSiteReportHandledMessage) {
-      privacyDashboardShowReportBrokenSite({});
       return false;
     }
     if (message instanceof ShowNativeFeedback) {
@@ -14539,6 +14549,14 @@
       invariant(window.PrivacyDashboard?.showNativeFeedback, "showNativeFeedback missing");
       window.PrivacyDashboard.showNativeFeedback();
     }
+    /**
+     * {@inheritDoc common.reportBrokenSiteShown}
+     * @type {import("./common.js").reportBrokenSiteShown}
+     */
+    reportBrokenSiteShown() {
+      invariant(window.PrivacyDashboard?.reportBrokenSiteShown, "reportBrokenSiteShown missing");
+      window.PrivacyDashboard.reportBrokenSiteShown();
+    }
   };
   var privacyDashboardApi;
   async function fetchAndroid(message) {
@@ -14589,6 +14607,9 @@
     }
     if (message instanceof ShowNativeFeedback) {
       return privacyDashboardApi.showNativeFeedback();
+    }
+    if (message instanceof ReportBrokenSiteShown) {
+      return privacyDashboardApi.reportBrokenSiteShown();
     }
     console.warn("unhandled message", message);
   }
@@ -14770,6 +14791,10 @@
       showNativeFeedback();
       return;
     }
+    if (message instanceof ReportBrokenSiteShown) {
+      reportBrokenSiteShown();
+      return;
+    }
     if (message instanceof SendToggleBreakageReport) {
       sendToggleBreakageReport();
       return;
@@ -14934,6 +14959,9 @@
   }
   function showNativeFeedback() {
     windowsPostMessage("ShowNativeFeedback", {});
+  }
+  function reportBrokenSiteShown() {
+    windowsPostMessage("ReportBrokenSiteShown", {});
   }
 
   // shared/js/browser/communication.js
@@ -15403,6 +15431,14 @@
     const nav = useNav();
     return T2(() => {
       const msg = new ShowNativeFeedback();
+      fetcher(msg).catch(console.error);
+    }, [nav]);
+  }
+  function useReportBrokenSiteShown() {
+    const fetcher = useFetcher();
+    const nav = useNav();
+    return T2(() => {
+      const msg = new ReportBrokenSiteShown();
       fetcher(msg).catch(console.error);
     }, [nav]);
   }
@@ -17384,6 +17420,10 @@
     const description = ns.report("selectTheCategoryType.title");
     const { push } = useNav();
     const { tab } = useData();
+    const reportBrokenSiteShown2 = useReportBrokenSiteShown();
+    p2(() => {
+      reportBrokenSiteShown2();
+    }, []);
     const showNativeFeedback2 = useShowNativeFeedback();
     return /* @__PURE__ */ y(BreakageScreenWrapper, { pageId: "choice-problem", className: "breakage-screen--choice" }, /* @__PURE__ */ y("div", { className: "padding-x-double" }, /* @__PURE__ */ y(KeyInsightsMain, { title: tab.domain }, description)), /* @__PURE__ */ y("div", { className: "padding-x" }, /* @__PURE__ */ y(Nav, null, /* @__PURE__ */ y(
       NavItem,

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@duckduckgo/autoconsent": "^12.5.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.1.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.5.0",
-        "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.0.0",
+        "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.1.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1734514764"
       },
       "devDependencies": {
@@ -77,7 +77,7 @@
     },
     "node_modules/@duckduckgo/privacy-dashboard": {
       "version": "7.3.2",
-      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#3f58e008d4e9d1b56ab12dbb95bd891045cf2758",
+      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-dashboard.git#c52bd5d851b1f8f0482e82b8720852670f525497",
       "engines": {
         "node": ">=22.0.0",
         "npm": ">=9.0.0"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@duckduckgo/autoconsent": "^12.5.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.1.0",
     "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.5.0",
-    "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.0.0",
+    "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.1.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1734514764"
   }
 }

--- a/privacy-dashboard/privacy-dashboard-api/src/main/java/com/duckduckgo/privacy/dashboard/api/ui/PrivacyDashboardHybridScreenParams.kt
+++ b/privacy-dashboard/privacy-dashboard-api/src/main/java/com/duckduckgo/privacy/dashboard/api/ui/PrivacyDashboardHybridScreenParams.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.privacy.dashboard.api.ui.DashboardOpener.NONE
 enum class DashboardOpener(val value: String) {
     MENU("menu"),
     DASHBOARD("dashboard"),
+    RELOAD_THREE_TIMES_WITHIN_20_SECONDS("reload-three-times-within-20-seconds"),
     NONE(""),
 }
 

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/pixels/PrivacyDashboardPixels.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/pixels/PrivacyDashboardPixels.kt
@@ -25,6 +25,8 @@ enum class PrivacyDashboardPixels(override val pixelName: String, val enqueue: B
     PRIVACY_DASHBOARD_FIRST_TIME_OPENED("m_privacy_dashboard_first_time_used"),
     BROKEN_SITE_ALLOWLIST_ADD("m_broken_site_allowlist_add"),
     BROKEN_SITE_ALLOWLIST_REMOVE("m_broken_site_allowlist_remove"),
+    REPORT_BROKEN_SITE_SHOWN("m_report-broken-site_shown"),
+    REPORT_BROKEN_SITE_SENT("m_report-broken-site_sent"),
 }
 
 enum class PrivacyDashboardCustomTabPixelNames(override val pixelName: String) : Pixel.PixelName {

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridActivity.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridActivity.kt
@@ -122,7 +122,7 @@ class PrivacyDashboardHybridActivity : DuckDuckGoActivity() {
 
                     val opener = when (reportFlow) {
                         ReportFlow.MENU -> DashboardOpener.MENU
-                        ReportFlow.RELOAD_THREE_TIMES_WITHIN_20_SECONDS -> DashboardOpener.NONE
+                        ReportFlow.RELOAD_THREE_TIMES_WITHIN_20_SECONDS -> DashboardOpener.RELOAD_THREE_TIMES_WITHIN_20_SECONDS
                         else -> DashboardOpener.DASHBOARD
                     }
 
@@ -146,7 +146,7 @@ class PrivacyDashboardHybridActivity : DuckDuckGoActivity() {
                             when (params.reportFlow) {
                                 BrokenSiteForm.BrokenSiteFormReportFlow.MENU -> DashboardOpener.MENU
                                 BrokenSiteForm.BrokenSiteFormReportFlow.RELOAD_THREE_TIMES_WITHIN_20_SECONDS ->
-                                    DashboardOpener.NONE
+                                    DashboardOpener.RELOAD_THREE_TIMES_WITHIN_20_SECONDS
                             }
                         }
                         else -> DashboardOpener.DASHBOARD

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridActivity.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridActivity.kt
@@ -119,7 +119,14 @@ class PrivacyDashboardHybridActivity : DuckDuckGoActivity() {
                         }
                         else -> ReportFlow.DASHBOARD
                     }
-                    viewModel.onSubmitBrokenSiteReport(payload, reportFlow)
+
+                    val opener = when (reportFlow) {
+                        ReportFlow.MENU -> DashboardOpener.MENU
+                        ReportFlow.RELOAD_THREE_TIMES_WITHIN_20_SECONDS -> DashboardOpener.NONE
+                        else -> DashboardOpener.DASHBOARD
+                    }
+
+                    viewModel.onSubmitBrokenSiteReport(payload, reportFlow, opener)
                     setResult(PrivacyDashboardHybridScreenResult.REPORT_SUBMITTED)
                     finish()
                 },
@@ -134,17 +141,17 @@ class PrivacyDashboardHybridActivity : DuckDuckGoActivity() {
                 },
                 onSeeWhatIsSent = {},
                 onReportBrokenSiteShown = {
-                    val reportFlow = when (val params = params) {
+                    val opener = when (val params = params) {
                         is BrokenSiteForm -> {
                             when (params.reportFlow) {
-                                BrokenSiteForm.BrokenSiteFormReportFlow.MENU -> ReportFlow.MENU
+                                BrokenSiteForm.BrokenSiteFormReportFlow.MENU -> DashboardOpener.MENU
                                 BrokenSiteForm.BrokenSiteFormReportFlow.RELOAD_THREE_TIMES_WITHIN_20_SECONDS ->
-                                    ReportFlow.RELOAD_THREE_TIMES_WITHIN_20_SECONDS
+                                    DashboardOpener.NONE
                             }
                         }
-                        else -> ReportFlow.DASHBOARD
+                        else -> DashboardOpener.DASHBOARD
                     }
-                    viewModel.onReportBrokenSiteShown(reportFlow)
+                    viewModel.onReportBrokenSiteShown(opener)
                 },
             ),
         )

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridActivity.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridActivity.kt
@@ -133,6 +133,19 @@ class PrivacyDashboardHybridActivity : DuckDuckGoActivity() {
                     this@PrivacyDashboardHybridActivity.finish()
                 },
                 onSeeWhatIsSent = {},
+                onReportBrokenSiteShown = {
+                    val reportFlow = when (val params = params) {
+                        is BrokenSiteForm -> {
+                            when (params.reportFlow) {
+                                BrokenSiteForm.BrokenSiteFormReportFlow.MENU -> ReportFlow.MENU
+                                BrokenSiteForm.BrokenSiteFormReportFlow.RELOAD_THREE_TIMES_WITHIN_20_SECONDS ->
+                                    ReportFlow.RELOAD_THREE_TIMES_WITHIN_20_SECONDS
+                            }
+                        }
+                        else -> ReportFlow.DASHBOARD
+                    }
+                    viewModel.onReportBrokenSiteShown(reportFlow)
+                },
             ),
         )
     }

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModel.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModel.kt
@@ -277,6 +277,14 @@ class PrivacyDashboardHybridViewModel @Inject constructor(
         return command.receiveAsFlow()
     }
 
+    private fun getReportBrokenSitePixelParams(reportFlow: ReportFlow): Map<String, String> {
+        val openerParam = when (reportFlow) {
+            ReportFlow.MENU -> "menu"
+            else -> "dashboard"
+        }
+        return mapOf("opener" to openerParam)
+    }
+
     fun onReportBrokenSiteSelected() {
         viewModelScope.launch(dispatcher.io()) {
             if (!webBrokenSiteFormFeature.isEnabled()) {
@@ -437,6 +445,12 @@ class PrivacyDashboardHybridViewModel @Inject constructor(
             val siteUrl = site.url
             if (siteUrl.isEmpty()) return@launch
 
+            val pixelParams = getReportBrokenSitePixelParams(reportFlow)
+            pixel.fire(
+                pixel = REPORT_BROKEN_SITE_SENT,
+                parameters = pixelParams,
+                type = Count)
+
             val brokenSite = BrokenSite(
                 category = request.category,
                 description = request.description,
@@ -468,6 +482,14 @@ class PrivacyDashboardHybridViewModel @Inject constructor(
 
             brokenSiteSender.submitBrokenSiteFeedback(brokenSite, toggle = false)
         }
+    }
+
+    fun onReportBrokenSiteShown(reportFlow: ReportFlow) {
+        val pixelParams = getReportBrokenSitePixelParams(reportFlow)
+        pixel.fire(
+            pixel = REPORT_BROKEN_SITE_SHOWN,
+            parameters = pixelParams,
+            type = Count)
     }
 
     fun onGetToggleReportOptions() {

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModel.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModel.kt
@@ -30,7 +30,6 @@ import com.duckduckgo.app.trackerdetection.model.TrackerStatus.BLOCKED
 import com.duckduckgo.brokensite.api.BrokenSite
 import com.duckduckgo.brokensite.api.BrokenSiteSender
 import com.duckduckgo.brokensite.api.ReportFlow
-import com.duckduckgo.brokensite.api.ReportFlow.RELOAD_THREE_TIMES_WITHIN_20_SECONDS
 import com.duckduckgo.browser.api.UserBrowserProperties
 import com.duckduckgo.browser.api.brokensite.BrokenSiteData
 import com.duckduckgo.browser.api.brokensite.BrokenSiteData.ReportFlow.DASHBOARD
@@ -442,7 +441,8 @@ class PrivacyDashboardHybridViewModel @Inject constructor(
             pixel.fire(
                 pixel = REPORT_BROKEN_SITE_SENT,
                 parameters = mapOf("opener" to opener.value),
-                type = Count)
+                type = Count,
+            )
 
             val brokenSite = BrokenSite(
                 category = request.category,
@@ -481,7 +481,8 @@ class PrivacyDashboardHybridViewModel @Inject constructor(
         pixel.fire(
             pixel = REPORT_BROKEN_SITE_SHOWN,
             parameters = mapOf("opener" to opener.value),
-            type = Count)
+            type = Count,
+        )
     }
 
     fun onGetToggleReportOptions() {

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardJavascriptInterface.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardJavascriptInterface.kt
@@ -30,6 +30,7 @@ class PrivacyDashboardJavascriptInterface constructor(
     val onRejectToggleReport: () -> Unit,
     val onSeeWhatIsSent: () -> Unit,
     val onShowNativeFeedback: () -> Unit,
+    val onReportBrokenSiteShown: () -> Unit,
 ) {
     @JavascriptInterface
     fun toggleAllowlist(payload: String) {
@@ -84,6 +85,11 @@ class PrivacyDashboardJavascriptInterface constructor(
     @JavascriptInterface
     fun showNativeFeedback() {
         onShowNativeFeedback()
+    }
+
+    @JavascriptInterface
+    fun reportBrokenSiteShown() {
+        onReportBrokenSiteShown()
     }
 
     companion object {

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardRenderer.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardRenderer.kt
@@ -43,6 +43,7 @@ class PrivacyDashboardRenderer(
     private val onRejectToggleReport: () -> Unit,
     private val onSeeWhatIsSent: () -> Unit,
     private val onShowNativeFeedback: () -> Unit,
+    private val onReportBrokenSiteShown: () -> Unit,
 ) {
 
     private var lastSeenPrivacyDashboardViewState: ViewState? = null
@@ -67,6 +68,7 @@ class PrivacyDashboardRenderer(
                 onRejectToggleReport = onRejectToggleReport,
                 onSeeWhatIsSent = onSeeWhatIsSent,
                 onShowNativeFeedback = onShowNativeFeedback,
+                onReportBrokenSiteShown = onReportBrokenSiteShown,
             ),
             PrivacyDashboardJavascriptInterface.JAVASCRIPT_INTERFACE_NAME,
         )

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardRendererFactory.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardRendererFactory.kt
@@ -43,6 +43,7 @@ sealed class RendererViewHolder {
         val onRejectToggleReport: () -> Unit,
         val onSeeWhatIsSent: () -> Unit,
         val onShowNativeFeedback: () -> Unit,
+        val onReportBrokenSiteShown: () -> Unit,
     ) : RendererViewHolder()
 }
 
@@ -68,6 +69,7 @@ class BrowserPrivacyDashboardRendererFactory @Inject constructor(
                 renderer.onRejectToggleReport,
                 renderer.onSeeWhatIsSent,
                 renderer.onShowNativeFeedback,
+                renderer.onReportBrokenSiteShown,
             )
         }
     }

--- a/privacy-dashboard/privacy-dashboard-impl/src/test/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModelTest.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/test/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModelTest.kt
@@ -288,6 +288,7 @@ class PrivacyDashboardHybridViewModelTest {
         testee.onSubmitBrokenSiteReport(
             payload = """{"category":"$category","description":"$description"}""",
             reportFlow = DASHBOARD,
+            opener = DashboardOpener.DASHBOARD
         )
 
         val expectedBrokenSite = BrokenSite(

--- a/privacy-dashboard/privacy-dashboard-impl/src/test/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModelTest.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/test/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModelTest.kt
@@ -151,6 +151,14 @@ class PrivacyDashboardHybridViewModelTest {
         }
     }
 
+    fun whenUserClicksOnReportBrokenSiteAndWebFormEnabledThenFireImpressionPixel() = runTest {
+        webBrokenSiteFormFeature.self().setRawStoredState(State(enable = true))
+
+        testee.onReportBrokenSiteSelected()
+
+        verify(pixel).fire(REPORT_BROKEN_SITE_SHOWN, mapOf("opener" to "dashboard"), type = Count)
+    }
+
     @Test
     fun whenSiteChangesThenViewStateUpdates() = runTest {
         testee.onSiteChanged(site())
@@ -306,6 +314,7 @@ class PrivacyDashboardHybridViewModelTest {
         val isToggleReport = false
 
         verify(brokenSiteSender).submitBrokenSiteFeedback(expectedBrokenSite, isToggleReport)
+        verify(pixel).fire(REPORT_BROKEN_SITE_SENT, mapOf("opener" to "dashboard"), type = Count)
     }
 
     @Test

--- a/privacy-dashboard/privacy-dashboard-impl/src/test/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModelTest.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/test/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModelTest.kt
@@ -288,7 +288,7 @@ class PrivacyDashboardHybridViewModelTest {
         testee.onSubmitBrokenSiteReport(
             payload = """{"category":"$category","description":"$description"}""",
             reportFlow = DASHBOARD,
-            opener = DashboardOpener.DASHBOARD
+            opener = DashboardOpener.DASHBOARD,
         )
 
         val expectedBrokenSite = BrokenSite(

--- a/privacy-dashboard/privacy-dashboard-impl/src/test/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardRendererTest.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/test/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardRendererTest.kt
@@ -74,6 +74,7 @@ class PrivacyDashboardRendererTest {
         {},
         {},
         {},
+        {},
     )
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1209173355503844/f

### Description

- Implements Privacy Dashboard message ReportBrokenSiteShown
- New pixels:
    - `m_report-broken-site_shown` triggered when the broken site form is presented
    - `m_report-broken-site_sent` triggered when the broken site form is sent. This is fired alongside the existing `epbf` pixel, but without any of the form data.

### Steps to test this PR

1. Invoke the breakage form in the two possible ways:
    - Open the Privacy Dashboard and click on "Report a problem with this site"
    - Open the app menu ••• and click on "Report Broken Site” (iOS)
2. Confirm that the pixel `m_report-broken-site_shown` was fired
3. Submit a report
4. Confirm that the pixels `epbf` and `m_report-broken-site_sent` were fired


### UI changes

N/A