### PR TITLE
Update Settings: Remove ripple for disabled ppro items

### DIFF
--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/listitem/SettingsListItem.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/listitem/SettingsListItem.kt
@@ -21,9 +21,11 @@ import android.util.AttributeSet
 import android.widget.ImageView
 import androidx.annotation.DrawableRes
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import com.duckduckgo.common.ui.view.StatusIndicatorView
 import com.duckduckgo.common.ui.view.StatusIndicatorView.Status
+import com.duckduckgo.common.ui.view.defaultSelectableItemBackground
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.view.text.DaxTextView
@@ -77,7 +79,15 @@ class SettingsListItem @JvmOverloads constructor(
 
     /** Sets the item click listener */
     fun setClickListener(onClick: (() -> Unit)?) {
-        binding.root.setOnClickListener { onClick?.invoke() }
+        with(binding) {
+            if (onClick == null) {
+                setOnClickListener(null)
+                root.background = null
+            } else {
+                setOnClickListener { onClick() }
+                root.background = ContextCompat.getDrawable(context, context.defaultSelectableItemBackground())
+            }
+        }
     }
 
     /** Sets whether the status indicator is on or off */


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207908166761516/1209246799465871/f 

### Description
Added ripple effect to clickable settings list items and removed background from non-clickable items to improve visual feedback and user interaction consistency.

### Steps to test this PR

_Settings List Items_
- [x] Navigate to settings
- [x] Purchase Privacy Pro Monthly
- [x] Verify Privacy Pro (VPN, PIR, ITR) items are clickable and have a ripple
- [x] Cancel Privacy Pro
- [x] Wait 5mins for expiration
- [x] Navigate out of settings and back in
- [x] Verify Privacy Pro items (VPN, PIR, ITR) have no ripple effect

### UI changes
**Before** 

https://github.com/user-attachments/assets/c13d1be6-dc71-4e08-bad8-8a08ac295d50

**After**

https://github.com/user-attachments/assets/e33059d7-9698-473b-8a76-c09ca29c7c6c