### PR TITLE
Multi-selection: Bookmarking

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -455,7 +455,11 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
     }
 
     private fun showBookmarkToast(numBookmarks: Int) {
-        val message = resources.getQuantityString(R.plurals.tabSwitcherBookmarkToast, numBookmarks, numBookmarks)
+        val message = if (numBookmarks == 0) {
+            getString(R.string.tabSwitcherBookmarkToastZero)
+        } else {
+            resources.getQuantityString(R.plurals.tabSwitcherBookmarkToast, numBookmarks, numBookmarks)
+        }
         Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
     }
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -441,7 +441,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
             is CloseAllTabsRequest -> showCloseAllTabsConfirmation()
             is Command.ShareLinks -> launchShareMultipleLinkChooser(command.links)
             is Command.ShareLink -> launchShareLinkChooser(command.link, command.title)
-            is Command.BookmarkTabsRequest -> showBookmarkTabsConfirmation(command.numTabs)
+            is Command.BookmarkTabsRequest -> showBookmarkTabsConfirmation(command.tabIds)
             is Command.ShowBookmarkToast -> showBookmarkToast(command.numBookmarks)
         }
     }
@@ -723,7 +723,8 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
             .show()
     }
 
-    private fun showBookmarkTabsConfirmation(numTabs: Int) {
+    private fun showBookmarkTabsConfirmation(tabIds: List<String>) {
+        val numTabs = tabIds.size
         val title = resources.getQuantityString(R.plurals.tabSwitcherBookmarkDialogTitle, numTabs, numTabs)
         TextAlertDialogBuilder(this)
             .setTitle(title)
@@ -733,7 +734,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
             .addEventListener(
                 object : TextAlertDialogBuilder.EventListener() {
                     override fun onPositiveButtonClicked() {
-                        viewModel.onBookmarkTabsConfirmed(numTabs)
+                        viewModel.onBookmarkTabsConfirmed(tabIds)
                     }
                 },
             )

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -25,6 +25,7 @@ import android.view.MenuItem
 import android.view.MotionEvent
 import android.view.View
 import android.widget.TextView
+import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatDelegate.FEATURE_SUPPORT_ACTION_BAR
 import androidx.appcompat.widget.Toolbar
@@ -63,6 +64,7 @@ import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.Mode
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.menu.PopupMenu
+import com.duckduckgo.common.ui.view.button.ButtonType
 import com.duckduckgo.common.ui.view.button.ButtonType.DESTRUCTIVE
 import com.duckduckgo.common.ui.view.button.ButtonType.GHOST_ALT
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
@@ -440,11 +442,21 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
             is Command.ShareLinks -> {
                 launchShareMultipleLinkChooser(command.links)
             }
-
             is Command.ShareLink -> {
                 launchShareLinkChooser(command.link, command.title)
             }
+            is Command.BookmarkTabs -> {
+                showBookmarkTabsConfirmation(command.numTabs)
+            }
+            is Command.ShowBookmarkToast -> {
+                showBookmarkToast(command.numBookmarks)
+            }
         }
+    }
+
+    private fun showBookmarkToast(numBookmarks: Int) {
+        val message = resources.getQuantityString(R.plurals.tabSwitcherBookmarkToast, numBookmarks, numBookmarks)
+        Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -709,6 +721,23 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
                 object : TextAlertDialogBuilder.EventListener() {
                     override fun onPositiveButtonClicked() {
                         viewModel.onCloseAllTabsConfirmed()
+                    }
+                },
+            )
+            .show()
+    }
+
+    private fun showBookmarkTabsConfirmation(numTabs: Int) {
+        val title = resources.getQuantityString(R.plurals.tabSwitcherBookmarkDialogTitle, numTabs, numTabs)
+        TextAlertDialogBuilder(this)
+            .setTitle(title)
+            .setMessage(R.string.tabSwitcherBookmarkDialogDescription)
+            .setPositiveButton(R.string.tabSwitcherBookmarkDialogPositiveButton, ButtonType.PRIMARY)
+            .setNegativeButton(R.string.cancel, GHOST_ALT)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() {
+                        viewModel.onBookmarkTabsConfirmed(numTabs)
                     }
                 },
             )

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -439,18 +439,10 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
         when (command) {
             is Close -> finishAfterTransition()
             is CloseAllTabsRequest -> showCloseAllTabsConfirmation()
-            is Command.ShareLinks -> {
-                launchShareMultipleLinkChooser(command.links)
-            }
-            is Command.ShareLink -> {
-                launchShareLinkChooser(command.link, command.title)
-            }
-            is Command.BookmarkTabs -> {
-                showBookmarkTabsConfirmation(command.numTabs)
-            }
-            is Command.ShowBookmarkToast -> {
-                showBookmarkToast(command.numBookmarks)
-            }
+            is Command.ShareLinks -> launchShareMultipleLinkChooser(command.links)
+            is Command.ShareLink -> launchShareLinkChooser(command.link, command.title)
+            is Command.BookmarkTabsRequest -> showBookmarkTabsConfirmation(command.numTabs)
+            is Command.ShowBookmarkToast -> showBookmarkToast(command.numBookmarks)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherSnackbar.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherSnackbar.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.tabs.ui
 
 import android.view.View
 import android.widget.TextView
+import com.google.android.material.R as materialR
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 
@@ -62,7 +63,7 @@ class TabSwitcherSnackbar(
             },
         )
         .setAnimationMode(BaseTransientBottomBar.ANIMATION_MODE_SLIDE)
