### PR TITLE
Fix translation in Russian

### DIFF
--- a/saved-sites/saved-sites-impl/src/main/res/values-bg/strings-saved-sites.xml
+++ b/saved-sites/saved-sites-impl/src/main/res/values-bg/strings-saved-sites.xml
@@ -59,8 +59,8 @@
     <!-- Bookmark folders -->
     <string name="bookmarkDialogTitleEdit">Редактиране на отметка</string>
     <string name="favoriteDialogTitleEdit">Редактиране на Предпочитан</string>
-    <string name="locationLabel">Местоположение</string>
-    <string name="folderLocationTitle">Изберете местоположение</string>
+    <string name="locationLabel" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Местоположение</string>
+    <string name="folderLocationTitle" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Изберете местоположение</string>
     <string name="addFolder">Добавяне на папка</string>
     <string name="editFolder">Редактиране на папка</string>
     <string name="bookmarkFolderDeleteDialogTitle" instruction="Dialog title for deleting a folder with bookmarks">"Изтриване на папката и нейното съдържание?"</string>

--- a/saved-sites/saved-sites-impl/src/main/res/values-cs/strings-saved-sites.xml
+++ b/saved-sites/saved-sites-impl/src/main/res/values-cs/strings-saved-sites.xml
@@ -61,8 +61,8 @@
     <!-- Bookmark folders -->
     <string name="bookmarkDialogTitleEdit">Upravit záložku</string>
     <string name="favoriteDialogTitleEdit">Upravit oblíbené</string>
-    <string name="locationLabel">Poloha</string>
-    <string name="folderLocationTitle">Vybrat umístění</string>
+    <string name="locationLabel" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Poloha</string>
+    <string name="folderLocationTitle" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Vybrat umístění</string>
     <string name="addFolder">Přidat složku</string>
     <string name="editFolder">Upravit složku</string>
     <string name="bookmarkFolderDeleteDialogTitle" instruction="Dialog title for deleting a folder with bookmarks">"Smazat složku a její obsah?"</string>

--- a/saved-sites/saved-sites-impl/src/main/res/values-da/strings-saved-sites.xml
+++ b/saved-sites/saved-sites-impl/src/main/res/values-da/strings-saved-sites.xml
@@ -59,8 +59,8 @@
     <!-- Bookmark folders -->
     <string name="bookmarkDialogTitleEdit">Rediger bogmærke</string>
     <string name="favoriteDialogTitleEdit">Rediger favorit</string>
-    <string name="locationLabel">Placering</string>
-    <string name="folderLocationTitle">Vælg placering</string>
+    <string name="locationLabel" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Placering</string>
+    <string name="folderLocationTitle" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Vælg placering</string>
     <string name="addFolder">Tilføj mappe</string>
     <string name="editFolder">Rediger mappe</string>
     <string name="bookmarkFolderDeleteDialogTitle" instruction="Dialog title for deleting a folder with bookmarks">"Vil du slette mappen og dens indhold?"</string>

--- a/saved-sites/saved-sites-impl/src/main/res/values-de/strings-saved-sites.xml
+++ b/saved-sites/saved-sites-impl/src/main/res/values-de/strings-saved-sites.xml
@@ -59,8 +59,8 @@
     <!-- Bookmark folders -->
     <string name="bookmarkDialogTitleEdit">Lesezeichen bearbeiten</string>
     <string name="favoriteDialogTitleEdit">Favorit bearbeiten</string>
-    <string name="locationLabel">Standort</string>
-    <string name="folderLocationTitle">Speicherort auswählen</string>
+    <string name="locationLabel" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Standort</string>
+    <string name="folderLocationTitle" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Speicherort auswählen</string>
     <string name="addFolder">Ordner hinzufügen</string>
     <string name="editFolder">Ordner bearbeiten</string>
     <string name="bookmarkFolderDeleteDialogTitle" instruction="Dialog title for deleting a folder with bookmarks">"Ordner und seinen Inhalt löschen?"</string>

