### PR TITLE
Use fireproofWebsitesSync when preserving local storage

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/weblocalstorage/WebLocalStorageManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/weblocalstorage/WebLocalStorageManager.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.app.browser.weblocalstorage
 
 import android.content.Context
-import com.duckduckgo.app.fire.FireproofRepository
+import com.duckduckgo.app.fire.fireproofwebsite.data.FireproofWebsiteRepository
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
@@ -46,7 +46,7 @@ class DuckDuckGoWebLocalStorageManager @Inject constructor(
     private val databaseProvider: Lazy<DB>,
     private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
     private val webLocalStorageSettingsJsonParser: WebLocalStorageSettingsJsonParser,
-    private val fireproofRepository: FireproofRepository,
+    private val fireproofWebsiteRepository: FireproofWebsiteRepository,
     private val dispatcherProvider: DispatcherProvider,
 ) : WebLocalStorageManager {
 
@@ -59,7 +59,7 @@ class DuckDuckGoWebLocalStorageManager @Inject constructor(
 
         val fireproofedDomains = if (androidBrowserConfigFeature.fireproofedWebLocalStorage().isEnabled()) {
             withContext(dispatcherProvider.io()) {
-                fireproofRepository.fireproofWebsites()
+                fireproofWebsiteRepository.fireproofWebsitesSync().map { it.domain }
             }
         } else {
             emptyList()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1209656726579252

### Description

- Use `fireproofWebsitesSync` instead of `fireproofWebsites` when preserving local storage.

### Steps to test this PR

- [ ] Log into bsky.app or proton.mail.me
- [ ] Fireproof the site
- [ ] Use the fire button
- [ ] Go back to bsky.app or proton.mail.me
- [ ] Verify that the site is still logged in