### PR TITLE
Configure timeout-minutes for GH actions which run Maestro tests

### DIFF
--- a/.github/workflows/ads-end-to-end.yml
+++ b/.github/workflows/ads-end-to-end.yml
@@ -56,11 +56,12 @@ jobs:
 
       - name: ADS Preview Flows
         uses: mobile-dev-inc/action-maestro-cloud@v1.9.7
+        timeout-minutes: 120
         with:
           api-key: ${{ secrets.ROBIN_API_KEY }}
           project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
           name: androidDesignSystem_${{ github.sha }}
-          timeout: 120
+          timeout: 180
           app-file: apk/release.apk
           android-api-level: 30
           workspace: .maestro

--- a/.github/workflows/ads-end-to-end.yml
+++ b/.github/workflows/ads-end-to-end.yml
@@ -61,7 +61,7 @@ jobs:
           api-key: ${{ secrets.ROBIN_API_KEY }}
           project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
           name: androidDesignSystem_${{ github.sha }}
-          timeout: 180
+          timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           app-file: apk/release.apk
           android-api-level: 30
           workspace: .maestro

--- a/.github/workflows/custom-tabs-nightly.yml
+++ b/.github/workflows/custom-tabs-nightly.yml
@@ -56,11 +56,12 @@ jobs:
 
       - name: Custom Tabs Flows
         uses: mobile-dev-inc/action-maestro-cloud@v1.9.7
+        timeout-minutes: 120
         with:
           api-key: ${{ secrets.ROBIN_API_KEY }}
           project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
           name: customTabs_${{ github.sha }}
-          timeout: 120
+          timeout: 180
           app-file: apk/release.apk
           android-api-level: 30
           workspace: .maestro

--- a/.github/workflows/custom-tabs-nightly.yml
+++ b/.github/workflows/custom-tabs-nightly.yml
@@ -61,7 +61,7 @@ jobs:
           api-key: ${{ secrets.ROBIN_API_KEY }}
           project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
           name: customTabs_${{ github.sha }}
-          timeout: 180
+          timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           app-file: apk/release.apk
           android-api-level: 30
           workspace: .maestro

--- a/.github/workflows/e2e-nightly-autofill.yml
+++ b/.github/workflows/e2e-nightly-autofill.yml
@@ -56,11 +56,12 @@ jobs:
 
       - name: Autofill Critical Path E2E Flows
         uses: mobile-dev-inc/action-maestro-cloud@v1.9.7
+        timeout-minutes: 120
         with:
           api-key: ${{ secrets.ROBIN_API_KEY }}
           project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
           name: autofill_${{ github.sha }}
-          timeout: 120
+          timeout: 180
           app-file: apk/release.apk
           android-api-level: 30
           workspace: .maestro

--- a/.github/workflows/e2e-nightly-autofill.yml
+++ b/.github/workflows/e2e-nightly-autofill.yml
@@ -61,7 +61,7 @@ jobs:
           api-key: ${{ secrets.ROBIN_API_KEY }}
           project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
           name: autofill_${{ github.sha }}
-          timeout: 180
+          timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           app-file: apk/release.apk
           android-api-level: 30
           workspace: .maestro

--- a/.github/workflows/end-to-end-robintest.yml
+++ b/.github/workflows/end-to-end-robintest.yml
@@ -61,7 +61,7 @@ jobs:
           api-key: ${{ secrets.ROBIN_API_KEY }}
           project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
           name: adClickTest_${{ github.sha }}
-          timeout: 180
+          timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           app-file: apk/release.apk
           android-api-level: 30
           workspace: .maestro
@@ -75,7 +75,7 @@ jobs:
           api-key: ${{ secrets.ROBIN_API_KEY }}
           project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
           name: privacyTest_${{ github.sha }}
-          timeout: 180
+          timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           app-file: apk/release.apk
           android-api-level: 30
           workspace: .maestro
