### PR TITLE
Add support for Malicious Site Protection RC exceptions

### DIFF
--- a/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionFeature.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionFeature.kt
@@ -19,10 +19,12 @@ package com.duckduckgo.malicioussiteprotection.impl
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.malicioussiteprotection.impl.remoteconfig.MaliciousSiteProtectionExceptionsStore
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
     featureName = "maliciousSiteProtection",
+    exceptionsStore = MaliciousSiteProtectionExceptionsStore::class,
 )
 /**
  * This is the class that represents the maliciousSiteProtection feature flags

--- a/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/data/db/MaliciousSiteDao.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/data/db/MaliciousSiteDao.kt
@@ -161,4 +161,19 @@ interface MaliciousSiteDao {
     private suspend fun getLatestRevision(feed: Feed, type: Type): Int {
         return getLatestRevision(feed = feed.name, type = type.name)?.revision ?: 0
     }
+
+    @Transaction
+    fun updateAllExceptions(exceptions: List<FeatureExceptionEntity>) {
+        deleteAllExceptions()
+        insertAllExceptions(exceptions)
+    }
+
+    @Query("DELETE FROM featureExceptions")
+    fun deleteAllExceptions() {}
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun insertAllExceptions(exceptions: List<FeatureExceptionEntity>)
+
+    @Query("SELECT * FROM featureExceptions")
+    fun getExceptions(): List<FeatureExceptionEntity>
 }

--- a/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/data/db/MaliciousSitesDataEntities.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/data/db/MaliciousSitesDataEntities.kt
@@ -44,3 +44,10 @@ data class FilterEntity(
     val regex: String,
     val type: String,
 )
+
+@Entity(tableName = "featureExceptions")
+data class FeatureExceptionEntity(
+    @PrimaryKey
+    val domain: String,
+    val reason: String?,
+)

--- a/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/data/db/MaliciousSitesDatabase.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/data/db/MaliciousSitesDatabase.kt
@@ -22,8 +22,8 @@ import androidx.room.migration.Migration
 
 @Database(
     exportSchema = true,
-    entities = [RevisionEntity::class, HashPrefixEntity::class, FilterEntity::class],
-    version = 1,
+    entities = [RevisionEntity::class, HashPrefixEntity::class, FilterEntity::class, FeatureExceptionEntity::class],
+    version = 2,
 )
 abstract class MaliciousSitesDatabase : RoomDatabase() {
     abstract fun maliciousSiteDao(): MaliciousSiteDao

--- a/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/remoteconfig/MaliciousSiteProtectionExceptionsStore.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/remoteconfig/MaliciousSiteProtectionExceptionsStore.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.malicioussiteprotection.impl.remoteconfig
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.FeatureExceptions
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.RemoteFeatureStoreNamed
+import com.duckduckgo.malicioussiteprotection.impl.MaliciousSiteProtectionFeature
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+@ContributesBinding(AppScope::class)
+@RemoteFeatureStoreNamed(MaliciousSiteProtectionFeature::class)
+class MaliciousSiteProtectionExceptionsStore @Inject constructor(
+    private val maliciousSiteProtectionRCRepository: MaliciousSiteProtectionRCRepository,
+) : FeatureExceptions.Store {
+    override fun insertAll(exception: List<FeatureException>) {
+        maliciousSiteProtectionRCRepository.insertAllExceptions(exception)
+    }
+}

--- a/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/remoteconfig/MaliciousSiteProtectionRCRepository.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/remoteconfig/MaliciousSiteProtectionRCRepository.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.malicioussiteprotection.impl.remoteconfig
+
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.di.IsMainProcess
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.malicioussiteprotection.impl.data.db.FeatureExceptionEntity
+import com.duckduckgo.malicioussiteprotection.impl.data.db.MaliciousSiteDao
+import com.squareup.anvil.annotations.ContributesBinding
+import java.util.concurrent.CopyOnWriteArrayList
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+interface MaliciousSiteProtectionRCRepository {
+    fun insertAllExceptions(exceptions: List<FeatureException>)
+    fun isExempted(hostName: String): Boolean
+    val exceptions: CopyOnWriteArrayList<FeatureException>
+}
+
+@ContributesBinding(AppScope::class)
+class RealMaliciousSiteProtectionRCRepository @Inject constructor(
+    @AppCoroutineScope coroutineScope: CoroutineScope,
+    dispatcherProvider: DispatcherProvider,
+    val dao: MaliciousSiteDao,
+    @IsMainProcess isMainProcess: Boolean,
+) : MaliciousSiteProtectionRCRepository {
+
+    override val exceptions = CopyOnWriteArrayList<FeatureException>()
+
+    init {
+        coroutineScope.launch(dispatcherProvider.io()) {
+            if (isMainProcess) {
+                loadToMemory()
+            }
+        }
+    }
+
+    override fun insertAllExceptions(exceptions: List<FeatureException>) {
+        dao.updateAllExceptions(exceptions.map { FeatureExceptionEntity(domain = it.domain, reason = it.reason) })
+        loadToMemory()
+    }
+
+    override fun isExempted(hostName: String): Boolean {
+        return exceptions.any { it.domain == hostName }
+    }
+
+    private fun loadToMemory() {
+        exceptions.clear()
+        val exceptionsEntityList = dao.getExceptions()
+        exceptions.addAll(exceptionsEntityList.map { FeatureException(domain = it.domain, reason = it.reason) })
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205008441501016/1209426268774143 

### Description
Process exceptions from RC and don't flag a site as malicious if domain matches an exception

### Steps to test this PR

_Feature 1_
- [x] Load https://broken.third-party.site/security/badware/malware.html
- [x] Check site isn't blocked
- [x] Check logcat for _"should not block (exempted) broken.third-party.site"_
    * Note: if this doesn't work, check the following:
         * Reinstall the app. Since exceptions were already present in the JSON but not parsed, there's a chance RC update logic hasn't triggered 
        * Check https://staticcdn.duckduckgo.com/trackerblocking/config/v4/android-config.json and see if broken.third-party.site is still added as an exception to maliciousSiteProtection
