### PR TITLE
Simplify unsupported application schemes test.

### DIFF
--- a/.maestro/security_tests/3_-_AddressBarSpoof,_appschemes.yaml
+++ b/.maestro/security_tests/3_-_AddressBarSpoof,_appschemes.yaml
@@ -15,17 +15,7 @@ tags:
             - pressKey: Enter
             - tapOn: "Got It"
             - tapOn: "Start"
-            # This test is expected to load spreadprivacy.com, not remain on the current page with spoofed content.
-            - assertVisible: "Spread Privacy" # DuckDuckGo blog homepage
+            # Simplified: Just ensure the address bar remains on the current URL, since these URL types are not supported in Android webview anymore.
             - copyTextFrom:
                 id: "omnibarTextInput"
-            - assertTrue: ${maestro.copiedText == "https://spreadprivacy.com/"} # DuckDuckGo blog home page
-            - tapOn:
-                id: "omnibarTextInput"
-            # Test 2
-            - inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-unsupported-scheme.html"
-            - pressKey: Enter
-            - tapOn: "Start"
-            - copyTextFrom:
-                id: "omnibarTextInput"
-            - assertTrue: ${maestro.copiedText == "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-unsupported-scheme.html"}
+            - assertTrue: ${maestro.copiedText == "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-application-scheme.html"}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414730916066338/1209505862915813

### Description
Android webview doesn't support these application schemes anymore that are being tested for address bar spoofing vulnerabilities. Now this test can be significantly simplified by just ensuring the address bar doesn't update at all.

### Steps to test this PR
`maestro test ./.maestro/security_tests/3_-_AddressBarSpoof,_appschemes.yaml`

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
