### PR TITLE
Make sure UnprotectedVpnControllerService requests go outside the VPN tunnel

### DIFF
--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/pixels/WireguardHandshakeMonitor.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/pixels/WireguardHandshakeMonitor.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.networkprotection.impl.pixels.WireguardHandshakeMonitor.Li
 import com.squareup.anvil.annotations.ContributesMultibinding
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
@@ -67,6 +68,7 @@ class WireguardHandshakeMonitor @Inject constructor(
 
     private val job = ConflatedJob()
     private val failureReported = AtomicBoolean(false)
+    private val attemptsWithZeroHandshakeEpoc = AtomicInteger(0)
 
     override fun onVpnStarted(coroutineScope: CoroutineScope) {
         job += coroutineScope.launch {
@@ -92,11 +94,15 @@ class WireguardHandshakeMonitor @Inject constructor(
         if (networkProtectionState.isEnabled()) {
             failureReported.set(false)
             currentNetworkState.start()
+            attemptsWithZeroHandshakeEpoc.set(0)
 
             while (isActive && networkProtectionState.isEnabled()) {
                 val nowSeconds = Instant.now().epochSecond
                 val lastHandshakeEpocSeconds = wgProtocol.getStatistics().lastHandshakeEpochSeconds
-                if (lastHandshakeEpocSeconds > 0) {
+                logcat { "Handshake monitoring $lastHandshakeEpocSeconds" }
+                if (lastHandshakeEpocSeconds > 0 || attemptsWithZeroHandshakeEpoc.compareAndSet(MAX_ATTEMPTS_WITH_NO_HS_EPOC, 0)) {
+                    attemptsWithZeroHandshakeEpoc.set(0) // reset in case lastHandshakeEpocSeconds > 0
+
                     val diff = nowSeconds - lastHandshakeEpocSeconds
                     if (diff.seconds.inWholeMinutes > REPORT_TUNNEL_FAILURE_IN_THRESHOLD_MINUTES && currentNetworkState.isConnected()) {
                         logcat(WARN) { "Last handshake was more than 5 minutes ago" }
@@ -118,6 +124,8 @@ class WireguardHandshakeMonitor @Inject constructor(
                             }
                         }
                     }
+                } else {
+                    attemptsWithZeroHandshakeEpoc.incrementAndGet()
                 }
                 delay(1.minutes.inWholeMilliseconds)
             }
@@ -127,6 +135,9 @@ class WireguardHandshakeMonitor @Inject constructor(
     companion object {
         // WG handshakes happen every 2min, this means we'd miss 2+ handshakes
         private const val REPORT_TUNNEL_FAILURE_IN_THRESHOLD_MINUTES = 5
+
+        // WG handshakes happen every 2min, this mean 5 handshakes
+        private const val MAX_ATTEMPTS_WITH_NO_HS_EPOC = 10
 
         // WG handshakes happen every 2min
         private const val REPORT_TUNNEL_FAILURE_RECOVERY_THRESHOLD_MINUTES = 2

--- a/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/feature/NetPInternalSettingsActivity.kt
+++ b/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/feature/NetPInternalSettingsActivity.kt
@@ -234,7 +234,11 @@ class NetPInternalSettingsActivity : DuckDuckGoActivity() {
 
         binding.forceRekey.setClickListener {
             lifecycleScope.launch {
-                sendBroadcast(Intent(DebugRekeyReceiver.ACTION_FORCE_REKEY))
+                Intent(DebugRekeyReceiver.ACTION_FORCE_REKEY).apply {
+                    setPackage(this@NetPInternalSettingsActivity.packageName)
+                }.also {
+                    sendBroadcast(it)
+                }
             }
         }
 

--- a/network-protection/network-protection-internal/src/main/res/layout/activity_netp_internal_settings.xml
+++ b/network-protection/network-protection-internal/src/main/res/layout/activity_netp_internal_settings.xml
@@ -110,6 +110,15 @@
                 app:primaryText="@string/netpForceRekey"
                 app:showSwitch="false"
                 />
+
+            <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+                android:id="@+id/egressFailure"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="@string/netpEgressFailure"
+                app:showSwitch="false"
+                />
+
             <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
                 android:id="@+id/changeEnvironment"
                 android:layout_width="match_parent"

--- a/network-protection/network-protection-internal/src/main/res/values/donottranslate.xml
+++ b/network-protection/network-protection-internal/src/main/res/values/donottranslate.xml
@@ -29,6 +29,7 @@
     <string name="netpDevSettingConnectionQuality">Connection Quality</string>
     <string name="netpPcapRecording">Enable PCAP recording</string>
     <string name="netpForceRekey">Force Rekey</string>
+    <string name="netpEgressFailure">Simulate egress failure</string>
     <string name="netpUnsafeWifiDetectionPrimary">Unsafe Wi-Fi detection</string>
     <string name="netpUnsafeWifiDetectionByline">Get notified when connected to unsafe Wi-Fi without a VPN.</string>
     <string name="netpBlockMalwarePrimary">Block Malware</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1198194956794324/1209378254127336

### Description
Make sure the `WgVpnControllerService` service marked as `UnprotectedVpnControllerService` makes calls outside the VPN tunnel.
This seems to fix rekey

### Steps to test this PR

_Test_
- [x] build the internal build
- [x] to go dev settings -> NetP dev settings and click on `Force rekey`
- [x] verify rekey should succeed all the time
- [x] verify the logcat contains `Request to: https://controller.netp.duckduckgo.com/register uses socket: <your local IP address>

