### PR TITLE
Reenable blocklist experiment feature

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -381,4 +381,6 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     DEDICATED_WEBVIEW_NEW_TAB_REQUESTED("m_dedicated_webview_new_tab_requested"),
     DEDICATED_WEBVIEW_NEW_TAB_OPENING("m_dedicated_webview_new_tab_opening"),
     DEDICATED_WEBVIEW_URL_EXTRACTION_FAILED("m_dedicated_webview_url_extraction_failed"),
+
+    BLOCKLIST_TDS_FAILURE("blocklist_experiment_tds_download_failure"),
 }

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/api/TrackerListService.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/api/TrackerListService.kt
@@ -24,11 +24,19 @@ import retrofit2.http.GET
 @ContributesServiceApi(AppScope::class)
 interface TrackerListService {
     @GET(TDS_URL)
+    @TdsRequired
     fun tds(): Call<TdsJson>
 
     @GET("/contentblocking/trackers-unprotected-temporary.txt")
     fun temporaryAllowList(): Call<String>
 }
+
+/**
+ * This annotation is used in interceptors to be able to intercept the annotated service calls
+ */
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class TdsRequired
 
 const val TDS_BASE_URL = "https://staticcdn.duckduckgo.com/trackerblocking/"
 const val TDS_PATH = "v5/current/android-tds.json"

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/api/TrackerListService.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/api/TrackerListService.kt
@@ -23,7 +23,7 @@ import retrofit2.http.GET
 
 @ContributesServiceApi(AppScope::class)
 interface TrackerListService {
-    @GET("$TDS_BASE_URL$TDS_PATH")
+    @GET(TDS_URL)
     fun tds(): Call<TdsJson>
 
     @GET("/contentblocking/trackers-unprotected-temporary.txt")
@@ -32,3 +32,4 @@ interface TrackerListService {
 
 const val TDS_BASE_URL = "https://staticcdn.duckduckgo.com/trackerblocking/"
 const val TDS_PATH = "v5/current/android-tds.json"
+const val TDS_URL = "$TDS_BASE_URL$TDS_PATH"

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/api/TrackerListService.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/api/TrackerListService.kt
@@ -23,7 +23,7 @@ import retrofit2.http.GET
 
 @ContributesServiceApi(AppScope::class)
 interface TrackerListService {
-    @GET(TDS_URL)
+    @GET("$TDS_BASE_URL$TDS_PATH")
     @TdsRequired
     fun tds(): Call<TdsJson>
 
@@ -40,4 +40,3 @@ annotation class TdsRequired
 
 const val TDS_BASE_URL = "https://staticcdn.duckduckgo.com/trackerblocking/"
 const val TDS_PATH = "v5/current/android-tds.json"
-const val TDS_URL = "$TDS_BASE_URL$TDS_PATH"

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt
@@ -3056,7 +3056,7 @@ class ContributesRemoteFeatureCodeGeneratorTest {
                 "testFeature",
                 """
                 {
-                    "hash": "3",
+                    "hash": "4",
                     "state": "disabled",
                     "features": {
                         "fooFeature": {
@@ -3091,8 +3091,7 @@ class ContributesRemoteFeatureCodeGeneratorTest {
         )
 
         assertFalse(testFeature.fooFeature().isEnabled(CONTROL))
-        assertFalse(testFeature.fooFeature().isEnabled(BLUE))
-        assertNull(testFeature.fooFeature().getRawStoredState()!!.assignedCohort)
+        assertTrue(testFeature.fooFeature().isEnabled(BLUE))
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1209138858416176/f 

### Description
This PR reenables the blocklist feature but this time checking the full tds URL rather than the base url only.

### Steps to test this PR

- [ ] Use `https://www.jsonblob.com/api/1331667217611415552` for the remote config
- [ ] Change the blocklist feature to only assign control
- [ ] Load the app
- [ ] You should see an `experiment_enroll` pixel for the control and the eTag (app.db in tdsmetadata table) should match the one from https://staticcdn.duckduckgo.com/trackerblocking/v5/current/ios-tds.json currently is `75cff4e36f76d9a81af0643d775008c9`
- [ ] Change the controlURL in the remote config to `something.json`, change the version and the hash from the blocklist too.
- [ ] Reload the app
- [ ] You should see a `blocklist_experiment_tds_download_failure` pixel with a corresponding error code.

