### PR TITLE
Fix Dax dialog scrolling for small devices

### DIFF
--- a/app/src/main/res/layout-land/content_onboarding_welcome_page.xml
+++ b/app/src/main/res/layout-land/content_onboarding_welcome_page.xml
@@ -28,9 +28,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:scaleType="centerCrop"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
         tools:srcCompat="@drawable/onboarding_background_small_light" />
 
     <LinearLayout
@@ -38,11 +35,11 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:orientation="vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/foregroundImageView"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent">
+        app:layout_constraintTop_toTopOf="parent">
 
         <androidx.appcompat.widget.AppCompatImageView
             android:id="@+id/daxLogo"
@@ -58,8 +55,8 @@
             android:layout_marginStart="54dp"
             android:layout_marginTop="@dimen/keyline_4"
             android:layout_marginEnd="54dp"
-            android:text="@string/onboardingWelcomeTitle"
             android:gravity="center"
+            android:text="@string/onboardingWelcomeTitle"
             app:typography="title" />
     </LinearLayout>
 
@@ -67,8 +64,8 @@
         android:id="@+id/foregroundImageView"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:paddingTop="@dimen/keyline_6"
         android:adjustViewBounds="true"
+        android:paddingTop="@dimen/keyline_6"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"

--- a/app/src/main/res/layout/content_onboarding_welcome_page.xml
+++ b/app/src/main/res/layout/content_onboarding_welcome_page.xml
@@ -66,8 +66,8 @@
             android:layout_marginStart="54dp"
             android:layout_marginTop="@dimen/keyline_4"
             android:layout_marginEnd="54dp"
-            android:text="@string/onboardingWelcomeTitle"
             android:gravity="center"
+            android:text="@string/onboardingWelcomeTitle"
             app:typography="title" />
     </LinearLayout>
 
@@ -75,12 +75,13 @@
         android:id="@+id/daxDialogCta"
         layout="@layout/pre_onboarding_dax_dialog_cta"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="56dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="32dp"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHeight_percent="0.85"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintWidth_max="600dp"
-        app:layout_constraintHeight_max="672dp"/>
+        app:layout_constraintWidth_max="600dp" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1208088786036608

### Description
Fix Dax dialog being cut off on the bottom of the pre-onbaording screen in small devices

### Steps to test this PR

- [x]  Fresh install on a small-screen device
- [x]  Tap 'Let's do it!' to view the comparison chart Dax dialog
- [x]  Ensure the dialog is fully visible (not cut off at the bottom)
- [x]  Verify the dialog is scrollable and the 'Choose your browser' button is accessible

### UI changes
| Before  | After |
| ------ | ----- |
<img width="561" alt="Screenshot 2025-02-03 at 15 09 21" src="https://github.com/user-attachments/assets/cf63c7d4-1f6c-410f-bef6-9aceaffff0d0" />|<img width="561" alt="Screenshot 2025-02-03 at 15 09 37" src="https://github.com/user-attachments/assets/74b50a57-132c-4a1e-9440-81ec2d65a82a" />|
