### PR TITLE
SplashScreen Animation: Add pixel

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/api/PixelParamRemovalInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/PixelParamRemovalInterceptor.kt
@@ -94,6 +94,7 @@ object PixelInterceptorPixelsRequiringDataCleaning : PixelParamRemovalPlugin {
             SITE_NOT_WORKING_SHOWN.pixelName to PixelParameter.removeAtb(),
             SITE_NOT_WORKING_WEBSITE_BROKEN.pixelName to PixelParameter.removeAtb(),
             AppPixelName.APP_VERSION_AT_SEARCH_TIME.pixelName to PixelParameter.removeAll(),
+            AppPixelName.SPLASHSCREEN_SHOWN.pixelName to PixelParameter.removeAll(),
         )
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/launch/LaunchBridgeActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/launch/LaunchBridgeActivity.kt
@@ -52,6 +52,7 @@ class LaunchBridgeActivity : DuckDuckGoActivity() {
             )
 
             lifecycleScope.launch {
+                viewModel.sendWelcomeScreenPixel()
                 delay(delay)
                 viewModel.determineViewToShow()
             }

--- a/app/src/main/java/com/duckduckgo/app/launch/LaunchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/launch/LaunchViewModel.kt
@@ -21,8 +21,10 @@ import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.onboarding.store.UserStageStore
 import com.duckduckgo.app.onboarding.store.isNewUser
 import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.HighlightsOnboardingExperimentManager
+import com.duckduckgo.app.pixels.AppPixelName.SPLASHSCREEN_SHOWN
 import com.duckduckgo.app.referral.AppInstallationReferrerStateListener
 import com.duckduckgo.app.referral.AppInstallationReferrerStateListener.Companion.MAX_REFERRER_WAIT_TIME_MS
+import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.utils.SingleLiveEvent
 import com.duckduckgo.di.scopes.ActivityScope
 import javax.inject.Inject
