### PR TITLE
Update content scope scripts to version 7.23.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
@@ -640,50 +640,10 @@
         });
     }
 
-    const baseFeatures = /** @type {const} */ ([
-        'fingerprintingAudio',
-        'fingerprintingBattery',
-        'fingerprintingCanvas',
-        'googleRejected',
-        'gpc',
-        'fingerprintingHardware',
-        'referrer',
-        'fingerprintingScreenSize',
-        'fingerprintingTemporaryStorage',
-        'navigatorInterface',
-        'elementHiding',
-        'exceptionHandler',
-        'apiManipulation',
-    ]);
-
-    const otherFeatures = /** @type {const} */ ([
-        'clickToLoad',
-        'cookie',
-        'messageBridge',
-        'duckPlayer',
-        'harmfulApis',
-        'webCompat',
-        'windowsPermissionUsage',
-        'brokerProtection',
-        'performanceMetrics',
-        'breakageReporting',
-        'autofillPasswordImport',
-    ]);
-
     /** @typedef {baseFeatures[number]|otherFeatures[number]} FeatureName */
     /** @type {Record<string, FeatureName[]>} */
     const platformSupport = {
-        apple: ['webCompat', ...baseFeatures],
-        'apple-isolated': ['duckPlayer', 'brokerProtection', 'performanceMetrics', 'clickToLoad', 'messageBridge'],
-        android: [...baseFeatures, 'webCompat', 'breakageReporting', 'duckPlayer', 'messageBridge'],
-        'android-broker-protection': ['brokerProtection'],
-        'android-autofill-password-import': ['autofillPasswordImport'],
-        windows: ['cookie', ...baseFeatures, 'windowsPermissionUsage', 'duckPlayer', 'brokerProtection', 'breakageReporting'],
-        firefox: ['cookie', ...baseFeatures, 'clickToLoad'],
-        chrome: ['cookie', ...baseFeatures, 'clickToLoad'],
-        'chrome-mv3': ['cookie', ...baseFeatures, 'clickToLoad'],
-        integration: [...baseFeatures, ...otherFeatures],
-    };
+        'android-autofill-password-import': ['autofillPasswordImport']};
 
     /**
      * Performance monitor, holds reference to PerformanceMark instances.

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -727,34 +727,10 @@
         'apiManipulation',
     ]);
 
-    const otherFeatures = /** @type {const} */ ([
-        'clickToLoad',
-        'cookie',
-        'messageBridge',
-        'duckPlayer',
-        'harmfulApis',
-        'webCompat',
-        'windowsPermissionUsage',
-        'brokerProtection',
-        'performanceMetrics',
-        'breakageReporting',
-        'autofillPasswordImport',
-    ]);
-
     /** @typedef {baseFeatures[number]|otherFeatures[number]} FeatureName */
     /** @type {Record<string, FeatureName[]>} */
     const platformSupport = {
-        apple: ['webCompat', ...baseFeatures],
-        'apple-isolated': ['duckPlayer', 'brokerProtection', 'performanceMetrics', 'clickToLoad', 'messageBridge'],
-        android: [...baseFeatures, 'webCompat', 'breakageReporting', 'duckPlayer', 'messageBridge'],
-        'android-broker-protection': ['brokerProtection'],
-        'android-autofill-password-import': ['autofillPasswordImport'],
-        windows: ['cookie', ...baseFeatures, 'windowsPermissionUsage', 'duckPlayer', 'brokerProtection', 'breakageReporting'],
-        firefox: ['cookie', ...baseFeatures, 'clickToLoad'],
-        chrome: ['cookie', ...baseFeatures, 'clickToLoad'],
-        'chrome-mv3': ['cookie', ...baseFeatures, 'clickToLoad'],
-        integration: [...baseFeatures, ...otherFeatures],
-    };
+        android: [...baseFeatures, 'webCompat', 'breakageReporting', 'duckPlayer', 'messageBridge']};
 
     /**
      * Performance monitor, holds reference to PerformanceMark instances.
@@ -4564,7 +4540,7 @@
     		}
 
 
-    		if (module.exports) {
+    		if (module && module.exports) {
     		  module.exports = impl;
     		} else {
     		  this.alea = impl;
@@ -4653,7 +4629,7 @@
     		  return prng;
     		}
 
-    		if (module.exports) {
+    		if (module && module.exports) {
     		  module.exports = impl;
     		} else {
     		  this.xor128 = impl;
@@ -4747,7 +4723,7 @@
     		  return prng;
     		}
 
-    		if (module.exports) {
+    		if (module && module.exports) {
     		  module.exports = impl;
     		} else {
     		  this.xorwow = impl;
@@ -4853,7 +4829,7 @@
     		  return prng;
     		}
 
-    		if (module.exports) {
+    		if (module && module.exports) {
     		  module.exports = impl;
     		} else {
     		  this.xorshift7 = impl;
@@ -5008,7 +4984,7 @@
     		  return prng;
     		}
 
-    		if (module.exports) {
+    		if (module && module.exports) {
     		  module.exports = impl;
     		} else {
     		  this.xor4096 = impl;
@@ -5118,7 +5094,7 @@
     		  return prng;
     		}
 
-    		if (module.exports) {
+    		if (module && module.exports) {
     		  module.exports = impl;
     		} else {
     		  this.tychei = impl;

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.css
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.css
@@ -948,7 +948,8 @@ html[data-focus-mode=on] .MobileApp_embed {
     max-width: unset;
     grid-template-rows: 0 0 auto 12px 0 max-content;
   }
-  .MobileApp_main[data-youtube-error=true] :is(.MobileApp_logo, .MobileApp_switch) {
+  .MobileApp_main[data-youtube-error=true] .MobileApp_logo,
+  .MobileApp_main[data-youtube-error=true] .MobileApp_switch {
     display: none;
   }
   .MobileApp_main[data-youtube-error=true] .MobileApp_buttons {

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
@@ -3155,7 +3155,7 @@
           /** @type {HTMLElement} */
           node
         );
