### PR TITLE
Fix Globe icon not always shown

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -310,6 +310,7 @@ class OmnibarLayoutViewModel @Inject constructor(
 
                 _viewState.update {
                     it.copy(
+                        viewMode = viewMode,
                         leadingIconState = leadingIcon,
                         scrollingEnabled = scrollingEnabled,
                         showVoiceSearch = shouldShowVoiceSearch(

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -287,6 +287,7 @@ class OmnibarLayoutViewModelTest {
             val viewState = awaitItem()
             assertTrue(viewState.leadingIconState == LeadingIconState.GLOBE)
             assertTrue(viewState.scrollingEnabled)
+            assertTrue(viewState.viewMode is ViewMode.Error)
         }
     }
 
@@ -298,6 +299,7 @@ class OmnibarLayoutViewModelTest {
             val viewState = awaitItem()
             assertTrue(viewState.leadingIconState == LeadingIconState.GLOBE)
             assertTrue(viewState.scrollingEnabled)
+            assertTrue(viewState.viewMode is ViewMode.SSLWarning)
         }
     }
 
@@ -309,6 +311,7 @@ class OmnibarLayoutViewModelTest {
             val viewState = awaitItem()
             assertTrue(viewState.leadingIconState == LeadingIconState.GLOBE)
             assertTrue(viewState.scrollingEnabled)
+            assertTrue(viewState.viewMode is ViewMode.MaliciousSiteWarning)
         }
     }
 
@@ -320,6 +323,7 @@ class OmnibarLayoutViewModelTest {
             val viewState = awaitItem()
             assertTrue(viewState.leadingIconState == LeadingIconState.SEARCH)
             assertFalse(viewState.scrollingEnabled)
+            assertTrue(viewState.viewMode is ViewMode.NewTab)
         }
     }
 
@@ -331,6 +335,7 @@ class OmnibarLayoutViewModelTest {
             val viewState = awaitItem()
             assertTrue(viewState.leadingIconState == LeadingIconState.SEARCH)
             assertTrue(viewState.scrollingEnabled)
+            assertTrue(viewState.viewMode is ViewMode.Browser)
         }
     }
 
@@ -342,6 +347,7 @@ class OmnibarLayoutViewModelTest {
         testee.viewState.test {
             val viewState = expectMostRecentItem()
             assertTrue(viewState.leadingIconState == LeadingIconState.SEARCH)
+            assertTrue(viewState.viewMode is ViewMode.Error)
         }
     }
 
@@ -353,6 +359,7 @@ class OmnibarLayoutViewModelTest {
         testee.viewState.test {
             val viewState = expectMostRecentItem()
             assertTrue(viewState.leadingIconState == LeadingIconState.SEARCH)
+            assertTrue(viewState.viewMode is ViewMode.SSLWarning)
         }
     }
 
@@ -364,6 +371,7 @@ class OmnibarLayoutViewModelTest {
         testee.viewState.test {
             val viewState = expectMostRecentItem()
             assertTrue(viewState.leadingIconState == LeadingIconState.SEARCH)
+            assertTrue(viewState.viewMode is ViewMode.MaliciousSiteWarning)
         }
     }
 
@@ -375,6 +383,7 @@ class OmnibarLayoutViewModelTest {
         testee.viewState.test {
             val viewState = expectMostRecentItem()
             assertTrue(viewState.leadingIconState == LeadingIconState.SEARCH)
+            assertTrue(viewState.viewMode is ViewMode.NewTab)
         }
     }
 
@@ -386,6 +395,7 @@ class OmnibarLayoutViewModelTest {
         testee.viewState.test {
             val viewState = awaitItem()
             assertTrue(viewState.leadingIconState == LeadingIconState.SEARCH)
+            assertTrue(viewState.viewMode is ViewMode.Browser)
         }
     }
 


### PR DESCRIPTION
Task/Issue URL:https://app.asana.com/0/1205008441501016/1209289567264349 

### Description
Fix Globe icon not always shown on error pages

### Steps to test this PR

_Feature 1_
- [ ] Open https://privacy-test-pages.site/security/badware/phishing.html
- [ ] On the error page, try focusing the omnibar, clearing text, opening and closing the context menu
- [ ] Check the icon is still the globe one
- [ ] Repeat the process for error view and SSL warning as well

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
