### PR TITLE
Add killswitch, support incremental rollouts, and force update when downloading privacy config

### DIFF
--- a/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionFeature.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionFeature.kt
@@ -35,4 +35,11 @@ interface MaliciousSiteProtectionFeature {
     @Toggle.InternalAlwaysEnabled
     @Toggle.DefaultValue(false)
     fun self(): Toggle
+
+    @Toggle.InternalAlwaysEnabled
+    @Toggle.DefaultValue(false)
+    fun visibleAndOnByDefault(): Toggle
+
+    @Toggle.DefaultValue(true)
+    fun canUpdateDatasets(): Toggle
 }

--- a/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionHashPrefixesUpdateWorker.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionHashPrefixesUpdateWorker.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.malicioussiteprotection.impl
 
 import android.content.Context
+import androidx.lifecycle.LifecycleOwner
 import androidx.work.BackoffPolicy
 import androidx.work.CoroutineWorker
 import androidx.work.ExistingPeriodicWorkPolicy
@@ -24,6 +25,7 @@ import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import com.duckduckgo.anvil.annotations.ContributesWorker
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.malicioussiteprotection.impl.data.MaliciousSiteRepository
@@ -66,14 +68,30 @@ class MaliciousSiteProtectionHashPrefixesUpdateWorker(
     scope = AppScope::class,
     boundType = PrivacyConfigCallbackPlugin::class,
 )
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = MainProcessLifecycleObserver::class,
+)
 @SingleInstanceIn(AppScope::class)
 class MaliciousSiteProtectionHashPrefixesUpdateWorkerScheduler @Inject constructor(
     private val workManager: WorkManager,
     private val maliciousSiteProtectionFeature: MaliciousSiteProtectionRCFeature,
 
-) : PrivacyConfigCallbackPlugin {
+) : PrivacyConfigCallbackPlugin, MainProcessLifecycleObserver {
+
+    override fun onCreate(owner: LifecycleOwner) {
+        enqueuePeriodicWork()
+    }
 
     override fun onPrivacyConfigDownloaded() {
+        enqueuePeriodicWork()
+    }
+
+    private fun enqueuePeriodicWork() {
+        if (maliciousSiteProtectionFeature.isFeatureEnabled().not() || maliciousSiteProtectionFeature.canUpdateDatasets().not()) {
+            workManager.cancelUniqueWork(MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_TAG)
+            return
+        }
         val workerRequest = PeriodicWorkRequestBuilder<MaliciousSiteProtectionHashPrefixesUpdateWorker>(
             maliciousSiteProtectionFeature.getHashPrefixUpdateFrequency(),
             TimeUnit.MINUTES,
@@ -83,7 +101,7 @@ class MaliciousSiteProtectionHashPrefixesUpdateWorkerScheduler @Inject construct
             .build()
         workManager.enqueueUniquePeriodicWork(
             MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_TAG,
-            ExistingPeriodicWorkPolicy.CANCEL_AND_REENQUEUE,
+            ExistingPeriodicWorkPolicy.UPDATE,
             workerRequest,
         )
     }

--- a/malicious-site-protection/malicious-site-protection-impl/src/test/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionFiltersUpdateWorkerTest.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/test/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionFiltersUpdateWorkerTest.kt
@@ -93,7 +93,7 @@ class MaliciousSiteProtectionFiltersUpdateWorkerSchedulerTest {
     private val scheduler = MaliciousSiteProtectionFiltersUpdateWorkerScheduler(workManager, maliciousSiteProtectionFeature)
 
     @Test
-    fun onPrivacyConfigDownloaded_schedulesWorkerWithUpdateFrequencyFromRCFlagAndReenqueuePolicy() {
+    fun onPrivacyConfigDownloaded_schedulesWorkerWithUpdateFrequencyFromRCFlagAndUpdatePolicy() {
         val updateFrequencyMinutes = 15L
 
         whenever(maliciousSiteProtectionFeature.getFilterSetUpdateFrequency()).thenReturn(updateFrequencyMinutes)
@@ -103,7 +103,7 @@ class MaliciousSiteProtectionFiltersUpdateWorkerSchedulerTest {
         val workRequestCaptor = ArgumentCaptor.forClass(PeriodicWorkRequest::class.java)
         verify(workManager).enqueueUniquePeriodicWork(
             eq("MALICIOUS_SITE_PROTECTION_FILTERS_UPDATE_WORKER_TAG"),
-            eq(ExistingPeriodicWorkPolicy.CANCEL_AND_REENQUEUE),
+            eq(ExistingPeriodicWorkPolicy.UPDATE),
             capture(workRequestCaptor),
         )
 

--- a/malicious-site-protection/malicious-site-protection-impl/src/test/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionHashPrefixesUpdateWorkerTest.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/test/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionHashPrefixesUpdateWorkerTest.kt
@@ -103,7 +103,7 @@ class MaliciousSiteProtectionHashPrefixesUpdateWorkerSchedulerTest {
         val workRequestCaptor = ArgumentCaptor.forClass(PeriodicWorkRequest::class.java)
         verify(workManager).enqueueUniquePeriodicWork(
             eq("MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_TAG"),
-            eq(ExistingPeriodicWorkPolicy.CANCEL_AND_REENQUEUE),
+            eq(ExistingPeriodicWorkPolicy.UPDATE),
             capture(workRequestCaptor),
         )
 

--- a/malicious-site-protection/malicious-site-protection-impl/src/test/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionHashPrefixesUpdateWorkerTest.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/test/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionHashPrefixesUpdateWorkerTest.kt
@@ -97,6 +97,8 @@ class MaliciousSiteProtectionHashPrefixesUpdateWorkerSchedulerTest {
         val updateFrequencyMinutes = 15L
 
         whenever(maliciousSiteProtectionFeature.getHashPrefixUpdateFrequency()).thenReturn(updateFrequencyMinutes)
+        whenever(maliciousSiteProtectionFeature.isFeatureEnabled()).thenReturn(true)
+        whenever(maliciousSiteProtectionFeature.canUpdateDatasets()).thenReturn(true)
 
         scheduler.onPrivacyConfigDownloaded()
 
@@ -112,5 +114,20 @@ class MaliciousSiteProtectionHashPrefixesUpdateWorkerSchedulerTest {
         val expectedInterval = TimeUnit.MINUTES.toMillis(updateFrequencyMinutes)
 
         assertEquals(expectedInterval, repeatInterval)
+    }
+
+    @Test
+    fun onPrivacyConfigDownloadedWithCanUpdateDatasetOff_cancelsWorker() {
+        val updateFrequencyMinutes = 15L
+
+        whenever(maliciousSiteProtectionFeature.getFilterSetUpdateFrequency()).thenReturn(updateFrequencyMinutes)
+        whenever(maliciousSiteProtectionFeature.isFeatureEnabled()).thenReturn(true)
+        whenever(maliciousSiteProtectionFeature.canUpdateDatasets()).thenReturn(false)
+
+        scheduler.onPrivacyConfigDownloaded()
+
+        verify(workManager).cancelUniqueWork(
+            eq("MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_TAG"),
+        )
     }
 }

--- a/malicious-site-protection/malicious-site-protection-impl/src/test/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionHashPrefixesUpdateWorkerTest.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/test/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionHashPrefixesUpdateWorkerTest.kt
@@ -22,6 +22,7 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.capture
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
 import org.mockito.kotlin.whenever
 
 @RunWith(AndroidJUnit4::class)
@@ -41,6 +42,7 @@ class MaliciousSiteProtectionHashPrefixesUpdateWorkerTest {
         worker.maliciousSiteRepository = maliciousSiteRepository
         worker.dispatcherProvider = dispatcherProvider
         worker.maliciousSiteProtectionFeature = maliciousSiteProtectionFeature
+        whenever(maliciousSiteProtectionFeature.canUpdateDatasets()).thenReturn(true)
     }
 
     @Test
@@ -49,6 +51,17 @@ class MaliciousSiteProtectionHashPrefixesUpdateWorkerTest {
 
         val result = worker.doWork()
 
+        verify(maliciousSiteRepository, never()).loadHashPrefixes()
+        assertEquals(success(), result)
+    }
+
+    @Test
+    fun doWork_returnsSuccessWhenUpdateDatasetsIsDisabled() = runTest {
+        whenever(maliciousSiteProtectionFeature.canUpdateDatasets()).thenReturn(false)
+
+        val result = worker.doWork()
+
+        verify(maliciousSiteRepository, never()).loadHashPrefixes()
         assertEquals(success(), result)
     }
 
@@ -80,17 +93,17 @@ class MaliciousSiteProtectionHashPrefixesUpdateWorkerSchedulerTest {
     private val scheduler = MaliciousSiteProtectionHashPrefixesUpdateWorkerScheduler(workManager, maliciousSiteProtectionFeature)
 
     @Test
-    fun onCreate_schedulesWorkerWithUpdateFrequencyFromRCFlag() {
+    fun onPrivacyConfigDownloaded_schedulesWorkerWithUpdateFrequencyFromRCFlag() {
         val updateFrequencyMinutes = 15L
 
         whenever(maliciousSiteProtectionFeature.getHashPrefixUpdateFrequency()).thenReturn(updateFrequencyMinutes)
 
-        scheduler.onCreate(mock())
+        scheduler.onPrivacyConfigDownloaded()
 
         val workRequestCaptor = ArgumentCaptor.forClass(PeriodicWorkRequest::class.java)
         verify(workManager).enqueueUniquePeriodicWork(
             eq("MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_TAG"),
-            eq(ExistingPeriodicWorkPolicy.UPDATE),
+            eq(ExistingPeriodicWorkPolicy.CANCEL_AND_REENQUEUE),
             capture(workRequestCaptor),
         )
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205008441501016/1209119876664187 

### Description
* Add visibleAndOnByDefault subfeature, so we can perform an incremental rollout
* Add canUpdateDatasets subfeature, so we can turn off dataset downloads if needed
* Force update datasets when RC flag is turned on

