### PR TITLE
Update methods for Duck.ai <> Native integration

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/duckchat/DuckChatJSHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/duckchat/DuckChatJSHelper.kt
@@ -49,8 +49,8 @@ class RealDuckChatJSHelper @Inject constructor(
         METHOD_GET_AI_CHAT_NATIVE_HANDOFF_DATA -> id?.let {
             SendResponseToJs(getAIChatNativeHandoffData(featureName, method, it))
         }
-        METHOD_GET_AI_CHAT_NATIVE_CONFIG -> id?.let {
-            SendResponseToJs(getAIChatNativeConfig(featureName, method, it))
+        METHOD_GET_AI_CHAT_NATIVE_CONFIG_VALUES -> id?.let {
+            SendResponseToJs(getAIChatNativeConfigValues(featureName, method, it))
         }
         METHOD_OPEN_AI_CHAT -> {
             val payload = extractPayload(data)
@@ -70,7 +70,7 @@ class RealDuckChatJSHelper @Inject constructor(
         return JsCallbackData(jsonPayload, featureName, method, id)
     }
 
-    private fun getAIChatNativeConfig(featureName: String, method: String, id: String): JsCallbackData {
+    private fun getAIChatNativeConfigValues(featureName: String, method: String, id: String): JsCallbackData {
         val jsonPayload = JSONObject().apply {
             put(PLATFORM, ANDROID)
             put(IS_HANDOFF_ENABLED, duckChat.isEnabled())
@@ -87,7 +87,7 @@ class RealDuckChatJSHelper @Inject constructor(
     companion object {
         const val DUCK_CHAT_FEATURE_NAME = "aiChat"
         private const val METHOD_GET_AI_CHAT_NATIVE_HANDOFF_DATA = "getAIChatNativeHandoffData"
-        private const val METHOD_GET_AI_CHAT_NATIVE_CONFIG = "getAIChatNativeConfigValues"
+        private const val METHOD_GET_AI_CHAT_NATIVE_CONFIG_VALUES = "getAIChatNativeConfigValues"
         private const val METHOD_OPEN_AI_CHAT = "openAIChat"
         private const val PAYLOAD = "aiChatPayload"
         private const val IS_HANDOFF_ENABLED = "isAIChatHandoffEnabled"

--- a/app/src/test/java/com/duckduckgo/app/browser/duckchat/RealDuckChatJSHelperTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/duckchat/RealDuckChatJSHelperTest.kt
@@ -143,9 +143,9 @@ class RealDuckChatJSHelperTest {
     }
 
     @Test
-    fun whenGetAIChatNativeConfigAndIdIsNullThenReturnNull() = runTest {
+    fun whenGetAIChatNativeConfigValuesAndIdIsNullThenReturnNull() = runTest {
         val featureName = "aiChat"
-        val method = "getAIChatNativeConfig"
+        val method = "getAIChatNativeConfigValues"
 
         val result = testee.processJsCallbackMessage(featureName, method, null, null)
 

--- a/app/src/test/java/com/duckduckgo/app/browser/duckchat/RealDuckChatJSHelperTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/duckchat/RealDuckChatJSHelperTest.kt
@@ -58,9 +58,9 @@ class RealDuckChatJSHelperTest {
     }
 
     @Test
-    fun whenGetUserValuesAndIdIsNullThenReturnNull() = runTest {
+    fun whenGetAIChatNativeHandoffDataAndIdIsNullThenReturnNull() = runTest {
         val featureName = "aiChat"
-        val method = "getUserValues"
+        val method = "getAIChatNativeHandoffData"
 
         val result = testee.processJsCallbackMessage(featureName, method, null, null)
 
@@ -68,9 +68,9 @@ class RealDuckChatJSHelperTest {
     }
 
     @Test
-    fun whenGetUserValuesAndDuckChatEnabledThenReturnSendResponseToJsWithDuckChatEnabled() = runTest {
+    fun whenGetAIChatNativeHandoffDataAndDuckChatEnabledThenReturnSendResponseToJsWithDuckChatEnabled() = runTest {
         val featureName = "aiChat"
-        val method = "getUserValues"
+        val method = "getAIChatNativeHandoffData"
         val id = "123"
 
         whenever(mockDuckChat.isEnabled()).thenReturn(true)
@@ -93,9 +93,9 @@ class RealDuckChatJSHelperTest {
     }
 
     @Test
-    fun whenGetUserValuesAndDuckChatDisabledThenReturnSendResponseToJsWithDuckChatDisabled() = runTest {
+    fun whenGetAIChatNativeHandoffDataAndDuckChatDisabledThenReturnSendResponseToJsWithDuckChatDisabled() = runTest {
         val featureName = "aiChat"
-        val method = "getUserValues"
+        val method = "getAIChatNativeHandoffData"
         val id = "123"
 
         whenever(mockDuckChat.isEnabled()).thenReturn(false)
@@ -118,9 +118,92 @@ class RealDuckChatJSHelperTest {
     }
 
     @Test
-    fun whenGetUserValuesAndPreferencesNullThenReturnSendResponseToJsWithPreferencesNull() = runTest {
+    fun whenGetAIChatNativeHandoffDataAndPreferencesNullThenReturnSendResponseToJsWithPreferencesNull() = runTest {
         val featureName = "aiChat"
-        val method = "getUserValues"
+        val method = "getAIChatNativeHandoffData"
+        val id = "123"
+
+        whenever(mockDuckChat.isEnabled()).thenReturn(true)
+        whenever(mockPreferencesStore.fetchAndClearUserPreferences()).thenReturn(null)
+
+        val result = testee.processJsCallbackMessage(featureName, method, id, null) as SendResponseToJs
+
+        val jsonPayload = JSONObject().apply {
+            put("platform", "android")
+            put("isAIChatHandoffEnabled", true)
+            put("aiChatPayload", null)
+        }
+
+        val expected = SendResponseToJs(JsCallbackData(jsonPayload, featureName, method, id))
+
+        assertEquals(expected.data.id, result.data.id)
+        assertEquals(expected.data.method, result.data.method)
+        assertEquals(expected.data.featureName, result.data.featureName)
+        assertEquals(expected.data.params.toString(), result.data.params.toString())
+    }
+
+    @Test
+    fun whenGetAIChatNativeConfigAndIdIsNullThenReturnNull() = runTest {
+        val featureName = "aiChat"
+        val method = "getAIChatNativeConfig"
+
+        val result = testee.processJsCallbackMessage(featureName, method, null, null)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun whenGetAIChatNativeConfigValuesAndDuckChatEnabledThenReturnSendResponseToJsWithDuckChatEnabled() = runTest {
+        val featureName = "aiChat"
+        val method = "getAIChatNativeConfigValues"
+        val id = "123"
+
+        whenever(mockDuckChat.isEnabled()).thenReturn(true)
+        whenever(mockPreferencesStore.fetchAndClearUserPreferences()).thenReturn("preferences")
+
+        val result = testee.processJsCallbackMessage(featureName, method, id, null) as SendResponseToJs
+
+        val jsonPayload = JSONObject().apply {
+            put("platform", "android")
+            put("isAIChatHandoffEnabled", true)
+        }
+
+        val expected = SendResponseToJs(JsCallbackData(jsonPayload, featureName, method, id))
+
+        assertEquals(expected.data.id, result.data.id)
+        assertEquals(expected.data.method, result.data.method)
+        assertEquals(expected.data.featureName, result.data.featureName)
+        assertEquals(expected.data.params.toString(), result.data.params.toString())
+    }
+
+    @Test
+    fun whenGetAIChatNativeConfigValuesAndDuckChatDisabledThenReturnSendResponseToJsWithDuckChatDisabled() = runTest {
+        val featureName = "aiChat"
+        val method = "getAIChatNativeConfigValues"
+        val id = "123"
+
+        whenever(mockDuckChat.isEnabled()).thenReturn(false)
+        whenever(mockPreferencesStore.fetchAndClearUserPreferences()).thenReturn("preferences")
+
+        val result = testee.processJsCallbackMessage(featureName, method, id, null) as SendResponseToJs
+
+        val jsonPayload = JSONObject().apply {
+            put("platform", "android")
+            put("isAIChatHandoffEnabled", false)
+        }
+
+        val expected = SendResponseToJs(JsCallbackData(jsonPayload, featureName, method, id))
+
+        assertEquals(expected.data.id, result.data.id)
+        assertEquals(expected.data.method, result.data.method)
+        assertEquals(expected.data.featureName, result.data.featureName)
+        assertEquals(expected.data.params.toString(), result.data.params.toString())
+    }
+
+    @Test
+    fun whenGetAIChatNativeConfigValuesAndPreferencesNullThenReturnSendResponseToJsWithPreferencesNull() = runTest {
+        val featureName = "aiChat"
+        val method = "getAIChatNativeConfigValues"
         val id = "123"
 
         whenever(mockDuckChat.isEnabled()).thenReturn(true)

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessaging.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessaging.kt
@@ -159,7 +159,8 @@ class ContentScopeScriptsJsMessaging @Inject constructor(
 
         override val featureName: String = "aiChat"
         override val methods: List<String> = listOf(
-            "getUserValues",
+            "getAIChatNativeHandoffData",
+            "getAIChatNativeConfigValues",
             "openAIChat",
         )
     }

--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessagingTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessagingTest.kt
@@ -167,12 +167,26 @@ class ContentScopeScriptsJsMessagingTest {
     }
 
     @Test
-    fun whenProcessDuckChatMessageWithGetUserValuesThenCallbackExecuted() = runTest {
+    fun whenProcessDuckChatMessageWithGetAIChatNativeHandoffDataThenCallbackExecuted() = runTest {
         givenInterfaceIsRegistered()
         whenever(mockWebView.url).thenReturn("https://duckduckgo.com")
 
         val message = """
-        {"context":"contentScopeScripts","featureName":"aiChat","id":"myId","method":"getUserValues","params":{"key":"value"}}
+        {"context":"contentScopeScripts","featureName":"aiChat","id":"myId","method":"getAIChatNativeHandoffData","params":{"key":"value"}}
+        """.trimIndent()
+
+        contentScopeScriptsJsMessaging.process(message, contentScopeScriptsJsMessaging.secret)
+
+        assertEquals(1, callback.counter)
+    }
+
+    @Test
+    fun whenProcessDuckChatMessageWithGetAIChatNativeConfigValuesThenCallbackExecuted() = runTest {
+        givenInterfaceIsRegistered()
+        whenever(mockWebView.url).thenReturn("https://duckduckgo.com")
+
+        val message = """
+        {"context":"contentScopeScripts","featureName":"aiChat","id":"myId","method":"getAIChatNativeConfigValues","params":{"key":"value"}}
         """.trimIndent()
 
         contentScopeScriptsJsMessaging.process(message, contentScopeScriptsJsMessaging.secret)
@@ -214,7 +228,7 @@ class ContentScopeScriptsJsMessagingTest {
         whenever(mockWebView.url).thenReturn("https://duckduckgo.com")
 
         val message = """
-        {"context":"contentScopeScripts","featureName":"invalidFeature","id":"myId","method":"getUserValues","params":{}}
+        {"context":"contentScopeScripts","featureName":"invalidFeature","id":"myId","method":"getAIChatNativeHandoffData","params":{}}
         """.trimIndent()
 
         contentScopeScriptsJsMessaging.process(message, contentScopeScriptsJsMessaging.secret)
@@ -228,7 +242,7 @@ class ContentScopeScriptsJsMessagingTest {
         whenever(mockWebView.url).thenReturn("https://invalid-domain.com")
 
         val message = """
-        {"context":"contentScopeScripts","featureName":"aiChat","id":"myId","method":"getUserValues","params":{}}
+        {"context":"contentScopeScripts","featureName":"aiChat","id":"myId","method":"getAIChatNativeHandoffData","params":{}}
         """.trimIndent()
 
         contentScopeScriptsJsMessaging.process(message, contentScopeScriptsJsMessaging.secret)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205782359654716/1209252104628635/f

### Description

- Renamed getUserValues to getAIChatNativeHandoffData
- Added getAIChatNativeConfigValues
- - This method is the same as getAIChatNativeHandoffData but does not contain a payload.

### Steps to test this PR

_Apply the patch linked in the task_

_Standard flow_
- [ ] Search for “bread recipe” (You may need to log in)
- [ ] Tap the “Ask AI Chat” button
- [ ] Verify that the dedicated WebView is opened with “bread recipe” auto-prompted

_DuckAssist_
- [ ] Go to settings in SERP > AI features
- [ ] Change the setting to show DuckAssist often
- [ ] Change the language to English(US)
- [ ] Search for “how tall is a giraffe” (You should see “DuckAssist”)
- [ ] Tap the “Ask AI Chat” button
- [ ] Verify that the dedicated WebView is opened

_Chat tab pill button_
- [ ] Tap the small chat button at the top of SERP
- [ ] Verify that the dedicated WebView is opened with the prompt pre-filled

