### PR TITLE
Additional "default browser" prompts: fixed an issue with disabling the experiment remotely

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/DefaultBrowserPromptsExperimentImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/DefaultBrowserPromptsExperimentImpl.kt
@@ -274,7 +274,10 @@ class DefaultBrowserPromptsExperimentImpl @Inject constructor(
                 }
             }
 
-            val action = experimentStageEvaluatorPluginPoint.getPlugins().first { it.targetCohort == activeCohortName }.evaluate(newExperimentStage)
+            val action = experimentStageEvaluatorPluginPoint.getPlugins()
+                .firstOrNull { it.targetCohort == activeCohortName }?.evaluate(newExperimentStage)
+                ?: DefaultBrowserPromptsExperimentStageAction.disableAll // if there's no matching evaluator, or cohort is null or disabled, clean up
+
             if (action.showMessageDialog) {
                 _commands.send(OpenMessageDialog)
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1208671518894266/1209349005070380

### Description

Checks whether there are valid evaluators for a cohort, or clean ups side effects if not. This helps with a situation when the experiment is disabled remotely and there's no current active cohort.

### Steps to test this PR

1. Open the app and go through onboarding. DDG **should not** be set as your default browser.
2. Load this config https://www.jsonblob.com/api/1337370852936835072 which contains the experiment enabled for variant 3.
3. Change the device's date to next day, a CTA dialog will show and a menu item will be added.
4. Load this config https://www.jsonblob.com/api/1337385724919603200 which has the experiment disabled.
5. The menu item should be gone.

Example video:

[Screen_recording_20250207_124710.webm](https://github.com/user-attachments/assets/75899ae7-9fc1-4e65-973a-a2df69a55d34)
