### PR TITLE
Add offerId to purchase method in SubscriptionsManager

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
@@ -105,11 +105,12 @@ interface SubscriptionsManager {
     suspend fun getSubscriptionOffer(): List<SubscriptionOffer>
 
     /**
-     * Launches the purchase flow for a given plan id
+     * Launches the purchase flow for a given combination of plan id and offer id
      */
     suspend fun purchase(
         activity: Activity,
         planId: String,
+        offerId: String? = null,
     )
 
     /**
@@ -747,6 +748,7 @@ class RealSubscriptionsManager @Inject constructor(
     override suspend fun purchase(
         activity: Activity,
         planId: String,
+        offerId: String?,
     ) {
         try {
             _currentPurchaseState.emit(CurrentPurchase.PreFlowInProgress)

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/billing/PlayBillingManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/billing/PlayBillingManager.kt
@@ -75,6 +75,7 @@ interface PlayBillingManager {
         activity: Activity,
         planId: String,
         externalId: String,
+        offerId: String? = null,
     )
 }
 
@@ -173,6 +174,7 @@ class RealPlayBillingManager @Inject constructor(
         activity: Activity,
         planId: String,
         externalId: String,
+        offerId: String?,
     ) = withContext(dispatcherProvider.io()) {
         if (!billingClient.ready) {
             logcat { "Service not ready" }
@@ -183,7 +185,7 @@ class RealPlayBillingManager @Inject constructor(
 
         val offerToken = productDetails
             ?.subscriptionOfferDetails
-            ?.find { it.basePlanId == planId }
+            ?.find { it.basePlanId == planId && it.offerId == offerId }
             ?.offerToken
 
         if (productDetails == null || offerToken == null) {

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
@@ -83,6 +83,7 @@ import org.junit.runners.Parameterized
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -360,7 +361,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
 
         subscriptionsManager.purchase(mock(), planId = "")
 
-        verify(playBillingManager).launchBillingFlow(any(), any(), externalId = eq("1234"))
+        verify(playBillingManager).launchBillingFlow(any(), any(), externalId = eq("1234"), isNull())
     }
 
     @Test
@@ -373,7 +374,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
 
         subscriptionsManager.purchase(mock(), "")
 
-        verify(playBillingManager).launchBillingFlow(any(), any(), externalId = eq("1234"))
+        verify(playBillingManager).launchBillingFlow(any(), any(), externalId = eq("1234"), isNull())
     }
 
     @Test
@@ -387,7 +388,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         subscriptionsManager.currentPurchaseState.test {
             subscriptionsManager.purchase(mock(), planId = "")
             assertTrue(awaitItem() is CurrentPurchase.PreFlowInProgress)
-            verify(playBillingManager, never()).launchBillingFlow(any(), any(), any())
+            verify(playBillingManager, never()).launchBillingFlow(any(), any(), any(), isNull())
             assertTrue(awaitItem() is CurrentPurchase.Recovered)
             cancelAndConsumeRemainingEvents()
         }
@@ -427,7 +428,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         subscriptionsManager.currentPurchaseState.test {
             subscriptionsManager.purchase(mock(), planId = "")
             assertTrue(awaitItem() is CurrentPurchase.PreFlowInProgress)
-            verify(playBillingManager).launchBillingFlow(any(), any(), externalId = eq("1234"))
+            verify(playBillingManager).launchBillingFlow(any(), any(), externalId = eq("1234"), isNull())
             assertTrue(awaitItem() is CurrentPurchase.PreFlowFinished)
             cancelAndConsumeRemainingEvents()
         }
@@ -510,7 +511,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
 
         subscriptionsManager.purchase(mock(), planId = "")
 
-        verify(playBillingManager).launchBillingFlow(any(), any(), any())
+        verify(playBillingManager).launchBillingFlow(any(), any(), any(), isNull())
     }
 
     @Test
@@ -520,7 +521,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
 
         subscriptionsManager.purchase(mock(), planId = "")
 
-        verify(playBillingManager).launchBillingFlow(any(), any(), any())
+        verify(playBillingManager).launchBillingFlow(any(), any(), any(), isNull())
     }
 
     @Test(expected = Exception::class)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201807753394693/1209226459318682/f

### Description
Include `offerId` argument in subscriptions purchase method

### Steps to test this PR

_Pre steps_
- [x] Apply patch to being able to test subscriptions in staging

_Privacy Pro Eligible US_
- [x] Make sure you are US eligible
- [x] Install form branch
- [x] Go to Settings
- [x] Check you can see Privacy Pro option
- [x] Tap on that option
- [x] Check Subscriptions page looks as expected with full price subscriptions
- [x] Purchase any of the options
- [x] Check Free Trial is not offered when GooglePlay dialog for purchase is shown
- [x] Subscribe
- [x] Check everything works as expected

_Privacy Pro Eligible ROW (Optional)_
- [x] Make sure you are ROW eligible
- [x] Install form branch
- [x] Check browser works as expected
- [x] Go to Settings
- [x] Check you can see Privacy Pro option
- [x] Tap on that option
- [x] Check Subscription page looks as expected
- [x] Purchase any of the options and check it works well
- [x] Go to Subscription Settings
- [x] Check everything works as expected

### No UI changes
