### PR TITLE
Update content scope scripts to version 7.28.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^12.13.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.2.2",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.27.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.28.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.4.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1741215780"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#256fb24cda51e1419884524737e18db4c5521058",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#ea3612664bed6bf2f4660258608a9a418ec71bdd",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -283,9 +283,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.9.tgz",
-      "integrity": "sha512-acBjXdRJ3A6Pb3tqnw9HZmyR3Fiol3aGxRCK1x3d+6CDAMjl7I649wpSd+yNURCjbOUGu9tqtLKnTGxmK6CyGw==",
+      "version": "22.13.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
+      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^12.13.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#16.2.2",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.27.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.28.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.4.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1741215780"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1209620190947490/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [x] All tests must pass