### PR TITLE
allow to add autofill domain info into text input

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2368,6 +2368,8 @@ class BrowserTabFragment :
 
         val authDialogBinding = HttpAuthenticationBinding.inflate(layoutInflater)
         authDialogBinding.httpAuthInformationText.text = getString(R.string.authenticationDialogMessage, request.site)
+        authDialogBinding.usernameInput.setAutofillDomain(request.site)
+        authDialogBinding.passwordInput.setAutofillDomain(request.site)
         CustomAlertDialogBuilder(requireActivity())
             .setPositiveButton(R.string.authenticationDialogPositiveButton)
             .setNegativeButton(R.string.authenticationDialogNegativeButton)

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/text/DaxTextInput.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/text/DaxTextInput.kt
@@ -33,6 +33,7 @@ import android.util.AttributeSet
 import android.util.SparseArray
 import android.view.View
 import android.view.View.OnFocusChangeListener
+import android.view.ViewStructure
 import android.view.inputmethod.EditorInfo
 import android.widget.TextView.OnEditorActionListener
 import androidx.annotation.DrawableRes
@@ -102,6 +103,7 @@ class DaxTextInput @JvmOverloads constructor(
     private var isPasswordShown: Boolean = false
     private var isClickable: Boolean = false
     private var internalFocusChangedListener: OnFocusChangeListener? = null
+    private var autofillDomain: String = ""
 
     init {
         context.obtainStyledAttributes(
@@ -223,6 +225,20 @@ class DaxTextInput @JvmOverloads constructor(
     fun showKeyboardDelayed() {
         binding.root.postDelayed(KEYBOARD_DELAY) {
             binding.internalEditText.showKeyboard()
+        }
+    }
+
+    fun setAutofillDomain(domain: String) {
+        this.autofillDomain = domain
+    }
+
+    override fun onProvideAutofillStructure(
+        structure: ViewStructure?,
+        flags: Int,
+    ) {
+        super.onProvideAutofillStructure(structure, flags)
+        this.autofillDomain.takeUnless { it.isBlank() }?.let {
+            structure?.setWebDomain(it)
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1209558372959664 

### Description
allow to indicate domain info into text input to improve heuristics in other password managers.

### Steps to test this PR
N/A

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
