### PR TITLE
Delete favicon along with preview

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2754,6 +2754,7 @@ class BrowserTabViewModel @Inject constructor(
 
     fun deleteTabPreview(tabId: String) {
         tabRepository.updateTabPreviewImage(tabId, null)
+        tabRepository.updateTabFavicon(tabId, null)
     }
 
     override fun handleAppLink(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1209289574297311 

### Description
Also delete favicon when deleting tab preview

### Steps to test this PR

_Feature 1_
- [ ] Open wikipedia.org
- [ ] Go to tab switcher, check there's a preview for Wikipedia with the Wikipedia favicon
- [ ] Open https://privacy-test-pages.site/security/badware/phishing.html
- [ ] Wait for the error page to show
- [ ] Open tab swticher
- [ ] Check there's no preview anymore, and the Wikipedia favicon has disappeared 

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