--- a/saved-sites/saved-sites-impl/src/main/res/values-el/strings-saved-sites.xml
+++ b/saved-sites/saved-sites-impl/src/main/res/values-el/strings-saved-sites.xml
@@ -59,8 +59,8 @@
     <!-- Bookmark folders -->
     <string name="bookmarkDialogTitleEdit">Επεξεργασία σελιδοδείκτη</string>
     <string name="favoriteDialogTitleEdit">Επεξεργασία αγαπημένων</string>
-    <string name="locationLabel">Τοποθεσία</string>
-    <string name="folderLocationTitle">Επιλέξτε τοποθεσία</string>
+    <string name="locationLabel" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Τοποθεσία</string>
+    <string name="folderLocationTitle" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Επιλέξτε τοποθεσία</string>
     <string name="addFolder">Προσθήκη φακέλου</string>
     <string name="editFolder">Επεξεργασία φακέλου</string>
     <string name="bookmarkFolderDeleteDialogTitle" instruction="Dialog title for deleting a folder with bookmarks">"Διαγραφή φακέλου και των περιεχομένων του;"</string>

--- a/saved-sites/saved-sites-impl/src/main/res/values-es/strings-saved-sites.xml
+++ b/saved-sites/saved-sites-impl/src/main/res/values-es/strings-saved-sites.xml
@@ -59,8 +59,8 @@
     <!-- Bookmark folders -->
     <string name="bookmarkDialogTitleEdit">Editar marcador</string>
     <string name="favoriteDialogTitleEdit">Editar favorito</string>
-    <string name="locationLabel">Ubicación</string>
-    <string name="folderLocationTitle">Seleccionar ubicación</string>
+    <string name="locationLabel" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Ubicación</string>
+    <string name="folderLocationTitle" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Seleccionar ubicación</string>
     <string name="addFolder">Añadir carpeta</string>
     <string name="editFolder">Editar carpeta</string>
     <string name="bookmarkFolderDeleteDialogTitle" instruction="Dialog title for deleting a folder with bookmarks">"¿Borrar carpeta y su contenido?"</string>

--- a/saved-sites/saved-sites-impl/src/main/res/values-et/strings-saved-sites.xml
+++ b/saved-sites/saved-sites-impl/src/main/res/values-et/strings-saved-sites.xml
@@ -59,8 +59,8 @@
     <!-- Bookmark folders -->
     <string name="bookmarkDialogTitleEdit">Redigeeri järjehoidjat</string>
     <string name="favoriteDialogTitleEdit">Redigeeri lemmikut</string>
-    <string name="locationLabel">Asukoht</string>
-    <string name="folderLocationTitle">Vali asukoht</string>
+    <string name="locationLabel" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Asukoht</string>
+    <string name="folderLocationTitle" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Vali asukoht</string>
     <string name="addFolder">Lisa kaust</string>
     <string name="editFolder">Redigeeri kausta</string>
     <string name="bookmarkFolderDeleteDialogTitle" instruction="Dialog title for deleting a folder with bookmarks">"Kas kustutada kaust ja selle sisu?"</string>

--- a/saved-sites/saved-sites-impl/src/main/res/values-fi/strings-saved-sites.xml
+++ b/saved-sites/saved-sites-impl/src/main/res/values-fi/strings-saved-sites.xml
@@ -59,8 +59,8 @@
     <!-- Bookmark folders -->
     <string name="bookmarkDialogTitleEdit">Muokkaa kirjanmerkkiä</string>
     <string name="favoriteDialogTitleEdit">Muokkaa suosikkia</string>
-    <string name="locationLabel">Sijainti</string>
-    <string name="folderLocationTitle">Valitse sijainti</string>
+    <string name="locationLabel" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Sijainti</string>
+    <string name="folderLocationTitle" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Valitse sijainti</string>
     <string name="addFolder">Lisää kansio</string>
     <string name="editFolder">Muokkaa kansiota</string>
     <string name="bookmarkFolderDeleteDialogTitle" instruction="Dialog title for deleting a folder with bookmarks">"Poista kansio ja sen sisältö?"</string>

--- a/saved-sites/saved-sites-impl/src/main/res/values-fr/strings-saved-sites.xml
+++ b/saved-sites/saved-sites-impl/src/main/res/values-fr/strings-saved-sites.xml
@@ -59,8 +59,8 @@
     <!-- Bookmark folders -->
     <string name="bookmarkDialogTitleEdit">Modifier le signet</string>
     <string name="favoriteDialogTitleEdit">Modifier le favori</string>
