### PR TITLE
Update content scope scripts to version 7.24.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^12.12.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.2.2",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.23.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.24.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.4.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1739774089"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#f7c579bc18d91093114036d37ef41c48e4977fb8",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#ece36244aaab4f6d582a746151fd4f618e0ed72e",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -283,9 +283,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.5.tgz",
-      "integrity": "sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg==",
+      "version": "22.13.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.9.tgz",
+      "integrity": "sha512-acBjXdRJ3A6Pb3tqnw9HZmyR3Fiol3aGxRCK1x3d+6CDAMjl7I649wpSd+yNURCjbOUGu9tqtLKnTGxmK6CyGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -670,18 +670,18 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.79",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.79.tgz",
-      "integrity": "sha512-HM+Ud/2oQuHt4I43Nvjc213Zji/z25NSH5OkJskJwHXNtYh9DTRlHMDFhms9dFMP7qyve/yVaXFIxmcJ7TdOjw==",
+      "version": "6.1.82",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.82.tgz",
+      "integrity": "sha512-Jabl32m21tt/d/PbDO88R43F8aY98Piiz6BVH9ShUlOAiiAELhEqwrAmBocjAqnCfoUeIsRU+h3IEzZd318F3w==",
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "6.1.79",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.79.tgz",
-      "integrity": "sha512-qAh6vDChn8fkkAaro/H632Af0yDQdcKGDQLYdwsv/c37VqKLiEO8loATjAgZPO2mwEgEYgzmxqtSLu293GjCTA==",
+      "version": "6.1.82",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.82.tgz",
+      "integrity": "sha512-0u+zRKQwEfLm9TYJQ16S6GFgzuFK/pn95sg0m81IUR7tzD8iDvy2YxSPR8Ycsu718tfhu+Lbn9BU8dlaTYjXUA==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^6.1.79"
+        "tldts-core": "^6.1.82"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^12.12.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.2.2",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.23.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.24.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.4.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1739774089"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1209564665484120/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass