### PR TITLE
Handle invalid_token error during migration to auth v2

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixel.kt
@@ -183,6 +183,10 @@ enum class SubscriptionPixel(
         baseName = "m_privacy-pro_auth_v2_migration_failure_io",
         types = setOf(Count, Daily()),
     ),
+    AUTH_V2_MIGRATION_FAILURE_INVALID_TOKEN(
+        baseName = "m_privacy-pro_auth_v2_migration_failure_invalid_token",
+        types = setOf(Count, Daily()),
+    ),
     AUTH_V2_MIGRATION_FAILURE_OTHER(
         baseName = "m_privacy-pro_auth_v2_migration_failure_other",
         types = setOf(Count, Daily()),

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelSender.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelSender.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.APP_SETTINGS_R
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.AUTH_V2_INVALID_REFRESH_TOKEN_DETECTED
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.AUTH_V2_INVALID_REFRESH_TOKEN_RECOVERED
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.AUTH_V2_INVALID_REFRESH_TOKEN_SIGNED_OUT
+import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.AUTH_V2_MIGRATION_FAILURE_INVALID_TOKEN
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.AUTH_V2_MIGRATION_FAILURE_IO
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.AUTH_V2_MIGRATION_FAILURE_OTHER
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.AUTH_V2_MIGRATION_SUCCESS
@@ -111,6 +112,7 @@ interface SubscriptionPixelSender {
     fun reportAuthV2InvalidRefreshTokenRecovered()
     fun reportAuthV2MigrationSuccess()
     fun reportAuthV2MigrationFailureIo()
+    fun reportAuthV2MigrationFailureInvalidToken()
     fun reportAuthV2MigrationFailureOther()
     fun reportAuthV2TokenValidationError()
     fun reportAuthV2TokenStoreError()
@@ -255,6 +257,10 @@ class SubscriptionPixelSenderImpl @Inject constructor(
 
     override fun reportAuthV2MigrationFailureIo() {
         fire(AUTH_V2_MIGRATION_FAILURE_IO)
+    }
+
+    override fun reportAuthV2MigrationFailureInvalidToken() {
+        fire(AUTH_V2_MIGRATION_FAILURE_INVALID_TOKEN)
     }
 
     override fun reportAuthV2MigrationFailureOther() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205648422731273/1209601572682035/f

### Description

This PR addresses an edge case where the device could migrate to auth v2 after the server has already removed the account.

### Steps to test this PR

See task.

### No UI changes
