### PR TITLE
Don't update privacy shield animation if unchanged

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -69,6 +69,7 @@ import com.duckduckgo.app.browser.omnibar.model.OmnibarPosition
 import com.duckduckgo.app.browser.viewstate.LoadingViewState
 import com.duckduckgo.app.browser.viewstate.OmnibarViewState
 import com.duckduckgo.app.global.model.PrivacyShield
+import com.duckduckgo.app.global.view.renderIfChanged
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.trackerdetection.model.Entity
 import com.duckduckgo.common.ui.DuckDuckGoActivity
@@ -231,6 +232,8 @@ open class OmnibarLayout @JvmOverloads constructor(
 
     private val conflatedStateJob = ConflatedJob()
     private val conflatedCommandJob = ConflatedJob()
+
+    private var lastSeenPrivacyShield: PrivacyShield? = null
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
@@ -637,13 +640,16 @@ open class OmnibarLayout @JvmOverloads constructor(
         privacyShield: PrivacyShield,
         viewMode: ViewMode,
     ) {
-        val shieldIcon = if (viewMode is ViewMode.Browser) {
-            shieldIcon
-        } else {
-            customTabToolbarContainer.customTabShieldIcon
-        }
+        renderIfChanged(privacyShield, lastSeenPrivacyShield) {
+            lastSeenPrivacyShield = privacyShield
+            val shieldIcon = if (viewMode is ViewMode.Browser) {
+                shieldIcon
+            } else {
+                customTabToolbarContainer.customTabShieldIcon
+            }
 
-        privacyShieldView.setAnimationView(shieldIcon, privacyShield)
+            privacyShieldView.setAnimationView(shieldIcon, privacyShield)
+        }
     }
 
     private fun renderOutline(enabled: Boolean) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1142021229838617/1209560036159812 

### Description
Fix privacy shield flickering by not updating the animation if unchanged

### Steps to test this PR

_Feature 1_
- Smoke test privacy shield in both MSP and regular sites. The icon shouldn't flicker with the same status


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209567544947320