### PR TITLE
Fix re-purchasing expired subscription shortly after account is deleted in BE

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
@@ -768,10 +768,10 @@ class RealSubscriptionsManager @Inject constructor(
                 isSignedInV2() -> try {
                     refreshSubscriptionData()
                 } catch (e: HttpException) {
-                    if (e.code() in listOf(400, 404)) {
-                        // expected if this is a first ever purchase using this account - ignore
-                    } else {
-                        throw e
+                    when (e.code()) {
+                        400, 404 -> {} // expected if this is a first ever purchase using this account - ignore
+                        401 -> signOut() // access token was rejected even though it's not expired - can happen if the account was removed from BE
+                        else -> throw e
                     }
                 }
 

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
@@ -70,6 +70,7 @@ import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -309,6 +310,26 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         assertNull(subscriptionsManager.getAccount())
         assertNull(authRepository.getAuthToken())
         assertNull(authRepository.getAccessToken())
+    }
+
+    @Test
+    fun whenPurchaseFlowIfUserIsSignedInAndSubscriptionFailsWith401ThenSignOutAndCreateNewAccount() = runTest {
+        givenUserIsSignedIn(accountExternalId = "5678")
+        givenSubscriptionFails(httpResponseCode = 401)
+        givenCreateAccountSucceeds()
+        val accountExternalId = authDataStore.externalId
+
+        subscriptionsManager.purchase(mock(), planId = "")
+
+        if (authApiV2Enabled) {
+            verify(authClient).authorize(any())
+            verify(authClient).createAccount(any())
+            verify(authClient).getTokens(any(), any(), any())
+        } else {
+            verify(authService).createAccount(any())
+        }
+
+        assertNotEquals(accountExternalId, authDataStore.externalId)
     }
 
     @Test
@@ -1381,7 +1402,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         authDataStore.refreshTokenV2ExpiresAt = null
     }
 
-    private fun givenUserIsSignedIn(useAuthV2: Boolean = authApiV2Enabled) {
+    private fun givenUserIsSignedIn(useAuthV2: Boolean = authApiV2Enabled, accountExternalId: String = "1234") {
         if (useAuthV2) {
             authDataStore.accessTokenV2 = FAKE_ACCESS_TOKEN_V2
             authDataStore.accessTokenV2ExpiresAt = timeProvider.currentTime + Duration.ofHours(4)
@@ -1391,7 +1412,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
             authDataStore.accessToken = "accessToken"
             authDataStore.authToken = "authToken"
         }
-        authDataStore.externalId = "1234"
+        authDataStore.externalId = accountExternalId
     }
 
     private suspend fun givenCreateAccountFails() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1209345290223153/f

### Description

This PR addresses an edge case, where where re-purchasing an expired subscription may be temporarily impossible. See task for details.

### Steps to test this PR

QA-optional

### No UI changes
