### PR TITLE
Aligning recovery code with connect flow

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
@@ -48,7 +48,6 @@ interface SyncFeature {
     @Toggle.DefaultValue(true)
     fun seamlessAccountSwitching(): Toggle
 
-    @InternalAlwaysEnabled
     @Toggle.DefaultValue(false)
     fun exchangeKeysToSyncWithAnotherDevice(): Toggle
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncService.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncService.kt
@@ -69,6 +69,16 @@ interface SyncService {
         @Path("device_id") deviceId: String,
     ): Call<ConnectKey>
 
+    @GET("$SYNC_PROD_ENVIRONMENT_URL/sync/exchange/{key_id}")
+    fun getEncryptedMessage(
+        @Path("key_id") keyId: String,
+    ): Call<EncryptedMessage>
+
+    @POST("$SYNC_PROD_ENVIRONMENT_URL/sync/exchange")
+    fun sendEncryptedMessage(
+        @Body request: EncryptedMessage,
+    ): Call<Void>
+
     @PATCH("$SYNC_PROD_ENVIRONMENT_URL/sync/data")
     fun patch(
         @Header("Authorization") token: String,
@@ -128,6 +138,11 @@ data class Logout(
 
 data class ConnectKey(
     @field:Json(name = "encrypted_recovery_key") val encryptedRecoveryKey: String,
+)
+
+data class EncryptedMessage(
+    @field:Json(name = "key_id") val keyId: String,
+    @field:Json(name = "encrypted_message") val encryptedMessage: String,
 )
 
 data class Connect(

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
@@ -28,19 +28,27 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.CREATE_ACCOUNT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.INVALID_CODE
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
 import com.duckduckgo.sync.impl.Clipboard
+import com.duckduckgo.sync.impl.CodeType.EXCHANGE
+import com.duckduckgo.sync.impl.ExchangeResult.AccountSwitchingRequired
+import com.duckduckgo.sync.impl.ExchangeResult.LoggedIn
+import com.duckduckgo.sync.impl.ExchangeResult.Pending
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.onFailure
+import com.duckduckgo.sync.impl.onSuccess
 import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.AskToSwitchAccount
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.LoginSuccess
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.ShowError
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.SwitchAccountSuccess
+import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Companion.POLLING_INTERVAL_EXCHANGE_FLOW
 import javax.inject.*
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -92,20 +100,58 @@ class EnterCodeViewModel @Inject constructor(
         pastedCode: String,
     ) {
         val previousPrimaryKey = syncAccountRepository.getAccountInfo().primaryKey
+        val codeType = syncAccountRepository.getCodeType(pastedCode)
         when (val result = syncAccountRepository.processCode(pastedCode)) {
             is Result.Success -> {
-                val postProcessCodePK = syncAccountRepository.getAccountInfo().primaryKey
-                val userSwitchedAccount = previousPrimaryKey.isNotBlank() && previousPrimaryKey != postProcessCodePK
-                val commandSuccess = if (userSwitchedAccount) {
-                    syncPixels.fireUserSwitchedAccount()
-                    SwitchAccountSuccess
+                if (codeType == EXCHANGE) {
+                    pollForRecoveryKey(previousPrimaryKey = previousPrimaryKey, code = pastedCode)
                 } else {
-                    LoginSuccess
+                    onLoginSuccess(previousPrimaryKey)
                 }
-                command.send(commandSuccess)
             }
             is Result.Error -> {
                 processError(result, pastedCode)
+            }
+        }
+    }
+
+    private suspend fun onLoginSuccess(previousPrimaryKey: String) {
+        val postProcessCodePK = syncAccountRepository.getAccountInfo().primaryKey
+        val userSwitchedAccount = previousPrimaryKey.isNotBlank() && previousPrimaryKey != postProcessCodePK
+        val commandSuccess = if (userSwitchedAccount) {
+            syncPixels.fireUserSwitchedAccount()
+            SwitchAccountSuccess
+        } else {
+            LoginSuccess
+        }
+        command.send(commandSuccess)
+    }
+
+    private fun pollForRecoveryKey(
+        previousPrimaryKey: String,
+        code: String,
+    ) {
+        viewModelScope.launch(dispatchers.io()) {
+            var polling = true
+            while (polling) {
+                delay(POLLING_INTERVAL_EXCHANGE_FLOW)
+                syncAccountRepository.pollForRecoveryCodeAndLogin()
+                    .onSuccess { success ->
+                        polling = false
+
+                        when (success) {
+                            is Pending -> return@onSuccess // continue polling
+                            is AccountSwitchingRequired -> command.send(AskToSwitchAccount(success.recoveryCode))
+                            LoggedIn -> onLoginSuccess(previousPrimaryKey)
+                        }
+                    }.onFailure {
+                        when (it.code) {
+                            CONNECT_FAILED.code, LOGIN_FAILED.code -> {
+                                polling = false
+                                processError(result = it, pastedCode = code)
+                            }
+                        }
+                    }
             }
         }
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
@@ -137,12 +137,16 @@ class EnterCodeViewModel @Inject constructor(
                 delay(POLLING_INTERVAL_EXCHANGE_FLOW)
                 syncAccountRepository.pollForRecoveryCodeAndLogin()
                     .onSuccess { success ->
-                        polling = false
-
                         when (success) {
                             is Pending -> return@onSuccess // continue polling
-                            is AccountSwitchingRequired -> command.send(AskToSwitchAccount(success.recoveryCode))
-                            LoggedIn -> onLoginSuccess(previousPrimaryKey)
+                            is AccountSwitchingRequired -> {
+                                polling = false
+                                command.send(AskToSwitchAccount(success.recoveryCode))
+                            }
+                            LoggedIn -> {
+                                polling = false
+                                onLoginSuccess(previousPrimaryKey)
+                            }
                         }
                     }.onFailure {
                         when (it.code) {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
@@ -106,14 +106,19 @@ class SyncConnectViewModel @Inject constructor(
             delay(POLLING_INTERVAL_EXCHANGE_FLOW)
             syncAccountRepository.pollForRecoveryCodeAndLogin()
                 .onSuccess { success ->
-                    polling = false
-
                     when (success) {
                         is Pending -> return@onSuccess // continue polling
-                        is AccountSwitchingRequired -> processError(Error(ALREADY_SIGNED_IN.code, success.recoveryCode))
-                        is LoggedIn -> command.send(LoginSuccess)
+                        is AccountSwitchingRequired -> {
+                            polling = false
+                            processError(Error(ALREADY_SIGNED_IN.code, success.recoveryCode))
+                        }
+                        is LoggedIn -> {
+                            polling = false
+                            command.send(LoginSuccess)
+                        }
                     }
                 }.onFailure {
+                    polling = false
                     processError(it)
                 }
         }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
@@ -114,6 +114,7 @@ class SyncConnectViewModel @Inject constructor(
                         }
                         is LoggedIn -> {
                             polling = false
+                            syncPixels.fireLoginPixel()
                             command.send(LoginSuccess)
                         }
                     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
@@ -29,6 +29,10 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.CREATE_ACCOUNT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.INVALID_CODE
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
 import com.duckduckgo.sync.impl.Clipboard
+import com.duckduckgo.sync.impl.CodeType.EXCHANGE
+import com.duckduckgo.sync.impl.ExchangeResult.AccountSwitchingRequired
+import com.duckduckgo.sync.impl.ExchangeResult.LoggedIn
+import com.duckduckgo.sync.impl.ExchangeResult.Pending
 import com.duckduckgo.sync.impl.QREncoder
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.R.dimen
@@ -54,6 +58,7 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import timber.log.Timber
 
 @ContributesViewModel(ActivityScope::class)
 class SyncConnectViewModel @Inject constructor(
@@ -76,7 +81,7 @@ class SyncConnectViewModel @Inject constructor(
             showQRCode()
             var polling = true
             while (polling) {
-                delay(POLLING_INTERVAL)
+                delay(POLLING_INTERVAL_CONNECT_FLOW)
                 syncAccountRepository.pollConnectionKeys()
                     .onSuccess { success ->
                         if (!success) return@onSuccess // continue polling
@@ -92,6 +97,25 @@ class SyncConnectViewModel @Inject constructor(
                         }
                     }
             }
+        }
+    }
+
+    private suspend fun pollForRecoveryKey() {
+        var polling = true
+        while (polling) {
+            delay(POLLING_INTERVAL_EXCHANGE_FLOW)
+            syncAccountRepository.pollForRecoveryCodeAndLogin()
+                .onSuccess { success ->
+                    polling = false
+
+                    when (success) {
+                        is Pending -> return@onSuccess // continue polling
+                        is AccountSwitchingRequired -> processError(Error(ALREADY_SIGNED_IN.code, success.recoveryCode))
+                        is LoggedIn -> command.send(LoginSuccess)
+                    }
+                }.onFailure {
+                    processError(it)
+                }
         }
     }
 
@@ -116,6 +140,7 @@ class SyncConnectViewModel @Inject constructor(
     fun onCopyCodeClicked() {
         viewModelScope.launch(dispatchers.io()) {
             syncAccountRepository.getConnectQR().getOrNull()?.let { code ->
+                Timber.d("Sync: recovery available for sharing manually: $code")
                 clipboard.copyToClipboard(code)
                 command.send(ShowMessage(R.string.sync_code_copied_message))
             } ?: command.send(FinishWithError)
@@ -142,25 +167,34 @@ class SyncConnectViewModel @Inject constructor(
 
     fun onQRCodeScanned(qrCode: String) {
         viewModelScope.launch(dispatchers.io()) {
+            val codeType = syncAccountRepository.getCodeType(qrCode)
             when (val result = syncAccountRepository.processCode(qrCode)) {
                 is Error -> {
-                    when (result.code) {
-                        ALREADY_SIGNED_IN.code -> R.string.sync_login_authenticated_device_error
-                        LOGIN_FAILED.code -> R.string.sync_connect_login_error
-                        CONNECT_FAILED.code -> R.string.sync_connect_generic_error
-                        CREATE_ACCOUNT_FAILED.code -> R.string.sync_create_account_generic_error
-                        INVALID_CODE.code -> R.string.sync_invalid_code_error
-                        else -> null
-                    }?.let { message ->
-                        command.send(ShowError(message = message, reason = result.reason))
-                    }
+                    processError(result)
                 }
 
                 is Success -> {
-                    syncPixels.fireLoginPixel()
-                    command.send(LoginSuccess)
+                    if (codeType == EXCHANGE) {
+                        pollForRecoveryKey()
+                    } else {
+                        syncPixels.fireLoginPixel()
+                        command.send(LoginSuccess)
+                    }
                 }
             }
+        }
+    }
+
+    private suspend fun processError(result: Error) {
+        when (result.code) {
+            ALREADY_SIGNED_IN.code -> R.string.sync_login_authenticated_device_error
+            LOGIN_FAILED.code -> R.string.sync_connect_login_error
+            CONNECT_FAILED.code -> R.string.sync_connect_generic_error
+            CREATE_ACCOUNT_FAILED.code -> R.string.sync_create_account_generic_error
+            INVALID_CODE.code -> R.string.sync_invalid_code_error
+            else -> null
+        }?.let { message ->
+            command.send(ShowError(message = message, reason = result.reason))
         }
     }
 
@@ -172,6 +206,7 @@ class SyncConnectViewModel @Inject constructor(
     }
 
     companion object {
-        const val POLLING_INTERVAL = 5000L
+        const val POLLING_INTERVAL_CONNECT_FLOW = 5_000L
+        const val POLLING_INTERVAL_EXCHANGE_FLOW = 2_000L
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
@@ -27,17 +27,25 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.CONNECT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.CREATE_ACCOUNT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.INVALID_CODE
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
+import com.duckduckgo.sync.impl.CodeType.EXCHANGE
+import com.duckduckgo.sync.impl.ExchangeResult.AccountSwitchingRequired
+import com.duckduckgo.sync.impl.ExchangeResult.LoggedIn
+import com.duckduckgo.sync.impl.ExchangeResult.Pending
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.Result.Error
+import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.SyncAccountRepository
+import com.duckduckgo.sync.impl.onFailure
+import com.duckduckgo.sync.impl.onSuccess
 import com.duckduckgo.sync.impl.pixels.SyncPixels
-import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command
+import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Companion.POLLING_INTERVAL_EXCHANGE_FLOW
 import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command.LoginSucess
 import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command.ReadTextCode
 import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command.ShowError
 import javax.inject.*
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
@@ -79,22 +87,55 @@ class SyncLoginViewModel @Inject constructor(
 
     fun onQRCodeScanned(qrCode: String) {
         viewModelScope.launch(dispatchers.io()) {
-            val result = syncAccountRepository.processCode(qrCode)
-            if (result is Error) {
-                when (result.code) {
-                    ALREADY_SIGNED_IN.code -> R.string.sync_login_authenticated_device_error
-                    LOGIN_FAILED.code -> R.string.sync_connect_login_error
-                    CONNECT_FAILED.code -> R.string.sync_connect_generic_error
-                    CREATE_ACCOUNT_FAILED.code -> R.string.sync_create_account_generic_error
-                    INVALID_CODE.code -> R.string.sync_invalid_code_error
-                    else -> null
-                }?.let { message ->
-                    command.send(ShowError(message = message, reason = result.reason))
+            val codeType = syncAccountRepository.getCodeType(qrCode)
+            when (val result = syncAccountRepository.processCode(qrCode)) {
+                is Error -> {
+                    processError(result)
                 }
-            } else {
-                syncPixels.fireLoginPixel()
-                command.send(LoginSucess)
+
+                is Success -> {
+                    if (codeType == EXCHANGE) {
+                        pollForRecoveryKey()
+                    } else {
+                        syncPixels.fireLoginPixel()
+                        command.send(LoginSucess)
+                    }
+                }
             }
+        }
+    }
+
+    private suspend fun processError(result: Error) {
+        when (result.code) {
+            ALREADY_SIGNED_IN.code -> R.string.sync_login_authenticated_device_error
+            LOGIN_FAILED.code -> R.string.sync_connect_login_error
+            CONNECT_FAILED.code -> R.string.sync_connect_generic_error
+            CREATE_ACCOUNT_FAILED.code -> R.string.sync_create_account_generic_error
+            INVALID_CODE.code -> R.string.sync_invalid_code_error
+            else -> null
+        }?.let { message ->
+            command.send(ShowError(message = message, reason = result.reason))
+        }
+    }
+
+    private suspend fun pollForRecoveryKey() {
+        var polling = true
+        while (polling) {
+            delay(POLLING_INTERVAL_EXCHANGE_FLOW)
+            syncAccountRepository.pollForRecoveryCodeAndLogin()
+                .onSuccess { success ->
+                    polling = false
+                    when (success) {
+                        is Pending -> return@onSuccess // continue polling
+                        is AccountSwitchingRequired -> processError(Error(ALREADY_SIGNED_IN.code, "user already signed in"))
+                        LoggedIn -> {
+                            syncPixels.fireLoginPixel()
+                            command.send(LoginSucess)
+                        }
+                    }
+                }.onFailure {
+                    processError(it)
+                }
         }
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
@@ -124,16 +124,20 @@ class SyncLoginViewModel @Inject constructor(
             delay(POLLING_INTERVAL_EXCHANGE_FLOW)
             syncAccountRepository.pollForRecoveryCodeAndLogin()
                 .onSuccess { success ->
-                    polling = false
                     when (success) {
                         is Pending -> return@onSuccess // continue polling
-                        is AccountSwitchingRequired -> processError(Error(ALREADY_SIGNED_IN.code, "user already signed in"))
+                        is AccountSwitchingRequired -> {
+                            polling = false
+                            processError(Error(ALREADY_SIGNED_IN.code, "user already signed in"))
+                        }
                         LoggedIn -> {
+                            polling = false
                             syncPixels.fireLoginPixel()
                             command.send(LoginSucess)
                         }
                     }
                 }.onFailure {
+                    polling = false
                     processError(it)
                 }
         }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
@@ -221,11 +221,16 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
                 delay(POLLING_INTERVAL_EXCHANGE_FLOW)
                 syncAccountRepository.pollForRecoveryCodeAndLogin()
                     .onSuccess { success ->
-                        polling = false
                         when (success) {
                             is Pending -> return@onSuccess // continue polling
-                            is AccountSwitchingRequired -> command.send(AskToSwitchAccount(success.recoveryCode))
-                            is LoggedIn -> onLoginSuccess(previousPrimaryKey)
+                            is AccountSwitchingRequired -> {
+                                polling = false
+                                command.send(AskToSwitchAccount(success.recoveryCode))
+                            }
+                            is LoggedIn -> {
+                                polling = false
+                                onLoginSuccess(previousPrimaryKey)
+                            }
                         }
                     }.onFailure {
                         polling = false

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
@@ -29,6 +29,10 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.CREATE_ACCOUNT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.INVALID_CODE
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
 import com.duckduckgo.sync.impl.Clipboard
+import com.duckduckgo.sync.impl.CodeType.EXCHANGE
+import com.duckduckgo.sync.impl.ExchangeResult.AccountSwitchingRequired
+import com.duckduckgo.sync.impl.ExchangeResult.LoggedIn
+import com.duckduckgo.sync.impl.ExchangeResult.Pending
 import com.duckduckgo.sync.impl.QREncoder
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.R.dimen
@@ -41,6 +45,7 @@ import com.duckduckgo.sync.impl.getOrNull
 import com.duckduckgo.sync.impl.onFailure
 import com.duckduckgo.sync.impl.onSuccess
 import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Companion.POLLING_INTERVAL_EXCHANGE_FLOW
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.AskToSwitchAccount
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.FinishWithError
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.LoginSuccess
@@ -52,12 +57,14 @@ import com.duckduckgo.sync.impl.ui.setup.EnterCodeContract.EnterCodeContractOutp
 import javax.inject.Inject
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import timber.log.Timber
 
 @ContributesViewModel(ActivityScope::class)
 class SyncWithAnotherActivityViewModel @Inject constructor(
@@ -71,27 +78,53 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
     private val command = Channel<Command>(1, DROP_OLDEST)
     fun commands(): Flow<Command> = command.receiveAsFlow()
 
+    private var exchangeInvitationCode: String? = null
+
     private val viewState = MutableStateFlow(ViewState())
     fun viewState(): Flow<ViewState> = viewState.onStart {
-        generateQRCode()
+        startExchangeProcess()
     }
 
-    private fun generateQRCode() {
+    private fun startExchangeProcess() {
         viewModelScope.launch(dispatchers.io()) {
             showQRCode()
+            var polling = syncFeature.exchangeKeysToSyncWithAnotherDevice().isEnabled()
+            while (polling) {
+                delay(POLLING_INTERVAL_EXCHANGE_FLOW)
+                syncAccountRepository.pollSecondDeviceExchangeAcknowledgement()
+                    .onSuccess { success ->
+                        if (!success) return@onSuccess // continue polling
+                        command.send(Command.LoginSuccess)
+                        polling = false
+                    }.onFailure {
+                        when (it.code) {
+                            CONNECT_FAILED.code, LOGIN_FAILED.code -> {
+                                command.send(Command.ShowError(string.sync_connect_login_error, it.reason))
+                                polling = false
+                            }
+                        }
+                    }
+            }
         }
     }
 
     private suspend fun showQRCode() {
-        syncAccountRepository.getRecoveryCode()
-            .onSuccess { connectQR ->
-                val qrBitmap = withContext(dispatchers.io()) {
-                    qrEncoder.encodeAsBitmap(connectQR, dimen.qrSizeSmall, dimen.qrSizeSmall)
-                }
-                viewState.emit(viewState.value.copy(qrCodeBitmap = qrBitmap))
-            }.onFailure {
-                command.send(Command.FinishWithError)
+        val shouldExchangeKeysToSyncAnotherDevice = syncFeature.exchangeKeysToSyncWithAnotherDevice().isEnabled()
+
+        if (!shouldExchangeKeysToSyncAnotherDevice) {
+            syncAccountRepository.getRecoveryCode()
+        } else {
+            syncAccountRepository.generateExchangeInvitationCode().also {
+                exchangeInvitationCode = it.getOrNull()
             }
+        }.onSuccess { connectQR ->
+            val qrBitmap = withContext(dispatchers.io()) {
+                qrEncoder.encodeAsBitmap(connectQR, dimen.qrSizeSmall, dimen.qrSizeSmall)
+            }
+            viewState.emit(viewState.value.copy(qrCodeBitmap = qrBitmap))
+        }.onFailure {
+            command.send(Command.FinishWithError)
+        }
     }
 
     fun onErrorDialogDismissed() {
@@ -102,7 +135,18 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
 
     fun onCopyCodeClicked() {
         viewModelScope.launch(dispatchers.io()) {
-            syncAccountRepository.getRecoveryCode().getOrNull()?.let { code ->
+            val shouldExchangeKeysToSyncAnotherDevice = syncFeature.exchangeKeysToSyncWithAnotherDevice().isEnabled()
+            if (!shouldExchangeKeysToSyncAnotherDevice) {
+                syncAccountRepository.getRecoveryCode()
+            } else {
+                if (exchangeInvitationCode != null) {
+                    Success(exchangeInvitationCode)
+                } else {
+                    Error(reason = "Exchange code is null").also {
+                        Timber.e("Sync-exchange: ${it.reason}")
+                    }
+                }
+            }.getOrNull()?.let { code ->
                 clipboard.copyToClipboard(code)
                 command.send(ShowMessage(string.sync_code_copied_message))
             } ?: command.send(FinishWithError)
@@ -136,23 +180,57 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
     fun onQRCodeScanned(qrCode: String) {
         viewModelScope.launch(dispatchers.io()) {
             val previousPrimaryKey = syncAccountRepository.getAccountInfo().primaryKey
+            val codeType = syncAccountRepository.getCodeType(qrCode)
             when (val result = syncAccountRepository.processCode(qrCode)) {
                 is Error -> {
+                    Timber.w("Sync: error processing code ${result.reason}")
                     emitError(result, qrCode)
                 }
 
                 is Success -> {
-                    val postProcessCodePK = syncAccountRepository.getAccountInfo().primaryKey
-                    syncPixels.fireLoginPixel()
-                    val userSwitchedAccount = previousPrimaryKey.isNotBlank() && previousPrimaryKey != postProcessCodePK
-                    val commandSuccess = if (userSwitchedAccount) {
-                        syncPixels.fireUserSwitchedAccount()
-                        SwitchAccountSuccess
+                    if (codeType == EXCHANGE) {
+                        pollForRecoveryKey(previousPrimaryKey = previousPrimaryKey, qrCode = qrCode)
                     } else {
-                        LoginSuccess
+                        onLoginSuccess(previousPrimaryKey)
                     }
-                    command.send(commandSuccess)
                 }
+            }
+        }
+    }
+
+    private suspend fun onLoginSuccess(previousPrimaryKey: String) {
+        val postProcessCodePK = syncAccountRepository.getAccountInfo().primaryKey
+        syncPixels.fireLoginPixel()
+        val userSwitchedAccount = previousPrimaryKey.isNotBlank() && previousPrimaryKey != postProcessCodePK
+        val commandSuccess = if (userSwitchedAccount) {
+            syncPixels.fireUserSwitchedAccount()
+            SwitchAccountSuccess
+        } else {
+            LoginSuccess
+        }
+        command.send(commandSuccess)
+    }
+
+    private fun pollForRecoveryKey(
+        previousPrimaryKey: String,
+        qrCode: String,
+    ) {
+        viewModelScope.launch(dispatchers.io()) {
+            var polling = true
+            while (polling) {
+                delay(POLLING_INTERVAL_EXCHANGE_FLOW)
+                syncAccountRepository.pollForRecoveryCodeAndLogin()
+                    .onSuccess { success ->
+                        polling = false
+                        when (success) {
+                            is Pending -> return@onSuccess // continue polling
+                            is AccountSwitchingRequired -> command.send(AskToSwitchAccount(success.recoveryCode))
+                            is LoggedIn -> onLoginSuccess(previousPrimaryKey)
+                        }
+                    }.onFailure {
+                        polling = false
+                        emitError(it, qrCode)
+                    }
             }
         }
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/TestSyncFixtures.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/TestSyncFixtures.kt
@@ -53,6 +53,9 @@ object TestSyncFixtures {
     const val hashedPassword = "hashedPassword"
     const val protectedEncryptionKey = "protectedEncryptionKey"
     const val encryptedRecoveryCode = "encrypted_recovery_code"
+    const val encryptedExchangeCode = "encrypted_exchange_code"
+    const val primaryDeviceKeyId = "primary_device_key_id"
+    const val otherDeviceKeyId = "other_device_key_id"
     val accountKeys = AccountKeys(
         result = 0,
         userId = userId,
@@ -192,8 +195,12 @@ object TestSyncFixtures {
         "\"bookmark4\"]},\"id\":\"bookmarks_root\",\"title\":\"Bookmarks\"}]}}"
 
     fun qrBitmap(): Bitmap {
-        return Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888)
+        return Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
     }
 
     fun pdfFile(): File = File("Sync Data Recovery - DuckDuckGo.pdf")
+
+    fun jsonExchangeKey(keyId: String, publicKey: String) = """
+        {"exchange_key":{"key_id":"$keyId","public_key":"$publicKey"}}
+    """.trimIndent()
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.sync.impl.ui
 
 import android.annotation.SuppressLint
+import android.graphics.Bitmap
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
@@ -26,17 +27,26 @@ import com.duckduckgo.sync.SyncAccountFixtures.accountA
 import com.duckduckgo.sync.SyncAccountFixtures.accountB
 import com.duckduckgo.sync.SyncAccountFixtures.noAccount
 import com.duckduckgo.sync.TestSyncFixtures
+import com.duckduckgo.sync.TestSyncFixtures.encryptedRecoveryCode
+import com.duckduckgo.sync.TestSyncFixtures.jsonExchangeKey
 import com.duckduckgo.sync.TestSyncFixtures.jsonRecoveryKeyEncoded
+import com.duckduckgo.sync.TestSyncFixtures.primaryDeviceKeyId
+import com.duckduckgo.sync.TestSyncFixtures.validLoginKeys
 import com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
 import com.duckduckgo.sync.impl.Clipboard
+import com.duckduckgo.sync.impl.CodeType.EXCHANGE
+import com.duckduckgo.sync.impl.ExchangeResult.AccountSwitchingRequired
+import com.duckduckgo.sync.impl.ExchangeResult.LoggedIn
 import com.duckduckgo.sync.impl.QREncoder
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.encodeB64
 import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command
+import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.AskToSwitchAccount
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.LoginSuccess
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.SwitchAccountSuccess
 import kotlinx.coroutines.test.runTest
@@ -80,11 +90,22 @@ class SyncWithAnotherDeviceViewModelTest {
     @Test
     fun whenScreenStartedThenShowQRCode() = runTest {
         val bitmap = TestSyncFixtures.qrBitmap()
-        whenever(syncRepository.getRecoveryCode()).thenReturn(Result.Success(jsonRecoveryKeyEncoded))
         whenever(qrEncoder.encodeAsBitmap(eq(jsonRecoveryKeyEncoded), any(), any())).thenReturn(bitmap)
+        whenever(syncRepository.getRecoveryCode()).thenReturn(Result.Success(jsonRecoveryKeyEncoded))
         testee.viewState().test {
             val viewState = awaitItem()
             Assert.assertEquals(bitmap, viewState.qrCodeBitmap)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenScreenStartedAndExchangingKeysEnabledThenExchangeKeysUsedInQrCode() = runTest {
+        val expectedBitmap = configureExchangeKeysSupported().first
+
+        testee.viewState().test {
+            val viewState = awaitItem()
+            Assert.assertEquals(expectedBitmap, viewState.qrCodeBitmap)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -105,8 +126,43 @@ class SyncWithAnotherDeviceViewModelTest {
     }
 
     @Test
+    fun whenGenerateRecoveryQRFailsAndExchangingKeysEnabledThenFinishWithError() = runTest {
+        configureExchangeKeysSupported()
+        whenever(syncRepository.generateExchangeInvitationCode()).thenReturn(Result.Error(reason = "error"))
+        testee.viewState().test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue(command is Command.FinishWithError)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun whenOnCopyCodeClickedThenShowMessage() = runTest {
         whenever(syncRepository.getRecoveryCode()).thenReturn(Result.Success(jsonRecoveryKeyEncoded))
+
+        // need to ensure view state is started
+        testee.viewState().test { cancelAndConsumeRemainingEvents() }
+
+        testee.onCopyCodeClicked()
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue(command is Command.ShowMessage)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenOnCopyCodeClickedAndExchangingKeysEnabledThenShowMessage() = runTest {
+        configureExchangeKeysSupported()
+
+        // need to ensure view state is started
+        testee.viewState().test { cancelAndConsumeRemainingEvents() }
 
         testee.onCopyCodeClicked()
 
@@ -121,9 +177,24 @@ class SyncWithAnotherDeviceViewModelTest {
     fun whenOnCopyCodeClickedThenCopyCodeToClipboard() = runTest {
         whenever(syncRepository.getRecoveryCode()).thenReturn(Result.Success(jsonRecoveryKeyEncoded))
 
+        // need to ensure view state is started
+        testee.viewState().test { cancelAndConsumeRemainingEvents() }
+
         testee.onCopyCodeClicked()
 
         verify(clipboard).copyToClipboard(jsonRecoveryKeyEncoded)
+    }
+
+    @Test
+    fun whenOnCopyCodeClickedAndExchangingKeysEnabledThenCopyCodeToClipboard() = runTest {
+        val expectedJson = configureExchangeKeysSupported().second
+
+        // need to ensure view state is started
+        testee.viewState().test { cancelAndConsumeRemainingEvents() }
+
+        testee.onCopyCodeClicked()
+
+        verify(clipboard).copyToClipboard(expectedJson)
     }
 
     @Test
@@ -151,6 +222,21 @@ class SyncWithAnotherDeviceViewModelTest {
     }
 
     @Test
+    fun whenUserScansRecoveryCodeAndExchangingKeysEnabledButSignedInThenCommandIsError() = runTest {
+        configureExchangeKeysSupported()
+        syncFeature.seamlessAccountSwitching().setRawStoredState(State(false))
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        whenever(syncRepository.processCode(jsonRecoveryKeyEncoded)).thenReturn(Result.Error(code = ALREADY_SIGNED_IN.code))
+        testee.commands().test {
+            testee.onQRCodeScanned(jsonRecoveryKeyEncoded)
+            val command = awaitItem()
+            assertTrue(command is Command.ShowError)
+            verifyNoInteractions(syncPixels)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun whenUserScansRecoveryCodeButSignedInThenCommandIsAskToSwitchAccount() = runTest {
         whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
         whenever(syncRepository.processCode(jsonRecoveryKeyEncoded)).thenReturn(Result.Error(code = ALREADY_SIGNED_IN.code))
@@ -164,7 +250,69 @@ class SyncWithAnotherDeviceViewModelTest {
     }
 
     @Test
+    fun whenUserScansRecoveryCodeAndExchangingKeysEnabledButSignedInThenCommandIsAskToSwitchAccount() = runTest {
+        configureExchangeKeysSupported()
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        whenever(syncRepository.processCode(jsonRecoveryKeyEncoded)).thenReturn(Result.Error(code = ALREADY_SIGNED_IN.code))
+        testee.commands().test {
+            testee.onQRCodeScanned(jsonRecoveryKeyEncoded)
+            val command = awaitItem()
+            assertTrue(command is Command.AskToSwitchAccount)
+            verifyNoInteractions(syncPixels)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenUserScansExchangeCodeAndExchangingKeysEnabledThenCommandIsLoginSuccess() = runTest {
+        val exchangeJson = configureExchangeKeysSupported().second
+
+        // configure success response: logged in
+        whenever(syncRepository.pollForRecoveryCodeAndLogin()).thenReturn(Success(LoggedIn))
+
+        testee.commands().test {
+            testee.onQRCodeScanned(exchangeJson.encodeB64())
+            val command = awaitItem()
+            assertTrue(command is LoginSuccess)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenUserScansExchangeCodeAndExchangingKeysEnabledButAccountSwitchingRequiredThenCommandIsAskToSwitchAccount() = runTest {
+        val exchangeJson = configureExchangeKeysSupported().second
+
+        // configure success response: account switching required
+        whenever(syncRepository.pollForRecoveryCodeAndLogin()).thenReturn(Success(AccountSwitchingRequired(encryptedRecoveryCode)))
+
+        testee.commands().test {
+            testee.onQRCodeScanned(exchangeJson.encodeB64())
+            val command = awaitItem()
+            assertTrue(command is AskToSwitchAccount)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun whenUserAcceptsToSwitchAccountThenPerformAction() = runTest {
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        whenever(syncRepository.logoutAndJoinNewAccount(jsonRecoveryKeyEncoded)).thenAnswer {
+            whenever(syncRepository.getAccountInfo()).thenReturn(accountB)
+            Success(true)
+        }
+
+        testee.onUserAcceptedJoiningNewAccount(jsonRecoveryKeyEncoded)
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue(command is SwitchAccountSuccess)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenUserAcceptsToSwitchAccountAndExchangingKeysEnabledThenPerformAction() = runTest {
+        configureExchangeKeysSupported()
         whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
         whenever(syncRepository.logoutAndJoinNewAccount(jsonRecoveryKeyEncoded)).thenAnswer {
             whenever(syncRepository.getAccountInfo()).thenReturn(accountB)
@@ -236,5 +384,19 @@ class SyncWithAnotherDeviceViewModelTest {
             verify(syncPixels).fireLoginPixel()
             cancelAndIgnoreRemainingEvents()
         }
+    }
+
+    private fun configureExchangeKeysSupported(): Pair<Bitmap, String> {
+        syncFeature.exchangeKeysToSyncWithAnotherDevice().setRawStoredState(State(true))
+        whenever(syncRepository.pollSecondDeviceExchangeAcknowledgement()).thenReturn(Success(true))
+        whenever(syncRepository.getCodeType(any())).thenReturn(EXCHANGE)
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        val bitmap = TestSyncFixtures.qrBitmap()
+        val jsonExchangeKey = jsonExchangeKey(primaryDeviceKeyId, validLoginKeys.primaryKey).also {
+            whenever(syncRepository.generateExchangeInvitationCode()).thenReturn(Success(it))
+            whenever(qrEncoder.encodeAsBitmap(eq(it), any(), any())).thenReturn(bitmap)
+        }
+        whenever(syncRepository.processCode(any())).thenReturn(Success(true))
+        return Pair(bitmap, jsonExchangeKey)
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.sync.impl.ui
 
+import android.annotation.SuppressLint
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
@@ -52,6 +53,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 
+@SuppressLint("DenyListedApi")
 @RunWith(AndroidJUnit4::class)
 class SyncWithAnotherDeviceViewModelTest {
     @get:Rule
@@ -63,6 +65,7 @@ class SyncWithAnotherDeviceViewModelTest {
     private val syncPixels: SyncPixels = mock()
     private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java).apply {
         this.seamlessAccountSwitching().setRawStoredState(State(true))
+        this.exchangeKeysToSyncWithAnotherDevice().setRawStoredState(State(false))
     }
 
     private val testee = SyncWithAnotherActivityViewModel(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1209272522976873/1209569901379925 

### Description
Aligns recovery code flow with connect code flow. 
- The feature is **disabled** by default. It will be enabled for all later via a FF update.
- You’ll need 2 or more devices to complete the tests.
- Suggested logcat filter: `package:mine & (message~:"Sync-exchange|InvitationFlow”)`

### Steps to test this PR

There is a matrix of test cases detailed here: [test scenarios](https://app.asana.com/0/1209272522976873/1209569901379925/f)

#### Feature enabled
- [x] Fresh install `internal` builds on two devices. 
- [x] Enable `exchangeKeysToSyncWithAnotherDevice` FF on all devices.
- [x] Run through the test scenarios in the linked task, verifying it behaves as expected in each case

#### Feature disabled on all devices
In these tests, we want to ensure existing behaviour happens and there’s no regressions introduced even when the FF is disabled. 

- [x] Ensure `exchangeKeysToSyncWithAnotherDevice` is disabled on all devices.
- [x] Run through the various sync scenarios ensuring everything behaves identically to production, devices can be joined etc..

#### Feature enabled on some, disabled on others
- [x] Enable the feature on one device, disable it on another
- [x] Verify that if the device where it is **disabled** is signed in and has its barcode scanned, this flow will work
- [x] Verify that if the device where it is **enabled** is signed in and has its barcode scanned, this won’t work

#### Smoke test cross-platform
- [ ] Help test compatibility against as many of macOS/iOS/Windows builds as you can 🙏
- [ ] Latest builds from other platforms available here:
  - [iOS](https://app.asana.com/0/0/1209666996614195/f)
  - [macOS](https://app.asana.com/0/1209272522976873/1209666996614200/f)
  - [windows](https://app.asana.com/0/1209272522976873/1209677677642394/f)

#### Verify errors states
- [x] Use your sync knowledge to pay particular to the places where errors might happen that aren’t already caught (e.g., what else is missing a `runCatching`, which other error flows / codes aren’t handled well enough etc…)

#### Verify pixels
- [x] Use your sync knowledge to consider if any pixels are erroneously being affected.