### PR TITLE
Perform deeper domain comparison for saving/updating autofill passwords

### DIFF
--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillFeature.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillFeature.kt
@@ -114,4 +114,12 @@ interface AutofillFeature {
      */
     @Toggle.DefaultValue(false)
     fun partialFormSaves(): Toggle
+
+    /**
+     * Kill switch for toggling how deep a domain comparison to do when saving/updating credentials.
+     * We want to limit times we save duplicates, and we can do that with a deeper comparison of domains to decide if we already have a matching cred.
+     * By deeper, this means comparing using E-TLD+1
+     */
+    @Toggle.DefaultValue(true)
+    fun deepDomainComparisonsOnExistingCredentialsChecks(): Toggle
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1203822806345703/1209273715877308/f 

### Description

- Right now, we will offer to autofill into a page which is considered an E-TLD+1 match
- But when it comes to offering to save a password, or update an existing one, we don’t consider E-TLD+1 which leads to more scenarios with duplicate passwords.

### Steps to test this PR

Detailed in [Test scenarios](https://app.asana.com/0/1209279526650235/1209279526650235/f)