### PR TITLE
Update content scope scripts to version 7.12.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
@@ -675,7 +675,7 @@
     const platformSupport = {
         apple: ['webCompat', ...baseFeatures],
         'apple-isolated': ['duckPlayer', 'brokerProtection', 'performanceMetrics', 'clickToLoad', 'messageBridge'],
-        android: [...baseFeatures, 'webCompat', 'breakageReporting', 'duckPlayer'],
+        android: [...baseFeatures, 'webCompat', 'breakageReporting', 'duckPlayer', 'messageBridge'],
         'android-autofill-password-import': ['autofillPasswordImport'],
         windows: ['cookie', ...baseFeatures, 'windowsPermissionUsage', 'duckPlayer', 'brokerProtection', 'breakageReporting'],
         firefox: ['cookie', ...baseFeatures, 'clickToLoad'],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -746,7 +746,7 @@
     const platformSupport = {
         apple: ['webCompat', ...baseFeatures],
         'apple-isolated': ['duckPlayer', 'brokerProtection', 'performanceMetrics', 'clickToLoad', 'messageBridge'],
-        android: [...baseFeatures, 'webCompat', 'breakageReporting', 'duckPlayer'],
+        android: [...baseFeatures, 'webCompat', 'breakageReporting', 'duckPlayer', 'messageBridge'],
         'android-autofill-password-import': ['autofillPasswordImport'],
         windows: ['cookie', ...baseFeatures, 'windowsPermissionUsage', 'duckPlayer', 'brokerProtection', 'breakageReporting'],
         firefox: ['cookie', ...baseFeatures, 'clickToLoad'],
@@ -10254,6 +10254,217 @@
         }
     }
 
