### PR TITLE
Do not autofocus omnibar on error page

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -3953,7 +3953,7 @@ class BrowserTabFragment :
                         hideNewTab()
                     }
 
-                    viewState.daxOnboardingComplete -> {
+                    viewState.daxOnboardingComplete && !viewState.isErrorShowing -> {
                         hideDaxBubbleCta()
                         showNewTab()
                     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2676,6 +2676,7 @@ class BrowserTabViewModel @Inject constructor(
     suspend fun refreshCta(): Cta? {
         if (currentGlobalLayoutState() is Browser) {
             val isBrowserShowing = currentBrowserViewState().browserShowing
+            val isErrorShowing = currentBrowserViewState().maliciousSiteDetected
             if (hasCtaBeenShownForCurrentPage.get() && isBrowserShowing) return null
             val cta = withContext(dispatchers.io()) {
                 ctaViewModel.refreshCta(
@@ -2692,6 +2693,7 @@ class BrowserTabViewModel @Inject constructor(
                 cta = cta,
                 daxOnboardingComplete = isOnboardingComplete,
                 isBrowserShowing = isBrowserShowing,
+                isErrorShowing = isErrorShowing,
             )
             ctaChangedTicker.emit(System.currentTimeMillis().toString())
             return cta
@@ -3212,6 +3214,7 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     override fun onReceivedMaliciousSiteWarning(url: Uri, feed: Feed, exempted: Boolean, clientSideHit: Boolean) {
+        site = siteFactory.buildSite(url = url.toString(), tabId = tabId)
         site?.maliciousSiteStatus = when (feed) {
             MALWARE -> MaliciousSiteStatus.MALWARE
             PHISHING -> MaliciousSiteStatus.PHISHING

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -835,7 +835,7 @@ class BrowserTabViewModel @Inject constructor(
         setAdClickActiveTabData(url)
 
         // we expect refreshCta to be called when a site is fully loaded if browsingShowing -trackers data available-.
-        if (!currentBrowserViewState().browserShowing) {
+        if (!currentBrowserViewState().browserShowing && !currentBrowserViewState().maliciousSiteDetected) {
             viewModelScope.launch {
                 val cta = refreshCta()
                 showOrHideKeyboard(cta) // we hide the keyboard when showing a DialogCta and HomeCta type in the home screen otherwise we show it

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -565,6 +565,9 @@ class OmnibarLayoutViewModel @Inject constructor(
 
     fun onAnimationStarted(decoration: LaunchTrackersAnimation) {
         Timber.d("Omnibar: LaunchTrackersAnimation")
+        if (_viewState.value.viewMode == MaliciousSiteWarning) {
+            return
+        }
         if (!decoration.entities.isNullOrEmpty()) {
             val hasFocus = _viewState.value.hasFocus
             if (!hasFocus) {

--- a/app/src/main/java/com/duckduckgo/app/browser/viewstate/CtaViewState.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/viewstate/CtaViewState.kt
@@ -22,4 +22,5 @@ data class CtaViewState(
     val cta: Cta? = null,
     val daxOnboardingComplete: Boolean = false,
     val isBrowserShowing: Boolean = true,
+    val isErrorShowing: Boolean = false,
 )


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1209363619593651/f 

### Description
* Do not auto-focus omnibar on error page
* Do not show trackers blocked animation on error page
* Update URL on omnibar even if site was prevented from loading
* Do not show search icon on error page


### Steps to test this PR

_Feature 1_
- [x] Open https://privacy-test-pages.site/security/badware/phishing.html
- [x] Click learn more
- [x] Navigate back
- [x] Check omnibar isn't focused when navigating back and showing error page

_Feature 2_
- [x] Open https://privacy-test-pages.site/security/badware/
- [x] Navigate to Standard Phishing Page
- [x] Check Globe icon is shown
- [x] Check the omnibar URL is  https://privacy-test-pages.site/security/badware/phishing.html

_Feature 3_
- [x] Open reddit.com
- [x] Once the trackers animation starts to show, navigate to https://privacy-test-pages.site/security/badware/phishing.html
- [x] Check the omnibar URL is  https://privacy-test-pages.site/security/badware/phishing.html
- [x] Check the trackers blocked animation isn't shown