@@ -89,7 +89,7 @@ jobs:
           api-key: ${{ secrets.ROBIN_API_KEY }}
           project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
           name: securityTest_${{ github.sha }}
-          timeout: 180
+          timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           app-file: apk/release.apk
           android-api-level: 30
           workspace: .maestro
@@ -103,7 +103,7 @@ jobs:
           api-key: ${{ secrets.ROBIN_API_KEY }}
           project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
           name: releaseTest_${{ github.sha }}
-          timeout: 180
+          timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           app-file: apk/release.apk
           android-api-level: 30
           workspace: .maestro
@@ -117,7 +117,7 @@ jobs:
           api-key: ${{ secrets.ROBIN_API_KEY }}
           project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
           name: notificationPermissionTest_${{ github.sha }}
-          timeout: 180
+          timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           app-file: apk/release.apk
           android-api-level: 33
           workspace: .maestro/notifications_permissions_android13_plus

--- a/.github/workflows/end-to-end-robintest.yml
+++ b/.github/workflows/end-to-end-robintest.yml
@@ -56,11 +56,12 @@ jobs:
 
       - name: Ad click detection flows
         uses: mobile-dev-inc/action-maestro-cloud@v1.9.7
+        timeout-minutes: 120
         with:
           api-key: ${{ secrets.ROBIN_API_KEY }}
           project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
           name: adClickTest_${{ github.sha }}
-          timeout: 120
+          timeout: 180
           app-file: apk/release.apk
           android-api-level: 30
           workspace: .maestro
@@ -69,11 +70,12 @@ jobs:
       - name: Privacy Tests
         if: always()
         uses: mobile-dev-inc/action-maestro-cloud@v1.9.7
+        timeout-minutes: 120
         with:
           api-key: ${{ secrets.ROBIN_API_KEY }}
           project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
           name: privacyTest_${{ github.sha }}
-          timeout: 120
+          timeout: 180
           app-file: apk/release.apk
           android-api-level: 30
           workspace: .maestro
@@ -82,11 +84,12 @@ jobs:
       - name: Security Tests
         if: always()
         uses: mobile-dev-inc/action-maestro-cloud@v1.9.7
+        timeout-minutes: 120
         with:
           api-key: ${{ secrets.ROBIN_API_KEY }}
           project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
           name: securityTest_${{ github.sha }}
-          timeout: 120
+          timeout: 180
           app-file: apk/release.apk
           android-api-level: 30
           workspace: .maestro
@@ -95,11 +98,12 @@ jobs:
       - name: Release Tests
         if: always()
         uses: mobile-dev-inc/action-maestro-cloud@v1.9.7
+        timeout-minutes: 120
         with:
           api-key: ${{ secrets.ROBIN_API_KEY }}
           project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
           name: releaseTest_${{ github.sha }}
-          timeout: 120
+          timeout: 180
           app-file: apk/release.apk
           android-api-level: 30
           workspace: .maestro
@@ -108,11 +112,12 @@ jobs:
       - name: Notifications permissions Android 13+
         if: always()
         uses: mobile-dev-inc/action-maestro-cloud@v1.9.7
+        timeout-minutes: 120
         with:
           api-key: ${{ secrets.ROBIN_API_KEY }}
           project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
           name: notificationPermissionTest_${{ github.sha }}
-          timeout: 120
+          timeout: 180
           app-file: apk/release.apk
           android-api-level: 33
           workspace: .maestro/notifications_permissions_android13_plus

--- a/.github/workflows/privacy-dashboard-end-to-end.yml
+++ b/.github/workflows/privacy-dashboard-end-to-end.yml
@@ -59,11 +59,12 @@ jobs:
 
       - name: Ad click detection flows
         uses: mobile-dev-inc/action-maestro-cloud@v1.9.7
+        timeout-minutes: 120
         with:
           api-key: ${{ secrets.ROBIN_API_KEY }}
           project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
           name: privacyDashboard_adClickTest_${{ github.sha }}
