### PR TITLE
Fix: Bookmarks screen UI issues

### DIFF
--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarkScreenViewHolders.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarkScreenViewHolders.kt
@@ -26,7 +26,6 @@ import androidx.recyclerview.widget.RecyclerView
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.common.ui.view.getColorFromAttr
 import com.duckduckgo.common.utils.baseHost
-import com.duckduckgo.mobile.android.databinding.RowTwoLineItemBinding
 import com.duckduckgo.saved.sites.impl.R
 import com.duckduckgo.saved.sites.impl.databinding.RowBookmarkTwoLineItemBinding
 import com.duckduckgo.saved.sites.impl.databinding.ViewSavedSiteEmptyHintBinding
@@ -152,7 +151,7 @@ sealed class BookmarkScreenViewHolders(itemView: View) : RecyclerView.ViewHolder
     }
 
     class BookmarkFoldersViewHolder(
-        private val binding: RowTwoLineItemBinding,
+        private val binding: RowBookmarkTwoLineItemBinding,
         private val onBookmarkFolderClick: (View, BookmarkFolder) -> Unit,
         private val onBookmarkFolderOverflowClick: (View, BookmarkFolder) -> Unit,
         private val onLongClick: () -> Unit,

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksAdapter.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksAdapter.kt
@@ -23,7 +23,6 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.duckduckgo.app.browser.favicon.FaviconManager
-import com.duckduckgo.mobile.android.databinding.RowTwoLineItemBinding
 import com.duckduckgo.saved.sites.impl.databinding.RowBookmarkTwoLineItemBinding
 import com.duckduckgo.saved.sites.impl.databinding.ViewSavedSiteEmptyHintBinding
 import com.duckduckgo.saved.sites.impl.databinding.ViewSavedSiteEmptySearchHintBinding
@@ -110,7 +109,7 @@ class BookmarksAdapter(
                 )
             }
             BOOKMARK_FOLDER_TYPE -> {
-                val binding = RowTwoLineItemBinding.inflate(inflater, parent, false)
+                val binding = RowBookmarkTwoLineItemBinding.inflate(inflater, parent, false)
                 return BookmarkFoldersViewHolder(
                     binding,
                     onBookmarkFolderClick,

--- a/saved-sites/saved-sites-impl/src/main/res/layout/activity_bookmarks.xml
+++ b/saved-sites/saved-sites-impl/src/main/res/layout/activity_bookmarks.xml
@@ -52,13 +52,16 @@
 
                     <com.duckduckgo.common.ui.view.text.DaxTextView
                         android:id="@+id/toolbar_title"
-                        android:layout_width="wrap_content"
+                        android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:text="@string/bookmarksActivityTitle"
+                        android:singleLine="true"
+                        android:ellipsize="end"
                         app:typography="h2"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toTopOf="parent"
-                        app:layout_constraintBottom_toBottomOf="parent"/>
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toStartOf="@id/searchMenu"/>
 
                     <FrameLayout
                         android:id="@+id/searchMenu"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414730916066338/1209489657638562

### Description

This PR fixes 2 bookmarks screen UI issues:
- display of long bookmark folder titles in the toolbar
- incorrect more menu button alignment for folders in the bookmark list

### Steps to test this PR

_Title_
- [x] Make sure you have some existing bookmarks
- [x] Go to the bookmarks screen
- [x] Add a new bookmark folder with a long name, such as "This is a very long bookmark folder name"
- [x] Tap on the bookmark 
- [x] Verify the toolbar title text is on a single line and wrapped

_List_
- [x] Make sure you have some existing bookmarks
- [x] Go to the bookmarks screen
- [x] Add a new bookmark folder
- [x] Verify the more menu button at the end of the folder item is aligned with the rest of the bookmarks

### UI changes

_Title_

| Before  | After |
| ------ | ----- |
![image](https://github.com/user-attachments/assets/b19b2b68-a934-4a66-9d78-65fda266d381)|![image](https://github.com/user-attachments/assets/57044ab9-d173-4934-ab30-d59cd341d538)|

_List_

| Before  | After |
| ------ | ----- |
![image](https://github.com/user-attachments/assets/df8fe2dc-464a-4237-8ee8-3601c078eb07)|![image](https://github.com/user-attachments/assets/5bcc2459-5f7f-472b-a3b2-3c2a82b7e830)|