-        return element.classList.contains("ytp-error") || !!element.querySelector("ytp-error");
+        return element.classList.contains("ytp-error") || !!element.querySelector(".ytp-error");
       }
       return false;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^12.11.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.2.2",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.22.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.23.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.4.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1739774089"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#c8428aec4646126b7aa4903f85caf6315d565995",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#f7c579bc18d91093114036d37ef41c48e4977fb8",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -670,18 +670,18 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.78",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.78.tgz",
-      "integrity": "sha512-jS0svNsB99jR6AJBmfmEWuKIgz91Haya91Z43PATaeHJ24BkMoNRb/jlaD37VYjb0mYf6gRL/HOnvS1zEnYBiw==",
+      "version": "6.1.79",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.79.tgz",
+      "integrity": "sha512-HM+Ud/2oQuHt4I43Nvjc213Zji/z25NSH5OkJskJwHXNtYh9DTRlHMDFhms9dFMP7qyve/yVaXFIxmcJ7TdOjw==",
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "6.1.78",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.78.tgz",
-      "integrity": "sha512-Va3dLQizeJ0PKGqbwSi8oW58xS2b/rXrRmHdk1ePyoDHZmedp/F3C7vHsnmGmKL1QDsE6Sb9ypJLRfIzvTMl6A==",
+      "version": "6.1.79",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.79.tgz",
+      "integrity": "sha512-qAh6vDChn8fkkAaro/H632Af0yDQdcKGDQLYdwsv/c37VqKLiEO8loATjAgZPO2mwEgEYgzmxqtSLu293GjCTA==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^6.1.78"
+        "tldts-core": "^6.1.79"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^12.11.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.2.2",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.22.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.23.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.4.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1739774089"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1209531901562272/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [x] All tests must pass