-          timeout: 120
+          timeout: 180
           app-file: apk/release.apk
           android-api-level: 30
           workspace: .maestro
@@ -72,11 +73,12 @@ jobs:
       - name: Privacy Tests
         if: always()
         uses: mobile-dev-inc/action-maestro-cloud@v1.9.7
+        timeout-minutes: 120
         with:
           api-key: ${{ secrets.ROBIN_API_KEY }}
           project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
           name: privacyDashboard_privacyTest_${{ github.sha }}
-          timeout: 120
+          timeout: 180
           app-file: apk/release.apk
           workspace: .maestro
           include-tags: privacyTest

--- a/.github/workflows/privacy-dashboard-end-to-end.yml
+++ b/.github/workflows/privacy-dashboard-end-to-end.yml
@@ -64,7 +64,7 @@ jobs:
           api-key: ${{ secrets.ROBIN_API_KEY }}
           project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
           name: privacyDashboard_adClickTest_${{ github.sha }}
-          timeout: 180
+          timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           app-file: apk/release.apk
           android-api-level: 30
           workspace: .maestro
@@ -78,7 +78,7 @@ jobs:
           api-key: ${{ secrets.ROBIN_API_KEY }}
           project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
           name: privacyDashboard_privacyTest_${{ github.sha }}
-          timeout: 180
+          timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           app-file: apk/release.apk
           workspace: .maestro
           include-tags: privacyTest

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -78,7 +78,7 @@ jobs:
           api-key: ${{ secrets.ROBIN_API_KEY }}
           project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
           name: releaseTest_${{ github.sha }}
-          timeout: 180
+          timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           app-file: apk/release.apk
           android-api-level: 30
           workspace: .maestro

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -73,11 +73,12 @@ jobs:
 
       - name: Release tests flows
         uses: mobile-dev-inc/action-maestro-cloud@v1.9.7
+        timeout-minutes: 120
         with:
           api-key: ${{ secrets.ROBIN_API_KEY }}
           project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
           name: releaseTest_${{ github.sha }}
-          timeout: 120
+          timeout: 180
           app-file: apk/release.apk
           android-api-level: 30
           workspace: .maestro

--- a/.github/workflows/sync-critical-path.yml
+++ b/.github/workflows/sync-critical-path.yml
@@ -63,11 +63,12 @@ jobs:
 
       - name: Sync Flows
         uses: mobile-dev-inc/action-maestro-cloud@v1.9.7
+        timeout-minutes: 120
         with:
           api-key: ${{ secrets.ROBIN_API_KEY }}
           project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
           name: sync_${{ github.sha }}
-          timeout: 120
+          timeout: 180
           app-file: apk/release.apk
           android-api-level: 30
           workspace: .maestro

--- a/.github/workflows/sync-critical-path.yml
+++ b/.github/workflows/sync-critical-path.yml
@@ -68,7 +68,7 @@ jobs:
           api-key: ${{ secrets.ROBIN_API_KEY }}
           project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
           name: sync_${{ github.sha }}
-          timeout: 180
+          timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           app-file: apk/release.apk
           android-api-level: 30
           workspace: .maestro


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/608920331025315/1209118297419133/f 

### Description
Adds `timeout-minutes` to all the steps which are triggering a Maestro test run on Robin.
- we want timeouts to be treated as a failure, not for the CI to give up on a timeout and report as a success
- configuring the timeouts this way gives us genuine timeouts that will fail the build if the `timeout-minutes` value is exceeded for that step.

### Steps to test this PR

- QA optional
- From a [manual test](https://github.com/duckduckgo/Android/actions/runs/13008016261/job/36279174407),  i confirmed using this approach will successfully time out and fail the build if the Robin tests take too long to run 👇
<img width="613" alt="Screenshot 2025-01-28 at 10 18 27" src="https://github.com/user-attachments/assets/0d8d5b12-202a-46b2-b638-8291aba83c50" />
