### PR TITLE
Additional "default browser" prompts: metrics

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -609,7 +609,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
             is Command.OpenInNewTab -> launchNewTab(command.url)
             is Command.OpenSavedSite -> currentTab?.submitQuery(command.url)
             is Command.ShowSetAsDefaultBrowserDialog -> showSetAsDefaultBrowserDialog()
-            is Command.HideSetAsDefaultBrowserDialog -> hideSetAsDefaultBrowserDialog()
+            is Command.DismissSetAsDefaultBrowserDialog -> dismissSetAsDefaultBrowserDialog()
             is ShowSystemDefaultAppsActivity -> showSystemDefaultAppsActivity(command.intent)
             is ShowSystemDefaultBrowserDialog -> showSystemDefaultBrowserDialog(command.intent)
         }
@@ -985,8 +985,8 @@ open class BrowserActivity : DuckDuckGoActivity() {
                 viewModel.onSetDefaultBrowserDialogShown()
             }
 
-            override fun onDismissed() {
-                viewModel.onSetDefaultBrowserDismissed()
+            override fun onCanceled() {
+                viewModel.onSetDefaultBrowserDialogCanceled()
             }
 
             override fun onSetBrowserButtonClicked() {
@@ -1001,7 +1001,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
         setAsDefaultBrowserDialog = dialog
     }
 
-    private fun hideSetAsDefaultBrowserDialog() {
+    private fun dismissSetAsDefaultBrowserDialog() {
         setAsDefaultBrowserDialog?.dismiss()
         setAsDefaultBrowserDialog = null
     }
@@ -1009,7 +1009,6 @@ open class BrowserActivity : DuckDuckGoActivity() {
     private fun showSystemDefaultAppsActivity(intent: Intent) {
         try {
             startDefaultAppsSystemActivityForResult.launch(intent)
-            viewModel.onSystemDefaultAppsActivityOpened()
         } catch (ex: Exception) {
             Timber.e(ex)
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/DefaultBrowserPromptsExperiment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/DefaultBrowserPromptsExperiment.kt
@@ -30,20 +30,32 @@ interface DefaultBrowserPromptsExperiment {
     fun onSetAsDefaultPopupMenuItemSelected()
 
     fun onMessageDialogShown()
-    fun onMessageDialogDismissed()
+    fun onMessageDialogCanceled()
     fun onMessageDialogConfirmationButtonClicked()
     fun onMessageDialogNotNowButtonClicked()
 
     fun onSystemDefaultBrowserDialogShown()
-    fun onSystemDefaultBrowserDialogSuccess()
-    fun onSystemDefaultBrowserDialogCanceled()
+    fun onSystemDefaultBrowserDialogSuccess(trigger: SetAsDefaultActionTrigger)
+    fun onSystemDefaultBrowserDialogCanceled(trigger: SetAsDefaultActionTrigger)
 
-    fun onSystemDefaultAppsActivityOpened()
-    fun onSystemDefaultAppsActivityClosed()
+    fun onSystemDefaultAppsActivityClosed(trigger: SetAsDefaultActionTrigger)
 
     sealed class Command {
         data object OpenMessageDialog : Command()
-        data class OpenSystemDefaultBrowserDialog(val intent: Intent) : Command()
-        data class OpenSystemDefaultAppsActivity(val intent: Intent) : Command()
+        data class OpenSystemDefaultBrowserDialog(
+            val intent: Intent,
+            val trigger: SetAsDefaultActionTrigger,
+        ) : Command()
+
+        data class OpenSystemDefaultAppsActivity(
+            val intent: Intent,
+            val trigger: SetAsDefaultActionTrigger,
+        ) : Command()
+    }
+
+    enum class SetAsDefaultActionTrigger {
+        DIALOG,
+        MENU,
+        UNKNOWN,
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/DefaultBrowserPromptsExperimentMetrics.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/DefaultBrowserPromptsExperimentMetrics.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.defaultbrowsing.prompts
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.ConversionWindow
+import com.duckduckgo.feature.toggles.api.MetricsPixel
+import com.duckduckgo.feature.toggles.api.MetricsPixelPlugin
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+@SingleInstanceIn(AppScope::class)
+class DefaultBrowserPromptsExperimentMetrics @Inject constructor(
+    private val defaultBrowserPromptsFeatureToggles: DefaultBrowserPromptsFeatureToggles,
+) : MetricsPixelPlugin {
+    override suspend fun getMetrics(): List<MetricsPixel> {
+        return listOf(
+            MetricsPixel(
+                metric = METRIC_DEFAULT_SET,
+                value = METRIC_VALUE_STAGE_1,
+                toggle = defaultBrowserPromptsFeatureToggles.defaultBrowserAdditionalPrompts202501(),
+                conversionWindow = (20..60 step 20).map { ConversionWindow(lowerWindow = 1, upperWindow = it) },
+            ),
+            MetricsPixel(
+                metric = METRIC_DEFAULT_SET,
+                value = METRIC_VALUE_STAGE_2,
+                toggle = defaultBrowserPromptsFeatureToggles.defaultBrowserAdditionalPrompts202501(),
+                conversionWindow = (20..60 step 20).map { ConversionWindow(lowerWindow = 1, upperWindow = it) },
+            ),
+            MetricsPixel(
+                metric = METRIC_DEFAULT_SET_VIA_CTA,
+                value = METRIC_VALUE_DIALOG,
+                toggle = defaultBrowserPromptsFeatureToggles.defaultBrowserAdditionalPrompts202501(),
+                conversionWindow = (20..60 step 20).map { ConversionWindow(lowerWindow = 1, upperWindow = it) },
+            ),
+            MetricsPixel(
+                metric = METRIC_DEFAULT_SET_VIA_CTA,
+                value = METRIC_VALUE_MENU,
+                toggle = defaultBrowserPromptsFeatureToggles.defaultBrowserAdditionalPrompts202501(),
+                conversionWindow = (20..60 step 20).map { ConversionWindow(lowerWindow = 1, upperWindow = it) },
+            ),
+            MetricsPixel(
+                metric = METRIC_STAGE_IMPRESSION,
+                value = METRIC_VALUE_STAGE_1,
+                toggle = defaultBrowserPromptsFeatureToggles.defaultBrowserAdditionalPrompts202501(),
+                conversionWindow = (20..60 step 20).map { ConversionWindow(lowerWindow = 1, upperWindow = it) },
+            ),
+            MetricsPixel(
+                metric = METRIC_STAGE_IMPRESSION,
+                value = METRIC_VALUE_STAGE_2,
+                toggle = defaultBrowserPromptsFeatureToggles.defaultBrowserAdditionalPrompts202501(),
+                conversionWindow = (20..60 step 20).map { ConversionWindow(lowerWindow = 1, upperWindow = it) },
+            ),
+        )
+    }
+
+    suspend fun getDefaultSetForStage1(): MetricsPixel? {
+        return this.getMetrics().firstOrNull { it.metric == METRIC_DEFAULT_SET && it.value == METRIC_VALUE_STAGE_1 }
+    }
+
+    suspend fun getDefaultSetForStage2(): MetricsPixel? {
+        return this.getMetrics().firstOrNull { it.metric == METRIC_DEFAULT_SET && it.value == METRIC_VALUE_STAGE_2 }
+    }
+
+    suspend fun getDefaultSetViaDialog(): MetricsPixel? {
+        return this.getMetrics().firstOrNull { it.metric == METRIC_DEFAULT_SET_VIA_CTA && it.value == METRIC_VALUE_DIALOG }
+    }
+
+    suspend fun getDefaultSetViaMenu(): MetricsPixel? {
+        return this.getMetrics().firstOrNull { it.metric == METRIC_DEFAULT_SET_VIA_CTA && it.value == METRIC_VALUE_MENU }
+    }
+
+    suspend fun getStageImpressionForStage1(): MetricsPixel? {
+        return this.getMetrics().firstOrNull { it.metric == METRIC_STAGE_IMPRESSION && it.value == METRIC_VALUE_STAGE_1 }
+    }
+
+    suspend fun getStageImpressionForStage2(): MetricsPixel? {
+        return this.getMetrics().firstOrNull { it.metric == METRIC_STAGE_IMPRESSION && it.value == METRIC_VALUE_STAGE_2 }
+    }
+
+    companion object {
+        const val METRIC_DEFAULT_SET = "defaultSet"
+        const val METRIC_DEFAULT_SET_VIA_CTA = "defaultSetViaCta"
+        const val METRIC_STAGE_IMPRESSION = "stageImpression"
+
+        const val METRIC_VALUE_STAGE_1 = "stage_1"
+        const val METRIC_VALUE_STAGE_2 = "stage_2"
+        const val METRIC_VALUE_DIALOG = "dialog"
+        const val METRIC_VALUE_MENU = "menu"
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/ui/DefaultBrowserBottomSheetDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/ui/DefaultBrowserBottomSheetDialog.kt
@@ -47,8 +47,8 @@ class DefaultBrowserBottomSheetDialog(private val context: Context) : BottomShee
             setRoundCorners(dialogInterface)
             eventListener?.onShown()
         }
-        setOnDismissListener {
-            eventListener?.onDismissed()
+        setOnCancelListener {
+            eventListener?.onCanceled()
         }
         binding.defaultBrowserBottomSheetDialogPrimaryButton.setOnClickListener {
             eventListener?.onSetBrowserButtonClicked()
@@ -77,7 +77,7 @@ class DefaultBrowserBottomSheetDialog(private val context: Context) : BottomShee
 
     interface EventListener {
         fun onShown()
-        fun onDismissed()
+        fun onCanceled()
         fun onSetBrowserButtonClicked()
         fun onNotNowButtonClicked()
     }

--- a/app/src/main/java/com/duckduckgo/app/global/api/PixelParamRemovalInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/PixelParamRemovalInterceptor.kt
@@ -95,6 +95,10 @@ object PixelInterceptorPixelsRequiringDataCleaning : PixelParamRemovalPlugin {
             SITE_NOT_WORKING_WEBSITE_BROKEN.pixelName to PixelParameter.removeAtb(),
             AppPixelName.APP_VERSION_AT_SEARCH_TIME.pixelName to PixelParameter.removeAll(),
             AppPixelName.MALICIOUS_SITE_PROTECTION_SETTING_TOGGLED.pixelName to PixelParameter.removeAtb(),
+            AppPixelName.SET_AS_DEFAULT_PROMPT_IMPRESSION.pixelName to PixelParameter.removeAll(),
+            AppPixelName.SET_AS_DEFAULT_PROMPT_CLICK.pixelName to PixelParameter.removeAll(),
+            AppPixelName.SET_AS_DEFAULT_PROMPT_DISMISSED.pixelName to PixelParameter.removeAll(),
+            AppPixelName.SET_AS_DEFAULT_IN_MENU_CLICK.pixelName to PixelParameter.removeAll(),
         )
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -387,4 +387,9 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     DEDICATED_WEBVIEW_URL_EXTRACTION_FAILED("m_dedicated_webview_url_extraction_failed"),
 
     BLOCKLIST_TDS_FAILURE("blocklist_experiment_tds_download_failure"),
+
+    SET_AS_DEFAULT_PROMPT_IMPRESSION("m_set-as-default_prompt_impression"),
+    SET_AS_DEFAULT_PROMPT_CLICK("m_set-as-default_prompt_click"),
+    SET_AS_DEFAULT_PROMPT_DISMISSED("m_set-as-default_prompt_dismissed"),
+    SET_AS_DEFAULT_IN_MENU_CLICK("m_set-as-default_in-menu_click"),
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
@@ -23,6 +23,7 @@ import androidx.lifecycle.Observer
 import com.duckduckgo.app.browser.BrowserViewModel.Command
 import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
 import com.duckduckgo.app.browser.defaultbrowsing.prompts.DefaultBrowserPromptsExperiment
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.DefaultBrowserPromptsExperiment.SetAsDefaultActionTrigger
 import com.duckduckgo.app.browser.omnibar.OmnibarEntryConverter
 import com.duckduckgo.app.fire.DataClearer
 import com.duckduckgo.app.generalsettings.showonapplaunch.ShowOnAppLaunchFeature
@@ -342,7 +343,8 @@ class BrowserViewModelTest {
     @Test
     fun `when default browser prompts experiment OpenSystemDefaultBrowserDialog command, then propagate it to consumers`() = runTest {
         val intent: Intent = mock()
-        defaultBrowserPromptsExperimentCommandsFlow.send(DefaultBrowserPromptsExperiment.Command.OpenSystemDefaultBrowserDialog(intent))
+        val trigger: SetAsDefaultActionTrigger = mock()
+        defaultBrowserPromptsExperimentCommandsFlow.send(DefaultBrowserPromptsExperiment.Command.OpenSystemDefaultBrowserDialog(intent, trigger))
 
         verify(mockCommandObserver).onChanged(commandCaptor.capture())
         assertEquals(Command.ShowSystemDefaultBrowserDialog(intent), commandCaptor.lastValue)
@@ -351,7 +353,8 @@ class BrowserViewModelTest {
     @Test
     fun `when default browser prompts experiment OpenSystemDefaultAppsActivity command, then propagate it to consumers`() = runTest {
         val intent: Intent = mock()
-        defaultBrowserPromptsExperimentCommandsFlow.send(DefaultBrowserPromptsExperiment.Command.OpenSystemDefaultAppsActivity(intent))
+        val trigger: SetAsDefaultActionTrigger = mock()
+        defaultBrowserPromptsExperimentCommandsFlow.send(DefaultBrowserPromptsExperiment.Command.OpenSystemDefaultAppsActivity(intent, trigger))
 
         verify(mockCommandObserver).onChanged(commandCaptor.capture())
         assertEquals(Command.ShowSystemDefaultAppsActivity(intent), commandCaptor.lastValue)
@@ -365,28 +368,28 @@ class BrowserViewModelTest {
     }
 
     @Test
-    fun `when onSetDefaultBrowserDismissed called, then pass that information to the experiment`() {
-        testee.onSetDefaultBrowserDismissed()
+    fun `when onSetDefaultBrowserDialogCanceled called, then pass that information to the experiment`() {
+        testee.onSetDefaultBrowserDialogCanceled()
 
-        verify(mockDefaultBrowserPromptsExperiment).onMessageDialogDismissed()
+        verify(mockDefaultBrowserPromptsExperiment).onMessageDialogCanceled()
     }
 
     @Test
-    fun `when onSetDefaultBrowserConfirmationButtonClicked called, then pass that information to the experiment`() {
+    fun `when onSetDefaultBrowserConfirmationButtonClicked called, then pass that information to the experiment and dismiss dialog`() {
         testee.onSetDefaultBrowserConfirmationButtonClicked()
 
         verify(mockDefaultBrowserPromptsExperiment).onMessageDialogConfirmationButtonClicked()
         verify(mockCommandObserver).onChanged(commandCaptor.capture())
-        assertEquals(Command.HideSetAsDefaultBrowserDialog, commandCaptor.lastValue)
+        assertEquals(Command.DismissSetAsDefaultBrowserDialog, commandCaptor.lastValue)
     }
 
     @Test
-    fun `when onSetDefaultBrowserNotNowButtonClicked called, then pass that information to the experiment`() {
+    fun `when onSetDefaultBrowserNotNowButtonClicked called, then pass that information to the experiment and dismiss dialog`() {
         testee.onSetDefaultBrowserNotNowButtonClicked()
 
         verify(mockDefaultBrowserPromptsExperiment).onMessageDialogNotNowButtonClicked()
         verify(mockCommandObserver).onChanged(commandCaptor.capture())
-        assertEquals(Command.HideSetAsDefaultBrowserDialog, commandCaptor.lastValue)
+        assertEquals(Command.DismissSetAsDefaultBrowserDialog, commandCaptor.lastValue)
     }
 
     @Test
@@ -397,31 +400,36 @@ class BrowserViewModelTest {
     }
 
     @Test
-    fun `when onSystemDefaultBrowserDialogSuccess called, then pass that information to the experiment`() {
+    fun `when onSystemDefaultBrowserDialogSuccess called, then pass that information to the experiment`() = runTest {
+        val intent: Intent = mock()
+        val trigger: SetAsDefaultActionTrigger = mock()
+        defaultBrowserPromptsExperimentCommandsFlow.send(DefaultBrowserPromptsExperiment.Command.OpenSystemDefaultBrowserDialog(intent, trigger))
+
         testee.onSystemDefaultBrowserDialogSuccess()
 
-        verify(mockDefaultBrowserPromptsExperiment).onSystemDefaultBrowserDialogSuccess()
+        verify(mockDefaultBrowserPromptsExperiment).onSystemDefaultBrowserDialogSuccess(trigger)
     }
 
     @Test
-    fun `when onSystemDefaultBrowserDialogCanceled called, then pass that information to the experiment`() {
+    fun `when onSystemDefaultBrowserDialogCanceled called, then pass that information to the experiment`() = runTest {
+        val intent: Intent = mock()
+        val trigger: SetAsDefaultActionTrigger = mock()
+        defaultBrowserPromptsExperimentCommandsFlow.send(DefaultBrowserPromptsExperiment.Command.OpenSystemDefaultBrowserDialog(intent, trigger))
+
         testee.onSystemDefaultBrowserDialogCanceled()
 
-        verify(mockDefaultBrowserPromptsExperiment).onSystemDefaultBrowserDialogCanceled()
+        verify(mockDefaultBrowserPromptsExperiment).onSystemDefaultBrowserDialogCanceled(trigger)
     }
 
     @Test
-    fun `when onSystemDefaultAppsActivityOpened called, then pass that information to the experiment`() {
-        testee.onSystemDefaultAppsActivityOpened()
+    fun `when onSystemDefaultAppsActivityClosed called, then pass that information to the experiment`() = runTest {
+        val intent: Intent = mock()
+        val trigger: SetAsDefaultActionTrigger = mock()
+        defaultBrowserPromptsExperimentCommandsFlow.send(DefaultBrowserPromptsExperiment.Command.OpenSystemDefaultAppsActivity(intent, trigger))
 
-        verify(mockDefaultBrowserPromptsExperiment).onSystemDefaultAppsActivityOpened()
-    }
-
-    @Test
-    fun `when onSystemDefaultAppsActivityClosed called, then pass that information to the experiment`() {
         testee.onSystemDefaultAppsActivityClosed()
 
-        verify(mockDefaultBrowserPromptsExperiment).onSystemDefaultAppsActivityClosed()
+        verify(mockDefaultBrowserPromptsExperiment).onSystemDefaultAppsActivityClosed(trigger)
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201621853593513/1208697958169120/f

Marking as blocked until all pixels are confirmed with the DS team. This is generally ready for a first round of reviews but some additional changes may be still introduced because of that.

### Steps to test this PR

You can follow instructions from https://github.com/duckduckgo/Android/pull/5476 to go through the experiment.

Test for below pixels:

| Action  | Pixel |
| ------ | ----- |
| Enrolled | `experiment_enroll_defaultBrowserAdditionalPrompts202501_variant_2 with params: {enrollmentDate=2025-01-27}` |
| Reached Stage 1 | `experiment_metrics_defaultBrowserAdditionalPrompts202501_variant_2 with params: {metric=stageImpression, value=stage_1, enrollmentDate=2025-01-27, conversionWindowDays=1-X}` (`X` is 20, 40, 60) |
| Reached Stage 2 | `experiment_metrics_defaultBrowserAdditionalPrompts202501_variant_2 with params: {metric=stageImpression, value=stage_2, enrollmentDate=2025-01-27, conversionWindowDays=1-X}` (`X` is 20, 40, 60) |
| Message dialog dismissed or "not now" clicked | `m_set-as-default_prompt_dismissed with params: {expVar=variant_2, expStage=stage_1}`|
| Message dialog confirmation clicked | `m_set-as-default_prompt_click with params: {expVar=variant_2, expStage=stage_1}`|
| Menu item clicked | `m_set-as-default_in-menu_click with params: {expVar=variant_2, expStage=stage_2}`|
| Browser set as default (from any source) | `experiment_metrics_defaultBrowserAdditionalPrompts202501_variant_2 with params: {metric=defaultSet, value=stage_2, enrollmentDate=2025-01-27, conversionWindowDays=1-X}` (`X` is 20, 40, 60) |
| Browser set as default when preceding action is dialog or menu. This is sent in addition to the above metric. | `experiment_metrics_defaultBrowserAdditionalPrompts202501_variant_2 with params: {metric=defaultSetViaCta, value=menu, enrollmentDate=2025-01-27, conversionWindowDays=1-X}` (`X` is 20, 40, 60) |
