### PR TITLE
Update content scope scripts to version 7.27.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^12.12.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.2.2",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.25.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.27.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.4.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1741119402"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#2a79e4959e192ca43ae42c978d63885404309cfd",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#256fb24cda51e1419884524737e18db4c5521058",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -303,9 +303,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -670,18 +670,18 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.82",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.82.tgz",
-      "integrity": "sha512-Jabl32m21tt/d/PbDO88R43F8aY98Piiz6BVH9ShUlOAiiAELhEqwrAmBocjAqnCfoUeIsRU+h3IEzZd318F3w==",
+      "version": "6.1.83",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.83.tgz",
+      "integrity": "sha512-I2wb9OJc6rXyh9d4aInhSNWChNI+ra6qDnFEGEwe9OoA68lE4Temw29bOkf1Uvwt8VZS079t1BFZdXVBmmB4dw==",
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "6.1.82",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.82.tgz",
-      "integrity": "sha512-0u+zRKQwEfLm9TYJQ16S6GFgzuFK/pn95sg0m81IUR7tzD8iDvy2YxSPR8Ycsu718tfhu+Lbn9BU8dlaTYjXUA==",
+      "version": "6.1.83",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.83.tgz",
+      "integrity": "sha512-nPNJOsVqQmfGcNW9QK90zKKmNZN2aPZWLnVqTemV7QSqaQai/fxQr9uD81hZazI+62A9BxvMa5i4R2+OLUdbrg==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^6.1.82"
+        "tldts-core": "^6.1.83"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^12.12.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.2.2",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.25.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.27.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.4.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1741119402"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1209603311550623/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass