### PR TITLE
Splashscreen Animation: Add error pixel params

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/launch/LaunchBridgeActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/launch/LaunchBridgeActivity.kt
@@ -16,6 +16,8 @@
 
 package com.duckduckgo.app.launch
 
+import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Bundle
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.lifecycleScope
@@ -43,7 +45,7 @@ class LaunchBridgeActivity : DuckDuckGoActivity() {
 
         configureObservers()
 
-        viewModel.launchSplashScreenFailToExitJob()
+        viewModel.launchSplashScreenFailToExitJob(getLauncherPackageName())
 
         splashScreen.setOnExitAnimationListener { splashScreenView ->
             viewModel.cancelSplashScreenFailToExitJob()
@@ -90,5 +92,13 @@ class LaunchBridgeActivity : DuckDuckGoActivity() {
         startActivity(BrowserActivity.intent(this))
         overridePendingTransition(0, 0)
         finish()
+    }
+
+    // Temporary to track splashscreen errors
+    private fun getLauncherPackageName(): String? {
+        val intent = Intent(Intent.ACTION_MAIN)
+        intent.addCategory(Intent.CATEGORY_HOME)
+        val resolveInfo = packageManager.resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY)
+        return resolveInfo?.activityInfo?.packageName
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/launch/LaunchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/launch/LaunchViewModel.kt
@@ -67,12 +67,12 @@ class LaunchViewModel @Inject constructor(
         }
     }
 
-    fun launchSplashScreenFailToExitJob() {
+    fun launchSplashScreenFailToExitJob(launcherPackageName: String?) {
         splashScreenFailToExitJob = viewModelScope.launch {
             delay(1.5.seconds)
             sendWelcomeScreenPixel()
             determineViewToShow()
-            pixel.fire(SPLASHSCREEN_FAILED_TO_LAUNCH)
+            sendSplashScreenFailedToLaunchPixel(launcherPackageName)
         }
     }
 
@@ -89,5 +89,15 @@ class LaunchViewModel @Inject constructor(
         }
 
         Timber.d("Waited ${System.currentTimeMillis() - startTime}ms for referrer")
+    }
+
+    // Temporary to track splashscreen errors
+    private fun sendSplashScreenFailedToLaunchPixel(launcherPackageName: String?) {
+        val resolvedLauncherPackageName = launcherPackageName ?: "unknown"
+        val params = mapOf(
+            "launcherPackageName" to resolvedLauncherPackageName,
+            "api" to android.os.Build.VERSION.SDK_INT.toString(),
+        )
+        pixel.fire(pixel = SPLASHSCREEN_FAILED_TO_LAUNCH, parameters = params)
     }
 }

--- a/app/src/test/java/com/duckduckgo/fakes/FakePixel.kt
+++ b/app/src/test/java/com/duckduckgo/fakes/FakePixel.kt
@@ -22,7 +22,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel.PixelType
 
 internal class FakePixel : Pixel {
 
-    val firedPixels = mutableListOf<String>()
+    val firedPixels = mutableMapOf<String, Map<String, String>>()
 
     override fun fire(
         pixel: PixelName,
@@ -30,7 +30,7 @@ internal class FakePixel : Pixel {
         encodedParameters: Map<String, String>,
         type: PixelType,
     ) {
-        firedPixels.add(pixel.pixelName)
+        firedPixels[pixel.pixelName] = parameters
     }
 
     override fun fire(
@@ -39,7 +39,7 @@ internal class FakePixel : Pixel {
         encodedParameters: Map<String, String>,
         type: PixelType,
     ) {
-        firedPixels.add(pixelName)
+        firedPixels[pixelName] = parameters
     }
 
     override fun enqueueFire(
@@ -47,7 +47,7 @@ internal class FakePixel : Pixel {
         parameters: Map<String, String>,
         encodedParameters: Map<String, String>,
     ) {
-        firedPixels.add(pixel.pixelName)
+        firedPixels[pixel.pixelName] = parameters
     }
 
     override fun enqueueFire(
@@ -55,6 +55,6 @@ internal class FakePixel : Pixel {
         parameters: Map<String, String>,
         encodedParameters: Map<String, String>,
     ) {
-        firedPixels.add(pixelName)
+        firedPixels[pixelName] = parameters
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1209572281087336

### Description
Added temporary pixel parameters to the splash screen failed to launch pixel to help diagnose splash screen issues.

### Steps to test this PR

_Splash Screen Pixel Params_
- [x] Launch the app on Android 12L (32) using Android Studio and verify it opens normally. As we know there's a bug launching from Android Studio you should NOT see the splashscreen logo.
- [x] Check logcat for `m_splashscreen_failed_to_launch` pixel and check it includes "launcherPackageName" and "api" parameters
- [x] Verify the launcher package name matches your device's default launcher
- [x] Verify the API level matches your device's Android version

### UI changes
No UI changes