-    <string name="locationLabel">Localisation</string>
-    <string name="folderLocationTitle">Sélectionner un emplacement</string>
+    <string name="locationLabel" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Localisation</string>
+    <string name="folderLocationTitle" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Sélectionner un emplacement</string>
     <string name="addFolder">Ajouter le dossier</string>
     <string name="editFolder">Modifier le dossier</string>
     <string name="bookmarkFolderDeleteDialogTitle" instruction="Dialog title for deleting a folder with bookmarks">"Supprimer le dossier et son contenu ?"</string>

--- a/saved-sites/saved-sites-impl/src/main/res/values-hr/strings-saved-sites.xml
+++ b/saved-sites/saved-sites-impl/src/main/res/values-hr/strings-saved-sites.xml
@@ -61,8 +61,8 @@
     <!-- Bookmark folders -->
     <string name="bookmarkDialogTitleEdit">Uredi knjižnu oznaku</string>
     <string name="favoriteDialogTitleEdit">Uredi Favorite</string>
-    <string name="locationLabel">Lokacija</string>
-    <string name="folderLocationTitle">Odaberi lokaciju</string>
+    <string name="locationLabel" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Lokacija</string>
+    <string name="folderLocationTitle" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Odaberi lokaciju</string>
     <string name="addFolder">Dodaj mapu</string>
     <string name="editFolder">Uredi mapu</string>
     <string name="bookmarkFolderDeleteDialogTitle" instruction="Dialog title for deleting a folder with bookmarks">"Želiš li izbrisati mapu i njezin sadržaj?"</string>

--- a/saved-sites/saved-sites-impl/src/main/res/values-hu/strings-saved-sites.xml
+++ b/saved-sites/saved-sites-impl/src/main/res/values-hu/strings-saved-sites.xml
@@ -59,8 +59,8 @@
     <!-- Bookmark folders -->
     <string name="bookmarkDialogTitleEdit">Könyvjelző szerkesztése</string>
     <string name="favoriteDialogTitleEdit">Kedvenc szerkesztése</string>
-    <string name="locationLabel">Hely</string>
-    <string name="folderLocationTitle">Hely kiválasztása</string>
+    <string name="locationLabel" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Hely</string>
+    <string name="folderLocationTitle" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Hely kiválasztása</string>
     <string name="addFolder">Mappa hozzáadása</string>
     <string name="editFolder">Mappa szerkesztése</string>
     <string name="bookmarkFolderDeleteDialogTitle" instruction="Dialog title for deleting a folder with bookmarks">"Törlöd a mappát a tartalmával együtt?"</string>

--- a/saved-sites/saved-sites-impl/src/main/res/values-it/strings-saved-sites.xml
+++ b/saved-sites/saved-sites-impl/src/main/res/values-it/strings-saved-sites.xml
@@ -59,8 +59,8 @@
     <!-- Bookmark folders -->
     <string name="bookmarkDialogTitleEdit">Modifica segnalibro</string>
     <string name="favoriteDialogTitleEdit">Modifica preferito</string>
-    <string name="locationLabel">Posizione</string>
-    <string name="folderLocationTitle">Seleziona la posizione</string>
+    <string name="locationLabel" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Posizione</string>
+    <string name="folderLocationTitle" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Seleziona la posizione</string>
     <string name="addFolder">Aggiungi cartella</string>
     <string name="editFolder">Modifica cartella</string>
     <string name="bookmarkFolderDeleteDialogTitle" instruction="Dialog title for deleting a folder with bookmarks">"Eliminare la cartella e i relativi contenuti?"</string>

--- a/saved-sites/saved-sites-impl/src/main/res/values-lt/strings-saved-sites.xml
+++ b/saved-sites/saved-sites-impl/src/main/res/values-lt/strings-saved-sites.xml
@@ -61,8 +61,8 @@
     <!-- Bookmark folders -->
     <string name="bookmarkDialogTitleEdit">Redaguoti žymę</string>
     <string name="favoriteDialogTitleEdit">Redaguoti mėgstamiausią</string>
