### PR TITLE
Bug fix: "Find in page" incorrectly starts from a higher activeMAtchIndex instead of 1

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoWebView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoWebView.kt
@@ -136,6 +136,7 @@ class DuckDuckGoWebView : WebView, NestedScrollingChild3 {
 
     override fun findAllAsync(find: String) {
         if (!isDestroyed) {
+            super.findAllAsync("")
             super.findAllAsync(find)
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1201807753394693/1209380103848620

### Description
See https://github.com/duckduckgo/Android/issues/5636

### Steps to test this PR

- [x] Open the page you want to search, e.g., [www.wikipedia.org](http://www.wikipedia.org/).
- [x] Tap the 'three-dot' menu button.
- [x] Tap 'Find in page' button.
- [x] Enter your search term or phrase in the search bar, e.g., 'h'.
- [ ] The search results should display '1/16' as the initial match, especially since the page is at the top without any scrolling.

### No UI changes
