### PR TITLE
Update survey param: locale

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/survey/rmf/DefaultSurveyParameters.kt
+++ b/app/src/main/java/com/duckduckgo/app/survey/rmf/DefaultSurveyParameters.kt
@@ -112,5 +112,5 @@ class LocaleSurveyParameterPlugin @Inject constructor(
 ) : SurveyParameterPlugin {
     override val surveyParamKey: String = "locale"
 
-    override suspend fun evaluate(): String = appBuildConfig.deviceLocale.toString()
+    override suspend fun evaluate(): String = "${appBuildConfig.deviceLocale.language}-${appBuildConfig.deviceLocale.country}"
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1209346433224872

### Description
Update locale survey param format from `en-US` to `en-US`

### Steps to test this PR

- [ ] Create a new JSONBlob with [RMF format](https://staticcdn.duckduckgo.com/remotemessaging/config/v1/android-config.json) and edit the following Message:

> {
      "id": "android_privacy_pro_exit_survey_1",
      "content": {
            "messageType": "big_single_action",
            "titleText": "Tell Us Why You Left Privacy Pro",
            "descriptionText": "By taking our brief survey, you'll help us improve Privacy Pro for all subscribers. ",
            "placeholder": "PrivacyShield",
            "primaryActionText": "Take Survey",
            "primaryAction": {
             "type": "survey",
              "value": "https://selfserve.decipherinc.com/survey/selfserve/32ab/privacypro_exitsurvey?list=3",
              "additionalParameters": {
                    "queryParams":"var;ddgv;man;mo;av;ppro_platform;ppro_billing;ppro_days_since_purchase;locale"
               }
            }
        },
      "matchingRules": []
    },

- Replace endpoint for the JSONBlob one in `RemoteMessagingService`
- Fresh install
- Finish onboarding
- Check RMF appears
- Tap on 'Take Survey' button
- [ ] Check locale is on the URL as a query param with format `language-country`

### No UI changes
