### PR TITLE
Make autofill username comparison case insensitive

### DIFF
--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillCredentialDialogs.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillCredentialDialogs.kt
@@ -88,10 +88,10 @@ interface CredentialUpdateExistingCredentialsDialog {
     sealed interface CredentialUpdateType : Parcelable {
 
         @Parcelize
-        object Username : CredentialUpdateType
+        data object Username : CredentialUpdateType
 
         @Parcelize
-        object Password : CredentialUpdateType
+        data object Password : CredentialUpdateType
     }
 
     companion object {

--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillFeature.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillFeature.kt
@@ -128,4 +128,10 @@ interface AutofillFeature {
      */
     @Toggle.DefaultValue(defaultValue = true)
     fun newScrollBehaviourInPasswordManagementScreen(): Toggle
+
+    /**
+     * Kill switch for making case insensitive checks on existing username matches
+     */
+    @Toggle.DefaultValue(defaultValue = true)
+    fun ignoreCaseOnUsernameComparisons(): Toggle
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/deduper/AutofillDeduplicationBestMatchFinder.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/deduper/AutofillDeduplicationBestMatchFinder.kt
@@ -20,7 +20,6 @@ import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.impl.deduper.AutofillDeduplicationMatchTypeDetector.MatchType.NotAMatch
 import com.duckduckgo.autofill.impl.deduper.AutofillDeduplicationMatchTypeDetector.MatchType.PartialMatch
 import com.duckduckgo.autofill.impl.deduper.AutofillDeduplicationMatchTypeDetector.MatchType.PerfectMatch
-import com.duckduckgo.autofill.impl.urlmatcher.AutofillUrlMatcher
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
@@ -35,7 +34,6 @@ interface AutofillDeduplicationBestMatchFinder {
 
 @ContributesBinding(AppScope::class)
 class RealAutofillDeduplicationBestMatchFinder @Inject constructor(
-    private val urlMatcher: AutofillUrlMatcher,
     private val matchTypeDetector: AutofillDeduplicationMatchTypeDetector,
 ) : AutofillDeduplicationBestMatchFinder {
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/deduper/AutofillDeduplicationUsernameAndPasswordMatcher.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/deduper/AutofillDeduplicationUsernameAndPasswordMatcher.kt
@@ -17,19 +17,22 @@
 package com.duckduckgo.autofill.impl.deduper
 
 import com.duckduckgo.autofill.api.domain.app.LoginCredentials
+import com.duckduckgo.autofill.impl.username.AutofillUsernameComparer
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 
 interface AutofillDeduplicationUsernameAndPasswordMatcher {
 
-    fun groupDuplicateCredentials(logins: List<LoginCredentials>): Map<Pair<String?, String?>, List<LoginCredentials>>
+    suspend fun groupDuplicateCredentials(logins: List<LoginCredentials>): Map<Pair<String?, String?>, List<LoginCredentials>>
 }
 
 @ContributesBinding(AppScope::class)
-class RealAutofillDeduplicationUsernameAndPasswordMatcher @Inject constructor() : AutofillDeduplicationUsernameAndPasswordMatcher {
+class RealAutofillDeduplicationUsernameAndPasswordMatcher @Inject constructor(
+    private val usernameComparer: AutofillUsernameComparer,
+) : AutofillDeduplicationUsernameAndPasswordMatcher {
 
-    override fun groupDuplicateCredentials(logins: List<LoginCredentials>): Map<Pair<String?, String?>, List<LoginCredentials>> {
-        return logins.groupBy { it.username to it.password }
+    override suspend fun groupDuplicateCredentials(logins: List<LoginCredentials>): Map<Pair<String?, String?>, List<LoginCredentials>> {
+        return usernameComparer.groupUsernamesAndPasswords(logins)
     }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/deduper/AutofillLoginDeduplicator.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/deduper/AutofillLoginDeduplicator.kt
@@ -23,7 +23,7 @@ import javax.inject.Inject
 
 interface AutofillLoginDeduplicator {
 
-    fun deduplicate(
+    suspend fun deduplicate(
         originalUrl: String,
         logins: List<LoginCredentials>,
     ): List<LoginCredentials>
@@ -35,7 +35,7 @@ class RealAutofillLoginDeduplicator @Inject constructor(
     private val bestMatchFinder: AutofillDeduplicationBestMatchFinder,
 ) : AutofillLoginDeduplicator {
 
-    override fun deduplicate(
+    override suspend fun deduplicate(
         originalUrl: String,
         logins: List<LoginCredentials>,
     ): List<LoginCredentials> {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/username/AutofillUsernameComparer.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/username/AutofillUsernameComparer.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.username
+
+import com.duckduckgo.autofill.api.AutofillFeature
+import com.duckduckgo.autofill.api.domain.app.LoginCredentials
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+import kotlinx.coroutines.withContext
+
+interface AutofillUsernameComparer {
+    suspend fun isEqual(
+        username1: String?,
+        username2: String?,
+    ): Boolean
+
+    suspend fun groupUsernamesAndPasswords(logins: List<LoginCredentials>): Map<Pair<String?, String?>, List<LoginCredentials>>
+}
+
+@ContributesBinding(AppScope::class)
+class RealAutofillUsernameComparer @Inject constructor(
+    private val autofillFeature: AutofillFeature,
+    private val dispatchers: DispatcherProvider,
+) : AutofillUsernameComparer {
+
+    override suspend fun isEqual(username1: String?, username2: String?): Boolean {
+        return withContext(dispatchers.io()) {
+            if (username1 == null && username2 == null) return@withContext true
+            if (username1 == null) return@withContext false
+            if (username2 == null) return@withContext false
+
+            username1.equals(username2, ignoreCase = autofillFeature.ignoreCaseOnUsernameComparisons().isEnabled())
+        }
+    }
+    override suspend fun groupUsernamesAndPasswords(logins: List<LoginCredentials>): Map<Pair<String?, String?>, List<LoginCredentials>> {
+        return if (autofillFeature.ignoreCaseOnUsernameComparisons().isEnabled()) {
+            logins.groupBy { it.username?.lowercase() to it.password }
+        } else {
+            logins.groupBy { it.username to it.password }
+        }
+    }
+}

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/AutofillStoreFixtures.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/AutofillStoreFixtures.kt
@@ -34,6 +34,7 @@ import com.duckduckgo.autofill.sync.SyncCredentialsListener
 import com.duckduckgo.autofill.sync.inMemoryAutofillDatabase
 import com.duckduckgo.common.utils.DispatcherProvider
 import kotlinx.coroutines.CoroutineScope
+import org.mockito.kotlin.mock
 
 fun fakeAutofillStore(
     secureStorage: SecureStorage = fakeStorage(),
@@ -56,6 +57,7 @@ fun fakeAutofillStore(
         coroutineScope,
     ),
     autofillFeature = autofillFeature,
+    usernameComparer = mock(),
 )
 
 fun fakeStorage(
@@ -73,7 +75,7 @@ fun lastUpdatedTimeProvider() = object : LastUpdatedTimeProvider {
 fun autofillDomainNameUrlMatcher() = AutofillDomainNameUrlMatcher(TestUrlUnicodeNormalizer())
 
 fun noopDeduplicator() = object : AutofillLoginDeduplicator {
-    override fun deduplicate(
+    override suspend fun deduplicate(
         originalUrl: String,
         logins: List<LoginCredentials>,
     ): List<LoginCredentials> = logins

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/deduper/RealLoginDeduplicatorBestMatchFinderTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/deduper/RealLoginDeduplicatorBestMatchFinderTest.kt
@@ -14,7 +14,6 @@ class RealLoginDeduplicatorBestMatchFinderTest {
     private val urlMatcher = AutofillDomainNameUrlMatcher(TestUrlUnicodeNormalizer())
     private val matchTypeDetector = RealAutofillDeduplicationMatchTypeDetector(urlMatcher)
     private val testee = RealAutofillDeduplicationBestMatchFinder(
-        urlMatcher = urlMatcher,
         matchTypeDetector = matchTypeDetector,
     )
 

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/service/AutofillServiceSuggestionsTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/service/AutofillServiceSuggestionsTest.kt
@@ -139,7 +139,7 @@ class AutofillServiceSuggestionsTest {
                 ),
             ),
             loginDeduplicator = object : AutofillLoginDeduplicator {
-                override fun deduplicate(
+                override suspend fun deduplicate(
                     originalUrl: String,
                     logins: List<LoginCredentials>,
                 ): List<LoginCredentials> {

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/username/RealAutofillUsernameComparerTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/username/RealAutofillUsernameComparerTest.kt
@@ -1,0 +1,78 @@
+package com.duckduckgo.autofill.impl.username
+
+import android.annotation.SuppressLint
+import com.duckduckgo.autofill.api.AutofillFeature
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+import org.junit.Rule
+import org.junit.Test
+
+@SuppressLint("DenyListedApi")
+class RealAutofillUsernameComparerTest {
+
+    private val feature = FakeFeatureToggleFactory.create(AutofillFeature::class.java)
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+    private val testee = RealAutofillUsernameComparer(
+        autofillFeature = feature,
+        dispatchers = coroutineTestRule.testDispatcherProvider,
+    )
+
+    @Test
+    fun whenBothUsernamesAreNullThenAreEqual() = runTest {
+        assertTrue(testee.isEqual(null, null))
+    }
+
+    @Test
+    fun whenBothUsernamesAreEmptyThenAreEqual() = runTest {
+        assertTrue(testee.isEqual("", ""))
+    }
+
+    @Test
+    fun whenFirstUsernameIsNullAndOtherIsNotThenAreNotEqual() = runTest {
+        assertFalse(testee.isEqual(null, "user"))
+    }
+
+    @Test
+    fun whenFirstUsernameIsEmptyAndOtherIsNotThenAreNotEqual() = runTest {
+        assertFalse(testee.isEqual("", "user"))
+    }
+
+    @Test
+    fun whenSecondUsernameIsNullAndOtherIsNotThenAreNotEqual() = runTest {
+        assertFalse(testee.isEqual("user", null))
+    }
+
+    @Test
+    fun whenSecondUsernameIsEmptyAndOtherIsNotThenAreNotEqual() = runTest {
+        assertFalse(testee.isEqual("user", ""))
+    }
+
+    @Test
+    fun whenOneUsernameIsEmptyAndOtherIsNotThenAreNotEqual() = runTest {
+        assertFalse(testee.isEqual("", "user2"))
+    }
+
+    @Test
+    fun whenUsernamesAreTotallyDifferentThenAreNotEqual() = runTest {
+        assertFalse(testee.isEqual("user1", "user2"))
+    }
+
+    @Test
+    fun whenUsernamesAreIdenticalIncludingCaseThenAreEqual() = runTest {
+        assertTrue(testee.isEqual("user", "user"))
+    }
+
+    @Test
+    fun whenUsernamesAreIdenticalApartFromCaseThenAreEqual() = runTest {
+        assertTrue(testee.isEqual("user", "USER"))
+
+        // check when feature flag disabled
+        feature.ignoreCaseOnUsernameComparisons().setRawStoredState(State(enable = false))
+        assertFalse(testee.isEqual("user", "USER"))
+    }
+}

--- a/autofill/autofill-internal/src/main/java/com/duckduckgo/autofill/internal/AutofillInternalSettingsActivity.kt
+++ b/autofill/autofill-internal/src/main/java/com/duckduckgo/autofill/internal/AutofillInternalSettingsActivity.kt
@@ -444,6 +444,16 @@ class AutofillInternalSettingsActivity : DuckDuckGoActivity() {
             }
         }
 
+        binding.addMixedCaseUsernameDuplicates.setClickListener {
+            lifecycleScope.launch(dispatchers.io()) {
+                val credentials = mutableListOf<LoginCredentials>()
+                credentials.add(sampleCredentials("https://autofill.me", username = "username"))
+                credentials.add(sampleCredentials("https://autofill.me", username = "UseRNamE"))
+                credentials.add(sampleCredentials("https://autofill.me", username = "USERNAME"))
+                credentials.save()
+            }
+        }
+
         binding.clearAllSavedLoginsButton.setClickListener {
             lifecycleScope.launch(dispatchers.io()) {
                 val count = autofillStore.getCredentialCount().first()

--- a/autofill/autofill-internal/src/main/res/layout/activity_autofill_internal_settings.xml
+++ b/autofill/autofill-internal/src/main/res/layout/activity_autofill_internal_settings.xml
@@ -44,6 +44,12 @@
             android:layout_height="wrap_content"
             app:primaryText="@string/autofillDevSettingsLoginsSectionTitle" />
 
+        <com.duckduckgo.common.ui.view.listitem.OneLineListItem
+            android:id="@+id/viewSavedLoginsButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:primaryText="@string/autofillDevSettingsViewSavedLogins" />
+
         <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
             android:id="@+id/addSampleLoginsButton"
             android:layout_width="match_parent"
@@ -80,17 +86,18 @@
             app:secondaryText="@string/autofillDevSettingsAddSampleLoginsMultipleSubdomainsSubtitle" />
 
         <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+            android:id="@+id/addMixedCaseUsernameDuplicates"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:primaryText="@string/autofillDevSettingsAddMixedUsernameCaseLogins"
+            app:secondaryText="@string/autofillDevSettingsAddMixedUsernameCaseLogins" />
+
+        <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
             android:id="@+id/clearAllSavedLoginsButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:primaryText="@string/autofillDevSettingsClearLogins"
             tools:secondaryText="@string/autofillDevSettingsClearLoginsSubtitle" />
-
-        <com.duckduckgo.common.ui.view.listitem.OneLineListItem
-            android:id="@+id/viewSavedLoginsButton"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:primaryText="@string/autofillDevSettingsViewSavedLogins" />
 
         <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
             android:id="@+id/importPasswordsSectionTitle"

--- a/autofill/autofill-internal/src/main/res/values/donottranslate.xml
+++ b/autofill/autofill-internal/src/main/res/values/donottranslate.xml
@@ -83,6 +83,8 @@
     <string name="autofillDevSettingsAddSampleLoginsSameSubdomainSubtitle">Adds multiple logins for https://fill.dev with same username and password</string>
     <string name="autofillDevSettingsAddSampleLoginsMultipleSubdomains">Add duplicate logins (across different subdomains)</string>
     <string name="autofillDevSettingsAddSampleLoginsMultipleSubdomainsSubtitle">Adds multiple logins for https://fill.dev with same username and password but across different subdomains</string>
+    <string name="autofillDevSettingsAddMixedUsernameCaseLogins">Add mixed case username duplicates</string>
+    <string name="autofillDevSettingsAddMixedUsernameCaseLoginsSubtitle">Adds multiple duplicate logins, different only from the case of the username</string>
 
     <string name="autofillDevSettingsSurveySectionTitle">Autofill Survey</string>
     <string name="autofillDevSettingsSurveySectionResetPreviousSurveysTitle">Previously Seen Surveys</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/608920331025315/1209488709393051 

### Description
Changes how we compare usernames to make them case-insensitive. 

Autofill subfeature `ignoreCaseOnUsernameComparisons` guards the new behaviour.
- new behaviour is enabled by default 
- disable the flag to revert to old behaviour

#### Where this change applies

- If multiple credentials saved which are identical apart from casing on username, these will be considered duplicates from the credential picker view (meaning they’ll be de-duped)
- If you already have a credential saved and are trying to save a new one with same username, the comparison between usernames will be case insensitive. So if `user` is saved and `USER` comes from the JS, these will be treated as equivalent
- The password management view will always show all saved credentials (no de-duping in this view)

### Steps to test this PR

#### De-duping credential picker
- [x] fresh `internal` install
- [x] Visit `Autofill Dev Settings` (from `Settings -> Autofill Dev Settings`)
- [x] Tap on `Add mixed case username duplicates`
- [x] Visit https://autofill.me/form/login-simple, verify you are prompted to autofill with **only 1 option offered**
- [x] Agree to autofill, and confirm it autofills successfully

#### Across subdomains
- [x] Visit password management screen, and choose one of the credentials to edit
- [x] Change its URL to have a subdomain (e.g. `example.autofill.me`) but keep the username
- [x] Add a new credential (`username=john`, `password=password`, `url=example.autofill.me`) and save
- [x] Return to https://autofill.me/form/login-simple (and refresh)
- [x] Verify you see 1 option `From This Website`, and 1 option `From example.autofill.me` (this verifies that it de-duped the username where case was different but credential was otherwise identical, and still included the credential for a subdomain with a different username) 

#### Prompted to update password (not save a new one) when only difference is casing on username
- [x] Visit https://autofill.me/form/registration-username
- [x] For username, enter `USERname` (match the case exactly)
- [x] For password, enter something different from what’s stored (e.g., `new-password` or autogenerate it)
- [x] Tap `Register` button. Verify you are prompted to `Update password` for the username
- [ ] Agree. Now visit password management page and verify the password has been updated for all 3 entries (by design, it updates multiple matches)


#### Reverting to old behaviour
- [x] Tap on `Settings -> Feature Flag Inventory`, and disable `ignoreCaseOnUsernameComparisons`
- [x] Verify the production behaviour happens. e.g., 
    - you get offered all saved passwords to autofill, even the “duplicates”
    - if you register using a username containing case differences, you are prompted to save rather than update
