### PR TITLE
Multi-selection: Selection mode

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabSwitcherItemDiffCallback.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabSwitcherItemDiffCallback.kt
@@ -19,13 +19,13 @@ package com.duckduckgo.app.browser.tabs.adapter
 import android.os.Bundle
 import androidx.recyclerview.widget.DiffUtil
 import com.duckduckgo.app.tabs.ui.TabSwitcherItem
-import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel
+import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.Mode
 
 class TabSwitcherItemDiffCallback(
     old: List<TabSwitcherItem>,
     new: List<TabSwitcherItem>,
-    private val oldMode: TabSwitcherViewModel.SelectionViewState.Mode = TabSwitcherViewModel.SelectionViewState.Mode.Normal,
-    private val newMode: TabSwitcherViewModel.SelectionViewState.Mode = TabSwitcherViewModel.SelectionViewState.Mode.Normal,
+    private val oldMode: Mode = Mode.Normal,
+    private val newMode: Mode = Mode.Normal,
 ) : DiffUtil.Callback() {
 
     // keep a local copy of the lists to avoid any changes to the lists during the diffing process
@@ -49,7 +49,8 @@ class TabSwitcherItemDiffCallback(
                     oldItem.tabEntity.viewed == newItem.tabEntity.viewed &&
                     oldItem.tabEntity.title == newItem.tabEntity.title &&
                     oldItem.tabEntity.url == newItem.tabEntity.url &&
-                    oldItem.isSelected == newItem.isSelected
+                    oldItem.isSelected == newItem.isSelected &&
+                    oldMode == newMode
             }
             else -> false
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabSwitcherItemDiffCallback.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabSwitcherItemDiffCallback.kt
@@ -20,7 +20,6 @@ import android.os.Bundle
 import androidx.recyclerview.widget.DiffUtil
 import com.duckduckgo.app.tabs.ui.TabSwitcherItem
 import com.duckduckgo.app.tabs.ui.TabSwitcherItem.SelectableTab
-import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.Mode
 
 class TabSwitcherItemDiffCallback(
     old: List<TabSwitcherItem>,

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabSwitcherItemDiffCallback.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabSwitcherItemDiffCallback.kt
@@ -19,7 +19,7 @@ package com.duckduckgo.app.browser.tabs.adapter
 import android.os.Bundle
 import androidx.recyclerview.widget.DiffUtil
 import com.duckduckgo.app.tabs.ui.TabSwitcherItem
-import com.duckduckgo.app.tabs.ui.TabSwitcherItem.SelectableTab
+import com.duckduckgo.app.tabs.ui.TabSwitcherItem.Tab.SelectableTab
 
 class TabSwitcherItemDiffCallback(
     old: List<TabSwitcherItem>,

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabSwitcherItemDiffCallback.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabSwitcherItemDiffCallback.kt
@@ -42,7 +42,8 @@ class TabSwitcherItemDiffCallback(old: List<TabSwitcherItem>, new: List<TabSwitc
                 oldItem.tabEntity.tabPreviewFile == newItem.tabEntity.tabPreviewFile &&
                     oldItem.tabEntity.viewed == newItem.tabEntity.viewed &&
                     oldItem.tabEntity.title == newItem.tabEntity.title &&
-                    oldItem.tabEntity.url == newItem.tabEntity.url
+                    oldItem.tabEntity.url == newItem.tabEntity.url &&
+                    oldItem.isSelected == newItem.isSelected
             }
             else -> false
         }
@@ -70,6 +71,10 @@ class TabSwitcherItemDiffCallback(old: List<TabSwitcherItem>, new: List<TabSwitc
 
                 if (oldItem.tabEntity.tabPreviewFile != newItem.tabEntity.tabPreviewFile) {
                     diffBundle.putString(DIFF_KEY_PREVIEW, newItem.tabEntity.tabPreviewFile)
+                }
+
+                if (oldItem.isSelected != newItem.isSelected) {
+                    diffBundle.putBoolean(DIFF_KEY_SELECTION, newItem.isSelected)
                 }
             }
         }
@@ -114,5 +119,6 @@ class TabSwitcherItemDiffCallback(old: List<TabSwitcherItem>, new: List<TabSwitc
         const val DIFF_KEY_URL = "url"
         const val DIFF_KEY_PREVIEW = "previewImage"
         const val DIFF_KEY_VIEWED = "viewed"
+        const val DIFF_KEY_SELECTION = "selection"
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabSwitcherItemDiffCallback.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabSwitcherItemDiffCallback.kt
@@ -19,13 +19,12 @@ package com.duckduckgo.app.browser.tabs.adapter
 import android.os.Bundle
 import androidx.recyclerview.widget.DiffUtil
 import com.duckduckgo.app.tabs.ui.TabSwitcherItem
+import com.duckduckgo.app.tabs.ui.TabSwitcherItem.SelectableTab
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.Mode
 
 class TabSwitcherItemDiffCallback(
     old: List<TabSwitcherItem>,
     new: List<TabSwitcherItem>,
-    private val oldMode: Mode = Mode.Normal,
-    private val newMode: Mode = Mode.Normal,
 ) : DiffUtil.Callback() {
 
     // keep a local copy of the lists to avoid any changes to the lists during the diffing process
@@ -49,8 +48,7 @@ class TabSwitcherItemDiffCallback(
                     oldItem.tabEntity.viewed == newItem.tabEntity.viewed &&
                     oldItem.tabEntity.title == newItem.tabEntity.title &&
                     oldItem.tabEntity.url == newItem.tabEntity.url &&
-                    oldItem.isSelected == newItem.isSelected &&
-                    oldMode == newMode
+                    (oldItem as? SelectableTab)?.isSelected == (newItem as? SelectableTab)?.isSelected
             }
             else -> false
         }
@@ -80,8 +78,8 @@ class TabSwitcherItemDiffCallback(
                     diffBundle.putString(DIFF_KEY_PREVIEW, newItem.tabEntity.tabPreviewFile)
                 }
 
-                if (oldItem.isSelected != newItem.isSelected || oldMode != newMode) {
-                    diffBundle.putBoolean(DIFF_KEY_SELECTION, newItem.isSelected)
+                if ((oldItem as? SelectableTab)?.isSelected != (newItem as? SelectableTab)?.isSelected) {
+                    diffBundle.putString(DIFF_KEY_SELECTION, null)
                 }
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabSwitcherItemDiffCallback.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabSwitcherItemDiffCallback.kt
@@ -19,8 +19,14 @@ package com.duckduckgo.app.browser.tabs.adapter
 import android.os.Bundle
 import androidx.recyclerview.widget.DiffUtil
 import com.duckduckgo.app.tabs.ui.TabSwitcherItem
+import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel
 
-class TabSwitcherItemDiffCallback(old: List<TabSwitcherItem>, new: List<TabSwitcherItem>) : DiffUtil.Callback() {
+class TabSwitcherItemDiffCallback(
+    old: List<TabSwitcherItem>,
+    new: List<TabSwitcherItem>,
+    private val oldMode: TabSwitcherViewModel.SelectionViewState.Mode = TabSwitcherViewModel.SelectionViewState.Mode.Normal,
+    private val newMode: TabSwitcherViewModel.SelectionViewState.Mode = TabSwitcherViewModel.SelectionViewState.Mode.Normal,
+) : DiffUtil.Callback() {
 
     // keep a local copy of the lists to avoid any changes to the lists during the diffing process
     private val oldList = old.toList()
@@ -73,7 +79,7 @@ class TabSwitcherItemDiffCallback(old: List<TabSwitcherItem>, new: List<TabSwitc
                     diffBundle.putString(DIFF_KEY_PREVIEW, newItem.tabEntity.tabPreviewFile)
                 }
 
-                if (oldItem.isSelected != newItem.isSelected) {
+                if (oldItem.isSelected != newItem.isSelected || oldMode != newMode) {
                     diffBundle.putBoolean(DIFF_KEY_SELECTION, newItem.isSelected)
                 }
             }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabItemDecorator.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabItemDecorator.kt
@@ -25,6 +25,8 @@ import android.view.View
 import androidx.core.content.ContextCompat
 import androidx.core.view.children
 import androidx.recyclerview.widget.RecyclerView
+import com.duckduckgo.app.tabs.ui.TabSwitcherItem.Tab.NormalTab
+import com.duckduckgo.app.tabs.ui.TabSwitcherItem.Tab.SelectableTab
 import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.mobile.android.R as CommonR
 
@@ -59,10 +61,10 @@ class TabItemDecorator(context: Context) : RecyclerView.ItemDecoration() {
             val positionInAdapter = recyclerView.getChildAdapterPosition(child)
             adapter.getTabSwitcherItem(positionInAdapter)?.let { tabSwitcherItem ->
                 when {
-                    tabSwitcherItem is TabSwitcherItem.SelectableTab && tabSwitcherItem.isSelected -> {
+                    tabSwitcherItem is SelectableTab && tabSwitcherItem.isSelected -> {
                         drawTabDecoration(child, canvas, selectionBorderStroke)
                     }
-                    tabSwitcherItem is TabSwitcherItem.NormalTab && tabSwitcherItem.isActive -> {
+                    tabSwitcherItem is NormalTab && tabSwitcherItem.isActive -> {
                         drawTabDecoration(child, canvas, activeTabBorderStroke)
                     }
                 }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabItemDecorator.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabItemDecorator.kt
@@ -65,7 +65,7 @@ class TabItemDecorator(
         recyclerView.children.forEach { child ->
             val positionInAdapter = recyclerView.getChildAdapterPosition(child)
             adapter.getTabSwitcherItem(positionInAdapter)?.let { tabSwitcherItem ->
-                if (tabSwitcherItem.isSelected) {
+                if ((tabSwitcherItem as? TabSwitcherItem.Tab)?.isSelected == true) {
                     drawSelectionTabDecoration(child, canvas)
                 } else if (tabSwitcherItem.id == highlightedTabId) {
                     drawActiveTabDecoration(child, canvas)

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabItemDecorator.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabItemDecorator.kt
@@ -29,15 +29,7 @@ import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.Mode
 import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.mobile.android.R as CommonR
 
-class TabItemDecorator(
-    context: Context,
-    tabSwitcherItemId: String?,
-    mode: Mode,
-) : RecyclerView.ItemDecoration() {
-
-    var highlightedTabId: String? = tabSwitcherItemId
-    var selectionMode: Mode = mode
-
+class TabItemDecorator(context: Context) : RecyclerView.ItemDecoration() {
     private val activeTabBorderStroke: Paint = Paint().apply {
         isAntiAlias = true
         style = Paint.Style.STROKE
@@ -67,12 +59,13 @@ class TabItemDecorator(
         recyclerView.children.forEach { child ->
             val positionInAdapter = recyclerView.getChildAdapterPosition(child)
             adapter.getTabSwitcherItem(positionInAdapter)?.let { tabSwitcherItem ->
-                if (selectionMode is Mode.Selection) {
-                    if (tabSwitcherItem is TabSwitcherItem.Tab && tabSwitcherItem.isSelected) {
+                when {
+                    tabSwitcherItem is TabSwitcherItem.SelectableTab && tabSwitcherItem.isSelected -> {
                         drawTabDecoration(child, canvas, selectionBorderStroke)
                     }
-                } else if (tabSwitcherItem.id == highlightedTabId) {
-                    drawTabDecoration(child, canvas, activeTabBorderStroke)
+                    tabSwitcherItem is TabSwitcherItem.NormalTab && tabSwitcherItem.isActive -> {
+                        drawTabDecoration(child, canvas, activeTabBorderStroke)
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabItemDecorator.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabItemDecorator.kt
@@ -25,7 +25,6 @@ import android.view.View
 import androidx.core.content.ContextCompat
 import androidx.core.view.children
 import androidx.recyclerview.widget.RecyclerView
-import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.Mode
 import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.mobile.android.R as CommonR
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabItemDecorator.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabItemDecorator.kt
@@ -25,16 +25,18 @@ import android.view.View
 import androidx.core.content.ContextCompat
 import androidx.core.view.children
 import androidx.recyclerview.widget.RecyclerView
+import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.Mode
 import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.mobile.android.R as CommonR
 
 class TabItemDecorator(
     context: Context,
-    var tabSwitcherItemId: String?,
+    tabSwitcherItemId: String?,
+    mode: Mode,
 ) : RecyclerView.ItemDecoration() {
 
     var highlightedTabId: String? = tabSwitcherItemId
-        private set
+    var selectionMode: Mode = mode
 
     private val activeTabBorderStroke: Paint = Paint().apply {
         isAntiAlias = true
@@ -65,8 +67,10 @@ class TabItemDecorator(
         recyclerView.children.forEach { child ->
             val positionInAdapter = recyclerView.getChildAdapterPosition(child)
             adapter.getTabSwitcherItem(positionInAdapter)?.let { tabSwitcherItem ->
-                if ((tabSwitcherItem as? TabSwitcherItem.Tab)?.isSelected == true) {
-                    drawTabDecoration(child, canvas, selectionBorderStroke)
+                if (selectionMode is Mode.Selection) {
+                    if (tabSwitcherItem is TabSwitcherItem.Tab && tabSwitcherItem.isSelected) {
+                        drawTabDecoration(child, canvas, selectionBorderStroke)
+                    }
                 } else if (tabSwitcherItem.id == highlightedTabId) {
                     drawTabDecoration(child, canvas, activeTabBorderStroke)
                 }
@@ -78,7 +82,7 @@ class TabItemDecorator(
 
     private fun drawTabDecoration(child: View, c: Canvas, paint: Paint) {
         selectionBorderStroke.alpha = (child.alpha * 255).toInt()
-        c.drawRoundRect(child.getBounds(), SELECTION_BORDER_WIDTH, SELECTION_BORDER_WIDTH, selectionBorderStroke)
+        c.drawRoundRect(child.getBounds(), BORDER_RADIUS, BORDER_RADIUS, paint)
     }
 
     private fun View.getBounds(): RectF {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabItemDecorator.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabItemDecorator.kt
@@ -66,9 +66,9 @@ class TabItemDecorator(
             val positionInAdapter = recyclerView.getChildAdapterPosition(child)
             adapter.getTabSwitcherItem(positionInAdapter)?.let { tabSwitcherItem ->
                 if ((tabSwitcherItem as? TabSwitcherItem.Tab)?.isSelected == true) {
-                    drawSelectionTabDecoration(child, canvas)
+                    drawTabDecoration(child, canvas, selectionBorderStroke)
                 } else if (tabSwitcherItem.id == highlightedTabId) {
-                    drawActiveTabDecoration(child, canvas)
+                    drawTabDecoration(child, canvas, activeTabBorderStroke)
                 }
             }
         }
@@ -76,18 +76,7 @@ class TabItemDecorator(
         super.onDrawOver(canvas, recyclerView, state)
     }
 
-    private fun drawActiveTabDecoration(
-        child: View,
-        c: Canvas,
-    ) {
-        activeTabBorderStroke.alpha = (child.alpha * 255).toInt()
-        c.drawRoundRect(child.getBounds(), BORDER_RADIUS, BORDER_RADIUS, activeTabBorderStroke)
-    }
-
-    private fun drawSelectionTabDecoration(
-        child: View,
-        c: Canvas,
-    ) {
+    private fun drawTabDecoration(child: View, c: Canvas, paint: Paint) {
         selectionBorderStroke.alpha = (child.alpha * 255).toInt()
         c.drawRoundRect(child.getBounds(), SELECTION_BORDER_WIDTH, SELECTION_BORDER_WIDTH, selectionBorderStroke)
     }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -483,9 +483,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
             R.id.downloads -> showDownloads()
             R.id.settings -> showSettings()
             android.R.id.home -> {
-                if (viewModel.onUpButtonPressed()) {
-                    finish()
-                }
+                viewModel.onUpButtonPressed()
                 return true
             }
         }
@@ -674,9 +672,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
             this,
             object : OnBackPressedCallback(true) {
                 override fun handleOnBackPressed() {
-                    if (viewModel.onBackButtonPressed()) {
-                        finish()
-                    }
+                    viewModel.onBackButtonPressed()
                 }
             },
         )

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -456,6 +456,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
     private fun initMenuClickListeners() {
         popupMenu.onMenuItemClicked(popupMenu.contentView.findViewById(R.id.newTabMenuItem)) { onNewTabRequested(fromOverflowMenu = true) }
         popupMenu.onMenuItemClicked(popupMenu.contentView.findViewById(R.id.selectAllMenuItem)) { viewModel.onSelectAllTabs() }
+        popupMenu.onMenuItemClicked(popupMenu.contentView.findViewById(R.id.deselectAllMenuItem)) { viewModel.onDeselectAllTabs() }
         popupMenu.onMenuItemClicked(popupMenu.contentView.findViewById(R.id.shareSelectedLinksMenuItem)) { viewModel.onShareSelectedTabs() }
         popupMenu.onMenuItemClicked(popupMenu.contentView.findViewById(R.id.bookmarkSelectedTabsMenuItem)) { viewModel.onBookmarkSelectedTabs() }
         popupMenu.onMenuItemClicked(popupMenu.contentView.findViewById(R.id.selectTabsMenuItem)) { viewModel.onSelectionModeRequested() }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -21,6 +21,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
+import android.view.MotionEvent
 import android.view.View
 import android.widget.TextView
 import androidx.activity.OnBackPressedCallback
@@ -231,6 +232,24 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
                         } else if (dy < 0) {
                             tabsFab.extend()
                         }
+                    }
+                },
+            )
+            tabsRecycler.addOnItemTouchListener(
+                object : RecyclerView.OnItemTouchListener {
+                    override fun onInterceptTouchEvent(rv: RecyclerView, e: MotionEvent): Boolean {
+                        if (e.action == MotionEvent.ACTION_DOWN && tabsRecycler.findChildViewUnder(e.x, e.y) == null) {
+                            viewModel.onEmptyAreaClicked()
+                        }
+                        return false
+                    }
+
+                    override fun onTouchEvent(rv: RecyclerView, e: MotionEvent) {
+                        // no-op
+                    }
+
+                    override fun onRequestDisallowInterceptTouchEvent(disallowIntercept: Boolean) {
+                        // no-op
                     }
                 },
             )

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -54,6 +54,9 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.TabManagerFeatureFlags
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType
+import com.duckduckgo.app.tabs.ui.TabSwitcherItem.NormalTab
+import com.duckduckgo.app.tabs.ui.TabSwitcherItem.SelectableTab
+import com.duckduckgo.app.tabs.ui.TabSwitcherItem.Tab
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.Close
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.CloseAllTabsRequest
@@ -219,7 +222,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
         val swipeListener = ItemTouchHelper(tabTouchHelper)
         swipeListener.attachToRecyclerView(tabsRecycler)
 
-        tabItemDecorator = TabItemDecorator(this, selectedTabId, viewModel.selectionViewState.value.mode)
+        tabItemDecorator = TabItemDecorator(this)
         tabsRecycler.addItemDecoration(tabItemDecorator)
 
         tabsRecycler.setHasFixedSize(true)
@@ -298,28 +301,28 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
             lifecycleScope.launch {
                 viewModel.selectionViewState.flowWithLifecycle(lifecycle, Lifecycle.State.STARTED).collectLatest {
                     tabsRecycler.invalidateItemDecorations()
-                    tabsAdapter.updateSelection(it.mode)
+                    tabsAdapter.updateData(it.items)
 
                     updateToolbarTitle(it.mode)
-                    updateTabGridItemDecorator(it.selectedTab?.tabId)
+                    updateTabGridItemDecorator()
 
                     invalidateOptionsMenu()
                 }
             }
         } else {
             viewModel.activeTab.observe(this) { tab ->
-                if (tab != null && tab.tabId != tabItemDecorator.highlightedTabId && !tab.deletable) {
-                    updateTabGridItemDecorator(tab.tabId)
+                if (tab != null && !tab.deletable) {
+                    updateTabGridItemDecorator()
                 }
             }
-        }
 
-        viewModel.tabSwitcherItems.observe(this) { tabSwitcherItems ->
-            tabsAdapter.updateData(tabSwitcherItems)
+            viewModel.tabSwitcherItems.observe(this) { tabSwitcherItems ->
+                tabsAdapter.updateData(tabSwitcherItems)
 
-            val noTabSelected = tabSwitcherItems.none { it.id == tabItemDecorator.highlightedTabId }
-            if (noTabSelected && tabSwitcherItems.isNotEmpty()) {
-                updateTabGridItemDecorator(tabSwitcherItems.last().id)
+                val noTabSelected = tabSwitcherItems.none { (it as? NormalTab)?.isActive == true }
+                if (noTabSelected && tabSwitcherItems.isNotEmpty()) {
+                    updateTabGridItemDecorator()
+                }
             }
         }
 
@@ -537,20 +540,17 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
 
     override fun onTabSelected(tab: TabEntity) {
         selectedTabId = tab.tabId
-        updateTabGridItemDecorator(selectedTabId)
         launch { viewModel.onTabSelected(tab) }
     }
 
-    private fun updateTabGridItemDecorator(tabId: String?) {
-        tabItemDecorator.highlightedTabId = tabId
-        tabItemDecorator.selectionMode = viewModel.selectionViewState.value.mode
+    private fun updateTabGridItemDecorator() {
         tabsRecycler.invalidateItemDecorations()
     }
 
     override fun onTabDeleted(position: Int, deletedBySwipe: Boolean) {
         tabsAdapter.getTabSwitcherItem(position)?.let { tab ->
             when (tab) {
-                is TabSwitcherItem.Tab -> {
+                is Tab -> {
                     launch {
                         viewModel.onMarkTabAsDeletable(
                             tab = tab.tabEntity,

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -27,7 +27,6 @@ import android.widget.TextView
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatDelegate.FEATURE_SUPPORT_ACTION_BAR
 import androidx.appcompat.widget.Toolbar
-import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -179,9 +178,12 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
     private fun configureFab() {
         tabsFab = binding.tabsFab
         if (tabManagerFeatureFlags.multiSelection().isEnabled()) {
-            tabsFab.show()
-            tabsFab.setOnClickListener {
-                viewModel.onFabClicked()
+            tabsFab.apply {
+                show()
+                extend()
+                setOnClickListener {
+                    viewModel.onFabClicked()
+                }
             }
         } else {
             tabsFab.hide()
@@ -481,8 +483,9 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
             R.id.downloads -> showDownloads()
             R.id.settings -> showSettings()
             android.R.id.home -> {
-                viewModel.onUpButtonPressed()
-                finish()
+                if (viewModel.onUpButtonPressed()) {
+                    finish()
+                }
                 return true
             }
         }
@@ -612,6 +615,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
                     }
                 },
             )
+            .setAnimationMode(BaseTransientBottomBar.ANIMATION_MODE_SLIDE)
             .apply { view.findViewById<TextView>(com.google.android.material.R.id.snackbar_text).maxLines = 1 }
             .show()
     }
@@ -670,8 +674,9 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
             this,
             object : OnBackPressedCallback(true) {
                 override fun handleOnBackPressed() {
-                    viewModel.onBackButtonPressed()
-                    finish()
+                    if (viewModel.onBackButtonPressed()) {
+                        finish()
+                    }
                 }
             },
         )

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -56,7 +56,6 @@ import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.Close
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.CloseAllTabsRequest
-import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.ViewState.Mode.Selection
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.menu.PopupMenu
@@ -217,8 +216,9 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
         val swipeListener = ItemTouchHelper(tabTouchHelper)
         swipeListener.attachToRecyclerView(tabsRecycler)
 
-        tabItemDecorator = TabItemDecorator(this, selectedTabId)
+        tabItemDecorator = TabItemDecorator(this, selectedTabId, viewModel.viewState.value.mode)
         tabsRecycler.addItemDecoration(tabItemDecorator)
+
         tabsRecycler.setHasFixedSize(true)
 
         if (tabManagerFeatureFlags.multiSelection().isEnabled()) {
@@ -238,35 +238,52 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
     }
 
     private fun configureObservers() {
-        viewModel.tabSwitcherItems.observe(this) { tabSwitcherItems ->
+        if (tabManagerFeatureFlags.multiSelection().isEnabled()) {
+            lifecycleScope.launch {
+                viewModel.viewState.flowWithLifecycle(lifecycle, Lifecycle.State.STARTED).collectLatest {
+                    tabsAdapter.updateData(it.tabs, it.mode)
 
-            render(tabSwitcherItems)
+                    tabsRecycler.invalidateItemDecorations()
 
-            val noTabSelected = tabSwitcherItems.none { it.id == tabItemDecorator.tabSwitcherItemId }
-            if (noTabSelected && tabSwitcherItems.isNotEmpty()) {
-                updateTabGridItemDecorator(tabSwitcherItems.last().id)
-            }
-        }
-        viewModel.activeTab.observe(this) { tab ->
-            if (tab != null && tab.tabId != tabItemDecorator.tabSwitcherItemId && !tab.deletable) {
-                updateTabGridItemDecorator(tab.tabId)
-            }
-        }
-        viewModel.deletableTabs.observe(this) {
-            if (it.isNotEmpty()) {
-                onDeletableTab(it.last())
-            }
-        }
+                    if (it.layoutType != null) {
+                        updateLayoutType(it.layoutType)
+                    }
 
-        lifecycleScope.launch {
-            viewModel.layoutType.flowWithLifecycle(lifecycle, Lifecycle.State.STARTED).filterNotNull().collect {
-                updateLayoutType(it)
-            }
-        }
+                    if (it.deletableTabs.isNotEmpty()) {
+                        onDeletableTab(it.deletableTabs.last())
+                    }
 
-        lifecycleScope.launch {
-            viewModel.viewState.flowWithLifecycle(lifecycle, Lifecycle.State.STARTED).collectLatest {
-                invalidateOptionsMenu()
+                    // if (it.selectedTab != null && it.selectedTab.tabId != tabItemDecorator.highlightedTabId && !it.selectedTab.deletable) {
+                    updateTabGridItemDecorator(it.selectedTab, it.mode)
+                    // }
+
+                    invalidateOptionsMenu()
+                }
+            }
+        } else {
+            viewModel.tabSwitcherItems.observe(this) { tabSwitcherItems ->
+                tabsAdapter.updateData(tabSwitcherItems)
+
+                val noTabSelected = tabSwitcherItems.none { it.id == tabItemDecorator.tabSwitcherItemId }
+                if (noTabSelected && tabSwitcherItems.isNotEmpty()) {
+                    updateTabGridItemDecorator(tabSwitcherItems.last().id)
+                }
+            }
+            viewModel.activeTab.observe(this) { tab ->
+                if (tab != null && tab.tabId != tabItemDecorator.tabSwitcherItemId && !tab.deletable) {
+                    updateTabGridItemDecorator(tab.tabId)
+                }
+            }
+            viewModel.deletableTabs.observe(this) {
+                if (it.isNotEmpty()) {
+                    onDeletableTab(it.last())
+                }
+            }
+
+            lifecycleScope.launch {
+                viewModel.layoutType.flowWithLifecycle(lifecycle, Lifecycle.State.STARTED).filterNotNull().collect {
+                    updateLayoutType(it)
+                }
             }
         }
 
@@ -340,10 +357,6 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
             viewModeMenuItem.title = getString(R.string.tabSwitcherListViewMenu)
             viewModeMenuItem.setVisible(true)
         }
-    }
-
-    private fun render(tabs: List<TabSwitcherItem>) {
-        tabsAdapter.updateData(tabs)
     }
 
     private fun scrollToShowCurrentTab() {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -53,8 +53,8 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.TabManagerFeatureFlags
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType
-import com.duckduckgo.app.tabs.ui.TabSwitcherItem.Tab.NormalTab
 import com.duckduckgo.app.tabs.ui.TabSwitcherItem.Tab
+import com.duckduckgo.app.tabs.ui.TabSwitcherItem.Tab.NormalTab
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.Close
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.CloseAllTabsRequest

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -53,7 +53,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.TabManagerFeatureFlags
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType
-import com.duckduckgo.app.tabs.ui.TabSwitcherItem.NormalTab
+import com.duckduckgo.app.tabs.ui.TabSwitcherItem.Tab.NormalTab
 import com.duckduckgo.app.tabs.ui.TabSwitcherItem.Tab
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.Close

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -301,7 +301,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
                     tabsAdapter.updateSelection(it.mode)
 
                     updateToolbarTitle(it.mode)
-                    updateTabGridItemDecorator(it.activeTab?.tabId)
+                    updateTabGridItemDecorator(it.selectedTab?.tabId)
 
                     invalidateOptionsMenu()
                 }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -442,7 +442,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
             val viewState = viewModel.selectionViewState.value
             val numSelectedTabs = (viewModel.selectionViewState.value.mode as? Selection)?.selectedTabs?.size ?: 0
 
-            layoutTypeMenuItem = menu.createDynamicInterface(numSelectedTabs, popupBinding, binding.tabsFab, viewState.dynamicInterface)
+            layoutTypeMenuItem = menu.createDynamicInterface(numSelectedTabs, popupBinding, binding.tabsFab, toolbar, viewState.dynamicInterface)
         } else {
             menuInflater.inflate(R.menu.menu_tab_switcher_activity, menu)
             layoutTypeMenuItem = menu.findItem(R.id.layoutTypeMenuItem)

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -230,33 +230,34 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
     }
 
     private fun handleSelectionModeCancellation() {
-        tabsRecycler.addOnItemTouchListener(object : RecyclerView.OnItemTouchListener {
-            private var lastEventAction: Int? = null
-            override fun onInterceptTouchEvent(rv: RecyclerView, e: MotionEvent): Boolean {
-                if (e.action == MotionEvent.ACTION_DOWN && tabsRecycler.findChildViewUnder(e.x, e.y) == null ||
-                    e.action == MotionEvent.ACTION_MOVE
-                ) {
-                    lastEventAction = e.action
-                } else if (e.action == MotionEvent.ACTION_UP) {
-                    if (lastEventAction == MotionEvent.ACTION_DOWN) {
-                        viewModel.onEmptyAreaClicked()
+        tabsRecycler.addOnItemTouchListener(
+            object : RecyclerView.OnItemTouchListener {
+                private var lastEventAction: Int? = null
+                override fun onInterceptTouchEvent(rv: RecyclerView, e: MotionEvent): Boolean {
+                    if (e.action == MotionEvent.ACTION_DOWN && tabsRecycler.findChildViewUnder(e.x, e.y) == null ||
+                        e.action == MotionEvent.ACTION_MOVE
+                    ) {
+                        lastEventAction = e.action
+                    } else if (e.action == MotionEvent.ACTION_UP) {
+                        if (lastEventAction == MotionEvent.ACTION_DOWN) {
+                            viewModel.onEmptyAreaClicked()
+                        }
+                        lastEventAction = null
                     }
-                    lastEventAction = null
+                    return false
                 }
-                return false
-            }
 
-            override fun onTouchEvent(
-                rv: RecyclerView,
-                e: MotionEvent,
-            ) {
-                // no-op
-            }
+                override fun onTouchEvent(
+                    rv: RecyclerView,
+                    e: MotionEvent,
+                ) {
+                    // no-op
+                }
 
-            override fun onRequestDisallowInterceptTouchEvent(disallowIntercept: Boolean) {
-                // no-op
-            }
-        },
+                override fun onRequestDisallowInterceptTouchEvent(disallowIntercept: Boolean) {
+                    // no-op
+                }
+            },
         )
     }
 
@@ -297,8 +298,11 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
                 viewModel.selectionViewState.flowWithLifecycle(lifecycle, Lifecycle.State.STARTED).collectLatest {
                     tabsRecycler.invalidateItemDecorations()
                     tabsAdapter.updateSelection(it.mode)
+
                     updateToolbarTitle(it.mode)
                     updateTabGridItemDecorator(it.activeTab?.tabId)
+                    updateFabType(it.fabType)
+
                     invalidateOptionsMenu()
                 }
             }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -237,9 +237,17 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
             )
             tabsRecycler.addOnItemTouchListener(
                 object : RecyclerView.OnItemTouchListener {
+                    private var lastEventAction: Int? = null
                     override fun onInterceptTouchEvent(rv: RecyclerView, e: MotionEvent): Boolean {
-                        if (e.action == MotionEvent.ACTION_DOWN && tabsRecycler.findChildViewUnder(e.x, e.y) == null) {
-                            viewModel.onEmptyAreaClicked()
+                        if (e.action == MotionEvent.ACTION_DOWN && tabsRecycler.findChildViewUnder(e.x, e.y) == null ||
+                            e.action == MotionEvent.ACTION_MOVE
+                        ) {
+                            lastEventAction = e.action
+                        } else if (e.action == MotionEvent.ACTION_UP) {
+                            if (lastEventAction == MotionEvent.ACTION_DOWN) {
+                                viewModel.onEmptyAreaClicked()
+                            }
+                            lastEventAction = null
                         }
                         return false
                     }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -55,7 +55,6 @@ import com.duckduckgo.app.tabs.TabManagerFeatureFlags
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType
 import com.duckduckgo.app.tabs.ui.TabSwitcherItem.NormalTab
-import com.duckduckgo.app.tabs.ui.TabSwitcherItem.SelectableTab
 import com.duckduckgo.app.tabs.ui.TabSwitcherItem.Tab
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.Close

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
@@ -40,10 +40,10 @@ import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.browser.tabpreview.WebViewPreviewPersister
 import com.duckduckgo.app.browser.tabs.adapter.TabSwitcherItemDiffCallback
 import com.duckduckgo.app.browser.tabs.adapter.TabSwitcherItemDiffCallback.Companion.DIFF_KEY_PREVIEW
+import com.duckduckgo.app.browser.tabs.adapter.TabSwitcherItemDiffCallback.Companion.DIFF_KEY_SELECTION
 import com.duckduckgo.app.browser.tabs.adapter.TabSwitcherItemDiffCallback.Companion.DIFF_KEY_TITLE
 import com.duckduckgo.app.browser.tabs.adapter.TabSwitcherItemDiffCallback.Companion.DIFF_KEY_URL
 import com.duckduckgo.app.browser.tabs.adapter.TabSwitcherItemDiffCallback.Companion.DIFF_KEY_VIEWED
-import com.duckduckgo.app.browser.tabs.adapter.TabSwitcherItemDiffCallback.Companion.DIFF_KEY_SELECTION
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType
 import com.duckduckgo.app.tabs.ui.TabSwitcherAdapter.TabSwitcherViewHolder.Companion.GRID_TAB

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
@@ -49,9 +49,9 @@ import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType
 import com.duckduckgo.app.tabs.ui.TabSwitcherAdapter.TabSwitcherViewHolder.Companion.GRID_TAB
 import com.duckduckgo.app.tabs.ui.TabSwitcherAdapter.TabSwitcherViewHolder.Companion.LIST_TAB
 import com.duckduckgo.app.tabs.ui.TabSwitcherAdapter.TabSwitcherViewHolder.TabViewHolder
-import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.ViewState.Mode
-import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.ViewState.Mode.Normal
-import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.ViewState.Mode.Selection
+import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.Mode
+import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.Mode.Normal
+import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.Mode.Selection
 import com.duckduckgo.common.ui.view.hide
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.utils.DispatcherProvider
@@ -311,8 +311,17 @@ class TabSwitcherAdapter(
         )
     }
 
-    fun updateData(updatedList: List<TabSwitcherItem>, uiMode: Mode = Normal) {
-        this.uiMode = uiMode
+    @SuppressLint("NotifyDataSetChanged")
+    fun updateSelection(mode: Mode) {
+        if (uiMode != mode) {
+            val diffResult = DiffUtil.calculateDiff(TabSwitcherItemDiffCallback(list, list, uiMode, mode))
+            diffResult.dispatchUpdatesTo(this)
+
+            uiMode = mode
+        }
+    }
+
+    fun updateData(updatedList: List<TabSwitcherItem>) {
         val diffResult = DiffUtil.calculateDiff(TabSwitcherItemDiffCallback(list, updatedList))
         list.clear()
         list.addAll(updatedList)

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
@@ -34,6 +34,7 @@ import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestManager
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
+import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.ItemTabGridBinding
 import com.duckduckgo.app.browser.databinding.ItemTabListBinding
 import com.duckduckgo.app.browser.favicon.FaviconManager
@@ -73,7 +74,7 @@ class TabSwitcherAdapter(
 
     private val list = mutableListOf<TabSwitcherItem>()
     private var isDragging: Boolean = false
-    private var layoutType: LayoutType = LayoutType.GRID
+    private var layoutType: LayoutType = GRID
 
     init {
         setHasStableIds(true)
@@ -113,10 +114,10 @@ class TabSwitcherAdapter(
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         when (holder) {
             is TabSwitcherViewHolder.GridTabViewHolder -> {
-                bindGridTab(holder, list[position])
+                bindGridTab(holder, list[position] as Tab)
             }
             is TabSwitcherViewHolder.ListTabViewHolder -> {
-                bindListTab(holder, list[position])
+                bindListTab(holder, list[position] as Tab)
             }
         }
     }
@@ -134,42 +135,34 @@ class TabSwitcherAdapter(
         }
     }
 
-    private fun bindListTab(holder: TabSwitcherViewHolder.ListTabViewHolder, tabItem: TabSwitcherItem) {
+    private fun bindListTab(holder: TabSwitcherViewHolder.ListTabViewHolder, tabItem: Tab) {
         val context = holder.binding.root.context
-        when (tabItem) {
-            is Tab -> {
-                holder.title.text = extractTabTitle(tabItem.tabEntity, context)
-                holder.url.text = tabItem.tabEntity.url ?: ""
-                holder.url.visibility = if (tabItem.tabEntity.url.isNullOrEmpty()) View.GONE else View.VISIBLE
-                updateUnreadIndicator(holder, tabItem.tabEntity)
-                loadFavicon(tabItem.tabEntity, holder.favicon)
-                loadSelectionState(holder, tabItem)
-                attachTabClickListeners(
-                    tabViewHolder = holder,
-                    bindingAdapterPosition = { holder.bindingAdapterPosition },
-                    tab = tabItem.tabEntity,
-                )
-            }
-        }
+        holder.title.text = extractTabTitle(tabItem.tabEntity, context)
+        holder.url.text = tabItem.tabEntity.url ?: ""
+        holder.url.visibility = if (tabItem.tabEntity.url.isNullOrEmpty()) View.GONE else View.VISIBLE
+        updateUnreadIndicator(holder, tabItem.tabEntity)
+        loadFavicon(tabItem.tabEntity, holder.favicon)
+        loadSelectionState(holder, tabItem)
+        attachTabClickListeners(
+            tabViewHolder = holder,
+            bindingAdapterPosition = { holder.bindingAdapterPosition },
+            tab = tabItem.tabEntity,
+        )
     }
 
-    private fun bindGridTab(holder: TabSwitcherViewHolder.GridTabViewHolder, tabItem: TabSwitcherItem) {
-        when (tabItem) {
-            is Tab -> {
-                val context = holder.binding.root.context
-                val glide = Glide.with(context)
-                holder.title.text = extractTabTitle(tabItem.tabEntity, context)
-                updateUnreadIndicator(holder, tabItem.tabEntity)
-                loadFavicon(tabItem.tabEntity, holder.favicon)
-                loadTabPreviewImage(tabItem.tabEntity, glide, holder)
-                loadSelectionState(holder, tabItem)
-                attachTabClickListeners(
-                    tabViewHolder = holder,
-                    bindingAdapterPosition = { holder.bindingAdapterPosition },
-                    tab = tabItem.tabEntity,
-                )
-            }
-        }
+    private fun bindGridTab(holder: TabSwitcherViewHolder.GridTabViewHolder, tab: Tab) {
+        val context = holder.binding.root.context
+        val glide = Glide.with(context)
+        holder.title.text = extractTabTitle(tab.tabEntity, context)
+        updateUnreadIndicator(holder, tab.tabEntity)
+        loadFavicon(tab.tabEntity, holder.favicon)
+        loadTabPreviewImage(tab.tabEntity, glide, holder)
+        loadSelectionState(holder, tab)
+        attachTabClickListeners(
+            tabViewHolder = holder,
+            bindingAdapterPosition = { holder.bindingAdapterPosition },
+            tab = tab.tabEntity,
+        )
     }
 
     private fun loadSelectionState(holder: TabViewHolder, tab: Tab) {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
@@ -43,11 +43,16 @@ import com.duckduckgo.app.browser.tabs.adapter.TabSwitcherItemDiffCallback.Compa
 import com.duckduckgo.app.browser.tabs.adapter.TabSwitcherItemDiffCallback.Companion.DIFF_KEY_TITLE
 import com.duckduckgo.app.browser.tabs.adapter.TabSwitcherItemDiffCallback.Companion.DIFF_KEY_URL
 import com.duckduckgo.app.browser.tabs.adapter.TabSwitcherItemDiffCallback.Companion.DIFF_KEY_VIEWED
+import com.duckduckgo.app.browser.tabs.adapter.TabSwitcherItemDiffCallback.Companion.DIFF_KEY_SELECTION
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType
 import com.duckduckgo.app.tabs.ui.TabSwitcherAdapter.TabSwitcherViewHolder.Companion.GRID_TAB
 import com.duckduckgo.app.tabs.ui.TabSwitcherAdapter.TabSwitcherViewHolder.Companion.LIST_TAB
 import com.duckduckgo.app.tabs.ui.TabSwitcherAdapter.TabSwitcherViewHolder.TabViewHolder
+import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.ViewState.Mode
+import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.ViewState.Mode.Normal
+import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.ViewState.Mode.Selection
+import com.duckduckgo.common.ui.view.hide
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.swap
@@ -67,6 +72,7 @@ class TabSwitcherAdapter(
     private val list = mutableListOf<TabSwitcherItem>()
     private var isDragging: Boolean = false
     private var layoutType: LayoutType = LayoutType.GRID
+    private var uiMode: Mode = Normal
 
     init {
         setHasStableIds(true)
@@ -106,12 +112,12 @@ class TabSwitcherAdapter(
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         when (holder) {
             is TabSwitcherViewHolder.GridTabViewHolder -> {
-                val tab = (list[position] as TabSwitcherItem.Tab).tabEntity
-                bindGridTab(holder, tab)
+                val tabItem = (list[position] as TabSwitcherItem.Tab)
+                bindGridTab(holder, tabItem)
             }
             is TabSwitcherViewHolder.ListTabViewHolder -> {
-                val tab = (list[position] as TabSwitcherItem.Tab).tabEntity
-                bindListTab(holder, tab)
+                val tabItem = (list[position] as TabSwitcherItem.Tab)
+                bindListTab(holder, tabItem)
             }
         }
     }
@@ -129,32 +135,49 @@ class TabSwitcherAdapter(
         }
     }
 
-    private fun bindListTab(holder: TabSwitcherViewHolder.ListTabViewHolder, tab: TabEntity) {
+    private fun bindListTab(holder: TabSwitcherViewHolder.ListTabViewHolder, tab: TabSwitcherItem.Tab) {
         val context = holder.binding.root.context
-        holder.title.text = extractTabTitle(tab, context)
-        holder.url.text = tab.url ?: ""
-        holder.url.visibility = if (tab.url.isNullOrEmpty()) View.GONE else View.VISIBLE
-        updateUnreadIndicator(holder, tab)
-        loadFavicon(tab, holder.favicon)
+        holder.title.text = extractTabTitle(tab.tabEntity, context)
+        holder.url.text = tab.tabEntity.url ?: ""
+        holder.url.visibility = if (tab.tabEntity.url.isNullOrEmpty()) View.GONE else View.VISIBLE
+        updateUnreadIndicator(holder, tab.tabEntity)
+        loadFavicon(tab.tabEntity, holder.favicon)
+        loadSelectionState(holder, tab)
         attachTabClickListeners(
             tabViewHolder = holder,
             bindingAdapterPosition = { holder.bindingAdapterPosition },
-            tab = tab,
+            tab = tab.tabEntity,
         )
     }
 
-    private fun bindGridTab(holder: TabSwitcherViewHolder.GridTabViewHolder, tab: TabEntity) {
+    private fun bindGridTab(holder: TabSwitcherViewHolder.GridTabViewHolder, tab: TabSwitcherItem.Tab) {
         val context = holder.binding.root.context
         val glide = Glide.with(context)
-        holder.title.text = extractTabTitle(tab, context)
-        updateUnreadIndicator(holder, tab)
-        loadFavicon(tab, holder.favicon)
-        loadTabPreviewImage(tab, glide, holder)
+        holder.title.text = extractTabTitle(tab.tabEntity, context)
+        updateUnreadIndicator(holder, tab.tabEntity)
+        loadFavicon(tab.tabEntity, holder.favicon)
+        loadTabPreviewImage(tab.tabEntity, glide, holder)
+        loadSelectionState(holder, tab)
         attachTabClickListeners(
             tabViewHolder = holder,
             bindingAdapterPosition = { holder.bindingAdapterPosition },
-            tab = tab,
+            tab = tab.tabEntity,
         )
+    }
+
+    private fun loadSelectionState(holder: TabViewHolder, tab: TabSwitcherItem.Tab) {
+        if (uiMode is Selection) {
+            if (tab.isSelected) {
+                holder.selectionIndicator.setImageResource(com.duckduckgo.mobile.android.R.drawable.ic_check_blue_round_24)
+            } else {
+                holder.selectionIndicator.setImageResource(com.duckduckgo.mobile.android.R.drawable.shape_grey_circle_24)
+            }
+            holder.selectionIndicator.show()
+            holder.close.hide()
+        } else {
+            holder.selectionIndicator.hide()
+            holder.close.show()
+        }
     }
 
     private fun extractTabTitle(tab: TabEntity, context: Context): String {
@@ -206,6 +229,10 @@ class TabSwitcherAdapter(
                 viewHolder.title.text = it
             }
 
+            if (bundle.containsKey(DIFF_KEY_SELECTION)) {
+                loadSelectionState(viewHolder, tab)
+            }
+
             if (bundle.containsKey(DIFF_KEY_VIEWED)) {
                 updateUnreadIndicator(viewHolder, tab.tabEntity)
             }
@@ -230,6 +257,10 @@ class TabSwitcherAdapter(
 
             bundle.getString(DIFF_KEY_TITLE)?.let {
                 viewHolder.title.text = it
+            }
+
+            if (bundle.containsKey(DIFF_KEY_SELECTION)) {
+                loadSelectionState(viewHolder, tab)
             }
 
             if (bundle.containsKey(DIFF_KEY_VIEWED)) {
@@ -280,7 +311,8 @@ class TabSwitcherAdapter(
         )
     }
 
-    fun updateData(updatedList: List<TabSwitcherItem>) {
+    fun updateData(updatedList: List<TabSwitcherItem>, uiMode: Mode = Normal) {
+        this.uiMode = uiMode
         val diffResult = DiffUtil.calculateDiff(TabSwitcherItemDiffCallback(list, updatedList))
         list.clear()
         list.addAll(updatedList)
@@ -329,6 +361,7 @@ class TabSwitcherAdapter(
             val title: TextView
             val close: ImageView
             val tabUnread: ImageView
+            val selectionIndicator: ImageView
         }
 
         data class GridTabViewHolder(
@@ -338,6 +371,7 @@ class TabSwitcherAdapter(
             override val title: TextView = binding.title,
             override val close: ImageView = binding.close,
             override val tabUnread: ImageView = binding.tabUnread,
+            override val selectionIndicator: ImageView = binding.selectionIndicator,
             val tabPreview: ImageView = binding.tabPreview,
         ) : TabSwitcherViewHolder(binding.root), TabViewHolder
 
@@ -348,6 +382,7 @@ class TabSwitcherAdapter(
             override val title: TextView = binding.title,
             override val close: ImageView = binding.close,
             override val tabUnread: ImageView = binding.tabUnread,
+            override val selectionIndicator: ImageView = binding.selectionIndicator,
             val url: TextView = binding.url,
         ) : TabSwitcherViewHolder(binding.root), TabViewHolder
     }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
@@ -52,7 +52,7 @@ import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType.LIST
 import com.duckduckgo.app.tabs.ui.TabSwitcherAdapter.TabSwitcherViewHolder.Companion.GRID_TAB
 import com.duckduckgo.app.tabs.ui.TabSwitcherAdapter.TabSwitcherViewHolder.Companion.LIST_TAB
 import com.duckduckgo.app.tabs.ui.TabSwitcherAdapter.TabSwitcherViewHolder.TabViewHolder
-import com.duckduckgo.app.tabs.ui.TabSwitcherItem.SelectableTab
+import com.duckduckgo.app.tabs.ui.TabSwitcherItem.Tab.SelectableTab
 import com.duckduckgo.app.tabs.ui.TabSwitcherItem.Tab
 import com.duckduckgo.common.ui.view.hide
 import com.duckduckgo.common.ui.view.show

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
@@ -57,11 +57,11 @@ import com.duckduckgo.common.ui.view.hide
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.swap
+import com.duckduckgo.mobile.android.R as commonR
+import java.io.File
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
-import java.io.File
-import com.duckduckgo.mobile.android.R as commonR
 
 class TabSwitcherAdapter(
     private val itemClickListener: TabSwitcherListener,

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
@@ -52,8 +52,8 @@ import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType.LIST
 import com.duckduckgo.app.tabs.ui.TabSwitcherAdapter.TabSwitcherViewHolder.Companion.GRID_TAB
 import com.duckduckgo.app.tabs.ui.TabSwitcherAdapter.TabSwitcherViewHolder.Companion.LIST_TAB
 import com.duckduckgo.app.tabs.ui.TabSwitcherAdapter.TabSwitcherViewHolder.TabViewHolder
-import com.duckduckgo.app.tabs.ui.TabSwitcherItem.Tab.SelectableTab
 import com.duckduckgo.app.tabs.ui.TabSwitcherItem.Tab
+import com.duckduckgo.app.tabs.ui.TabSwitcherItem.Tab.SelectableTab
 import com.duckduckgo.common.ui.view.hide
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.utils.DispatcherProvider

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
@@ -46,20 +46,22 @@ import com.duckduckgo.app.browser.tabs.adapter.TabSwitcherItemDiffCallback.Compa
 import com.duckduckgo.app.browser.tabs.adapter.TabSwitcherItemDiffCallback.Companion.DIFF_KEY_VIEWED
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType
+import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType.GRID
+import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType.LIST
 import com.duckduckgo.app.tabs.ui.TabSwitcherAdapter.TabSwitcherViewHolder.Companion.GRID_TAB
 import com.duckduckgo.app.tabs.ui.TabSwitcherAdapter.TabSwitcherViewHolder.Companion.LIST_TAB
 import com.duckduckgo.app.tabs.ui.TabSwitcherAdapter.TabSwitcherViewHolder.TabViewHolder
-import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.Mode
-import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.Mode.Normal
-import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.Mode.Selection
+import com.duckduckgo.app.tabs.ui.TabSwitcherItem.SelectableTab
+import com.duckduckgo.app.tabs.ui.TabSwitcherItem.Tab
 import com.duckduckgo.common.ui.view.hide
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.swap
-import java.io.File
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
+import java.io.File
+import com.duckduckgo.mobile.android.R as commonR
 
 class TabSwitcherAdapter(
     private val itemClickListener: TabSwitcherListener,
@@ -72,7 +74,6 @@ class TabSwitcherAdapter(
     private val list = mutableListOf<TabSwitcherItem>()
     private var isDragging: Boolean = false
     private var layoutType: LayoutType = LayoutType.GRID
-    private var uiMode: Mode = Normal
 
     init {
         setHasStableIds(true)
@@ -87,11 +88,11 @@ class TabSwitcherAdapter(
         return when (viewType) {
             GRID_TAB -> {
                 val binding = ItemTabGridBinding.inflate(inflater, parent, false)
-                return TabSwitcherViewHolder.GridTabViewHolder(binding)
+                TabSwitcherViewHolder.GridTabViewHolder(binding)
             }
             LIST_TAB -> {
                 val binding = ItemTabListBinding.inflate(inflater, parent, false)
-                return TabSwitcherViewHolder.ListTabViewHolder(binding)
+                TabSwitcherViewHolder.ListTabViewHolder(binding)
             }
             else -> throw IllegalArgumentException("Unknown viewType: $viewType")
         }
@@ -99,10 +100,10 @@ class TabSwitcherAdapter(
 
     override fun getItemViewType(position: Int): Int =
         when (list[position]) {
-            is TabSwitcherItem.Tab -> {
+            is Tab -> {
                 when (layoutType) {
-                    LayoutType.GRID -> GRID_TAB
-                    LayoutType.LIST -> LIST_TAB
+                    GRID -> GRID_TAB
+                    LIST -> LIST_TAB
                 }
             }
         }
@@ -112,12 +113,10 @@ class TabSwitcherAdapter(
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         when (holder) {
             is TabSwitcherViewHolder.GridTabViewHolder -> {
-                val tabItem = (list[position] as TabSwitcherItem.Tab)
-                bindGridTab(holder, tabItem)
+                bindGridTab(holder, list[position])
             }
             is TabSwitcherViewHolder.ListTabViewHolder -> {
-                val tabItem = (list[position] as TabSwitcherItem.Tab)
-                bindListTab(holder, tabItem)
+                bindListTab(holder, list[position])
             }
         }
     }
@@ -135,48 +134,59 @@ class TabSwitcherAdapter(
         }
     }
 
-    private fun bindListTab(holder: TabSwitcherViewHolder.ListTabViewHolder, tab: TabSwitcherItem.Tab) {
+    private fun bindListTab(holder: TabSwitcherViewHolder.ListTabViewHolder, tabItem: TabSwitcherItem) {
         val context = holder.binding.root.context
-        holder.title.text = extractTabTitle(tab.tabEntity, context)
-        holder.url.text = tab.tabEntity.url ?: ""
-        holder.url.visibility = if (tab.tabEntity.url.isNullOrEmpty()) View.GONE else View.VISIBLE
-        updateUnreadIndicator(holder, tab.tabEntity)
-        loadFavicon(tab.tabEntity, holder.favicon)
-        loadSelectionState(holder, tab)
-        attachTabClickListeners(
-            tabViewHolder = holder,
-            bindingAdapterPosition = { holder.bindingAdapterPosition },
-            tab = tab.tabEntity,
-        )
-    }
-
-    private fun bindGridTab(holder: TabSwitcherViewHolder.GridTabViewHolder, tab: TabSwitcherItem.Tab) {
-        val context = holder.binding.root.context
-        val glide = Glide.with(context)
-        holder.title.text = extractTabTitle(tab.tabEntity, context)
-        updateUnreadIndicator(holder, tab.tabEntity)
-        loadFavicon(tab.tabEntity, holder.favicon)
-        loadTabPreviewImage(tab.tabEntity, glide, holder)
-        loadSelectionState(holder, tab)
-        attachTabClickListeners(
-            tabViewHolder = holder,
-            bindingAdapterPosition = { holder.bindingAdapterPosition },
-            tab = tab.tabEntity,
-        )
-    }
-
-    private fun loadSelectionState(holder: TabViewHolder, tab: TabSwitcherItem.Tab) {
-        if (uiMode is Selection) {
-            if (tab.isSelected) {
-                holder.selectionIndicator.setImageResource(com.duckduckgo.mobile.android.R.drawable.ic_check_blue_round_24)
-            } else {
-                holder.selectionIndicator.setImageResource(com.duckduckgo.mobile.android.R.drawable.shape_grey_circle_24)
+        when (tabItem) {
+            is Tab -> {
+                holder.title.text = extractTabTitle(tabItem.tabEntity, context)
+                holder.url.text = tabItem.tabEntity.url ?: ""
+                holder.url.visibility = if (tabItem.tabEntity.url.isNullOrEmpty()) View.GONE else View.VISIBLE
+                updateUnreadIndicator(holder, tabItem.tabEntity)
+                loadFavicon(tabItem.tabEntity, holder.favicon)
+                loadSelectionState(holder, tabItem)
+                attachTabClickListeners(
+                    tabViewHolder = holder,
+                    bindingAdapterPosition = { holder.bindingAdapterPosition },
+                    tab = tabItem.tabEntity,
+                )
             }
-            holder.selectionIndicator.show()
-            holder.close.hide()
-        } else {
-            holder.selectionIndicator.hide()
-            holder.close.show()
+        }
+    }
+
+    private fun bindGridTab(holder: TabSwitcherViewHolder.GridTabViewHolder, tabItem: TabSwitcherItem) {
+        when (tabItem) {
+            is Tab -> {
+                val context = holder.binding.root.context
+                val glide = Glide.with(context)
+                holder.title.text = extractTabTitle(tabItem.tabEntity, context)
+                updateUnreadIndicator(holder, tabItem.tabEntity)
+                loadFavicon(tabItem.tabEntity, holder.favicon)
+                loadTabPreviewImage(tabItem.tabEntity, glide, holder)
+                loadSelectionState(holder, tabItem)
+                attachTabClickListeners(
+                    tabViewHolder = holder,
+                    bindingAdapterPosition = { holder.bindingAdapterPosition },
+                    tab = tabItem.tabEntity,
+                )
+            }
+        }
+    }
+
+    private fun loadSelectionState(holder: TabViewHolder, tab: Tab) {
+        when (tab) {
+            is SelectableTab -> {
+                if (tab.isSelected) {
+                    holder.selectionIndicator.setImageResource(commonR.drawable.ic_check_blue_round_24)
+                } else {
+                    holder.selectionIndicator.setImageResource(commonR.drawable.shape_grey_circle_24)
+                }
+                holder.selectionIndicator.show()
+                holder.close.hide()
+            }
+            else -> {
+                holder.selectionIndicator.hide()
+                holder.close.show()
+            }
         }
     }
 
@@ -199,12 +209,12 @@ class TabSwitcherAdapter(
         when (holder.itemViewType) {
             GRID_TAB -> handlePayloadsForGridTab(
                 viewHolder = holder as TabSwitcherViewHolder.GridTabViewHolder,
-                tab = list[position] as TabSwitcherItem.Tab,
+                tab = list[position] as Tab,
                 payloads = payloads,
             )
             LIST_TAB -> handlePayloadsForListTab(
                 viewHolder = holder as TabSwitcherViewHolder.ListTabViewHolder,
-                tab = list[position] as TabSwitcherItem.Tab,
+                tab = list[position] as Tab,
                 payloads = payloads,
             )
         }
@@ -212,7 +222,7 @@ class TabSwitcherAdapter(
 
     private fun handlePayloadsForGridTab(
         viewHolder: TabSwitcherViewHolder.GridTabViewHolder,
-        tab: TabSwitcherItem.Tab,
+        tab: Tab,
         payloads: MutableList<Any>,
     ) {
         for (payload in payloads) {
@@ -241,7 +251,7 @@ class TabSwitcherAdapter(
 
     private fun handlePayloadsForListTab(
         viewHolder: TabSwitcherViewHolder.ListTabViewHolder,
-        tab: TabSwitcherItem.Tab,
+        tab: Tab,
         payloads: MutableList<Any>,
     ) {
         for (payload in payloads) {
@@ -311,16 +321,6 @@ class TabSwitcherAdapter(
         )
     }
 
-    @SuppressLint("NotifyDataSetChanged")
-    fun updateSelection(mode: Mode) {
-        if (uiMode != mode) {
-            val diffResult = DiffUtil.calculateDiff(TabSwitcherItemDiffCallback(list, list, uiMode, mode))
-            diffResult.dispatchUpdatesTo(this)
-
-            uiMode = mode
-        }
-    }
-
     fun updateData(updatedList: List<TabSwitcherItem>) {
         val diffResult = DiffUtil.calculateDiff(TabSwitcherItemDiffCallback(list, updatedList))
         list.clear()
@@ -331,7 +331,7 @@ class TabSwitcherAdapter(
     fun getTabSwitcherItem(position: Int): TabSwitcherItem? = list.getOrNull(position)
 
     fun getAdapterPositionForTab(tabId: String?): Int = list.indexOfFirst {
-        it is TabSwitcherItem.Tab && it.tabEntity.tabId == tabId
+        it is Tab && it.tabEntity.tabId == tabId
     }
 
     fun onDraggingStarted() {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
@@ -177,8 +177,10 @@ class TabSwitcherAdapter(
             is SelectableTab -> {
                 if (tab.isSelected) {
                     holder.selectionIndicator.setImageResource(commonR.drawable.ic_check_blue_round_24)
+                    holder.selectionIndicator.contentDescription = holder.rootView.resources.getString(R.string.tabSelectedIndicator)
                 } else {
                     holder.selectionIndicator.setImageResource(commonR.drawable.shape_grey_circle_24)
+                    holder.selectionIndicator.contentDescription = holder.rootView.resources.getString(R.string.tabNotSelectedIndicator)
                 }
                 holder.selectionIndicator.show()
                 holder.close.hide()

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherDynamicMenu.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherDynamicMenu.kt
@@ -22,8 +22,8 @@ import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.view.isVisible
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.PopupTabsMenuBinding
-import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.ViewState.DynamicInterface
-import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.ViewState.FabType
+import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.DynamicInterface
+import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.FabType
 import com.duckduckgo.mobile.android.R as CommonR
 import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
 
@@ -40,7 +40,7 @@ fun Menu.createDynamicInterface(
 
     popupMenu.newTabMenuItem.isVisible = dynamicMenu.isNewTabVisible
     popupMenu.selectAllMenuItem.isVisible = dynamicMenu.isSelectAllVisible
-    // popupMenu.deselectAllMenuItem.isVisible = dynamicMenu.isDeselectAllVisible
+    popupMenu.deselectAllMenuItem.isVisible = dynamicMenu.isDeselectAllVisible
     popupMenu.selectionActionsDivider.isVisible = dynamicMenu.isSelectionActionsDividerVisible
     popupMenu.shareSelectedLinksMenuItem.isVisible = dynamicMenu.isShareSelectedLinksVisible
     popupMenu.bookmarkSelectedTabsMenuItem.isVisible = dynamicMenu.isBookmarkSelectedTabsVisible
@@ -72,6 +72,7 @@ fun Menu.createDynamicInterface(
                 icon = AppCompatResources.getDrawable(context, CommonR.drawable.ic_close_24)
             }
         }
+        extend()
     }
 
     return layoutButton

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherDynamicMenu.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherDynamicMenu.kt
@@ -19,10 +19,13 @@ package com.duckduckgo.app.tabs.ui
 import android.view.Menu
 import android.view.MenuItem
 import androidx.appcompat.content.res.AppCompatResources
+import androidx.appcompat.widget.Toolbar
 import androidx.core.view.isVisible
 import androidx.core.view.postDelayed
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.PopupTabsMenuBinding
+import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.BackButtonType.ARROW
+import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.BackButtonType.CLOSE
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.DynamicInterface
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.FabType
 import com.duckduckgo.mobile.android.R as CommonR
@@ -34,6 +37,7 @@ fun Menu.createDynamicInterface(
     numSelectedTabs: Int,
     popupMenu: PopupTabsMenuBinding,
     fab: ExtendedFloatingActionButton,
+    toolbar: Toolbar,
     dynamicMenu: DynamicInterface,
 ): MenuItem {
     findItem(R.id.fireMenuItem).isVisible = dynamicMenu.isFireButtonVisible
@@ -83,6 +87,11 @@ fun Menu.createDynamicInterface(
                 hide()
             }
         }
+    }
+
+    toolbar.navigationIcon = when (dynamicMenu.backButtonType) {
+        ARROW -> AppCompatResources.getDrawable(toolbar.context, CommonR.drawable.ic_arrow_left_24)
+        CLOSE -> AppCompatResources.getDrawable(toolbar.context, CommonR.drawable.ic_close_24)
     }
 
     return layoutButton

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherDynamicMenu.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherDynamicMenu.kt
@@ -20,12 +20,15 @@ import android.view.Menu
 import android.view.MenuItem
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.view.isVisible
+import androidx.core.view.postDelayed
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.PopupTabsMenuBinding
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.DynamicInterface
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.FabType
 import com.duckduckgo.mobile.android.R as CommonR
 import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
+
+private const val FAB_HIDE_DELAY = 500L
 
 fun Menu.createDynamicInterface(
     numSelectedTabs: Int,
@@ -61,18 +64,25 @@ fun Menu.createDynamicInterface(
     }
 
     fab.apply {
-        isVisible = dynamicMenu.isFabVisible
-        when (dynamicMenu.fabType) {
-            FabType.NEW_TAB -> {
-                text = resources.getString(R.string.newTabMenuItem)
-                icon = AppCompatResources.getDrawable(context, CommonR.drawable.ic_add_24)
+        if (dynamicMenu.isFabVisible) {
+            when (dynamicMenu.fabType) {
+                FabType.NEW_TAB -> {
+                    text = resources.getString(R.string.newTabMenuItem)
+                    icon = AppCompatResources.getDrawable(context, CommonR.drawable.ic_add_24)
+                }
+                FabType.CLOSE_TABS -> {
+                    text = resources.getQuantityString(R.plurals.closeTabsMenuItem, numSelectedTabs, numSelectedTabs)
+                    icon = AppCompatResources.getDrawable(context, CommonR.drawable.ic_close_24)
+                }
             }
-            FabType.CLOSE_TABS -> {
-                text = resources.getQuantityString(R.plurals.closeTabsMenuItem, numSelectedTabs, numSelectedTabs)
-                icon = AppCompatResources.getDrawable(context, CommonR.drawable.ic_close_24)
+
+            show()
+            extend()
+        } else {
+            fab.postDelayed(FAB_HIDE_DELAY) {
+                hide()
             }
         }
-        extend()
     }
 
     return layoutButton

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherItem.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherItem.kt
@@ -20,5 +20,5 @@ import com.duckduckgo.app.tabs.model.TabEntity
 
 sealed class TabSwitcherItem(val id: String) {
 
-    data class Tab(val tabEntity: TabEntity) : TabSwitcherItem(tabEntity.tabId)
+    data class Tab(val tabEntity: TabEntity, val isSelected: Boolean) : TabSwitcherItem(tabEntity.tabId)
 }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherItem.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherItem.kt
@@ -22,12 +22,12 @@ sealed class TabSwitcherItem(val id: String) {
     sealed class Tab(val tabEntity: TabEntity) : TabSwitcherItem(tabEntity.tabId) {
         data class NormalTab(
             private val entity: TabEntity,
-            val isActive: Boolean
+            val isActive: Boolean,
         ) : Tab(entity)
 
         data class SelectableTab(
             private val entity: TabEntity,
-            val isSelected: Boolean
+            val isSelected: Boolean,
         ) : Tab(entity)
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherItem.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherItem.kt
@@ -19,7 +19,15 @@ package com.duckduckgo.app.tabs.ui
 import com.duckduckgo.app.tabs.model.TabEntity
 
 sealed class TabSwitcherItem(val id: String) {
-    abstract class Tab(val tabEntity: TabEntity) : TabSwitcherItem(tabEntity.tabId)
-    data class NormalTab(private val entity: TabEntity, val isActive: Boolean) : Tab(entity)
-    data class SelectableTab(private val entity: TabEntity, val isSelected: Boolean) : Tab(entity)
+    sealed class Tab(val tabEntity: TabEntity) : TabSwitcherItem(tabEntity.tabId) {
+        data class NormalTab(
+            private val entity: TabEntity,
+            val isActive: Boolean
+        ) : Tab(entity)
+
+        data class SelectableTab(
+            private val entity: TabEntity,
+            val isSelected: Boolean
+        ) : Tab(entity)
+    }
 }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherItem.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherItem.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.tabs.ui
 import com.duckduckgo.app.tabs.model.TabEntity
 
 sealed class TabSwitcherItem(val id: String) {
-
-    data class Tab(val tabEntity: TabEntity, val isSelected: Boolean) : TabSwitcherItem(tabEntity.tabId)
+    abstract class Tab(val tabEntity: TabEntity) : TabSwitcherItem(tabEntity.tabId)
+    data class NormalTab(private val entity: TabEntity, val isActive: Boolean) : Tab(entity)
+    data class SelectableTab(private val entity: TabEntity, val isSelected: Boolean) : Tab(entity)
 }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -165,6 +165,7 @@ class TabSwitcherViewModel @Inject constructor(
     }
 
     fun onSelectAllTabs() {
+        _selectionViewState.update { it.copy(mode = SelectionViewState.Mode.Selection(tabs.value?.map { it.tabId } ?: emptyList())) }
     }
 
     fun onShareSelectedTabs() {
@@ -253,6 +254,16 @@ class TabSwitcherViewModel @Inject constructor(
     }
 
     fun onFabClicked() {
+        when (selectionViewState.value.fabType) {
+            SelectionViewState.FabType.NEW_TAB -> {
+                viewModelScope.launch {
+                    onNewTabRequested(fromOverflowMenu = false)
+                }
+            }
+            SelectionViewState.FabType.CLOSE_TABS -> {
+                onCloseSelectedTabs()
+            }
+        }
     }
 
     fun onDuckChatMenuClicked() {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -38,6 +38,8 @@ import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType.LIST
 import com.duckduckgo.app.tabs.ui.TabSwitcherItem.Tab
 import com.duckduckgo.app.tabs.ui.TabSwitcherItem.Tab.NormalTab
 import com.duckduckgo.app.tabs.ui.TabSwitcherItem.Tab.SelectableTab
+import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.BackButtonType.ARROW
+import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.BackButtonType.CLOSE
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.FabType
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.Mode.Normal
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.Mode.Selection
@@ -323,7 +325,7 @@ class TabSwitcherViewModel @Inject constructor(
 
     data class SelectionViewState(
         val items: List<TabSwitcherItem> = emptyList(),
-        val mode: Mode = Mode.Normal,
+        val mode: Mode = Normal,
     ) {
         val dynamicInterface: DynamicInterface
             get() = when (mode) {
@@ -346,9 +348,10 @@ class TabSwitcherViewModel @Inject constructor(
                         isMoreMenuItemEnabled = isThereNotJustNewTabPage,
                         isFabVisible = isThereNotJustNewTabPage,
                         fabType = FabType.NEW_TAB,
+                        backButtonType = ARROW
                     )
                 }
-                is Mode.Selection -> {
+                is Selection -> {
                     val areNoTabsSelected = mode.selectedTabs.isNotEmpty()
                     val areAllTabsSelected = mode.selectedTabs.size == items.size
                     DynamicInterface(
@@ -368,6 +371,7 @@ class TabSwitcherViewModel @Inject constructor(
                         isMoreMenuItemEnabled = true,
                         isFabVisible = areNoTabsSelected,
                         fabType = FabType.CLOSE_TABS,
+                        backButtonType = CLOSE
                     )
                 }
             }
@@ -389,11 +393,17 @@ class TabSwitcherViewModel @Inject constructor(
             val isMoreMenuItemEnabled: Boolean,
             val isFabVisible: Boolean,
             val fabType: FabType,
+            val backButtonType: BackButtonType,
         )
 
         enum class FabType {
             NEW_TAB,
             CLOSE_TABS,
+        }
+
+        enum class BackButtonType {
+            ARROW,
+            CLOSE,
         }
 
         sealed interface Mode {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -196,6 +196,12 @@ class TabSwitcherViewModel @Inject constructor(
         }
     }
 
+    fun onEmptyAreaClicked() {
+        if (tabManagerFeatureFlags.multiSelection().isEnabled() && _selectionViewState.value.mode is SelectionViewState.Mode.Selection) {
+            _selectionViewState.update { it.copy(mode = SelectionViewState.Mode.Normal) }
+        }
+    }
+
     fun onUpButtonPressed() {
         pixel.fire(AppPixelName.TAB_MANAGER_UP_BUTTON_PRESSED)
     }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -224,22 +224,34 @@ class TabSwitcherViewModel @Inject constructor(
             pixel.fire(AppPixelName.TAB_MANAGER_MENU_CLOSE_ALL_TABS_CONFIRMED)
 
             // Trigger a normal mode when there are no tabs
-            _selectionViewState.update { it.copy(mode = SelectionViewState.Mode.Normal) }
+            _selectionViewState.update { it.copy(mode = Normal) }
         }
     }
 
     fun onEmptyAreaClicked() {
         if (tabManagerFeatureFlags.multiSelection().isEnabled() && _selectionViewState.value.mode is Selection) {
-            _selectionViewState.update { it.copy(mode = SelectionViewState.Mode.Normal) }
+            _selectionViewState.update { it.copy(mode = Normal) }
         }
     }
 
-    fun onUpButtonPressed() {
+    fun onUpButtonPressed(): Boolean {
         pixel.fire(AppPixelName.TAB_MANAGER_UP_BUTTON_PRESSED)
+
+        return cancelSelectionOrExit()
     }
 
-    fun onBackButtonPressed() {
+    fun onBackButtonPressed(): Boolean {
         pixel.fire(AppPixelName.TAB_MANAGER_BACK_BUTTON_PRESSED)
+
+        return cancelSelectionOrExit()
+    }
+
+    private fun cancelSelectionOrExit(): Boolean {
+        if (tabManagerFeatureFlags.multiSelection().isEnabled() && _selectionViewState.value.mode is Selection) {
+            _selectionViewState.update { it.copy(mode = Normal) }
+            return false
+        }
+        return true
     }
 
     fun onMenuOpened() {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -91,8 +91,6 @@ class TabSwitcherViewModel @Inject constructor(
     sealed class Command {
         data object Close : Command()
         data object CloseAllTabsRequest : Command()
-        data class ShareLink(val link: String, val title: String) : Command()
-        data class ShareLinks(val links: List<String>) : Command()
     }
 
     suspend fun onNewTabRequested(fromOverflowMenu: Boolean) {
@@ -185,16 +183,6 @@ class TabSwitcherViewModel @Inject constructor(
     }
 
     fun onShareSelectedTabs() {
-        val selectedTabs = (selectionViewState.value.mode as? SelectionViewState.Mode.Selection)?.selectedTabs ?: emptyList()
-        if (selectedTabs.size == 1) {
-            command.value = Command.ShareLink(
-                link = tabs.value?.firstOrNull { it.tabId == selectedTabs.first() }?.url ?: "",
-                title = tabs.value?.firstOrNull { it.tabId == selectedTabs.first() }?.title ?: "",
-            )
-        } else if (selectedTabs.size > 1) {
-            val links = tabs.value?.filter { it.tabId in selectedTabs }?.mapNotNull { it.url }
-            command.value = Command.ShareLinks(links ?: emptyList())
-        }
     }
 
     fun onBookmarkSelectedTabs() {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -71,7 +71,7 @@ class TabSwitcherViewModel @Inject constructor(
 
     val command: SingleLiveEvent<Command> = SingleLiveEvent()
 
-    private val _selectionViewState = MutableStateFlow<SelectionViewState>(SelectionViewState())
+    private val _selectionViewState = MutableStateFlow(SelectionViewState())
     val selectionViewState = combine(
         _selectionViewState,
         tabRepository.flowTabs,
@@ -86,7 +86,7 @@ class TabSwitcherViewModel @Inject constructor(
     val tabSwitcherItems: LiveData<List<TabSwitcherItem>> = if (tabManagerFeatureFlags.multiSelection().isEnabled()) {
         tabRepository.flowTabs.combine(_selectionViewState) { tabEntities, viewState ->
             tabEntities.map {
-                TabSwitcherItem.Tab(it, viewState.mode is SelectionViewState.Mode.Selection && it.tabId in viewState.mode.selectedTabs)
+                TabSwitcherItem.Tab(it, viewState.mode is Selection && it.tabId in viewState.mode.selectedTabs)
             }
         }.asLiveData()
     } else {
@@ -128,13 +128,13 @@ class TabSwitcherViewModel @Inject constructor(
     }
 
     suspend fun onTabSelected(tab: TabEntity) {
-        if (tabManagerFeatureFlags.multiSelection().isEnabled() && _selectionViewState.value.mode is SelectionViewState.Mode.Selection) {
+        if (tabManagerFeatureFlags.multiSelection().isEnabled() && _selectionViewState.value.mode is Selection) {
             _selectionViewState.update {
-                val selectionMode = it.mode as SelectionViewState.Mode.Selection
+                val selectionMode = it.mode as Selection
                 if (tab.tabId in selectionMode.selectedTabs) {
-                    it.copy(mode = SelectionViewState.Mode.Selection(selectionMode.selectedTabs - tab.tabId))
+                    it.copy(mode = Selection(selectionMode.selectedTabs - tab.tabId))
                 } else {
-                    it.copy(mode = SelectionViewState.Mode.Selection(selectionMode.selectedTabs + tab.tabId))
+                    it.copy(mode = Selection(selectionMode.selectedTabs + tab.tabId))
                 }
             }
         } else {
@@ -158,10 +158,10 @@ class TabSwitcherViewModel @Inject constructor(
             pixel.fire(AppPixelName.TAB_MANAGER_CLOSE_TAB_CLICKED)
         }
 
-        (_selectionViewState.value.mode as? SelectionViewState.Mode.Selection)?.let { selectionMode ->
+        (_selectionViewState.value.mode as? Selection)?.let { selectionMode ->
             if (tab.tabId in selectionMode.selectedTabs) {
                 _selectionViewState.update {
-                    it.copy(mode = SelectionViewState.Mode.Selection(selectionMode.selectedTabs - tab.tabId))
+                    it.copy(mode = Selection(selectionMode.selectedTabs - tab.tabId))
                 }
             }
         }
@@ -170,9 +170,9 @@ class TabSwitcherViewModel @Inject constructor(
     suspend fun undoDeletableTab(tab: TabEntity) {
         tabRepository.undoDeletable(tab)
 
-        (_selectionViewState.value.mode as? SelectionViewState.Mode.Selection)?.let { selectionMode ->
+        (_selectionViewState.value.mode as? Selection)?.let { selectionMode ->
             _selectionViewState.update {
-                it.copy(mode = SelectionViewState.Mode.Selection(selectionMode.selectedTabs + tab.tabId))
+                it.copy(mode = Selection(selectionMode.selectedTabs + tab.tabId))
             }
         }
     }
@@ -190,11 +190,11 @@ class TabSwitcherViewModel @Inject constructor(
     }
 
     fun onSelectAllTabs() {
-        _selectionViewState.update { it.copy(mode = SelectionViewState.Mode.Selection(tabSwitcherItems.value?.map { it.id } ?: emptyList())) }
+        _selectionViewState.update { it.copy(mode = Selection(tabSwitcherItems.value?.map { it.id } ?: emptyList())) }
     }
 
     fun onDeselectAllTabs() {
-        _selectionViewState.update { it.copy(mode = SelectionViewState.Mode.Selection(emptyList())) }
+        _selectionViewState.update { it.copy(mode = Selection(emptyList())) }
     }
 
     fun onShareSelectedTabs() {
@@ -204,7 +204,7 @@ class TabSwitcherViewModel @Inject constructor(
     }
 
     fun onSelectionModeRequested() {
-        _selectionViewState.update { it.copy(mode = SelectionViewState.Mode.Selection(emptyList())) }
+        _selectionViewState.update { it.copy(mode = Selection(emptyList())) }
     }
 
     fun onCloseSelectedTabs() {
@@ -230,7 +230,7 @@ class TabSwitcherViewModel @Inject constructor(
     }
 
     fun onEmptyAreaClicked() {
-        if (tabManagerFeatureFlags.multiSelection().isEnabled() && _selectionViewState.value.mode is SelectionViewState.Mode.Selection) {
+        if (tabManagerFeatureFlags.multiSelection().isEnabled() && _selectionViewState.value.mode is Selection) {
             _selectionViewState.update { it.copy(mode = SelectionViewState.Mode.Normal) }
         }
     }
@@ -389,7 +389,7 @@ class TabSwitcherViewModel @Inject constructor(
         sealed interface Mode {
             data object Normal : Mode
             data class Selection(
-                val selectedTabs: List<String> = emptyList<String>(),
+                val selectedTabs: List<String> = emptyList(),
             ) : Mode
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -35,6 +35,9 @@ import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType.GRID
 import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType.LIST
+import com.duckduckgo.app.tabs.ui.TabSwitcherItem.Tab
+import com.duckduckgo.app.tabs.ui.TabSwitcherItem.Tab.NormalTab
+import com.duckduckgo.app.tabs.ui.TabSwitcherItem.Tab.SelectableTab
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.FabType
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.Mode.Normal
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.Mode.Selection
@@ -82,16 +85,16 @@ class TabSwitcherViewModel @Inject constructor(
         viewState.copy(
             items = tabs.map {
                 if (viewState.mode is Selection) {
-                    TabSwitcherItem.SelectableTab(it, isSelected = it.tabId in viewState.mode.selectedTabs)
+                    SelectableTab(it, isSelected = it.tabId in viewState.mode.selectedTabs)
                 } else {
-                    TabSwitcherItem.NormalTab(it, isActive = it.tabId == activeTab?.tabId)
+                    NormalTab(it, isActive = it.tabId == activeTab?.tabId)
                 }
             },
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), SelectionViewState())
 
     val tabSwitcherItems: LiveData<List<TabSwitcherItem>> = tabRepository.liveTabs.map { tabEntities ->
-        tabEntities.map { TabSwitcherItem.NormalTab(it, isActive = it.tabId == activeTab.value?.tabId) }
+        tabEntities.map { NormalTab(it, isActive = it.tabId == activeTab.value?.tabId) }
     }
 
     val layoutType = tabRepository.tabSwitcherData
@@ -105,7 +108,7 @@ class TabSwitcherViewModel @Inject constructor(
 
     suspend fun onNewTabRequested(fromOverflowMenu: Boolean) {
         if (swipingTabsFeature.isEnabled) {
-            val tabItemList = tabSwitcherItems.value?.filterIsInstance<TabSwitcherItem.Tab>()
+            val tabItemList = tabSwitcherItems.value?.filterIsInstance<Tab>()
             val emptyTabItem = tabItemList?.firstOrNull { tabItem -> tabItem.tabEntity.url.isNullOrBlank() }
             val emptyTabId = emptyTabItem?.tabEntity?.tabId
 
@@ -216,7 +219,7 @@ class TabSwitcherViewModel @Inject constructor(
         viewModelScope.launch(dispatcherProvider.io()) {
             tabSwitcherItems.value?.forEach { tabSwitcherItem ->
                 when (tabSwitcherItem) {
-                    is TabSwitcherItem.Tab -> onTabDeleted(tabSwitcherItem.tabEntity)
+                    is Tab -> onTabDeleted(tabSwitcherItem.tabEntity)
                 }
             }
             // Make sure all exemptions are removed as all tabs are deleted.
@@ -325,7 +328,7 @@ class TabSwitcherViewModel @Inject constructor(
         val dynamicInterface: DynamicInterface
             get() = when (mode) {
                 is Normal -> {
-                    val isThereNotJustNewTabPage = items.size != 1 || (items.first() as? TabSwitcherItem.Tab)?.tabEntity?.url != null
+                    val isThereNotJustNewTabPage = items.size != 1 || (items.first() as? Tab)?.tabEntity?.url != null
                     DynamicInterface(
                         isLayoutTypeButtonVisible = true,
                         isFireButtonVisible = true,

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -20,7 +20,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.map
-import androidx.lifecycle.switchMap
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.adclick.api.AdClickManager
 import com.duckduckgo.anvil.annotations.ContributesViewModel
@@ -87,7 +86,7 @@ class TabSwitcherViewModel @Inject constructor(
                 } else {
                     TabSwitcherItem.NormalTab(it, isActive = it.tabId == activeTab?.tabId)
                 }
-            }
+            },
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), SelectionViewState())
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -269,20 +269,20 @@ class TabSwitcherViewModel @Inject constructor(
     }
 
     fun onLayoutTypeToggled() {
-        // viewModelScope.launch(dispatcherProvider.io()) {
-        //     val newLayoutType = when (layoutType.value) {
-        //         GRID -> {
-        //             pixel.fire(AppPixelName.TAB_MANAGER_LIST_VIEW_BUTTON_CLICKED)
-        //             LIST
-        //         }
-        //         LIST -> {
-        //             pixel.fire(AppPixelName.TAB_MANAGER_GRID_VIEW_BUTTON_CLICKED)
-        //             GRID
-        //         }
-        //         else -> null
-        //     }
-        //     newLayoutType?.let { tabRepository.setTabLayoutType(it) }
-        // }
+        viewModelScope.launch(dispatcherProvider.io()) {
+            val newLayoutType = when (layoutType.value) {
+                GRID -> {
+                    pixel.fire(AppPixelName.TAB_MANAGER_LIST_VIEW_BUTTON_CLICKED)
+                    LIST
+                }
+                LIST -> {
+                    pixel.fire(AppPixelName.TAB_MANAGER_GRID_VIEW_BUTTON_CLICKED)
+                    GRID
+                }
+                else -> null
+            }
+            newLayoutType?.let { tabRepository.setTabLayoutType(it) }
+        }
     }
 
     fun onFabClicked() {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -20,12 +20,15 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.map
+import androidx.lifecycle.switchMap
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.adclick.api.AdClickManager
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.browser.SwipingTabsFeatureProvider
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.pixels.AppPixelName
+import com.duckduckgo.app.pixels.AppPixelName.TAB_MANAGER_GRID_VIEW_BUTTON_CLICKED
+import com.duckduckgo.app.pixels.AppPixelName.TAB_MANAGER_LIST_VIEW_BUTTON_CLICKED
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.app.tabs.TabManagerFeatureFlags
@@ -76,23 +79,21 @@ class TabSwitcherViewModel @Inject constructor(
         _selectionViewState,
         tabRepository.flowTabs,
         tabRepository.flowSelectedTab,
-    ) { viewState, tabs, selectedTab ->
+    ) { viewState, tabs, activeTab ->
         viewState.copy(
-            items = tabs.map { TabSwitcherItem.Tab(it, false) },
-            selectedTab = selectedTab,
+            items = tabs.map {
+                if (viewState.mode is Selection) {
+                    TabSwitcherItem.SelectableTab(it, isSelected = it.tabId in viewState.mode.selectedTabs)
+                } else {
+                    TabSwitcherItem.NormalTab(it, isActive = it.tabId == activeTab?.tabId)
+                }
+            }
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), SelectionViewState())
 
-    val tabSwitcherItems: LiveData<List<TabSwitcherItem>> = if (tabManagerFeatureFlags.multiSelection().isEnabled()) {
-        tabRepository.flowTabs.combine(_selectionViewState) { tabEntities, viewState ->
-            tabEntities.map {
-                TabSwitcherItem.Tab(it, viewState.mode is Selection && it.tabId in viewState.mode.selectedTabs)
-            }
-        }.asLiveData()
-    } else {
-        tabRepository.liveTabs.map { tabEntities ->
-            tabEntities.map { TabSwitcherItem.Tab(it, false) }
-        }
+    val tabSwitcherItems: LiveData<List<TabSwitcherItem>> = tabRepository.liveTabs.map { tabEntities ->
+        val activeTabId = tabRepository.liveSelectedTab.value?.tabId
+        tabEntities.map { TabSwitcherItem.NormalTab(it, isActive = it.tabId == activeTabId) }
     }
 
     val layoutType = tabRepository.tabSwitcherData
@@ -311,7 +312,6 @@ class TabSwitcherViewModel @Inject constructor(
 
     data class SelectionViewState(
         val items: List<TabSwitcherItem> = emptyList(),
-        val selectedTab: TabEntity? = null,
         val mode: Mode = Mode.Normal,
     ) {
         val dynamicInterface: DynamicInterface

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -244,8 +244,9 @@ class TabSwitcherViewModel @Inject constructor(
 
         if (tabManagerFeatureFlags.multiSelection().isEnabled() && _selectionViewState.value.mode is Selection) {
             _selectionViewState.update { it.copy(mode = Normal) }
+        } else {
+            command.value = Command.Close
         }
-        command.value = Command.Close
     }
 
     fun onBackButtonPressed() {
@@ -253,8 +254,9 @@ class TabSwitcherViewModel @Inject constructor(
 
         if (tabManagerFeatureFlags.multiSelection().isEnabled() && _selectionViewState.value.mode is Selection) {
             _selectionViewState.update { it.copy(mode = Normal) }
+        } else {
+            command.value = Command.Close
         }
-        command.value = Command.Close
     }
 
     fun onMenuOpened() {
@@ -348,7 +350,7 @@ class TabSwitcherViewModel @Inject constructor(
                         isMoreMenuItemEnabled = isThereNotJustNewTabPage,
                         isFabVisible = isThereNotJustNewTabPage,
                         fabType = FabType.NEW_TAB,
-                        backButtonType = ARROW
+                        backButtonType = ARROW,
                     )
                 }
                 is Selection -> {
@@ -371,7 +373,7 @@ class TabSwitcherViewModel @Inject constructor(
                         isMoreMenuItemEnabled = true,
                         isFabVisible = areNoTabsSelected,
                         fabType = FabType.CLOSE_TABS,
-                        backButtonType = CLOSE
+                        backButtonType = CLOSE,
                     )
                 }
             }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -174,6 +174,7 @@ class TabSwitcherViewModel @Inject constructor(
     }
 
     fun onSelectionModeRequested() {
+        _selectionViewState.update { it.copy(mode = SelectionViewState.Mode.Selection(emptyList())) }
     }
 
     fun onCloseSelectedTabs() {
@@ -246,18 +247,6 @@ class TabSwitcherViewModel @Inject constructor(
     }
 
     fun onFabClicked() {
-        when {
-            selectionViewState.value.mode is SelectionViewState.Mode.Normal -> {
-                _selectionViewState.update { it.copy(mode = SelectionViewState.Mode.Selection(emptyList())) }
-            }
-            selectionViewState.value.mode is SelectionViewState.Mode.Selection -> {
-                if ((selectionViewState.value.mode as SelectionViewState.Mode.Selection).selectedTabs.isEmpty()) {
-                    _selectionViewState.update { it.copy(mode = SelectionViewState.Mode.Selection(listOf("123", "456"))) }
-                } else {
-                    _selectionViewState.update { it.copy(mode = SelectionViewState.Mode.Normal) }
-                }
-            }
-        }
     }
 
     fun onDuckChatMenuClicked() {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -234,24 +234,22 @@ class TabSwitcherViewModel @Inject constructor(
         }
     }
 
-    fun onUpButtonPressed(): Boolean {
+    fun onUpButtonPressed() {
         pixel.fire(AppPixelName.TAB_MANAGER_UP_BUTTON_PRESSED)
 
-        return cancelSelectionOrExit()
-    }
-
-    fun onBackButtonPressed(): Boolean {
-        pixel.fire(AppPixelName.TAB_MANAGER_BACK_BUTTON_PRESSED)
-
-        return cancelSelectionOrExit()
-    }
-
-    private fun cancelSelectionOrExit(): Boolean {
         if (tabManagerFeatureFlags.multiSelection().isEnabled() && _selectionViewState.value.mode is Selection) {
             _selectionViewState.update { it.copy(mode = Normal) }
-            return false
         }
-        return true
+        command.value = Command.Close
+    }
+
+    fun onBackButtonPressed() {
+        pixel.fire(AppPixelName.TAB_MANAGER_BACK_BUTTON_PRESSED)
+
+        if (tabManagerFeatureFlags.multiSelection().isEnabled() && _selectionViewState.value.mode is Selection) {
+            _selectionViewState.update { it.copy(mode = Normal) }
+        }
+        command.value = Command.Close
     }
 
     fun onMenuOpened() {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -24,6 +24,7 @@ import androidx.lifecycle.viewModelScope
 import com.duckduckgo.adclick.api.AdClickManager
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.browser.SwipingTabsFeatureProvider
+import com.duckduckgo.app.browser.di.BrowserModule_WebViewSessionStorageFactory.webViewSessionStorage
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -31,11 +32,9 @@ import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.app.tabs.TabManagerFeatureFlags
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
-import com.duckduckgo.app.tabs.model.TabSwitcherData
 import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType.GRID
 import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType.LIST
-import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.ViewState.Mode
-import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.ViewState.Mode.Normal
+import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.Mode.Normal
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.SingleLiveEvent
 import com.duckduckgo.common.utils.extensions.toBinaryString
@@ -63,9 +62,7 @@ class TabSwitcherViewModel @Inject constructor(
     private val duckChat: DuckChat,
     private val tabManagerFeatureFlags: TabManagerFeatureFlags,
 ) : ViewModel() {
-    val tabSwitcherItems: LiveData<List<TabSwitcherItem>> = tabRepository.liveTabs.map { tabEntities ->
-        tabEntities.map { TabSwitcherItem.Tab(it, false) }
-    }
+
     val activeTab = tabRepository.liveSelectedTab
     val deletableTabs: LiveData<List<TabEntity>> = tabRepository.flowDeletableTabs.asLiveData(
         context = viewModelScope.coroutineContext,
@@ -73,9 +70,9 @@ class TabSwitcherViewModel @Inject constructor(
 
     val command: SingleLiveEvent<Command> = SingleLiveEvent()
 
-    private val _viewState = MutableStateFlow<ViewState>(ViewState())
-    val viewState = combine(
-        _viewState,
+    private val _selectionViewState = MutableStateFlow<SelectionViewState>(SelectionViewState())
+    val selectionViewState = combine(
+        _selectionViewState,
         tabRepository.flowTabs,
         tabRepository.flowSelectedTab,
     ) { viewState, tabs, selectedTab ->
@@ -83,7 +80,13 @@ class TabSwitcherViewModel @Inject constructor(
             items = tabs.map { TabSwitcherItem.Tab(it, false) },
             selectedTab = selectedTab,
         )
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), ViewState())
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), SelectionViewState())
+
+    val tabSwitcherItems: LiveData<List<TabSwitcherItem>> = tabRepository.flowTabs.combine(_selectionViewState) { tabEntities, viewState ->
+        tabEntities.map {
+            TabSwitcherItem.Tab(it, viewState.mode is SelectionViewState.Mode.Selection && it.tabId in viewState.mode.selectedTabs)
+        }
+    }.asLiveData()
 
     sealed class Command {
         data object Close : Command()
@@ -114,13 +117,13 @@ class TabSwitcherViewModel @Inject constructor(
     }
 
     suspend fun onTabSelected(tab: TabEntity) {
-        if (tabManagerFeatureFlags.multiSelection().isEnabled() && _viewState.value.mode is ViewState.Mode.Selection) {
-            _viewState.update {
-                val selectionMode = it.mode as ViewState.Mode.Selection
+        if (tabManagerFeatureFlags.multiSelection().isEnabled() && _selectionViewState.value.mode is SelectionViewState.Mode.Selection) {
+            _selectionViewState.update {
+                val selectionMode = it.mode as SelectionViewState.Mode.Selection
                 if (tab.tabId in selectionMode.selectedTabs) {
-                    it.copy(mode = ViewState.Mode.Selection(selectionMode.selectedTabs - tab.tabId))
+                    it.copy(mode = SelectionViewState.Mode.Selection(selectionMode.selectedTabs - tab.tabId))
                 } else {
-                    it.copy(mode = ViewState.Mode.Selection(selectionMode.selectedTabs + tab.tabId))
+                    it.copy(mode = SelectionViewState.Mode.Selection(selectionMode.selectedTabs + tab.tabId))
                 }
             }
         } else {
@@ -227,27 +230,31 @@ class TabSwitcherViewModel @Inject constructor(
 
     fun onLayoutTypeToggled() {
         // viewModelScope.launch(dispatcherProvider.io()) {
-        //     val newLayoutType = if (layoutType == GRID) {
-        //         pixel.fire(AppPixelName.TAB_MANAGER_LIST_VIEW_BUTTON_CLICKED)
-        //         LIST
-        //     } else {
-        //         pixel.fire(AppPixelName.TAB_MANAGER_GRID_VIEW_BUTTON_CLICKED)
-        //         GRID
+        //     val newLayoutType = when (layoutType.value) {
+        //         GRID -> {
+        //             pixel.fire(AppPixelName.TAB_MANAGER_LIST_VIEW_BUTTON_CLICKED)
+        //             LIST
+        //         }
+        //         LIST -> {
+        //             pixel.fire(AppPixelName.TAB_MANAGER_GRID_VIEW_BUTTON_CLICKED)
+        //             GRID
+        //         }
+        //         else -> null
         //     }
-        //     tabRepository.setTabLayoutType(newLayoutType)
+        //     newLayoutType?.let { tabRepository.setTabLayoutType(it) }
         // }
     }
 
     fun onFabClicked() {
         when {
-            _viewState.value.mode is ViewState.Mode.Normal -> {
-                _viewState.update { it.copy(mode = ViewState.Mode.Selection(emptyList())) }
+            selectionViewState.value.mode is SelectionViewState.Mode.Normal -> {
+                _selectionViewState.update { it.copy(mode = SelectionViewState.Mode.Selection(emptyList())) }
             }
-            _viewState.value.mode is ViewState.Mode.Selection -> {
-                if ((_viewState.value.mode as ViewState.Mode.Selection).selectedTabs.isEmpty()) {
-                    _viewState.update { it.copy(mode = ViewState.Mode.Selection(listOf("123", "456"))) }
+            selectionViewState.value.mode is SelectionViewState.Mode.Selection -> {
+                if ((selectionViewState.value.mode as SelectionViewState.Mode.Selection).selectedTabs.isEmpty()) {
+                    _selectionViewState.update { it.copy(mode = SelectionViewState.Mode.Selection(listOf("123", "456"))) }
                 } else {
-                    _viewState.update { it.copy(mode = ViewState.Mode.Normal) }
+                    _selectionViewState.update { it.copy(mode = SelectionViewState.Mode.Normal) }
                 }
             }
         }
@@ -265,7 +272,7 @@ class TabSwitcherViewModel @Inject constructor(
         }
     }
 
-    data class ViewState(
+    data class SelectionViewState(
         val items: List<TabSwitcherItem> = emptyList(),
         val selectedTab: TabEntity? = null,
         val mode: Mode = Mode.Normal,

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -186,6 +186,10 @@ class TabSwitcherViewModel @Inject constructor(
         _selectionViewState.update { it.copy(mode = SelectionViewState.Mode.Selection(tabSwitcherItems.value?.map { it.id } ?: emptyList())) }
     }
 
+    fun onDeselectAllTabs() {
+        _selectionViewState.update { it.copy(mode = SelectionViewState.Mode.Selection(emptyList())) }
+    }
+
     fun onShareSelectedTabs() {
     }
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -270,18 +270,17 @@ class TabSwitcherViewModel @Inject constructor(
 
     fun onLayoutTypeToggled() {
         viewModelScope.launch(dispatcherProvider.io()) {
-            val newLayoutType = when (layoutType.value) {
+            when (layoutType.value) {
                 GRID -> {
-                    pixel.fire(AppPixelName.TAB_MANAGER_LIST_VIEW_BUTTON_CLICKED)
-                    LIST
+                    pixel.fire(TAB_MANAGER_LIST_VIEW_BUTTON_CLICKED)
+                    tabRepository.setTabLayoutType(LIST)
                 }
                 LIST -> {
-                    pixel.fire(AppPixelName.TAB_MANAGER_GRID_VIEW_BUTTON_CLICKED)
-                    GRID
+                    pixel.fire(TAB_MANAGER_GRID_VIEW_BUTTON_CLICKED)
+                    tabRepository.setTabLayoutType(GRID)
                 }
-                else -> null
+                else -> Unit
             }
-            newLayoutType?.let { tabRepository.setTabLayoutType(it) }
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -91,8 +91,7 @@ class TabSwitcherViewModel @Inject constructor(
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), SelectionViewState())
 
     val tabSwitcherItems: LiveData<List<TabSwitcherItem>> = tabRepository.liveTabs.map { tabEntities ->
-        val activeTabId = tabRepository.liveSelectedTab.value?.tabId
-        tabEntities.map { TabSwitcherItem.NormalTab(it, isActive = it.tabId == activeTabId) }
+        tabEntities.map { TabSwitcherItem.NormalTab(it, isActive = it.tabId == activeTab.value?.tabId) }
     }
 
     val layoutType = tabRepository.tabSwitcherData

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -19,12 +19,10 @@ package com.duckduckgo.app.tabs.ui
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
-import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.adclick.api.AdClickManager
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.browser.SwipingTabsFeatureProvider
-import com.duckduckgo.app.browser.di.BrowserModule_WebViewSessionStorageFactory.webViewSessionStorage
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -34,7 +32,9 @@ import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType.GRID
 import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType.LIST
+import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.FabType
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.Mode.Normal
+import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.Mode.Selection
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.SingleLiveEvent
 import com.duckduckgo.common.utils.extensions.toBinaryString
@@ -87,6 +87,10 @@ class TabSwitcherViewModel @Inject constructor(
             TabSwitcherItem.Tab(it, viewState.mode is SelectionViewState.Mode.Selection && it.tabId in viewState.mode.selectedTabs)
         }
     }.asLiveData()
+
+    val layoutType = tabRepository.tabSwitcherData
+        .map { it.layoutType }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), null)
 
     sealed class Command {
         data object Close : Command()
@@ -179,7 +183,7 @@ class TabSwitcherViewModel @Inject constructor(
     }
 
     fun onSelectAllTabs() {
-        _selectionViewState.update { it.copy(mode = SelectionViewState.Mode.Selection(tabs.value?.map { it.tabId } ?: emptyList())) }
+        _selectionViewState.update { it.copy(mode = SelectionViewState.Mode.Selection(tabSwitcherItems.value?.map { it.id } ?: emptyList())) }
     }
 
     fun onShareSelectedTabs() {
@@ -271,13 +275,13 @@ class TabSwitcherViewModel @Inject constructor(
     }
 
     fun onFabClicked() {
-        when (selectionViewState.value.fabType) {
-            SelectionViewState.FabType.NEW_TAB -> {
+        when (selectionViewState.value.dynamicInterface.fabType) {
+            FabType.NEW_TAB -> {
                 viewModelScope.launch {
                     onNewTabRequested(fromOverflowMenu = false)
                 }
             }
-            SelectionViewState.FabType.CLOSE_TABS -> {
+            FabType.CLOSE_TABS -> {
                 onCloseSelectedTabs()
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -194,6 +194,9 @@ class TabSwitcherViewModel @Inject constructor(
             // Make sure all exemptions are removed as all tabs are deleted.
             adClickManager.clearAll()
             pixel.fire(AppPixelName.TAB_MANAGER_MENU_CLOSE_ALL_TABS_CONFIRMED)
+
+            // Trigger a normal mode when there are no tabs
+            _selectionViewState.update { it.copy(mode = SelectionViewState.Mode.Normal) }
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -31,6 +31,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.app.tabs.TabManagerFeatureFlags
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.app.tabs.model.TabSwitcherData
 import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType.GRID
 import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType.LIST
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.ViewState.Mode
@@ -63,7 +64,7 @@ class TabSwitcherViewModel @Inject constructor(
     private val tabManagerFeatureFlags: TabManagerFeatureFlags,
 ) : ViewModel() {
     val tabSwitcherItems: LiveData<List<TabSwitcherItem>> = tabRepository.liveTabs.map { tabEntities ->
-        tabEntities.map { TabSwitcherItem.Tab(it) }
+        tabEntities.map { TabSwitcherItem.Tab(it, false) }
     }
     val activeTab = tabRepository.liveSelectedTab
     val deletableTabs: LiveData<List<TabEntity>> = tabRepository.flowDeletableTabs.asLiveData(
@@ -73,22 +74,16 @@ class TabSwitcherViewModel @Inject constructor(
     val command: SingleLiveEvent<Command> = SingleLiveEvent()
 
     private val _viewState = MutableStateFlow<ViewState>(ViewState())
-    val viewState = combine(_viewState, tabRepository.flowTabs) { viewState, tabs ->
-        viewState.copy(items = tabs.map { TabSwitcherItem.Tab(it) })
+    val viewState = combine(
+        _viewState,
+        tabRepository.flowTabs,
+        tabRepository.flowSelectedTab,
+    ) { viewState, tabs, selectedTab ->
+        viewState.copy(
+            items = tabs.map { TabSwitcherItem.Tab(it, false) },
+            selectedTab = selectedTab,
+        )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), ViewState())
-
-    val layoutType = if (tabManagerFeatureFlags.multiSelection().isEnabled()) {
-        combine(tabRepository.tabSwitcherData, viewState) { tabSwitcherData, viewState ->
-            if (viewState.dynamicInterface.isLayoutTypeButtonVisible) {
-                tabSwitcherData.layoutType
-            } else {
-                null
-            }
-        }
-    } else {
-        tabRepository.tabSwitcherData
-            .map { it.layoutType }
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), null)
 
     sealed class Command {
         data object Close : Command()
@@ -119,9 +114,20 @@ class TabSwitcherViewModel @Inject constructor(
     }
 
     suspend fun onTabSelected(tab: TabEntity) {
-        tabRepository.select(tab.tabId)
-        command.value = Command.Close
-        pixel.fire(AppPixelName.TAB_MANAGER_SWITCH_TABS)
+        if (tabManagerFeatureFlags.multiSelection().isEnabled() && _viewState.value.mode is ViewState.Mode.Selection) {
+            _viewState.update {
+                val selectionMode = it.mode as ViewState.Mode.Selection
+                if (tab.tabId in selectionMode.selectedTabs) {
+                    it.copy(mode = ViewState.Mode.Selection(selectionMode.selectedTabs - tab.tabId))
+                } else {
+                    it.copy(mode = ViewState.Mode.Selection(selectionMode.selectedTabs + tab.tabId))
+                }
+            }
+        } else {
+            tabRepository.select(tab.tabId)
+            command.value = Command.Close
+            pixel.fire(AppPixelName.TAB_MANAGER_SWITCH_TABS)
+        }
     }
 
     suspend fun onTabDeleted(tab: TabEntity) {
@@ -220,16 +226,16 @@ class TabSwitcherViewModel @Inject constructor(
     }
 
     fun onLayoutTypeToggled() {
-        viewModelScope.launch(dispatcherProvider.io()) {
-            val newLayoutType = if (layoutType.value == GRID) {
-                pixel.fire(AppPixelName.TAB_MANAGER_LIST_VIEW_BUTTON_CLICKED)
-                LIST
-            } else {
-                pixel.fire(AppPixelName.TAB_MANAGER_GRID_VIEW_BUTTON_CLICKED)
-                GRID
-            }
-            tabRepository.setTabLayoutType(newLayoutType)
-        }
+        // viewModelScope.launch(dispatcherProvider.io()) {
+        //     val newLayoutType = if (layoutType == GRID) {
+        //         pixel.fire(AppPixelName.TAB_MANAGER_LIST_VIEW_BUTTON_CLICKED)
+        //         LIST
+        //     } else {
+        //         pixel.fire(AppPixelName.TAB_MANAGER_GRID_VIEW_BUTTON_CLICKED)
+        //         GRID
+        //     }
+        //     tabRepository.setTabLayoutType(newLayoutType)
+        // }
     }
 
     fun onFabClicked() {
@@ -260,8 +266,9 @@ class TabSwitcherViewModel @Inject constructor(
     }
 
     data class ViewState(
-        val mode: Mode = Normal,
         val items: List<TabSwitcherItem> = emptyList(),
+        val selectedTab: TabEntity? = null,
+        val mode: Mode = Mode.Normal,
     ) {
         val dynamicInterface: DynamicInterface
             get() = when (mode) {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.tabs.ui
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
+import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.adclick.api.AdClickManager
 import com.duckduckgo.anvil.annotations.ContributesViewModel
@@ -82,11 +83,17 @@ class TabSwitcherViewModel @Inject constructor(
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), SelectionViewState())
 
-    val tabSwitcherItems: LiveData<List<TabSwitcherItem>> = tabRepository.flowTabs.combine(_selectionViewState) { tabEntities, viewState ->
-        tabEntities.map {
-            TabSwitcherItem.Tab(it, viewState.mode is SelectionViewState.Mode.Selection && it.tabId in viewState.mode.selectedTabs)
+    val tabSwitcherItems: LiveData<List<TabSwitcherItem>> = if (tabManagerFeatureFlags.multiSelection().isEnabled()) {
+        tabRepository.flowTabs.combine(_selectionViewState) { tabEntities, viewState ->
+            tabEntities.map {
+                TabSwitcherItem.Tab(it, viewState.mode is SelectionViewState.Mode.Selection && it.tabId in viewState.mode.selectedTabs)
+            }
+        }.asLiveData()
+    } else {
+        tabRepository.liveTabs.map { tabEntities ->
+            tabEntities.map { TabSwitcherItem.Tab(it, false) }
         }
-    }.asLiveData()
+    }
 
     val layoutType = tabRepository.tabSwitcherData
         .map { it.layoutType }

--- a/app/src/main/res/layout/item_tab_grid.xml
+++ b/app/src/main/res/layout/item_tab_grid.xml
@@ -62,6 +62,18 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="@id/favicon" />
 
+        <ImageView
+            android:id="@+id/selectionIndicator"
+            android:padding="@dimen/keyline_2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:importantForAccessibility="no"
+            android:src="@drawable/shape_grey_circle_24"
+            android:visibility="invisible"
+            app:layout_constraintBottom_toBottomOf="@id/favicon"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@id/favicon" />
+
         <com.duckduckgo.common.ui.view.text.DaxTextView
             android:id="@+id/title"
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/item_tab_grid.xml
+++ b/app/src/main/res/layout/item_tab_grid.xml
@@ -64,7 +64,7 @@
 
         <ImageView
             android:id="@+id/selectionIndicator"
-            android:contentDescription="@string/selectionStateIndicator"
+            android:contentDescription="@string/tabNotSelectedIndicator"
             android:padding="@dimen/keyline_2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/item_tab_grid.xml
+++ b/app/src/main/res/layout/item_tab_grid.xml
@@ -64,10 +64,10 @@
 
         <ImageView
             android:id="@+id/selectionIndicator"
+            android:contentDescription="@string/selectionStateIndicator"
             android:padding="@dimen/keyline_2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:importantForAccessibility="no"
             android:src="@drawable/shape_grey_circle_24"
             android:visibility="invisible"
             app:layout_constraintBottom_toBottomOf="@id/favicon"

--- a/app/src/main/res/layout/item_tab_list.xml
+++ b/app/src/main/res/layout/item_tab_list.xml
@@ -74,10 +74,10 @@
 
         <ImageView
             android:id="@+id/selectionIndicator"
+            android:contentDescription="@string/selectionStateIndicator"
             android:padding="@dimen/keyline_2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:importantForAccessibility="no"
             android:visibility="invisible"
             android:src="@drawable/shape_grey_circle_24"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/item_tab_list.xml
+++ b/app/src/main/res/layout/item_tab_list.xml
@@ -74,7 +74,7 @@
 
         <ImageView
             android:id="@+id/selectionIndicator"
-            android:contentDescription="@string/selectionStateIndicator"
+            android:contentDescription="@string/tabNotSelectedIndicator"
             android:padding="@dimen/keyline_2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/item_tab_list.xml
+++ b/app/src/main/res/layout/item_tab_list.xml
@@ -71,6 +71,19 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
+
+        <ImageView
+            android:id="@+id/selectionIndicator"
+            android:padding="@dimen/keyline_2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:importantForAccessibility="no"
+            android:visibility="invisible"
+            android:src="@drawable/shape_grey_circle_24"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
         <com.duckduckgo.common.ui.view.text.DaxTextView
             android:id="@+id/title"
             android:layout_width="0dp"

--- a/app/src/main/res/layout/popup_tabs_menu.xml
+++ b/app/src/main/res/layout/popup_tabs_menu.xml
@@ -33,6 +33,12 @@
         android:layout_height="wrap_content"
         app:primaryText="@string/selectAllTabsMenuItem" />
 
+    <com.duckduckgo.common.ui.view.PopupMenuItemView
+        android:id="@+id/deselectAllMenuItem"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:primaryText="@string/deselectAllTabsMenuItem" />
+
     <com.duckduckgo.common.ui.view.divider.HorizontalDivider
         android:id="@+id/selectionActionsDivider"
         android:layout_width="match_parent"

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -83,7 +83,8 @@
     <string name="selectAllTabsMenuItem">Select All</string>
     <string name="deselectAllTabsMenuItem">Deselect All</string>
     <string name="tabSelectionTitle" tools:ignore="MissingInstruction">%1$d Selected</string>
-    <string name="selectionStateIndicator">Selection state indicator</string>
+    <string name="tabSelectedIndicator">Tab selected indicator</string>
+    <string name="tabNotSelectedIndicator">Tab not selected indicator</string>
 
     <plurals name="shareLinksMenuItem" tools:ignore="ImpliedQuantity,MissingInstruction">
         <item quantity="one">Share Link</item>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -83,14 +83,17 @@
     <string name="selectAllTabsMenuItem">Select All</string>
     <string name="deselectAllTabsMenuItem">Deselect All</string>
     <string name="tabSelectionTitle" tools:ignore="MissingInstruction">%1$d Selected</string>
+
     <plurals name="shareLinksMenuItem" tools:ignore="ImpliedQuantity,MissingInstruction">
         <item quantity="one">Share Link</item>
         <item quantity="other">Share %1$d Links</item>
     </plurals>
+
     <plurals name="bookmarkTabsMenuItem" tools:ignore="ImpliedQuantity,MissingInstruction">
         <item quantity="one">Bookmark Tab</item>
         <item quantity="other">Bookmark %1$d Tabs</item>
     </plurals>
+
     <plurals name="closeTabsMenuItem" tools:ignore="ImpliedQuantity,MissingInstruction">
         <item quantity="one">Close Tab</item>
         <item quantity="other">Close %1$d Tabs</item>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -81,6 +81,7 @@
 
     <string name="selectTabsMenuItem">Select Tabs</string>
     <string name="selectAllTabsMenuItem">Select All</string>
+    <string name="tabSelectionTitle">%1$d Selected</string>
     <plurals name="shareLinksMenuItem" tools:ignore="ImpliedQuantity,MissingInstruction">
         <item quantity="one">Share Link</item>
         <item quantity="other">Share %1$d Links</item>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -81,6 +81,7 @@
 
     <string name="selectTabsMenuItem">Select Tabs</string>
     <string name="selectAllTabsMenuItem">Select All</string>
+    <string name="deselectAllTabsMenuItem">Deselect All</string>
     <string name="tabSelectionTitle" tools:ignore="MissingInstruction">%1$d Selected</string>
     <plurals name="shareLinksMenuItem" tools:ignore="ImpliedQuantity,MissingInstruction">
         <item quantity="one">Share Link</item>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -81,7 +81,7 @@
 
     <string name="selectTabsMenuItem">Select Tabs</string>
     <string name="selectAllTabsMenuItem">Select All</string>
-    <string name="tabSelectionTitle">%1$d Selected</string>
+    <string name="tabSelectionTitle" tools:ignore="MissingInstruction">%1$d Selected</string>
     <plurals name="shareLinksMenuItem" tools:ignore="ImpliedQuantity,MissingInstruction">
         <item quantity="one">Share Link</item>
         <item quantity="other">Share %1$d Links</item>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -83,6 +83,7 @@
     <string name="selectAllTabsMenuItem">Select All</string>
     <string name="deselectAllTabsMenuItem">Deselect All</string>
     <string name="tabSelectionTitle" tools:ignore="MissingInstruction">%1$d Selected</string>
+    <string name="selectionStateIndicator">Selection state indicator</string>
 
     <plurals name="shareLinksMenuItem" tools:ignore="ImpliedQuantity,MissingInstruction">
         <item quantity="one">Share Link</item>

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -105,11 +105,12 @@ class TabSwitcherViewModelTest {
 
     private lateinit var testee: TabSwitcherViewModel
 
+    private val tabList = listOf(TabEntity("1", position = 1), TabEntity("2", position = 2))
     private val repoDeletableTabs = Channel<List<TabEntity>>()
-    private val tabs = MutableLiveData<List<TabEntity>>()
+    private val tabs = MutableLiveData<List<TabEntity>>(tabList)
 
     private val tabSwitcherData = TabSwitcherData(NEW, GRID)
-    private val flowTabs = flowOf(listOf(TabEntity("1", position = 1), TabEntity("2", position = 2)))
+    private val flowTabs = flowOf(tabList)
 
     @Before
     fun before() {
@@ -267,16 +268,13 @@ class TabSwitcherViewModelTest {
 
     @Test
     fun whenOnCloseAllTabsConfirmedThenTabDeletedAndTabIdClearedAndSessionDeletedAndPixelFired() = runTest {
-        val tab = TabEntity("ID", position = 0)
-        tabs.value = listOf(tab)
-
         testee.tabSwitcherItems.blockingObserve()
 
         testee.onCloseAllTabsConfirmed()
 
-        verify(mockTabRepository).delete(tab)
-        verify(mockAdClickManager).clearTabId(tab.tabId)
-        verify(mockWebViewSessionStorage).deleteSession(tab.tabId)
+        verify(mockTabRepository).delete(tabList.first())
+        verify(mockAdClickManager).clearTabId(tabList.first().tabId)
+        verify(mockWebViewSessionStorage).deleteSession(tabList.first().tabId)
         verify(mockPixel).fire(AppPixelName.TAB_MANAGER_MENU_CLOSE_ALL_TABS_CONFIRMED)
     }
 

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -21,6 +21,7 @@ package com.duckduckgo.app.tabs.ui
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
+import androidx.lifecycle.liveData
 import com.duckduckgo.adclick.api.AdClickManager
 import com.duckduckgo.app.browser.SwipingTabsFeature
 import com.duckduckgo.app.browser.SwipingTabsFeatureProvider
@@ -116,7 +117,7 @@ class TabSwitcherViewModelTest {
     fun before() {
         MockitoAnnotations.openMocks(this)
 
-        swipingTabsFeature.self().setRawStoredState(State(enable = true))
+        swipingTabsFeature.self().setRawStoredState(State(enable = false))
         tabManagerFeatureFlags.multiSelection().setRawStoredState(State(enable = false))
 
         whenever(mockTabRepository.flowDeletableTabs)
@@ -129,6 +130,7 @@ class TabSwitcherViewModelTest {
         whenever(mockTabRepository.tabSwitcherData).thenReturn(flowOf(tabSwitcherData))
         whenever(mockTabRepository.flowTabs).thenReturn(flowTabs)
         whenever(statisticsDataStore.variant).thenReturn("")
+        whenever(mockTabRepository.liveSelectedTab).thenReturn(liveData { null })
 
         initializeViewModel()
     }

--- a/common/common-ui/src/main/res/drawable/ic_check_blue_round_24.xml
+++ b/common/common-ui/src/main/res/drawable/ic_check_blue_round_24.xml
@@ -1,0 +1,17 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <group>
+    <clip-path
+        android:pathData="M0,0h24v24h-24z"/>
+    <path
+        android:pathData="M12,12m-12,0a12,12 0,1 1,24 0a12,12 0,1 1,-24 0"
+        android:fillColor="@color/blue50"/>
+    <path
+        android:pathData="M18.12,6.715C18.553,7.057 18.627,7.686 18.285,8.12L10.785,17.62C10.608,17.844 10.344,17.982 10.059,17.998C9.773,18.015 9.495,17.909 9.293,17.707L5.793,14.207C5.402,13.817 5.402,13.184 5.793,12.793C6.183,12.402 6.817,12.402 7.207,12.793L9.912,15.498L16.715,6.88C17.057,6.447 17.686,6.373 18.12,6.715Z"
+        android:fillColor="#ffffff"
+        android:fillType="evenOdd"/>
+  </group>
+</vector>

--- a/common/common-ui/src/main/res/drawable/shape_grey_circle_24.xml
+++ b/common/common-ui/src/main/res/drawable/shape_grey_circle_24.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2025 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <size
+        android:width="24dp"
+        android:height="24dp"/>
+    <stroke
+        android:width="2dp"
+        android:color="#3D000000"/>
+</shape>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1207969573539955

### Description

This PR adds the tab selection UI and allows the tabs to be selected after triggering the selection mode. The selection mode can be cancelled by tapping anywhere outside a tab.

Some menu items and buttons are already functional, namely:

- New Tab
- FAB New Tab
- Select Tabs (triggers the selection mode)
- Select All (in selection mode)
- Close All Tabs (in selection mode)

Non-functional items:

- All sharing menu items and toolbar buttons
- All bookmarking menu items and toolbar buttons
- All selection-related tab closing (including the FAB)

### Steps to test this PR

_Entering and leaving the selection mode_
- [x] Navigate to the tab switcher
- [x] Make sure you have at least 3 tabs
- [x] Tap on the More menu button
- [x] Tap on Select Tabs
- [x] Verify the selection mode is triggered
- [x] Verify all tabs are deselected
- [x] Verify the sharing and bookmark toolbar buttons are disabled
- [x] Verify the FAB shows "New Tab"
- [x] Tap on a tab
- [x] Verify the tab gets selected (both with a checkmark and decoration)
- [x] Verify the sharing and bookmark toolbar buttons are enabled
- [x] Verify the FAB shows "Close Tabs"
- [x] Verify the toolbar title shows the correct number of selected tabs
- [x] Tap on the empty area
- [x] Verify the tab switcher goes back to the normal mode

_Selecting all tabs_

- [x] Navigate to the tab switcher
- [x] Make sure you have at least 3 tabs
- [x] Trigger the selection mode
- [x] Tap on the more menu and tap on Select All
- [x] Verify all tabs are selected
- [x] Verify the toolbar title shows the correct number of selected tabs
- [x] Tap on the more menu again
- [x] Verify the sharing, bookmarking and closing menu items show the correct number of selected tabs
- [x] Verify the Select all menu item is gone
- [x] Verify the Close Other Tabs item is gone
- [x] Deselect one tab
- [x] Tap on the more menu
- [x] Verify the Select All and Close Other Tabs are back
- [x] Verify the correct number of tabs is shown in the menu items and the toolbar

_Closing all tabs_

- [x] Navigate to the tab switcher
- [x] Trigger the selection mode
- [x] Tap on the more menu and tap on Close All Tabs
- [x] Verify a confirmation dialog is displayed
- [x] Tap on Close
- [x] Verify all tabs are removed

_Adding a new tab_

- [x] Navigate to the tab switcher
- [x] Tap on the more menu and tap on New tab
- [x] Verify a new tab is added (or selected, if a NTP already exists) and the app navigates back to the browser
- [x] Go back to the tab switcher
- [x] Tap on the FAB with a New tab title
- [x] Verify a new tab is added again the same way

_List layout selection_

- [x] Navigate to the tab switcher
- [x] Tap on the list layout toolbar button
- [x] Tap on the More menu and tap on Select Tabs
- [x] Verify the selection mode is triggered
- [x] Smoke test the selection behavior and verify it behaves the same way as grid layout

### Demo

https://github.com/user-attachments/assets/c2dbf94a-78aa-4107-8b34-7a1868d7fed0


