### PR TITLE
Fix back navigation when site blocked before added to webview history

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserStateModifier.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserStateModifier.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.browser
 
 import com.duckduckgo.app.browser.viewstate.BrowserViewState
 import com.duckduckgo.app.browser.viewstate.HighlightableButton
+import com.duckduckgo.app.global.model.MaliciousSiteStatus
 import io.reactivex.annotations.CheckReturnValue
 
 class BrowserStateModifier {
@@ -35,6 +36,8 @@ class BrowserStateModifier {
             canFindInPage = true,
             addToHomeEnabled = true,
             canPrintPage = true,
+            maliciousSiteStatus = null,
+            maliciousSiteBlocked = false,
         )
     }
 
@@ -52,11 +55,13 @@ class BrowserStateModifier {
             addToHomeEnabled = false,
             canGoBack = false,
             canPrintPage = false,
+            maliciousSiteStatus = null,
+            maliciousSiteBlocked = false,
         )
     }
 
     @CheckReturnValue
-    fun copyForMaliciousErrorShowing(original: BrowserViewState): BrowserViewState {
+    fun copyForMaliciousErrorShowing(original: BrowserViewState, maliciousSiteStatus: MaliciousSiteStatus): BrowserViewState {
         return original.copy(
             browserShowing = false,
             canChangePrivacyProtection = false,
@@ -70,6 +75,7 @@ class BrowserStateModifier {
             canPrintPage = false,
             showPrivacyShield = HighlightableButton.Visible(enabled = false),
             maliciousSiteBlocked = true,
+            maliciousSiteStatus = maliciousSiteStatus,
         )
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1381,7 +1381,7 @@ class BrowserTabFragment :
         errorView.errorLayout.show()
     }
 
-    private fun showMaliciousWarning(url: Uri, feed: Feed) {
+    private fun showMaliciousWarning(url: Uri, feed: Feed, onMaliciousWarningShown: (errorNavigationState: ErrorNavigationState) -> Unit) {
         webViewContainer.gone()
         newBrowserTab.newTabLayout.gone()
         newBrowserTab.newTabContainerLayout.gone()
@@ -1401,13 +1401,18 @@ class BrowserTabFragment :
         }
         maliciousWarningView.show()
         binding.focusDummy.requestFocus()
+        val navigationList = webView?.safeCopyBackForwardList() ?: return
+        onMaliciousWarningShown(ErrorNavigationState(navigationList, url, SITE_SECURITY_WARNING))
     }
 
-    private fun hideMaliciousWarning() {
+    private fun hideMaliciousWarning(uri: Uri, title: String?) {
         val navList = webView?.safeCopyBackForwardList()
         val currentIndex = navList?.currentIndex ?: 0
 
         if (currentIndex >= 0) {
+            // We force the error state to clear out any previous navigation status that might have been set since the error
+            // was shown and might prevent a clean page refresh
+            navList?.let { viewModel.navigationStateChanged(ErrorNavigationState(it, uri, title)) }
             Timber.d("MaliciousSite: hiding warning page and triggering a reload of the previous")
             viewModel.recoverFromWarningPage(true)
             refresh()
@@ -1802,8 +1807,8 @@ class BrowserTabFragment :
             )
 
             is Command.WebViewError -> showError(it.errorType, it.url)
-            is Command.ShowWarningMaliciousSite -> showMaliciousWarning(it.url, it.feed)
-            is Command.HideWarningMaliciousSite -> hideMaliciousWarning()
+            is Command.ShowWarningMaliciousSite -> showMaliciousWarning(it.url, it.feed, it.onMaliciousWarningShown)
+            is Command.HideWarningMaliciousSite -> hideMaliciousWarning(it.url, it.title)
             is Command.EscapeMaliciousSite -> onEscapeMaliciousSite()
             is Command.CloseCustomTab -> closeCustomTab()
             is Command.BypassMaliciousSiteWarning -> onBypassMaliciousWarning(it.url, it.feed)

--- a/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
@@ -27,6 +27,7 @@ import android.webkit.ValueCallback
 import androidx.annotation.DrawableRes
 import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteSuggestion
 import com.duckduckgo.app.browser.BrowserTabViewModel.FileChooserRequestedParams
+import com.duckduckgo.app.browser.ErrorNavigationState
 import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType.AppLink
 import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType.NonHttpAppLink
 import com.duckduckgo.app.browser.SslErrorResponse
@@ -221,9 +222,13 @@ sealed class Command {
     data class ShowWarningMaliciousSite(
         val url: Uri,
         val feed: Feed,
+        val onMaliciousWarningShown: (errorNavigationState: ErrorNavigationState) -> Unit,
     ) : Command()
 
-    data object HideWarningMaliciousSite : Command()
+    data class HideWarningMaliciousSite(
+        val url: Uri,
+        val title: String?,
+    ) : Command()
 
     data object EscapeMaliciousSite : Command()
 

--- a/app/src/main/java/com/duckduckgo/app/browser/viewstate/BrowserViewState.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/viewstate/BrowserViewState.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.browser.viewstate
 import com.duckduckgo.app.browser.SSLErrorType
 import com.duckduckgo.app.browser.SpecialUrlDetector
 import com.duckduckgo.app.browser.WebViewErrorResponse
+import com.duckduckgo.app.global.model.MaliciousSiteStatus
 import com.duckduckgo.privacyprotectionspopup.api.PrivacyProtectionsPopupViewState
 import com.duckduckgo.savedsites.api.models.SavedSite
 
@@ -54,6 +55,7 @@ data class BrowserViewState(
     val browserError: WebViewErrorResponse = WebViewErrorResponse.OMITTED,
     val sslError: SSLErrorType = SSLErrorType.NONE,
     val maliciousSiteBlocked: Boolean = false,
+    val maliciousSiteStatus: MaliciousSiteStatus? = null,
     val privacyProtectionsPopupViewState: PrivacyProtectionsPopupViewState = PrivacyProtectionsPopupViewState.Gone,
     val showDuckChatOption: Boolean = false,
 )


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1209377556005337 

### Description
Fix back navigation when site blocked before added to webview history, which was causing omnibar URL and privacy shield icon not to update correctly

### Steps to test this PR

_Feature 1_
- [ ] Open [wikipedia.org](https://wikipedia.org/)
- [ ] Open https://privacy-test-pages.site/security/badware/phishing.html
- [ ] Navigate back
- [ ] Notice wikipedia is loaded with the right omnibar text and icon, even after reload
