### PR TITLE
Update content scope scripts to version 7.29.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -415,50 +415,10 @@
         // TBD other platforms
     }
 
-    const baseFeatures = /** @type {const} */ ([
-        'fingerprintingAudio',
-        'fingerprintingBattery',
-        'fingerprintingCanvas',
-        'googleRejected',
-        'gpc',
-        'fingerprintingHardware',
-        'referrer',
-        'fingerprintingScreenSize',
-        'fingerprintingTemporaryStorage',
-        'navigatorInterface',
-        'elementHiding',
-        'exceptionHandler',
-        'apiManipulation',
-    ]);
-
-    const otherFeatures = /** @type {const} */ ([
-        'clickToLoad',
-        'cookie',
-        'messageBridge',
-        'duckPlayer',
-        'harmfulApis',
-        'webCompat',
-        'windowsPermissionUsage',
-        'brokerProtection',
-        'performanceMetrics',
-        'breakageReporting',
-        'autofillPasswordImport',
-    ]);
-
     /** @typedef {baseFeatures[number]|otherFeatures[number]} FeatureName */
     /** @type {Record<string, FeatureName[]>} */
     const platformSupport = {
-        apple: ['webCompat', ...baseFeatures],
-        'apple-isolated': ['duckPlayer', 'brokerProtection', 'performanceMetrics', 'clickToLoad', 'messageBridge'],
-        android: [...baseFeatures, 'webCompat', 'breakageReporting', 'duckPlayer', 'messageBridge'],
-        'android-broker-protection': ['brokerProtection'],
-        'android-autofill-password-import': ['autofillPasswordImport'],
-        windows: ['cookie', ...baseFeatures, 'windowsPermissionUsage', 'duckPlayer', 'brokerProtection', 'breakageReporting'],
-        firefox: ['cookie', ...baseFeatures, 'clickToLoad'],
-        chrome: ['cookie', ...baseFeatures, 'clickToLoad'],
-        'chrome-mv3': ['cookie', ...baseFeatures, 'clickToLoad'],
-        integration: [...baseFeatures, ...otherFeatures],
-    };
+        'android-broker-protection': ['brokerProtection']};
 
     /**
      * Performance monitor, holds reference to PerformanceMark instances.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^12.13.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.28.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.29.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.4.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1741215780"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#ea3612664bed6bf2f4660258608a9a418ec71bdd",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#5c952d2e50d6de15c9bbdee9ca033b209abd752b",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -670,18 +670,18 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.83",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.83.tgz",
-      "integrity": "sha512-I2wb9OJc6rXyh9d4aInhSNWChNI+ra6qDnFEGEwe9OoA68lE4Temw29bOkf1Uvwt8VZS079t1BFZdXVBmmB4dw==",
+      "version": "6.1.84",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.84.tgz",
+      "integrity": "sha512-NaQa1W76W2aCGjXybvnMYzGSM4x8fvG2AN/pla7qxcg0ZHbooOPhA8kctmOZUDfZyhDL27OGNbwAeig8P4p1vg==",
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "6.1.83",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.83.tgz",
-      "integrity": "sha512-nPNJOsVqQmfGcNW9QK90zKKmNZN2aPZWLnVqTemV7QSqaQai/fxQr9uD81hZazI+62A9BxvMa5i4R2+OLUdbrg==",
+      "version": "6.1.84",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-6.1.84.tgz",
+      "integrity": "sha512-ee8K2ooTDAJhhGT0FrPAtkql/k8MM0/3O3RRAJ4C9pjuO1wwFnfRbSY6fYT7h2mFrdcDzb6Kre591UroI+pTNA==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^6.1.83"
+        "tldts-core": "^6.1.84"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^12.13.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.28.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#7.29.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.4.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1741215780"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass