### PR TITLE
Add AI Chat SERP integration

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -159,6 +159,8 @@ import com.duckduckgo.app.browser.commands.Command.WebShareRequest
 import com.duckduckgo.app.browser.commands.Command.WebViewError
 import com.duckduckgo.app.browser.commands.NavigationCommand
 import com.duckduckgo.app.browser.customtabs.CustomTabPixelNames
+import com.duckduckgo.app.browser.duckchat.DuckChatJSHelper
+import com.duckduckgo.app.browser.duckchat.RealDuckChatJSHelper.Companion.DUCK_CHAT_FEATURE_NAME
 import com.duckduckgo.app.browser.duckplayer.DUCK_PLAYER_FEATURE_NAME
 import com.duckduckgo.app.browser.duckplayer.DUCK_PLAYER_PAGE_FEATURE_NAME
 import com.duckduckgo.app.browser.duckplayer.DuckPlayerJSHelper
@@ -429,6 +431,7 @@ class BrowserTabViewModel @Inject constructor(
     private val duckPlayer: DuckPlayer,
     private val duckChat: DuckChat,
     private val duckPlayerJSHelper: DuckPlayerJSHelper,
+    private val duckChatJSHelper: DuckChatJSHelper,
     private val refreshPixelSender: RefreshPixelSender,
     private val changeOmnibarPositionFeature: ChangeOmnibarPositionFeature,
     private val highlightsOnboardingExperimentManager: HighlightsOnboardingExperimentManager,
@@ -3254,6 +3257,17 @@ class BrowserTabViewModel @Inject constructor(
                 viewModelScope.launch(dispatchers.io()) {
                     val webViewUrl = withContext(dispatchers.main()) { getWebViewUrl() }
                     val response = duckPlayerJSHelper.processJsCallbackMessage(featureName, method, id, data, webViewUrl, tabId, isActiveCustomTab)
+                    withContext(dispatchers.main()) {
+                        response?.let {
+                            command.value = it
+                        }
+                    }
+                }
+            }
+
+            DUCK_CHAT_FEATURE_NAME -> {
+                viewModelScope.launch(dispatchers.io()) {
+                    val response = duckChatJSHelper.processJsCallbackMessage(featureName, method, id, data)
                     withContext(dispatchers.main()) {
                         response?.let {
                             command.value = it

--- a/app/src/main/java/com/duckduckgo/app/browser/duckchat/DuckChatJSHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/duckchat/DuckChatJSHelper.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.duckchat
+
+import com.duckduckgo.app.browser.commands.Command
+import com.duckduckgo.app.browser.commands.Command.SendResponseToJs
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.js.messaging.api.JsCallbackData
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+import org.json.JSONObject
+
+interface DuckChatJSHelper {
+    suspend fun processJsCallbackMessage(
+        featureName: String,
+        method: String,
+        id: String?,
+        data: JSONObject?,
+    ): Command?
+}
+
+@ContributesBinding(AppScope::class)
+class RealDuckChatJSHelper @Inject constructor(
+    private val duckChat: DuckChat,
+    private val preferencesStore: DuckChatPreferencesStore,
+) : DuckChatJSHelper {
+    private fun getUserValues(featureName: String, method: String, id: String): JsCallbackData {
+        val jsonPayload = JSONObject().apply {
+            put(PLATFORM, ANDROID)
+            put(IS_HANDOFF_ENABLED, duckChat.isEnabled())
+            put(PAYLOAD, preferencesStore.fetchAndClearUserPreferences())
+        }
+        return JsCallbackData(jsonPayload, featureName, method, id)
+    }
+
+    override suspend fun processJsCallbackMessage(
+        featureName: String,
+        method: String,
+        id: String?,
+        data: JSONObject?,
+    ): Command? = when (method) {
+        METHOD_GET_USER_VALUES -> id?.let {
+            SendResponseToJs(getUserValues(featureName, method, it))
+        }
+        METHOD_OPEN_AI_CHAT -> {
+            data?.optString(PAYLOAD).let { payload ->
+                preferencesStore.updateUserPreferences(payload)
+            }
+            duckChat.openDuckChat()
+            null
+        }
+        else -> null
+    }
+
+    companion object {
+        const val DUCK_CHAT_FEATURE_NAME = "aiChat"
+        private const val METHOD_GET_USER_VALUES = "getUserValues"
+        private const val METHOD_OPEN_AI_CHAT = "openAIChat"
+        private const val PAYLOAD = "aiChatPayload"
+        private const val IS_HANDOFF_ENABLED = "isAIChatHandoffEnabled"
+        private const val PLATFORM = "platform"
+        private const val ANDROID = "android"
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/duckchat/DuckChatJSHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/duckchat/DuckChatJSHelper.kt
@@ -58,13 +58,18 @@ class RealDuckChatJSHelper @Inject constructor(
             SendResponseToJs(getUserValues(featureName, method, it))
         }
         METHOD_OPEN_AI_CHAT -> {
-            data?.optString(PAYLOAD).let { payload ->
-                preferencesStore.updateUserPreferences(payload)
-            }
+            val payload = extractPayload(data)
+            preferencesStore.updateUserPreferences(payload)
             duckChat.openDuckChat()
             null
         }
         else -> null
+    }
+
+    private fun extractPayload(data: JSONObject?): String? {
+        return data?.takeIf {
+            it.opt(PAYLOAD) != JSONObject.NULL
+        }?.optString(PAYLOAD)
     }
 
     companion object {

--- a/app/src/main/java/com/duckduckgo/app/browser/duckchat/DuckChatPreferencesStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/duckchat/DuckChatPreferencesStore.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.duckchat
+
+import androidx.core.content.edit
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface DuckChatPreferencesStore {
+    fun fetchAndClearUserPreferences(): String?
+    fun updateUserPreferences(userPreferences: String?)
+}
+
+@ContributesBinding(AppScope::class)
+class RealDuckChatPreferencesStore @Inject constructor(
+    private val sharedPreferencesProvider: SharedPreferencesProvider,
+) : DuckChatPreferencesStore {
+
+    private val preferences by lazy {
+        sharedPreferencesProvider.getSharedPreferences(FILENAME)
+    }
+
+    override fun fetchAndClearUserPreferences(): String? =
+        preferences.getString(USER_PREFERENCES, null).also {
+            preferences.edit { remove(USER_PREFERENCES) }
+        }
+
+    override fun updateUserPreferences(userPreferences: String?) {
+        preferences.edit {
+            putString(USER_PREFERENCES, userPreferences)
+        }
+    }
+
+    companion object {
+        const val FILENAME = "com.duckduckgo.app.duckchat"
+        const val USER_PREFERENCES = "DUCK_CHAT_USER_PREFERENCES"
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/browser/duckchat/RealDuckChatJSHelperTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/duckchat/RealDuckChatJSHelperTest.kt
@@ -30,7 +30,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 
 @RunWith(AndroidJUnit4::class)
@@ -144,17 +143,6 @@ class RealDuckChatJSHelperTest {
     }
 
     @Test
-    fun whenOpenAIChatThenOpenDuckChat() = runTest {
-        val featureName = "aiChat"
-        val method = "openAIChat"
-        val id = "123"
-
-        assertNull(testee.processJsCallbackMessage(featureName, method, id, null))
-        verify(mockDuckChat).openDuckChat()
-        verifyNoInteractions(mockPreferencesStore)
-    }
-
-    @Test
     fun whenOpenAIChatAndHasPayloadThenUpdateStoreAndOpenDuckChat() = runTest {
         val featureName = "aiChat"
         val method = "openAIChat"
@@ -166,6 +154,29 @@ class RealDuckChatJSHelperTest {
         assertNull(testee.processJsCallbackMessage(featureName, method, id, data))
 
         verify(mockPreferencesStore).updateUserPreferences(payloadString)
+        verify(mockDuckChat).openDuckChat()
+    }
+
+    @Test
+    fun whenOpenAIChatAndDataIsNullThenUpdateStoreAndOpenDuckChat() = runTest {
+        val featureName = "aiChat"
+        val method = "openAIChat"
+        val id = "123"
+
+        assertNull(testee.processJsCallbackMessage(featureName, method, id, null))
+        verify(mockPreferencesStore).updateUserPreferences(null)
+        verify(mockDuckChat).openDuckChat()
+    }
+
+    @Test
+    fun whenOpenAIChatAndPayloadIsNullThenUpdateStoreAndOpenDuckChat() = runTest {
+        val featureName = "aiChat"
+        val method = "openAIChat"
+        val id = "123"
+        val data = JSONObject(mapOf("aiChatPayload" to JSONObject.NULL))
+
+        assertNull(testee.processJsCallbackMessage(featureName, method, id, data))
+        verify(mockPreferencesStore).updateUserPreferences(null)
         verify(mockDuckChat).openDuckChat()
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/duckchat/RealDuckChatJSHelperTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/duckchat/RealDuckChatJSHelperTest.kt
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.duckchat
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.browser.commands.Command.SendResponseToJs
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.js.messaging.api.JsCallbackData
+import kotlinx.coroutines.test.runTest
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class RealDuckChatJSHelperTest {
+
+    @get:Rule
+    var coroutineRule = CoroutineTestRule()
+
+    private val mockDuckChat: DuckChat = mock()
+    private val mockPreferencesStore: DuckChatPreferencesStore = mock()
+
+    private val testee = RealDuckChatJSHelper(
+        duckChat = mockDuckChat,
+        preferencesStore = mockPreferencesStore,
+    )
+
+    @Test
+    fun whenMethodIsUnknownThenReturnNull() = runTest {
+        val featureName = "aiChat"
+        val method = "unknownMethod"
+        val id = "123"
+
+        val result = testee.processJsCallbackMessage(featureName, method, id, null)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun whenGetUserValuesAndIdIsNullThenReturnNull() = runTest {
+        val featureName = "aiChat"
+        val method = "getUserValues"
+
+        val result = testee.processJsCallbackMessage(featureName, method, null, null)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun whenGetUserValuesAndDuckChatEnabledThenReturnSendResponseToJsWithDuckChatEnabled() = runTest {
+        val featureName = "aiChat"
+        val method = "getUserValues"
+        val id = "123"
+
+        whenever(mockDuckChat.isEnabled()).thenReturn(true)
+        whenever(mockPreferencesStore.fetchAndClearUserPreferences()).thenReturn("preferences")
+
+        val result = testee.processJsCallbackMessage(featureName, method, id, null) as SendResponseToJs
+
+        val jsonPayload = JSONObject().apply {
+            put("platform", "android")
+            put("isAIChatHandoffEnabled", true)
+            put("aiChatPayload", "preferences")
+        }
+
+        val expected = SendResponseToJs(JsCallbackData(jsonPayload, featureName, method, id))
+
+        assertEquals(expected.data.id, result.data.id)
+        assertEquals(expected.data.method, result.data.method)
+        assertEquals(expected.data.featureName, result.data.featureName)
+        assertEquals(expected.data.params.toString(), result.data.params.toString())
+    }
+
+    @Test
+    fun whenGetUserValuesAndDuckChatDisabledThenReturnSendResponseToJsWithDuckChatDisabled() = runTest {
+        val featureName = "aiChat"
+        val method = "getUserValues"
+        val id = "123"
+
+        whenever(mockDuckChat.isEnabled()).thenReturn(false)
+        whenever(mockPreferencesStore.fetchAndClearUserPreferences()).thenReturn("preferences")
+
+        val result = testee.processJsCallbackMessage(featureName, method, id, null) as SendResponseToJs
+
+        val jsonPayload = JSONObject().apply {
+            put("platform", "android")
+            put("isAIChatHandoffEnabled", false)
+            put("aiChatPayload", "preferences")
+        }
+
+        val expected = SendResponseToJs(JsCallbackData(jsonPayload, featureName, method, id))
+
+        assertEquals(expected.data.id, result.data.id)
+        assertEquals(expected.data.method, result.data.method)
+        assertEquals(expected.data.featureName, result.data.featureName)
+        assertEquals(expected.data.params.toString(), result.data.params.toString())
+    }
+
+    @Test
+    fun whenGetUserValuesAndPreferencesNullThenReturnSendResponseToJsWithPreferencesNull() = runTest {
+        val featureName = "aiChat"
+        val method = "getUserValues"
+        val id = "123"
+
+        whenever(mockDuckChat.isEnabled()).thenReturn(true)
+        whenever(mockPreferencesStore.fetchAndClearUserPreferences()).thenReturn(null)
+
+        val result = testee.processJsCallbackMessage(featureName, method, id, null) as SendResponseToJs
+
+        val jsonPayload = JSONObject().apply {
+            put("platform", "android")
+            put("isAIChatHandoffEnabled", true)
+            put("aiChatPayload", null)
+        }
+
+        val expected = SendResponseToJs(JsCallbackData(jsonPayload, featureName, method, id))
+
+        assertEquals(expected.data.id, result.data.id)
+        assertEquals(expected.data.method, result.data.method)
+        assertEquals(expected.data.featureName, result.data.featureName)
+        assertEquals(expected.data.params.toString(), result.data.params.toString())
+    }
+
+    @Test
+    fun whenOpenAIChatThenOpenDuckChat() = runTest {
+        val featureName = "aiChat"
+        val method = "openAIChat"
+        val id = "123"
+
+        assertNull(testee.processJsCallbackMessage(featureName, method, id, null))
+        verify(mockDuckChat).openDuckChat()
+        verifyNoInteractions(mockPreferencesStore)
+    }
+
+    @Test
+    fun whenOpenAIChatAndHasPayloadThenUpdateStoreAndOpenDuckChat() = runTest {
+        val featureName = "aiChat"
+        val method = "openAIChat"
+        val id = "123"
+        val payload = JSONObject(mapOf("key" to "value"))
+        val payloadString = payload.toString()
+        val data = JSONObject(mapOf("aiChatPayload" to payloadString))
+
+        assertNull(testee.processJsCallbackMessage(featureName, method, id, data))
+
+        verify(mockPreferencesStore).updateUserPreferences(payloadString)
+        verify(mockDuckChat).openDuckChat()
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/browser/duckchat/RealDuckChatPreferencesStoreTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/duckchat/RealDuckChatPreferencesStoreTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.duckchat
+
+import android.content.SharedPreferences
+import com.duckduckgo.app.browser.duckchat.RealDuckChatPreferencesStore.Companion.USER_PREFERENCES
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.test.api.InMemorySharedPreferences
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class RealDuckChatPreferencesStoreTest {
+
+    @get:Rule
+    var coroutineRule = CoroutineTestRule()
+
+    private lateinit var preferences: SharedPreferences
+    private lateinit var testee: RealDuckChatPreferencesStore
+
+    @Before
+    fun setup() = runTest {
+        preferences = InMemorySharedPreferences()
+
+        testee = RealDuckChatPreferencesStore(
+            object : SharedPreferencesProvider {
+                override fun getSharedPreferences(name: String, multiprocess: Boolean, migrate: Boolean): SharedPreferences {
+                    return preferences
+                }
+
+                override fun getEncryptedSharedPreferences(name: String, multiprocess: Boolean): SharedPreferences {
+                    return preferences
+                }
+            },
+        )
+    }
+
+    @Test
+    fun whenFetchAndClearUserPreferencesAndPreferencesExistThenReturnAndClearPreferences() = runTest {
+        val storedPreferences = "userPreferences"
+        preferences.edit().putString(USER_PREFERENCES, storedPreferences).apply()
+
+        val result = testee.fetchAndClearUserPreferences()
+
+        assertEquals(storedPreferences, result)
+        assertNull(preferences.getString(USER_PREFERENCES, null))
+        assertNull(testee.fetchAndClearUserPreferences())
+    }
+
+    @Test
+    fun whenFetchAndClearUserPreferencesAndNoPreferencesExistThenReturnNull() = runTest {
+        val result = testee.fetchAndClearUserPreferences()
+
+        assertNull(result)
+    }
+
+    @Test
+    fun whenUpdateUserPreferencesThenStoreProvidedPreferences() = runTest {
+        val newPreferences = "newUserPreferences"
+
+        testee.updateUserPreferences(newPreferences)
+
+        assertEquals(newPreferences, preferences.getString(USER_PREFERENCES, null))
+    }
+
+    @Test
+    fun whenUpdateUserPreferencesWithNullThenStoreNullPreferences() = runTest {
+        testee.updateUserPreferences(null)
+
+        assertNull(preferences.getString(USER_PREFERENCES, null))
+    }
+}

--- a/breakage-reporting/breakage-reporting-impl/src/main/java/com/duckduckgo/breakagereporting/impl/BreakageReportingMessageHandlerPlugin.kt
+++ b/breakage-reporting/breakage-reporting-impl/src/main/java/com/duckduckgo/breakagereporting/impl/BreakageReportingMessageHandlerPlugin.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.breakagereporting.impl
 
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.common.utils.DispatcherProvider
-import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.js.messaging.api.JsMessage
 import com.duckduckgo.js.messaging.api.JsMessageCallback
 import com.duckduckgo.js.messaging.api.JsMessageHandler
@@ -27,7 +27,7 @@ import javax.inject.Inject
 import javax.inject.Named
 import kotlinx.coroutines.CoroutineScope
 
-@ContributesBinding(FragmentScope::class)
+@ContributesBinding(ActivityScope::class)
 @Named("breakageMessageHandler")
 class BreakageReportingMessageHandlerPlugin @Inject constructor(
     @AppCoroutineScope val appCoroutineScope: CoroutineScope,

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessaging.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessaging.kt
@@ -154,7 +154,7 @@ class ContentScopeScriptsJsMessaging @Inject constructor(
         }
 
         override val allowedDomains: List<String> = listOf(
-            "duckduckgo.com",
+            AppUrl.Url.HOST,
         )
 
         override val featureName: String = "aiChat"

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessaging.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessaging.kt
@@ -22,7 +22,7 @@ import androidx.core.net.toUri
 import com.duckduckgo.common.utils.AppUrl
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.contentscopescripts.impl.CoreContentScopeScripts
-import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.duckplayer.api.YOUTUBE_HOST
 import com.duckduckgo.duckplayer.api.YOUTUBE_MOBILE_HOST
 import com.duckduckgo.js.messaging.api.JsCallbackData
@@ -43,7 +43,7 @@ import logcat.LogPriority
 import logcat.asLog
 import logcat.logcat
 
-@ContributesBinding(FragmentScope::class)
+@ContributesBinding(ActivityScope::class)
 @Named("ContentScopeScripts")
 class ContentScopeScriptsJsMessaging @Inject constructor(
     private val jsMessageHelper: JsMessageHelper,
@@ -62,7 +62,7 @@ class ContentScopeScriptsJsMessaging @Inject constructor(
     override val secret: String = coreContentScopeScripts.secret
     override val allowedDomains: List<String> = emptyList()
 
-    private val handlers: List<JsMessageHandler> = listOf(ContentScopeHandler(), breakageHandler, DuckPlayerHandler())
+    private val handlers: List<JsMessageHandler> = listOf(ContentScopeHandler(), breakageHandler, DuckPlayerHandler(), DuckChatHandler())
 
     @JavascriptInterface
     override fun process(message: String, secret: String) {
@@ -75,7 +75,11 @@ class ContentScopeScriptsJsMessaging @Inject constructor(
             jsMessage?.let {
                 if (this.secret == secret && context == jsMessage.context && (allowedDomains.isEmpty() || allowedDomains.contains(domain))) {
                     handlers.firstOrNull {
-                        it.methods.contains(jsMessage.method) && it.featureName == jsMessage.featureName
+                        it.methods.contains(jsMessage.method) && it.featureName == jsMessage.featureName && (
+                            it.allowedDomains.isEmpty() || it.allowedDomains.contains(
+                                domain,
+                            )
+                            )
                     }?.process(jsMessage, secret, jsMessageCallback)
                 }
             }
@@ -144,6 +148,22 @@ class ContentScopeScriptsJsMessaging @Inject constructor(
             "initialSetup",
             "reportPageException",
             "reportInitException",
+        )
+    }
+
+    inner class DuckChatHandler : JsMessageHandler {
+        override fun process(jsMessage: JsMessage, secret: String, jsMessageCallback: JsMessageCallback?) {
+            jsMessageCallback?.process(featureName, jsMessage.method, jsMessage.id ?: "", jsMessage.params)
+        }
+
+        override val allowedDomains: List<String> = listOf(
+            "duckduckgo.com",
+        )
+
+        override val featureName: String = "aiChat"
+        override val methods: List<String> = listOf(
+            "getUserValues",
+            "openAIChat",
         )
     }
 }

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessaging.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessaging.kt
@@ -75,11 +75,8 @@ class ContentScopeScriptsJsMessaging @Inject constructor(
             jsMessage?.let {
                 if (this.secret == secret && context == jsMessage.context && (allowedDomains.isEmpty() || allowedDomains.contains(domain))) {
                     handlers.firstOrNull {
-                        it.methods.contains(jsMessage.method) && it.featureName == jsMessage.featureName && (
-                            it.allowedDomains.isEmpty() || it.allowedDomains.contains(
-                                domain,
-                            )
-                            )
+                        it.methods.contains(jsMessage.method) && it.featureName == jsMessage.featureName &&
+                            (it.allowedDomains.isEmpty() || it.allowedDomains.contains(domain))
                     }?.process(jsMessage, secret, jsMessageCallback)
                 }
             }

--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessagingTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessagingTest.kt
@@ -166,6 +166,76 @@ class ContentScopeScriptsJsMessagingTest {
         assertEquals(0, callback.counter)
     }
 
+    @Test
+    fun whenProcessDuckChatMessageWithGetUserValuesThenCallbackExecuted() = runTest {
+        givenInterfaceIsRegistered()
+        whenever(mockWebView.url).thenReturn("https://duckduckgo.com")
+
+        val message = """
+        {"context":"contentScopeScripts","featureName":"aiChat","id":"myId","method":"getUserValues","params":{"key":"value"}}
+        """.trimIndent()
+
+        contentScopeScriptsJsMessaging.process(message, contentScopeScriptsJsMessaging.secret)
+
+        assertEquals(1, callback.counter)
+    }
+
+    @Test
+    fun whenProcessDuckChatMessageWithOpenAIChatThenCallbackExecuted() = runTest {
+        givenInterfaceIsRegistered()
+        whenever(mockWebView.url).thenReturn("https://duckduckgo.com")
+
+        val message = """
+        {"context":"contentScopeScripts","featureName":"aiChat","id":"myId","method":"openAIChat","params":{"key":"value"}}
+        """.trimIndent()
+
+        contentScopeScriptsJsMessaging.process(message, contentScopeScriptsJsMessaging.secret)
+
+        assertEquals(1, callback.counter)
+    }
+
+    @Test
+    fun whenProcessDuckChatMessageWithUnknownMethodThenDoNothing() = runTest {
+        givenInterfaceIsRegistered()
+        whenever(mockWebView.url).thenReturn("https://duckduckgo.com")
+
+        val message = """
+        {"context":"contentScopeScripts","featureName":"aiChat","id":"myId","method":"unknownMethod","params":{}}
+        """.trimIndent()
+
+        contentScopeScriptsJsMessaging.process(message, contentScopeScriptsJsMessaging.secret)
+
+        assertEquals(0, callback.counter)
+    }
+
+    @Test
+    fun whenProcessDuckChatMessageWithInvalidFeatureNameThenDoNothing() = runTest {
+        givenInterfaceIsRegistered()
+        whenever(mockWebView.url).thenReturn("https://duckduckgo.com")
+
+        val message = """
+        {"context":"contentScopeScripts","featureName":"invalidFeature","id":"myId","method":"getUserValues","params":{}}
+        """.trimIndent()
+
+        contentScopeScriptsJsMessaging.process(message, contentScopeScriptsJsMessaging.secret)
+
+        assertEquals(0, callback.counter)
+    }
+
+    @Test
+    fun whenProcessDuckChatMessageWithInvalidDomainThenDoNothing() = runTest {
+        givenInterfaceIsRegistered()
+        whenever(mockWebView.url).thenReturn("https://invalid-domain.com")
+
+        val message = """
+        {"context":"contentScopeScripts","featureName":"aiChat","id":"myId","method":"getUserValues","params":{}}
+        """.trimIndent()
+
+        contentScopeScriptsJsMessaging.process(message, contentScopeScriptsJsMessaging.secret)
+
+        assertEquals(0, callback.counter)
+    }
+
     private val callback = object : JsMessageCallback() {
         var counter = 0
         override fun process(featureName: String, method: String, id: String?, data: JSONObject?) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1209228531591905/f

### Description

- Uses the C-S-S navigatorInterface + messageBridge to link directly from SERP into the dedicated AI Chat WebView.
- Tapping the "Ask AI Chat" button in SERP will auto-prompt the dedicated WebView with the pre-filled prompt (Also works for "DuckAssist").
- The functionality is disabled when aiChat is disabled in the config.

### Steps to test this PR

_Apply the patch linked in the task_
- [ ] Search for “bread recipe” (You may need to log in)
- [ ] Tap the “Ask AI Chat” button
- [ ] Verify that the dedicated WebView is opened with “bread recipe” auto-prompted
- [ ] Go to settings in SERP > AI features
- [ ] Change the setting to show DuckAssist often
- [ ] Change the language to English(US)
- [ ] Search for “how tall is a giraffe” (You should see “DuckAssist”)
- [ ] Tap the “Ask AI Chat” button
- [ ] Verify that the dedicated WebView is opened
- [ ] Verify that you can scroll up to reveal info above “Tell me more”

_Disable `aiChat` in the config linked in the task and load it up_
- [ ] Search for “bread recipe”
- [ ] Tap the “Ask AI Chat” button
- [ ] Verify that AI Chat is **not** opened in the dedicated WebView
