### PR TITLE
moves autofill service (and activities) to its own process

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
@@ -39,6 +39,7 @@ import kotlinx.coroutines.*
 import timber.log.Timber
 
 private const val VPN_PROCESS_NAME = "vpn"
+private const val AUTOFILL_SERVICE_PROCESS_NAME = "autofill"
 
 open class DuckDuckGoApplication : HasDaggerInjector, MultiProcessApplication() {
 
@@ -113,6 +114,14 @@ open class DuckDuckGoApplication : HasDaggerInjector, MultiProcessApplication() 
                     }
                 }
             }
+        }
+
+        runInSecondaryProcessNamed(AUTOFILL_SERVICE_PROCESS_NAME) {
+            configureLogging()
+            configureStrictMode()
+            Timber.d("Init for secondary process $shortProcessName with pid=${android.os.Process.myPid()}")
+            configureDependencyInjection()
+            configureUncaughtExceptionHandler()
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/DuckDuckGoApplication.kt
@@ -39,7 +39,6 @@ import kotlinx.coroutines.*
 import timber.log.Timber
 
 private const val VPN_PROCESS_NAME = "vpn"
-private const val AUTOFILL_SERVICE_PROCESS_NAME = "autofill"
 
 open class DuckDuckGoApplication : HasDaggerInjector, MultiProcessApplication() {
 
@@ -114,14 +113,6 @@ open class DuckDuckGoApplication : HasDaggerInjector, MultiProcessApplication() 
                     }
                 }
             }
-        }
-
-        runInSecondaryProcessNamed(AUTOFILL_SERVICE_PROCESS_NAME) {
-            configureLogging()
-            configureStrictMode()
-            Timber.d("Init for secondary process $shortProcessName with pid=${android.os.Process.myPid()}")
-            configureDependencyInjection()
-            configureUncaughtExceptionHandler()
         }
     }
 

--- a/autofill/autofill-impl/src/main/AndroidManifest.xml
+++ b/autofill/autofill-impl/src/main/AndroidManifest.xml
@@ -24,17 +24,36 @@
             android:configChanges="orientation|screenSize"
             android:exported="false"
             android:windowSoftInputMode="adjustResize" />
+
+        <!-- Autofill Service runs on its own process https://app.asana.com/0/72649045549333/1209537052601451 -->
         <activity
             android:name=".service.AutofillProviderFillSuggestionActivity"
             android:configChanges="orientation|screenSize"
             android:exported="false"
+            android:process=":autofill"
             android:theme="@style/Theme.AppCompat.Transparent.NoActionBar"
             android:windowSoftInputMode="adjustResize" />
         <activity
             android:name=".service.AutofillProviderChooseActivity"
             android:configChanges="orientation|screenSize"
             android:exported="false"
+            android:process=":autofill"
             android:windowSoftInputMode="adjustResize" />
+        <service
+            android:name="com.duckduckgo.autofill.impl.service.RealAutofillService"
+            android:exported="true"
+            android:label="@string/serviceName"
+            android:enabled="false"
+            android:process=":autofill"
+            android:permission="android.permission.BIND_AUTOFILL_SERVICE">
+            <intent-filter>
+                <action android:name="android.service.autofill.AutofillService" />
+            </intent-filter>
+            <meta-data
+                android:name="android.autofill"
+                android:resource="@xml/service_configuration" />
+        </service>
+        <!-- Autofill Service -->
     </application>
 
 </manifest>

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/RealAutofillService.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/RealAutofillService.kt
@@ -102,7 +102,9 @@ class RealAutofillService : AutofillService() {
 
                 callback.onSuccess(response)
             }.onFailure {
-                pixel.fire(AutofillPixelNames.AUTOFILL_SERVICE_CRASH, mapOf("message" to it.extractExceptionCause()))
+                if (it !is kotlinx.coroutines.CancellationException) {
+                    pixel.fire(AutofillPixelNames.AUTOFILL_SERVICE_CRASH, mapOf("message" to it.extractExceptionCause()))
+                }
                 callback.onSuccess(null)
             }
         }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/store/AutofillFeatureRepository.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/store/AutofillFeatureRepository.kt
@@ -51,7 +51,7 @@ class RealAutofillFeatureRepository @Inject constructor(
     init {
         appCoroutineScope.launch(dispatcherProvider.io()) {
             Timber.i("DDGAutofillService: Init AutofillFeatureRepository from $processName")
-            if (isMainProcess || processName == "autofill") { // TODO: Revisit this after merging autofill process PR
+            if (isMainProcess || processName == ":autofill") {
                 loadToMemory()
             }
         }

--- a/autofill/autofill-impl/src/main/res/values/donottranslate.xml
+++ b/autofill/autofill-impl/src/main/res/values/donottranslate.xml
@@ -15,6 +15,7 @@
   -->
 
 <resources>
+    <string name="serviceName" translatable="false">DuckDuckGo</string>
     <string name="autofill_service_suggestion_open_passwords">Open Passwords</string>
     <string name="autofill_service_select_password_activity">Select a Saved Password</string>
 </resources>

--- a/autofill/autofill-internal/src/main/AndroidManifest.xml
+++ b/autofill/autofill-internal/src/main/AndroidManifest.xml
@@ -22,18 +22,5 @@
             android:exported="true"
             android:label="@string/autofillDevSettingsTitle"
             android:parentActivityName="com.duckduckgo.app.settings.SettingsActivity" />
-        <service
-            android:name="com.duckduckgo.autofill.impl.service.RealAutofillService"
-            android:exported="true"
-            android:label="@string/appName"
-            android:enabled="false"
-            android:permission="android.permission.BIND_AUTOFILL_SERVICE">
-            <intent-filter>
-                <action android:name="android.service.autofill.AutofillService" />
-            </intent-filter>
-            <meta-data
-                android:name="android.autofill"
-                android:resource="@xml/service_configuration" />
-        </service>
     </application>
 </manifest>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1200156640058969/1209537052601451 

### Description
Moves Autofill Service (and activities) to its own process

### Steps to test this PR

_Feature 1_
- [ ] When using autofill in other apps
- [ ] ensure we don't refresh atb (nor emit exti)
- [ ] ensure no ml pixel is sent when selecting a suggestion

then smoke test the service

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
