### PR TITLE
Target Android 15: Add ELF alignment verification CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,19 @@ jobs:
       - name: Build
         run: ./gradlew androidTestsBuild
 
+      - name: Find test APK path
+        id: find-apk
+        run: |
+          TEST_APK_PATH=$(find . -path '*/build/outputs/apk/play/debug/*.apk' -type f -print -quit)
+          echo "Found test APK at: $TEST_APK_PATH"
+          echo "apk_path=$TEST_APK_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Make script executable
+        run: chmod +x scripts/check_elf_alignment.sh
+
+      - name: Check native libraries alignment
+        run: ./scripts/check_elf_alignment.sh ${{ steps.find-apk.outputs.apk_path }}
+
       - name: Run Android Tests
         run: ./gradlew runFlankAndroidTests
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,26 +160,44 @@ jobs:
         run: chmod +x scripts/check_elf_alignment.sh
 
       - name: Check native libraries alignment
+        id: check-alignment
+        continue-on-error: true
         run: ./scripts/check_elf_alignment.sh ${{ steps.find-apk.outputs.apk_path }}
 
+      - name: Handle native alignment failure
+        if: steps.check-alignment.outcome == 'failure'
+        run: |
+          echo "::error::Native library alignment check failed!"
+          echo "::error::Please check the native libraries in your APK for correct page size alignment."
+          exit 1
+
       - name: Run Android Tests
+        if: steps.check-alignment.outcome == 'success'
         run: ./gradlew runFlankAndroidTests
 
       - name: Bundle the Android CI tests report
-        if: always()
+        if: |
+          always() &&
+          steps.check-alignment.outcome == 'success'
         run: find . -type d -name 'fladleResults' | zip -@ -r android-tests-report.zip
 
       - name: Generate json file with failures
