### PR TITLE
Fix notification set color

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/notification/NotificationFactory.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/NotificationFactory.kt
@@ -41,7 +41,7 @@ class NotificationFactory @Inject constructor(
             .setContentTitle(specification.title)
             .setContentText(specification.description)
             .setStyle(NotificationCompat.BigTextStyle().bigText(specification.description))
-            .setColor(ContextCompat.getColor(context, specification.color))
+            .setColor(specification.color)
             .setContentIntent(launchIntent)
             .setDeleteIntent(cancelIntent)
             .setAutoCancel(specification.autoCancel)

--- a/app/src/main/java/com/duckduckgo/app/notification/NotificationFactory.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/NotificationFactory.kt
@@ -21,7 +21,6 @@ import android.app.PendingIntent
 import android.content.Context
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
-import androidx.core.content.ContextCompat
 import com.duckduckgo.app.notification.model.NotificationSpec
 import javax.inject.Inject
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1209283169834729

### Description
- `context.getColorFromAttr` already returns a `ColorInt`, so `setColor(ContextCompat.getColor(…` causes: https://github.com/duckduckgo/Android/issues/5563

### Steps to test this PR
- [ ] Go to dev settings and trigger a notification
- [ ] Verify that the notification is triggered and the app does not crash
