### PR TITLE
Export Feature Flag Inventory so it can be accessed more quickly

### DIFF
--- a/feature-toggles/feature-toggles-internal/src/main/AndroidManifest.xml
+++ b/feature-toggles/feature-toggles-internal/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
         <activity
             android:name="com.duckduckgo.examplefeature.internal.ui.FeatureToggleInventoryActivity"
             android:label="Feature Flag Inventory"
-            android:exported="false"
+            android:exported="true"
         />
 
     </application>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/608920331025315/1209308971637996 

### Description

In internal builds, we have Feature Flag Inventory available for toggling features flags from the UI inside our app.

It can only be launched from the settings UI:
- (exit whatever screen you might have been in)
- Overflow
- Settings
- Scroll
- Feature Flag Inventory

Objective
- Mark the activity as exported
- This would allow it to be launched directly. e.g., an alias from the command line. 
- As well as being easier to trigger as a developer, it would also have the advantage that you can quickly get to the screen without losing your current place in the app.

### Steps to test this PR
QA optional