### PR TITLE
Send switch pixel only when user changes to a different sync account

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
@@ -91,10 +91,12 @@ class EnterCodeViewModel @Inject constructor(
     private suspend fun authFlow(
         pastedCode: String,
     ) {
-        val userSignedIn = syncAccountRepository.isSignedIn()
+        val previousPrimaryKey = syncAccountRepository.getAccountInfo().primaryKey
         when (val result = syncAccountRepository.processCode(pastedCode)) {
             is Result.Success -> {
-                val commandSuccess = if (userSignedIn) {
+                val postProcessCodePK = syncAccountRepository.getAccountInfo().primaryKey
+                val userSwitchedAccount = previousPrimaryKey.isNotBlank() && previousPrimaryKey != postProcessCodePK
+                val commandSuccess = if (userSwitchedAccount) {
                     syncPixels.fireUserSwitchedAccount()
                     SwitchAccountSuccess
                 } else {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/SyncAccountFixtures.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/SyncAccountFixtures.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync
+
+import com.duckduckgo.sync.impl.AccountInfo
+
+object SyncAccountFixtures {
+    val accountA = AccountInfo(
+        userId = "userIdA",
+        primaryKey = "primaryKeyA",
+        deviceName = "deviceNameA",
+        deviceId = "deviceIdA",
+        isSignedIn = true,
+        secretKey = "secretKeyA",
+    )
+
+    val accountB = AccountInfo(
+        userId = "userIdB",
+        primaryKey = "primaryKeyB",
+        deviceName = "deviceNameB",
+        deviceId = "deviceIdB",
+        isSignedIn = true,
+        secretKey = "secretKeyB",
+    )
+
+    val noAccount = AccountInfo()
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1200156640058969/1209059053489790/f 

### Description
Ensure we send a switch pixel only when the user has changed to another sync account.

### Steps to test this PR
!! In order to test this you will need 2 devices, and add filter in logcat to only visualize pixels

_Feature 1_
- [x] Fresh install the app in both devices
- [x] Device A create a sync account
- [x] Device A go to settings -> sync (signed in state) -> Sync with Another Device
- [x] Device B go to settings -> sync (signed out state) -> Sync with Another Device
- [x] Device A read QR code in Device B
- [x] Ensure Device A didn't send pixel `sync_user_switched_account`

_Feature 2_
- [x] logout from both sync accounts in both devices
- [x] Device A create a sync account
- [x] Device B create a sync account
- [x] Device A go to settings -> sync (signed in state) -> Sync with Another Device
- [x] Device B go to settings -> sync (signed in state) -> Sync with Another Device
- [x] Device A read QR code in Device B
- [x] Ensure Device A sends pixel `sync_user_switched_account`


### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
