### PR TITLE
Show on App Launch: Use string resources for settings

### DIFF
--- a/app/src/main/res/layout/activity_show_on_app_launch_setting.xml
+++ b/app/src/main/res/layout/activity_show_on_app_launch_setting.xml
@@ -41,21 +41,21 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:minHeight="@dimen/oneLineItemHeight"
-                app:primaryText="Last Opened Tab" />
+                app:primaryText="@string/showOnAppLaunchOptionLastOpenedTab" />
 
             <com.duckduckgo.common.ui.view.listitem.RadioListItem
                 android:id="@+id/newTabCheckListItem"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:minHeight="@dimen/oneLineItemHeight"
-                app:primaryText="New Tab Page" />
+                app:primaryText="@string/showOnAppLaunchOptionNewTabPage" />
 
             <com.duckduckgo.common.ui.view.listitem.RadioListItem
                 android:id="@+id/specificPageCheckListItem"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:minHeight="@dimen/oneLineItemHeight"
-                app:primaryText="Specific Page" />
+                app:primaryText="@string/showOnAppLaunchOptionSpecificPage" />
 
             <com.duckduckgo.common.ui.view.text.DaxTextInput
                 android:id="@+id/specificPageUrlInput"

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -792,4 +792,5 @@
     <!-- DuckChat -->
     <string name="duckChatTitle">Duck.ai</string>
     <string name="duckChatMenuItem">Uus AI vestlus</string>
+
 </resources>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -132,8 +132,8 @@
     <string name="settingsAboutDuckduckgo">Apie „DuckDuckGo“</string>
     <string name="settingsVersion">Versija</string>
     <string name="leaveFeedback">Bendrinti atsiliepimą</string>
-    <string name="settingsEmailProtectionTitle">El. pašto apsauga</string>
     <string name="leaveFeedbackNew">Siųsti atsiliepimą</string>
+    <string name="settingsEmailProtectionTitle">El. pašto apsauga</string>
     <string name="settingsEmailProtectionSubtitle">Blokuokite el. laiškų sekimo priemones ir paslėpkite savo adresą</string>
     <string name="settingsHeadingMore">Daugiau iš „DuckDuckGo“</string>
     <string name="settingsHeadingNextSteps">Tolesni veiksmai</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-pl/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-pl/strings-subscriptions.xml
@@ -44,9 +44,9 @@
     <string name="subscriptionRemoved">Twoja subskrypcja została usunięta z tego urządzenia</string>
     <string name="removeFromDevice">Usunąć z tego urządzenia?</string>
     <string name="removeFromDeviceDescription">Nie będziesz już mieć dostępu do subskrypcji Privacy Pro na tym urządzeniu. Nie spowoduje to anulowania Twojej subskrypcji, która pozostanie aktywna na pozostałych urządzeniach.</string>
-    <string name="subscriptionsDataMonthly" instruction="First placeholder is renews or expires, second is a date in format MMMM dd, yyyy">Twoja miesięczna subskrypcja %1$s w dniu %2$s.</string>
-    <string name="subscriptionsDataYearly" instruction="First placeholder is renews or expires, second is a date in format MMMM dd, yyyy">Twoja roczna subskrypcja %1$s w dniu %2$s.</string>
-    <string name="subscriptionsExpiredData" instruction="The placeholder is a date in format MMMM dd, yyyy">Twoja subskrypcja wygasła w dniu %1$s.</string>
+    <string name="subscriptionsDataMonthly" instruction="First placeholder is renews or expires, second is a date in format MMMM dd, yyyy">Twoja miesięczna subskrypcja %1$s %2$s.</string>
+    <string name="subscriptionsDataYearly" instruction="First placeholder is renews or expires, second is a date in format MMMM dd, yyyy">Twoja roczna subskrypcja %1$s %2$s.</string>
+    <string name="subscriptionsExpiredData" instruction="The placeholder is a date in format MMMM dd, yyyy">Twoja subskrypcja wygasła %1$s.</string>
     <string name="monthlySubscription">Subskrypcja miesięczna</string>
     <string name="yearlySubscription">Subskrypcja roczna</string>
     <string name="renews">zostaje odnowiona</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202552961248957/1209246799465881/f 

### Description
Replaced hardcoded strings with string resources in the app launch settings screen for better localization support. Updated text references for "Last Opened Tab," "New Tab Page," and "Specific Page" options.

### Steps to test this PR

_String Resources Implementation_
- [ ] Navigate to Show on App launch settings
- [ ] Verify "Last Opened Tab" displays correctly from string resources
- [ ] Verify "New Tab Page" displays correctly from string resources
- [ ] Verify "Specific Page" displays correctly from string resources
- [ ] Test in different locales to ensure proper translation support

### UI changes
| Before  | After |
| ------ | ----- |
|![Screenshot_20250127_160409](https://github.com/user-attachments/assets/39c0ed22-a23a-4fe4-b137-c88cf04f2cf1)|![Screenshot_20250127_161411](https://github.com/user-attachments/assets/40026550-b30a-46bd-9e9e-89b45362c4cc)|