### PR TITLE
Update content scope scripts to version 7.22.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^12.11.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.2.2",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.20.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.22.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.4.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1739774089"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#695df496504a9a98ee15a32ad1be25c94a5bb532",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#c8428aec4646126b7aa4903f85caf6315d565995",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -283,9 +283,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.4.tgz",
-      "integrity": "sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==",
+      "version": "22.13.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.5.tgz",
+      "integrity": "sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^12.11.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.2.2",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.20.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.22.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.4.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1739774089"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1209492594044014/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass