### PR TITLE
Move Duck.AI Settings Item below DuckPlayer

### DIFF
--- a/app/src/main/res/layout/content_settings_main_settings.xml
+++ b/app/src/main/res/layout/content_settings_main_settings.xml
@@ -80,15 +80,15 @@
         app:primaryText="@string/settingsDataClearing"
         app:leadingIcon="@drawable/ic_fire_color_24"/>
 
-    <include
-        android:id="@+id/includeDuckChatSetting"
-        layout="@layout/view_settings_item_duck_chat" />
-
     <LinearLayout
         android:id="@+id/settingsSectionDuckPlayer"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical" >
     </LinearLayout>
+
+    <include
+        android:id="@+id/includeDuckChatSetting"
+        layout="@layout/view_settings_item_duck_chat" />
 
 </LinearLayout>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202552961248957/1209646376530330

### Description
Moved the DuckChat setting to the bottom of the settings menu, placing it after the DuckPlayer section.

### Steps to test this PR

_Settings Menu Order_
- [x] Open the app settings
- [x] Verify that the DuckChat setting now appears at the bottom of the settings menu
- [x] Verify that the DuckChat setting appears after the DuckPlayer section

[See iOS Designs
](https://www.figma.com/design/CjH849hL53lhsPlf6Ufeo4/%E2%9A%99%EF%B8%8F-Browser-Settings-Documentation-(All-Platforms)?node-id=7605-431388&t=M5NCXq9ECQAtY1ek-0)

### UI changes
| Before  | After |
| ------ | ----- |
|![Screenshot_20250312_090329](https://github.com/user-attachments/assets/540eab67-4ea8-4614-aea5-0554f8457462)|![Screenshot_20250312_090117](https://github.com/user-attachments/assets/f11af23e-2053-4339-8dff-12ac0cf6ddc4)|