### PR TITLE
Update reference tests to version 1741119402

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.2.2",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.24.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.4.0",
-        "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1739774089"
+        "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1741119402"
       },
       "devDependencies": {
         "@rollup/plugin-json": "^4.1.0",
@@ -84,7 +84,7 @@
       }
     },
     "node_modules/@duckduckgo/privacy-reference-tests": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#658c8a694724c01fee523c9f586a5e5a56637d6f",
+      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#26641401de2b308e792b61c2d3a68d824ec959a2",
       "license": "Apache-2.0"
     },
     "node_modules/@ghostery/adblocker": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.2.2",
     "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.24.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.4.0",
-    "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1739774089"
+    "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1741119402"
   }
 }


### PR DESCRIPTION
- Automated reference tests dependency update

This PR updates the reference tests dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/0/1203766026095653/f for further information on what to do next.

- [ ] All tests must pass