-    <string name="locationLabel">Vieta</string>
-    <string name="folderLocationTitle">Pasirinkti vietą</string>
+    <string name="locationLabel" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Vieta</string>
+    <string name="folderLocationTitle" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Pasirinkti vietą</string>
     <string name="addFolder">Pridėti aplanką</string>
     <string name="editFolder">Redaguoti aplanką</string>
     <string name="bookmarkFolderDeleteDialogTitle" instruction="Dialog title for deleting a folder with bookmarks">"Ištrinti aplanką ir jo turinį?"</string>

--- a/saved-sites/saved-sites-impl/src/main/res/values-lv/strings-saved-sites.xml
+++ b/saved-sites/saved-sites-impl/src/main/res/values-lv/strings-saved-sites.xml
@@ -60,8 +60,8 @@
     <!-- Bookmark folders -->
     <string name="bookmarkDialogTitleEdit">Rediģēt grāmatzīmi</string>
     <string name="favoriteDialogTitleEdit">Rediģēt izlasi</string>
-    <string name="locationLabel">Atrašanās vieta</string>
-    <string name="folderLocationTitle">Atlasi atrašanās vietu</string>
+    <string name="locationLabel" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Atrašanās vieta</string>
+    <string name="folderLocationTitle" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Atlasi atrašanās vietu</string>
     <string name="addFolder">Pievienot mapi</string>
     <string name="editFolder">Rediģēt mapi</string>
     <string name="bookmarkFolderDeleteDialogTitle" instruction="Dialog title for deleting a folder with bookmarks">"Dzēst mapi un tās saturu?"</string>

--- a/saved-sites/saved-sites-impl/src/main/res/values-nb/strings-saved-sites.xml
+++ b/saved-sites/saved-sites-impl/src/main/res/values-nb/strings-saved-sites.xml
@@ -59,8 +59,8 @@
     <!-- Bookmark folders -->
     <string name="bookmarkDialogTitleEdit">Rediger bokmerke</string>
     <string name="favoriteDialogTitleEdit">Rediger favoritt</string>
-    <string name="locationLabel">Posisjon</string>
-    <string name="folderLocationTitle">Velg sted</string>
+    <string name="locationLabel" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Posisjon</string>
+    <string name="folderLocationTitle" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Velg sted</string>
     <string name="addFolder">Legg til mappe</string>
     <string name="editFolder">Rediger mappe</string>
     <string name="bookmarkFolderDeleteDialogTitle" instruction="Dialog title for deleting a folder with bookmarks">"Vil du slette mappen og innholdet?"</string>

--- a/saved-sites/saved-sites-impl/src/main/res/values-nl/strings-saved-sites.xml
+++ b/saved-sites/saved-sites-impl/src/main/res/values-nl/strings-saved-sites.xml
@@ -59,8 +59,8 @@
     <!-- Bookmark folders -->
     <string name="bookmarkDialogTitleEdit">Bladwijzer bewerken</string>
     <string name="favoriteDialogTitleEdit">Favoriet bewerken</string>
-    <string name="locationLabel">Locatie</string>
-    <string name="folderLocationTitle">Locatie selecteren</string>
+    <string name="locationLabel" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Locatie</string>
+    <string name="folderLocationTitle" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Locatie selecteren</string>
     <string name="addFolder">Map toevoegen</string>
     <string name="editFolder">Map bewerken</string>
     <string name="bookmarkFolderDeleteDialogTitle" instruction="Dialog title for deleting a folder with bookmarks">"Map en inhoud verwijderen?"</string>

--- a/saved-sites/saved-sites-impl/src/main/res/values-pl/strings-saved-sites.xml
+++ b/saved-sites/saved-sites-impl/src/main/res/values-pl/strings-saved-sites.xml
@@ -61,8 +61,8 @@
     <!-- Bookmark folders -->
     <string name="bookmarkDialogTitleEdit">Edytuj zakładkę</string>
     <string name="favoriteDialogTitleEdit">Edytuj ulubione</string>
