### PR TITLE
Add Autofill service metrics

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
@@ -190,7 +190,7 @@ enum class AutofillPixelNames(override val pixelName: String) : Pixel.PixelName 
     AUTOFILL_SERVICE_PASSWORDS_DISMISSED("autofill_extension_passwords_dismissed"),
     AUTOFILL_SERVICE_PASSWORDS_DISMISSED_AUTH("autofill_extension_passwords_dismissed_auth"),
     AUTOFILL_SERVICE_PASSWORD_SELECTED("autofill_extension_password_selected"),
-    AUTOFILL_SERVICE_PASSWORDS_SEARCH("autofill_extension_passwords_search"), // doesn't apply, we automatically focus the search bar
+    AUTOFILL_SERVICE_PASSWORDS_SEARCH("autofill_extension_passwords_search"),
     AUTOFILL_SERVICE_PASSWORDS_SEARCH_INPUT("autofill_extension_passwords_search_input"), // when user types in the search bar first time
     AUTOFILL_SERVICE_CRASH("autofill_service_crash"),
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
@@ -36,6 +36,18 @@ import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ONBOARDING
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ONBOARDING_SAVE_PROMPT_EXCLUDE
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ONBOARDING_SAVE_PROMPT_SAVED
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ONBOARDING_SAVE_PROMPT_SHOWN
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SERVICE_CRASH
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SERVICE_DISABLED
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SERVICE_DISABLED_DAU
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SERVICE_ENABLED
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SERVICE_ENABLED_DAU
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SERVICE_PASSWORDS_DISMISSED
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SERVICE_PASSWORDS_DISMISSED_AUTH
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SERVICE_PASSWORDS_OPEN
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SERVICE_PASSWORDS_SEARCH
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SERVICE_PASSWORDS_SEARCH_INPUT
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SERVICE_PASSWORD_SELECTED
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SERVICE_SUGGESTION_CONFIRMED
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SITE_BREAKAGE_REPORT
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SITE_BREAKAGE_REPORT_AVAILABLE
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SITE_BREAKAGE_REPORT_CONFIRMATION_CONFIRMED
@@ -180,6 +192,7 @@ enum class AutofillPixelNames(override val pixelName: String) : Pixel.PixelName 
     AUTOFILL_SERVICE_PASSWORD_SELECTED("autofill_extension_password_selected"),
     AUTOFILL_SERVICE_PASSWORDS_SEARCH("autofill_extension_passwords_search"), // doesn't apply, we automatically focus the search bar
     AUTOFILL_SERVICE_PASSWORDS_SEARCH_INPUT("autofill_extension_passwords_search_input"), // when user types in the search bar first time
+    AUTOFILL_SERVICE_CRASH("autofill_service_crash"),
 }
 
 @ContributesMultibinding(
@@ -227,6 +240,19 @@ object AutofillPixelsRequiringDataCleaning : PixelParamRemovalPlugin {
 
             AUTOFILL_DECLINE_PROMPT_TO_DISABLE_AUTOFILL_SNACKBAR_SHOWN.pixelName to PixelParameter.removeAtb(),
             AUTOFILL_DECLINE_PROMPT_TO_DISABLE_AUTOFILL_SNACKBAR_OPEN_SETTINGS.pixelName to PixelParameter.removeAtb(),
+
+            AUTOFILL_SERVICE_ENABLED.pixelName to PixelParameter.removeAtb(),
+            AUTOFILL_SERVICE_ENABLED_DAU.pixelName to PixelParameter.removeAtb(),
+            AUTOFILL_SERVICE_DISABLED.pixelName to PixelParameter.removeAtb(),
+            AUTOFILL_SERVICE_DISABLED_DAU.pixelName to PixelParameter.removeAtb(),
+            AUTOFILL_SERVICE_SUGGESTION_CONFIRMED.pixelName to PixelParameter.removeAtb(),
+            AUTOFILL_SERVICE_PASSWORDS_OPEN.pixelName to PixelParameter.removeAtb(),
+            AUTOFILL_SERVICE_PASSWORDS_DISMISSED.pixelName to PixelParameter.removeAtb(),
+            AUTOFILL_SERVICE_PASSWORDS_DISMISSED_AUTH.pixelName to PixelParameter.removeAtb(),
+            AUTOFILL_SERVICE_PASSWORD_SELECTED.pixelName to PixelParameter.removeAtb(),
+            AUTOFILL_SERVICE_PASSWORDS_SEARCH.pixelName to PixelParameter.removeAtb(),
+            AUTOFILL_SERVICE_PASSWORDS_SEARCH_INPUT.pixelName to PixelParameter.removeAtb(),
+            AUTOFILL_SERVICE_CRASH.pixelName to PixelParameter.removeAtb(),
         )
     }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
