### PR TITLE
Update AI chat open pixel

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -266,6 +266,7 @@ import com.duckduckgo.downloads.api.DownloadsFileActions
 import com.duckduckgo.downloads.api.FileDownloader
 import com.duckduckgo.downloads.api.FileDownloader.PendingFileDownload
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.impl.DuckChatPixelName
 import com.duckduckgo.duckplayer.api.DuckPlayer
 import com.duckduckgo.duckplayer.api.DuckPlayerSettingsNoParams
 import com.duckduckgo.js.messaging.api.JsCallbackData
@@ -1026,6 +1027,7 @@ class BrowserTabFragment :
                 onOmnibarNewTabRequested()
             }
             onMenuItemClicked(duckChatMenuItem) {
+                pixel.fire(DuckChatPixelName.DUCK_CHAT_OPEN)
                 duckChat.openDuckChat()
             }
             onMenuItemClicked(bookmarksMenuItem) {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -62,6 +62,7 @@ import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.impl.DuckChatPixelName
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import javax.inject.Inject
@@ -330,7 +331,10 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
             R.id.fire -> onFire()
             R.id.newTab -> onNewTabRequested(fromOverflowMenu = false)
             R.id.newTabOverflow -> onNewTabRequested(fromOverflowMenu = true)
-            R.id.duckChat -> duckChat.openDuckChat()
+            R.id.duckChat -> {
+                pixel.fire(DuckChatPixelName.DUCK_CHAT_OPEN)
+                duckChat.openDuckChat()
+            }
             R.id.closeAllTabs -> closeAllTabs()
             R.id.downloads -> showDownloads()
             R.id.settings -> showSettings()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -139,7 +139,6 @@ class RealDuckChat @Inject constructor(
     }
 
     private fun openDuckChat(parameters: Map<String, String>) {
-        pixel.fire(DuckChatPixelName.DUCK_CHAT_OPEN)
         val url = appendParameters(parameters, duckChatLink)
         startDuckChatActivity(url)
     }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -126,18 +126,6 @@ class RealDuckChatTest {
     }
 
     @Test
-    fun whenOpenDuckChatCalled_pixelIsSent() {
-        testee.openDuckChat()
-        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_OPEN)
-    }
-
-    @Test
-    fun whenOpenDuckChatWithAutoPromptCalled_pixelIsSent() {
-        testee.openDuckChatWithAutoPrompt("example")
-        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_OPEN)
-    }
-
-    @Test
     fun whenOpenDuckChatCalled_activityStarted() {
         testee.openDuckChat()
         verify(mockGlobalActivityStarter).startIntent(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1209368325379704

### Description
- `aichat_open` is currently measuring total opens, it should only measure menu clicks.

### Steps to test this PR

_Overflow menu_
- [x] Open the overflow menu
- [x] Tap “New AI Chat"
- [x] Verify that `aichat_open` pixel is sent

_Tabswitcher_
- [x] Open the tab switcher overflow menu
- [x] Tap “New AI Chat"
- [x] Verify that `aichat_open` pixel is sent
