### PR TITLE
Fix ship review issues

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -936,6 +936,7 @@ class BrowserTabViewModelTest {
             Feed.PHISHING,
             exempted = false,
             clientSideHit = false,
+            isMainframe = true,
         )
 
         testee.navigationStateChanged(
@@ -953,6 +954,7 @@ class BrowserTabViewModelTest {
             Feed.PHISHING,
             exempted = false,
             clientSideHit = false,
+            isMainframe = true,
         )
         testee.navigationStateChanged(
             buildWebNavigation(originalUrl = "https://www.example.com", currentUrl = "https://www.example.com", title = "title"),

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -3822,9 +3822,19 @@ class BrowserTabFragment :
                 if (isHidden) {
                     return@launch
                 }
+                /*
+                 * Since we introduce a delay on trackers animation, we need to make sure the conditions
+                 * haven't changed between the time trackers animation was emitted, and the time it'll
+                 * be started
+                 */
                 val privacyProtectionsPopupVisible = lastSeenBrowserViewState
                     ?.privacyProtectionsPopupViewState is PrivacyProtectionsPopupViewState.Visible
-                if (lastSeenOmnibarViewState?.isEditing != true && !privacyProtectionsPopupVisible) {
+                if (
+                    lastSeenOmnibarViewState?.isEditing != true &&
+                    !privacyProtectionsPopupVisible &&
+                    lastSeenBrowserViewState?.browserShowing == true &&
+                    lastSeenBrowserViewState?.maliciousSiteBlocked == false
+                ) {
                     val site = viewModel.siteLiveData.value
                     val events = site?.orderedTrackerBlockedEntities()
                     activity?.let { activity ->

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1389,6 +1389,8 @@ class BrowserTabFragment :
     private fun showMaliciousWarning(
         siteUrl: Uri,
         feed: Feed,
+        clientSideHit: Boolean,
+        isMainframe: Boolean,
         onMaliciousWarningShown: (errorNavigationState: ErrorNavigationState) -> Unit,
     ) {
         webViewContainer.gone()
@@ -1411,16 +1413,28 @@ class BrowserTabFragment :
         maliciousWarningView.show()
         binding.focusDummy.requestFocus()
         val navigationList = webView?.safeCopyBackForwardList() ?: return
-        onMaliciousWarningShown(ErrorNavigationState(navigationList, maliciousSiteUrl = siteUrl, SITE_SECURITY_WARNING))
+        onMaliciousWarningShown(
+            ErrorNavigationState(
+                navigationList,
+                maliciousSiteUrl = siteUrl,
+                SITE_SECURITY_WARNING,
+                clientSideHit = clientSideHit,
+                isMainframe = isMainframe,
+            ),
+        )
     }
 
-    private fun hideMaliciousWarning() {
+    private fun hideMaliciousWarning(canGoBack: Boolean) {
         val navList = webView?.safeCopyBackForwardList()
         val currentIndex = navList?.currentIndex ?: 0
 
         if (currentIndex >= 0) {
             viewModel.recoverFromWarningPage(true)
-            refresh()
+            if (webView?.canGoBack() == true && canGoBack) {
+                webView?.goBack()
+            } else {
+                refresh()
+            }
         } else {
             Timber.d("MaliciousSite: no previous page to load, showing home")
             viewModel.recoverFromWarningPage(false)
@@ -1815,8 +1829,14 @@ class BrowserTabFragment :
             )
 
             is Command.WebViewError -> showError(it.errorType, it.url)
-            is Command.ShowWarningMaliciousSite -> showMaliciousWarning(it.siteUrl, it.feed, it.onMaliciousWarningShown)
-            is Command.HideWarningMaliciousSite -> hideMaliciousWarning()
+            is Command.ShowWarningMaliciousSite -> showMaliciousWarning(
+                it.siteUrl,
+                it.feed,
+                it.clientSideHit,
+                it.isMainFrame,
+                it.onMaliciousWarningShown,
+            )
+            is Command.HideWarningMaliciousSite -> hideMaliciousWarning(it.canGoBack)
             is Command.EscapeMaliciousSite -> onEscapeMaliciousSite()
             is Command.CloseCustomTab -> closeCustomTab()
             is Command.BypassMaliciousSiteWarning -> onBypassMaliciousWarning(it.url, it.feed)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -3309,11 +3309,11 @@ class BrowserTabViewModel @Inject constructor(
         if (!exempted) {
             if (currentBrowserViewState().maliciousSiteBlocked && previousSite?.url == url.toString()) {
                 Timber.tag("Cris").d("maliciousSiteBlocked already shown for $url, previousSite: ${previousSite.url}")
-                return
+            } else {
+                val params = mapOf(CATEGORY_KEY to feed.name.lowercase(), CLIENT_SIDE_HIT_KEY to clientSideHit.toString())
+                pixel.fire(AppPixelName.MALICIOUS_SITE_PROTECTION_ERROR_SHOWN, params)
             }
             Timber.d("Received MaliciousSiteWarning for $url, feed: $feed, exempted: false, clientSideHit: $clientSideHit")
-            val params = mapOf(CATEGORY_KEY to feed.name.lowercase(), CLIENT_SIDE_HIT_KEY to clientSideHit.toString())
-            pixel.fire(AppPixelName.MALICIOUS_SITE_PROTECTION_ERROR_SHOWN, params)
 
             viewModelScope.launch(dispatchers.main()) {
                 loadingViewState.value =

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1324,7 +1324,7 @@ class BrowserTabViewModel @Inject constructor(
         }
 
         if (currentBrowserViewState().maliciousSiteBlocked) {
-            command.postValue(HideWarningMaliciousSite)
+            command.postValue(HideWarningMaliciousSite(navigation.canGoBack))
             return true
         }
 
@@ -3289,6 +3289,7 @@ class BrowserTabViewModel @Inject constructor(
         feed: Feed,
         exempted: Boolean,
         clientSideHit: Boolean,
+        isMainframe: Boolean,
     ) {
         val previousSite = site
 
@@ -3333,7 +3334,7 @@ class BrowserTabViewModel @Inject constructor(
                     )
 
                 command.value =
-                    ShowWarningMaliciousSite(siteUrl, feed) { navigationStateChanged(it) }
+                    ShowWarningMaliciousSite(siteUrl, feed, clientSideHit, isMainframe) { navigationStateChanged(it) }
             }
         } else {
             viewModelScope.launch(dispatchers.main()) {

--- a/app/src/main/java/com/duckduckgo/app/browser/WebNavigationState.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebNavigationState.kt
@@ -169,7 +169,7 @@ data class ErrorNavigationState(
 
     override val stepsToPreviousPage: Int = if (stack.isHttpsUpgrade) 2 else 1
 
-    override val canGoBack: Boolean = stack.currentIndex >= stepsToPreviousPage && ((isMainframe && clientSideHit) || !isMainframe)
+    override val canGoBack: Boolean = stack.currentIndex >= stepsToPreviousPage && (!isMainframe || clientSideHit)
 
     override val canGoForward: Boolean = stack.currentIndex + 1 < stack.size
 

--- a/app/src/main/java/com/duckduckgo/app/browser/WebNavigationState.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebNavigationState.kt
@@ -169,7 +169,7 @@ data class ErrorNavigationState(
 
     override val stepsToPreviousPage: Int = if (stack.isHttpsUpgrade) 2 else 1
 
-    override val canGoBack: Boolean = stack.currentIndex >= stepsToPreviousPage && (!isMainframe || clientSideHit)
+    override val canGoBack: Boolean = stack.currentIndex >= stepsToPreviousPage && !(isMainframe && clientSideHit)
 
     override val canGoForward: Boolean = stack.currentIndex + 1 < stack.size
 

--- a/app/src/main/java/com/duckduckgo/app/browser/WebNavigationState.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebNavigationState.kt
@@ -155,6 +155,8 @@ data class ErrorNavigationState(
     val stack: WebBackForwardList,
     private val maliciousSiteUrl: Uri,
     private val maliciousSiteTitle: String?,
+    private val clientSideHit: Boolean,
+    private val isMainframe: Boolean,
 ) : WebNavigationState {
 
     private val maliciousSiteUrlString: String = maliciousSiteUrl.toString()
@@ -167,7 +169,7 @@ data class ErrorNavigationState(
 
     override val stepsToPreviousPage: Int = if (stack.isHttpsUpgrade) 2 else 1
 
-    override val canGoBack: Boolean = stack.currentIndex >= stepsToPreviousPage
+    override val canGoBack: Boolean = stack.currentIndex >= stepsToPreviousPage && ((isMainframe && clientSideHit) || !isMainframe)
 
     override val canGoForward: Boolean = stack.currentIndex + 1 < stack.size
 

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
@@ -103,6 +103,7 @@ interface WebViewClientListener {
         feed: Feed,
         exempted: Boolean,
         clientSideHit: Boolean,
+        isMainframe: Boolean,
     )
     fun onReceivedMaliciousSiteSafe(
         url: Uri,

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewRequestInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewRequestInterceptor.kt
@@ -224,7 +224,7 @@ class WebViewRequestInterceptor(
                     documentUrl = documentUrl,
                     feed = result.feed,
                     exempted = result.exempted,
-                    clientSideHit = true,
+                    clientSideHit = result.clientSideHit,
                     isForMainFrame = isForMainFrame,
                 )
                 return !result.exempted
@@ -248,7 +248,7 @@ class WebViewRequestInterceptor(
                     documentUrl = documentUrl,
                     feed = isMalicious.feed,
                     exempted = false,
-                    clientSideHit = false,
+                    clientSideHit = true,
                     isForMainFrame = isForMainFrame,
                 )
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewRequestInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewRequestInterceptor.kt
@@ -272,6 +272,7 @@ class WebViewRequestInterceptor(
             feed = feed,
             exempted = exempted,
             clientSideHit = clientSideHit,
+            isMainframe = isForMainFrame,
         )
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewRequestInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewRequestInterceptor.kt
@@ -248,7 +248,7 @@ class WebViewRequestInterceptor(
                     documentUrl = documentUrl,
                     feed = isMalicious.feed,
                     exempted = false,
-                    clientSideHit = true,
+                    clientSideHit = false,
                     isForMainFrame = isForMainFrame,
                 )
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
@@ -222,10 +222,14 @@ sealed class Command {
     data class ShowWarningMaliciousSite(
         val siteUrl: Uri,
         val feed: Feed,
+        val clientSideHit: Boolean,
+        val isMainFrame: Boolean,
         val onMaliciousWarningShown: (errorNavigationState: ErrorNavigationState) -> Unit,
     ) : Command()
 
-    data object HideWarningMaliciousSite : Command()
+    data class HideWarningMaliciousSite(
+        val canGoBack: Boolean,
+    ) : Command()
 
     data object EscapeMaliciousSite : Command()
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -153,6 +153,7 @@ open class OmnibarLayout @JvmOverloads constructor(
     private var omnibarItemPressedListener: Omnibar.ItemPressedListener? = null
 
     private var decoration: Decoration? = null
+    private var lastViewMode: Mode? = null
     private var stateBuffer: MutableList<StateChange> = mutableListOf()
 
     internal val findInPage by lazy { IncludeFindInPageBinding.bind(findViewById(R.id.findInPage)) }
@@ -252,6 +253,11 @@ open class OmnibarLayout @JvmOverloads constructor(
             viewModel.commands().flowWithLifecycle(lifecycleOwner.lifecycle).collectLatest {
                 processCommand(it)
             }
+        }
+
+        if (lastViewMode != null) {
+            decorateDeferred(lastViewMode!!)
+            lastViewMode = null
         }
 
         if (decoration != null) {
@@ -530,8 +536,13 @@ open class OmnibarLayout @JvmOverloads constructor(
         if (isAttachedToWindow) {
             decorateDeferred(decoration)
         } else {
-            if (this.decoration == null) {
-                Timber.d("Omnibar: decorate not attached saving $decoration")
+            /* TODO (cbarreiro): This is a temporary solution to prevent one-time decorations causing mode to be lost when view is not attached
+             *  As a long-term solution, we should move mode to StateChange, and only have one-time decorations here
+             */
+            if (decoration is Mode) {
+                lastViewMode = decoration
+                this.decoration = null
+            } else if (this.decoration == null) {
                 this.decoration = decoration
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/webview/MaliciousSiteBlockerWebViewIntegration.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/webview/MaliciousSiteBlockerWebViewIntegration.kt
@@ -131,6 +131,11 @@ class RealMaliciousSiteBlockerWebViewIntegration @Inject constructor(
         data class Safe(val isForMainFrame: Boolean) : IsMaliciousViewData()
         data object WaitForConfirmation : IsMaliciousViewData()
         data object Ignored : IsMaliciousViewData()
+
+        /**
+         * @param exempted true if the site was exempted from blocking by the user
+         * @param clientSideHit true if the site was blocked entirely by the client side
+         */
         data class MaliciousSite(val url: Uri, val feed: Feed, val exempted: Boolean, val clientSideHit: Boolean) : IsMaliciousViewData()
     }
 
@@ -160,13 +165,13 @@ class RealMaliciousSiteBlockerWebViewIntegration @Inject constructor(
             }
             when (result) {
                 is ConfirmedResult -> {
-                    processedUrls[url] = ProcessedUrlStatus(result.status, clientSideHit = false)
+                    processedUrls[url] = ProcessedUrlStatus(result.status, clientSideHit = true)
                     when (val status = result.status) {
                         is Malicious -> {
                             if (isForIframe) {
                                 firePixelForMaliciousIframe(status.feed)
                             }
-                            return IsMaliciousViewData.MaliciousSite(url, status.feed, exempted = false, clientSideHit = false)
+                            return IsMaliciousViewData.MaliciousSite(url, status.feed, exempted = false, clientSideHit = true)
                         }
 
                         is Safe -> {
@@ -194,7 +199,7 @@ class RealMaliciousSiteBlockerWebViewIntegration @Inject constructor(
 
         if (exemptedUrl != null) {
             Timber.d("Previously exempted, skipping $requestUrl as ${exemptedUrl.feed}")
-            return IsMaliciousViewData.MaliciousSite(requestUrl, exemptedUrl.feed, true, clientSideHit = false)
+            return IsMaliciousViewData.MaliciousSite(requestUrl, exemptedUrl.feed, true, clientSideHit = true)
         }
 
         processedUrls[requestUrl]?.let {
@@ -226,10 +231,10 @@ class RealMaliciousSiteBlockerWebViewIntegration @Inject constructor(
                 when (val result = checkMaliciousUrl(url, confirmationCallback)) {
                     is ConfirmedResult -> {
                         val status = result.status
-                        processedUrls[url] = ProcessedUrlStatus(status, clientSideHit = false)
+                        processedUrls[url] = ProcessedUrlStatus(status, clientSideHit = true)
                         when (status) {
                             is Malicious -> {
-                                return@runBlocking IsMaliciousViewData.MaliciousSite(url, status.feed, exempted = false, clientSideHit = false)
+                                return@runBlocking IsMaliciousViewData.MaliciousSite(url, status.feed, exempted = false, clientSideHit = true)
                             }
                             is Safe -> {
                                 return@runBlocking IsMaliciousViewData.Safe(true)
@@ -261,7 +266,7 @@ class RealMaliciousSiteBlockerWebViewIntegration @Inject constructor(
             } else {
                 Safe
             }
-            processedUrls[url] = ProcessedUrlStatus(it, clientSideHit = true)
+            processedUrls[url] = ProcessedUrlStatus(it, clientSideHit = false)
             confirmationCallback(isMalicious)
         }
     }

--- a/app/src/test/java/com/duckduckgo/app/browser/ErrorNavigationStateTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/ErrorNavigationStateTest.kt
@@ -11,10 +11,10 @@ import org.junit.runner.RunWith
 class ErrorNavigationStateTest {
 
     @Test
-    fun whenStackContainsBackItemsAndErrorNavigationStateWithClientSideHitAndMainFrame_canGoBack_returnsTrue() {
+    fun whenStackContainsBackItemsAndErrorNavigationStateWithClientSideHitAndMainFrame_canGoBack_returnsFalse() {
         val testee = createErrorNavigationState(clientSideHit = true, isMainframe = true)
 
-        assertTrue(testee.canGoBack)
+        assertFalse(testee.canGoBack)
     }
 
     @Test
@@ -25,10 +25,10 @@ class ErrorNavigationStateTest {
     }
 
     @Test
-    fun whenStackContainsBackItemsAndErrorNavigationStateWithClientSideHitFalseAndMainFrame_canGoBack_returnsFalse() {
+    fun whenStackContainsBackItemsAndErrorNavigationStateWithClientSideHitFalseAndMainFrame_canGoBack_returnsTrue() {
         val testee = createErrorNavigationState(clientSideHit = false, isMainframe = true)
 
-        assertFalse(testee.canGoBack)
+        assertTrue(testee.canGoBack)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/ErrorNavigationStateTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/ErrorNavigationStateTest.kt
@@ -1,0 +1,55 @@
+package com.duckduckgo.app.browser
+
+import androidx.core.net.toUri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ErrorNavigationStateTest {
+
+    @Test
+    fun whenStackContainsBackItemsAndErrorNavigationStateWithClientSideHitAndMainFrame_canGoBack_returnsTrue() {
+        val testee = createErrorNavigationState(clientSideHit = true, isMainframe = true)
+
+        assertTrue(testee.canGoBack)
+    }
+
+    @Test
+    fun whenStackContainsBackItemsAndErrorNavigationStateWithClientSideHitAndMainFrameFalse_canGoBack_returnsFalse() {
+        val testee = createErrorNavigationState(clientSideHit = true, isMainframe = false)
+
+        assertTrue(testee.canGoBack)
+    }
+
+    @Test
+    fun whenStackContainsBackItemsAndErrorNavigationStateWithClientSideHitFalseAndMainFrame_canGoBack_returnsFalse() {
+        val testee = createErrorNavigationState(clientSideHit = false, isMainframe = true)
+
+        assertFalse(testee.canGoBack)
+    }
+
+    @Test
+    fun whenStackContainsBackItemsAndErrorNavigationStateWithClientSideHitFalseAndMainFrameFalse_canGoBack_returnsTrue() {
+        val testee = createErrorNavigationState(clientSideHit = false, isMainframe = false)
+
+        assertTrue(testee.canGoBack)
+    }
+
+    private fun createErrorNavigationState(clientSideHit: Boolean, isMainframe: Boolean): ErrorNavigationState {
+        val testBackForwardList = TestBackForwardList().apply {
+            addPageToHistory("example.com".toHistoryItem())
+            addPageToHistory("example2.com".toHistoryItem())
+        }
+
+        return ErrorNavigationState(
+            testBackForwardList,
+            "https://malicious.com".toUri(),
+            maliciousSiteTitle = null,
+            clientSideHit = clientSideHit,
+            isMainframe = isMainframe,
+        )
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/browser/TestBackForwardList.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/TestBackForwardList.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser
+
+import android.webkit.WebBackForwardList
+import android.webkit.WebHistoryItem
+
+class TestBackForwardList : WebBackForwardList() {
+
+    private val fakeHistory: MutableList<WebHistoryItem> = mutableListOf()
+    private var fakeCurrentIndex = -1
+
+    fun addPageToHistory(webHistoryItem: WebHistoryItem) {
+        fakeHistory.add(webHistoryItem)
+        fakeCurrentIndex++
+    }
+
+    override fun getSize() = fakeHistory.size
+
+    override fun getItemAtIndex(index: Int): WebHistoryItem = fakeHistory[index]
+
+    override fun getCurrentItem(): WebHistoryItem? = null
+
+    override fun getCurrentIndex(): Int = fakeCurrentIndex
+
+    override fun clone(): WebBackForwardList = throw NotImplementedError()
+}

--- a/app/src/test/java/com/duckduckgo/app/browser/TestHistoryItem.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/TestHistoryItem.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser
+
+import android.graphics.Bitmap
+import android.webkit.WebHistoryItem
+
+class TestHistoryItem(
+    private val url: String,
+) : WebHistoryItem() {
+
+    override fun getUrl(): String = url
+
+    override fun getOriginalUrl(): String = url
+
+    override fun getTitle(): String = url
+
+    override fun getFavicon(): Bitmap = throw NotImplementedError()
+
+    override fun clone(): WebHistoryItem = throw NotImplementedError()
+}
+
+fun String.toHistoryItem(): WebHistoryItem {
+    return TestHistoryItem(this)
+}

--- a/app/src/test/java/com/duckduckgo/app/browser/WebViewNavigationStateTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/WebViewNavigationStateTest.kt
@@ -16,9 +16,7 @@
 
 package com.duckduckgo.app.browser
 
-import android.graphics.Bitmap
 import android.webkit.WebBackForwardList
-import android.webkit.WebHistoryItem
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -57,44 +55,4 @@ class WebViewNavigationStateTest {
     private fun webViewState(stack: WebBackForwardList): WebViewNavigationState {
         return WebViewNavigationState(stack = stack, progress = null)
     }
-
-    private fun String.toHistoryItem(): WebHistoryItem {
-        return TestHistoryItem(this)
-    }
-}
-
-private class TestBackForwardList : WebBackForwardList() {
-
-    private val fakeHistory: MutableList<WebHistoryItem> = mutableListOf()
-    private var fakeCurrentIndex = -1
-
-    fun addPageToHistory(webHistoryItem: WebHistoryItem) {
-        fakeHistory.add(webHistoryItem)
-        fakeCurrentIndex++
-    }
-
-    override fun getSize() = fakeHistory.size
-
-    override fun getItemAtIndex(index: Int): WebHistoryItem = fakeHistory[index]
-
-    override fun getCurrentItem(): WebHistoryItem? = null
-
-    override fun getCurrentIndex(): Int = fakeCurrentIndex
-
-    override fun clone(): WebBackForwardList = throw NotImplementedError()
-}
-
-private class TestHistoryItem(
-    private val url: String,
-) : WebHistoryItem() {
-
-    override fun getUrl(): String = url
-
-    override fun getOriginalUrl(): String = url
-
-    override fun getTitle(): String = url
-
-    override fun getFavicon(): Bitmap = throw NotImplementedError()
-
-    override fun clone(): WebHistoryItem = throw NotImplementedError()
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/webview/RealMaliciousSiteBlockerWebViewIntegrationTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/webview/RealMaliciousSiteBlockerWebViewIntegrationTest.kt
@@ -132,7 +132,7 @@ class RealMaliciousSiteBlockerWebViewIntegrationTest {
         whenever(maliciousSiteProtection.isMalicious(any(), any())).thenReturn(ConfirmedResult(Malicious(MALWARE)))
 
         val result = testee.shouldIntercept(request, maliciousUri) {}
-        assertEquals(MaliciousSite(maliciousUri, MALWARE, exempted = false, clientSideHit = false), result)
+        assertEquals(MaliciousSite(maliciousUri, MALWARE, exempted = false, clientSideHit = true), result)
     }
 
     @Test
@@ -171,7 +171,7 @@ class RealMaliciousSiteBlockerWebViewIntegrationTest {
 
         val result = testee.shouldIntercept(request, maliciousUri) {}
         verify(mockPixel).fire(AppPixelName.MALICIOUS_SITE_DETECTED_IN_IFRAME, mapOf("category" to MALWARE.name.lowercase()))
-        assertEquals(MaliciousSite(maliciousUri, MALWARE, exempted = false, clientSideHit = false), result)
+        assertEquals(MaliciousSite(maliciousUri, MALWARE, exempted = false, clientSideHit = true), result)
     }
 
     @Test
@@ -198,7 +198,7 @@ class RealMaliciousSiteBlockerWebViewIntegrationTest {
         whenever(maliciousSiteProtection.isMalicious(any(), any())).thenReturn(ConfirmedResult(Malicious(MALWARE)))
 
         val result = testee.shouldOverrideUrlLoading(maliciousUri, true) {}
-        assertEquals(MaliciousSite(maliciousUri, MALWARE, exempted = false, clientSideHit = false), result)
+        assertEquals(MaliciousSite(maliciousUri, MALWARE, exempted = false, clientSideHit = true), result)
     }
 
     @Test
@@ -331,7 +331,7 @@ class RealMaliciousSiteBlockerWebViewIntegrationTest {
         whenever(mockExemptedUrlsHolder.exemptedMaliciousUrls).thenReturn(setOf(ExemptedUrl(maliciousUri, MALWARE)))
 
         val result = testee.shouldIntercept(request, maliciousUri) {}
-        assertEquals(MaliciousSite(maliciousUri, MALWARE, exempted = true, clientSideHit = false), result)
+        assertEquals(MaliciousSite(maliciousUri, MALWARE, exempted = true, clientSideHit = true), result)
     }
 
     @Test
@@ -340,7 +340,7 @@ class RealMaliciousSiteBlockerWebViewIntegrationTest {
         whenever(mockExemptedUrlsHolder.exemptedMaliciousUrls).thenReturn(setOf(ExemptedUrl(maliciousUri, MALWARE)))
 
         val result = testee.shouldOverrideUrlLoading(maliciousUri, true) {}
-        assertEquals(MaliciousSite(maliciousUri, MALWARE, exempted = true, clientSideHit = false), result)
+        assertEquals(MaliciousSite(maliciousUri, MALWARE, exempted = true, clientSideHit = true), result)
     }
 
     @Test
@@ -352,13 +352,13 @@ class RealMaliciousSiteBlockerWebViewIntegrationTest {
         whenever(maliciousSiteProtection.isMalicious(any(), any())).thenReturn(ConfirmedResult(Malicious(MALWARE)))
 
         val result = testee.shouldIntercept(request, maliciousUri) {}
-        assertEquals(MaliciousSite(maliciousUri, MALWARE, exempted = false, clientSideHit = false), result)
+        assertEquals(MaliciousSite(maliciousUri, MALWARE, exempted = false, clientSideHit = true), result)
 
         val result2 = testee.shouldIntercept(request, maliciousUri) {}
         verify(mockPixel, times(1)).fire(AppPixelName.MALICIOUS_SITE_DETECTED_IN_IFRAME, mapOf("category" to MALWARE.name.lowercase()))
         verify(maliciousSiteProtection, times(1)).isMalicious(eq(maliciousUri), any())
 
-        assertEquals(MaliciousSite(maliciousUri, MALWARE, exempted = false, clientSideHit = false), result2)
+        assertEquals(MaliciousSite(maliciousUri, MALWARE, exempted = false, clientSideHit = true), result2)
     }
 
     private fun updateFeatureEnabled(enabled: Boolean) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1142021229838617/task/1209533874972459

Includes: 
* [Better handling of back navigation](https://app.asana.com/0/0/1209599023979002/f)
* [Fix shield icon shown on race condition after starting trackers animation](https://app.asana.com/0/0/1209599023979004/f)
* [Fix shield icon sometimes being shown after closing and reopening the app](https://app.asana.com/0/0/1209599023979006/f)

### Description
* Fix back navigation issues: Allow back navigation if iframe blocked, or mainframe blocked from client
* Fix wrong omnibar icon shown when closing and reopening the app with error tab inactive
* Fix error page not shown for popup with blank target

### Steps to test this PR

_Test 1_
- Open https://privacy-test-pages.site/security/badware/phishing-popups.html
- Tap on Open Phishing Popup (_blank)
- Check error page is shown, and `m_malicious-site-protection_error-page-shown` is only fired once

**[Better handling of back navigation](https://app.asana.com/0/0/1209599023979002/f)**
_Test 1_
- [x] Load https://privacy-test-pages.site/security/badware/
- [x] Open [Standard Phishing Test](https://broken.third-party.site/security/badware/phishing.html)
- [x] Navigate back from error page
- [x] Check https://privacy-test-pages.site/security/badware/ is shown

_Test 2_
- [x] Load https://privacy-test-pages.site/security/badware/
- [x] Open [Phishing iFrame Loader](https://broken.third-party.site/security/badware/phishing-iframe-loader.html)
- [x] Navigate back from error page
- [x] Check https://privacy-test-pages.site/security/badware/ is shown

_Test 3_
- [x] Load https://privacy-test-pages.site/security/badware/
- [x] Open [Phishing JS Redirector (Direct)](https://privacy-test-pages.site/security/badware/phishing-js-redirector-helper.html)
- [x] Navigate back from error page
- [x] Check https://privacy-test-pages.site/security/badware/ is shown



> [!NOTE]  
> These issues are caused by race conditions, so testing several times is advised

**[Fix shield icon shown on race condition after starting trackers animation](https://app.asana.com/0/0/1209599023979004/f)**
_Test 1_
- [x] Load https://privacy-test-pages.site/security/badware/
Navigate to https://privacy-test-pages.site/security/badware/phishing-iframe-loader.html. Since this page contains a malicious iframe, it will be loaded normally, and blocked later, once the iframe starts to load
- [x] Check shield icon not visible in error page

**[Fix shield icon sometimes being shown after closing and reopening the app](https://app.asana.com/0/0/1209599023979006/f)**
_Test 1_
- [x] Open https://privacy-test-pages.site/security/badware/
- [x] Navigate to https://privacy-test-pages.site/security/badware/phishing-iframe-loader.html
- [x] Once the error page is shown, open a new tab and load [wikipedia.org](https://wikipedia.org/)
- [x] While on the wikipedia tab, close and kill the app
- [x] Reopen the app, and wait for wikipedia to load
- [x] Switch to the previous tab
- [x] Check globe icon is shown



### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
