### PR TITLE
Send pixel category param as lowercase

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1882,7 +1882,7 @@ class BrowserTabViewModel @Inject constructor(
     ) {
         when (action) {
             LeaveSite -> {
-                val params = mapOf(CATEGORY_KEY to feed.name)
+                val params = mapOf(CATEGORY_KEY to feed.name.lowercase())
                 pixel.fire(AppPixelName.MALICIOUS_SITE_PROTECTION_VISIT_SITE, params)
                 if (activeCustomTab) {
                     command.postValue(CloseCustomTab)
@@ -3206,7 +3206,7 @@ class BrowserTabViewModel @Inject constructor(
             PHISHING -> MaliciousSiteStatus.PHISHING
         }
         if (!exempted) {
-            val params = mapOf(CATEGORY_KEY to feed.name, CLIENT_SIDE_HIT_KEY to clientSideHit.toString())
+            val params = mapOf(CATEGORY_KEY to feed.name.lowercase(), CLIENT_SIDE_HIT_KEY to clientSideHit.toString())
             pixel.fire(AppPixelName.MALICIOUS_SITE_PROTECTION_ERROR_SHOWN, params)
             loadingViewState.postValue(
                 currentLoadingViewState().copy(isLoading = false, progress = 100, url = url.toString()),

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1882,8 +1882,6 @@ class BrowserTabViewModel @Inject constructor(
     ) {
         when (action) {
             LeaveSite -> {
-                val params = mapOf(CATEGORY_KEY to feed.name.lowercase())
-                pixel.fire(AppPixelName.MALICIOUS_SITE_PROTECTION_VISIT_SITE, params)
                 if (activeCustomTab) {
                     command.postValue(CloseCustomTab)
                 } else {
@@ -1894,6 +1892,8 @@ class BrowserTabViewModel @Inject constructor(
             }
 
             VisitSite -> {
+                val params = mapOf(CATEGORY_KEY to feed.name.lowercase())
+                pixel.fire(AppPixelName.MALICIOUS_SITE_PROTECTION_VISIT_SITE, params)
                 command.postValue(BypassMaliciousSiteWarning(url, feed))
                 browserViewState.value = currentBrowserViewState().copy(
                     browserShowing = true,


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/0/0/1209359933476105/f

### Description
We should be firing all pixel params in lowercase, so need to convert the malicious feed category param before sending.

### Steps to test this PR

_Feature 1_
- [x] Filter logcat on "pixel"
- [x] Navigate to [privacy test pages phishing page](https://www.privacy-test-pages.site/security/badware/phishing.html)
- [x] Check that `m_malicious-site-protection_error-page-shown` pixel is sent with `category` param in all lowercase
- [x] Click "Advanced" and "Accept Risk and Visit Site"
- [x] Check that `m_malicious-site-protection_visit-site` pixel is sent with `category` param all lowercase
