### PR TITLE
Update content scope scripts to version 7.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "1.0.0",
       "dependencies": {
         "@duckduckgo/autoconsent": "^12.9.0",
-        "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.4.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.2.1",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.17.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.18.0",
+        "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.4.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1738159777"
       },
       "devDependencies": {
         "@rollup/plugin-json": "^4.1.0",
-        "@rollup/plugin-node-resolve": gt "^13.0.6",
+        "@rollup/plugin-node-resolve": "^13.0.6",
         "rollup": "^2.61.0",
         "rollup-plugin-terser": "^7.0.2"
       }
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#1876d68142cf4f9abfaaee235a015d287eb71226",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#874b27ad51d1784c934760c85493f78e609c4409",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -651,9 +651,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.38.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.38.1.tgz",
-      "integrity": "sha512-GWANVlPM/ZfYzuPHjq0nxT+EbOEDDN3Jwhwdg1D8TU8oSkktp8w64Uq4auuGLxFSoNTRDncTq2hQHX1Ld9KHkA==",
+      "version": "5.38.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.38.2.tgz",
+      "integrity": "sha512-w8CXxxbFA5zfNsR/i8HZq5bvn18AK0O9jj7hyo1YqkovLxEFa0uP0LCVGZRqiRaKRFxXhELBp8SteeAjEnfeJg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^12.9.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.2.1",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.17.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.18.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.4.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1738159777"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1209394211370089/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass