### PR TITLE
Show on App Launch: Use string resources for settings 

### DIFF
--- a/app/src/main/res/layout/activity_show_on_app_launch_setting.xml
+++ b/app/src/main/res/layout/activity_show_on_app_launch_setting.xml
@@ -41,21 +41,21 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:minHeight="@dimen/oneLineItemHeight"
-                app:primaryText="Last Opened Tab" />
+                app:primaryText="@string/showOnAppLaunchOptionLastOpenedTab" />
 
             <com.duckduckgo.common.ui.view.listitem.RadioListItem
                 android:id="@+id/newTabCheckListItem"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:minHeight="@dimen/oneLineItemHeight"
-                app:primaryText="New Tab Page" />
+                app:primaryText="@string/showOnAppLaunchOptionNewTabPage" />
 
             <com.duckduckgo.common.ui.view.listitem.RadioListItem
                 android:id="@+id/specificPageCheckListItem"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:minHeight="@dimen/oneLineItemHeight"
-                app:primaryText="Specific Page" />
+                app:primaryText="@string/showOnAppLaunchOptionSpecificPage" />
 
             <com.duckduckgo.common.ui.view.text.DaxTextInput
                 android:id="@+id/specificPageUrlInput"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202552961248957/1209246799465881/f 

### Description
Replaced hardcoded strings with string resources in the app launch settings screen for better localization support. Updated text references for "Last Opened Tab," "New Tab Page," and "Specific Page" options.

### Steps to test this PR

_String Resources Implementation_
- [x] Navigate to Show on App launch settings
- [x] Verify "Last Opened Tab" displays correctly from string resources
- [x] Verify "New Tab Page" displays correctly from string resources
- [x] Verify "Specific Page" displays correctly from string resources
- [x] Test in different locales to ensure proper translation support

### UI changes
| Before  | After |
| ------ | ----- |
|![Screenshot_20250127_160409](https://github.com/user-attachments/assets/39c0ed22-a23a-4fe4-b137-c88cf04f2cf1)|![Screenshot_20250127_161411](https://github.com/user-attachments/assets/40026550-b30a-46bd-9e9e-89b45362c4cc)|