### PR TITLE
Disable broken site reporting & privacy protections toggle when viewing through Duck Player

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -2785,7 +2785,7 @@ class BrowserTabViewModelTest {
     fun whenUserInDuckPlayerThenCannotReportSite() {
         setupNavigation(skipHome = false, isBrowsing = true)
         whenever(mockDuckPlayer.isDuckPlayerUri(anyString())).thenReturn(true)
-        assertFalse(browserViewState().canChangePrivacyProtection)
+        assertFalse(browserViewState().canReportSite)
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -2782,6 +2782,20 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenUserInDuckPlayerThenCannotReportSite() {
+        setupNavigation(skipHome = false, isBrowsing = true)
+        whenever(mockDuckPlayer.isDuckPlayerUri(anyString())).thenReturn(true)
+        assertFalse(browserViewState().canChangePrivacyProtection)
+    }
+
+    @Test
+    fun whenUserInDuckPlayerThenCannotAllowList() {
+        setupNavigation(skipHome = false, isBrowsing = true)
+        whenever(mockDuckPlayer.isDuckPlayerUri(anyString())).thenReturn(true)
+        assertFalse(browserViewState().canChangePrivacyProtection)
+    }
+
+    @Test
     fun whenUserBrowsingPressesBackThenCannotAddToHome() {
         setupNavigation(skipHome = false, isBrowsing = true, canGoBack = false)
         assertTrue(testee.onUserPressedBack())

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1509,7 +1509,7 @@ class BrowserTabViewModel @Inject constructor(
             canSharePage = domain != null,
             showPrivacyShield = HighlightableButton.Visible(enabled = true),
             canReportSite = domain != null && !duckPlayer.isDuckPlayerUri(url),
-            canChangePrivacyProtection = domain != null,
+            canChangePrivacyProtection = domain != null && !duckPlayer.isDuckPlayerUri(url),
             isPrivacyProtectionDisabled = false,
             canFindInPage = true,
             canChangeBrowsingMode = true,

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1508,7 +1508,7 @@ class BrowserTabViewModel @Inject constructor(
             addToHomeEnabled = domain != null,
             canSharePage = domain != null,
             showPrivacyShield = HighlightableButton.Visible(enabled = true),
-            canReportSite = domain != null,
+            canReportSite = domain != null && !duckPlayer.isDuckPlayerUri(url),
             canChangePrivacyProtection = domain != null,
             isPrivacyProtectionDisabled = false,
             canFindInPage = true,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201870266890790/1209422420805301

### Description
We should check for duckplayer url when setting canReportSite

### Steps to test this PR

_Feature 1_
- [ ] Set "Open YouTube Videos in DuckPlayer" to **Always**
- [ ] Enable "Open DuckPlayer in a new tab" 
- [ ] Search for any video and click or enter a URL directly (e.g., https://youtu.be/3ml7yeKBUhc)
- [ ] Confirm that "Report Broken Site" is not showing in the 3-dot/overflow menu
- [ ] Disable "Open DuckPlayer in a new tab" and repeat check
- [ ] Set "Open YouTube Videos in DuckPlayer" to **Ask Every Time** and repeat check
- [ ] Enable "Open DuckPlayer in a new tab" and repeat check
- [ ] Reset "Open YouTube Videos in DuckPlayer" to **Always**
- [ ] Use a note-taking or any other external app to open a YouTube link directly and repeat check
- [ ] Disable "Open DuckPlayer in a new tab"
- [ ] Set "Open YouTube Videos in DuckPlayer" to **Ask Every Time** and repeat check
- [ ] Enable "Open DuckPlayer in a new tab" and repeat check

### UI changes
| Before  | After |
| ------ | ----- |
![reportingEnabled](https://github.com/user-attachments/assets/e1fb147d-3f0c-43c6-b3cb-6410aa375cc6)|![after](https://github.com/user-attachments/assets/f8b70904-0e77-42df-85b2-dbdcae187cd2)