-    <string name="locationLabel">Lokalizacja</string>
-    <string name="folderLocationTitle">Wybierz lokalizację</string>
+    <string name="locationLabel" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Lokalizacja</string>
+    <string name="folderLocationTitle" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Wybierz lokalizację</string>
     <string name="addFolder">Dodaj folder</string>
     <string name="editFolder">Edytuj folder</string>
     <string name="bookmarkFolderDeleteDialogTitle" instruction="Dialog title for deleting a folder with bookmarks">"Usunąć folder i jego zawartość?"</string>

--- a/saved-sites/saved-sites-impl/src/main/res/values-pt/strings-saved-sites.xml
+++ b/saved-sites/saved-sites-impl/src/main/res/values-pt/strings-saved-sites.xml
@@ -59,8 +59,8 @@
     <!-- Bookmark folders -->
     <string name="bookmarkDialogTitleEdit">Editar marcador</string>
     <string name="favoriteDialogTitleEdit">Editar favorito</string>
-    <string name="locationLabel">Localização</string>
-    <string name="folderLocationTitle">Selecione a localização</string>
+    <string name="locationLabel" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Localização</string>
+    <string name="folderLocationTitle" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Selecione a localização</string>
     <string name="addFolder">Adicionar pasta</string>
     <string name="editFolder">Editar pasta</string>
     <string name="bookmarkFolderDeleteDialogTitle" instruction="Dialog title for deleting a folder with bookmarks">"Eliminar pasta e respetivo conteúdo?"</string>

--- a/saved-sites/saved-sites-impl/src/main/res/values-ro/strings-saved-sites.xml
+++ b/saved-sites/saved-sites-impl/src/main/res/values-ro/strings-saved-sites.xml
@@ -60,8 +60,8 @@
     <!-- Bookmark folders -->
     <string name="bookmarkDialogTitleEdit">Editare marcaj</string>
     <string name="favoriteDialogTitleEdit">Editare favorit</string>
-    <string name="locationLabel">Locație</string>
-    <string name="folderLocationTitle">Selectează locația</string>
+    <string name="locationLabel" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Locație</string>
+    <string name="folderLocationTitle" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Selectează locația</string>
     <string name="addFolder">Adaugă dosar</string>
     <string name="editFolder">Editează dosarul</string>
     <string name="bookmarkFolderDeleteDialogTitle" instruction="Dialog title for deleting a folder with bookmarks">"Ștergi folderul și conținutul acestuia?"</string>

--- a/saved-sites/saved-sites-impl/src/main/res/values-ru/strings-saved-sites.xml
+++ b/saved-sites/saved-sites-impl/src/main/res/values-ru/strings-saved-sites.xml
@@ -61,8 +61,8 @@
     <!-- Bookmark folders -->
     <string name="bookmarkDialogTitleEdit">Редактировать закладку</string>
     <string name="favoriteDialogTitleEdit">Изменить избранное</string>
-    <string name="locationLabel">Геопозиция</string>
-    <string name="folderLocationTitle">Выберите геопозицию</string>
+    <string name="locationLabel" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Местоположение</string>
+    <string name="folderLocationTitle" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Выберите местоположение</string>
     <string name="addFolder">Добавить папку</string>
     <string name="editFolder">Изменить папку</string>
     <string name="bookmarkFolderDeleteDialogTitle" instruction="Dialog title for deleting a folder with bookmarks">"Удалить папку вместе с содержимым?"</string>

--- a/saved-sites/saved-sites-impl/src/main/res/values-sk/strings-saved-sites.xml
+++ b/saved-sites/saved-sites-impl/src/main/res/values-sk/strings-saved-sites.xml
@@ -61,8 +61,8 @@
     <!-- Bookmark folders -->
     <string name="bookmarkDialogTitleEdit">Upraviť záložku</string>
     <string name="favoriteDialogTitleEdit">Úprava obľúbenej položky</string>
-    <string name="locationLabel">Poloha</string>
-    <string name="folderLocationTitle">Vyberte polohu</string>
+    <string name="locationLabel" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Poloha</string>
+    <string name="folderLocationTitle" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Vyberte polohu</string>
     <string name="addFolder">Pridať priečinok</string>
     <string name="editFolder">Úprava priečinka</string>
     <string name="bookmarkFolderDeleteDialogTitle" instruction="Dialog title for deleting a folder with bookmarks">"Má sa odstrániť priečinok a jeho obsah?"</string>

