### PR TITLE
Autofill suggestion: hide second line if subtitle empty

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/AutofillServiceViewProvider.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/AutofillServiceViewProvider.kt
@@ -22,6 +22,7 @@ import android.app.slice.Slice
 import android.content.Context
 import android.graphics.drawable.Icon
 import android.service.autofill.InlinePresentation
+import android.view.View
 import android.widget.RemoteViews
 import android.widget.inline.InlinePresentationSpec
 import androidx.annotation.DrawableRes
@@ -137,6 +138,10 @@ class RealAutofillServiceViewProvider @Inject constructor(
             setImageViewResource(
                 R.id.ddgIcon,
                 iconRes,
+            )
+            setViewVisibility(
+                R.id.subtitle,
+                if (subtitle.isEmpty()) View.GONE else View.VISIBLE,
             )
         }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1149059203486286/1209453476472064

### Description
Hide subtitle when string is empty, making suggestion a single line.

### Steps to test this PR

_Feature 1_
- [ ] from an api 29 device o no keyboard
- [ ] select ddg as autofill provider
- [ ] visit fill.dev on another browser
- [ ] focus a field to get suggestions
- [ ] they should show as dropdown
- [ ] ensure entry point to DDG is single line

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
