### PR TITLE
Use specialized VpnRemoteWorkerService

### DIFF
--- a/app-tracking-protection/vpn-api/build.gradle
+++ b/app-tracking-protection/vpn-api/build.gradle
@@ -26,8 +26,6 @@ dependencies {
 
     implementation AndroidX.core.ktx
     implementation KotlinX.coroutines.core
-    // WorkManager
-    implementation "androidx.work:work-multiprocess:_"
 
     testImplementation project(':vpn-api-test')
     androidTestImplementation project(':vpn-api-test')

--- a/app-tracking-protection/vpn-api/src/main/AndroidManifest.xml
+++ b/app-tracking-protection/vpn-api/src/main/AndroidManifest.xml
@@ -15,12 +15,4 @@
   -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <application>
-        <!-- This is the Worker Service where VPN workers need to bind into -->
-        <service
-                android:name="androidx.work.multiprocess.RemoteWorkerService"
-                android:exported="false"
-                android:process=":vpn" />
-    </application>
 </manifest>

--- a/app-tracking-protection/vpn-impl/build.gradle
+++ b/app-tracking-protection/vpn-impl/build.gradle
@@ -78,6 +78,9 @@ dependencies {
     implementation AndroidX.lifecycle.commonJava8
     implementation AndroidX.lifecycle.liveDataKtx
 
+    // WorkManager
+    implementation "androidx.work:work-multiprocess:_"
+
     implementation "androidx.viewpager2:viewpager2:_"
 
     // multi-process shared preferences

--- a/app-tracking-protection/vpn-impl/src/main/AndroidManifest.xml
+++ b/app-tracking-protection/vpn-impl/src/main/AndroidManifest.xml
@@ -11,10 +11,16 @@
         android:largeHeap="true"
         android:theme="@style/Theme.DuckDuckGo.Light">
 
+        <!-- This is the Worker Service where VPN workers need to bind into -->
+        <service
+                android:name=".worker.VpnRemoteWorkerService"
+                android:exported="false"
+                android:process=":vpn" />
+
         <activity
-            android:name=".service.VpnPermissionRequesterActivity"
-            android:exported="false"
-            android:screenOrientation="portrait" />
+                android:name=".service.VpnPermissionRequesterActivity"
+                android:exported="false"
+                android:screenOrientation="portrait" />
 
         <activity
             android:name="com.duckduckgo.mobile.android.vpn.ui.onboarding.VpnOnboardingActivity"

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/health/AppTPCPUMonitor.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/health/AppTPCPUMonitor.kt
@@ -22,9 +22,9 @@ import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.di.scopes.VpnScope
-import com.duckduckgo.mobile.android.vpn.boundToVpnProcess
 import com.duckduckgo.mobile.android.vpn.service.VpnServiceCallbacks
 import com.duckduckgo.mobile.android.vpn.state.VpnStateMonitor.VpnStopReason
+import com.duckduckgo.mobile.android.vpn.worker.boundToVpnProcess
 import com.squareup.anvil.annotations.ContributesMultibinding
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/health/CPUMonitorWorker.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/health/CPUMonitorWorker.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import androidx.work.WorkerParameters
 import androidx.work.multiprocess.RemoteCoroutineWorker
 import com.duckduckgo.anvil.annotations.ContributesWorker
+import com.duckduckgo.app.di.ProcessName
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixels
@@ -43,10 +44,14 @@ class CPUMonitorWorker(
     @Inject
     lateinit var dispatcherProvider: DispatcherProvider
 
+    @Inject @ProcessName
+    lateinit var processName: String
+
     // TODO: move thresholds to remote config
     private val alertThresholds = listOf(30, 20, 10, 5).sortedDescending()
 
     override suspend fun doRemoteWork(): Result {
+        logcat { "CPUMonitorWorker in process $processName" }
         return withContext(dispatcherProvider.io()) {
             try {
                 val avgCPUUsagePercent = cpuUsageReader.readCPUUsage()

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/worker/VpnRemoteWorkerService.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/worker/VpnRemoteWorkerService.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.worker
+
+import androidx.work.multiprocess.RemoteWorkerService
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.app.di.ProcessName
+import com.duckduckgo.di.scopes.VpnScope
+import dagger.android.AndroidInjection
+import javax.inject.Inject
+import logcat.AndroidLogcatLogger
+import logcat.LogPriority.DEBUG
+import logcat.LogcatLogger
+import logcat.logcat
+
+@InjectWith(VpnScope::class)
+class VpnRemoteWorkerService constructor() : RemoteWorkerService() {
+    @Inject
+    @ProcessName
+    lateinit var processName: String
+
+    override fun onCreate() {
+        super.onCreate()
+        AndroidInjection.inject(this)
+        LogcatLogger.install(AndroidLogcatLogger(DEBUG))
+        logcat { "VPN-WORKER: running in process $processName" }
+    }
+}

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/worker/WorkerExtensions.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/worker/WorkerExtensions.kt
@@ -14,19 +14,18 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.mobile.android.vpn
+package com.duckduckgo.mobile.android.vpn.worker
 
 import android.content.ComponentName
 import androidx.work.Data
 import androidx.work.PeriodicWorkRequest
 import androidx.work.multiprocess.RemoteListenableWorker
-import androidx.work.multiprocess.RemoteWorkerService
 
 /**
  * Use this extension function to make sure your [PeriodicWorkRequest] runs in the VPN process
  */
 fun PeriodicWorkRequest.Builder.boundToVpnProcess(applicationId: String): PeriodicWorkRequest.Builder {
-    val componentName = ComponentName(applicationId, RemoteWorkerService::class.java.name)
+    val componentName = ComponentName(applicationId, VpnRemoteWorkerService::class.java.name)
     val data = Data.Builder()
         .putString(RemoteListenableWorker.ARGUMENT_PACKAGE_NAME, componentName.packageName)
         .putString(RemoteListenableWorker.ARGUMENT_CLASS_NAME, componentName.className)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202552961248957/1209631586705997

### Description
Create the specialized VpnRemoteWorkerService to create workers in the VPN process

### Steps to test this PR

_Test_
- [x] Filter logcat by `VPN-WORKER` and `CPUMonitorWorker`
- [x] In `AppTPCPUMonitor` line 49, replace `TimeUnit.MINUTES` by `TimeUnit.SECONDS`
- [x] In `AppTPCPUMonitor` line 52, replace `ExistingPeriodicWorkPolicy.KEEP` by `ExistingPeriodicWorkPolicy.REPLACE`
- [x] build eg. internal debug and install
- [x] launch app and enable VPN
- [x] in 10 seconds `CPUMonitorWorker in process :vpn` and `VPN-WORKER: running in process :vpn` logs should appear
- [x] smoke test VPN
