### PR TITLE
Update reference tests to version 1741215780

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.2.2",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.25.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.4.0",
-        "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1741119402"
+        "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1741215780"
       },
       "devDependencies": {
         "@rollup/plugin-json": "^4.1.0",
@@ -84,7 +84,7 @@
       }
     },
     "node_modules/@duckduckgo/privacy-reference-tests": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#26641401de2b308e792b61c2d3a68d824ec959a2",
+      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#49a9f735391a35c6d1bebd88c77035ea4a81a346",
       "license": "Apache-2.0"
     },
     "node_modules/@ghostery/adblocker": {
@@ -303,9 +303,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -670,18 +670,18 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.82",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.82.tgz",
-      "integrity": "sha512-Jabl32m21tt/d/PbDO88R43F8aY98Piiz6BVH9ShUlOAiiAELhEqwrAmBocjAqnCfoUeIsRU+h3IEzZd318F3w==",
+      "version": "6.1.83",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.83.tgz",
+      "integrity": "sha512-I2wb9OJc6rXyh9d4aInhSNWChNI+ra6qDnFEGEwe9OoA68lE4Temw29bOkf1Uvwt8VZS079t1BFZdXVBmmB4dw==",
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "6.1.82",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.82.tgz",
-      "integrity": "sha512-0u+zRKQwEfLm9TYJQ16S6GFgzuFK/pn95sg0m81IUR7tzD8iDvy2YxSPR8Ycsu718tfhu+Lbn9BU8dlaTYjXUA==",
+      "version": "6.1.83",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.83.tgz",
+      "integrity": "sha512-nPNJOsVqQmfGcNW9QK90zKKmNZN2aPZWLnVqTemV7QSqaQai/fxQr9uD81hZazI+62A9BxvMa5i4R2+OLUdbrg==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^6.1.82"
+        "tldts-core": "^6.1.83"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.2.2",
     "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.25.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.4.0",
-    "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1741119402"
+    "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1741215780"
   }
 }


### PR DESCRIPTION
- Automated reference tests dependency update

This PR updates the reference tests dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/0/1203766026095653/f for further information on what to do next.

- [ ] All tests must pass