### PR TITLE
Fix build-ad-hoc ref input

### DIFF
--- a/.github/workflows/build-ad-hoc.yml
+++ b/.github/workflows/build-ad-hoc.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           submodules: recursive
           token: ${{ secrets.GT_DAXMOBILE }}
-          ref: ${{ github.event.inputs.app-version }}
+          ref: ${{ github.event.inputs.ref }}
       - name: Set up JDK version
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202552961248957/1209524992278444

### Description
build-ad-hoc.yml has a ref input parameter to specify a branch, tag or commit, which is never used. When checking out the repo, a non-existing variable is read instead, defaulting to develop. Therefore, it's not possible to produce ad-hoc apks for branches other than develop

**Before**
Setting `feature/cris/malicious-site-protection/fix-back-nav-from-error-page` as ref, produces the following output:
```
usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +2b158df88972514f2bac3bc68b9acb82361b64cb:refs/remotes/origin/develop

From [https://github.com/duckduckgo/Android](https://github.com/duckduckgo/Android)

\* \[new ref\] 2b158df88972514f2bac3bc68b9acb82361b64cb -> origin/develop
```

**After**
Setting `feature/cris/malicious-site-protection/fix-back-nav-from-error-page` as ref, produces the following output:
```
 /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +refs/heads/feature/cris/malicious-site-protection/fix-back-nav-from-error-page*:refs/remotes/origin/feature/cris/malicious-site-protection/fix-back-nav-from-error-page* +refs/tags/feature/cris/malicious-site-protection/fix-back-nav-from-error-page*:refs/tags/feature/cris/malicious-site-protection/fix-back-nav-from-error-page*
  From https://github.com/duckduckgo/Android
   * [new branch]      feature/cris/malicious-site-protection/fix-back-nav-from-error-page -> origin/feature/cris/malicious-site-protection/fix-back-nav-from-error-page
```

