### PR TITLE
Show on App Launch: Remove temporary pixels

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModel.kt
@@ -21,7 +21,6 @@ import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption
 import com.duckduckgo.app.generalsettings.showonapplaunch.store.ShowOnAppLaunchOptionDataStore
-import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import javax.inject.Inject
@@ -32,14 +31,12 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 @ContributesViewModel(ActivityScope::class)
 class ShowOnAppLaunchViewModel @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
     private val showOnAppLaunchOptionDataStore: ShowOnAppLaunchOptionDataStore,
     private val urlConverter: UrlConverter,
-    private val pixel: Pixel,
 ) : ViewModel() {
 
     data class ViewState(
@@ -65,23 +62,15 @@ class ShowOnAppLaunchViewModel @Inject constructor(
     }
 
     fun onShowOnAppLaunchOptionChanged(option: ShowOnAppLaunchOption) {
-        Timber.i("User changed show on app launch option to $option")
         viewModelScope.launch(dispatcherProvider.io()) {
-            firePixel(option)
             showOnAppLaunchOptionDataStore.setShowOnAppLaunchOption(option)
         }
     }
 
     fun setSpecificPageUrl(url: String) {
-        Timber.i("Setting specific page url to $url")
         viewModelScope.launch(dispatcherProvider.io()) {
             val convertedUrl = urlConverter.convertUrl(url)
             showOnAppLaunchOptionDataStore.setSpecificPageUrl(convertedUrl)
         }
-    }
-
-    private fun firePixel(option: ShowOnAppLaunchOption) {
-        val pixelName = ShowOnAppLaunchOption.getPixelName(option)
-        pixel.fire(pixelName)
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/model/ShowOnAppLaunchOption.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/model/ShowOnAppLaunchOption.kt
@@ -16,10 +16,6 @@
 
 package com.duckduckgo.app.generalsettings.showonapplaunch.model
 
-import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_GENERAL_APP_LAUNCH_LAST_OPENED_TAB_SELECTED
-import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_GENERAL_APP_LAUNCH_NEW_TAB_PAGE_SELECTED
-import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_GENERAL_APP_LAUNCH_SPECIFIC_PAGE_SELECTED
-
 sealed class ShowOnAppLaunchOption(val id: Int) {
 
     data object LastOpenedTab : ShowOnAppLaunchOption(1)
@@ -33,12 +29,6 @@ sealed class ShowOnAppLaunchOption(val id: Int) {
             2 -> NewTabPage
             3 -> SpecificPage("")
             else -> throw IllegalArgumentException("Unknown id: $id")
-        }
-
-        fun getPixelName(option: ShowOnAppLaunchOption) = when (option) {
-            LastOpenedTab -> SETTINGS_GENERAL_APP_LAUNCH_LAST_OPENED_TAB_SELECTED
-            NewTabPage -> SETTINGS_GENERAL_APP_LAUNCH_NEW_TAB_PAGE_SELECTED
-            is SpecificPage -> SETTINGS_GENERAL_APP_LAUNCH_SPECIFIC_PAGE_SELECTED
         }
 
         fun getDailyPixelValue(option: ShowOnAppLaunchOption) = when (option) {

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -146,9 +146,6 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     SETTINGS_COOKIE_POPUP_PROTECTION_PRESSED("ms_cookie_popup_protection_setting_pressed"),
     SETTINGS_FIRE_BUTTON_PRESSED("ms_fire_button_setting_pressed"),
     SETTINGS_GENERAL_APP_LAUNCH_PRESSED("m_settings_general_app_launch_pressed"),
-    SETTINGS_GENERAL_APP_LAUNCH_LAST_OPENED_TAB_SELECTED("m_settings_general_app_launch_last_opened_tab_selected"),
-    SETTINGS_GENERAL_APP_LAUNCH_NEW_TAB_PAGE_SELECTED("m_settings_general_app_launch_new_tab_page_selected"),
-    SETTINGS_GENERAL_APP_LAUNCH_SPECIFIC_PAGE_SELECTED("m_settings_general_app_launch_specific_page_selected"),
 
     SURVEY_CTA_SHOWN(pixelName = "mus_cs"),
     SURVEY_CTA_DISMISSED(pixelName = "mus_cd"),

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModelTest.kt
@@ -19,14 +19,9 @@ package com.duckduckgo.app.generalsettings.showonapplaunch
 import app.cash.turbine.test
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.LastOpenedTab
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.NewTabPage
-import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.SpecificPage
 import com.duckduckgo.app.generalsettings.showonapplaunch.store.FakeShowOnAppLaunchOptionDataStore
-import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_GENERAL_APP_LAUNCH_LAST_OPENED_TAB_SELECTED
-import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_GENERAL_APP_LAUNCH_NEW_TAB_PAGE_SELECTED
-import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_GENERAL_APP_LAUNCH_SPECIFIC_PAGE_SELECTED
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.DispatcherProvider
-import com.duckduckgo.fakes.FakePixel
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -40,14 +35,12 @@ class ShowOnAppLaunchViewModelTest {
 
     private lateinit var testee: ShowOnAppLaunchViewModel
     private lateinit var fakeDataStore: FakeShowOnAppLaunchOptionDataStore
-    private lateinit var fakePixel: FakePixel
     private val dispatcherProvider: DispatcherProvider = coroutineTestRule.testDispatcherProvider
 
     @Before
     fun setup() {
         fakeDataStore = FakeShowOnAppLaunchOptionDataStore(LastOpenedTab)
-        fakePixel = FakePixel()
-        testee = ShowOnAppLaunchViewModel(dispatcherProvider, fakeDataStore, FakeUrlConverter(), fakePixel)
+        testee = ShowOnAppLaunchViewModel(dispatcherProvider, fakeDataStore, FakeUrlConverter())
     }
 
     @Test
@@ -87,28 +80,6 @@ class ShowOnAppLaunchViewModelTest {
             val updatedState = awaitItem()
             assertEquals(LastOpenedTab, updatedState.selectedOption)
         }
-    }
-
-    @Test
-    fun whenOptionChangedToLastOpenedPageThenLastOpenedPageIsFired() = runTest {
-        testee.onShowOnAppLaunchOptionChanged(NewTabPage)
-        testee.onShowOnAppLaunchOptionChanged(LastOpenedTab)
-        assertEquals(2, fakePixel.firedPixels.size)
-        assertEquals(SETTINGS_GENERAL_APP_LAUNCH_LAST_OPENED_TAB_SELECTED.pixelName, fakePixel.firedPixels.last())
-    }
-
-    @Test
-    fun whenOptionChangedToNewTabPageThenNewTabPagePixelIsFired() = runTest {
-        testee.onShowOnAppLaunchOptionChanged(NewTabPage)
-        assertEquals(1, fakePixel.firedPixels.size)
-        assertEquals(SETTINGS_GENERAL_APP_LAUNCH_NEW_TAB_PAGE_SELECTED.pixelName, fakePixel.firedPixels[0])
-    }
-
-    @Test
-    fun whenOptionChangedToSpecificPageThenSpecificPixelIsFired() = runTest {
-        testee.onShowOnAppLaunchOptionChanged(SpecificPage("https://example.com"))
-        assertEquals(1, fakePixel.firedPixels.size)
-        assertEquals(SETTINGS_GENERAL_APP_LAUNCH_SPECIFIC_PAGE_SELECTED.pixelName, fakePixel.firedPixels[0])
     }
 
     private class FakeUrlConverter : UrlConverter {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207908166761516/1208302992661645 

### Description
Removes pixel tracking for app launch settings options. This includes removing the pixel firing logic from the ShowOnAppLaunchViewModel and deleting the associated pixel names from AppPixelName.

### Steps to test this PR

_App Launch Settings_
- [x] Navigate to Settings > App Launch
- [x] Change between different launch options (Last Opened Tab, New Tab Page, Specific Page)
- [x] Verify the functionality continues to work as expected
- [x] Verify no pixel tracking events are being sent when changing options

### UI changes
No UI changes