### PR TITLE
Additional "default browser" prompts: refactored remote config parsing code to match expected schema

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/DefaultBrowserPromptsFeatureToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/DefaultBrowserPromptsFeatureToggles.kt
@@ -35,8 +35,8 @@ interface DefaultBrowserPromptsFeatureToggles {
 
     enum class AdditionalPromptsCohortName(override val cohortName: String) : CohortName {
         CONTROL("control"),
-        VARIANT_1("variant_1"),
-        VARIANT_2("variant_2"),
-        VARIANT_3("variant_3"),
+        VARIANT_1("variant1"),
+        VARIANT_2("variant2"),
+        VARIANT_3("variant3"),
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/diagrams/default_browser_prompts_experiment_class_diagram.puml
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/diagrams/default_browser_prompts_experiment_class_diagram.puml
@@ -59,9 +59,9 @@ end note
 
 enum AdditionalPromptsCohortName {
   + CONTROL("control")
-  + VARIANT_1("variant_1")
-  + VARIANT_2("variant_2")
-  + VARIANT_3("variant_3")
+  + VARIANT_1("variant1")
+  + VARIANT_2("variant2")
+  + VARIANT_3("variant3")
 }
 
 interface DefaultBrowserPromptsFeatureToggles {

--- a/app/src/test/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/DefaultBrowserPromptsExperimentImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/DefaultBrowserPromptsExperimentImplTest.kt
@@ -27,7 +27,7 @@ import com.duckduckgo.app.browser.defaultbrowsing.prompts.DefaultBrowserPromptsE
 import com.duckduckgo.app.browser.defaultbrowsing.prompts.DefaultBrowserPromptsExperimentImpl.Companion.FALLBACK_TO_DEFAULT_APPS_SCREEN_THRESHOLD_MILLIS
 import com.duckduckgo.app.browser.defaultbrowsing.prompts.DefaultBrowserPromptsExperimentImpl.Companion.PIXEL_PARAM_KEY_STAGE
 import com.duckduckgo.app.browser.defaultbrowsing.prompts.DefaultBrowserPromptsExperimentImpl.Companion.PIXEL_PARAM_KEY_VARIANT
-import com.duckduckgo.app.browser.defaultbrowsing.prompts.DefaultBrowserPromptsExperimentImpl.FeatureSettings
+import com.duckduckgo.app.browser.defaultbrowsing.prompts.DefaultBrowserPromptsExperimentImpl.FeatureSettingsConfigModel
 import com.duckduckgo.app.browser.defaultbrowsing.prompts.DefaultBrowserPromptsFeatureToggles.AdditionalPromptsCohortName
 import com.duckduckgo.app.browser.defaultbrowsing.prompts.store.DefaultBrowserPromptsDataStore
 import com.duckduckgo.app.browser.defaultbrowsing.prompts.store.DefaultBrowserPromptsDataStore.ExperimentStage
@@ -104,7 +104,7 @@ class DefaultBrowserPromptsExperimentImplTest {
 
     @Mock private lateinit var moshiMock: Moshi
 
-    @Mock private lateinit var featureSettingsJsonAdapterMock: JsonAdapter<FeatureSettings>
+    @Mock private lateinit var featureSettingsJsonAdapterMock: JsonAdapter<FeatureSettingsConfigModel>
 
     @Mock private lateinit var systemDefaultBrowserDialogIntentMock: Intent
 
@@ -145,7 +145,7 @@ class DefaultBrowserPromptsExperimentImplTest {
 
         whenever(featureTogglesMock.defaultBrowserAdditionalPrompts202501()).thenReturn(additionalPromptsToggleMock)
         whenever(defaultRoleBrowserDialogMock.createIntent(appContextMock)).thenReturn(systemDefaultBrowserDialogIntentMock)
-        whenever(moshiMock.adapter<FeatureSettings>(any())).thenReturn(featureSettingsJsonAdapterMock)
+        whenever(moshiMock.adapter<FeatureSettingsConfigModel>(any())).thenReturn(featureSettingsJsonAdapterMock)
         fakeUserAppStageFlow = MutableSharedFlow()
         whenever(userStageStoreMock.userAppStageFlow()).thenReturn(fakeUserAppStageFlow)
         runBlocking {
@@ -1078,15 +1078,14 @@ class DefaultBrowserPromptsExperimentImplTest {
         activeDaysUntilStage1: Int,
         activeDaysUntilStage2: Int,
         activeDaysUntilStop: Int,
-    ): FeatureSettings {
-        val settings = FeatureSettings(
-            activeDaysUntilStage1 = activeDaysUntilStage1,
-            activeDaysUntilStage2 = activeDaysUntilStage2,
-            activeDaysUntilStop = activeDaysUntilStop,
+    ) {
+        val settings = FeatureSettingsConfigModel(
+            activeDaysUntilStage1 = activeDaysUntilStage1.toString(),
+            activeDaysUntilStage2 = activeDaysUntilStage2.toString(),
+            activeDaysUntilStop = activeDaysUntilStop.toString(),
         )
         whenever(additionalPromptsToggleMock.getSettings()).thenReturn(additionalPromptsFeatureSettingsFake)
         whenever(featureSettingsJsonAdapterMock.fromJson(additionalPromptsFeatureSettingsFake)).thenReturn(settings)
-        return settings
     }
 
     private suspend fun mockStageEvaluator(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1208671518894266/1209523191422601

### Description

Adjust the implementation to be able to use config entry that matches the schema.

### Steps to test this PR
Test config:
```json
    "defaultBrowserPrompts": {
      "state": "enabled",
      "exceptions": [],
      "features": {
        "defaultBrowserAdditionalPrompts202501": {
          "state": "enabled",
          "settings": {
            "activeDaysUntilStage1": "1",
            "activeDaysUntilStage2": "3",
            "activeDaysUntilStop": "5"
          },
          "cohorts": [
            {
              "name": "control",
              "weight": 0
            },
            {
              "name": "variant1",
              "weight": 0
            },
            {
              "name": "variant2",
              "weight": 1
            },
            {
              "name": "variant3",
              "weight": 0
            }
          ]
        }
      }
    }
```

1. Load this config: https://www.jsonblob.com/api/1344630015471575040
2. Move the device's calendar date by one day.
3. Restart/resume the app - a CTA should be shown.
4. Move the device's calendar date by one day and restart/resume the app, **twice** - a new menu item should be added.
5. Move the device's calendar date by one day and restart/resume the app, **twice** - menu should be removed.