### PR TITLE
Check enableMaliciousSiteProtection flag to set settigns visibility

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/generalsettings/GeneralSettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/GeneralSettingsActivity.kt
@@ -126,11 +126,20 @@ class GeneralSettingsActivity : DuckDuckGoActivity() {
                     } else {
                         binding.autocompleteRecentlyVisitedSitesToggle.isVisible = false
                     }
-                    binding.maliciousDisabledMessage.isVisible = !it.maliciousSiteProtectionEnabled
-                    binding.maliciousToggle.quietlySetIsChecked(
-                        newCheckedState = it.maliciousSiteProtectionEnabled,
-                        changeListener = maliciousSiteProtectionToggleListener,
-                    )
+                    if (it.maliciousSiteProtectionFeatureAvailable) {
+                        binding.maliciousDisabledMessage.isVisible = !it.maliciousSiteProtectionEnabled
+                        binding.maliciousToggle.quietlySetIsChecked(
+                            newCheckedState = it.maliciousSiteProtectionEnabled,
+                            changeListener = maliciousSiteProtectionToggleListener,
+                        )
+                    } else {
+                        binding.maliciousDisabledMessage.isVisible = false
+                    }
+                    binding.maliciousLearnMore.isVisible = it.maliciousSiteProtectionFeatureAvailable
+                    binding.maliciousSiteDivider.isVisible = it.maliciousSiteProtectionFeatureAvailable
+                    binding.maliciousSiteHeading.isVisible = it.maliciousSiteProtectionFeatureAvailable
+                    binding.maliciousToggle.isVisible = it.maliciousSiteProtectionFeatureAvailable
+
                     if (it.showVoiceSearch) {
                         binding.voiceSearchToggle.isVisible = true
                         binding.voiceSearchToggle.quietlySetIsChecked(viewState.voiceSearchEnabled, voiceSearchChangeListener)

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/GeneralSettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/GeneralSettingsViewModel.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.app.pixels.AppPixelName.AUTOCOMPLETE_GENERAL_SETTINGS_TOGG
 import com.duckduckgo.app.pixels.AppPixelName.AUTOCOMPLETE_GENERAL_SETTINGS_TOGGLED_ON
 import com.duckduckgo.app.pixels.AppPixelName.AUTOCOMPLETE_RECENT_SITES_GENERAL_SETTINGS_TOGGLED_OFF
 import com.duckduckgo.app.pixels.AppPixelName.AUTOCOMPLETE_RECENT_SITES_GENERAL_SETTINGS_TOGGLED_ON
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.utils.DispatcherProvider
@@ -59,6 +60,7 @@ class GeneralSettingsViewModel @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
     private val showOnAppLaunchFeature: ShowOnAppLaunchFeature,
     private val showOnAppLaunchOptionDataStore: ShowOnAppLaunchOptionDataStore,
+    private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
 ) : ViewModel() {
 
     data class ViewState(
@@ -70,6 +72,7 @@ class GeneralSettingsViewModel @Inject constructor(
         val isShowOnAppLaunchOptionVisible: Boolean,
         val showOnAppLaunchSelectedOption: ShowOnAppLaunchOption,
         val maliciousSiteProtectionEnabled: Boolean,
+        val maliciousSiteProtectionFeatureAvailable: Boolean,
     )
 
     sealed class Command {
@@ -98,6 +101,7 @@ class GeneralSettingsViewModel @Inject constructor(
                 isShowOnAppLaunchOptionVisible = showOnAppLaunchFeature.self().isEnabled(),
                 showOnAppLaunchSelectedOption = showOnAppLaunchOptionDataStore.optionFlow.first(),
                 maliciousSiteProtectionEnabled = settingsDataStore.maliciousSiteProtectionEnabled,
+                maliciousSiteProtectionFeatureAvailable = androidBrowserConfigFeature.enableMaliciousSiteProtection().isEnabled(),
             )
         }
 

--- a/app/src/main/res/layout/activity_general_settings.xml
+++ b/app/src/main/res/layout/activity_general_settings.xml
@@ -81,6 +81,7 @@
                 tools:secondaryText="Last Opened Tab" />
 
             <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+                android:id="@+id/maliciousSiteDivider"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
 

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/GeneralSettingsViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/GeneralSettingsViewModelTest.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchO
 import com.duckduckgo.app.generalsettings.showonapplaunch.store.FakeShowOnAppLaunchOptionDataStore
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_GENERAL_APP_LAUNCH_PRESSED
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.common.test.CoroutineTestRule
@@ -85,6 +86,8 @@ internal class GeneralSettingsViewModelTest {
     val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
 
     private val dispatcherProvider = coroutineTestRule.testDispatcherProvider
+
+    private val fakeBrowserConfigFeature = FakeFeatureToggleFactory.create(AndroidBrowserConfigFeature::class.java)
 
     @Before
     fun before() {
@@ -363,6 +366,7 @@ internal class GeneralSettingsViewModelTest {
         isShowOnAppLaunchOptionVisible = fakeShowOnAppLaunchFeatureToggle.self().isEnabled(),
         showOnAppLaunchSelectedOption = LastOpenedTab,
         maliciousSiteProtectionEnabled = true,
+        maliciousSiteProtectionFeatureAvailable = false,
     )
 
     private fun initTestee() {
@@ -375,6 +379,7 @@ internal class GeneralSettingsViewModelTest {
             dispatcherProvider,
             fakeShowOnAppLaunchFeatureToggle,
             fakeShowOnAppLaunchOptionDataStore,
+            fakeBrowserConfigFeature,
         )
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1209386990832086/f 

### Description
Check enableMaliciousSiteProtection flag to set settings visibility

### Steps to test this PR

_Feature 1_
- [x] With enableMaliciousSiteProtection disabled, check MSP settings are not shown in general settings

_Feature 2_ 
- [x] With enableMaliciousSiteProtection enabled, check MSP settings are shown in general settings and are functional
