### PR TITLE
Additional "default browser" prompts: fixed an issue with active days conversion window

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/di/DefaultBrowserPromptsExperimentModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/di/DefaultBrowserPromptsExperimentModule.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
+import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
@@ -28,7 +29,7 @@ import javax.inject.Qualifier
 
 @ContributesTo(AppScope::class)
 @Module
-object DefaultBrowserPromptsDataStoreModule {
+object DefaultBrowserPromptsExperimentModule {
 
     private val Context.defaultBrowserPromptsDataStore: DataStore<Preferences> by preferencesDataStore(
         name = "default_browser_prompts",
@@ -36,7 +37,10 @@ object DefaultBrowserPromptsDataStoreModule {
 
     @Provides
     @DefaultBrowserPrompts
-    fun defaultBrowserPromptsDataStore(context: Context): DataStore<Preferences> = context.defaultBrowserPromptsDataStore
+    fun providesDefaultBrowserPromptsDataStore(context: Context): DataStore<Preferences> = context.defaultBrowserPromptsDataStore
+
+    @Provides
+    fun providesExperimentAppUsageDao(database: AppDatabase) = database.experimentAppUsageDao()
 }
 
 @Qualifier

--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/store/ExperimentAppUsageRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/store/ExperimentAppUsageRepository.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.defaultbrowsing.prompts.store
+
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.State.Cohort
+import java.time.format.DateTimeParseException
+
+/**
+ * Tracks the days app is used to leverage for purposes related to experiments run with the [NA Experiment Framework](https://app.asana.com/0/1208889145294658/1208889101183474).
+ *
+ * See [Cohort.enrollmentDateET] for how the framework stores enrollment dates.
+ */
+interface ExperimentAppUsageRepository {
+
+    suspend fun recordAppUsedNow()
+
+    /**
+     * Returns the number of active days the app has been used since enrollment.
+     *
+     * Crossing a dateline in local time will not increment the returned count.
+     * Only if a given instant crossed dateline in ET timezone, the value will be incremented.
+     *
+     * @return Count if successful.
+     *  [UserNotEnrolledException] if the given feature is disable or user is not assigned to a cohort.
+     *  [DateTimeParseException] if the enrollment date is malformed.
+     */
+    suspend fun getActiveDaysUsedSinceEnrollment(toggle: Toggle): Result<Long>
+
+    class UserNotEnrolledException : Exception()
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/store/ExperimentAppUsageRepositoryImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/store/ExperimentAppUsageRepositoryImpl.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.defaultbrowsing.prompts.store
+
+import androidx.room.Dao
+import androidx.room.Entity
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.PrimaryKey
+import androidx.room.Query
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.store.ExperimentAppUsageRepository.UserNotEnrolledException
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import java.time.temporal.ChronoUnit
+import javax.inject.Inject
+import kotlinx.coroutines.withContext
+
+@ContributesBinding(scope = AppScope::class)
+@SingleInstanceIn(scope = AppScope::class)
+class ExperimentAppUsageRepositoryImpl @Inject constructor(
+    private val dispatchers: DispatcherProvider,
+    private val experimentAppUsageDao: ExperimentAppUsageDao,
+) : ExperimentAppUsageRepository {
+
+    override suspend fun recordAppUsedNow() = withContext(dispatchers.io()) {
+        val isoDateET = ZonedDateTime.now(ZoneId.of("America/New_York"))
+            .truncatedTo(ChronoUnit.DAYS)
+            .format(DateTimeFormatter.ISO_LOCAL_DATE)
+
+        experimentAppUsageDao.insert(ExperimentAppUsageEntity(isoDateET))
+    }
+
+    override suspend fun getActiveDaysUsedSinceEnrollment(toggle: Toggle): Result<Long> = withContext(dispatchers.io()) {
+        toggle.getCohort()?.enrollmentDateET?.let { enrollmentZonedDateTimeETString ->
+            try {
+                val isoDateET = ZonedDateTime.parse(enrollmentZonedDateTimeETString)
+                    .truncatedTo(ChronoUnit.DAYS)
+                    .format(DateTimeFormatter.ISO_LOCAL_DATE)
+
+                val daysUsed = experimentAppUsageDao.getNumberOfDaysAppUsedSinceDateET(isoDateET)
+                Result.success(daysUsed)
+            } catch (ex: DateTimeParseException) {
+                Result.failure(ex)
+            }
+        } ?: Result.failure(UserNotEnrolledException())
+    }
+}
+
+@Dao
+abstract class ExperimentAppUsageDao {
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    abstract fun insert(experimentAppUsageEntity: ExperimentAppUsageEntity)
+
+    @Query("SELECT COUNT(*) from experiment_app_usage_entity WHERE isoDateET > :isoDateET")
+    abstract fun getNumberOfDaysAppUsedSinceDateET(isoDateET: String): Long
+}
+
+@Entity(tableName = "experiment_app_usage_entity")
+data class ExperimentAppUsageEntity(@PrimaryKey val isoDateET: String)

--- a/app/src/main/java/com/duckduckgo/app/global/db/AppDatabase.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/db/AppDatabase.kt
@@ -26,6 +26,8 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 import com.duckduckgo.app.bookmarks.db.*
 import com.duckduckgo.app.browser.cookies.db.AuthCookieAllowedDomainEntity
 import com.duckduckgo.app.browser.cookies.db.AuthCookiesAllowedDomainsDao
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.store.ExperimentAppUsageDao
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.store.ExperimentAppUsageEntity
 import com.duckduckgo.app.browser.pageloadpixel.PageLoadedPixelDao
 import com.duckduckgo.app.browser.pageloadpixel.PageLoadedPixelEntity
 import com.duckduckgo.app.browser.pageloadpixel.firstpaint.PagePaintedPixelDao
@@ -73,7 +75,7 @@ import com.duckduckgo.savedsites.store.SavedSitesRelationsDao
 
 @Database(
     exportSchema = true,
-    version = 56,
+    version = 57,
     entities = [
         TdsTracker::class,
         TdsEntity::class,
@@ -107,6 +109,7 @@ import com.duckduckgo.savedsites.store.SavedSitesRelationsDao
         Entity::class,
         Relation::class,
         RefreshEntity::class,
+        ExperimentAppUsageEntity::class,
     ],
 )
 
@@ -161,6 +164,8 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun syncRelationsDao(): SavedSitesRelationsDao
 
     abstract fun refreshDao(): RefreshDao
+
+    abstract fun experimentAppUsageDao(): ExperimentAppUsageDao
 }
 
 @Suppress("PropertyName")

--- a/app/src/test/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/DefaultBrowserPromptsExperimentImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/DefaultBrowserPromptsExperimentImplTest.kt
@@ -31,6 +31,7 @@ import com.duckduckgo.app.browser.defaultbrowsing.prompts.DefaultBrowserPromptsE
 import com.duckduckgo.app.browser.defaultbrowsing.prompts.DefaultBrowserPromptsFeatureToggles.AdditionalPromptsCohortName
 import com.duckduckgo.app.browser.defaultbrowsing.prompts.store.DefaultBrowserPromptsDataStore
 import com.duckduckgo.app.browser.defaultbrowsing.prompts.store.DefaultBrowserPromptsDataStore.ExperimentStage
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.store.ExperimentAppUsageRepository
 import com.duckduckgo.app.global.DefaultRoleBrowserDialog
 import com.duckduckgo.app.onboarding.store.AppStage
 import com.duckduckgo.app.onboarding.store.UserStageStore
@@ -39,7 +40,6 @@ import com.duckduckgo.app.pixels.AppPixelName.SET_AS_DEFAULT_PROMPT_CLICK
 import com.duckduckgo.app.pixels.AppPixelName.SET_AS_DEFAULT_PROMPT_DISMISSED
 import com.duckduckgo.app.pixels.AppPixelName.SET_AS_DEFAULT_PROMPT_IMPRESSION
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.usage.app.AppDaysUsedRepository
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.plugins.PluginPoint
@@ -49,8 +49,6 @@ import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.feature.toggles.api.Toggle.State.Cohort
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
-import java.time.Instant
-import java.util.Date
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -98,7 +96,7 @@ class DefaultBrowserPromptsExperimentImplTest {
 
     @Mock private lateinit var defaultBrowserDetectorMock: DefaultBrowserDetector
 
-    @Mock private lateinit var appDaysUsedRepositoryMock: AppDaysUsedRepository
+    @Mock private lateinit var experimentAppUsageRepositoryMock: ExperimentAppUsageRepository
 
     @Mock private lateinit var userStageStoreMock: UserStageStore
 
@@ -137,7 +135,6 @@ class DefaultBrowserPromptsExperimentImplTest {
     private lateinit var dataStoreMock: DefaultBrowserPromptsDataStore
 
     private val fakeEnrollmentDateETString = "2025-01-16T00:00-05:00[America/New_York]"
-    private val fakeEnrollmentDate = Date.from(Instant.ofEpochMilli(1737003600000))
 
     private lateinit var fakeUserAppStageFlow: MutableSharedFlow<AppStage>
 
@@ -376,6 +373,7 @@ class DefaultBrowserPromptsExperimentImplTest {
             activeDaysUntilStage2 = 3,
             activeDaysUntilStop = 5,
         )
+        whenever(experimentAppUsageRepositoryMock.getActiveDaysUsedSinceEnrollment(additionalPromptsToggleMock)).thenReturn(Result.success(0))
         val evaluatorMock = mockStageEvaluator(
             forNewStage = ExperimentStage.ENROLLED,
             forCohortName = AdditionalPromptsCohortName.VARIANT_2,
@@ -404,6 +402,7 @@ class DefaultBrowserPromptsExperimentImplTest {
             activeDaysUntilStage2 = 3,
             activeDaysUntilStop = 5,
         )
+        whenever(experimentAppUsageRepositoryMock.getActiveDaysUsedSinceEnrollment(additionalPromptsToggleMock)).thenReturn(Result.success(0))
         val evaluatorMock = mockStageEvaluator(
             forNewStage = ExperimentStage.ENROLLED,
             forCohortName = AdditionalPromptsCohortName.VARIANT_2,
@@ -444,7 +443,7 @@ class DefaultBrowserPromptsExperimentImplTest {
             activeDaysUntilStage2 = 3,
             activeDaysUntilStop = 5,
         )
-        whenever(appDaysUsedRepositoryMock.getNumberOfDaysAppUsedSinceDate(fakeEnrollmentDate)).thenReturn(0)
+        whenever(experimentAppUsageRepositoryMock.getActiveDaysUsedSinceEnrollment(additionalPromptsToggleMock)).thenReturn(Result.success(0))
         val evaluatorMock = mockStageEvaluator(
             forNewStage = ExperimentStage.ENROLLED,
             forCohortName = AdditionalPromptsCohortName.VARIANT_2,
@@ -476,7 +475,7 @@ class DefaultBrowserPromptsExperimentImplTest {
             activeDaysUntilStage2 = 3,
             activeDaysUntilStop = 5,
         )
-        whenever(appDaysUsedRepositoryMock.getNumberOfDaysAppUsedSinceDate(fakeEnrollmentDate)).thenReturn(1)
+        whenever(experimentAppUsageRepositoryMock.getActiveDaysUsedSinceEnrollment(additionalPromptsToggleMock)).thenReturn(Result.success(1))
         val evaluatorMock = mockStageEvaluator(
             forNewStage = ExperimentStage.STAGE_1,
             forCohortName = AdditionalPromptsCohortName.VARIANT_2,
@@ -513,7 +512,7 @@ class DefaultBrowserPromptsExperimentImplTest {
             activeDaysUntilStage2 = 3,
             activeDaysUntilStop = 5,
         )
-        whenever(appDaysUsedRepositoryMock.getNumberOfDaysAppUsedSinceDate(fakeEnrollmentDate)).thenReturn(2)
+        whenever(experimentAppUsageRepositoryMock.getActiveDaysUsedSinceEnrollment(additionalPromptsToggleMock)).thenReturn(Result.success(2))
         val evaluatorMock = mockStageEvaluator(
             forNewStage = ExperimentStage.STAGE_1,
             forCohortName = AdditionalPromptsCohortName.VARIANT_2,
@@ -545,7 +544,7 @@ class DefaultBrowserPromptsExperimentImplTest {
             activeDaysUntilStage2 = 3,
             activeDaysUntilStop = 5,
         )
-        whenever(appDaysUsedRepositoryMock.getNumberOfDaysAppUsedSinceDate(fakeEnrollmentDate)).thenReturn(3)
+        whenever(experimentAppUsageRepositoryMock.getActiveDaysUsedSinceEnrollment(additionalPromptsToggleMock)).thenReturn(Result.success(3))
         val evaluatorMock = mockStageEvaluator(
             forNewStage = ExperimentStage.STAGE_2,
             forCohortName = AdditionalPromptsCohortName.VARIANT_2,
@@ -582,7 +581,7 @@ class DefaultBrowserPromptsExperimentImplTest {
             activeDaysUntilStage2 = 3,
             activeDaysUntilStop = 5,
         )
-        whenever(appDaysUsedRepositoryMock.getNumberOfDaysAppUsedSinceDate(fakeEnrollmentDate)).thenReturn(4)
+        whenever(experimentAppUsageRepositoryMock.getActiveDaysUsedSinceEnrollment(additionalPromptsToggleMock)).thenReturn(Result.success(4))
         val evaluatorMock = mockStageEvaluator(
             forNewStage = ExperimentStage.STAGE_2,
             forCohortName = AdditionalPromptsCohortName.VARIANT_2,
@@ -614,7 +613,7 @@ class DefaultBrowserPromptsExperimentImplTest {
             activeDaysUntilStage2 = 3,
             activeDaysUntilStop = 5,
         )
-        whenever(appDaysUsedRepositoryMock.getNumberOfDaysAppUsedSinceDate(fakeEnrollmentDate)).thenReturn(5)
+        whenever(experimentAppUsageRepositoryMock.getActiveDaysUsedSinceEnrollment(additionalPromptsToggleMock)).thenReturn(Result.success(5))
         val evaluatorMock = mockStageEvaluator(
             forNewStage = ExperimentStage.STOPPED,
             forCohortName = AdditionalPromptsCohortName.VARIANT_2,
@@ -766,7 +765,7 @@ class DefaultBrowserPromptsExperimentImplTest {
             activeDaysUntilStage2 = 3,
             activeDaysUntilStop = 5,
         )
-        whenever(appDaysUsedRepositoryMock.getNumberOfDaysAppUsedSinceDate(fakeEnrollmentDate)).thenReturn(1)
+        whenever(experimentAppUsageRepositoryMock.getActiveDaysUsedSinceEnrollment(additionalPromptsToggleMock)).thenReturn(Result.success(1))
         val evaluatorMock = mockStageEvaluator(
             forNewStage = ExperimentStage.STAGE_1,
             forCohortName = AdditionalPromptsCohortName.VARIANT_2,
@@ -800,7 +799,7 @@ class DefaultBrowserPromptsExperimentImplTest {
             activeDaysUntilStage2 = 3,
             activeDaysUntilStop = 5,
         )
-        whenever(appDaysUsedRepositoryMock.getNumberOfDaysAppUsedSinceDate(fakeEnrollmentDate)).thenReturn(3)
+        whenever(experimentAppUsageRepositoryMock.getActiveDaysUsedSinceEnrollment(additionalPromptsToggleMock)).thenReturn(Result.success(3))
         val evaluatorMock = mockStageEvaluator(
             forNewStage = ExperimentStage.STAGE_2,
             forCohortName = AdditionalPromptsCohortName.VARIANT_2,
@@ -837,7 +836,7 @@ class DefaultBrowserPromptsExperimentImplTest {
             activeDaysUntilStage2 = 3,
             activeDaysUntilStop = 5,
         )
-        whenever(appDaysUsedRepositoryMock.getNumberOfDaysAppUsedSinceDate(fakeEnrollmentDate)).thenReturn(3)
+        whenever(experimentAppUsageRepositoryMock.getActiveDaysUsedSinceEnrollment(additionalPromptsToggleMock)).thenReturn(Result.success(3))
         val evaluatorMock = mockStageEvaluator(
             forNewStage = ExperimentStage.STAGE_2,
             forCohortName = AdditionalPromptsCohortName.VARIANT_2,
@@ -961,6 +960,15 @@ class DefaultBrowserPromptsExperimentImplTest {
         verify(pixelMock).fire(SET_AS_DEFAULT_IN_MENU_CLICK, expectedParams)
     }
 
+    @Test
+    fun `when resumed, record app usage`() = runTest {
+        val testee = createTestee()
+
+        testee.onResume(lifecycleOwnerMock)
+
+        verify(experimentAppUsageRepositoryMock).recordAppUsedNow()
+    }
+
     private fun createTestee(
         appCoroutineScope: CoroutineScope = coroutinesTestRule.testScope,
         dispatchers: DispatcherProvider = coroutinesTestRule.testDispatcherProvider,
@@ -968,7 +976,7 @@ class DefaultBrowserPromptsExperimentImplTest {
         defaultBrowserPromptsFeatureToggles: DefaultBrowserPromptsFeatureToggles = featureTogglesMock,
         defaultBrowserDetector: DefaultBrowserDetector = defaultBrowserDetectorMock,
         defaultRoleBrowserDialog: DefaultRoleBrowserDialog = defaultRoleBrowserDialogMock,
-        appDaysUsedRepository: AppDaysUsedRepository = appDaysUsedRepositoryMock,
+        experimentAppUsageRepository: ExperimentAppUsageRepository = experimentAppUsageRepositoryMock,
         userStageStore: UserStageStore = userStageStoreMock,
         defaultBrowserPromptsDataStore: DefaultBrowserPromptsDataStore = dataStoreMock,
         experimentStageEvaluatorPluginPoint: PluginPoint<DefaultBrowserPromptsExperimentStageEvaluator> = experimentStageEvaluatorPluginPointMock,
@@ -982,7 +990,7 @@ class DefaultBrowserPromptsExperimentImplTest {
         defaultBrowserPromptsFeatureToggles = defaultBrowserPromptsFeatureToggles,
         defaultBrowserDetector = defaultBrowserDetector,
         defaultRoleBrowserDialog = defaultRoleBrowserDialog,
-        appDaysUsedRepository = appDaysUsedRepository,
+        experimentAppUsageRepository = experimentAppUsageRepository,
         userStageStore = userStageStore,
         defaultBrowserPromptsDataStore = defaultBrowserPromptsDataStore,
         experimentStageEvaluatorPluginPoint = experimentStageEvaluatorPluginPoint,

--- a/app/src/test/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/store/ExperimentAppUsageRepositoryImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/store/ExperimentAppUsageRepositoryImplTest.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.defaultbrowsing.prompts.store
+
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.store.ExperimentAppUsageRepository.UserNotEnrolledException
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.State.Cohort
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import java.time.temporal.ChronoUnit
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class ExperimentAppUsageRepositoryImplTest {
+
+    @get:Rule
+    var coroutinesTestRule = CoroutineTestRule()
+
+    @Mock private lateinit var experimentAppUsageDaoMock: ExperimentAppUsageDao
+
+    @Before
+    fun setup() {
+        MockitoAnnotations.openMocks(this)
+    }
+
+    @Test
+    fun `when record usage, then insert ET time`() = runTest {
+        val expected = ExperimentAppUsageEntity(
+            isoDateET = ZonedDateTime.now(ZoneId.of("America/New_York"))
+                .truncatedTo(ChronoUnit.DAYS)
+                .format(DateTimeFormatter.ISO_LOCAL_DATE),
+        )
+        val testee = ExperimentAppUsageRepositoryImpl(
+            dispatchers = coroutinesTestRule.testDispatcherProvider,
+            experimentAppUsageDao = experimentAppUsageDaoMock,
+        )
+
+        testee.recordAppUsedNow()
+
+        verify(experimentAppUsageDaoMock).insert(expected)
+    }
+
+    @Test
+    fun `when active days since enrollment queried and no cohort assigned, return failure`() = runTest {
+        val toggleMock = mock<Toggle>()
+        whenever(toggleMock.getCohort()).thenReturn(null)
+        val testee = ExperimentAppUsageRepositoryImpl(
+            dispatchers = coroutinesTestRule.testDispatcherProvider,
+            experimentAppUsageDao = experimentAppUsageDaoMock,
+        )
+
+        val actual = testee.getActiveDaysUsedSinceEnrollment(toggleMock)
+
+        Assert.assertTrue(actual.exceptionOrNull() is UserNotEnrolledException)
+    }
+
+    @Test
+    fun `when active days since enrollment queried and malformed date, return failure`() = runTest {
+        val fakeCohort = Cohort(
+            name = "fakeCohort",
+            weight = 1,
+            enrollmentDateET = "2025-01-16",
+        )
+        val toggleMock = mock<Toggle>()
+        whenever(toggleMock.getCohort()).thenReturn(fakeCohort)
+        val testee = ExperimentAppUsageRepositoryImpl(
+            dispatchers = coroutinesTestRule.testDispatcherProvider,
+            experimentAppUsageDao = experimentAppUsageDaoMock,
+        )
+
+        val actual = testee.getActiveDaysUsedSinceEnrollment(toggleMock)
+
+        Assert.assertTrue(actual.exceptionOrNull() is DateTimeParseException)
+    }
+
+    @Test
+    fun `when active days since enrollment queried and user is enrolled, return success`() = runTest {
+        val zonedDateTimeString = "2025-01-16T00:00-05:00[America/New_York]"
+        val fakeCohort = Cohort(
+            name = "fakeCohort",
+            weight = 1,
+            enrollmentDateET = zonedDateTimeString,
+        )
+        val toggleMock = mock<Toggle>()
+        whenever(toggleMock.getCohort()).thenReturn(fakeCohort)
+        val expectedIsoDateString = "2025-01-16"
+        val expectedValue = 2L
+        whenever(experimentAppUsageDaoMock.getNumberOfDaysAppUsedSinceDateET(expectedIsoDateString)).thenReturn(expectedValue)
+        val testee = ExperimentAppUsageRepositoryImpl(
+            dispatchers = coroutinesTestRule.testDispatcherProvider,
+            experimentAppUsageDao = experimentAppUsageDaoMock,
+        )
+
+        val actual = testee.getActiveDaysUsedSinceEnrollment(toggleMock)
+
+        Assert.assertEquals(Result.success(expectedValue), actual)
+    }
+}

--- a/browser-api/src/main/java/com/duckduckgo/app/usage/app/AppDaysUsedRepository.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/usage/app/AppDaysUsedRepository.kt
@@ -34,7 +34,10 @@ interface AppDaysUsedRepository {
     suspend fun recordAppUsedToday()
 
     /**
-     * Get the number of days the app has been used since a given date
+     * Get the number of days the app has been used since a given date.
+     *
+     * The provided [date] is compared against records of app usage collected by day-truncated local date at a time of capture.
+     * It might not be precise enough for all applications.
      */
     suspend fun getNumberOfDaysAppUsedSinceDate(date: Date): Long
 

--- a/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureToggles.kt
+++ b/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureToggles.kt
@@ -229,7 +229,12 @@ interface Toggle {
         data class Cohort(
             val name: String,
             val weight: Int,
-            // This is nullable because only assigned cohort should have a value here, it's ET timezone
+
+            /**
+             * Represents serialized [ZonedDateTime] with "America/New_York" zone ID.
+             *
+             * This is nullable because only assigned cohort should have a value here, it's ET timezone
+             */
             val enrollmentDateET: String? = null,
         ) {
             companion object {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1208671518894266/1209329916239779

### Description

Adds `ExperimentAppUsageRepository` with an ability to store and query the "app days used" variable that is based on the ET timezone, instead of local timezone. This in turn is used in the default browser prompts experiment to ensure that the stages are triggered precisely at the same time as the A/B/N experiment shifts the app use day counter (used for validating conversion windows).

### Steps to test this PR

Apply this JSON Blob:
```diff
diff --git a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
index ca0870311..5a904f76b 100644
--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
@@ -27,4 +27,5 @@ enum class PrivacyFeatureName(val value: String) {
     TrackingParametersFeatureName("trackingParameters"),
 }
 
-const val PRIVACY_REMOTE_CONFIG_URL = "https://staticcdn.duckduckgo.com/trackerblocking/config/v4/android-config.json"
+// const val PRIVACY_REMOTE_CONFIG_URL = "https://staticcdn.duckduckgo.com/trackerblocking/config/v4/android-config.json"
+const val PRIVACY_REMOTE_CONFIG_URL = "https://www.jsonblob.com/api/1329809981419216896"
```

Once built with the right config, ensure that you **don't have DDG app set as a default browser**, only then you'll be assigned to the experiment. Then:

1. Set device's date to 2 PM CET.
2. Open the application and go through onboarding.
3. Change date to 1 AM CET on the following day.
4. Resume/restart the application.
  a. You should not see the default browser CTA.
5. Move the time forward to 6 AM CET.
6. Resume/restart the application.
  a. You should see a CTA.
7. Click "Set As Default Browser" and set default browser.
8. Filter logs for `defaultBrowserAdditionalPrompts202501` and make sure that the two pixels below were sent.

You can also look at the `App Inspection -> Database inspector` and track changes to `app.db.experiment_app_usage_entity` table as you change dates.

```
Pixel sent: experiment_metrics_defaultBrowserAdditionalPrompts202501_variant_3 with params: {metric=defaultSetViaCta, value=dialog, enrollmentDate=2025-02-05, conversionWindowDays=1-40} {}

Pixel sent: experiment_metrics_defaultBrowserAdditionalPrompts202501_variant_3 with params: {metric=defaultSet, value=stage_1, enrollmentDate=2025-02-05, conversionWindowDays=1-40} {}
```