--- a/saved-sites/saved-sites-impl/src/main/res/values-sl/strings-saved-sites.xml
+++ b/saved-sites/saved-sites-impl/src/main/res/values-sl/strings-saved-sites.xml
@@ -61,8 +61,8 @@
     <!-- Bookmark folders -->
     <string name="bookmarkDialogTitleEdit">Uredi zaznamek</string>
     <string name="favoriteDialogTitleEdit">Uredi priljubljeno</string>
-    <string name="locationLabel">Lokacija</string>
-    <string name="folderLocationTitle">Izberite lokacijo</string>
+    <string name="locationLabel" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Lokacija</string>
+    <string name="folderLocationTitle" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Izberite lokacijo</string>
     <string name="addFolder">Dodaj mapo</string>
     <string name="editFolder">Uredi mapo</string>
     <string name="bookmarkFolderDeleteDialogTitle" instruction="Dialog title for deleting a folder with bookmarks">"Želite izbrisati mapo in njeno vsebino?"</string>

--- a/saved-sites/saved-sites-impl/src/main/res/values-sv/strings-saved-sites.xml
+++ b/saved-sites/saved-sites-impl/src/main/res/values-sv/strings-saved-sites.xml
@@ -59,8 +59,8 @@
     <!-- Bookmark folders -->
     <string name="bookmarkDialogTitleEdit">Redigera bokmärke</string>
     <string name="favoriteDialogTitleEdit">Redigera favorit</string>
-    <string name="locationLabel">Plats</string>
-    <string name="folderLocationTitle">Välj plats</string>
+    <string name="locationLabel" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Plats</string>
+    <string name="folderLocationTitle" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Välj plats</string>
     <string name="addFolder">Lägg till mapp</string>
     <string name="editFolder">Redigera mapp</string>
     <string name="bookmarkFolderDeleteDialogTitle" instruction="Dialog title for deleting a folder with bookmarks">"Ta bort mappen och dess innehåll?"</string>

--- a/saved-sites/saved-sites-impl/src/main/res/values-tr/strings-saved-sites.xml
+++ b/saved-sites/saved-sites-impl/src/main/res/values-tr/strings-saved-sites.xml
@@ -59,8 +59,8 @@
     <!-- Bookmark folders -->
     <string name="bookmarkDialogTitleEdit">Yer İşaretini Düzenle</string>
     <string name="favoriteDialogTitleEdit">Favoriyi Düzenle</string>
-    <string name="locationLabel">Konum</string>
-    <string name="folderLocationTitle">Konum Seç</string>
+    <string name="locationLabel" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Konum</string>
+    <string name="folderLocationTitle" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Konum Seç</string>
     <string name="addFolder">Klasör Ekle</string>
     <string name="editFolder">Klasörü Düzenle</string>
     <string name="bookmarkFolderDeleteDialogTitle" instruction="Dialog title for deleting a folder with bookmarks">"Klasör ve içeriği silinsin mi?"</string>

--- a/saved-sites/saved-sites-impl/src/main/res/values/strings-saved-sites.xml
+++ b/saved-sites/saved-sites-impl/src/main/res/values/strings-saved-sites.xml
@@ -59,8 +59,8 @@
     <!-- Bookmark folders -->
     <string name="bookmarkDialogTitleEdit">Edit Bookmark</string>
     <string name="favoriteDialogTitleEdit">Edit Favorite</string>
-    <string name="locationLabel">Location</string>
-    <string name="folderLocationTitle">Select Location</string>
+    <string name="locationLabel" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Location</string>
+    <string name="folderLocationTitle" instruction="Refers to the folder where a bookmark is saved, not a geographical location">Select Location</string>
     <string name="addFolder">Add Folder</string>
     <string name="editFolder">Edit Folder</string>
     <string name="bookmarkFolderDeleteDialogTitle" instruction="Dialog title for deleting a folder with bookmarks">"Delete folder and its contents?"</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414730916066338/1209407999578316

### Description

"Location", "Choose location" in the Edit bookmark dialog is wrongly translated to Russian as "Геопозиция", "Выберите геопозицию" ("Geolocation", "Choose geolocation").

### Steps to test this PR

QA-optional

### No UI changes
