### PR TITLE
Implement pixels for feature discoverability

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -200,6 +200,7 @@ import com.duckduckgo.downloads.api.DownloadStateListener
 import com.duckduckgo.downloads.api.FileDownloader
 import com.duckduckgo.downloads.api.FileDownloader.PendingFileDownload
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.impl.DuckChatPixelName
 import com.duckduckgo.duckplayer.api.DuckPlayer
 import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerOrigin.AUTO
 import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerOrigin.OVERLAY
@@ -5781,6 +5782,28 @@ class BrowserTabViewModelTest {
         ) { "someUrl" }
         verify(mockDuckChatJSHelper).processJsCallbackMessage(DUCK_CHAT_FEATURE_NAME, "method", "id", null)
         assertCommandNotIssued<Command.SendResponseToJs>()
+    }
+
+    @Test
+    fun whenDuckChatMenuItemClickedAndItWasntUsedBeforeThenOpenDuckChatAndSendPixel() = runTest {
+        whenever(mockDuckChat.wasOpenedBefore()).thenReturn(false)
+
+        testee.onDuckChatMenuClicked()
+
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_OPEN)
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_OPEN_BROWSER_MENU, mapOf("was_used_before" to "0"))
+        verify(mockDuckChat).openDuckChat()
+    }
+
+    @Test
+    fun whenDuckChatMenuItemClickedAndItWasUsedBeforeThenOpenDuckChatAndSendPixel() = runTest {
+        whenever(mockDuckChat.wasOpenedBefore()).thenReturn(true)
+
+        testee.onDuckChatMenuClicked()
+
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_OPEN)
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_OPEN_BROWSER_MENU, mapOf("was_used_before" to "1"))
+        verify(mockDuckChat).openDuckChat()
     }
 
     private fun aCredential(): LoginCredentials {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -267,7 +267,6 @@ import com.duckduckgo.downloads.api.DownloadsFileActions
 import com.duckduckgo.downloads.api.FileDownloader
 import com.duckduckgo.downloads.api.FileDownloader.PendingFileDownload
 import com.duckduckgo.duckchat.api.DuckChat
-import com.duckduckgo.duckchat.impl.DuckChatPixelName
 import com.duckduckgo.duckplayer.api.DuckPlayer
 import com.duckduckgo.duckplayer.api.DuckPlayerSettingsNoParams
 import com.duckduckgo.js.messaging.api.JsCallbackData
@@ -1028,8 +1027,7 @@ class BrowserTabFragment :
                 onOmnibarNewTabRequested()
             }
             onMenuItemClicked(duckChatMenuItem) {
-                pixel.fire(DuckChatPixelName.DUCK_CHAT_OPEN)
-                duckChat.openDuckChat()
+                viewModel.onDuckChatMenuClicked()
             }
             onMenuItemClicked(bookmarksMenuItem) {
                 browserActivity?.launchBookmarks()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -285,6 +285,7 @@ import com.duckduckgo.common.utils.SingleLiveEvent
 import com.duckduckgo.common.utils.baseHost
 import com.duckduckgo.common.utils.device.DeviceInfo
 import com.duckduckgo.common.utils.extensions.asLocationPermissionOrigin
+import com.duckduckgo.common.utils.extensions.toBinaryString
 import com.duckduckgo.common.utils.isMobileSite
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.common.utils.plugins.headers.CustomHeadersProvider
@@ -295,6 +296,7 @@ import com.duckduckgo.downloads.api.DownloadStateListener
 import com.duckduckgo.downloads.api.FileDownloader
 import com.duckduckgo.downloads.api.FileDownloader.PendingFileDownload
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.impl.DuckChatPixelName
 import com.duckduckgo.duckplayer.api.DuckPlayer
 import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.ENABLED
 import com.duckduckgo.history.api.NavigationHistory
@@ -3827,6 +3829,18 @@ class BrowserTabViewModel @Inject constructor(
 
     private fun onUserSwitchedToTab(tabId: String) {
         command.value = Command.SwitchToTab(tabId)
+    }
+
+    fun onDuckChatMenuClicked() {
+        viewModelScope.launch {
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_OPEN)
+
+            val wasUsedBefore = duckChat.wasOpenedBefore()
+            val params = mapOf("was_used_before" to wasUsedBefore.toBinaryString())
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_OPEN_BROWSER_MENU, parameters = params)
+
+            duckChat.openDuckChat()
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/duckduckgo/app/settings/NewSettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/NewSettingsViewModel.kt
@@ -31,7 +31,6 @@ import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_APPEARANCE_PRESSED
 import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_APPTP_PRESSED
 import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_COOKIE_POPUP_PROTECTION_PRESSED
 import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_DEFAULT_BROWSER_PRESSED
-import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_EMAIL_PROTECTION_PRESSED
 import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_FIRE_BUTTON_PRESSED
 import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_GENERAL_PRESSED
 import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_NEXT_STEPS_ADDRESS_BAR
@@ -281,7 +280,7 @@ class NewSettingsViewModel @Inject constructor(
             }
             this@NewSettingsViewModel.command.send(command)
         }
-        pixel.fire(SETTINGS_EMAIL_PROTECTION_PRESSED)
+        settingsPixelDispatcher.fireEmailPressed()
     }
 
     fun onAppTPSettingClicked() {

--- a/app/src/main/java/com/duckduckgo/app/settings/NewSettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/NewSettingsViewModel.kt
@@ -39,7 +39,6 @@ import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_NEXT_STEPS_VOICE_SEARCH
 import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_OPENED
 import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_PERMISSIONS_PRESSED
 import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_PRIVATE_SEARCH_PRESSED
-import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_SYNC_PRESSED
 import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_WEB_TRACKING_PROTECTION_PRESSED
 import com.duckduckgo.app.settings.NewSettingsViewModel.Command.LaunchAboutScreen
 import com.duckduckgo.app.settings.NewSettingsViewModel.Command.LaunchAccessibilitySettings
@@ -106,6 +105,7 @@ class NewSettingsViewModel @Inject constructor(
     private val duckChat: DuckChat,
     private val voiceSearchAvailability: VoiceSearchAvailability,
     private val privacyProUnifiedFeedback: PrivacyProUnifiedFeedback,
+    private val settingsPixelDispatcher: SettingsPixelDispatcher,
 ) : ViewModel(), DefaultLifecycleObserver {
 
     data class ViewState(
@@ -301,7 +301,7 @@ class NewSettingsViewModel @Inject constructor(
 
     fun onSyncSettingClicked() {
         viewModelScope.launch { command.send(LaunchSyncSettings) }
-        pixel.fire(SETTINGS_SYNC_PRESSED)
+        settingsPixelDispatcher.fireSyncPressed()
     }
 
     fun onFireButtonSettingClicked() {

--- a/app/src/main/java/com/duckduckgo/app/settings/NewSettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/NewSettingsViewModel.kt
@@ -316,6 +316,7 @@ class NewSettingsViewModel @Inject constructor(
 
     fun onDuckChatSettingClicked() {
         viewModelScope.launch { command.send(LaunchDuckChatScreen) }
+        settingsPixelDispatcher.fireDuckChatPressed()
     }
 
     fun onAppearanceSettingClicked() {

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsPixelDispatcher.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsPixelDispatcher.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.settings
+
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_SYNC_PRESSED
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.common.utils.extensions.toBinaryString
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.api.SyncState.OFF
+import com.duckduckgo.sync.api.SyncStateMonitor
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
+
+/**
+ * Utility to dispatch pixels triggered by interactions on the settings screen.
+ */
+interface SettingsPixelDispatcher {
+    fun fireSyncPressed()
+}
+
+@ContributesBinding(scope = AppScope::class)
+@SingleInstanceIn(AppScope::class)
+class SettingsPixelDispatcherImpl @Inject constructor(
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val pixel: Pixel,
+    private val syncStateMonitor: SyncStateMonitor,
+) : SettingsPixelDispatcher {
+
+    override fun fireSyncPressed() {
+        appCoroutineScope.launch {
+            val syncState = syncStateMonitor.syncState().firstOrNull()
+            val isEnabled = syncState != null && syncState != OFF
+            pixel.fire(
+                pixel = SETTINGS_SYNC_PRESSED,
+                parameters = mapOf(
+                    PARAM_SYNC_IS_ENABLED to isEnabled.toBinaryString(),
+                ),
+            )
+        }
+    }
+
+    private companion object {
+        const val PARAM_SYNC_IS_ENABLED = "is_enabled"
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsPixelDispatcher.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsPixelDispatcher.kt
@@ -21,6 +21,8 @@ import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_SYNC_PRESSED
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.utils.extensions.toBinaryString
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.impl.DuckChatPixelName.DUCK_CHAT_SETTINGS_PRESSED
 import com.duckduckgo.sync.api.SyncState.OFF
 import com.duckduckgo.sync.api.SyncStateMonitor
 import com.squareup.anvil.annotations.ContributesBinding
@@ -35,6 +37,7 @@ import kotlinx.coroutines.launch
  */
 interface SettingsPixelDispatcher {
     fun fireSyncPressed()
+    fun fireDuckChatPressed()
 }
 
 @ContributesBinding(scope = AppScope::class)
@@ -43,6 +46,7 @@ class SettingsPixelDispatcherImpl @Inject constructor(
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val pixel: Pixel,
     private val syncStateMonitor: SyncStateMonitor,
+    private val duckChat: DuckChat,
 ) : SettingsPixelDispatcher {
 
     override fun fireSyncPressed() {
@@ -58,7 +62,20 @@ class SettingsPixelDispatcherImpl @Inject constructor(
         }
     }
 
+    override fun fireDuckChatPressed() {
+        appCoroutineScope.launch {
+            val wasUsedBefore = duckChat.wasOpenedBefore()
+            pixel.fire(
+                pixel = DUCK_CHAT_SETTINGS_PRESSED,
+                parameters = mapOf(
+                    PARAM_DUCK_CHAT_USED_BEFORE to wasUsedBefore.toBinaryString(),
+                ),
+            )
+        }
+    }
+
     private companion object {
         const val PARAM_SYNC_IS_ENABLED = "is_enabled"
+        const val PARAM_DUCK_CHAT_USED_BEFORE = "was_used_before"
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -62,7 +62,6 @@ import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.duckchat.api.DuckChat
-import com.duckduckgo.duckchat.impl.DuckChatPixelName
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import javax.inject.Inject
@@ -333,8 +332,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
             R.id.newTab -> onNewTabRequested(fromOverflowMenu = false)
             R.id.newTabOverflow -> onNewTabRequested(fromOverflowMenu = true)
             R.id.duckChat -> {
-                pixel.fire(DuckChatPixelName.DUCK_CHAT_OPEN)
-                duckChat.openDuckChat()
+                viewModel.onDuckChatMenuClicked()
             }
             R.id.closeAllTabs -> closeAllTabs()
             R.id.downloads -> showDownloads()

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -34,7 +34,10 @@ import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType.GRID
 import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType.LIST
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.SingleLiveEvent
+import com.duckduckgo.common.utils.extensions.toBinaryString
 import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.impl.DuckChatPixelName
 import javax.inject.Inject
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.first
@@ -50,6 +53,7 @@ class TabSwitcherViewModel @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
     private val pixel: Pixel,
     private val swipingTabsFeature: SwipingTabsFeatureProvider,
+    private val duckChat: DuckChat,
 ) : ViewModel() {
     val tabSwitcherItems: LiveData<List<TabSwitcherItem>> = tabRepository.liveTabs.map { tabEntities ->
         tabEntities.map { TabSwitcherItem.Tab(it) }
@@ -186,6 +190,18 @@ class TabSwitcherViewModel @Inject constructor(
                 GRID
             }
             tabRepository.setTabLayoutType(newLayoutType)
+        }
+    }
+
+    fun onDuckChatMenuClicked() {
+        viewModelScope.launch {
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_OPEN)
+
+            val wasUsedBefore = duckChat.wasOpenedBefore()
+            val params = mapOf("was_used_before" to wasUsedBefore.toBinaryString())
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_OPEN_NEW_TAB_MENU, parameters = params)
+
+            duckChat.openDuckChat()
         }
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/settings/NewSettingsViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/settings/NewSettingsViewModelTest.kt
@@ -122,4 +122,11 @@ class NewSettingsViewModelTest {
 
         verify(settingsPixelDispatcherMock).fireSyncPressed()
     }
+
+    @Test
+    fun `when Duck Chat pressed then pixel is fired`() {
+        testee.onDuckChatSettingClicked()
+
+        verify(settingsPixelDispatcherMock).fireDuckChatPressed()
+    }
 }

--- a/app/src/test/java/com/duckduckgo/app/settings/NewSettingsViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/settings/NewSettingsViewModelTest.kt
@@ -129,4 +129,11 @@ class NewSettingsViewModelTest {
 
         verify(settingsPixelDispatcherMock).fireDuckChatPressed()
     }
+
+    @Test
+    fun `when Email pressed then pixel is fired`() {
+        testee.onEmailProtectionSettingClicked()
+
+        verify(settingsPixelDispatcherMock).fireEmailPressed()
+    }
 }

--- a/app/src/test/java/com/duckduckgo/app/settings/NewSettingsViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/settings/NewSettingsViewModelTest.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.settings
+
+import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
+import com.duckduckgo.app.pixels.AppPixelName
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.autoconsent.api.Autoconsent
+import com.duckduckgo.autofill.api.AutofillCapabilityChecker
+import com.duckduckgo.autofill.api.email.EmailManager
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckplayer.api.DuckPlayer
+import com.duckduckgo.mobile.android.app.tracking.AppTrackingProtection
+import com.duckduckgo.subscriptions.api.PrivacyProUnifiedFeedback
+import com.duckduckgo.subscriptions.api.Subscriptions
+import com.duckduckgo.sync.api.DeviceSyncState
+import com.duckduckgo.voice.api.VoiceSearchAvailability
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.*
+
+class NewSettingsViewModelTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+
+    @Mock
+    private lateinit var defaultWebBrowserCapabilityMock: DefaultBrowserDetector
+
+    @Mock
+    private lateinit var appTrackingProtectionMock: AppTrackingProtection
+
+    @Mock
+    private lateinit var pixelMock: Pixel
+
+    @Mock
+    private lateinit var emailManagerMock: EmailManager
+
+    @Mock
+    private lateinit var autofillCapabilityCheckerMock: AutofillCapabilityChecker
+
+    @Mock
+    private lateinit var deviceSyncStateMock: DeviceSyncState
+
+    @Mock
+    private lateinit var dispatcherProviderMock: DispatcherProvider
+
+    @Mock
+    private lateinit var autoconsentMock: Autoconsent
+
+    @Mock
+    private lateinit var subscriptionsMock: Subscriptions
+
+    @Mock
+    private lateinit var duckPlayerMock: DuckPlayer
+
+    @Mock
+    private lateinit var duckChatMock: DuckChat
+
+    @Mock
+    private lateinit var voiceSearchAvailabilityMock: VoiceSearchAvailability
+
+    @Mock
+    private lateinit var privacyProUnifiedFeedbackMock: PrivacyProUnifiedFeedback
+
+    @Mock
+    private lateinit var settingsPixelDispatcherMock: SettingsPixelDispatcher
+
+    private lateinit var testee: NewSettingsViewModel
+
+    @Before
+    fun before() {
+        MockitoAnnotations.openMocks(this)
+
+        testee = NewSettingsViewModel(
+            defaultWebBrowserCapability = defaultWebBrowserCapabilityMock,
+            appTrackingProtection = appTrackingProtectionMock,
+            pixel = pixelMock,
+            emailManager = emailManagerMock,
+            autofillCapabilityChecker = autofillCapabilityCheckerMock,
+            deviceSyncState = deviceSyncStateMock,
+            dispatcherProvider = dispatcherProviderMock,
+            autoconsent = autoconsentMock,
+            subscriptions = subscriptionsMock,
+            duckPlayer = duckPlayerMock,
+            duckChat = duckChatMock,
+            voiceSearchAvailability = voiceSearchAvailabilityMock,
+            privacyProUnifiedFeedback = privacyProUnifiedFeedbackMock,
+            settingsPixelDispatcher = settingsPixelDispatcherMock,
+        )
+    }
+
+    @Test
+    fun `when ViewModel initialised then pixel is fired`() {
+        testee // init
+        verify(pixelMock).fire(AppPixelName.SETTINGS_OPENED)
+    }
+
+    @Test
+    fun `when sync pressed then pixel is fired`() {
+        testee.onSyncSettingClicked()
+
+        verify(settingsPixelDispatcherMock).fireSyncPressed()
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/settings/SettingsPixelDispatcherTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/settings/SettingsPixelDispatcherTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.settings
+
+import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_SYNC_PRESSED
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.sync.api.SyncState
+import com.duckduckgo.sync.api.SyncStateMonitor
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class SettingsPixelDispatcherTest {
+
+    @get:Rule
+    var coroutinesTestRule = CoroutineTestRule()
+
+    @Mock private lateinit var pixelMock: Pixel
+
+    @Mock private lateinit var syncStateMonitorMock: SyncStateMonitor
+
+    lateinit var testee: SettingsPixelDispatcherImpl
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+    }
+
+    @Test
+    fun `when fireSyncPressed and sync state is null, then send a pixel with disabled state`() = runTest {
+        whenever(syncStateMonitorMock.syncState()).thenReturn(emptyFlow())
+
+        val testee = createTestee()
+        testee.fireSyncPressed()
+
+        verify(pixelMock).fire(
+            pixel = SETTINGS_SYNC_PRESSED,
+            parameters = mapOf("is_enabled" to "0"),
+        )
+    }
+
+    @Test
+    fun `when fireSyncPressed and sync state is OFF, then send a pixel with disabled state`() = runTest {
+        whenever(syncStateMonitorMock.syncState()).thenReturn(flowOf(SyncState.OFF))
+
+        val testee = createTestee()
+        testee.fireSyncPressed()
+
+        verify(pixelMock).fire(
+            pixel = SETTINGS_SYNC_PRESSED,
+            parameters = mapOf("is_enabled" to "0"),
+        )
+    }
+
+    @Test
+    fun `when fireSyncPressed and sync state is FAILED, then send a pixel with enabled state`() = runTest {
+        whenever(syncStateMonitorMock.syncState()).thenReturn(flowOf(SyncState.FAILED))
+
+        val testee = createTestee()
+        testee.fireSyncPressed()
+
+        verify(pixelMock).fire(
+            pixel = SETTINGS_SYNC_PRESSED,
+            parameters = mapOf("is_enabled" to "1"),
+        )
+    }
+
+    @Test
+    fun `when fireSyncPressed and sync state is READY, then send a pixel with enabled state`() = runTest {
+        whenever(syncStateMonitorMock.syncState()).thenReturn(flowOf(SyncState.READY))
+
+        val testee = createTestee()
+        testee.fireSyncPressed()
+
+        verify(pixelMock).fire(
+            pixel = SETTINGS_SYNC_PRESSED,
+            parameters = mapOf("is_enabled" to "1"),
+        )
+    }
+
+    @Test
+    fun `when fireSyncPressed and sync state is IN_PROGRESS, then send a pixel with enabled state`() = runTest {
+        whenever(syncStateMonitorMock.syncState()).thenReturn(flowOf(SyncState.IN_PROGRESS))
+
+        val testee = createTestee()
+        testee.fireSyncPressed()
+
+        verify(pixelMock).fire(
+            pixel = SETTINGS_SYNC_PRESSED,
+            parameters = mapOf("is_enabled" to "1"),
+        )
+    }
+
+    private fun createTestee() = SettingsPixelDispatcherImpl(
+        appCoroutineScope = coroutinesTestRule.testScope,
+        pixel = pixelMock,
+        syncStateMonitor = syncStateMonitorMock,
+    )
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModel.kt
@@ -102,6 +102,7 @@ import com.duckduckgo.autofill.impl.ui.credential.repository.DuckAddressStatusRe
 import com.duckduckgo.autofill.impl.ui.credential.repository.DuckAddressStatusRepository.ActivationStatusResult
 import com.duckduckgo.autofill.impl.urlmatcher.AutofillUrlMatcher
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.extensions.toBinaryString
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.sync.api.engine.SyncEngine
 import com.duckduckgo.sync.api.engine.SyncEngine.SyncTrigger.FEATURE_READ
@@ -665,10 +666,13 @@ class AutofillSettingsViewModel @Inject constructor(
      * There are multiple ways to launch this screen, so we include a source parameter to differentiate between them.
      */
     fun sendLaunchPixel(launchSource: AutofillSettingsLaunchSource) {
-        Timber.v("Opened autofill management screen from from %s", launchSource)
+        viewModelScope.launch {
+            Timber.v("Opened autofill management screen from from %s", launchSource)
 
-        val source = launchSource.asString()
-        pixel.fire(AUTOFILL_MANAGEMENT_SCREEN_OPENED, mapOf("source" to source))
+            val source = launchSource.asString()
+            val hasCredentialsSaved = autofillStore.getCredentialCount().first() > 0
+            pixel.fire(AUTOFILL_MANAGEMENT_SCREEN_OPENED, mapOf("source" to source, "has_credentials_saved" to hasCredentialsSaved.toBinaryString()))
+        }
     }
 
     fun onUserConfirmationToClearNeverSavedSites() {

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModelTest.kt
@@ -712,49 +712,67 @@ class AutofillSettingsViewModelTest {
     @Test
     fun whenScreenLaunchedFromSnackbarThenCorrectLaunchPixelSent() {
         testee.sendLaunchPixel(BrowserSnackbar)
-        val expectedParams = mapOf("source" to "browser_snackbar")
+        val expectedParams = mapOf("source" to "browser_snackbar", "has_credentials_saved" to "0")
         verify(pixel).fire(eq(AUTOFILL_MANAGEMENT_SCREEN_OPENED), eq(expectedParams), any(), eq(Count))
     }
 
     @Test
     fun whenScreenLaunchedFromBrowserThenCorrectLaunchPixelSent() {
         testee.sendLaunchPixel(BrowserOverflow)
-        val expectedParams = mapOf("source" to "overflow_menu")
+        val expectedParams = mapOf("source" to "overflow_menu", "has_credentials_saved" to "0")
         verify(pixel).fire(eq(AUTOFILL_MANAGEMENT_SCREEN_OPENED), eq(expectedParams), any(), eq(Count))
     }
 
     @Test
     fun whenScreenLaunchedFromSyncThenCorrectLaunchPixelSent() {
         testee.sendLaunchPixel(Sync)
-        val expectedParams = mapOf("source" to "sync")
+        val expectedParams = mapOf("source" to "sync", "has_credentials_saved" to "0")
         verify(pixel).fire(eq(AUTOFILL_MANAGEMENT_SCREEN_OPENED), eq(expectedParams), any(), eq(Count))
     }
 
     @Test
     fun whenScreenLaunchedFromDisablePromptThenCorrectLaunchPixelSent() {
         testee.sendLaunchPixel(DisableInSettingsPrompt)
-        val expectedParams = mapOf("source" to "save_login_disable_prompt")
+        val expectedParams = mapOf("source" to "save_login_disable_prompt", "has_credentials_saved" to "0")
         verify(pixel).fire(eq(AUTOFILL_MANAGEMENT_SCREEN_OPENED), eq(expectedParams), any(), eq(Count))
     }
 
     @Test
     fun whenScreenLaunchedFromNewTabShortcutThenCorrectLaunchPixelSent() {
         testee.sendLaunchPixel(NewTabShortcut)
-        val expectedParams = mapOf("source" to "new_tab_page_shortcut")
+        val expectedParams = mapOf("source" to "new_tab_page_shortcut", "has_credentials_saved" to "0")
         verify(pixel).fire(eq(AUTOFILL_MANAGEMENT_SCREEN_OPENED), eq(expectedParams), any(), eq(Count))
     }
 
     @Test
     fun whenScreenLaunchedFromSettingsActivityThenCorrectLaunchPixelSent() {
         testee.sendLaunchPixel(SettingsActivity)
-        val expectedParams = mapOf("source" to "settings")
+        val expectedParams = mapOf("source" to "settings", "has_credentials_saved" to "0")
         verify(pixel).fire(eq(AUTOFILL_MANAGEMENT_SCREEN_OPENED), eq(expectedParams), any(), eq(Count))
     }
 
     @Test
     fun whenScreenLaunchedFromInternalDevSettingsActivityThenCorrectLaunchPixelSent() {
         testee.sendLaunchPixel(InternalDevSettings)
-        val expectedParams = mapOf("source" to "internal_dev_settings")
+        val expectedParams = mapOf("source" to "internal_dev_settings", "has_credentials_saved" to "0")
+        verify(pixel).fire(eq(AUTOFILL_MANAGEMENT_SCREEN_OPENED), eq(expectedParams), any(), eq(Count))
+    }
+
+    @Test
+    fun `when screen launched from settings activity and one credential saved then correct launch pixel sent`() = runTest {
+        whenever(mockStore.getCredentialCount()).thenReturn(flowOf(1))
+
+        testee.sendLaunchPixel(SettingsActivity)
+        val expectedParams = mapOf("source" to "settings", "has_credentials_saved" to "1")
+        verify(pixel).fire(eq(AUTOFILL_MANAGEMENT_SCREEN_OPENED), eq(expectedParams), any(), eq(Count))
+    }
+
+    @Test
+    fun `when screen launched from browser menu and multiple credentials saved then correct launch pixel sent`() = runTest {
+        whenever(mockStore.getCredentialCount()).thenReturn(flowOf(7))
+
+        testee.sendLaunchPixel(BrowserOverflow)
+        val expectedParams = mapOf("source" to "overflow_menu", "has_credentials_saved" to "1")
         verify(pixel).fire(eq(AUTOFILL_MANAGEMENT_SCREEN_OPENED), eq(expectedParams), any(), eq(Count))
     }
 

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
@@ -54,4 +54,9 @@ interface DuckChat {
      * @return true if it is a DuckChat URL, false otherwise.
      */
     fun isDuckChatUrl(uri: Uri): Boolean
+
+    /**
+     * Returns `true` if Duck Chat was ever opened before.
+     */
+    suspend fun wasOpenedBefore(): Boolean
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/DuckChatDataStore.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/DuckChatDataStore.kt
@@ -22,6 +22,7 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.impl.SharedPreferencesDuckChatDataStore.Keys.DUCK_CHAT_OPENED
 import com.duckduckgo.duckchat.impl.SharedPreferencesDuckChatDataStore.Keys.DUCK_CHAT_SHOW_IN_MENU
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
@@ -31,6 +32,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 
@@ -38,6 +40,8 @@ interface DuckChatDataStore {
     suspend fun setShowInBrowserMenu(showDuckChat: Boolean)
     fun observeShowInBrowserMenu(): Flow<Boolean>
     fun getShowInBrowserMenu(): Boolean
+    suspend fun registerOpened()
+    suspend fun wasOpenedBefore(): Boolean
 }
 
 @ContributesBinding(AppScope::class)
@@ -49,6 +53,7 @@ class SharedPreferencesDuckChatDataStore @Inject constructor(
 
     private object Keys {
         val DUCK_CHAT_SHOW_IN_MENU = booleanPreferencesKey(name = "DUCK_CHAT_SHOW_IN_MENU")
+        val DUCK_CHAT_OPENED = booleanPreferencesKey(name = "DUCK_CHAT_OPENED")
     }
 
     private val duckChatShowInBrowserMenu: StateFlow<Boolean> = store.data
@@ -68,5 +73,13 @@ class SharedPreferencesDuckChatDataStore @Inject constructor(
 
     override fun getShowInBrowserMenu(): Boolean {
         return duckChatShowInBrowserMenu.value
+    }
+
+    override suspend fun registerOpened() {
+        store.edit { it[DUCK_CHAT_OPENED] = true }
+    }
+
+    override suspend fun wasOpenedBefore(): Boolean {
+        return store.data.map { it[DUCK_CHAT_OPENED] }.firstOrNull() ?: false
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/DuckChatFeatureRepository.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/DuckChatFeatureRepository.kt
@@ -26,6 +26,8 @@ interface DuckChatFeatureRepository {
     suspend fun setShowInBrowserMenu(showDuckChat: Boolean)
     fun observeShowInBrowserMenu(): Flow<Boolean>
     fun shouldShowInBrowserMenu(): Boolean
+    suspend fun registerOpened()
+    suspend fun wasOpenedBefore(): Boolean
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -44,5 +46,13 @@ class RealDuckChatFeatureRepository @Inject constructor(
 
     override fun shouldShowInBrowserMenu(): Boolean {
         return duckChatDataStore.getShowInBrowserMenu()
+    }
+
+    override suspend fun registerOpened() {
+        duckChatDataStore.registerOpened()
+    }
+
+    override suspend fun wasOpenedBefore(): Boolean {
+        return duckChatDataStore.wasOpenedBefore()
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/DuckChatPixels.kt
@@ -23,13 +23,19 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.DuckChatPixelName.DUCK_CHAT_MENU_SETTING_OFF
 import com.duckduckgo.duckchat.impl.DuckChatPixelName.DUCK_CHAT_MENU_SETTING_ON
 import com.duckduckgo.duckchat.impl.DuckChatPixelName.DUCK_CHAT_OPEN
+import com.duckduckgo.duckchat.impl.DuckChatPixelName.DUCK_CHAT_OPEN_BROWSER_MENU
+import com.duckduckgo.duckchat.impl.DuckChatPixelName.DUCK_CHAT_OPEN_NEW_TAB_MENU
+import com.duckduckgo.duckchat.impl.DuckChatPixelName.DUCK_CHAT_SETTINGS_PRESSED
 import com.squareup.anvil.annotations.ContributesMultibinding
 import javax.inject.Inject
 
 enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
     DUCK_CHAT_OPEN("aichat_open"),
+    DUCK_CHAT_OPEN_BROWSER_MENU("aichat_open_browser_menu"),
+    DUCK_CHAT_OPEN_NEW_TAB_MENU("aichat_open_new_tab_menu"),
     DUCK_CHAT_MENU_SETTING_OFF("aichat_menu_setting_off"),
     DUCK_CHAT_MENU_SETTING_ON("aichat_menu_setting_on"),
+    DUCK_CHAT_SETTINGS_PRESSED("settings_aichat_pressed"),
 }
 
 @ContributesMultibinding(AppScope::class)
@@ -39,6 +45,9 @@ class DuckChatParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin
             DUCK_CHAT_OPEN.pixelName to PixelParameter.removeAtb(),
             DUCK_CHAT_MENU_SETTING_OFF.pixelName to PixelParameter.removeAtb(),
             DUCK_CHAT_MENU_SETTING_ON.pixelName to PixelParameter.removeAtb(),
+            DUCK_CHAT_OPEN_BROWSER_MENU.pixelName to PixelParameter.removeAtb(),
+            DUCK_CHAT_OPEN_NEW_TAB_MENU.pixelName to PixelParameter.removeAtb(),
+            DUCK_CHAT_SETTINGS_PRESSED.pixelName to PixelParameter.removeAtb(),
         )
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -141,6 +141,9 @@ class RealDuckChat @Inject constructor(
     private fun openDuckChat(parameters: Map<String, String>) {
         val url = appendParameters(parameters, duckChatLink)
         startDuckChatActivity(url)
+        appCoroutineScope.launch {
+            duckChatFeatureRepository.registerOpened()
+        }
     }
 
     private fun startDuckChatActivity(url: String) {
@@ -186,6 +189,10 @@ class RealDuckChat @Inject constructor(
             val queryParameters = uri.queryParameterNames
             queryParameters.contains(CHAT_QUERY_NAME) && uri.getQueryParameter(CHAT_QUERY_NAME) == CHAT_QUERY_VALUE
         }.getOrDefault(false)
+    }
+
+    override suspend fun wasOpenedBefore(): Boolean {
+        return duckChatFeatureRepository.wasOpenedBefore()
     }
 
     private fun cacheDuckChatLink() {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/DuckChatFeatureRepositoryTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/DuckChatFeatureRepositoryTest.kt
@@ -54,4 +54,20 @@ class DuckChatFeatureRepositoryTest {
 
         assertTrue(testee.shouldShowInBrowserMenu())
     }
+
+    @Test
+    fun `when register Duck Chat opened, then data store called`() = runTest {
+        testee.registerOpened()
+
+        verify(mockDatabase).registerOpened()
+    }
+
+    @Test
+    fun `when was opened before checked, then return data from the store`() = runTest {
+        whenever(mockDatabase.wasOpenedBefore()).thenReturn(true)
+
+        val result = testee.wasOpenedBefore()
+
+        assertTrue(result)
+    }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -126,7 +126,7 @@ class RealDuckChatTest {
     }
 
     @Test
-    fun whenOpenDuckChatCalled_activityStarted() {
+    fun whenOpenDuckChatCalled_activityStarted() = runTest {
         testee.openDuckChat()
         verify(mockGlobalActivityStarter).startIntent(
             mockContext,
@@ -137,10 +137,11 @@ class RealDuckChatTest {
             ),
         )
         verify(mockContext).startActivity(any())
+        verify(mockDuckPlayerFeatureRepository).registerOpened()
     }
 
     @Test
-    fun whenOpenDuckChatCalledWithQuery_activityStartedWithQuery() {
+    fun whenOpenDuckChatCalledWithQuery_activityStartedWithQuery() = runTest {
         testee.openDuckChat(query = "example")
         verify(mockGlobalActivityStarter).startIntent(
             mockContext,
@@ -151,10 +152,11 @@ class RealDuckChatTest {
             ),
         )
         verify(mockContext).startActivity(any())
+        verify(mockDuckPlayerFeatureRepository).registerOpened()
     }
 
     @Test
-    fun whenOpenDuckChatCalledWithQueryAndAutoPrompt_activityStartedWithQueryAndAutoPrompt() {
+    fun whenOpenDuckChatCalledWithQueryAndAutoPrompt_activityStartedWithQueryAndAutoPrompt() = runTest {
         testee.openDuckChatWithAutoPrompt(query = "example")
         verify(mockGlobalActivityStarter).startIntent(
             mockContext,
@@ -165,6 +167,7 @@ class RealDuckChatTest {
             ),
         )
         verify(mockContext).startActivity(any())
+        verify(mockDuckPlayerFeatureRepository).registerOpened()
     }
 
     @Test
@@ -180,6 +183,13 @@ class RealDuckChatTest {
     @Test
     fun whenIsNotDuckDuckGoHostAndDuckChatEnabled_isNotDuckChatUrl() {
         assertFalse(testee.isDuckChatUrl("https://example.com/?ia=chat".toUri()))
+    }
+
+    @Test
+    fun `when was opened before queried, then repo state is returned`() = runTest {
+        whenever(mockDuckPlayerFeatureRepository.wasOpenedBefore()).thenReturn(true)
+
+        assertTrue(testee.wasOpenedBefore())
     }
 
     private fun setFeatureToggle(enabled: Boolean) {

--- a/duckplayer/duckplayer-api/src/main/java/com/duckduckgo/duckplayer/api/DuckPlayer.kt
+++ b/duckplayer/duckplayer-api/src/main/java/com/duckduckgo/duckplayer/api/DuckPlayer.kt
@@ -199,6 +199,11 @@ interface DuckPlayer {
     fun setDuckPlayerOrigin(origin: DuckPlayerOrigin)
 
     /**
+     * Returns `true` if Duck Player was ever used before.
+     */
+    suspend fun wasUsedBefore(): Boolean
+
+    /**
      * Data class representing user preferences for Duck Player.
      *
      * @property overlayInteracted A boolean indicating whether the overlay was interacted with.

--- a/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerDataStore.kt
+++ b/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerDataStore.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.duckplayer.impl.SharedPreferencesDuckPlayerDataStore.Keys.
 import com.duckduckgo.duckplayer.impl.SharedPreferencesDuckPlayerDataStore.Keys.DUCK_PLAYER_OPEN_IN_NEW_TAB
 import com.duckduckgo.duckplayer.impl.SharedPreferencesDuckPlayerDataStore.Keys.DUCK_PLAYER_RC
 import com.duckduckgo.duckplayer.impl.SharedPreferencesDuckPlayerDataStore.Keys.DUCK_PLAYER_USER_ONBOARDED
+import com.duckduckgo.duckplayer.impl.SharedPreferencesDuckPlayerDataStore.Keys.DUCK_PLAYER_WAS_USED
 import com.duckduckgo.duckplayer.impl.SharedPreferencesDuckPlayerDataStore.Keys.DUCK_PLAYER_YOUTUBE_PATH
 import com.duckduckgo.duckplayer.impl.SharedPreferencesDuckPlayerDataStore.Keys.DUCK_PLAYER_YOUTUBE_REFERRER_HEADERS
 import com.duckduckgo.duckplayer.impl.SharedPreferencesDuckPlayerDataStore.Keys.OVERLAY_INTERACTED
@@ -40,6 +41,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 
@@ -97,6 +99,10 @@ interface DuckPlayerDataStore {
     fun observeOpenInNewTab(): Flow<Boolean>
 
     fun getOpenInNewTab(): Boolean
+
+    suspend fun wasUsedBefore(): Boolean
+
+    suspend fun setUsed()
 }
 
 @ContributesBinding(AppScope::class)
@@ -119,6 +125,7 @@ class SharedPreferencesDuckPlayerDataStore @Inject constructor(
         val DUCK_PLAYER_YOUTUBE_EMBED_URL = stringPreferencesKey(name = "DUCK_PLAYER_YOUTUBE_EMBED_URL")
         val DUCK_PLAYER_USER_ONBOARDED = booleanPreferencesKey(name = "DUCK_PLAYER_USER_ONBOARDED")
         val DUCK_PLAYER_OPEN_IN_NEW_TAB = booleanPreferencesKey(name = "DUCK_PLAYER_OPEN_IN_NEW_TAB")
+        val DUCK_PLAYER_WAS_USED = booleanPreferencesKey(name = "DUCK_PLAYER_WAS_USED")
     }
 
     private val overlayInteracted: StateFlow<Boolean> = store.data
@@ -311,5 +318,13 @@ class SharedPreferencesDuckPlayerDataStore @Inject constructor(
 
     override fun getOpenInNewTab(): Boolean {
         return duckPlayerOpenInNewTab.value
+    }
+
+    override suspend fun wasUsedBefore(): Boolean {
+        return store.data.map { it[DUCK_PLAYER_WAS_USED] }.firstOrNull() ?: false
+    }
+
+    override suspend fun setUsed() {
+        store.edit { it[DUCK_PLAYER_WAS_USED] = true }
     }
 }

--- a/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerFeatureRepository.kt
+++ b/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerFeatureRepository.kt
@@ -70,6 +70,9 @@ interface DuckPlayerFeatureRepository {
     fun setOpenInNewTab(enabled: Boolean)
     fun observeOpenInNewTab(): Flow<Boolean>
     fun shouldOpenInNewTab(): Boolean
+
+    suspend fun wasUsedBefore(): Boolean
+    suspend fun setUsed()
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -200,5 +203,13 @@ class RealDuckPlayerFeatureRepository @Inject constructor(
 
     override fun shouldOpenInNewTab(): Boolean {
         return duckPlayerDataStore.getOpenInNewTab()
+    }
+
+    override suspend fun wasUsedBefore(): Boolean {
+        return duckPlayerDataStore.wasUsedBefore()
+    }
+
+    override suspend fun setUsed() {
+        duckPlayerDataStore.setUsed()
     }
 }

--- a/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerSettings.kt
+++ b/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerSettings.kt
@@ -19,9 +19,12 @@ package com.duckduckgo.duckplayer.impl
 import android.content.Context
 import android.view.View
 import com.duckduckgo.anvil.annotations.PriorityKey
+import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.ui.view.listitem.OneLineListItem
+import com.duckduckgo.common.utils.extensions.toBinaryString
 import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.duckplayer.api.DuckPlayer
 import com.duckduckgo.duckplayer.api.DuckPlayerSettingsNoParams
 import com.duckduckgo.duckplayer.impl.DuckPlayerPixelName.DUCK_PLAYER_SETTINGS_PRESSED
 import com.duckduckgo.mobile.android.R as CommonR
@@ -30,6 +33,8 @@ import com.duckduckgo.settings.api.DuckPlayerSettingsPlugin
 import com.duckduckgo.settings.api.SettingsPageFeature
 import com.squareup.anvil.annotations.ContributesMultibinding
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 @ContributesMultibinding(ActivityScope::class)
 @PriorityKey(100)
@@ -37,6 +42,8 @@ class DuckPlayerSettingsTitle @Inject constructor(
     private val globalActivityStarter: GlobalActivityStarter,
     private val pixel: Pixel,
     private val settingsPageFeature: SettingsPageFeature,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val duckPlayer: DuckPlayer,
 ) : DuckPlayerSettingsPlugin {
     override fun getView(context: Context): View {
         return OneLineListItem(context).apply {
@@ -46,8 +53,11 @@ class DuckPlayerSettingsTitle @Inject constructor(
 
             setPrimaryText(context.getString(R.string.duck_player_setting_title))
             setOnClickListener {
-                pixel.fire(DUCK_PLAYER_SETTINGS_PRESSED)
                 globalActivityStarter.start(this.context, DuckPlayerSettingsNoParams, null)
+                appCoroutineScope.launch {
+                    val wasUsedBefore = duckPlayer.wasUsedBefore()
+                    pixel.fire(DUCK_PLAYER_SETTINGS_PRESSED, parameters = mapOf("was_used_before" to wasUsedBefore.toBinaryString()))
+                }
             }
         }
     }

--- a/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/RealDuckPlayer.kt
+++ b/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/RealDuckPlayer.kt
@@ -337,6 +337,9 @@ class RealDuckPlayer @Inject constructor(
                     AlwaysAsk -> "default"
                     else -> null
                 }?.let { setting ->
+                    appCoroutineScope.launch {
+                        duckPlayerFeatureRepository.setUsed()
+                    }
                     pixel.fire(
                         DUCK_PLAYER_DAILY_UNIQUE_VIEW,
                         type = Daily(),
@@ -492,5 +495,9 @@ class RealDuckPlayer @Inject constructor(
 
     override fun setDuckPlayerOrigin(origin: DuckPlayerOrigin) {
         duckPlayerOrigin = origin
+    }
+
+    override suspend fun wasUsedBefore(): Boolean {
+        return duckPlayerFeatureRepository.wasUsedBefore()
     }
 }

--- a/duckplayer/duckplayer-impl/src/test/kotlin/com/duckduckgo/duckplayer/impl/RealDuckPlayerTest.kt
+++ b/duckplayer/duckplayer-impl/src/test/kotlin/com/duckduckgo/duckplayer/impl/RealDuckPlayerTest.kt
@@ -640,6 +640,7 @@ class RealDuckPlayerTest {
             type = Daily(),
             parameters = mapOf("setting" to "always", "newtab" to "false"),
         )
+        verify(mockDuckPlayerFeatureRepository).setUsed()
         assertEquals("text/html", result?.mimeType)
     }
 

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/cohort/NetpCohortPixelInterceptor.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/cohort/NetpCohortPixelInterceptor.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.networkprotection.impl.cohort
 import androidx.annotation.VisibleForTesting
 import com.duckduckgo.common.utils.plugins.pixel.PixelInterceptorPlugin
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.networkprotection.impl.pixels.NetworkProtectionPixelNames.NETP_SETTINGS_PRESSED
 import com.squareup.anvil.annotations.ContributesMultibinding
 import javax.inject.Inject
 import logcat.logcat
@@ -84,6 +85,7 @@ class NetpCohortPixelInterceptor @Inject constructor(
             "m_netp_ev_terms_accepted",
             "m_netp_imp_geoswitching",
             "m_netp_ev_geoswitching",
+            NETP_SETTINGS_PRESSED.pixelName,
         )
     }
 }

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/subscription/settings/LegacyProSettingNetPViewModel.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/subscription/settings/LegacyProSettingNetPViewModel.kt
@@ -26,6 +26,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.extensions.toBinaryString
 import com.duckduckgo.mobile.android.R as CommonR
 import com.duckduckgo.navigation.api.GlobalActivityStarter.ActivityParams
 import com.duckduckgo.networkprotection.api.NetworkProtectionAccessState
@@ -101,7 +102,8 @@ class LegacyProSettingNetPViewModel(
             val screen = networkProtectionAccessState.getScreenForCurrentState()
             screen?.let {
                 command.send(OpenNetPScreen(screen))
-                pixel.fire(NETP_SETTINGS_PRESSED)
+                val wasUsedBefore = networkProtectionState.isOnboarded()
+                pixel.fire(NETP_SETTINGS_PRESSED, parameters = mapOf("was_used_before" to wasUsedBefore.toBinaryString()))
             } ?: logcat { "Get screen for current NetP state is null" }
         }
     }

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/subscription/settings/ProSettingNetPViewModel.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/subscription/settings/ProSettingNetPViewModel.kt
@@ -24,6 +24,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.extensions.toBinaryString
 import com.duckduckgo.navigation.api.GlobalActivityStarter.ActivityParams
 import com.duckduckgo.networkprotection.api.NetworkProtectionAccessState
 import com.duckduckgo.networkprotection.api.NetworkProtectionState
@@ -136,7 +137,8 @@ class ProSettingNetPViewModel(
             val screen = networkProtectionAccessState.getScreenForCurrentState()
             screen?.let {
                 command.send(OpenNetPScreen(screen))
-                pixel.fire(NETP_SETTINGS_PRESSED)
+                val wasUsedBefore = networkProtectionState.isOnboarded()
+                pixel.fire(NETP_SETTINGS_PRESSED, parameters = mapOf("was_used_before" to wasUsedBefore.toBinaryString()))
             } ?: logcat { "Get screen for current NetP state is null" }
         }
     }

--- a/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/cohort/NetpCohortPixelInterceptorTest.kt
+++ b/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/cohort/NetpCohortPixelInterceptorTest.kt
@@ -157,6 +157,18 @@ class NetpCohortPixelInterceptorTest {
         assertEquals(null, result.body)
     }
 
+    @Test
+    fun `when cohort local date is not set then send exempted main VPN settings pressed pixel`() {
+        whenever(netpCohortStore.cohortLocalDate).thenReturn(null)
+        val pixelUrl = String.format(PIXEL_TEMPLATE, "m_netp_ev_setting_pressed_c")
+
+        val result = testee.intercept(FakeChain(pixelUrl))
+
+        assertEquals(pixelUrl, result.request.url.toString())
+        assertEquals("", result.message)
+        assertEquals(null, result.body)
+    }
+
     companion object {
         private const val PIXEL_TEMPLATE = "https://improving.duckduckgo.com/t/%s_android_phone?appVersion=5.135.0&test=1"
     }

--- a/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/subscription/settings/LegacyProSettingNetPViewModelTest.kt
+++ b/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/subscription/settings/LegacyProSettingNetPViewModelTest.kt
@@ -65,15 +65,32 @@ class LegacyProSettingNetPViewModelTest {
     }
 
     @Test
-    fun whenNetPSettingClickedThenReturnScreenForCurrentState() = runTest {
+    fun `when NetP setting clicked and not onboarded then return screen for current state and send pixel`() = runTest {
         val testScreen = object : ActivityParams {}
         whenever(networkProtectionAccessState.getScreenForCurrentState()).thenReturn(testScreen)
+        whenever(networkProtectionState.isOnboarded()).thenReturn(false)
 
         proSettingNetPViewModel.commands().test {
             proSettingNetPViewModel.onNetPSettingClicked()
 
             assertEquals(Command.OpenNetPScreen(testScreen), awaitItem())
-            verify(pixel).fire(NETP_SETTINGS_PRESSED)
+            verify(pixel).fire(NETP_SETTINGS_PRESSED, parameters = mapOf("was_used_before" to "0"))
+
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when NetP setting clicked and onboarded then return screen for current state and send pixel`() = runTest {
+        val testScreen = object : ActivityParams {}
+        whenever(networkProtectionAccessState.getScreenForCurrentState()).thenReturn(testScreen)
+        whenever(networkProtectionState.isOnboarded()).thenReturn(true)
+
+        proSettingNetPViewModel.commands().test {
+            proSettingNetPViewModel.onNetPSettingClicked()
+
+            assertEquals(Command.OpenNetPScreen(testScreen), awaitItem())
+            verify(pixel).fire(NETP_SETTINGS_PRESSED, parameters = mapOf("was_used_before" to "1"))
 
             cancelAndConsumeRemainingEvents()
         }

--- a/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/subscription/settings/ProSettingNetPViewModelTest.kt
+++ b/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/subscription/settings/ProSettingNetPViewModelTest.kt
@@ -71,15 +71,32 @@ class ProSettingNetPViewModelTest {
     }
 
     @Test
-    fun `when netp Setting clicked then netp screen is opened`() = runTest {
+    fun `when NetP setting clicked and not onboarded then return screen for current state and send pixel`() = runTest {
         val testScreen = object : ActivityParams {}
         whenever(networkProtectionAccessState.getScreenForCurrentState()).thenReturn(testScreen)
+        whenever(networkProtectionState.isOnboarded()).thenReturn(false)
 
         proSettingNetPViewModel.commands().test {
             proSettingNetPViewModel.onNetPSettingClicked()
 
             assertEquals(Command.OpenNetPScreen(testScreen), awaitItem())
-            verify(pixel).fire(NETP_SETTINGS_PRESSED)
+            verify(pixel).fire(NETP_SETTINGS_PRESSED, parameters = mapOf("was_used_before" to "0"))
+
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when NetP setting clicked and onboarded then return screen for current state and send pixel`() = runTest {
+        val testScreen = object : ActivityParams {}
+        whenever(networkProtectionAccessState.getScreenForCurrentState()).thenReturn(testScreen)
+        whenever(networkProtectionState.isOnboarded()).thenReturn(true)
+
+        proSettingNetPViewModel.commands().test {
+            proSettingNetPViewModel.onNetPSettingClicked()
+
+            assertEquals(Command.OpenNetPScreen(testScreen), awaitItem())
+            verify(pixel).fire(NETP_SETTINGS_PRESSED, parameters = mapOf("was_used_before" to "1"))
 
             cancelAndConsumeRemainingEvents()
         }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixel.kt
@@ -22,7 +22,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
 
 enum class SubscriptionPixel(
-    private val baseName: String,
+    val baseName: String,
     private val types: Set<PixelType>,
     private val withSuffix: Boolean = true,
 ) {
@@ -125,6 +125,10 @@ enum class SubscriptionPixel(
     ),
     APP_SETTINGS_IDTR_CLICK(
         baseName = "m_privacy-pro_app-settings_identity-theft-restoration_click",
+        type = Count,
+    ),
+    APP_SETTINGS_GET_SUBSCRIPTION_CLICK(
+        baseName = "m_privacy-pro_app-settings_get_click",
         type = Count,
     ),
     APP_SETTINGS_RESTORE_PURCHASE_CLICK(

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelParamRemovalPlugin.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelParamRemovalPlugin.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.subscriptions.impl.pixels
 import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin
 import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin.PixelParameter
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.APP_SETTINGS_GET_SUBSCRIPTION_CLICK
 import com.squareup.anvil.annotations.ContributesMultibinding
 import javax.inject.Inject
 
@@ -29,6 +30,7 @@ class SubscriptionPixelParamRemovalPlugin @Inject constructor() : PixelParamRemo
             "m_subscribe" to PixelParameter.removeAtb(),
             "m_subscribe" to PixelParameter.removeOSVersion(),
             "m_ppro_feedback" to PixelParameter.removeAtb(),
+            APP_SETTINGS_GET_SUBSCRIPTION_CLICK.baseName to PixelParameter.removeAtb(),
         )
     }
 }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelSender.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelSender.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.common.utils.extensions.toSanitizedLanguageTag
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.ACTIVATE_SUBSCRIPTION_ENTER_EMAIL_CLICK
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.ACTIVATE_SUBSCRIPTION_RESTORE_PURCHASE_CLICK
+import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.APP_SETTINGS_GET_SUBSCRIPTION_CLICK
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.APP_SETTINGS_IDTR_CLICK
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.APP_SETTINGS_PIR_CLICK
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.APP_SETTINGS_RESTORE_PURCHASE_CLICK
@@ -90,6 +91,7 @@ interface SubscriptionPixelSender {
     fun reportSubscriptionSettingsShown()
     fun reportAppSettingsPirClick()
     fun reportAppSettingsIdtrClick()
+    fun reportAppSettingsGetSubscriptionClick()
     fun reportAppSettingsRestorePurchaseClick()
     fun reportSubscriptionSettingsChangePlanOrBillingClick()
     fun reportSubscriptionSettingsRemoveFromDeviceClick()
@@ -195,6 +197,9 @@ class SubscriptionPixelSenderImpl @Inject constructor(
 
     override fun reportAppSettingsIdtrClick() =
         fire(APP_SETTINGS_IDTR_CLICK)
+
+    override fun reportAppSettingsGetSubscriptionClick() =
+        fire(APP_SETTINGS_GET_SUBSCRIPTION_CLICK)
 
     override fun reportAppSettingsRestorePurchaseClick() =
         fire(APP_SETTINGS_RESTORE_PURCHASE_CLICK)

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/settings/views/LegacyProSettingViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/settings/views/LegacyProSettingViewModel.kt
@@ -77,6 +77,7 @@ class LegacyProSettingViewModel @Inject constructor(
     }
 
     fun onBuy() {
+        pixelSender.reportAppSettingsGetSubscriptionClick()
         sendCommand(OpenBuyScreen)
     }
 

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/settings/views/ProSettingViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/settings/views/ProSettingViewModel.kt
@@ -77,6 +77,7 @@ class ProSettingViewModel @Inject constructor(
     }
 
     fun onBuy() {
+        pixelSender.reportAppSettingsGetSubscriptionClick()
         sendCommand(OpenBuyScreen)
     }
 

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/settings/views/LegacyProSettingViewModelTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/settings/views/LegacyProSettingViewModelTest.kt
@@ -46,6 +46,7 @@ class LegacyProSettingViewModelTest {
         viewModel.commands().test {
             viewModel.onBuy()
             assertTrue(awaitItem() is OpenBuyScreen)
+            verify(pixelSender).reportAppSettingsGetSubscriptionClick()
             cancelAndConsumeRemainingEvents()
         }
     }
@@ -55,6 +56,7 @@ class LegacyProSettingViewModelTest {
         viewModel.commands().test {
             viewModel.onRestore()
             assertTrue(awaitItem() is OpenRestoreScreen)
+            verify(pixelSender).reportAppSettingsRestorePurchaseClick()
             cancelAndConsumeRemainingEvents()
         }
     }

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/settings/views/ProSettingViewModelTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/settings/views/ProSettingViewModelTest.kt
@@ -46,6 +46,7 @@ class ProSettingViewModelTest {
         viewModel.commands().test {
             viewModel.onBuy()
             assertTrue(awaitItem() is OpenBuyScreen)
+            verify(pixelSender).reportAppSettingsGetSubscriptionClick()
             cancelAndConsumeRemainingEvents()
         }
     }
@@ -55,6 +56,7 @@ class ProSettingViewModelTest {
         viewModel.commands().test {
             viewModel.onRestore()
             assertTrue(awaitItem() is OpenRestoreScreen)
+            verify(pixelSender).reportAppSettingsRestorePurchaseClick()
             cancelAndConsumeRemainingEvents()
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1209376654707617

### Description
Implements the required pixels (see the task).

I suggest reviewing commit by commit. If that's still problematic, let me know, I'm happy to separate the changes into independent PRs.

### Steps to test this PR
- [x] Passwords & Autofill
  - [x] Open the setting screen.
  - [x] Verify that `m_autofill_management_opened` pixel is sent with `has_credentials_saved=0` parameter.
  - [x] Save a password and reopen the setting screen.
  - [x] Verify that `m_autofill_management_opened` pixel is sent with `has_credentials_saved=1` parameter.
- [x] Sync
  - [x] Open the setting screen.
  - [x] Verify that `ms_sync_pressed` pixel is sent with `is_enabled=0` parameter.
  - [x] Enable sync and reopen the setting screen.
  - [x] Verify that `ms_sync_pressed` pixel is sent with `is_enabled=1` parameter.
- [x] Duck Chat
  - [x] Open Duck Chat settings screen.
  - [x] Verify that `settings_aichat_pressed` pixel is sent with `was_used_before=0` parameter.
  - [x] Open Duck Chat from browser overflow menu.
  - [x] Verify that `aichat_open_browser_menu` pixel is sent with `was_used_before=0` parameter.
  - [x] Open Duck Chat from new tab overflow menu.
  - [x] Verify that `aichat_open_new_tab_menu` pixel is sent with `was_used_before=1` parameter.
  - [x] Open Duck Chat settings screen.
  - [x] Verify that `settings_aichat_pressed` pixel is sent with `was_used_before=1` parameter.
- [x] Duck Player
  - [x] Open Duck Player setting screen.
  - [x] Verify that `duckplayer_setting_pressed` pixel is sent with `was_used_before=0` parameter.
  - [x] Open a video with Duck Player.
  - [x] Open Duck Player setting screen.
  - [x] Verify that `duckplayer_setting_pressed` pixel is sent with `was_used_before=1` parameter.
- [x] Email protection
  - [x] Open email protection setting screen.
  - [x] Verify that `ms_email_protection_setting_pressed` pixel is sent with `is_signed_in=0` parameter.
  - [x] Sign in with an email and reopen the setting screen.
  - [x] Verify that `ms_email_protection_setting_pressed` pixel is sent with `is_signed_in=1` parameter.
- [ ] Privacy Pro
  - [ ] Click on "Get Privacy Pro".
  - [ ] Verify that `m_privacy-pro_app-settings_get_click` pixel is sent.
- [x] VPN
  - [x] Activate a test subscription (or make PPro screens available via other means) and open VPN settings screen.
  - [x] Verify that `m_netp_ev_setting_pressed_c` pixel is sent with `was_used_before=0` parameter.
  - [x] Enable VPN and reopen the VPN settings page.
  - [x] Verify that `m_netp_ev_setting_pressed_c` pixel is sent with `was_used_before=1` parameter.
  - [x] Disable VPN and reopen the VPN settings page.
  - [x] Verify that `m_netp_ev_setting_pressed_c` pixel is sent with `was_used_before=1` parameter.

