### PR TITLE
Fix incorrect color resolution in NotificationFactory

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/notification/NotificationFactory.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/NotificationFactory.kt
@@ -21,7 +21,6 @@ import android.app.PendingIntent
 import android.content.Context
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
-import androidx.core.content.ContextCompat
 import com.duckduckgo.app.notification.model.NotificationSpec
 import javax.inject.Inject
 
@@ -41,7 +40,7 @@ class NotificationFactory @Inject constructor(
             .setContentTitle(specification.title)
             .setContentText(specification.description)
             .setStyle(NotificationCompat.BigTextStyle().bigText(specification.description))
-            .setColor(ContextCompat.getColor(context, specification.color))
+            .setColor(specification.color)
             .setContentIntent(launchIntent)
             .setDeleteIntent(cancelIntent)
             .setAutoCancel(specification.autoCancel)


### PR DESCRIPTION
Task/Issue URL:  https://github.com/duckduckgo/Android/issues/5563

### Description
Updated `NotificationFactory` to use the already resolved `@ColorInt` value from `ClearDataSpecification` instead of incorrectly passing it to `ContextCompat.getColor()`, which expects a `@ColorRes`. This prevents unnecessary lookups and ensures correct color application. 
### Steps to test this PR


### UI changes


https://github.com/user-attachments/assets/6bf32b2b-c7c2-450f-9484-93f90a3cc3e0

