### PR TITLE
Navigate back when possible from malicious error page

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1808,7 +1808,6 @@ class BrowserTabFragment :
             is Command.EscapeMaliciousSite -> onEscapeMaliciousSite()
             is Command.CloseCustomTab -> closeCustomTab()
             is Command.BypassMaliciousSiteWarning -> onBypassMaliciousWarning(it.url, it.feed)
-            is Command.BypassMaliciousSiteWarning -> onBypassMaliciousWarning(it.url, it.feed)
             is OpenBrokenSiteLearnMore -> openBrokenSiteLearnMore(it.url)
             is ReportBrokenSiteError -> openBrokenSiteReportError(it.url)
             is Command.SendResponseToJs -> contentScopeScripts.onResponse(it.data)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1882,7 +1882,9 @@ class BrowserTabViewModel @Inject constructor(
     ) {
         when (action) {
             LeaveSite -> {
-                if (activeCustomTab) {
+                if (webNavigationState?.canGoBack == true) {
+                    command.postValue(HideWarningMaliciousSite)
+                } else if (activeCustomTab) {
                     command.postValue(CloseCustomTab)
                 } else {
                     command.postValue(EscapeMaliciousSite)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1209289574297313/f

### Description
Take users to previous URL on Leave Site button press when history exists instead of always closing tab and opening a new one.

### Steps to test this PR

_Feature 1_
- [ ] Open a new tab and accumulate some safe site history
- [ ] Go to https://privacy-test-pages.site/security/badware/malware.html in the same tab
- [ ] Tap Leave Site and check that tab goes back to last safe URL instead of closing and opening a new tab
- [ ] Open a new tab and directly go to https://privacy-test-pages.site/security/badware/malware.html
- [ ] Tap Leave Site and check that tab is closed and a fresh one is opened
