### PR TITLE
enable showing suggestions inside DDG (behind FF)

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/AutofillServiceFeature.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/AutofillServiceFeature.kt
@@ -38,4 +38,8 @@ interface AutofillServiceFeature {
     @Toggle.DefaultValue(false)
     @InternalAlwaysEnabled
     fun canMapAppToDomain(): Toggle
+
+    @Toggle.DefaultValue(false)
+    @InternalAlwaysEnabled
+    fun canAutofillInsideDDG(): Toggle
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1209399460038441 

### Description
show suggestions inside DDG app
Put it behind a FF in case we uncover unexpected behaviors

### Steps to test this PR

_Feature 1_
- [ ] Visiting fill.dev or other sites inside DDG
- [ ] focus on login fields
- [ ] you should see suggestions as in other apps

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
