### PR TITLE
Duck.ai rotation fix

### DIFF
--- a/duckchat/duckchat-impl/src/main/AndroidManifest.xml
+++ b/duckchat/duckchat-impl/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
         <activity
             android:name="com.duckduckgo.duckchat.impl.DuckChatWebViewActivity"
             android:exported="false"
-            android:label="@string/duck_chat_title" />
+            android:label="@string/duck_chat_title"
+            android:configChanges="keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|navigation|keyboard"/>
     </application>
 </manifest>

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/DuckChatWebViewActivity.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/DuckChatWebViewActivity.kt
@@ -132,7 +132,8 @@ class DuckChatWebViewActivity : DuckDuckGoActivity() {
                         when (featureName) {
                             DUCK_CHAT_FEATURE_NAME -> {
                                 appCoroutineScope.launch(dispatcherProvider.io()) {
-                                    duckChatJSHelper.processJsCallbackMessage(featureName, method, id, data)?.let { response ->
+                                    val response = duckChatJSHelper.processJsCallbackMessage(featureName, method, id, data)
+                                    response?.let {
                                         withContext(dispatcherProvider.main()) {
                                             contentScopeScripts.onResponse(response)
                                         }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/DuckChatWebViewActivity.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/DuckChatWebViewActivity.kt
@@ -132,8 +132,7 @@ class DuckChatWebViewActivity : DuckDuckGoActivity() {
                         when (featureName) {
                             DUCK_CHAT_FEATURE_NAME -> {
                                 appCoroutineScope.launch(dispatcherProvider.io()) {
-                                    val response = duckChatJSHelper.processJsCallbackMessage(featureName, method, id, data)
-                                    response?.let {
+                                    duckChatJSHelper.processJsCallbackMessage(featureName, method, id, data)?.let { response ->
                                         withContext(dispatcherProvider.main()) {
                                             contentScopeScripts.onResponse(response)
                                         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1200204095367872/1209507829379943/f

### Description

- Fixes a bug where chat history was lost when rotating the device.

### Steps to test this PR

- [ ] Open Duck.ai and type a prompt
- [ ] Rotate the device
- [ ] Verify that chat history is not lost
