### PR TITLE
Remove App Tracking subtitle assertion from Maestro test

### DIFF
--- a/.maestro/app_tp/app_tp_onboarding.yaml
+++ b/.maestro/app_tp/app_tp_onboarding.yaml
@@ -17,7 +17,6 @@ tags:
         - tapOn:
             text: "Settings"
             index: 0
-        - assertVisible: "Block app trackers on your device"
         - tapOn: "App Tracking Protection"
         - assertVisible: "One easy step for better app privacy!"
         - assertVisible: "Continue"


### PR DESCRIPTION
Remove assertion for App Tracking Protection subtitle text which is no longer displayed in settings

Task/Issue URL: https://app.asana.com/0/488551667048375/1209394870150674

### Description
The settings menu item for App Tracking Protection no longer displays the subtitle "Block app trackers on your device", so the corresponding assertion check has been removed from the test.

### Steps to test this PR

Run `maestro test .maestro/app_tp/app_tp_onboarding.yaml` locally

### UI changes
N/A