### PR TITLE
Refresh sync settings screen automatically

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
@@ -47,4 +47,11 @@ interface SyncFeature {
 
     @Toggle.DefaultValue(true)
     fun seamlessAccountSwitching(): Toggle
+
+    @InternalAlwaysEnabled
+    @Toggle.DefaultValue(false)
+    fun exchangeKeysToSyncWithAnotherDevice(): Toggle
+
+    @Toggle.DefaultValue(true)
+    fun automaticallyUpdateSyncSettings(): Toggle
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeatureToggle.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeatureToggle.kt
@@ -50,6 +50,8 @@ interface SyncFeatureToggle {
     fun allowCreateAccount(): Boolean
 
     fun allowCreateAccountOnNewerVersion(): Boolean
+
+    fun automaticallyUpdateSyncSettings(): Boolean
 }
 
 @ContributesBinding(
@@ -109,6 +111,10 @@ class SyncRemoteFeatureToggle @Inject constructor(
 
     override fun allowCreateAccountOnNewerVersion(): Boolean {
         return isToggleEnabledOnNewerVersion(syncFeature.level3AllowCreateAccount())
+    }
+
+    override fun automaticallyUpdateSyncSettings(): Boolean {
+        return syncFeature.automaticallyUpdateSyncSettings().isEnabled()
     }
 
     private fun isToggleEnabledOnNewerVersion(toggle: Toggle): Boolean {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncDisabledViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncDisabledViewModelTest.kt
@@ -262,6 +262,7 @@ class FakeSyncFeatureToggle : SyncFeatureToggle {
     var allowSetupFlowsOnNewerVersion: Boolean = true
     var allowCreateAccount: Boolean = true
     var allowCreateAccountOnNewerVersion: Boolean = true
+    var automaticallyUpdateSyncSettings: Boolean = true
     override fun showSync() = showSync
     override fun allowDataSyncing() = allowDataSyncing
     override fun allowDataSyncingOnNewerVersion() = allowDataSyncingOnNewerVersion
@@ -269,4 +270,5 @@ class FakeSyncFeatureToggle : SyncFeatureToggle {
     override fun allowSetupFlowsOnNewerVersion() = allowSetupFlowsOnNewerVersion
     override fun allowCreateAccount() = allowCreateAccount
     override fun allowCreateAccountOnNewerVersion() = allowCreateAccountOnNewerVersion
+    override fun automaticallyUpdateSyncSettings() = automaticallyUpdateSyncSettings
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/608920331025315/task/1209669301264637 

### Description
Allows the sync settings screen to automatically refresh while it is being viewed. This is in part to provide a better UX to https://github.com/duckduckgo/Android/pull/5762.

### Steps to test this PR

- [x] Enter sync settings with sync disabled. Verify everything looks as expected and there is no visual updates to the UI
- [x] Enable sync. Verify everything looks as expected and there is no visual updates to the UI.
- [x] Sync with another device, such that you can see two devices in this view; your device, plus one other
- [x] On the other device, turn off sync
- [x] Back on the first device, verify it updates within the next 5s to show the other device is now gone
- [x] Disable `sync / automaticallyUpdateSyncSettings` feature flag and return to the sync settings screen. Repeat the above test and verify the other device doesn’t automatically update since background refreshing is disabled (i.e., fallback to original behaviour when flag disabled)
- [x] Smoke test any other related sync scenarios you think might be problematic because of this