+    /**
+     * @typedef {Pick<import("../captured-globals.js"),
+     *    "dispatchEvent" | "addEventListener" | "CustomEvent">
+     * } Captured
+     */
+
+    /**
+     * This part has access to messaging handlers
+     */
+    class MessageBridge extends ContentFeature {
+        /** @type {Captured} */
+        captured = capturedGlobals;
+        /**
+         * A mapping of feature names to instances of `Messaging`.
+         * This allows the bridge to handle more than 1 feature at a time.
+         * @type {Map<string, Messaging>}
+         */
+        proxies = new Map$1();
+
+        /**
+         * If any subscriptions are created, we store the cleanup functions
+         * for later use.
+         * @type {Map<string, () => void>}
+         */
+        subscriptions = new Map$1();
+
+        /**
+         * This side of the bridge can only be instantiated once,
+         * so we use this flag to ensure we can handle multiple invocations
+         */
+        installed = false;
+
+        init(args) {
+            /**
+             * This feature never operates in a frame or insecure context
+             */
+            if (isBeingFramed() || !isSecureContext) return;
+            /**
+             * This feature never operates without messageSecret
+             */
+            if (!args.messageSecret) return;
+
+            const { captured } = this;
+
+            /**
+             * @param {string} eventName
+             * @return {`${string}-${string}`}
+             */
+            function appendToken(eventName) {
+                return `${eventName}-${args.messageSecret}`;
+            }
+
+            /**
+             * @param {{name: string; id: string} & Record<string, any>} incoming
+             */
+            const reply = (incoming) => {
+                if (!args.messageSecret) return this.log('ignoring because args.messageSecret was absent');
+                const eventName = appendToken(incoming.name + '-' + incoming.id);
+                const event = new captured.CustomEvent(eventName, { detail: incoming });
+                captured.dispatchEvent(event);
+            };
+
+            /**
+             * @template T
+             * @param {{ create: (params: any) => T | null, NAME: string }} ClassType - A class with a `create` static method.
+             * @param {(instance: T) => void} callback - A callback that receives an instance of the class.
+             */
+            const accept = (ClassType, callback) => {
+                captured.addEventListener(appendToken(ClassType.NAME), (/** @type {CustomEvent<unknown>} */ e) => {
+                    this.log(`${ClassType.NAME}`, JSON.stringify(e.detail));
+                    const instance = ClassType.create(e.detail);
+                    if (instance) {
+                        callback(instance);
+                    } else {
+                        this.log('Failed to create an instance');
+                    }
+                });
+            };
+
+            /**
+             * These are all the messages we accept from the page-world.
+             */
+            this.log(`bridge is installing...`);
+            accept(InstallProxy, (install) => {
+                this.installProxyFor(install, args.messagingConfig, reply);
+            });
+            accept(ProxyNotification, (notification) => this.proxyNotification(notification));
+            accept(ProxyRequest, (request) => this.proxyRequest(request, reply));
+            accept(SubscriptionRequest, (subscription) => this.proxySubscription(subscription, reply));
+            accept(SubscriptionUnsubscribe, (unsubscribe) => this.removeSubscription(unsubscribe.id));
+        }
+
+        /**
+         * Installing a feature proxy is the act of creating a fresh instance of 'Messaging', but
+         * using the same underlying transport
+         *
+         * @param {InstallProxy} install
+         * @param {import('@duckduckgo/messaging').MessagingConfig} config
+         * @param {(payload: {name: string; id: string} & Record<string, any>) => void} reply
+         */
+        installProxyFor(install, config, reply) {
+            const { id, featureName } = install;
+            if (this.proxies.has(featureName)) return this.log('ignoring `installProxyFor` because it exists', featureName);
+            const allowed = this.getFeatureSettingEnabled(featureName);
+            if (!allowed) {
+                return this.log('not installing proxy, because', featureName, 'was not enabled');
+            }
+
+            const ctx = { ...this.messaging.messagingContext, featureName };
+            const messaging = new Messaging(ctx, config);
+            this.proxies.set(featureName, messaging);
+
+            this.log('did install proxy for ', featureName);
+            reply(new DidInstall({ id }));
+        }
+
+        /**
+         * @param {ProxyRequest} request
+         * @param {(payload: {name: string; id: string} & Record<string, any>) => void} reply
+         */
+        async proxyRequest(request, reply) {
+            const { id, featureName, method, params } = request;
+
+            const proxy = this.proxies.get(featureName);
+            if (!proxy) return this.log('proxy was not installed for ', featureName);
+
+            this.log('will proxy', request);
+
+            try {
+                const result = await proxy.request(method, params);
+                const responseEvent = new ProxyResponse({
+                    method,
+                    featureName,
+                    result,
+                    id,
+                });
+                reply(responseEvent);
+            } catch (e) {
+                const errorResponseEvent = new ProxyResponse({
+                    method,
+                    featureName,
+                    error: { message: e.message },
+                    id,
+                });
+                reply(errorResponseEvent);
+            }
+        }
+
+        /**
+         * @param {SubscriptionRequest} subscription
+         * @param {(payload: {name: string; id: string} & Record<string, any>) => void} reply
+         */
+        proxySubscription(subscription, reply) {
+            const { id, featureName, subscriptionName } = subscription;
+            const proxy = this.proxies.get(subscription.featureName);
+            if (!proxy) return this.log('proxy was not installed for', featureName);
+
+            this.log('will setup subscription', subscription);
+
+            // cleanup existing subscriptions first
+            const prev = this.subscriptions.get(id);
+            if (prev) {
+                this.removeSubscription(id);
+            }
+
+            const unsubscribe = proxy.subscribe(subscriptionName, (/** @type {Record<string, any>} */ data) => {
+                const responseEvent = new SubscriptionResponse({
+                    subscriptionName,
+                    featureName,
+                    params: data,
+                    id,
+                });
+                reply(responseEvent);
+            });
+
+            this.subscriptions.set(id, unsubscribe);
+        }
+
+        /**
+         * @param {string} id
+         */
+        removeSubscription(id) {
+            const unsubscribe = this.subscriptions.get(id);
+            this.log(`will remove subscription`, id);
+            unsubscribe?.();
+            this.subscriptions.delete(id);
+        }
+
+        /**
+         * @param {ProxyNotification} notification
+         */
+        proxyNotification(notification) {
+            const proxy = this.proxies.get(notification.featureName);
+            if (!proxy) return this.log('proxy was not installed for', notification.featureName);
+
+            this.log('will proxy notification', notification);
+            proxy.notify(notification.method, notification.params);
+        }
+
+        /**
+         * @param {Parameters<console['log']>} args
+         */
+        log(...args) {
+            if (this.isDebug) {
+                console.log('[isolated]', ...args);
+            }
+        }
+
+        load(args) {}
+    }
+
     var platformFeatures = {
         ddg_feature_fingerprintingAudio: FingerprintingAudio,
         ddg_feature_fingerprintingBattery: FingerprintingBattery,
@@ -10270,7 +10481,8 @@
         ddg_feature_apiManipulation: ApiManipulation,
         ddg_feature_webCompat: WebCompat,
         ddg_feature_breakageReporting: BreakageReporting,
-        ddg_feature_duckPlayer: DuckPlayerFeature
+        ddg_feature_duckPlayer: DuckPlayerFeature,
+        ddg_feature_messageBridge: MessageBridge
     };
 
     let initArgs = null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^12.7.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.1.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.10.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.12.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.1.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1737732449"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#181696656f3627c1b3ca8cda06d54971e03436ef",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#a7fd7059d1bec77a04b209eb40ca63de25c3e557",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -283,9 +283,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.10.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.10.tgz",
-      "integrity": "sha512-X47y/mPNzxviAGY5TcYPtYL8JsY3kAq2n8fMmKoRCxq/c4v4pyGNCzM2R6+M5/umG4ZfHuT+sgqDYqWc9rJ6ww==",
+      "version": "22.12.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.12.0.tgz",
+      "integrity": "sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^12.7.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.1.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.10.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.12.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.1.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1737732449"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1209261327263714/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [x] All tests must pass