-        if: ${{ failure() }}
+        if: |
+          failure() &&
+          steps.check-alignment.outcome == 'success'
         run: cat build/fladle/fladleResults/HtmlErrorReport.html | cut -d\`  -f2 >> results.json
 
       - name: Print failure report
-        if: ${{ failure() }}
+        if: |
+          failure() &&
+          steps.check-alignment.outcome == 'success'
         run: |
           jq -r '.[] | .label as $id | .items[] | "Test:", $id, "Failure:", .label, "URL:", .url, "\n"' results.json
 
       - name: Upload the Android CI tests report
-        if: always()
+        if: |
+          always() &&
+          steps.check-alignment.outcome == 'success'
         uses: actions/upload-artifact@v4
         with:
           name: android-tests-report

--- a/scripts/check_elf_alignment.sh
+++ b/scripts/check_elf_alignment.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+progname="${0##*/}"
+progname="${progname%.sh}"
+# usage: check_elf_alignment.sh [path to *.so files|path to *.apk]
+cleanup_trap() {
+  if [ -n "${tmp}" -a -d "${tmp}" ]; then
+    rm -rf ${tmp}
+  fi
+  exit $1
+}
+usage() {
+  echo "Host side script to check the ELF alignment of shared libraries."
+  echo "Shared libraries are reported ALIGNED when their ELF regions are"
+  echo "16 KB or 64 KB aligned. Otherwise they are reported as UNALIGNED."
+  echo
+  echo "Usage: ${progname} [input-path|input-APK|input-APEX]"
+}
+if [ ${#} -ne 1 ]; then
+  usage
+  exit
+fi
+case ${1} in
+  --help | -h | -\?)
+    usage
+    exit
+    ;;
+  *)
+    dir="${1}"
+    ;;
+esac
+if ! [ -f "${dir}" -o -d "${dir}" ]; then
+  echo "Invalid file: ${dir}" >&2
+  exit 1
+fi
+if [[ "${dir}" == *.apk ]]; then
+  trap 'cleanup_trap' EXIT
+  echo
+  echo "Recursively analyzing $dir"
+  echo
+  if { zipalign --help 2>&1 | grep -q "\-P <pagesize_kb>"; }; then
+    echo "=== APK zip-alignment ==="
+    zipalign -v -c -P 16 4 "${dir}" | egrep 'lib/arm64-v8a|lib/x86_64|Verification'
+    echo "========================="
+  else
+    echo "NOTICE: Zip alignment check requires build-tools version 35.0.0-rc3 or higher."
+    echo "  You can install the latest build-tools by running the below command"
+    echo "  and updating your \$PATH:"
+    echo
+    echo "    sdkmanager \"build-tools;35.0.0-rc3\""
+  fi
+  dir_filename=$(basename "${dir}")
+  tmp=$(mktemp -d -t "${dir_filename%.apk}_out_XXXXX")
+  unzip "${dir}" lib/* -d "${tmp}" >/dev/null 2>&1
+  dir="${tmp}"
+fi
+if [[ "${dir}" == *.apex ]]; then
+  trap 'cleanup_trap' EXIT
+  echo
+  echo "Recursively analyzing $dir"
+  echo
+  dir_filename=$(basename "${dir}")
+  tmp=$(mktemp -d -t "${dir_filename%.apex}_out_XXXXX")
+  deapexer extract "${dir}" "${tmp}" || { echo "Failed to deapex." && exit 1; }
+  dir="${tmp}"
+fi
+RED=$(tput setaf 1)
+GREEN=$(tput setaf 2)
+ENDCOLOR=$(tput sgr0)
+unaligned_libs=()
+echo
+echo "=== ELF alignment ==="
+matches="$(find "${dir}" -type f)"
+IFS=$'\n'
+exit_code=0
+
+for match in $matches; do
+  [[ "${match}" == *".apk" ]] && echo "WARNING: doesn't recursively inspect .apk file: ${match}"
+  [[ "${match}" == *".apex" ]] && echo "WARNING: doesn't recursively inspect .apex file: ${match}"
+  [[ $(file "${match}") == *"ELF"* ]] || continue
+  res="$(objdump -p "${match}" | grep LOAD | awk '{ print $NF }' | head -1)"
+  if [[ $res =~ 2\*\*(1[4-9]|[2-9][0-9]|[1-9][0-9]{2,}) ]]; then
+    echo -e "${match}: ${GREEN}ALIGNED${ENDCOLOR} ($res)"
+  else
+    echo -e "${match}: ${RED}UNALIGNED${ENDCOLOR} ($res)"
+    unaligned_libs+=("${match}")
+    exit_code=1
+  fi
+done
+
+if [ ${#unaligned_libs[@]} -gt 0 ]; then
+  echo -e "${RED}Found ${#unaligned_libs[@]} unaligned libs (only arm64-v8a/x86_64 libs need to be aligned).${ENDCOLOR}"
+  cleanup_trap 1  # Exit with error code 1 when unaligned libs are found
+elif [ -n "${dir_filename}" ]; then
+  echo -e "ELF Verification Successful"
+fi
+echo "====================="
+cleanup_trap 0  # Exit with code 0 only if no unaligned libs were found


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1209378846484863

### Description
Added ELF alignment verification to the CI pipeline to ensure native libraries are properly aligned at 16KB or 64KB boundaries. This includes a new shell script that checks alignment in APK files and reports any misaligned libraries.

A passing build using playDebug: https://github.com/duckduckgo/Android/actions/runs/13291887849/job/37114510525?pr=5634

A failing build using internalDebug (because of Flipper which we know about)
https://github.com/duckduckgo/Android/actions/runs/13292470506/job/37116369658?pr=5634

### Steps to test this PR

_ELF Alignment Verification_
- [x] Build a debug APK using `./gradlew androidTestsBuild`
- [x] Run `./scripts/check_elf_alignment.sh path/to/your/app.apk`
- [x] Verify that all native libraries are reported as ALIGNED
- [x] Check that the CI pipeline successfully executes the alignment verification step

### UI changes
No UI changes in this PR