### PR TITLE
SplashScreen Animation: Add fail to launch mitigation

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/api/PixelParamRemovalInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/PixelParamRemovalInterceptor.kt
@@ -102,6 +102,7 @@ object PixelInterceptorPixelsRequiringDataCleaning : PixelParamRemovalPlugin {
             AppPixelName.SET_AS_DEFAULT_PROMPT_DISMISSED.pixelName to PixelParameter.removeAll(),
             AppPixelName.SET_AS_DEFAULT_IN_MENU_CLICK.pixelName to PixelParameter.removeAll(),
             AppPixelName.SPLASHSCREEN_SHOWN.pixelName to PixelParameter.removeAll(),
+            AppPixelName.SPLASHSCREEN_FAILED_TO_LAUNCH.pixelName to PixelParameter.removeAll(),
             AppPixelName.MENU_ACTION_NEW_TAB_PRESSED_FROM_SITE.pixelName to PixelParameter.removeAll(),
             AppPixelName.MENU_ACTION_NEW_TAB_PRESSED_FROM_SERP.pixelName to PixelParameter.removeAll(),
         )

--- a/app/src/main/java/com/duckduckgo/app/launch/LaunchBridgeActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/launch/LaunchBridgeActivity.kt
@@ -43,7 +43,11 @@ class LaunchBridgeActivity : DuckDuckGoActivity() {
 
         configureObservers()
 
+        viewModel.launchSplashScreenFailToExitJob()
+
         splashScreen.setOnExitAnimationListener { splashScreenView ->
+            viewModel.cancelSplashScreenFailToExitJob()
+
             val splashScreenAnimationEndTime =
                 Instant.ofEpochMilli(splashScreenView.iconAnimationStartMillis + splashScreenView.iconAnimationDurationMillis)
             val remainingAnimationTime = Instant.now().until(

--- a/app/src/main/java/com/duckduckgo/app/launch/LaunchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/launch/LaunchViewModel.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.launch
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.onboarding.store.UserStageStore
 import com.duckduckgo.app.onboarding.store.isNewUser
@@ -27,6 +28,10 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.utils.SingleLiveEvent
 import com.duckduckgo.di.scopes.ActivityScope
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import timber.log.Timber
 
@@ -37,6 +42,8 @@ class LaunchViewModel @Inject constructor(
     private val pixel: Pixel,
 ) :
     ViewModel() {
+
+    private var splashScreenFailToExitJob: Job? = null
 
     val command: SingleLiveEvent<Command> = SingleLiveEvent()
 
@@ -57,6 +64,18 @@ class LaunchViewModel @Inject constructor(
         } else {
             command.value = Command.Home()
         }
+    }
+
+    fun launchSplashScreenFailToExitJob() {
+        splashScreenFailToExitJob = viewModelScope.launch {
+            delay(1.5.seconds)
+            sendWelcomeScreenPixel()
+            determineViewToShow()
+        }
+    }
+
+    fun cancelSplashScreenFailToExitJob() {
+        splashScreenFailToExitJob?.cancel()
     }
 
     private suspend fun waitForReferrerData() {

--- a/app/src/main/java/com/duckduckgo/app/launch/LaunchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/launch/LaunchViewModel.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.onboarding.store.UserStageStore
 import com.duckduckgo.app.onboarding.store.isNewUser
+import com.duckduckgo.app.pixels.AppPixelName.SPLASHSCREEN_FAILED_TO_LAUNCH
 import com.duckduckgo.app.pixels.AppPixelName.SPLASHSCREEN_SHOWN
 import com.duckduckgo.app.referral.AppInstallationReferrerStateListener
 import com.duckduckgo.app.referral.AppInstallationReferrerStateListener.Companion.MAX_REFERRER_WAIT_TIME_MS
@@ -71,6 +72,7 @@ class LaunchViewModel @Inject constructor(
             delay(1.5.seconds)
             sendWelcomeScreenPixel()
             determineViewToShow()
+            pixel.fire(SPLASHSCREEN_FAILED_TO_LAUNCH)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -38,6 +38,7 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     PROTECTION_TOGGLE_BROKEN_SITE_REPORT("m_protection-toggled-off-breakage-report"),
 
     SPLASHSCREEN_SHOWN("m_splashscreen_shown"),
+    SPLASHSCREEN_FAILED_TO_LAUNCH("m_splashscreen_failed_to_launch"),
 
     PREONBOARDING_INTRO_SHOWN_UNIQUE("m_preonboarding_intro_shown_unique"),
     PREONBOARDING_COMPARISON_CHART_SHOWN_UNIQUE("m_preonboarding_comparison_chart_shown_unique"),

--- a/common/common-ui/src/main/res/values-v33/design-system-theming.xml
+++ b/common/common-ui/src/main/res/values-v33/design-system-theming.xml
@@ -16,7 +16,6 @@
 
 <resources>
     <style name="Theme.DuckDuckGo.Splash" parent="Theme.SplashScreen">
-        <item name="android:windowSplashScreenAnimationDuration">1435</item>
         <item name="windowSplashScreenAnimatedIcon">@drawable/splash_screen_wink</item>
     </style>
 </resources>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207908166761516/1209495201524764 

### Description
Added a fallback mechanism to handle cases where the splash screen exit animation fails to trigger. The fallback automatically proceeds to the next screen after a 1.5-second delay if the normal exit animation doesn't occur.

We now also only target Android 13 and above with the Splashscreen animation after seeing mention of issues on Android 12L.

### Steps to test this PR

_Android 12L testing fallback_
- [ ] We can actually rely on the Android Studio launch bug to test this
- [ ] Create an emulator with API 32 (get one with the play store)
- [ ] Run the branch from the Android Studio
- [ ] The app should *not* show the splashscreen (remember we're using the bug
- [ ] Check that `m_splashscreen_failed_to_launch` pixel fired
- [ ] After ~1.5 seconds the app should launch into onboarding/browser

_Android 12L testing normal launch_
- [ ] Close the app from before
- [ ] Locate the app on the home screen/app launcher
- [ ] Launch the app
- [ ] The static logo splashscreen should show
- [ ] The app should launch into onboarding/browser

_Test other OS versions_

Test that the splashscreen still works on other Android OS versions. A suggested range could be 26, 30, 33, 35

On 33+
- [x] Open the app
- [x] Animated splashscreen should play
- [x] The app should launch into onboarding/browser

On <= 32
- [ ] Open the app
- [x] Static splashscreen logo should be visible
- [ ] The app should launch into onboarding/browser

### UI changes
No visual changes to the splash screen appearance or animation.

### Demo 

**Emulator Android 12L Simulating fallback**

https://github.com/user-attachments/assets/9fe72a79-dfa3-4d13-85dc-1cba4707ae29

**Emulator Android 12L back to static logo**

https://github.com/user-attachments/assets/0abb3831-128a-4023-961e-6158da169f13

**Device Pixel 6a Android 12L (32)**

https://github.com/user-attachments/assets/17056b5a-a6af-40ae-ae0a-d6169b22ee59

**Device Fujitsu F-01L Android 8.1 (27)**

https://github.com/user-attachments/assets/7b44d546-16cb-4317-8c25-14f0acab8d5e

**Device Samsung Galaxy Note 9 Android 10 (29)**

https://github.com/user-attachments/assets/dc039f7c-c5cd-4997-9558-54e18de30c31

**Device Motorola G20 Android 11 (30)**

https://github.com/user-attachments/assets/5d6f26e7-df05-4765-832c-2e67ac5b049e

**Device Samsung Galaxy A51 Android 12 (31)**

https://github.com/user-attachments/assets/09bb06be-ea39-40bf-b00b-84f684c71799

**Device Oppo CPH2557 Android 14 (34)**

https://github.com/user-attachments/assets/602d31ad-fb7f-4352-91a9-eb77a8ebfcc7

