### PR TITLE
Change Apple ID to Apple Account

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/res/values-bg/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-bg/strings-subscriptions.xml
@@ -95,7 +95,6 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Актуализиране или отмяна на плана</string>
-    <string name="changePlanDescription">Вашият абонамент е закупен през Apple App Store. За да промените плана или настройките за фактуриране, влезте в Настройки &gt; Apple ID &gt; Абонаменти на устройство, вписано със същия Apple ID, който е използван за закупуване на абонамента.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Активирайте Privacy Pro на настолен компютър, за да настроите Personal Information Removal</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-bg/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-bg/strings-subscriptions.xml
@@ -95,6 +95,7 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Актуализиране или отмяна на плана</string>
+    <string name="changePlanDescription">Вашият абонамент е закупен през Apple App Store. За да промените плана или настройките за фактуриране, отидете на Настройки &gt; Apple Account &gt; Абонаменти на устройство, вписано със същия Apple Account, използван за закупуване на абонамента ви.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Активирайте Privacy Pro на настолен компютър, за да настроите Personal Information Removal</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-cs/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-cs/strings-subscriptions.xml
@@ -95,7 +95,6 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Aktualizace nebo zrušení tarifu</string>
-    <string name="changePlanDescription">Tvoje předplatné bylo zakoupeno prostřednictvím obchodu Apple App Store. Pokud chceš změnit tarif nebo nastavení fakturace, na zařízení, které je přihlášené ke stejnému Apple ID, jaké jsi použil(a) k pořízení předplatného, přejdi do Nastavení &gt; Apple ID &gt; Předplatná.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Aktivuj si na počítači službu Privacy Pro a nastav si v ní funkci Personal Information Removal</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-cs/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-cs/strings-subscriptions.xml
@@ -95,6 +95,7 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Aktualizace nebo zrušení tarifu</string>
+    <string name="changePlanDescription">Tvoje předplatné bylo zakoupeno prostřednictvím obchodu Apple App Store. Pokud chceš změnit tarif nebo nastavení fakturace, na zařízení, které je přihlášené ke stejnému účtu Apple, jaké jsi použil(a) k pořízení předplatného, přejdi do Nastavení &gt; Účet Apple &gt; Předplatná.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Aktivuj si na počítači službu Privacy Pro a nastav si v ní funkci Personal Information Removal</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-da/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-da/strings-subscriptions.xml
@@ -95,7 +95,6 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Opdater abonnement eller annuller</string>
-    <string name="changePlanDescription">Dit abonnement blev købt gennem Apple App Store. Hvis du vil ændre dit abonnement eller dine faktureringsindstillinger, skal du gå til Indstillinger &gt; Apple ID &gt; Abonnementer på en enhed, der er logget ind med det samme Apple ID, som blev brugt til at købe dit abonnement.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Aktivér Privacy Pro på en computer for at opsætte Personal Information Removal</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-da/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-da/strings-subscriptions.xml
@@ -95,6 +95,7 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Opdater abonnement eller annuller</string>
+    <string name="changePlanDescription">Dit abonnement blev købt gennem Apple App Store. Hvis du vil ændre dit abonnement eller dine faktureringsindstillinger, skal du gå til Indstillinger &gt; Apple-konto &gt; Abonnementer på en enhed, der er logget ind med den samme Apple-konto, som blev brugt til at købe dit abonnement.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Aktivér Privacy Pro på en computer for at opsætte Personal Information Removal</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-de/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-de/strings-subscriptions.xml
@@ -95,7 +95,6 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Tarif aktualisieren oder kündigen</string>
-    <string name="changePlanDescription">Dein Abonnement wurde über den Apple App Store erworben. Um deinen Tarif oder deine Rechnungseinstellungen zu ändern, gehe auf einem Gerät, auf dem du mit derselben Apple-ID angemeldet bist, die du für den Kauf deines Abonnements verwendet hast, zu Einstellungen &gt; Apple-ID &gt; Abonnements.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Aktiviere Privacy Pro auf dem Desktop, um Personal Information Removal einzurichten</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-de/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-de/strings-subscriptions.xml
@@ -95,6 +95,7 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Tarif aktualisieren oder kündigen</string>
+    <string name="changePlanDescription">Dein Abonnement wurde über den Apple App Store erworben. Um deinen Tarif oder deine Rechnungseinstellungen zu ändern, gehe auf einem Gerät, auf dem du mit derselben Apple-Konto angemeldet bist, die du für den Kauf deines Abonnements verwendet hast, zu Einstellungen &gt; Apple-Konto &gt; Abonnements.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Aktiviere Privacy Pro auf dem Desktop, um Personal Information Removal einzurichten</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-el/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-el/strings-subscriptions.xml
@@ -95,7 +95,6 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Ενημέρωση προγράμματος ή ακύρωση</string>
-    <string name="changePlanDescription">Η συνδρομή σας αγοράστηκε μέσω του Apple Play Store. Για να αλλάξετε το πρόγραμμα ή τις ρυθμίσεις χρέωσης, μεταβείτε στις επιλογές Ρυθμίσεις &gt; Αναγνωριστικό Apple &gt; Συνδρομές, σε μια συσκευή που έχει συνδεθεί με το ίδιο Αναγνωριστικό Apple που χρησιμοποιήθηκε για την αγορά της συνδρομής σας.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Ενεργοποιήστε το Privacy Pro στην επιφάνεια εργασίας για να ρυθμίσετε το Personal Information Removal</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-el/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-el/strings-subscriptions.xml
@@ -95,6 +95,7 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Ενημέρωση προγράμματος ή ακύρωση</string>
+    <string name="changePlanDescription">Η συνδρομή σας αγοράστηκε μέσω του Apple Play Store. Για να αλλάξετε το πρόγραμμα ή τις ρυθμίσεις χρέωσης, μεταβείτε στις επιλογές Ρυθμίσεις &gt; Λογαριασμός Apple &gt; Συνδρομές, σε μια συσκευή που έχει συνδεθεί με τον ίδιο Λογαριασμό Apple που χρησιμοποιήθηκε για την αγορά της συνδρομής σας.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Ενεργοποιήστε το Privacy Pro στην επιφάνεια εργασίας για να ρυθμίσετε το Personal Information Removal</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-es/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-es/strings-subscriptions.xml
@@ -95,6 +95,7 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Actualizar el plan o cancelar</string>
+    <string name="changePlanDescription">Has adquirido tu suscripción a través de la App Store de Apple. Para cambiar tu plan o la configuración de facturación, ve a Ajustes &gt; Cuenta de Apple &gt; Suscripciones en un dispositivo con la misma Cuenta de Apple que usaste para comprar tu suscripción.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Activa Privacy Pro en el escritorio para configurar Personal Information Removal</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-es/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-es/strings-subscriptions.xml
@@ -95,7 +95,6 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Actualizar el plan o cancelar</string>
-    <string name="changePlanDescription">Has adquirido tu suscripción a través de la App Store de Apple. Para cambiar tu plan o la configuración de facturación, ve a Ajustes &gt; ID de Apple ID &gt; Suscripciones en un dispositivo con la misma ID de Apple que usaste para comprar tu suscripción.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Activa Privacy Pro en el escritorio para configurar Personal Information Removal</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-et/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-et/strings-subscriptions.xml
@@ -95,7 +95,6 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Uuenda plaani või loobu</string>
-    <string name="changePlanDescription">Sinu tellimus osteti Apple\'i App Store\'i kaudu. Paketi või arveldusseadete muutmiseks ava Seaded &gt; Apple ID &gt; Tellimused seadmes, mis on sisse logitud sama Apple ID-ga, millega ostsid oma tellimuse.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Personal Information Removal\'i seadistamiseks aktiveerige töölaual Privacy Pro</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-et/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-et/strings-subscriptions.xml
@@ -95,6 +95,7 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Uuenda plaani või loobu</string>
+    <string name="changePlanDescription">Teie tellimus osteti Apple\'i App Store\'i kaudu. Paketi või arvelduse seadistuste muutmiseks avage jaotis Seaded &gt; Apple\'i konto &gt; Tellimused seadmel, mis on sisse logitud sama Apple\'i kontoga, millelt ostsite oma tellimuse.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Personal Information Removal\'i seadistamiseks aktiveerige töölaual Privacy Pro</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-fi/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-fi/strings-subscriptions.xml
@@ -95,7 +95,6 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Päivitä tilaus tai peruuta</string>
-    <string name="changePlanDescription">Tilauksesi on ostettu Applen App Storesta. Jos haluat muuttaa tilaustasi tai laskutusasetuksiasi, siirry kohtaan Asetukset &gt; Apple ID &gt; Tilaukset sillä laitteella, johon on kirjauduttu samalla Apple ID:llä, jolla tilaus on ostettu.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Aktivoi Privacy Pro tietokoneella Personal Information Removalin asentamiseksi</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-fi/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-fi/strings-subscriptions.xml
@@ -95,6 +95,7 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Päivitä tilaus tai peruuta</string>
+    <string name="changePlanDescription">Tilauksesi on ostettu Applen App Storesta. Jos haluat muuttaa tilaustasi tai laskutusasetuksiasi, siirry kohtaan Asetukset &gt; Apple-tili &gt; Tilaukset sillä laitteella, jolla on kirjauduttu samalle Apple-tilille, jota käytit tilauksesi ostamiseen.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Aktivoi Privacy Pro tietokoneella Personal Information Removalin asentamiseksi</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-fr/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-fr/strings-subscriptions.xml
@@ -95,6 +95,7 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Modifier le forfait ou le résilier</string>
+    <string name="changePlanDescription">Votre abonnement a été souscrit via l\'App Store d\'Apple. Pour modifier votre forfait ou vos paramètres de facturation, allez dans Réglages &gt; Compte Apple &gt; Abonnements sur un appareil connecté au même compte Apple que celui utilisé pour souscrire votre abonnement.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Activez Privacy Pro sur ordinateur pour configurer Personal Information Removal</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-fr/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-fr/strings-subscriptions.xml
@@ -95,7 +95,6 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Modifier le forfait ou le résilier</string>
-    <string name="changePlanDescription">Votre abonnement a été souscrit via l\'App Store d\'Apple. Pour modifier votre forfait ou vos paramètres de facturation, allez dans Réglages &gt; ID Apple &gt; Abonnements sur un appareil connecté au même identifiant Apple que celui utilisé pour souscrire votre abonnement.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Activez Privacy Pro sur ordinateur pour configurer Personal Information Removal</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-hr/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-hr/strings-subscriptions.xml
@@ -95,7 +95,6 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Ažuriraj plan ili odustani</string>
-    <string name="changePlanDescription">Tvoja pretplata kupljena je putem Apple App Storea. Za promjenu postavki plana ili naplate, idi na Postavke &gt; Apple ID &gt; Pretplate na uređaju prijavljenom na isti Apple ID koji je korišten za kupnju pretplate.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Aktiviraj Privacy Pro na radnoj površini kako bi postavio Personal Information Removal</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-hr/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-hr/strings-subscriptions.xml
@@ -95,6 +95,7 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Ažuriraj plan ili odustani</string>
+    <string name="changePlanDescription">Tvoja pretplata kupljena je putem Apple App Storea. Za promjenu postavki plana ili naplate, idi na Postavke &gt; Apple račun &gt; Pretplate na uređaju prijavljenom na isti Apple račun koji je korišten za kupnju pretplate.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Aktiviraj Privacy Pro na radnoj površini kako bi postavio Personal Information Removal</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-hu/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-hu/strings-subscriptions.xml
@@ -95,7 +95,6 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Csomag frissítése vagy lemondása</string>
-    <string name="changePlanDescription">Előfizetésed az Apple App Store áruházban lett megvásárolva. A csomag vagy a számlázási beállítások módosításához lépj a Beállítások &gt; Apple-fiók &gt; Előfizetések menüpontra egy olyan eszközön, amely ugyanabba az Apple-fiókba van bejelentkezve mint, amellyel az előfizetés meg lett vásárolva.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Privacy Pro aktiválása asztali számítógépen a Personal Information Removal beállításához</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-hu/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-hu/strings-subscriptions.xml
@@ -95,6 +95,7 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Csomag frissítése vagy lemondása</string>
+    <string name="changePlanDescription">Előfizetésed az Apple App Store áruházban lett megvásárolva. A csomag vagy a számlázási beállítások módosításához lépj a Beállítások &gt; Apple-fiók &gt; Előfizetések menüpontra egy olyan eszközön, amely ugyanabba az Apple-fiókba van bejelentkezve, mint amellyel az előfizetés meg lett vásárolva.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Privacy Pro aktiválása asztali számítógépen a Personal Information Removal beállításához</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-it/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-it/strings-subscriptions.xml
@@ -95,7 +95,6 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Aggiorna o o annulla il piano</string>
-    <string name="changePlanDescription">L\'abbonamento è stato acquistato tramite l\'App Store di Apple. Per modificare il tuo piano o le impostazioni di fatturazione, vai su Impostazioni &gt; ID Apple &gt; Abbonamenti su un dispositivo che ha effettuato l\'accesso con lo stesso ID Apple utilizzato per acquistare l\'abbonamento.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Attiva Privacy Pro sul desktop per impostare Personal Information Removal</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-it/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-it/strings-subscriptions.xml
@@ -95,6 +95,7 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Aggiorna o o annulla il piano</string>
+    <string name="changePlanDescription">L\'abbonamento è stato acquistato tramite l\'App Store di Apple. Per modificare il tuo piano o le impostazioni di fatturazione, vai su Impostazioni &gt; Account Apple &gt; Abbonamenti su un dispositivo che ha effettuato l\'accesso con lo stesso account Apple utilizzato per acquistare l\'abbonamento.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Attiva Privacy Pro sul desktop per impostare Personal Information Removal</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-lt/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-lt/strings-subscriptions.xml
@@ -95,6 +95,7 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Atnaujinkite planą arba atšaukite</string>
+    <string name="changePlanDescription">Jūsų prenumerata buvo įsigyta per „Apple App Store“. Norėdami pakeisti savo plano ar atsiskaitymo nustatymus, eikite į Nustatymai &gt; „Apple“ paskyra &gt; Prenumeratos įrenginyje, prijungtame prie tos pačios „Apple“ paskyros, naudotos prenumeratai įsigyti.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Aktyvuokite „Privacy Pro“ darbalaukyje, kad nustatytumėte Asmeninės informacijos pašalinimą.</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-lt/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-lt/strings-subscriptions.xml
@@ -95,7 +95,6 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Atnaujinkite planą arba atšaukite</string>
-    <string name="changePlanDescription">Jūsų prenumerata buvo įsigyta per „Apple App Store“. Norėdami pakeisti savo plano ar atsiskaitymo nustatymus, eikite į Nustatymai &gt; Apple ID &gt; Prenumeratos įrenginyje, prisijungusiame prie to paties „Apple ID“, naudoto prenumeratai įsigyti.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Aktyvuokite „Privacy Pro“ darbalaukyje, kad nustatytumėte Asmeninės informacijos pašalinimą.</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-lv/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-lv/strings-subscriptions.xml
@@ -95,6 +95,7 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Atjaunināt plānu vai atcelt</string>
+    <string name="changePlanDescription">Tavs abonements tika iegādāts Apple App Store veikalā. Lai mainītu plāna vai norēķinu iestatījumus, atver sadaļu Iestatījumi &gt; Apple konts &gt; Abonementi ierīcē, kas pierakstīta tajā pašā Apple kontā, kas izmantots abonementa iegādei.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Aktivizē Privacy Pro datorā, lai iestatītu Personal Information Removal</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-lv/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-lv/strings-subscriptions.xml
@@ -95,7 +95,6 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Atjaunināt plānu vai atcelt</string>
-    <string name="changePlanDescription">Tavs abonements tika iegādāts Apple App Store veikalā. Lai mainītu plāna vai norēķinu iestatījumus, atver sadaļu Iestatījumi &gt; Apple ID &gt; Abonementi ierīcē, kas pierakstīta tajā pašā Apple ID, kas izmantots abonementa iegādei.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Aktivizē Privacy Pro datorā, lai iestatītu Personal Information Removal</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-nb/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-nb/strings-subscriptions.xml
@@ -95,6 +95,7 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Oppdater eller avslutt abonnementet</string>
+    <string name="changePlanDescription">Abonnementet ditt ble kjøpt gjennom Apple App Store. Hvis du vil endre abonnementet eller faktureringsinnstillingene, må du gå til Innstillinger &gt; Apple-konto &gt; Abonnementer på en enhet som er logget på samme Apple-konto som ble brukt til å kjøpe abonnementet.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Aktiver Privacy Pro på en datamaskin for å konfigurere Personal Information Removal</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-nb/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-nb/strings-subscriptions.xml
@@ -95,7 +95,6 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Oppdater eller avslutt abonnementet</string>
-    <string name="changePlanDescription">Abonnementet ditt ble kjøpt gjennom Apple App Store. Hvis du vil endre abonnementet eller faktureringsinnstillingene, må du gå til Innstillinger &gt; Apple ID &gt; Abonnementer på en enhet som er logget på samme Apple ID som ble brukt til å kjøpe abonnementet.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Aktiver Privacy Pro på en datamaskin for å konfigurere Personal Information Removal</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-nl/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-nl/strings-subscriptions.xml
@@ -95,6 +95,7 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Plan bijwerken of annuleren</string>
+    <string name="changePlanDescription">Je abonnement is aangeschaft via de Apple App Store. Om je abonnement of factureringsinstellingen te wijzigen, ga je naar \'Instellingen\' &gt; \'Apple-account\' &gt; \'Abonnementen\' op een apparaat dat is aangemeld bij hetzelfde Apple-account waarmee je het abonnement hebt gekocht.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Activeer Privacy Pro op je desktop om Personal Information Removal in te stellen.</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-nl/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-nl/strings-subscriptions.xml
@@ -95,7 +95,6 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Plan bijwerken of annuleren</string>
-    <string name="changePlanDescription">Je abonnement is aangeschaft via de Apple App Store. Je kunt je abonnement of factureringsinstellingen wijzigen door \'Instellingen\' &gt; \'Apple-ID\' &gt; \'Abonnementen\' te openen op een apparaat dat is aangemeld bij dezelfde Apple-ID waarmee je het abonnement hebt gekocht.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Activeer Privacy Pro op je desktop om Personal Information Removal in te stellen.</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-pl/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-pl/strings-subscriptions.xml
@@ -95,7 +95,6 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Aktualizuj lub anuluj plan</string>
-    <string name="changePlanDescription">Twoja subskrypcja została zakupiona za pośrednictwem sklepu Apple App Store. Aby zmienić plan lub ustawienia rozliczeń, wybierz kolejno Ustawienia &gt; Apple ID &gt; Subskrypcje na urządzeniu zalogowanym na konto Apple ID wykorzystane do zakupu subskrypcji.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Aktywuj Privacy Pro na komputerze, aby skonfigurować usługę Personal Information Removal</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-pl/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-pl/strings-subscriptions.xml
@@ -95,6 +95,7 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Aktualizuj lub anuluj plan</string>
+    <string name="changePlanDescription">Twoja subskrypcja została zakupiona za pośrednictwem sklepu Apple App Store. Aby zmienić plan lub ustawienia rozliczeń, wybierz kolejno Ustawienia &gt; Konto Apple &gt; Subskrypcje na urządzeniu zalogowanym na konto Apple wykorzystane do zakupu subskrypcji.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Aktywuj Privacy Pro na komputerze, aby skonfigurować usługę Personal Information Removal</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-pt/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-pt/strings-subscriptions.xml
@@ -95,6 +95,7 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Atualizar Plano ou Cancelar</string>
+    <string name="changePlanDescription">A tua subscrição foi adquirida na Apple App Store. Para alterares o teu plano ou as definições de faturação, acede a Definições &gt; Conta Apple &gt; Subscrições num dispositivo com sessão iniciada na mesma conta Apple utilizada para comprar a tua subscrição.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Ativa o Privacy Pro no computador para configurar a Personal Information Removal</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-pt/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-pt/strings-subscriptions.xml
@@ -95,7 +95,6 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Atualizar Plano ou Cancelar</string>
-    <string name="changePlanDescription">A tua subscrição foi adquirida na Apple App Store. Para alterares o teu plano ou as definições de faturação, acede a Definições &gt; ID Apple &gt; Subscrições num dispositivo com sessão iniciada no mesmo ID Apple usado para comprar a tua subscrição.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Ativa o Privacy Pro no computador para configurar a Personal Information Removal</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-ro/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-ro/strings-subscriptions.xml
@@ -95,6 +95,7 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Actualizează planul sau anulează</string>
+    <string name="changePlanDescription">Abonamentul tău a fost achiziționat prin Apple App Store. Pentru a-ți modifica planul sau setările de facturare, accesează Setări &gt; Cont Apple &gt; Abonamente pe un dispozitiv conectat la același cont Apple folosit pentru achiziționarea abonamentului.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Activează Privacy Pro pe desktop pentru a configura Personal Information Removal</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-ro/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-ro/strings-subscriptions.xml
@@ -95,7 +95,6 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Actualizează planul sau anulează</string>
-    <string name="changePlanDescription">Abonamentul tău a fost achiziționat prin Apple App Store. Pentru a-ți modifica planul sau setările de facturare, accesează Setări &gt; Apple ID &gt; Abonamente pe un dispozitiv conectat la același ID Apple folosit pentru achiziționarea abonamentului.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Activează Privacy Pro pe desktop pentru a configura Personal Information Removal</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-ru/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-ru/strings-subscriptions.xml
@@ -95,6 +95,7 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Изменить или отменить подписку</string>
+    <string name="changePlanDescription">Подписка приобретена в магазине приложений Apple App Store. Чтобы изменить тарифный план или платежные параметры, откройте раздел «Настройки &gt; Аккаунт Apple &gt; Подписки» на устройстве, где выполнен вход в ту же учетную запись Apple, через которую была оформлена подписка.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Чтобы включить функцию Personal Information Removal, активируйте подписку Privacy Pro на настольном компьютере</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-ru/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-ru/strings-subscriptions.xml
@@ -95,7 +95,6 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Изменить или отменить подписку</string>
-    <string name="changePlanDescription">Подписка приобретена в магазине приложений Apple App Store. Чтобы изменить тарифный план или платежные параметры, откройте раздел «Настройки &gt; Apple ID &gt; Подписки» на устройстве, где выполнен вход под тем же идентификатором Apple ID, с помощью которого была оформлена подписка.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Чтобы включить функцию Personal Information Removal, активируйте подписку Privacy Pro на настольном компьютере</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-sk/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-sk/strings-subscriptions.xml
@@ -95,7 +95,6 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Aktualizovať plán alebo zrušiť</string>
-    <string name="changePlanDescription">Tvoje predplatné bolo zakúpené prostredníctvom obchodu Apple App Store. Ak chceš zmeniť nastavenia plánu alebo fakturácie, prejdi do časti Nastavenia &gt; Apple ID &gt; Predplatné na zariadení prihlásenom do rovnakého Apple ID, ktoré bolo použité na zakúpenie predplatného.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Aktivuj si Privacy Pro na pracovnej ploche a nastav si Personal Information Removal</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-sk/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-sk/strings-subscriptions.xml
@@ -95,6 +95,7 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Aktualizovať plán alebo zrušiť</string>
+    <string name="changePlanDescription">Tvoje predplatné bolo zakúpené prostredníctvom obchodu Apple App Store. Ak chceš zmeniť svoje nastavenia plánu alebo fakturácie, prejdi do časti Nastavenia &gt; Apple účet &gt; Predplatné na zariadení prihlásenom do rovnakého Apple účtu, ktorý bol použitý na zakúpenie predplatného.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Aktivuj si Privacy Pro na pracovnej ploche a nastav si Personal Information Removal</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-sl/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-sl/strings-subscriptions.xml
@@ -95,7 +95,6 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Posodobitev paketa ali preklic</string>
-    <string name="changePlanDescription">Vaša naročnina je bila kupljena v trgovini Apple App Store. Če želite spremeniti nastavitve načrta ali obračunavanja, pojdite v Nastavitve &gt; Apple ID &gt; Naročnine v napravi, ki je prijavljena v isti Apple ID, ki je bil uporabljen za nakup naročnine.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Aktivirajte Privacy Pro na namizju, da nastavite Personal Information Removal</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-sl/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-sl/strings-subscriptions.xml
@@ -95,6 +95,7 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Posodobitev paketa ali preklic</string>
+    <string name="changePlanDescription">Vaša naročnina je bila kupljena v trgovini Apple App Store. Če želite spremeniti naročnino ali nastavitve obračunavanja, v napravi, ki je prijavljena v isti račun Apple, kot je bil uporabljen za nakup naročnine, odprite Nastavitve &gt; Račun Apple &gt; Naročnine.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Aktivirajte Privacy Pro na namizju, da nastavite Personal Information Removal</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-sv/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-sv/strings-subscriptions.xml
@@ -95,6 +95,7 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Uppdatera abonnemang eller avbryt</string>
+    <string name="changePlanDescription">Ditt abonnemang köptes genom Apple App Store. För att ändra ditt abonnemang eller faktureringsinställningar går du till Inställningar &gt; Apple-konto &gt; Abonnemang på en enhet som är inloggad på det Apple-konto som användes för att köpa ditt abonnemang.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Aktivera Privacy Pro på en dator för att konfigurera Personal Information Removal</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-sv/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-sv/strings-subscriptions.xml
@@ -95,7 +95,6 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Uppdatera abonnemang eller avbryt</string>
-    <string name="changePlanDescription">Ditt abonnemang köptes genom Apple App Store. För att ändra ditt abonnemang eller faktureringsinställningar går du till Inställningar &gt; Apple-konto &gt; Abonnemang på en enhet som är inloggad på det Apple-konto som användes för att köpa ditt abonnemang.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Aktivera Privacy Pro på en dator för att konfigurera Personal Information Removal</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-tr/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-tr/strings-subscriptions.xml
@@ -95,7 +95,6 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Planı Güncelle veya İptal Et</string>
-    <string name="changePlanDescription">Aboneliğiniz Apple App Store üzerinden satın alınmış. Planınızı veya faturalandırma ayarlarınızı değiştirmek için lütfen aboneliğinizi satın alırken kullandığınız Apple Kimliği ile giriş yapmış bir cihazdan Ayarlar &gt; Apple Kimliği &gt; Abonelikler bölümüne gidin.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Personal Information Removal kurulumu için masaüstünde Privacy Pro\'yu etkinleştirin</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values-tr/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-tr/strings-subscriptions.xml
@@ -95,6 +95,7 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Planı Güncelle veya İptal Et</string>
+    <string name="changePlanDescription">Aboneliğiniz Apple App Store üzerinden satın alınmış. Planınızı veya faturalandırma ayarlarınızı değiştirmek için lütfen aboneliğinizi satın alırken kullandığınız Apple Hesabı ile giriş yapmış bir cihazdan Ayarlar &gt; Apple Hesabı &gt; Abonelikler bölümüne gidin.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Personal Information Removal kurulumu için masaüstünde Privacy Pro\'yu etkinleştirin</string>

--- a/subscriptions/subscriptions-impl/src/main/res/values/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values/strings-subscriptions.xml
@@ -94,7 +94,7 @@
 
     <!-- Change Plan -->
     <string name="changePlanTitle">Update Plan or Cancel</string>
-    <string name="changePlanDescription">Your subscription was purchased through the Apple App Store. To change your plan or billing settings, please go to Settings > Apple ID > Subscriptions on a device signed in to the same Apple ID used to purchase your subscription.</string>
+    <string name="changePlanDescription">Your subscription was purchased through the Apple App Store. To change your plan or billing settings, please go to Settings > Apple Account > Subscriptions on a device signed in to the same Apple Account used to purchase your subscription.</string>
 
     <!-- PIR Activity-->
     <string name="pirTitle">Activate Privacy Pro on desktop to set up Personal Information Removal</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205648422731273/1209235571983213

### Description

Apple ID is now called Apple Account. This PR updates string resources to reflect that change.

### Steps to test this PR

QA-optional

### No UI changes
