### PR TITLE
Check maliciousSiteProtection flag to set settigns visibility

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/generalsettings/GeneralSettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/GeneralSettingsViewModel.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.history.api.NavigationHistory
+import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection
 import com.duckduckgo.voice.api.VoiceSearchAvailability
 import com.duckduckgo.voice.impl.VoiceSearchPixelNames.VOICE_SEARCH_GENERAL_SETTINGS_OFF
 import com.duckduckgo.voice.impl.VoiceSearchPixelNames.VOICE_SEARCH_GENERAL_SETTINGS_ON
@@ -61,6 +62,7 @@ class GeneralSettingsViewModel @Inject constructor(
     private val showOnAppLaunchFeature: ShowOnAppLaunchFeature,
     private val showOnAppLaunchOptionDataStore: ShowOnAppLaunchOptionDataStore,
     private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
+    private val maliciousSiteProtection: MaliciousSiteProtection,
 ) : ViewModel() {
 
     data class ViewState(
@@ -101,7 +103,8 @@ class GeneralSettingsViewModel @Inject constructor(
                 isShowOnAppLaunchOptionVisible = showOnAppLaunchFeature.self().isEnabled(),
                 showOnAppLaunchSelectedOption = showOnAppLaunchOptionDataStore.optionFlow.first(),
                 maliciousSiteProtectionEnabled = settingsDataStore.maliciousSiteProtectionEnabled,
-                maliciousSiteProtectionFeatureAvailable = androidBrowserConfigFeature.enableMaliciousSiteProtection().isEnabled(),
+                maliciousSiteProtectionFeatureAvailable =
+                androidBrowserConfigFeature.enableMaliciousSiteProtection().isEnabled() && maliciousSiteProtection.isFeatureEnabled(),
             )
         }
 

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/GeneralSettingsViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/GeneralSettingsViewModelTest.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.history.api.NavigationHistory
+import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection
 import com.duckduckgo.voice.api.VoiceSearchAvailability
 import com.duckduckgo.voice.impl.VoiceSearchPixelNames
 import com.duckduckgo.voice.store.VoiceSearchRepository
@@ -48,6 +49,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
+import org.mockito.Mockito.mock
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
@@ -88,6 +90,8 @@ internal class GeneralSettingsViewModelTest {
     private val dispatcherProvider = coroutineTestRule.testDispatcherProvider
 
     private val fakeBrowserConfigFeature = FakeFeatureToggleFactory.create(AndroidBrowserConfigFeature::class.java)
+
+    private val mockMaliciousSiteProtection: MaliciousSiteProtection = mock()
 
     @Before
     fun before() {
@@ -380,6 +384,7 @@ internal class GeneralSettingsViewModelTest {
             fakeShowOnAppLaunchFeatureToggle,
             fakeShowOnAppLaunchOptionDataStore,
             fakeBrowserConfigFeature,
+            mockMaliciousSiteProtection,
         )
     }
 }

--- a/malicious-site-protection/malicious-site-protection-api/src/main/kotlin/com/duckduckgo/malicioussiteprotection/api/MaliciousSiteProtection.kt
+++ b/malicious-site-protection/malicious-site-protection-api/src/main/kotlin/com/duckduckgo/malicioussiteprotection/api/MaliciousSiteProtection.kt
@@ -22,6 +22,8 @@ interface MaliciousSiteProtection {
 
     suspend fun isMalicious(url: Uri, confirmationCallback: (maliciousStatus: MaliciousStatus) -> Unit): IsMaliciousResult
 
+    fun isFeatureEnabled(): Boolean
+
     sealed class MaliciousStatus {
         data class Malicious(val feed: Feed) : MaliciousStatus()
         data object Safe : MaliciousStatus()

--- a/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/domain/RealMaliciousSiteProtection.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/domain/RealMaliciousSiteProtection.kt
@@ -48,6 +48,10 @@ class RealMaliciousSiteProtection @Inject constructor(
 
     private val timber = Timber.tag("MaliciousSiteProtection")
 
+    override fun isFeatureEnabled(): Boolean {
+        return maliciousSiteProtectionRCFeature.isFeatureEnabled()
+    }
+
     override suspend fun isMalicious(
         url: Uri,
         confirmationCallback: (confirmedResult: MaliciousStatus) -> Unit,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1209390510093034 

### Description

### Steps to test this PR

### Description
Check maliciousSiteProtection flag to set settings visibility

### Steps to test this PR

_Feature 1_
- [ ] With enableMaliciousSiteProtection disabled, check MSP settings are not shown in general settings

_Feature 2_ 
- [ ] With enableMaliciousSiteProtection (androidbrowserconfig) and maliciousSiteProtection enabled, check MSP settings are shown in general settings and are functional

_Feature 3_ 
- [ ] With e maliciousSiteProtection disabled, check MSP settings are not shown in general settings

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
