### PR TITLE
Remove custom logic for sizing autofill overflow menu popup

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillManagementRecyclerAdapter.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillManagementRecyclerAdapter.kt
@@ -18,10 +18,8 @@ package com.duckduckgo.autofill.impl.ui.credential.management
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.content.res.Configuration
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import android.view.ViewGroup.LayoutParams
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.RecyclerView
@@ -192,20 +190,11 @@ class AutofillManagementRecyclerAdapter(
         context: Context,
         loginCredentials: LoginCredentials,
     ): PopupMenu {
-        return PopupMenu(LayoutInflater.from(context), R.layout.overflow_menu_list_item, width = getPopupMenuWidth(context)).apply {
+        return PopupMenu(LayoutInflater.from(context), R.layout.overflow_menu_list_item).apply {
             onMenuItemClicked(contentView.findViewById(R.id.item_overflow_edit)) { onContextMenuItemClicked(Edit(loginCredentials)) }
             onMenuItemClicked(contentView.findViewById(R.id.item_overflow_delete)) { onContextMenuItemClicked(Delete(loginCredentials)) }
             onMenuItemClicked(contentView.findViewById(R.id.item_copy_username)) { onContextMenuItemClicked(CopyUsername(loginCredentials)) }
             onMenuItemClicked(contentView.findViewById(R.id.item_copy_password)) { onContextMenuItemClicked(CopyPassword(loginCredentials)) }
-        }
-    }
-
-    private fun getPopupMenuWidth(context: Context): Int {
-        val orientation = context.resources.configuration.orientation
-        return if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
-            LayoutParams.WRAP_CONTENT
-        } else {
-            context.resources.getDimensionPixelSize(R.dimen.credentialManagementListItemPopupMenuWidth)
         }
     }
 

--- a/autofill/autofill-impl/src/main/res/values/autofill-impl-dimensions.xml
+++ b/autofill/autofill-impl/src/main/res/values/autofill-impl-dimensions.xml
@@ -15,7 +15,6 @@
   -->
 
 <resources>
-    <dimen name="credentialManagementListItemPopupMenuWidth">200dp</dimen>
     <dimen name="autofillBottomSheetBottomPadding">30dp</dimen>
     <dimen name="autofillBottomSheetContentMaxWidth">480dp</dimen>
 </resources>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1209252957928805/f 

### Description
Updates the password management screen so that popup menus (triggered from a password’s overflow menu) take on the default size instead of specifying a custom width.

### Steps to test this PR
- [x] On a phone, visit `Settings->Passwords`, manually add a password, then return to the password list view.
- [x] Tap on the password’s overflow, and verify the sizing of the popup menu looks ok
- [x] Flip to landscape, and check it still looks good. 
- [x] As a final check, keep it in landscape and leave the screen. re-enter password management screen and check the overflow size is still good.
- [x] Repeat on a tablet.