### PR TITLE
Fix purchase method call in RealSubscriptionsManagerTest

### DIFF
--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
@@ -319,7 +319,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         givenCreateAccountSucceeds()
         val accountExternalId = authDataStore.externalId
 
-        subscriptionsManager.purchase(mock(), planId = "")
+        subscriptionsManager.purchase(activity = mock(), planId = "", offerId = null)
 
         if (authApiV2Enabled) {
             verify(authClient).authorize(any())


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202552961248957/1209584430633449 

### Description
Added `offerId` parameter with null default value to the `purchase` method call in `RealSubscriptionsManagerTest`.

The PR where the test was added: [`d5315e0` (#5608)](https://github.com/duckduckgo/Android/pull/5608/commits/d5315e07a1862157885ca0042a2f8f3d1cd9a252#r1983806357)

### Steps to test this PR

_Purchase Method Testing_
- [x] Verify that existing purchase tests continue to pass

### UI changes
No UI changes in this PR