### PR TITLE
Add Malicious Site Protection algorithm pixels

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/fakes/FakeMaliciousSiteBlockerWebViewIntegration.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/fakes/FakeMaliciousSiteBlockerWebViewIntegration.kt
@@ -41,7 +41,7 @@ class FakeMaliciousSiteBlockerWebViewIntegration : MaliciousSiteBlockerWebViewIn
         return Safe
     }
 
-    override fun onPageLoadStarted() {
+    override fun onPageLoadStarted(url: String) {
         // no-op
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -3219,7 +3219,7 @@ class BrowserTabViewModel @Inject constructor(
 
         if (!exempted) {
             if (currentBrowserViewState().maliciousSiteDetected && previousSite?.url == url.toString()) return
-            Timber.tag("Cris").d("Received MaliciousSiteWarning for $url, feed: $feed, exempted: false, clientSideHit: $clientSideHit")
+            Timber.d("Received MaliciousSiteWarning for $url, feed: $feed, exempted: false, clientSideHit: $clientSideHit")
             val params = mapOf(CATEGORY_KEY to feed.name.lowercase(), CLIENT_SIDE_HIT_KEY to clientSideHit.toString())
             pixel.fire(AppPixelName.MALICIOUS_SITE_PROTECTION_ERROR_SHOWN, params)
             loadingViewState.postValue(

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewRequestInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewRequestInterceptor.kt
@@ -94,7 +94,7 @@ class WebViewRequestInterceptor(
 
     override fun onPageStarted(url: String) {
         requestFilterer.registerOnPageCreated(url)
-        maliciousSiteBlockerWebViewIntegration.onPageLoadStarted()
+        maliciousSiteBlockerWebViewIntegration.onPageLoadStarted(url)
     }
 
     /**

--- a/app/src/main/java/com/duckduckgo/app/browser/webview/MaliciousSiteBlockerWebViewIntegration.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/webview/MaliciousSiteBlockerWebViewIntegration.kt
@@ -141,8 +141,6 @@ class RealMaliciousSiteBlockerWebViewIntegration @Inject constructor(
             return IsMaliciousViewData.Safe
         }
 
-        Timber.d("shouldIntercept ${request.url}")
-
         val url = request.url.let {
             if (it.fragment != null) {
                 it.buildUpon().fragment(null).build()
@@ -269,7 +267,7 @@ class RealMaliciousSiteBlockerWebViewIntegration @Inject constructor(
             } else {
                 Safe
             }
-            processedUrls[url] = isMalicious
+            processedUrls[url] = it
             confirmationCallback(isMalicious)
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -392,4 +392,6 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     SET_AS_DEFAULT_PROMPT_CLICK("m_set-as-default_prompt_click"),
     SET_AS_DEFAULT_PROMPT_DISMISSED("m_set-as-default_prompt_dismissed"),
     SET_AS_DEFAULT_IN_MENU_CLICK("m_set-as-default_in-menu_click"),
+
+    MALICIOUS_SITE_DETECTED_IN_IFRAME("m_malicious-site-protection_iframe-loaded"),
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/webview/RealMaliciousSiteBlockerWebViewIntegrationTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/webview/RealMaliciousSiteBlockerWebViewIntegrationTest.kt
@@ -264,6 +264,7 @@ class RealMaliciousSiteBlockerWebViewIntegrationTest {
         val firstCallbackResult = firstCallbackDeferred.await()
         val secondCallbackResult = secondCallbackDeferred.await()
 
+        assertTrue(testee.processedUrls[maliciousUri.toString()] is Malicious)
         assertEquals(false, firstCallbackResult)
         assertEquals(true, secondCallbackResult)
     }

--- a/malicious-site-protection/malicious-site-protection-impl/build.gradle
+++ b/malicious-site-protection/malicious-site-protection-impl/build.gradle
@@ -54,6 +54,8 @@ dependencies {
 
     implementation Google.android.material
 
+    implementation project(path: ':statistics-api')
+
     testImplementation AndroidX.test.ext.junit
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.5.2'
     testImplementation Testing.junit4

--- a/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSitePixelName.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSitePixelName.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.malicioussiteprotection.impl
+
+import com.duckduckgo.app.statistics.pixels.Pixel
+
+enum class MaliciousSitePixelName(override val pixelName: String) : Pixel.PixelName {
+    MALICIOUS_SITE_CLIENT_TIMEOUT("m_malicious-site-protection_client-timeout"),
+}

--- a/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/data/MaliciousSiteRepository.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/data/MaliciousSiteRepository.kt
@@ -56,6 +56,8 @@ interface MaliciousSiteRepository {
     suspend fun loadHashPrefixes(): Result<Unit>
 }
 
+private const val MATCHES_ENDPOINT_TIMEOUT = 1000L
+
 @ContributesBinding(AppScope::class)
 @SingleInstanceIn(AppScope::class)
 class RealMaliciousSiteRepository @Inject constructor(
@@ -84,7 +86,7 @@ class RealMaliciousSiteRepository @Inject constructor(
 
     override suspend fun matches(hashPrefix: String): List<Match> {
         return try {
-            withTimeout(1000) {
+            withTimeout(MATCHES_ENDPOINT_TIMEOUT) {
                 maliciousSiteService.getMatches(hashPrefix).matches.mapNotNull {
                     val feed = when (it.feed.uppercase()) {
                         PHISHING.name -> PHISHING

--- a/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/data/MaliciousSiteRepository.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/data/MaliciousSiteRepository.kt
@@ -16,11 +16,13 @@
 
 package com.duckduckgo.malicioussiteprotection.impl.data
 
+import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed
 import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed.MALWARE
 import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed.PHISHING
+import com.duckduckgo.malicioussiteprotection.impl.MaliciousSitePixelName.MALICIOUS_SITE_CLIENT_TIMEOUT
 import com.duckduckgo.malicioussiteprotection.impl.data.db.MaliciousSiteDao
 import com.duckduckgo.malicioussiteprotection.impl.data.db.RevisionEntity
 import com.duckduckgo.malicioussiteprotection.impl.data.network.FilterResponse
@@ -42,7 +44,9 @@ import com.duckduckgo.malicioussiteprotection.impl.models.Type.HASH_PREFIXES
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
 import javax.inject.Inject
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 
 interface MaliciousSiteRepository {
     suspend fun containsHashPrefix(hashPrefix: String): Boolean
@@ -58,6 +62,7 @@ class RealMaliciousSiteRepository @Inject constructor(
     private val maliciousSiteDao: MaliciousSiteDao,
     private val maliciousSiteService: MaliciousSiteService,
     private val dispatcherProvider: DispatcherProvider,
+    private val pixels: Pixel,
 ) : MaliciousSiteRepository {
 
     override suspend fun containsHashPrefix(hashPrefix: String): Boolean {
@@ -79,18 +84,23 @@ class RealMaliciousSiteRepository @Inject constructor(
 
     override suspend fun matches(hashPrefix: String): List<Match> {
         return try {
-            maliciousSiteService.getMatches(hashPrefix).matches.mapNotNull {
-                val feed = when (it.feed.uppercase()) {
-                    PHISHING.name -> PHISHING
-                    MALWARE.name -> MALWARE
-                    else -> null
-                }
-                if (feed != null) {
-                    Match(it.hostname, it.url, it.regex, it.hash, feed)
-                } else {
-                    null
+            withTimeout(1000) {
+                maliciousSiteService.getMatches(hashPrefix).matches.mapNotNull {
+                    val feed = when (it.feed.uppercase()) {
+                        PHISHING.name -> PHISHING
+                        MALWARE.name -> MALWARE
+                        else -> null
+                    }
+                    if (feed != null) {
+                        Match(it.hostname, it.url, it.regex, it.hash, feed)
+                    } else {
+                        null
+                    }
                 }
             }
+        } catch (e: TimeoutCancellationException) {
+            pixels.fire(MALICIOUS_SITE_CLIENT_TIMEOUT)
+            listOf()
         } catch (e: Exception) {
             listOf()
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1209304069660515

### Description
*  Add Malicious Site Protection algorithm pixels

### Steps to test this PR

_Feature 1_
- [x] Load https://privacy-test-pages.site/security/badware/phishing-legit-iframe-loader.html
- [x] Check m_malicious-site-protection_iframe-loaded with params: {category=phishing}  is fired
- [x] Check m_malicious-site-protection_error-page-shown is fired

_Feature 2_
- [x] Set timeout to 10ms in override suspend fun matches(hashPrefix: String): List<Match>
- [x] Load https://privacy-test-pages.site/security/badware/phishing-legit-iframe-loader.html
- [x] Check no error page is shown and m_malicious-site-protection_client-timeout is fired

_Feature 3_
- [x] Load https://privacy-test-pages.site/security/badware/
- [x] Click on "Phishing iFrame Loader"
- [x] Check m_malicious-site-protection_iframe-loaded and m_malicious-site-protection_error-page-shown are fired only once

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