@@ -168,6 +168,18 @@ enum class AutofillPixelNames(override val pixelName: String) : Pixel.PixelName 
     AUTOFILL_SITE_BREAKAGE_REPORT_CONFIRMATION_DISPLAYED("autofill_logins_report_confirmation_displayed"),
     AUTOFILL_SITE_BREAKAGE_REPORT_CONFIRMATION_DISMISSED("autofill_logins_report_confirmation_dismissed"),
     AUTOFILL_SITE_BREAKAGE_REPORT_CONFIRMATION_CONFIRMED("autofill_logins_report_confirmation_confirmed"),
+
+    AUTOFILL_SERVICE_ENABLED("autofill_extension_enabled"),
+    AUTOFILL_SERVICE_ENABLED_DAU("autofill_extension_toggled_on"),
+    AUTOFILL_SERVICE_DISABLED("autofill_extension_disabled"),
+    AUTOFILL_SERVICE_DISABLED_DAU("autofill_extension_toggled_off"),
+    AUTOFILL_SERVICE_SUGGESTION_CONFIRMED("autofill_extension_quicktype_confirmed"),
+    AUTOFILL_SERVICE_PASSWORDS_OPEN("autofill_extension_passwords_opened"),
+    AUTOFILL_SERVICE_PASSWORDS_DISMISSED("autofill_extension_passwords_dismissed"),
+    AUTOFILL_SERVICE_PASSWORDS_DISMISSED_AUTH("autofill_extension_passwords_dismissed_auth"),
+    AUTOFILL_SERVICE_PASSWORD_SELECTED("autofill_extension_password_selected"),
+    AUTOFILL_SERVICE_PASSWORDS_SEARCH("autofill_extension_passwords_search"), // doesn't apply, we automatically focus the search bar
+    AUTOFILL_SERVICE_PASSWORDS_SEARCH_INPUT("autofill_extension_passwords_search_input"), // when user types in the search bar first time
 }
 
 @ContributesMultibinding(

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/AutofillProviderChooseActivity.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/AutofillProviderChooseActivity.kt
@@ -37,6 +37,7 @@ import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator.AuthResult.Su
 import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator.AuthResult.UserCancelled
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SERVICE_PASSWORDS_DISMISSED
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SERVICE_PASSWORDS_DISMISSED_AUTH
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SERVICE_PASSWORDS_OPEN
 import com.duckduckgo.autofill.impl.service.AutofillProviderChooseViewModel.Command
 import com.duckduckgo.autofill.impl.service.AutofillProviderChooseViewModel.Command.AutofillLogin
 import com.duckduckgo.autofill.impl.service.AutofillProviderChooseViewModel.Command.ContinueWithoutAuthentication
@@ -94,7 +95,7 @@ class AutofillProviderChooseActivity : DuckDuckGoActivity() {
         setupToolbar(binding.toolbar)
         setTitle(R.string.autofill_service_select_password_activity)
         observeViewModel()
-        viewModel.onActivityCreated()
+        pixel.fire(AUTOFILL_SERVICE_PASSWORDS_OPEN)
     }
 
     private fun observeViewModel() {
@@ -127,12 +128,7 @@ class AutofillProviderChooseActivity : DuckDuckGoActivity() {
             }
 
             ContinueWithoutAuthentication -> {
-                Timber.i("DDGAutofillService ContinueWithoutAuthentication credentialId: $credentialId")
-                credentialId?.let { nonNullId ->
-                    viewModel.continueAfterAuthentication(nonNullId)
-                } ?: run {
-                    showListMode()
-                }
+                showListMode()
             }
 
             is AutofillLogin -> {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/AutofillProviderChooseActivity.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/AutofillProviderChooseActivity.kt
@@ -26,6 +26,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.impl.R
@@ -34,6 +35,8 @@ import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator
 import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator.AuthResult.Error
 import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator.AuthResult.Success
 import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator.AuthResult.UserCancelled
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SERVICE_PASSWORDS_DISMISSED
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SERVICE_PASSWORDS_DISMISSED_AUTH
 import com.duckduckgo.autofill.impl.service.AutofillProviderChooseViewModel.Command
 import com.duckduckgo.autofill.impl.service.AutofillProviderChooseViewModel.Command.AutofillLogin
 import com.duckduckgo.autofill.impl.service.AutofillProviderChooseViewModel.Command.ContinueWithoutAuthentication
@@ -67,6 +70,9 @@ class AutofillProviderChooseActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var autofillServiceActivityHandler: AutofillServiceActivityHandler
 
+    @Inject
+    lateinit var pixel: Pixel
+
     private var assistStructure: AssistStructure? = null
 
     private val credentialId: Long?
@@ -88,6 +94,7 @@ class AutofillProviderChooseActivity : DuckDuckGoActivity() {
         setupToolbar(binding.toolbar)
         setTitle(R.string.autofill_service_select_password_activity)
         observeViewModel()
+        viewModel.onActivityCreated()
     }
 
     private fun observeViewModel() {
@@ -108,6 +115,7 @@ class AutofillProviderChooseActivity : DuckDuckGoActivity() {
                         }
 
                         UserCancelled -> {
+                            pixel.fire(AUTOFILL_SERVICE_PASSWORDS_DISMISSED_AUTH)
                             finish()
                         }
 
@@ -164,6 +172,7 @@ class AutofillProviderChooseActivity : DuckDuckGoActivity() {
         if (isSearchBarVisible()) {
             hideSearchBar()
         } else {
+            pixel.fire(AUTOFILL_SERVICE_PASSWORDS_DISMISSED)
             super.onBackPressed()
         }
     }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/AutofillProviderChooseViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/AutofillProviderChooseViewModel.kt
@@ -69,10 +69,6 @@ class AutofillProviderChooseViewModel @Inject constructor(
         data object ForceFinish : Command()
     }
 
-    fun onActivityCreated() {
-        pixel.fire(AUTOFILL_SERVICE_PASSWORDS_OPEN)
-    }
-
     fun onUserAuthenticatedSuccessfully() {
         viewModelScope.launch(dispatchers.io()) {
             autofillProviderDeviceAuth.recordSuccessfulAuthorization()

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/AutofillProviderChooseViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/AutofillProviderChooseViewModel.kt
@@ -22,7 +22,6 @@ import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
-import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SERVICE_PASSWORDS_OPEN
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SERVICE_SUGGESTION_CONFIRMED
 import com.duckduckgo.autofill.impl.securestorage.WebsiteLoginDetailsWithCredentials
 import com.duckduckgo.autofill.impl.service.AutofillProviderChooseViewModel.Command.AutofillLogin

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/AutofillProviderCredentialsListViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/AutofillProviderCredentialsListViewModel.kt
@@ -22,6 +22,8 @@ import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SERVICE_PASSWORDS_SEARCH_INPUT
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SERVICE_PASSWORD_SELECTED
 import com.duckduckgo.autofill.impl.store.InternalAutofillStore
 import com.duckduckgo.autofill.impl.ui.credential.management.searching.CredentialListFilter
 import com.duckduckgo.common.utils.DispatcherProvider
@@ -52,6 +54,8 @@ class AutofillProviderCredentialsListViewModel @Inject constructor(
 
     private var combineJob: Job? = null
 
+    private var hasPreviouslySearched = false
+
     fun onViewCreated() {
         if (combineJob != null) return
         combineJob = viewModelScope.launch(dispatchers.io()) {
@@ -68,12 +72,17 @@ class AutofillProviderCredentialsListViewModel @Inject constructor(
     }
 
     fun onSearchQueryChanged(searchText: String) {
+        if (!hasPreviouslySearched) {
+            pixel.fire(AUTOFILL_SERVICE_PASSWORDS_SEARCH_INPUT)
+            hasPreviouslySearched = true
+        }
         Timber.v("Search query changed: %s", searchText)
         searchQueryFilter.value = searchText
         _viewState.value = _viewState.value.copy(credentialSearchQuery = searchText)
     }
 
     fun onCredentialSelected(credentials: LoginCredentials) {
+        pixel.fire(AUTOFILL_SERVICE_PASSWORD_SELECTED)
         credentials.updateLastUsedTimestamp()
     }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/AutofillServiceStatusLifecycleObserver.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/AutofillServiceStatusLifecycleObserver.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.service
+
+import android.view.autofill.AutofillManager
+import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SERVICE_DISABLED
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SERVICE_ENABLED
+import com.duckduckgo.autofill.impl.service.store.AutofillServiceStore
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = MainProcessLifecycleObserver::class,
+)
+class AutofillServiceStatusLifecycleObserver@Inject constructor(
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val dispatcherProvider: DispatcherProvider,
+    private val autofillManager: AutofillManager?,
+    private val autofillServiceStore: AutofillServiceStore,
+    private val appBuildConfig: AppBuildConfig,
+    private val pixel: Pixel,
+) : MainProcessLifecycleObserver {
+
+    override fun onStart(owner: LifecycleOwner) {
+        super.onStart(owner)
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            Timber.e("Autofill service component observer status")
+            runCatching {
+                autofillManager ?: return@runCatching
+                val isDefault = autofillManager.hasEnabledAutofillServices()
+                var ddgIsServiceComponentName = false
+                if (appBuildConfig.sdkInt >= 28) { // This is a fallback logic in case previous check fails
+                    ddgIsServiceComponentName = autofillManager.autofillServiceComponentName
+                        ?.packageName?.contains("com.duckduckgo.mobile.android") ?: false
+                }
+                val newDefaultState = isDefault || ddgIsServiceComponentName
+
+                if (autofillServiceStore.isDefaultAutofillProvider() != newDefaultState) {
+                    triggerPixel(newDefaultState)
+                    autofillServiceStore.updateDefaultAutofillProvider(newDefaultState)
+                }
+            }.onFailure {
+                Timber.e("Failed to update autofill service status")
+            }
+        }
+    }
+
+    private fun triggerPixel(newIsEnabledState: Boolean) {
+        val pixelName = if (newIsEnabledState) AUTOFILL_SERVICE_ENABLED else AUTOFILL_SERVICE_DISABLED
+        pixel.fire(pixelName)
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/AutofillServiceStatusLifecycleObserver.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/AutofillServiceStatusLifecycleObserver.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.autofill.impl.service
 
+import android.annotation.SuppressLint
 import android.view.autofill.AutofillManager
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.di.AppCoroutineScope
@@ -46,6 +47,7 @@ class AutofillServiceStatusLifecycleObserver@Inject constructor(
     private val pixel: Pixel,
 ) : MainProcessLifecycleObserver {
 
+    @SuppressLint("NewApi")
     override fun onStart(owner: LifecycleOwner) {
         super.onStart(owner)
         appCoroutineScope.launch(dispatcherProvider.io()) {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/AutofillSimpleCredentialsListFragment.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/AutofillSimpleCredentialsListFragment.kt
@@ -32,10 +32,12 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.RecyclerView
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.browser.favicon.FaviconManager
+import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.impl.R
 import com.duckduckgo.autofill.impl.databinding.FragmentAutofillProviderListBinding
 import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SERVICE_PASSWORDS_SEARCH
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillManagementRecyclerAdapterLegacy
 import com.duckduckgo.autofill.impl.ui.credential.management.sorting.CredentialGrouper
 import com.duckduckgo.autofill.impl.ui.credential.management.sorting.InitialExtractor
@@ -84,6 +86,9 @@ class AutofillSimpleCredentialsListFragment : DuckDuckGoFragment(R.layout.fragme
 
     @Inject
     lateinit var globalActivityStarter: GlobalActivityStarter
+
+    @Inject
+    lateinit var pixel: Pixel
 
     val viewModel by lazy {
         ViewModelProvider(requireActivity(), viewModelFactory)[AutofillProviderCredentialsListViewModel::class.java]
@@ -137,6 +142,7 @@ class AutofillSimpleCredentialsListFragment : DuckDuckGoFragment(R.layout.fragme
 
     private fun initializeSearchBar() {
         searchMenuItem?.setOnMenuItemClickListener {
+            pixel.fire(AUTOFILL_SERVICE_PASSWORDS_SEARCH)
             showSearchBar()
             return@setOnMenuItemClickListener true
         }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/RealAutofillService.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/RealAutofillService.kt
@@ -23,11 +23,9 @@ import android.service.autofill.FillRequest
 import android.service.autofill.SaveCallback
 import android.service.autofill.SaveRequest
 import android.service.autofill.SavedDatasetsInfoCallback
-import android.util.Base64
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelName
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames
 import com.duckduckgo.common.utils.ConflatedJob
@@ -102,7 +100,7 @@ class RealAutofillService : AutofillService() {
 
                 callback.onSuccess(response)
             }.onFailure {
-                pixel.fire(AutofillPixelNames.AUTOFILL_SERVICE_CRASH,  mapOf("message" to it.extractExceptionCause()))
+                pixel.fire(AutofillPixelNames.AUTOFILL_SERVICE_CRASH, mapOf("message" to it.extractExceptionCause()))
                 callback.onSuccess(null)
             }
         }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/store/AutofillServiceModule.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/store/AutofillServiceModule.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.service.store
+
+import android.content.Context
+import android.view.autofill.AutofillManager
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesTo
+import dagger.Module
+import dagger.Provides
+import dagger.SingleInstanceIn
+import javax.inject.Qualifier
+
+@Module
+@ContributesTo(AppScope::class)
+class AutofillServiceModule {
+
+    private val Context.autofillServiceStore: DataStore<Preferences> by preferencesDataStore(
+        name = "autofill_service_store",
+    )
+
+    @Provides
+    @SingleInstanceIn(AppScope::class)
+    @AutofillServiceDataStore
+    fun providesAutofillServiceStore(context: Context): DataStore<Preferences> {
+        return context.autofillServiceStore
+    }
+
+    @Provides
+    fun providesAutofillManager(context: Context): AutofillManager? {
+        return kotlin.runCatching { context.getSystemService(AutofillManager::class.java) as AutofillManager }.getOrNull()
+    }
+}
+
+@Qualifier
+annotation class AutofillServiceDataStore

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/store/AutofillServiceStore.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/store/AutofillServiceStore.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.service.store
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+import kotlinx.coroutines.flow.firstOrNull
+import timber.log.Timber
+
+interface AutofillServiceStore {
+    suspend fun isDefaultAutofillProvider(): Boolean
+    suspend fun updateDefaultAutofillProvider(isDefault: Boolean)
+}
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealAutofillServiceStore @Inject constructor(
+    @AutofillServiceDataStore private val store: DataStore<Preferences>,
+) : AutofillServiceStore {
+
+    override suspend fun isDefaultAutofillProvider(): Boolean {
+        return store.data.firstOrNull()?.get(enabledByUserKey) ?: false
+    }
+
+    override suspend fun updateDefaultAutofillProvider(isDefault: Boolean) {
+        Timber.i("DDGAutofillService updating default autofill provider to $isDefault")
+        store.edit {
+            it[enabledByUserKey] = isDefault
+        }
+    }
+
+    companion object {
+        private val enabledByUserKey = booleanPreferencesKey("enabled_by_user_key")
+    }
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/FakeAutofillServiceStore.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/FakeAutofillServiceStore.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill
+
+import com.duckduckgo.autofill.impl.service.store.AutofillServiceStore
+
+class FakeAutofillServiceStore: AutofillServiceStore {
+    private var isAutofillEnabled = false
+
+    override suspend fun isDefaultAutofillProvider(): Boolean = isAutofillEnabled
+
+    override suspend fun updateDefaultAutofillProvider(isDefault: Boolean) {
+        isAutofillEnabled = isDefault
+    }
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/FakeAutofillServiceStore.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/FakeAutofillServiceStore.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.autofill
 
 import com.duckduckgo.autofill.impl.service.store.AutofillServiceStore
 
-class FakeAutofillServiceStore: AutofillServiceStore {
+class FakeAutofillServiceStore : AutofillServiceStore {
     private var isAutofillEnabled = false
 
     override suspend fun isDefaultAutofillProvider(): Boolean = isAutofillEnabled

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/engagement/store/DefaultAutofillEngagementRepositoryTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/engagement/store/DefaultAutofillEngagementRepositoryTest.kt
@@ -66,7 +66,7 @@ class DefaultAutofillEngagementRepositoryTest {
         dispatchers = coroutineTestRule.testDispatcherProvider,
         secureStorage = secureStorage,
         deviceAuthenticator = deviceAuthenticator,
-        autofillServiceStore = autofillServiceStore
+        autofillServiceStore = autofillServiceStore,
     )
 
     @Test

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/service/AutofillProviderChooseViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/service/AutofillProviderChooseViewModelTest.kt
@@ -48,7 +48,7 @@ class AutofillProviderChooseViewModelTest {
             autofillFeature = autofillFeature,
         ),
         appCoroutineScope = coroutineRule.testScope,
-        pixel = pixel
+        pixel = pixel,
     )
 
     @Test
@@ -112,7 +112,7 @@ class AutofillProviderChooseViewModelTest {
             assertFalse(twitterCredentials.lastUsedMillis == updatedCredential.lastUsedMillis)
         }
     }
-    
+
     @Test
     fun whenContinueAfterAuthenticationThenFireAutofillServiceSuggestionConfirmedPixel() = runTest {
         givenLocalCredentials(twitterCredentials)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1200156640058969/1209303556783952

### Description
Adds metrics around the autofill service

### Steps to test this PR
Notice: specs are present in https://app.asana.com/0/1200156640058969/1209115687167237
Use `message~:"Pixel sent: autofill_"` as filter
Test cases in https://app.asana.com/0/488551667048375/1209504798589773


### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
