### PR TITLE
Fix for the backwards typing bug

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -2311,13 +2311,6 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenUserSubmitsQueryThenCaretDoesNotMoveToTheEnd() {
-        whenever(mockOmnibarConverter.convertQueryToUrl("foo", null)).thenReturn("foo.com")
-        testee.onUserSubmittedQuery("foo")
-        assertFalse(omnibarViewState().shouldMoveCaretToEnd)
-    }
-
-    @Test
     fun whenUserRequestedToOpenNewTabThenGenerateWebViewPreviewImage() {
         testee.userRequestedOpeningNewTab()
         assertCommandIssued<Command.GenerateWebViewPreviewImage>()
@@ -5166,7 +5159,6 @@ class BrowserTabViewModelTest {
         assertEquals(false, loadingViewState().isLoading)
 
         assertEquals("", omnibarViewState().omnibarText)
-        assertEquals(false, omnibarViewState().shouldMoveCaretToEnd)
         assertEquals(true, omnibarViewState().forceExpand)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1096,7 +1096,6 @@ class BrowserTabViewModel @Inject constructor(
         findInPageViewState.value = FindInPageViewState(visible = false)
         omnibarViewState.value = currentOmnibarViewState().copy(
             omnibarText = trimmedInput,
-            shouldMoveCaretToEnd = false,
             forceExpand = true,
         )
         browserViewState.value = currentBrowserViewState().copy(
@@ -1356,7 +1355,6 @@ class BrowserTabViewModel @Inject constructor(
         findInPageViewState.value = FindInPageViewState()
         omnibarViewState.value = currentOmnibarViewState().copy(
             omnibarText = "",
-            shouldMoveCaretToEnd = false,
             forceExpand = true,
         )
         loadingViewState.value = currentLoadingViewState().copy(isLoading = false)
@@ -1496,7 +1494,6 @@ class BrowserTabViewModel @Inject constructor(
         val omnibarText = omnibarTextForUrl(url)
         omnibarViewState.value = currentOmnibarViewState.copy(
             omnibarText = omnibarText,
-            shouldMoveCaretToEnd = false,
             forceExpand = true,
         )
         val currentBrowserViewState = currentBrowserViewState()
@@ -1666,7 +1663,6 @@ class BrowserTabViewModel @Inject constructor(
         omnibarViewState.postValue(
             currentOmnibarViewState.copy(
                 omnibarText = omnibarText,
-                shouldMoveCaretToEnd = false,
                 forceExpand = false,
             ),
         )
@@ -3530,7 +3526,6 @@ class BrowserTabViewModel @Inject constructor(
         } else {
             omnibarViewState.value = currentOmnibarViewState().copy(
                 omnibarText = "",
-                shouldMoveCaretToEnd = false,
                 forceExpand = true,
             )
             loadingViewState.value = currentLoadingViewState().copy(isLoading = false)

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -427,7 +427,15 @@ class OmnibarLayout @JvmOverloads constructor(
             is StartTrackersAnimation -> {
                 startTrackersAnimation(command.entities)
             }
+
+            OmnibarLayoutViewModel.Command.MoveCaretToFront -> {
+                moveCaretToFront()
+            }
         }
+    }
+
+    private fun moveCaretToFront() {
+        omnibarTextInput.setSelection(0)
     }
 
     private fun renderTabIcon(viewState: ViewState) {
@@ -498,10 +506,6 @@ class OmnibarLayout @JvmOverloads constructor(
         }
         if (viewState.expanded) {
             setExpanded(true, viewState.expandedAnimated)
-        }
-
-        if (viewState.shouldMoveCaretToStart) {
-            omnibarTextInput.setSelection(0)
         }
 
         if (viewState.isLoading) {

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -435,7 +435,9 @@ class OmnibarLayout @JvmOverloads constructor(
     }
 
     private fun moveCaretToFront() {
-        omnibarTextInput.setSelection(0)
+        omnibarTextInput.post {
+            omnibarTextInput.setSelection(0)
+        }
     }
 
     private fun renderTabIcon(viewState: ViewState) {

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -499,9 +499,6 @@ class OmnibarLayout @JvmOverloads constructor(
         if (viewState.expanded) {
             setExpanded(true, viewState.expandedAnimated)
         }
-        if (viewState.shouldMoveCaretToEnd) {
-            omnibarTextInput.setSelection(viewState.omnibarText.length)
-        }
 
         if (viewState.shouldMoveCaretToStart) {
             omnibarTextInput.setSelection(0)

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -110,7 +110,6 @@ class OmnibarLayoutViewModel @Inject constructor(
         val expanded: Boolean = false,
         val expandedAnimated: Boolean = false,
         val updateOmnibarText: Boolean = false,
-        val shouldMoveCaretToStart: Boolean = false,
         val tabCount: Int = 0,
         val hasUnreadTabs: Boolean = false,
         val shouldUpdateTabsCount: Boolean = false,
@@ -130,6 +129,7 @@ class OmnibarLayoutViewModel @Inject constructor(
     sealed class Command {
         data object CancelTrackersAnimation : Command()
         data class StartTrackersAnimation(val entities: List<Entity>?) : Command()
+        data object MoveCaretToFront : Command()
     }
 
     enum class LeadingIconState {
@@ -167,7 +167,6 @@ class OmnibarLayoutViewModel @Inject constructor(
                     showTabsMenu = showControls,
                     showFireIcon = showControls,
                     showBrowserMenu = showControls,
-                    shouldMoveCaretToStart = false,
                     showVoiceSearch = shouldShowVoiceSearch(
                         hasFocus = true,
                         query = _viewState.value.omnibarText,
@@ -207,10 +206,13 @@ class OmnibarLayoutViewModel @Inject constructor(
                         hasQueryChanged = false,
                         urlLoaded = _viewState.value.url,
                     ),
-                    shouldMoveCaretToStart = true,
                     updateOmnibarText = shouldUpdateOmnibarText,
                     omnibarText = omnibarText,
                 )
+            }
+
+            viewModelScope.launch {
+                command.send(Command.MoveCaretToFront)
             }
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -110,7 +110,6 @@ class OmnibarLayoutViewModel @Inject constructor(
         val expanded: Boolean = false,
         val expandedAnimated: Boolean = false,
         val updateOmnibarText: Boolean = false,
-        val shouldMoveCaretToEnd: Boolean = false,
         val shouldMoveCaretToStart: Boolean = false,
         val tabCount: Int = 0,
         val hasUnreadTabs: Boolean = false,
@@ -494,7 +493,6 @@ class OmnibarLayoutViewModel @Inject constructor(
                     it.copy(
                         expanded = omnibarViewState.forceExpand,
                         expandedAnimated = omnibarViewState.forceExpand,
-                        shouldMoveCaretToEnd = omnibarViewState.shouldMoveCaretToEnd,
                         omnibarText = omnibarViewState.omnibarText,
                         updateOmnibarText = true,
                         showVoiceSearch = shouldShowVoiceSearch(

--- a/app/src/main/java/com/duckduckgo/app/browser/viewstate/OmnibarViewState.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/viewstate/OmnibarViewState.kt
@@ -19,8 +19,6 @@ package com.duckduckgo.app.browser.viewstate
 data class OmnibarViewState(
     val omnibarText: String = "",
     val isEditing: Boolean = false,
-    val shouldMoveCaretToEnd: Boolean = false,
-    val shouldMoveCaretToStart: Boolean = false,
     val navigationChange: Boolean = false,
     val forceExpand: Boolean = true,
 )

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -155,7 +155,6 @@ class OmnibarLayoutViewModelTest {
             assertFalse(viewState.showTabsMenu)
             assertFalse(viewState.showFireIcon)
             assertFalse(viewState.showBrowserMenu)
-            assertFalse(viewState.shouldMoveCaretToStart)
             assertTrue(viewState.highlightPrivacyShield == HighlightableButton.Gone)
             assertTrue(viewState.showVoiceSearch)
         }
@@ -174,7 +173,6 @@ class OmnibarLayoutViewModelTest {
             assertTrue(viewState.showTabsMenu)
             assertTrue(viewState.showFireIcon)
             assertTrue(viewState.showBrowserMenu)
-            assertFalse(viewState.shouldMoveCaretToStart)
             assertTrue(viewState.highlightPrivacyShield == HighlightableButton.Gone)
             assertTrue(viewState.showVoiceSearch)
         }
@@ -194,9 +192,13 @@ class OmnibarLayoutViewModelTest {
             assertTrue(viewState.showTabsMenu)
             assertTrue(viewState.showFireIcon)
             assertTrue(viewState.showBrowserMenu)
-            assertTrue(viewState.shouldMoveCaretToStart)
             assertTrue(viewState.highlightFireButton == HighlightableButton.Visible(highlighted = false))
             assertTrue(viewState.showVoiceSearch)
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            awaitItem().assertCommand(Command.MoveCaretToFront::class)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -215,9 +217,13 @@ class OmnibarLayoutViewModelTest {
             assertTrue(viewState.showTabsMenu)
             assertTrue(viewState.showFireIcon)
             assertTrue(viewState.showBrowserMenu)
-            assertTrue(viewState.shouldMoveCaretToStart)
             assertTrue(viewState.highlightFireButton == HighlightableButton.Visible(highlighted = false))
             assertTrue(viewState.showVoiceSearch)
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            awaitItem().assertCommand(Command.MoveCaretToFront::class)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -236,9 +242,13 @@ class OmnibarLayoutViewModelTest {
             assertTrue(viewState.showTabsMenu)
             assertTrue(viewState.showFireIcon)
             assertTrue(viewState.showBrowserMenu)
-            assertTrue(viewState.shouldMoveCaretToStart)
             assertTrue(viewState.highlightFireButton == HighlightableButton.Visible(highlighted = false))
             assertTrue(viewState.showVoiceSearch)
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            awaitItem().assertCommand(Command.MoveCaretToFront::class)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -257,9 +267,13 @@ class OmnibarLayoutViewModelTest {
             assertTrue(viewState.showTabsMenu)
             assertTrue(viewState.showFireIcon)
             assertTrue(viewState.showBrowserMenu)
-            assertTrue(viewState.shouldMoveCaretToStart)
             assertTrue(viewState.highlightFireButton == HighlightableButton.Visible(highlighted = false))
             assertTrue(viewState.showVoiceSearch)
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            awaitItem().assertCommand(Command.MoveCaretToFront::class)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -795,7 +795,6 @@ class OmnibarLayoutViewModelTest {
             navigationChange = false,
             omnibarText = QUERY,
             forceExpand = false,
-            shouldMoveCaretToEnd = true,
         )
         testee.onExternalStateChange(StateChange.OmnibarStateChange(omnibarState))
 
@@ -805,7 +804,6 @@ class OmnibarLayoutViewModelTest {
             assertTrue(viewState.expandedAnimated == omnibarState.forceExpand)
             assertTrue(viewState.omnibarText == QUERY)
             assertTrue(viewState.updateOmnibarText)
-            assertTrue(viewState.shouldMoveCaretToEnd == omnibarState.shouldMoveCaretToEnd)
         }
     }
 
@@ -815,7 +813,6 @@ class OmnibarLayoutViewModelTest {
             navigationChange = false,
             omnibarText = QUERY,
             forceExpand = false,
-            shouldMoveCaretToEnd = true,
         )
         testee.onExternalStateChange(StateChange.OmnibarStateChange(omnibarState))
         testee.onOmnibarFocusChanged(true, QUERY)
@@ -836,7 +833,6 @@ class OmnibarLayoutViewModelTest {
             assertTrue(viewState.expandedAnimated == omnibarState.forceExpand)
             assertTrue(viewState.omnibarText == QUERY)
             assertTrue(viewState.updateOmnibarText)
-            assertTrue(viewState.shouldMoveCaretToEnd == omnibarState.shouldMoveCaretToEnd)
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1209104073191021

### Description

This PR fixes the backwards typing bug (typing from right-to-left) by replacing the `shouldMoveCaretToStart` ViewState parameter with a command, so that it's executed only once when the omnibar loses focus. 

I've also removed `shouldMoveCaretToEnd` because it was not used (enabled) anywhere in the code. 

### Steps to test this PR

_The fix_
- [x] Start with a single NTP
- [x] Type something and verify it's left-to-right
- [x] Delete the text
- [x] Pull down the notification bar and change the dark mode setting
- [x] Pull up the notification bar
- [x] Type something in the address bar
- [x] Notice the text is correctly written left-to-right

_Long URL shown from the start_
- [x] Navigate to some website where the URL is longer than the address bar
- [x] Tap on the webview so that the address bar loses focus
- [x] Verify that the URL is shown from the beginning, not just its end