-        .apply { view.findViewById<TextView>(com.google.android.material.R.id.snackbar_text).maxLines = 1 }
+        .apply { view.findViewById<TextView>(materialR.id.snackbar_text).maxLines = 1 }
 
     fun show() {
         snackbar.show()

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherSnackbar.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherSnackbar.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.tabs.ui
+
+import android.view.View
+import android.widget.TextView
+import com.google.android.material.snackbar.BaseTransientBottomBar
+import com.google.android.material.snackbar.Snackbar
+
+class TabSwitcherSnackbar(
+    anchorView: View,
+    message: String,
+    private val action: String? = null,
+    private val showAction: Boolean = false,
+    private val onAction: () -> Unit = {},
+    private val onDismiss: () -> Unit = {},
+) {
+    companion object {
+        private const val SNACKBAR_DISPLAY_TIME_MS = 3500
+    }
+
+    private val snackbar = Snackbar.make(anchorView, message, Snackbar.LENGTH_LONG)
+        .setDuration(SNACKBAR_DISPLAY_TIME_MS) // 3.5 seconds
+        .apply {
+            if (showAction) {
+                setAction(action) {
+                    // noop, handled in onDismissed callback
+                }
+            }
+        }
+        .addCallback(
+            object : Snackbar.Callback() {
+                override fun onDismissed(
+                    transientBottomBar: Snackbar?,
+                    event: Int,
+                ) {
+                    when (event) {
+                        // handle the UNDO action here as we only have one
+                        BaseTransientBottomBar.BaseCallback.DISMISS_EVENT_ACTION -> onAction()
+                        BaseTransientBottomBar.BaseCallback.DISMISS_EVENT_SWIPE,
+                        BaseTransientBottomBar.BaseCallback.DISMISS_EVENT_TIMEOUT,
+                        -> onDismiss()
+                        BaseTransientBottomBar.BaseCallback.DISMISS_EVENT_CONSECUTIVE,
+                        BaseTransientBottomBar.BaseCallback.DISMISS_EVENT_MANUAL,
+                        -> { /* noop */ }
+                    }
+                }
+            },
+        )
+        .setAnimationMode(BaseTransientBottomBar.ANIMATION_MODE_SLIDE)
+        .apply { view.findViewById<TextView>(com.google.android.material.R.id.snackbar_text).maxLines = 1 }
+
+    fun show() {
+        snackbar.show()
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherSnackbar.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherSnackbar.kt
@@ -35,7 +35,7 @@ class TabSwitcherSnackbar(
     }
 
     private val snackbar = Snackbar.make(anchorView, message, Snackbar.LENGTH_LONG)
-        .setDuration(SNACKBAR_DISPLAY_TIME_MS) // 3.5 seconds
+        .setDuration(SNACKBAR_DISPLAY_TIME_MS)
         .apply {
             if (showAction) {
                 setAction(action) {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -16,7 +16,6 @@
 
 package com.duckduckgo.app.tabs.ui
 
-import android.R.attr.mode
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
@@ -46,7 +45,7 @@ import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.BackBu
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.FabType
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.Mode.Normal
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.Mode.Selection
-import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.BookmarkTabs
+import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.BookmarkTabsRequest
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.ShareLink
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.ShareLinks
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.ShowBookmarkToast
@@ -133,7 +132,7 @@ class TabSwitcherViewModel @Inject constructor(
         data object CloseAllTabsRequest : Command()
         data class ShareLink(val link: String, val title: String) : Command()
         data class ShareLinks(val links: List<String>) : Command()
-        data class BookmarkTabs(val numTabs: Int) : Command()
+        data class BookmarkTabsRequest(val numTabs: Int) : Command()
         data class ShowBookmarkToast(val numBookmarks: Int) : Command()
     }
 
@@ -250,11 +249,11 @@ class TabSwitcherViewModel @Inject constructor(
     fun onBookmarkSelectedTabs() {
         when (val mode = selectionViewState.value.mode) {
             is SelectionViewState.Mode.Normal -> {
-                command.value = BookmarkTabs(1)
+                command.value = BookmarkTabsRequest(1)
             }
 
             is SelectionViewState.Mode.Selection -> {
-                command.value = BookmarkTabs(mode.selectedTabs.size)
+                command.value = BookmarkTabsRequest(mode.selectedTabs.size)
             }
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -132,7 +132,7 @@ class TabSwitcherViewModel @Inject constructor(
         data object CloseAllTabsRequest : Command()
         data class ShareLink(val link: String, val title: String) : Command()
         data class ShareLinks(val links: List<String>) : Command()
-        data class BookmarkTabsRequest(val numTabs: Int) : Command()
+        data class BookmarkTabsRequest(val tabIds: List<String>) : Command()
         data class ShowBookmarkToast(val numBookmarks: Int) : Command()
     }
 
@@ -164,9 +164,9 @@ class TabSwitcherViewModel @Inject constructor(
             _selectionViewState.update {
                 val selectionMode = it.mode as Selection
                 if (tab.tabId in selectionMode.selectedTabs) {
-                    it.copy(mode = Selection(selectionMode.selectedTabs - tab.tabId))
+                    it.copy(mode = Selection(selectedTabs = selectionMode.selectedTabs - tab.tabId))
                 } else {
-                    it.copy(mode = Selection(selectionMode.selectedTabs + tab.tabId))
+                    it.copy(mode = Selection(selectedTabs = selectionMode.selectedTabs + tab.tabId))
                 }
             }
         } else {
@@ -193,7 +193,7 @@ class TabSwitcherViewModel @Inject constructor(
         (_selectionViewState.value.mode as? Selection)?.let { selectionMode ->
             if (tab.tabId in selectionMode.selectedTabs) {
                 _selectionViewState.update {
-                    it.copy(mode = Selection(selectionMode.selectedTabs - tab.tabId))
+                    it.copy(mode = Selection(selectedTabs = selectionMode.selectedTabs - tab.tabId))
                 }
             }
         }
@@ -204,7 +204,7 @@ class TabSwitcherViewModel @Inject constructor(
 
         (_selectionViewState.value.mode as? Selection)?.let { selectionMode ->
             _selectionViewState.update {
-                it.copy(mode = Selection(selectionMode.selectedTabs + tab.tabId))
+                it.copy(mode = Selection(selectedTabs = selectionMode.selectedTabs + tab.tabId))
             }
         }
     }
@@ -222,7 +222,7 @@ class TabSwitcherViewModel @Inject constructor(
     }
 
     fun onSelectAllTabs() {
-        _selectionViewState.update { it.copy(mode = Selection(tabItems.map { tab -> tab.id })) }
+        _selectionViewState.update { it.copy(mode = Selection(selectedTabs = tabItems.map { tab -> tab.id })) }
     }
 
     fun onDeselectAllTabs() {
@@ -248,12 +248,14 @@ class TabSwitcherViewModel @Inject constructor(
 
     fun onBookmarkSelectedTabs() {
         when (val mode = selectionViewState.value.mode) {
-            is SelectionViewState.Mode.Normal -> {
-                command.value = BookmarkTabsRequest(1)
+            is Normal -> {
+                activeTab.value?.tabId?.let { tabId ->
+                    command.value = BookmarkTabsRequest(listOf(tabId))
+                }
             }
 
-            is SelectionViewState.Mode.Selection -> {
-                command.value = BookmarkTabsRequest(mode.selectedTabs.size)
+            is Selection -> {
+                command.value = BookmarkTabsRequest(mode.selectedTabs)
             }
         }
     }
@@ -272,34 +274,11 @@ class TabSwitcherViewModel @Inject constructor(
     fun onCloseOtherTabs() {
     }
 
-    fun onBookmarkTabsConfirmed(numTabs: Int) {
+    fun onBookmarkTabsConfirmed(tabIds: List<String>) {
         viewModelScope.launch {
-            val numBookmarkedTabs = when (val mode = selectionViewState.value.mode) {
-                is SelectionViewState.Mode.Selection -> {
-                    // bookmark selected tabs (or all tabs if none selected)
-                    if (mode.selectedTabs.isNotEmpty()) {
-                        bookmarkTabs(mode.selectedTabs)
-                    } else {
-                        bookmarkAllTabs()
-                    }
-                }
-
-                SelectionViewState.Mode.Normal -> {
-                    if (numTabs == 1) {
-                        activeTab.value?.tabId?.let { bookmarkTabs(listOf(it)) } ?: 0
-                    } else {
-                        bookmarkAllTabs()
-                    }
-                }
-            }
+            val numBookmarkedTabs = bookmarkTabs(tabIds)
             command.value = ShowBookmarkToast(numBookmarkedTabs)
         }
-    }
-
-    private suspend fun bookmarkAllTabs(): Int {
-        return tabSwitcherItems.value?.filterIsInstance<TabSwitcherItem.Tab>()?.let { tabIds ->
-            bookmarkTabs(tabIds.map { it.id })
-        } ?: 0
     }
 
     private suspend fun bookmarkTabs(tabIds: List<String>): Int {
@@ -323,21 +302,25 @@ class TabSwitcherViewModel @Inject constructor(
             pixel.fire(AppPixelName.TAB_MANAGER_MENU_CLOSE_ALL_TABS_CONFIRMED)
 
             // Trigger a normal mode when there are no tabs
-            _selectionViewState.update { it.copy(mode = Normal) }
+            triggerNormalMode()
         }
     }
 
     fun onEmptyAreaClicked() {
         if (tabManagerFeatureFlags.multiSelection().isEnabled() && _selectionViewState.value.mode is Selection) {
-            _selectionViewState.update { it.copy(mode = Normal) }
+            triggerNormalMode()
         }
+    }
+
+    private fun triggerNormalMode() {
+        _selectionViewState.update { it.copy(mode = Normal) }
     }
 
     fun onUpButtonPressed() {
         pixel.fire(AppPixelName.TAB_MANAGER_UP_BUTTON_PRESSED)
 
         if (tabManagerFeatureFlags.multiSelection().isEnabled() && _selectionViewState.value.mode is Selection) {
-            _selectionViewState.update { it.copy(mode = Normal) }
+            triggerNormalMode()
         } else {
             command.value = Command.Close
         }
@@ -347,7 +330,7 @@ class TabSwitcherViewModel @Inject constructor(
         pixel.fire(AppPixelName.TAB_MANAGER_BACK_BUTTON_PRESSED)
 
         if (tabManagerFeatureFlags.multiSelection().isEnabled() && _selectionViewState.value.mode is Selection) {
-            _selectionViewState.update { it.copy(mode = Normal) }
+            triggerNormalMode()
         } else {
             command.value = Command.Close
         }
@@ -409,7 +392,7 @@ class TabSwitcherViewModel @Inject constructor(
 
     private suspend fun saveSiteBookmark(tabId: String) = withContext(dispatcherProvider.io()) {
         var bookmark: Bookmark? = null
-        (tabSwitcherItems.value?.firstOrNull { it.id == tabId } as? TabSwitcherItem.Tab)?.let { tab ->
+        (tabSwitcherItems.value?.firstOrNull { it.id == tabId } as? Tab)?.let { tab ->
             tab.tabEntity.url?.let { url ->
                 if (url.isNotBlank()) {
                     // Only bookmark new sites

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.app.tabs.ui
 
+import android.R.attr.mode
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
@@ -24,6 +25,7 @@ import androidx.lifecycle.viewModelScope
 import com.duckduckgo.adclick.api.AdClickManager
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.browser.SwipingTabsFeatureProvider
+import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.pixels.AppPixelName.TAB_MANAGER_GRID_VIEW_BUTTON_CLICKED
@@ -39,19 +41,23 @@ import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType.LIST
 import com.duckduckgo.app.tabs.ui.TabSwitcherItem.Tab
 import com.duckduckgo.app.tabs.ui.TabSwitcherItem.Tab.NormalTab
 import com.duckduckgo.app.tabs.ui.TabSwitcherItem.Tab.SelectableTab
-import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.ShareLink
-import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.ShareLinks
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.BackButtonType.ARROW
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.BackButtonType.CLOSE
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.FabType
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.Mode.Normal
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.Mode.Selection
+import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.BookmarkTabs
+import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.ShareLink
+import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.ShareLinks
+import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.ShowBookmarkToast
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.SingleLiveEvent
 import com.duckduckgo.common.utils.extensions.toBinaryString
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.impl.DuckChatPixelName
+import com.duckduckgo.savedsites.api.SavedSitesRepository
+import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -61,6 +67,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @ContributesViewModel(ActivityScope::class)
 class TabSwitcherViewModel @Inject constructor(
@@ -72,6 +79,8 @@ class TabSwitcherViewModel @Inject constructor(
     private val swipingTabsFeature: SwipingTabsFeatureProvider,
     private val duckChat: DuckChat,
     private val tabManagerFeatureFlags: TabManagerFeatureFlags,
+    private val faviconManager: FaviconManager,
+    private val savedSitesRepository: SavedSitesRepository,
 ) : ViewModel() {
 
     val activeTab = tabRepository.liveSelectedTab
@@ -122,6 +131,8 @@ class TabSwitcherViewModel @Inject constructor(
         data object CloseAllTabsRequest : Command()
         data class ShareLink(val link: String, val title: String) : Command()
         data class ShareLinks(val links: List<String>) : Command()
+        data class BookmarkTabs(val numTabs: Int) : Command()
+        data class ShowBookmarkToast(val numBookmarks: Int) : Command()
     }
 
     suspend fun onNewTabRequested(fromOverflowMenu: Boolean) {
@@ -235,6 +246,15 @@ class TabSwitcherViewModel @Inject constructor(
     }
 
     fun onBookmarkSelectedTabs() {
+        when (val mode = selectionViewState.value.mode) {
+            is SelectionViewState.Mode.Normal -> {
+                command.value = BookmarkTabs(1)
+            }
+
+            is SelectionViewState.Mode.Selection -> {
+                command.value = BookmarkTabs(mode.selectedTabs.size)
+            }
+        }
     }
 
     fun onSelectionModeRequested() {
@@ -246,9 +266,54 @@ class TabSwitcherViewModel @Inject constructor(
     }
 
     fun onCloseSelectedTabs() {
+        (selectionViewState.value.mode as? SelectionViewState.Mode.Selection)?.selectedTabs?.size?.let { numTabs ->
+            if (numTabs > 0) {
+                command.value = BookmarkTabs(numTabs)
+            }
+        }
     }
 
     fun onCloseOtherTabs() {
+    }
+
+    fun onBookmarkTabsConfirmed(numTabs: Int) {
+        val numBookmarkedTabs = when (val mode = selectionViewState.value.mode) {
+            is SelectionViewState.Mode.Selection -> {
+                // bookmark selected tabs (or all tabs if none selected)
+                if (mode.selectedTabs.isNotEmpty()) {
+                    bookmarkTabs(mode.selectedTabs)
+                } else {
+                    bookmarkAllTabs()
+                }
+            }
+
+            SelectionViewState.Mode.Normal -> {
+                if (numTabs == 1) {
+                    activeTab.value?.tabId?.let { bookmarkTabs(listOf(it)) } ?: 0
+                } else {
+                    bookmarkAllTabs()
+                }
+            }
+        }
+        command.value = ShowBookmarkToast(numBookmarkedTabs)
+    }
+
+    private fun bookmarkAllTabs(): Int {
+        return tabSwitcherItems.value?.filterIsInstance<TabSwitcherItem.Tab>()?.let { tabIds ->
+            bookmarkTabs(tabIds.map { it.id })
+        } ?: 0
+    }
+
+    private fun bookmarkTabs(tabIds: List<String>): Int {
+        var bookmarkedSites = 0
+        tabIds.forEach {
+            viewModelScope.launch {
+                if (saveSiteBookmark(it) != null) {
+                    bookmarkedSites++
+                }
+            }
+        }
+        return bookmarkedSites
     }
 
     fun onCloseAllTabsConfirmed() {
@@ -345,6 +410,22 @@ class TabSwitcherViewModel @Inject constructor(
                 onCloseSelectedTabs()
             }
         }
+    }
+
+    private suspend fun saveSiteBookmark(tabId: String) = withContext(dispatcherProvider.io()) {
+        var bookmark: Bookmark? = null
+        (tabSwitcherItems.value?.firstOrNull { it.id == tabId } as? TabSwitcherItem.Tab)?.let { tab ->
+            tab.tabEntity.url?.let { url ->
+                if (url.isNotBlank()) {
+                    // Only bookmark new sites
+                    if (savedSitesRepository.getBookmark(url) == null) {
+                        faviconManager.persistCachedFavicon(tabId, url)
+                        bookmark = savedSitesRepository.insertBookmark(url, tab.tabEntity.title.orEmpty())
+                    }
+                }
+            }
+        }
+        return@withContext bookmark
     }
 
     fun onDuckChatMenuClicked() {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -406,19 +406,20 @@ class TabSwitcherViewModel @Inject constructor(
     }
 
     private suspend fun saveSiteBookmark(tabId: String) = withContext(dispatcherProvider.io()) {
-        var bookmark: Bookmark? = null
-        (tabItems.firstOrNull { it.id == tabId } as? Tab)?.let { tab ->
-            tab.tabEntity.url?.let { url ->
-                if (url.isNotBlank()) {
-                    // Only bookmark new sites
-                    if (savedSitesRepository.getBookmark(url) == null) {
-                        faviconManager.persistCachedFavicon(tabId, url)
-                        bookmark = savedSitesRepository.insertBookmark(url, tab.tabEntity.title.orEmpty())
-                    }
-                }
+        val targetTabItem = tabItems.firstOrNull { it.id == tabId }
+        val targetTab = targetTabItem?.takeIf { it is Tab }?.let { it as Tab }
+
+        val targetTabUrl = targetTab?.tabEntity?.url
+        val isUrlNotBlank = targetTabUrl?.isNotBlank() ?: false
+
+        if (isUrlNotBlank) {
+            // Only bookmark new sites
+            savedSitesRepository.getBookmark(targetTabUrl!!) ?: run {
+                faviconManager.persistCachedFavicon(tabId, targetTabUrl)
+                return@withContext savedSitesRepository.insertBookmark(targetTabUrl, targetTab.tabEntity.title.orEmpty())
             }
         }
-        return@withContext bookmark
+        return@withContext null
     }
 
     fun onDuckChatMenuClicked() {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -263,12 +263,13 @@ class TabSwitcherViewModel @Inject constructor(
     }
 
     fun undoBookmarkAction() {
-        recentlySavedBookmarks.forEach { bookmark ->
-            viewModelScope.launch(dispatcherProvider.io()) {
+        viewModelScope.launch(dispatcherProvider.io()) {
+            recentlySavedBookmarks.forEach { bookmark ->
                 savedSitesRepository.delete(bookmark)
             }
+
+            recentlySavedBookmarks.clear()
         }
-        recentlySavedBookmarks.clear()
     }
 
     fun finishBookmarkAction() {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -40,15 +40,15 @@ import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType.LIST
 import com.duckduckgo.app.tabs.ui.TabSwitcherItem.Tab
 import com.duckduckgo.app.tabs.ui.TabSwitcherItem.Tab.NormalTab
 import com.duckduckgo.app.tabs.ui.TabSwitcherItem.Tab.SelectableTab
+import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.BookmarkTabsRequest
+import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.ShareLink
+import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.ShareLinks
+import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.ShowUndoBookmarkMessage
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.BackButtonType.ARROW
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.BackButtonType.CLOSE
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.FabType
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.Mode.Normal
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.Mode.Selection
-import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.BookmarkTabsRequest
-import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.ShareLink
-import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.ShareLinks
-import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.ShowBookmarkToast
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.SingleLiveEvent
 import com.duckduckgo.common.utils.extensions.toBinaryString
@@ -127,13 +127,15 @@ class TabSwitcherViewModel @Inject constructor(
             }
         }
 
+    private val recentlySavedBookmarks = mutableListOf<Bookmark>()
+
     sealed class Command {
         data object Close : Command()
         data object CloseAllTabsRequest : Command()
         data class ShareLink(val link: String, val title: String) : Command()
         data class ShareLinks(val links: List<String>) : Command()
         data class BookmarkTabsRequest(val tabIds: List<String>) : Command()
-        data class ShowBookmarkToast(val numBookmarks: Int) : Command()
+        data class ShowUndoBookmarkMessage(val numBookmarks: Int) : Command()
     }
 
     suspend fun onNewTabRequested(fromOverflowMenu: Boolean) {
@@ -260,6 +262,35 @@ class TabSwitcherViewModel @Inject constructor(
         }
     }
 
+    fun undoBookmarkAction() {
+        recentlySavedBookmarks.forEach { bookmark ->
+            viewModelScope.launch(dispatcherProvider.io()) {
+                savedSitesRepository.delete(bookmark)
+            }
+        }
+        recentlySavedBookmarks.clear()
+    }
+
+    fun finishBookmarkAction() {
+        recentlySavedBookmarks.clear()
+    }
+
+    fun onBookmarkTabsConfirmed(tabIds: List<String>) {
+        viewModelScope.launch {
+            recentlySavedBookmarks.addAll(bookmarkTabs(tabIds))
+            command.value = ShowUndoBookmarkMessage(recentlySavedBookmarks.size)
+        }
+    }
+
+    private suspend fun bookmarkTabs(tabIds: List<String>): List<Bookmark> {
+        val results = tabIds.map { tabId ->
+            viewModelScope.async {
+                saveSiteBookmark(tabId)
+            }
+        }
+        return results.awaitAll().filterNotNull()
+    }
+
     fun onSelectionModeRequested() {
         triggerEmptySelectionMode()
     }
@@ -272,22 +303,6 @@ class TabSwitcherViewModel @Inject constructor(
     }
 
     fun onCloseOtherTabs() {
-    }
-
-    fun onBookmarkTabsConfirmed(tabIds: List<String>) {
-        viewModelScope.launch {
-            val numBookmarkedTabs = bookmarkTabs(tabIds)
-            command.value = ShowBookmarkToast(numBookmarkedTabs)
-        }
-    }
-
-    private suspend fun bookmarkTabs(tabIds: List<String>): Int {
-        val results = tabIds.map { tabId ->
-            viewModelScope.async {
-                saveSiteBookmark(tabId)
-            }
-        }
-        return results.awaitAll().count { it != null }
     }
 
     fun onCloseAllTabsConfirmed() {
@@ -392,7 +407,7 @@ class TabSwitcherViewModel @Inject constructor(
 
     private suspend fun saveSiteBookmark(tabId: String) = withContext(dispatcherProvider.io()) {
         var bookmark: Bookmark? = null
-        (tabSwitcherItems.value?.firstOrNull { it.id == tabId } as? Tab)?.let { tab ->
+        (tabItems.firstOrNull { it.id == tabId } as? Tab)?.let { tab ->
             tab.tabEntity.url?.let { url ->
                 if (url.isNotBlank()) {
                     // Only bookmark new sites

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -93,6 +93,17 @@
         <item quantity="other">Share %1$d Links</item>
     </plurals>
 
+    <plurals name="tabSwitcherBookmarkDialogTitle" tools:ignore="ImpliedQuantity,MissingInstruction">
+        <item quantity="one">Bookmark Selected Tab?</item>
+        <item quantity="other">Bookmark %1$d Tabs?</item>
+    </plurals>
+    <plurals name="tabSwitcherBookmarkToast" tools:ignore="ImpliedQuantity,MissingInstruction">
+        <item quantity="zero">No new bookmark was added.</item>
+        <item quantity="one">One new bookmark was added.</item>
+        <item quantity="other">%1$d new bookmarks were added.</item>
+    </plurals>
+    <string name="tabSwitcherBookmarkDialogDescription">Existing bookmarks will not be duplicated.</string>
+    <string name="tabSwitcherBookmarkDialogPositiveButton">Bookmark</string>
     <plurals name="bookmarkTabsMenuItem" tools:ignore="ImpliedQuantity,MissingInstruction">
         <item quantity="one">Bookmark Tab</item>
         <item quantity="other">Bookmark %1$d Tabs</item>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -97,8 +97,8 @@
         <item quantity="one">Bookmark Selected Tab?</item>
         <item quantity="other">Bookmark %1$d Tabs?</item>
     </plurals>
+    <string name="tabSwitcherBookmarkToastZero">No unique bookmark was added.</string>
     <plurals name="tabSwitcherBookmarkToast" tools:ignore="ImpliedQuantity,MissingInstruction">
-        <item quantity="zero">No new bookmark was added.</item>
         <item quantity="one">One new bookmark was added.</item>
         <item quantity="other">%1$d new bookmarks were added.</item>
     </plurals>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -97,10 +97,9 @@
         <item quantity="one">Bookmark Selected Tab?</item>
         <item quantity="other">Bookmark %1$d Tabs?</item>
     </plurals>
-    <string name="tabSwitcherBookmarkToastZero">No unique bookmark was added.</string>
     <plurals name="tabSwitcherBookmarkToast" tools:ignore="ImpliedQuantity,MissingInstruction">
-        <item quantity="one">One new bookmark was added.</item>
-        <item quantity="other">%1$d new bookmarks were added.</item>
+        <item quantity="one">%1$d bookmark added</item>
+        <item quantity="other">%1$d bookmarks added</item>
     </plurals>
     <string name="tabSwitcherBookmarkDialogDescription">Existing bookmarks will not be duplicated.</string>
     <string name="tabSwitcherBookmarkDialogPositiveButton">Bookmark</string>

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -25,6 +25,8 @@ import androidx.lifecycle.liveData
 import com.duckduckgo.adclick.api.AdClickManager
 import com.duckduckgo.app.browser.SwipingTabsFeature
 import com.duckduckgo.app.browser.SwipingTabsFeatureProvider
+import com.duckduckgo.app.browser.favicon.FaviconManager
+import com.duckduckgo.app.browser.favicon.FaviconModule_FaviconManagerFactory.faviconManager
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -45,6 +47,7 @@ import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.impl.DuckChatPixelName
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.savedsites.api.SavedSitesRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.collect
@@ -99,6 +102,12 @@ class TabSwitcherViewModelTest {
     @Mock
     private lateinit var duckChatMock: DuckChat
 
+    @Mock
+    private lateinit var faviconManager: FaviconManager
+
+    @Mock
+    private lateinit var savedSitesRepository: SavedSitesRepository
+
     private val tabManagerFeatureFlags = FakeFeatureToggleFactory.create(TabManagerFeatureFlags::class.java)
 
     private val swipingTabsFeature = FakeFeatureToggleFactory.create(SwipingTabsFeature::class.java)
@@ -145,6 +154,8 @@ class TabSwitcherViewModelTest {
             swipingTabsFeatureProvider,
             duckChatMock,
             tabManagerFeatureFlags,
+            faviconManager,
+            savedSitesRepository,
         )
         testee.command.observeForever(mockCommandObserver)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1209118961868653

### Description

This PR adds the bookmarking functionality to the tab switcher.

### Steps to test this PR

_Bookmarking selected tabs_
- [x] Make sure you have at least 3 distinct sites/tabs
- [x] Make sure no bookmarks exist
- [x] Go to the tab switcher
- [x] Tap on the more menu button
- [x] Tap on `Select Tab`
- [x] Tap on the more menu button
- [x] Verify only `Select All` menu is availabe
- [x] Select 2 tabs
- [x] Tap on the bookmark toolbar button
- [x] Verify that `Bookmark 2 Tabs?` dialog appears
- [x] Tap on Bookmark
- [x] Verify that this snackbar appears: `2 bookmarks added`
- [x] Navigate to Bookmarks and verify the bookmarks were really created

_Undo bookmark action_
- [x] Make sure you have at least 1 tab
- [x] Make sure no bookmarks exist
- [x] Go to the tab switcher -> Select a tab -> Tap on the bookmark menu
- [x] Verify that this snackbar appears: `1 bookmarks added` with the `Undo` action
- [x] Tap on the `Undo` action
- [x] Navigate to Bookmarks
- [x] Verify the bookmark is not listed

_Bookmarking unique and non-NTP tabs_
- [x] Make sure you have 4 distinct sites/tabs, including 1 NTP
- [x] Make sure one of them is already bookmarked
- [x] Go to the tab switcher
- [x] Tap on the more menu button
- [x] Tap on `Select Tabs`
- [x] Tap on `Select All`
- [x] Verify that `Bookmark 4 Tabs?` dialog appears
- [x] Tap on Bookmark
- [x] Verify that this snackbar appears: `2 bookmarks added` (NTP and the existing bookmark skipped)
- [x] Tap on the more menu and bookmark the selected tabs again
- [x] Verify that this snackbar appears: `0 bookmarks added`, now without the `Undo` action
- [x] Navigate to Bookmarks and verify the 2 bookmarks added previously were really created

