### PR TITLE
Tab Switcher Animation: Add pixels

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -407,4 +407,8 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     SET_AS_DEFAULT_IN_MENU_CLICK("m_set-as-default_in-menu_click"),
 
     MALICIOUS_SITE_DETECTED_IN_IFRAME("m_malicious-site-protection_iframe-loaded"),
+
+    TAB_MANAGER_INFO_PANEL_IMPRESSIONS("m_tab_manager_info_panel_impressions"),
+    TAB_MANAGER_INFO_PANEL_DISMISSED("m_tab_manager_info_panel_dismissed"),
+    TAB_MANAGER_INFO_PANEL_TAPPED("m_tab_manager_info_panel_tapped"),
 }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -514,7 +514,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
                         )
                     }
                 }
-                is TrackerAnimationInfoPanel -> Unit // TODO delete from list
+                is TrackerAnimationInfoPanel -> Unit
             }
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.browser.SwipingTabsFeatureProvider
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.pixels.AppPixelName
+import com.duckduckgo.app.pixels.AppPixelName.TAB_MANAGER_INFO_PANEL_DISMISSED
 import com.duckduckgo.app.pixels.AppPixelName.TAB_MANAGER_INFO_PANEL_TAPPED
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
@@ -254,6 +255,8 @@ class TabSwitcherViewModel @Inject constructor(
     fun onTrackerAnimationTileNegativeButtonClicked() {
         viewModelScope.launch {
             tabSwitcherDataStore.setIsAnimationTileDismissed(isDismissed = true)
+            val trackerCount = webTrackersBlockedAppRepository.getTrackerCountForLast7Days()
+            pixel.fire(pixel = TAB_MANAGER_INFO_PANEL_DISMISSED, parameters = mapOf("trackerCount" to trackerCount.toString()))
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -260,6 +260,10 @@ class TabSwitcherViewModel @Inject constructor(
         }
     }
 
+    fun onTrackerAnimationInfoPanelVisible() {
+        pixel.fire(pixel = AppPixelName.TAB_MANAGER_INFO_PANEL_IMPRESSIONS)
+    }
+
     private suspend fun LiveDataScope<List<TabSwitcherItem>>.collectTabItemsWithOptionalAnimationTile(
         tabEntities: List<TabEntity>,
     ) {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.browser.SwipingTabsFeatureProvider
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
 import com.duckduckgo.app.pixels.AppPixelName
+import com.duckduckgo.app.pixels.AppPixelName.TAB_MANAGER_INFO_PANEL_TAPPED
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.app.tabs.TabSwitcherAnimationFeature
@@ -240,6 +241,7 @@ class TabSwitcherViewModel @Inject constructor(
     }
 
     fun onTrackerAnimationInfoPanelClicked() {
+        pixel.fire(TAB_MANAGER_INFO_PANEL_TAPPED)
         command.value = ShowAnimatedTileDismissalDialog
     }
 

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -567,7 +567,7 @@ class TabSwitcherViewModelTest {
     }
 
     @Test
-    fun `when Animation Tile positive button clicked then Animation Tile is removed`() = runTest {
+    fun `when Animation Tile negative button clicked then Animation Tile is removed`() = runTest {
         initializeViewModel(FakeTabSwitcherDataStore())
 
         tabSwitcherAnimationFeature.self().setRawStoredState(State(enable = true))

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -490,7 +490,7 @@ class TabSwitcherViewModelTest {
     }
 
     @Test
-    fun `when Animation Tile Visible then Tab Switcher Items Include Animation Tile And Tabs`() = runTest {
+    fun `when animated info panel then tab switcher items include animation tile and tabs`() = runTest {
         tabSwitcherAnimationFeature.self().setRawStoredState(State(enable = true))
 
         val tab1 = TabEntity("1", position = 1)
@@ -511,7 +511,7 @@ class TabSwitcherViewModelTest {
     }
 
     @Test
-    fun `when Animation Tile Not Visible then Tab Switcher Items Contain Only Tabs`() = runTest {
+    fun `when animated info panel not visible then tab switcher items contain only tabs`() = runTest {
         tabSwitcherAnimationFeature.self().setRawStoredState(State(enable = true))
 
         val tab1 = TabEntity("1", position = 1)
@@ -531,7 +531,7 @@ class TabSwitcherViewModelTest {
     }
 
     @Test
-    fun `when Tab Switcher Animation Feature disabled then Tab Switcher Items Contain Only Tabs`() = runTest {
+    fun `when tab switcher animation feature disabled then tab switcher items contain only tabs`() = runTest {
         initializeViewModel(FakeTabSwitcherDataStore())
         tabSwitcherAnimationFeature.self().setRawStoredState(State(enable = false))
         whenever(mockTabSwitcherPrefsDataStore.isAnimationTileDismissed()).thenReturn(flowOf(true))
@@ -549,7 +549,7 @@ class TabSwitcherViewModelTest {
     }
 
     @Test
-    fun `when Animation Tile positive button clicked then Animation Tile is still visible`() = runTest {
+    fun `when animated info panel positive button clicked then animated info panel is still visible`() = runTest {
         initializeViewModel(FakeTabSwitcherDataStore())
         whenever(mockWebTrackersBlockedAppRepository.getTrackerCountForLast7Days()).thenReturn(15)
 
@@ -567,7 +567,7 @@ class TabSwitcherViewModelTest {
     }
 
     @Test
-    fun `when Animation Tile negative button clicked then Animation Tile is removed`() = runTest {
+    fun `when animated info panel negative button clicked then animated info panel is removed`() = runTest {
         initializeViewModel(FakeTabSwitcherDataStore())
 
         tabSwitcherAnimationFeature.self().setRawStoredState(State(enable = true))
@@ -586,7 +586,7 @@ class TabSwitcherViewModelTest {
     }
 
     @Test
-    fun `when Animation Tile visible then impressions pixel fired`() = runTest {
+    fun `when animated info panel visible then impressions pixel fired`() = runTest {
         initializeViewModel(FakeTabSwitcherDataStore())
         tabSwitcherAnimationFeature.self().setRawStoredState(State(enable = true))
         whenever(mockWebTrackersBlockedAppRepository.getTrackerCountForLast7Days()).thenReturn(15)
@@ -597,7 +597,7 @@ class TabSwitcherViewModelTest {
     }
 
     @Test
-    fun `when Animation Tile clicked then tapped pixel fired`() = runTest {
+    fun `when animated info panel clicked then tapped pixel fired`() = runTest {
         initializeViewModel(FakeTabSwitcherDataStore())
         tabSwitcherAnimationFeature.self().setRawStoredState(State(enable = true))
         whenever(mockWebTrackersBlockedAppRepository.getTrackerCountForLast7Days()).thenReturn(15)
@@ -608,7 +608,7 @@ class TabSwitcherViewModelTest {
     }
 
     @Test
-    fun `when Animation Tile negative button clicked then dismiss pixel fired`() = runTest {
+    fun `when animated info panel negative button clicked then dismiss pixel fired`() = runTest {
         initializeViewModel(FakeTabSwitcherDataStore())
         tabSwitcherAnimationFeature.self().setRawStoredState(State(enable = true))
         whenever(mockWebTrackersBlockedAppRepository.getTrackerCountForLast7Days()).thenReturn(15)

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -585,6 +585,39 @@ class TabSwitcherViewModelTest {
         assertFalse(items.first() is TabSwitcherItem.TrackerAnimationInfoPanel)
     }
 
+    @Test
+    fun `when Animation Tile visible then impressions pixel fired`() = runTest {
+        initializeViewModel(FakeTabSwitcherDataStore())
+        tabSwitcherAnimationFeature.self().setRawStoredState(State(enable = true))
+        whenever(mockWebTrackersBlockedAppRepository.getTrackerCountForLast7Days()).thenReturn(15)
+
+        testee.onTrackerAnimationInfoPanelVisible()
+
+        verify(mockPixel).fire(AppPixelName.TAB_MANAGER_INFO_PANEL_IMPRESSIONS)
+    }
+
+    @Test
+    fun `when Animation Tile clicked then tapped pixel fired`() = runTest {
+        initializeViewModel(FakeTabSwitcherDataStore())
+        tabSwitcherAnimationFeature.self().setRawStoredState(State(enable = true))
+        whenever(mockWebTrackersBlockedAppRepository.getTrackerCountForLast7Days()).thenReturn(15)
+
+        testee.onTrackerAnimationInfoPanelClicked()
+
+        verify(mockPixel).fire(AppPixelName.TAB_MANAGER_INFO_PANEL_TAPPED)
+    }
+
+    @Test
+    fun `when Animation Tile negative button clicked then dismiss pixel fired`() = runTest {
+        initializeViewModel(FakeTabSwitcherDataStore())
+        tabSwitcherAnimationFeature.self().setRawStoredState(State(enable = true))
+        whenever(mockWebTrackersBlockedAppRepository.getTrackerCountForLast7Days()).thenReturn(15)
+
+        testee.onTrackerAnimationTileNegativeButtonClicked()
+
+        verify(mockPixel).fire(pixel = AppPixelName.TAB_MANAGER_INFO_PANEL_DISMISSED, parameters = mapOf("trackerCount" to "15"))
+    }
+
     private class FakeTabSwitcherDataStore : TabSwitcherDataStore {
 
         private val animationTileDismissedFlow = MutableStateFlow(false)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1207908166761516/1209726015931612/f

### Description
Added tracking for the tab manager info panel with three new pixels:
- `m_tab_manager_info_panel_impressions` - Fired when the panel becomes visible
- `m_tab_manager_info_panel_dismissed` - Fired when the panel is dismissed, includes tracker count
- `m_tab_manager_info_panel_tapped` - Fired when the panel is tapped

Implemented visibility detection for the tracker animation info panel in the tab switcher to accurately track impressions.

### Steps to test this PR

Pre-requisite: Enable `tabSwitcherAnimation` feature flag

_m_tab_manager_info_panel_impressions_
- [x] Start with no tabs
- [x] Open the TabSwitcher
- [x] Verify `m_tab_manager_info_panel_impressions` fires
- [x] Add many tabs (use developer settings to easily add 100)
- [x] Ensure that the active tab is one where you cannot see the animated info panel
- [x] Close the TabSwitcher
- [x] Open the TabSwitcher
- [x] Ensure that `m_tab_manager_info_panel_impressions` is **not** fired
- [x] Scroll up slowly to the animated tile until the bottom of the info panel is barely visible
- [x] Ensure that `m_tab_manager_info_panel_impressions` is **not** fired
- [x] Scroll up until ~75% of the tile is visible
- [x] Ensure that `m_tab_manager_info_panel_impressions` **is** fired
- [x] Scroll away from the InfoPanel until it is not visible
- [x] Scroll back to the InfoPanel 
- [x] Ensure that `m_tab_manager_info_panel_impressions` **is** fired
- [x] Scroll away from the InfoPanel until it is not visible
- [x] Switch layouts
- [x] Ensure that `m_tab_manager_info_panel_impressions` is **not** fired

_m_tab_manager_info_panel_tapped_
- [x] Open the TabSwitcher
- [x] Tap on the panel and verify the tapped pixel is fired

_m_tab_manager_info_panel_dismissed_
- [x] Dismiss the panel and verify the dismissed pixel is fired with tracker count

### UI changes
N/A