### PR TITLE
Handle 404 from /api/subscription

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
@@ -745,7 +745,7 @@ class RealSubscriptionsManager @Inject constructor(
                 isSignedInV2() -> try {
                     refreshSubscriptionData()
                 } catch (e: HttpException) {
-                    if (e.code() == 400) {
+                    if (e.code() in listOf(400, 404)) {
                         // expected if this is a first ever purchase using this account - ignore
                     } else {
                         throw e

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
@@ -504,9 +504,19 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
     }
 
     @Test
-    fun whenPurchaseIfSignedInAndSubscriptionRefreshFailsThenLaunchesPurchaseFlow() = runTest {
+    fun whenPurchaseIfSignedInAndSubscriptionRefreshFailsWith400StatusThenLaunchesPurchaseFlow() = runTest {
         givenUserIsSignedIn()
-        givenSubscriptionFails()
+        givenSubscriptionFails(httpResponseCode = 400)
+
+        subscriptionsManager.purchase(mock(), planId = "")
+
+        verify(playBillingManager).launchBillingFlow(any(), any(), any())
+    }
+
+    @Test
+    fun whenPurchaseIfSignedInAndSubscriptionRefreshFailsWith404StatusThenLaunchesPurchaseFlow() = runTest {
+        givenUserIsSignedIn()
+        givenSubscriptionFails(httpResponseCode = 404)
 
         subscriptionsManager.purchase(mock(), planId = "")
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205648422731273/1209217826294375/f

### Description

/api/subscription endpoint currently returns 400 when no subscription is found, but that will change to 404. We should handle both 400 and 404 for now. 

### Steps to test this PR

QA-optional

### No UI changes