@@ -34,6 +36,7 @@ class LaunchViewModel @Inject constructor(
     private val userStageStore: UserStageStore,
     private val appReferrerStateListener: AppInstallationReferrerStateListener,
     private val highlightsOnboardingExperimentManager: HighlightsOnboardingExperimentManager,
+    private val pixel: Pixel,
 ) :
     ViewModel() {
 
@@ -42,6 +45,10 @@ class LaunchViewModel @Inject constructor(
     sealed class Command {
         data object Onboarding : Command()
         data class Home(val replaceExistingSearch: Boolean = false) : Command()
+    }
+
+    fun sendWelcomeScreenPixel() {
+        pixel.fire(SPLASHSCREEN_SHOWN)
     }
 
     suspend fun determineViewToShow() {

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -37,6 +37,8 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     BROKEN_SITE_ALLOWLIST_REMOVE("m_broken_site_allowlist_remove"),
     PROTECTION_TOGGLE_BROKEN_SITE_REPORT("m_protection-toggled-off-breakage-report"),
 
+    SPLASHSCREEN_SHOWN("m_splashscreen_shown"),
+
     PREONBOARDING_INTRO_SHOWN_UNIQUE("m_preonboarding_intro_shown_unique"),
     PREONBOARDING_COMPARISON_CHART_SHOWN_UNIQUE("m_preonboarding_comparison_chart_shown_unique"),
     PREONBOARDING_CHOOSE_BROWSER_PRESSED("m_preonboarding_choose_browser_pressed"),

--- a/app/src/test/java/com/duckduckgo/app/launch/LaunchViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/launch/LaunchViewModelTest.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.app.onboarding.store.UserStageStore
 import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.HighlightsOnboardingExperimentManager
 import com.duckduckgo.app.referral.StubAppReferrerFoundStateListener
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.fakes.FakePixel
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Rule
@@ -49,6 +50,7 @@ class LaunchViewModelTest {
     private val mockHighlightsOnboardingExperimentManager: HighlightsOnboardingExperimentManager = mock {
         on { it.isHighlightsEnabled() } doReturn false
     }
+    private val fakePixel: FakePixel = FakePixel()
 
     private lateinit var testee: LaunchViewModel
 
@@ -63,6 +65,7 @@ class LaunchViewModelTest {
             userStageStore,
             StubAppReferrerFoundStateListener("xx"),
             mockHighlightsOnboardingExperimentManager,
+            fakePixel,
         )
         whenever(userStageStore.getUserAppStage()).thenReturn(AppStage.NEW)
         testee.command.observeForever(mockCommandObserver)
@@ -78,6 +81,7 @@ class LaunchViewModelTest {
             userStageStore,
             StubAppReferrerFoundStateListener("xx", mockDelayMs = 1_000),
             mockHighlightsOnboardingExperimentManager,
+            fakePixel,
         )
         whenever(userStageStore.getUserAppStage()).thenReturn(AppStage.NEW)
         testee.command.observeForever(mockCommandObserver)
@@ -93,6 +97,7 @@ class LaunchViewModelTest {
             userStageStore,
             StubAppReferrerFoundStateListener("xx", mockDelayMs = Long.MAX_VALUE),
             mockHighlightsOnboardingExperimentManager,
+            fakePixel,
         )
         whenever(userStageStore.getUserAppStage()).thenReturn(AppStage.NEW)
         testee.command.observeForever(mockCommandObserver)
@@ -108,6 +113,7 @@ class LaunchViewModelTest {
             userStageStore,
             StubAppReferrerFoundStateListener("xx"),
             mockHighlightsOnboardingExperimentManager,
+            fakePixel,
         )
         whenever(userStageStore.getUserAppStage()).thenReturn(AppStage.DAX_ONBOARDING)
         testee.command.observeForever(mockCommandObserver)
@@ -121,6 +127,7 @@ class LaunchViewModelTest {
             userStageStore,
             StubAppReferrerFoundStateListener("xx", mockDelayMs = 1_000),
             mockHighlightsOnboardingExperimentManager,
+            fakePixel,
         )
         whenever(userStageStore.getUserAppStage()).thenReturn(AppStage.DAX_ONBOARDING)
         testee.command.observeForever(mockCommandObserver)
@@ -134,6 +141,7 @@ class LaunchViewModelTest {
             userStageStore,
             StubAppReferrerFoundStateListener("xx", mockDelayMs = Long.MAX_VALUE),
             mockHighlightsOnboardingExperimentManager,
+            fakePixel,
         )
         whenever(userStageStore.getUserAppStage()).thenReturn(AppStage.DAX_ONBOARDING)
         testee.command.observeForever(mockCommandObserver)
@@ -147,6 +155,7 @@ class LaunchViewModelTest {
             userStageStore,
             StubAppReferrerFoundStateListener("xx", mockDelayMs = Long.MAX_VALUE),
             mockHighlightsOnboardingExperimentManager,
+            fakePixel,
         )
         whenever(mockHighlightsOnboardingExperimentManager.isHighlightsEnabled()).thenReturn(true)
         whenever(userStageStore.getUserAppStage()).thenReturn(AppStage.NEW)

--- a/app/src/test/java/com/duckduckgo/app/launch/LaunchViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/launch/LaunchViewModelTest.kt
@@ -23,11 +23,13 @@ import com.duckduckgo.app.launch.LaunchViewModel.Command.Onboarding
 import com.duckduckgo.app.onboarding.store.AppStage
 import com.duckduckgo.app.onboarding.store.UserStageStore
 import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.HighlightsOnboardingExperimentManager
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.referral.StubAppReferrerFoundStateListener
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.fakes.FakePixel
 import kotlinx.coroutines.test.runTest
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
@@ -164,5 +166,19 @@ class LaunchViewModelTest {
         testee.determineViewToShow()
 
         verify(mockHighlightsOnboardingExperimentManager).setExperimentVariants()
+    }
+
+    @Test
+    fun whenSendingWelcomeScreenPixelThenSplashScreenShownPixelIsSent() = runTest {
+        testee = LaunchViewModel(
+            userStageStore,
+            StubAppReferrerFoundStateListener("xx", mockDelayMs = Long.MAX_VALUE),
+            mockHighlightsOnboardingExperimentManager,
+            fakePixel,
+        )
+
+        testee.sendWelcomeScreenPixel()
+
+        assertEquals(AppPixelName.SPLASHSCREEN_SHOWN.pixelName, fakePixel.firedPixels.first())
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207908166761516/1209192748061745

### Description
Added a new pixel tracking event `m_splashscreen_shown` that fires when the app's splash screen is displayed. The pixel is configured to remove all parameters for privacy protection.

### Steps to test this PR

_Splash Screen Pixel Cold Start_
- [ ] Launch the app from a cold start (force close the app if necessary)
- [ ] Verify in the network logs that the `m_splashscreen_shown` pixel is fired
- [ ] Confirm that the pixel is sent without ATB or other tracking parameters

_Splash Screen Pixel Warm Start_
- [ ] Press back to close the app
- [ ] Open the app
- [ ] Verify in the network logs that the `m_splashscreen_shown` pixel is fired
- [ ] Confirm that the pixel is sent without ATB or other tracking parameters

### UI changes
No UI changes were made in this PR.