### PR TITLE
Fix: Navigation of a link that opens a new tab is broken

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -952,7 +952,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
         openMessageInNewTabJob = lifecycleScope.launch {
             if (swipingTabsFeature.isEnabled) {
                 tabPagerAdapter.setMessageForNewFragment(message)
-                tabManager.openNewTab(sourceTabId)
+                tabManager.openNewTab(sourceTabId = sourceTabId)
             } else {
                 val tabId = viewModel.onNewTabRequested(sourceTabId = sourceTabId)
                 val fragment = openNewTab(tabId, null, false, intent?.getBooleanExtra(LAUNCH_FROM_EXTERNAL_EXTRA, false) ?: false)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414730916066338/1209512583266733

### Description

Fixes a bug when tapping on a link that opens a new tab is broken. 

### Steps to test this PR

- [x] Navigate to `https://www.mariotti1908.it/riparazioni-sartoriali-t/`
- [x] Tap on the FB icon
- [x] Notice the FB page is correctly opened in a new tab

