### PR TITLE
Fix not scrolling to active tab in TabSwitcher

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -195,6 +195,11 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
             if (noTabSelected && tabSwitcherItems.isNotEmpty()) {
                 updateTabGridItemDecorator(tabSwitcherItems.last().id)
             }
+
+            if (firstTimeLoadingTabsList) {
+                firstTimeLoadingTabsList = false
+                scrollToActiveTab()
+            }
         }
         viewModel.activeTab.observe(this) { tab ->
             if (tab != null && tab.tabId != tabItemDecorator.tabSwitcherItemId && !tab.deletable) {
@@ -242,13 +247,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
         tabsAdapter.onLayoutTypeChanged(layoutType)
         tabTouchHelper.onLayoutTypeChanged(layoutType)
 
-        if (firstTimeLoadingTabsList) {
-            firstTimeLoadingTabsList = false
-
-            scrollToShowCurrentTab()
-        } else {
-            scrollToPreviousCenterOffset(centerOffsetPercent)
-        }
+        scrollToPreviousCenterOffset(centerOffsetPercent)
 
         tabsRecycler.show()
     }
@@ -290,7 +289,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
         tabsAdapter.updateData(tabs)
     }
 
-    private fun scrollToShowCurrentTab() {
+    private fun scrollToActiveTab() {
         val index = tabsAdapter.adapterPositionForTab(selectedTabId)
         if (index != -1) {
             scrollToPosition(index)

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -38,6 +38,8 @@ import com.duckduckgo.common.utils.extensions.toBinaryString
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.impl.DuckChatPixelName
+import javax.inject.Inject
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.conflate
@@ -46,8 +48,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import javax.inject.Inject
-import kotlin.time.Duration.Companion.milliseconds
 
 @OptIn(FlowPreview::class)
 @ContributesViewModel(ActivityScope::class)

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -21,6 +21,7 @@ package com.duckduckgo.app.tabs.ui
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
+import androidx.lifecycle.asFlow
 import com.duckduckgo.adclick.api.AdClickManager
 import com.duckduckgo.app.browser.SwipingTabsFeature
 import com.duckduckgo.app.browser.SwipingTabsFeatureProvider
@@ -47,6 +48,8 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -263,16 +266,16 @@ class TabSwitcherViewModelTest {
 
     @Test
     fun whenOnCloseAllTabsConfirmedThenTabDeletedAndTabIdClearedAndSessionDeletedAndPixelFired() = runTest {
-        val tab = TabEntity("ID", position = 0)
-        tabs.value = listOf(tab)
-
         testee.tabSwitcherItems.blockingObserve()
 
         testee.onCloseAllTabsConfirmed()
 
-        verify(mockTabRepository).delete(tab)
-        verify(mockAdClickManager).clearTabId(tab.tabId)
-        verify(mockWebViewSessionStorage).deleteSession(tab.tabId)
+        flowTabs.first().forEach { tab ->
+            verify(mockTabRepository).delete(tab)
+            verify(mockAdClickManager).clearTabId(tab.tabId)
+            verify(mockWebViewSessionStorage).deleteSession(tab.tabId)
+        }
+
         verify(mockPixel).fire(AppPixelName.TAB_MANAGER_MENU_CLOSE_ALL_TABS_CONFIRMED)
     }
 

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -21,7 +21,6 @@ package com.duckduckgo.app.tabs.ui
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
-import androidx.lifecycle.asFlow
 import com.duckduckgo.adclick.api.AdClickManager
 import com.duckduckgo.app.browser.SwipingTabsFeature
 import com.duckduckgo.app.browser.SwipingTabsFeatureProvider
@@ -49,7 +48,6 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1209726056913497/f

### Description

This PR improves the tab switcher scrolling behaviour by:

1. Moving the `scrollToActiveTab()` call to happen after tabs are loaded, ensuring it only runs once the tab list is populated
2. Renaming `scrollToShowCurrentTab()` to `scrollToActiveTab()` for clarity
3. Implementing debounce and conflate on tab repository flow to prevent rapid UI updates

### Steps to test this PR

_Tab Switcher Scrolling_
- [x] Open multiple tabs (remember you can use the developer settings to load a bunch of tabs)
- [x] Open the tab switcher and verify it automatically scrolls to show the active tab
- [x] Select a tab at the bottom of the list
- [x] Open the tab switcher and verify it automatically scrolls to show the active tab
- [x] Select a tab at the bottom of the list
- [x] Open the tab switcher and verify it automatically scrolls to show the active tab
- [x] Switch between different tab layout types and verify scrolling behavior remains consistent
- [x] Verify that rapid tab operations don't cause UI jitter

### UI changes
N/A

### Demo

https://github.com/user-attachments/assets/f45495e3-fc05-413a-b80b-bd2ddcd61eae