### PR TITLE
Show prompt if all in-context dialogs have been shown

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -302,19 +302,6 @@ class CtaViewModel @Inject constructor(
         !hideTips() &&
         (daxDialogNetworkShown() || daxDialogOtherShown() || daxDialogSerpShown() || daxDialogTrackersFoundShown())
 
-    private suspend fun canShowOnboardingDaxDialogCta(): Boolean {
-        return when {
-            !daxOnboardingActive() || hideTips() -> false
-            extendedOnboardingFeatureToggles.noBrowserCtas().isEnabled() -> {
-                settingsDataStore.hideTips = true
-                userStageStore.stageCompleted(AppStage.DAX_ONBOARDING)
-                false
-            }
-
-            else -> true
-        }
-    }
-
     private suspend fun canShowPrivacyProCta(): Boolean {
         return daxOnboardingActive() && !hideTips() && !daxDialogPrivacyProShown() &&
             subscriptions.isEligible() && extendedOnboardingFeatureToggles.privacyProCta().isEnabled()

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -334,7 +334,7 @@ class CtaViewModel @Inject constructor(
                 return null
             }
 
-            if (!canShowOnboardingDaxDialogCta()) {
+            if (areInContextDaxDialogsCompleted()) {
                 return if (brokenSitePrompt.shouldShowBrokenSitePrompt(nonNullSite.url)) {
                     BrokenSitePromptDialogCta()
                 } else {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205008441501016/1209303563866691 

### Description
Do not wait for the full onboarding to be completed to be able to show the broken site prompt, just wait for all in-context dialogs to show

### Steps to test this PR

_Feature 1_
- [x] Fresh install
- [x] Complete the onboarding including all in-context dialogs but not the PPro one
- [x] Visit wikipedia.org and refresh 3 times in succession
- [x] Check the broken sites prompt is shown

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
