### PR TITLE
Update content scope scripts to version 7.10.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
@@ -4024,6 +4024,7 @@
      * @property {string} [injectName]
      * @property {object} trackerLookup - provided currently only by the extension
      * @property {import('@duckduckgo/messaging').MessagingConfig} [messagingConfig]
+     * @property {string} [messageSecret] - optional, used in the messageBridge creation
      */
 
     /**
@@ -4140,6 +4141,7 @@
             site: processedConfig.site,
             bundledConfig: processedConfig.bundledConfig,
             messagingConfig: processedConfig.messagingConfig,
+            messageSecret: processedConfig.messageSecret,
         });
 
         init(processedConfig);

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -10297,6 +10297,7 @@
      * @property {string} [injectName]
      * @property {object} trackerLookup - provided currently only by the extension
      * @property {import('@duckduckgo/messaging').MessagingConfig} [messagingConfig]
+     * @property {string} [messageSecret] - optional, used in the messageBridge creation
      */
 
     /**
@@ -10413,6 +10414,7 @@
             site: processedConfig.site,
             bundledConfig: processedConfig.bundledConfig,
             messagingConfig: processedConfig.messagingConfig,
+            messageSecret: processedConfig.messageSecret,
         });
 
         init(processedConfig);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^12.7.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.1.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.9.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.10.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.1.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1734514764"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#bd438c982a2680ed54778a4818dc1652f30cd254",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#181696656f3627c1b3ca8cda06d54971e03436ef",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -88,13 +88,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@ghostery/adblocker": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.4.0.tgz",
-      "integrity": "sha512-MK5kIksx7LyVgBeE7cJ35koqOIakT9/DT/Kuqev9i8yZYAEqD+BZl7FsqsxEaj0uIBtDzi0mDVKIhRRaZi0BXQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.5.0.tgz",
+      "integrity": "sha512-CcmWiTLKxDqYiTlPyOAWr3xeZYXjWlpu6UOCDkk33k0w7jTgVrdvwbXf8Tv4XE0m3uNX6Idfj4H+Umv8L3AiUw==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-content": "^2.4.0",
-        "@ghostery/adblocker-extended-selectors": "^2.4.0",
+        "@ghostery/adblocker-content": "^2.5.0",
+        "@ghostery/adblocker-extended-selectors": "^2.5.0",
         "@remusao/guess-url-type": "^1.3.0",
         "@remusao/small": "^1.2.1",
         "@remusao/smaz": "^1.9.1",
@@ -102,18 +102,18 @@
       }
     },
     "node_modules/@ghostery/adblocker-content": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.4.0.tgz",
-      "integrity": "sha512-7iNMWbE3dhCiFZPHJFsmmwXAcCPOf54dufFEaDBgVpMUZWXsawBzcpkweRRb+7Jq4kV+Q4GjZkLv468VjgjJTQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.5.0.tgz",
+      "integrity": "sha512-Gn9fslZdacx1m1e3/2LSUPWagLObYmIDbkgvZTtgqT/OHc17VbM71AxWEjtC/xzo5K4PI25958PjvidoEH7ufw==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-extended-selectors": "^2.4.0"
+        "@ghostery/adblocker-extended-selectors": "^2.5.0"
       }
     },
     "node_modules/@ghostery/adblocker-extended-selectors": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.4.0.tgz",
-      "integrity": "sha512-f/eYidvN5aSWLe4suH0J20K5yv/3AZmCP+m1sdW0l5bsy3sJcQlT2W0zBULJwgKJBqHBWzVUSm0S3eV//LPLSQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.5.0.tgz",
+      "integrity": "sha512-/GBAwErjktcBKLjCMl/n+jz2MxXFfTmEGw+hcPtAhEin49eSC09PK1TAdzDPDXkCTF4Jmb/zC+MYtbX1eZ1WsQ==",
       "license": "MPL-2.0"
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -670,18 +670,18 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.74",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.74.tgz",
-      "integrity": "sha512-gTwtY6L2GfuxiL4CWpLknv9JDYYqBvKCk/BT5uAaAvCA0s6pzX7lr2IrkQZSUlnSjRHIjTl8ZwKCVXJ7XNRWYw==",
+      "version": "6.1.75",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.75.tgz",
+      "integrity": "sha512-AOvV5YYIAFFBfransBzSTyztkc3IMfz5Eq3YluaRiEu55nn43Fzaufx70UqEKYr8BoLCach4q8g/bg6e5+/aFw==",
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "6.1.74",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.74.tgz",
-      "integrity": "sha512-ryoxUvUmhrlGDgTcNu6Qc3nizKyDXOcmwJsW8IZSAhrfCHYbh2xnixh7eU69WApkLAm17pXDjR7J4zs1sm4ocw==",
+      "version": "6.1.75",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.75.tgz",
+      "integrity": "sha512-iTy/MkRgDWJClAi3v8jzB4vGSws8MW/Z6asSol2KRbBu3sbyFhRBeV8xhxEHcvfLw9QrObaPpdYc4+XihicHdQ==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^6.1.74"
+        "tldts-core": "^6.1.75"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^12.7.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.1.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.9.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.10.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.1.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1734514764"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414730916066338/1209239612696930/f

- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [x] All tests must pass