### PR TITLE
Do not render privacy shield if not shown

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -62,6 +62,8 @@ import com.duckduckgo.app.browser.omnibar.OmnibarLayout.Decoration.Outline
 import com.duckduckgo.app.browser.omnibar.OmnibarLayout.Decoration.PrivacyShieldChanged
 import com.duckduckgo.app.browser.omnibar.OmnibarLayoutViewModel.Command.CancelTrackersAnimation
 import com.duckduckgo.app.browser.omnibar.OmnibarLayoutViewModel.Command.StartTrackersAnimation
+import com.duckduckgo.app.browser.omnibar.OmnibarLayoutViewModel.LeadingIconState
+import com.duckduckgo.app.browser.omnibar.OmnibarLayoutViewModel.LeadingIconState.PRIVACY_SHIELD
 import com.duckduckgo.app.browser.omnibar.OmnibarLayoutViewModel.ViewState
 import com.duckduckgo.app.browser.omnibar.animations.BrowserTrackersAnimatorHelper
 import com.duckduckgo.app.browser.omnibar.animations.PrivacyShieldAnimationHelper
@@ -399,7 +401,11 @@ open class OmnibarLayout @JvmOverloads constructor(
             }
         }
 
-        renderPrivacyShield(viewState.privacyShield, viewState.viewMode)
+        if (viewState.leadingIconState == PRIVACY_SHIELD) {
+            renderPrivacyShield(viewState.privacyShield, viewState.viewMode)
+        } else {
+            lastSeenPrivacyShield = null
+        }
         renderButtons(viewState)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1209571266884765

### Description
Don't call renderPrivacyIcon if another leadingIcon is being shown. Otherwise, lastSeenPrivacyShield might contain inaccurate data of a state that was never displayed, leading to inconsistent UI

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
