### PR TITLE
Fix export Duck.ai chat not downloading

### DIFF
--- a/downloads/downloads-api/src/main/java/com/duckduckgo/downloads/api/FileDownloader.kt
+++ b/downloads/downloads-api/src/main/java/com/duckduckgo/downloads/api/FileDownloader.kt
@@ -36,5 +36,7 @@ interface FileDownloader {
         val subfolder: String,
         val directory: File = Environment.getExternalStoragePublicDirectory(subfolder),
         val isUrlCompressed: Boolean = false,
+        val fileName: String? = null,
+        val fileType: String? = null,
     ) : Serializable
 }

--- a/downloads/downloads-api/src/main/java/com/duckduckgo/downloads/api/FileDownloader.kt
+++ b/downloads/downloads-api/src/main/java/com/duckduckgo/downloads/api/FileDownloader.kt
@@ -37,6 +37,5 @@ interface FileDownloader {
         val directory: File = Environment.getExternalStoragePublicDirectory(subfolder),
         val isUrlCompressed: Boolean = false,
         val fileName: String? = null,
-        val fileType: String? = null,
     ) : Serializable
 }

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DataUriDownloader.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DataUriDownloader.kt
@@ -42,7 +42,7 @@ class DataUriDownloader @Inject constructor(
         callback: DownloadCallback,
     ) {
         try {
-            when (val parsedDataUri = dataUriParser.generate(pending.url, pending.fileName, pending.fileType)) {
+            when (val parsedDataUri = dataUriParser.generate(pending.url, pending.fileName)) {
                 is ParseResult.Invalid -> {
                     logcat { "Failed to extract data from data URI" }
                     callback.onError(url = pending.url, reason = DataUriParseException)

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DataUriDownloader.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DataUriDownloader.kt
@@ -42,7 +42,7 @@ class DataUriDownloader @Inject constructor(
         callback: DownloadCallback,
     ) {
         try {
-            when (val parsedDataUri = dataUriParser.generate(pending.url)) {
+            when (val parsedDataUri = dataUriParser.generate(pending.url, pending.fileName, pending.fileType)) {
                 is ParseResult.Invalid -> {
                     logcat { "Failed to extract data from data URI" }
                     callback.onError(url = pending.url, reason = DataUriParseException)

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DataUriParser.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DataUriParser.kt
@@ -25,7 +25,7 @@ import okio.ByteString.Companion.decodeBase64
 
 class DataUriParser @Inject constructor() {
 
-    fun generate(url: String): ParseResult {
+    fun generate(url: String, fileName: String? = null, fileType: String? = null): ParseResult {
         val offset = url.indexOf(',')
         if (offset == -1) {
             return ParseResult.Invalid
@@ -46,8 +46,8 @@ class DataUriParser @Inject constructor() {
         val fileTypeGeneral = result.groupValues[REGEX_GROUP_FILE_TYPE_GENERAL]
         val fileTypeSpecific = result.groupValues[REGEX_GROUP_FILE_TYPE_SPECIFIC]
 
-        val suffix = parseSuffix(mimeType, url, data)
-        val filename = UUID.randomUUID().toString()
+        val suffix = fileType ?: parseSuffix(mimeType, url, data)
+        val filename = fileName ?: UUID.randomUUID().toString()
         val generatedFilename = GeneratedFilename(name = filename, fileType = suffix)
 
         return ParsedDataUri(fileTypeGeneral, fileTypeSpecific, data, mimeType, generatedFilename)

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DataUriParser.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DataUriParser.kt
@@ -25,7 +25,7 @@ import okio.ByteString.Companion.decodeBase64
 
 class DataUriParser @Inject constructor() {
 
-    fun generate(url: String, fileName: String? = null, fileType: String? = null): ParseResult {
+    fun generate(url: String, fileName: String? = null): ParseResult {
         val offset = url.indexOf(',')
         if (offset == -1) {
             return ParseResult.Invalid
@@ -46,7 +46,7 @@ class DataUriParser @Inject constructor() {
         val fileTypeGeneral = result.groupValues[REGEX_GROUP_FILE_TYPE_GENERAL]
         val fileTypeSpecific = result.groupValues[REGEX_GROUP_FILE_TYPE_SPECIFIC]
 
-        val suffix = fileType ?: parseSuffix(mimeType, url, data)
+        val suffix = parseSuffix(mimeType, url, data)
         val filename = fileName ?: UUID.randomUUID().toString()
         val generatedFilename = GeneratedFilename(name = filename, fileType = suffix)
 
@@ -54,10 +54,12 @@ class DataUriParser @Inject constructor() {
     }
 
     private fun parseSuffix(mimeType: String, url: String, data: String): String {
-        // MimeTypeMap returns the wrong value for "jpeg" types on some OS versions.
-        if (mimeType == "image/jpeg") return "jpg"
+        val baseMimeType = mimeType.substringBefore(';')
 
-        if ((mimeType == "text/plain" || mimeType == "application/octet-stream") && url.contains("base64", ignoreCase = true)) {
+        // MimeTypeMap returns the wrong value for "jpeg" types on some OS versions.
+        if (baseMimeType == "image/jpeg") return "jpg"
+
+        if ((baseMimeType == "text/plain" || baseMimeType == "application/octet-stream") && url.contains("base64", ignoreCase = true)) {
             val dataPart = data.take(if (data.length > MAX_LENGTH_FOR_MIME_TYPE_DETECTION) MAX_LENGTH_FOR_MIME_TYPE_DETECTION else data.length)
             val suffix = determineSuffixFromUrlPart(dataPart)
             if (suffix != null) {
@@ -65,7 +67,7 @@ class DataUriParser @Inject constructor() {
             }
         }
 
-        return MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType) ?: ""
+        return MimeTypeMap.getSingleton().getExtensionFromMimeType(baseMimeType) ?: ""
     }
 
     private fun determineSuffixFromUrlPart(dataPart: String): String? {

--- a/downloads/downloads-impl/src/test/java/com/duckduckgo/downloads/impl/DataUriParserTest.kt
+++ b/downloads/downloads-impl/src/test/java/com/duckduckgo/downloads/impl/DataUriParserTest.kt
@@ -150,33 +150,14 @@ class DataUriParserTest {
     }
 
     @Test
-    fun whenFileNameAndFileTypeProvidedThenParseDataUriWithProvidedFileNameAndFileType() {
-        val parseResult = testee.generate("data:text/plain;base64,Qk1AwgEA", fileName = "file_name", fileType = "txt")
-        assertTrue(parseResult is ParsedDataUri)
-        parseResult as ParsedDataUri
-
-        assertEquals("file_name.txt", parseResult.filename.toString())
-        assertEquals("txt", parseResult.filename.fileType)
-        assertEquals("file_name", parseResult.filename.name)
+    fun whenMimeTypeParametersArePresentThenStripParametersAndParseDataUri() {
+        val parsed = testee.generate("data:text/plain;charset=utf-8;base64,77u/VGhpcyBjb252ZXJz") as ParsedDataUri
+        assertEquals("txt", parsed.filename.fileType)
     }
 
     @Test
     fun whenFileNameProvidedThenParseDataUriWithProvidedFileName() {
-        val parseResult = testee.generate("data:image/jpeg;base64,RUJQVlA4WAo", fileName = "file_name")
-        assertTrue(parseResult is ParsedDataUri)
-        parseResult as ParsedDataUri
-
-        assertEquals("file_name.jpg", parseResult.filename.toString())
-        assertEquals("jpg", parseResult.filename.fileType)
-        assertEquals("file_name", parseResult.filename.name)
-    }
-
-    @Test
-    fun whenFileTypeProvidedThenParseDataUriWithProvidedFileType() {
-        val parseResult = testee.generate("data:image/jpeg;base64,RUJQVlA4WAo", fileType = "txt")
-        assertTrue(parseResult is ParsedDataUri)
-        parseResult as ParsedDataUri
-
-        assertEquals("txt", parseResult.filename.fileType)
+        val parseResult = testee.generate("data:text/plain;base64,77u/VGhpcyBjb252ZXJz", fileName = "file_name") as ParsedDataUri
+        assertEquals("file_name.txt", parseResult.filename.toString())
     }
 }

--- a/downloads/downloads-impl/src/test/java/com/duckduckgo/downloads/impl/DataUriParserTest.kt
+++ b/downloads/downloads-impl/src/test/java/com/duckduckgo/downloads/impl/DataUriParserTest.kt
@@ -148,4 +148,15 @@ class DataUriParserTest {
         val parsed = testee.generate("data:application/octet-stream;base64,JVBERi0xLjMKJeL") as ParsedDataUri
         assertEquals("pdf", parsed.filename.fileType)
     }
+
+    @Test
+    fun whenFilenameParameterIsProvidedThenItIsUsedInParsedDataUri() {
+        val parseResult = testee.generate("data:text/plain;base64,Qk1AwgEA", "file_name", "txt")
+        assertTrue(parseResult is ParsedDataUri)
+        parseResult as ParsedDataUri
+
+        assertEquals("file_name.txt", parseResult.filename.toString())
+        assertEquals("txt", parseResult.filename.fileType)
+        assertEquals("file_name", parseResult.filename.name)
+    }
 }

--- a/downloads/downloads-impl/src/test/java/com/duckduckgo/downloads/impl/DataUriParserTest.kt
+++ b/downloads/downloads-impl/src/test/java/com/duckduckgo/downloads/impl/DataUriParserTest.kt
@@ -150,13 +150,33 @@ class DataUriParserTest {
     }
 
     @Test
-    fun whenFilenameParameterIsProvidedThenItIsUsedInParsedDataUri() {
-        val parseResult = testee.generate("data:text/plain;base64,Qk1AwgEA", "file_name", "txt")
+    fun whenFileNameAndFileTypeProvidedThenParseDataUriWithProvidedFileNameAndFileType() {
+        val parseResult = testee.generate("data:text/plain;base64,Qk1AwgEA", fileName = "file_name", fileType = "txt")
         assertTrue(parseResult is ParsedDataUri)
         parseResult as ParsedDataUri
 
         assertEquals("file_name.txt", parseResult.filename.toString())
         assertEquals("txt", parseResult.filename.fileType)
         assertEquals("file_name", parseResult.filename.name)
+    }
+
+    @Test
+    fun whenFileNameProvidedThenParseDataUriWithProvidedFileName() {
+        val parseResult = testee.generate("data:image/jpeg;base64,RUJQVlA4WAo", fileName = "file_name")
+        assertTrue(parseResult is ParsedDataUri)
+        parseResult as ParsedDataUri
+
+        assertEquals("file_name.jpg", parseResult.filename.toString())
+        assertEquals("jpg", parseResult.filename.fileType)
+        assertEquals("file_name", parseResult.filename.name)
+    }
+
+    @Test
+    fun whenFileTypeProvidedThenParseDataUriWithProvidedFileType() {
+        val parseResult = testee.generate("data:image/jpeg;base64,RUJQVlA4WAo", fileType = "txt")
+        assertTrue(parseResult is ParsedDataUri)
+        parseResult as ParsedDataUri
+
+        assertEquals("txt", parseResult.filename.fileType)
     }
 }

--- a/duckchat/duckchat-impl/build.gradle
+++ b/duckchat/duckchat-impl/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation project(':common-utils')
     implementation project(':browser-api')
     implementation project(':js-messaging-api')
+    implementation project(':downloads-api')
 
     anvil project(path: ':anvil-compiler')
     implementation project(path: ':anvil-annotations')

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/DuckChatWebViewActivity.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/DuckChatWebViewActivity.kt
@@ -19,7 +19,6 @@ package com.duckduckgo.duckchat.impl
 import android.Manifest
 import android.annotation.SuppressLint
 import android.content.pm.PackageManager
-import android.os.Build
 import android.os.Bundle
 import android.os.Environment
 import android.os.Message
@@ -290,7 +289,7 @@ class DuckChatWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationDialog
     }
 
     private fun minSdk30(): Boolean {
-        return appBuildConfig.sdkInt >= Build.VERSION_CODES.R
+        return appBuildConfig.sdkInt >= 30
     }
 
     @Suppress("NewApi")

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/DuckChatWebViewActivity.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/DuckChatWebViewActivity.kt
@@ -16,30 +16,51 @@
 
 package com.duckduckgo.duckchat.impl
 
+import android.Manifest
 import android.annotation.SuppressLint
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
+import android.os.Environment
 import android.os.Message
 import android.view.MenuItem
 import android.webkit.WebChromeClient
 import android.webkit.WebSettings
 import android.webkit.WebView
+import androidx.annotation.AnyThread
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.tabs.BrowserNav
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.ui.DuckDuckGoActivity
+import com.duckduckgo.common.ui.view.makeSnackbarWithNoBottomInset
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.downloads.api.DOWNLOAD_SNACKBAR_DELAY
+import com.duckduckgo.downloads.api.DOWNLOAD_SNACKBAR_LENGTH
+import com.duckduckgo.downloads.api.DownloadCommand
+import com.duckduckgo.downloads.api.DownloadConfirmationDialogListener
+import com.duckduckgo.downloads.api.DownloadStateListener
+import com.duckduckgo.downloads.api.DownloadsFileActions
+import com.duckduckgo.downloads.api.FileDownloader
+import com.duckduckgo.downloads.api.FileDownloader.PendingFileDownload
 import com.duckduckgo.duckchat.impl.RealDuckChatJSHelper.Companion.DUCK_CHAT_FEATURE_NAME
 import com.duckduckgo.duckchat.impl.databinding.ActivityDuckChatWebviewBinding
 import com.duckduckgo.js.messaging.api.JsMessageCallback
 import com.duckduckgo.js.messaging.api.JsMessaging
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.navigation.api.getActivityParams
+import com.google.android.material.snackbar.Snackbar
+import java.io.File
 import javax.inject.Inject
 import javax.inject.Named
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.cancellable
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
@@ -50,7 +71,7 @@ internal data class DuckChatWebViewActivityWithParams(
 
 @InjectWith(ActivityScope::class)
 @ContributeToActivityStarter(DuckChatWebViewActivityWithParams::class)
-class DuckChatWebViewActivity : DuckDuckGoActivity() {
+class DuckChatWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationDialogListener {
 
     @Inject
     lateinit var webViewClient: DuckChatWebViewClient
@@ -72,7 +93,22 @@ class DuckChatWebViewActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var browserNav: BrowserNav
 
+    @Inject
+    lateinit var appBuildConfig: AppBuildConfig
+
+    @Inject
+    lateinit var fileDownloader: FileDownloader
+
+    @Inject
+    lateinit var downloadCallback: DownloadStateListener
+
+    @Inject
+    lateinit var downloadsFileActions: DownloadsFileActions
+
     private val binding: ActivityDuckChatWebviewBinding by viewBinding()
+
+    private var pendingFileDownload: PendingFileDownload? = null
+    private val downloadMessagesJob = ConflatedJob()
 
     private val toolbar
         get() = binding.includeToolbar.toolbar
@@ -118,6 +154,10 @@ class DuckChatWebViewActivity : DuckDuckGoActivity() {
                 setSupportMultipleWindows(true)
                 databaseEnabled = false
                 setSupportZoom(true)
+            }
+
+            it.setDownloadListener { url, _, contentDisposition, mimeType, _ ->
+                requestFileDownload(url, contentDisposition, mimeType)
             }
 
             contentScopeScripts.register(
@@ -169,7 +209,112 @@ class DuckChatWebViewActivity : DuckDuckGoActivity() {
         }
     }
 
+    override fun continueDownload(pendingFileDownload: PendingFileDownload) {
+        fileDownloader.enqueueDownload(pendingFileDownload)
+    }
+
+    override fun cancelDownload() {
+        // NOOP
+    }
+
+    private fun launchDownloadMessagesJob() {
+        downloadMessagesJob += lifecycleScope.launch {
+            downloadCallback.commands().cancellable().collect {
+                processFileDownloadedCommand(it)
+            }
+        }
+    }
+
+    private fun processFileDownloadedCommand(command: DownloadCommand) {
+        when (command) {
+            is DownloadCommand.ShowDownloadStartedMessage -> downloadStarted(command)
+            is DownloadCommand.ShowDownloadFailedMessage -> downloadFailed(command)
+            is DownloadCommand.ShowDownloadSuccessMessage -> downloadSucceeded(command)
+        }
+    }
+
+    @SuppressLint("WrongConstant")
+    private fun downloadStarted(command: DownloadCommand.ShowDownloadStartedMessage) {
+        binding.root.makeSnackbarWithNoBottomInset(getString(command.messageId, command.fileName), DOWNLOAD_SNACKBAR_LENGTH)?.show()
+    }
+
+    private fun downloadFailed(command: DownloadCommand.ShowDownloadFailedMessage) {
+        val downloadFailedSnackbar = binding.root.makeSnackbarWithNoBottomInset(getString(command.messageId), Snackbar.LENGTH_LONG)
+        binding.root.postDelayed({ downloadFailedSnackbar.show() }, DOWNLOAD_SNACKBAR_DELAY)
+    }
+
+    private fun downloadSucceeded(command: DownloadCommand.ShowDownloadSuccessMessage) {
+        val downloadSucceededSnackbar = binding.root.makeSnackbarWithNoBottomInset(
+            getString(command.messageId, command.fileName),
+            Snackbar.LENGTH_LONG,
+        )
+            .apply {
+                this.setAction(R.string.downloadsDownloadFinishedActionName) {
+                    val result = downloadsFileActions.openFile(context, File(command.filePath))
+                    if (!result) {
+                        view.makeSnackbarWithNoBottomInset(getString(R.string.downloadsCannotOpenFileErrorMessage), Snackbar.LENGTH_LONG).show()
+                    }
+                }
+            }
+        binding.root.postDelayed({ downloadSucceededSnackbar.show() }, DOWNLOAD_SNACKBAR_DELAY)
+    }
+
+    private fun requestFileDownload(
+        url: String,
+        contentDisposition: String?,
+        mimeType: String,
+    ) {
+        pendingFileDownload = PendingFileDownload(
+            url = url,
+            contentDisposition = contentDisposition,
+            mimeType = mimeType,
+            subfolder = Environment.DIRECTORY_DOWNLOADS,
+            fileName = "duck.ai_${System.currentTimeMillis()}",
+            fileType = "txt",
+        )
+
+        if (hasWriteStoragePermission()) {
+            downloadFile()
+        } else {
+            requestWriteStoragePermission()
+        }
+    }
+
+    @AnyThread
+    private fun downloadFile() {
+        val pendingDownload = pendingFileDownload ?: return
+
+        pendingFileDownload = null
+
+        continueDownload(pendingDownload)
+    }
+
+    private fun minSdk30(): Boolean {
+        return appBuildConfig.sdkInt >= Build.VERSION_CODES.R
+    }
+
+    @Suppress("NewApi")
+    private fun hasWriteStoragePermission(): Boolean {
+        return minSdk30() ||
+            ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun requestWriteStoragePermission() {
+        requestPermissions(arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE), PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE)
+    }
+
+    override fun onResume() {
+        launchDownloadMessagesJob()
+        super.onResume()
+    }
+
+    override fun onDestroy() {
+        downloadMessagesJob.cancel()
+        super.onDestroy()
+    }
+
     companion object {
+        private const val PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE = 200
         private const val CUSTOM_UA =
             "Mozilla/5.0 (Linux; Android 12) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/124.0.0.0 Mobile DuckDuckGo/5 Safari/537.36"
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/DuckChatWebViewActivity.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/DuckChatWebViewActivity.kt
@@ -269,7 +269,6 @@ class DuckChatWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationDialog
             mimeType = mimeType,
             subfolder = Environment.DIRECTORY_DOWNLOADS,
             fileName = "duck.ai_${System.currentTimeMillis()}",
-            fileType = "txt",
         )
 
         if (hasWriteStoragePermission()) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/DuckChatWebViewActivity.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/DuckChatWebViewActivity.kt
@@ -248,10 +248,10 @@ class DuckChatWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationDialog
             Snackbar.LENGTH_LONG,
         )
             .apply {
-                this.setAction(R.string.downloadsDownloadFinishedActionName) {
+                this.setAction(R.string.duck_chat_download_finished_action_name) {
                     val result = downloadsFileActions.openFile(context, File(command.filePath))
                     if (!result) {
-                        view.makeSnackbarWithNoBottomInset(getString(R.string.downloadsCannotOpenFileErrorMessage), Snackbar.LENGTH_LONG).show()
+                        view.makeSnackbarWithNoBottomInset(getString(R.string.duck_chat_cannot_open_file_error_message), Snackbar.LENGTH_LONG).show()
                     }
                 }
             }

--- a/duckchat/duckchat-impl/src/main/res/values-bg/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-bg/strings-duckchat.xml
@@ -20,4 +20,7 @@
     <string name="duck_chat_title">Duck.ai</string>
     <string name="duck_chat_settings_activity_description">Duck.ai е незадължителна функция, чрез която можете да разговаряте анонимно с популярни AI чат модели от трети страни. Чатовете Ви не се използват за обучение на AI.\n<annotation type="learn_more_link">Научете повече</annotation></string>
     <string name="duck_chat_visibility_setting">Показване на Duck.ai в менюто на браузъра</string>
+
+    <string name="duck_chat_download_finished_action_name">Отваряне</string>
+    <string name="duck_chat_cannot_open_file_error_message">Файлът не може да се отвори. Проверете за съвместимо приложение.</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-cs/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-cs/strings-duckchat.xml
@@ -20,4 +20,7 @@
     <string name="duck_chat_title">Duck.ai</string>
     <string name="duck_chat_settings_activity_description">Duck.ai je volitelná funkce, která umožňuje anonymně chatovat s populárními AI chatovacími modely třetích stran. Tvoje chaty neslouží k trénování umělé inteligence.\n<annotation type="learn_more_link">Další informace</annotation></string>
     <string name="duck_chat_visibility_setting">Zobrazit Duck.ai v nabídce prohlížeče</string>
+
+    <string name="duck_chat_download_finished_action_name">Otevřít</string>
+    <string name="duck_chat_cannot_open_file_error_message">Soubor nejde otevřít. Zkus vyhledat kompatibilní aplikaci.</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-da/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-da/strings-duckchat.xml
@@ -20,4 +20,7 @@
     <string name="duck_chat_title">Duck.ai</string>
     <string name="duck_chat_settings_activity_description">Duck.ai er en valgfri funktion, der giver dig mulighed for at chatte anonymt med populære tredjeparts AI-chatmodeller. Dine chats bruges ikke til at træne AI.\n<annotation type="learn_more_link">Læs mere</annotation></string>
     <string name="duck_chat_visibility_setting">Vis Duck.ai i browsermenuen</string>
+
+    <string name="duck_chat_download_finished_action_name">Åben</string>
+    <string name="duck_chat_cannot_open_file_error_message">Kan ikke åbne filen. Kontrollér, om der er en kompatibel app.</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-de/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-de/strings-duckchat.xml
@@ -20,4 +20,7 @@
     <string name="duck_chat_title">Duck.ai</string>
     <string name="duck_chat_settings_activity_description">Duck.ai ist eine optionale Funktion, mit der du anonym mit beliebten KI-Chatmodellen von Drittanbietern chatten kannst. Deine Chats werden nicht zum Trainieren von KI verwendet.\n<annotation type="learn_more_link">Mehr erfahren</annotation></string>
     <string name="duck_chat_visibility_setting">Duck.ai im Browser-Menü anzeigen</string>
+
+    <string name="duck_chat_download_finished_action_name">Öffnen</string>
+    <string name="duck_chat_cannot_open_file_error_message">Datei kann nicht geöffnet werden. Nach einer kompatiblen App suchen.</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-el/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-el/strings-duckchat.xml
@@ -20,4 +20,7 @@
     <string name="duck_chat_title">Duck.ai</string>
     <string name="duck_chat_settings_activity_description">Το Duck.ai αποτελεί προαιρετική λειτουργία που σας επιτρέπει να συνομιλείτε ανώνυμα με δημοφιλή μοντέλα τρίτων για συνομιλία μέσω τεχνητής νοημοσύνης. Οι συνομιλίες σας δεν χρησιμοποιούνται για την εκπαίδευση τεχνητής συνομιλίας.\n<annotation type="learn_more_link">Μάθετε περισσότερα</annotation></string>
     <string name="duck_chat_visibility_setting">Εμφάνιση του Duck.ai στο μενού του προγράμματος περιήγησης</string>
+
+    <string name="duck_chat_download_finished_action_name">Άνοιγμα</string>
+    <string name="duck_chat_cannot_open_file_error_message">Δεν ήταν δυνατό το άνοιγμα του αρχείου. Ελέγξτε για μια συμβατή εφαρμογή.</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-es/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-es/strings-duckchat.xml
@@ -20,4 +20,7 @@
     <string name="duck_chat_title">Duck.ai</string>
     <string name="duck_chat_settings_activity_description">Duck.ai es una función opcional que te permite chatear de forma anónima con modelos populares de chat de IA de terceros. Tus chats no se utilizan para entrenar la IA.\n<annotation type="learn_more_link">Más información</annotation></string>
     <string name="duck_chat_visibility_setting">Mostrar Duck.ai en el menú del navegador</string>
+
+    <string name="duck_chat_download_finished_action_name">Abrir</string>
+    <string name="duck_chat_cannot_open_file_error_message">No se puede abrir el archivo. Busca una aplicación compatible.</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-et/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-et/strings-duckchat.xml
@@ -20,4 +20,7 @@
     <string name="duck_chat_title">Duck.ai</string>
     <string name="duck_chat_settings_activity_description">Duck.ai on valikuline funktsioon, mis võimaldab anonüümselt vestelda populaarsete kolmanda poole AI vestlusmudelitega. Teie vestlusi ei kasutata tehisintellekti treenimiseks.\n<annotation type="learn_more_link">Lisateave</annotation></string>
     <string name="duck_chat_visibility_setting">Kuva Duck.ai brauseri menüüs</string>
+
+    <string name="duck_chat_download_finished_action_name">Avatud</string>
+    <string name="duck_chat_cannot_open_file_error_message">Faili ei saa avada. Otsi ühilduvat rakendust.</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-fi/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-fi/strings-duckchat.xml
@@ -20,4 +20,7 @@
     <string name="duck_chat_title">Duck.ai</string>
     <string name="duck_chat_settings_activity_description">Duck.ai on valinnainen ominaisuus, jonka avulla voit keskustella anonyymisti suosittujen kolmannen osapuolen tekoälykeskustelumallien kanssa. Keskustelujasi ei käytetä tekoälyn kouluttamiseen.\n<annotation type="learn_more_link">Lue lisää</annotation></string>
     <string name="duck_chat_visibility_setting">Näytä Duck.ai selainvalikossa</string>
+
+    <string name="duck_chat_download_finished_action_name">Avaa</string>
+    <string name="duck_chat_cannot_open_file_error_message">Tiedoston avaaminen ei onnistu. Tarkista yhteensopiva sovellus.</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-fr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-fr/strings-duckchat.xml
@@ -20,4 +20,7 @@
     <string name="duck_chat_title">Duck.ai</string>
     <string name="duck_chat_settings_activity_description">Duck.ai est une fonctionnalité optionnelle qui vous permet de discuter anonymement avec des modèles de chat IA tiers populaires. Vos discussions ne servent pas à entraîner l’IA.\n<annotation type="learn_more_link">En savoir plus</annotation></string>
     <string name="duck_chat_visibility_setting">Afficher Duck.ai dans le menu du navigateur</string>
+
+    <string name="duck_chat_download_finished_action_name">Ouvrir</string>
+    <string name="duck_chat_cannot_open_file_error_message">Impossible d\'ouvrir le fichier. Vérifiez la compatibilité de l\'application.</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-hr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-hr/strings-duckchat.xml
@@ -20,4 +20,7 @@
     <string name="duck_chat_title">Duck.ai</string>
     <string name="duck_chat_settings_activity_description">Duck.ai izborna je značajka koja ti omogućuje anonimno čavrljanje s popularnim AI modelima \'chata\' trećih strana. Tvoja čavrljanja se ne koriste za obuku AI-a.\n<annotation type="learn_more_link">Saznaj više</annotation></string>
     <string name="duck_chat_visibility_setting">Prikaži Duck.ai u izborniku preglednika</string>
+
+    <string name="duck_chat_download_finished_action_name">Otvori</string>
+    <string name="duck_chat_cannot_open_file_error_message">Datoteka se ne može otvoriti. Provjerite postoji li kompatibilna aplikacija.</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-hu/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-hu/strings-duckchat.xml
@@ -20,4 +20,7 @@
     <string name="duck_chat_title">Duck.ai</string>
     <string name="duck_chat_settings_activity_description">A Duck.ai egy opcionális funkció, amely lehetővé teszi a harmadik féltől származó népszerű AI-csevegési modellekkel való névtelen csevegést. A csevegéseidet nem használjuk fel az AI tanítására.\n<annotation type="learn_more_link">További részletek</annotation></string>
     <string name="duck_chat_visibility_setting">Duck.ai megjelenítése a böngésző menüjében</string>
+
+    <string name="duck_chat_download_finished_action_name">Megnyitás</string>
+    <string name="duck_chat_cannot_open_file_error_message">A fájl nem nyitható meg. Keress kompatibilis alkalmazást.</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-it/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-it/strings-duckchat.xml
@@ -20,4 +20,7 @@
     <string name="duck_chat_title">Duck.ai</string>
     <string name="duck_chat_settings_activity_description">Duck.ai è una funzionalità opzionale che consente di chattare in forma anonima con i più diffusi modelli di chat AI di terze parti. Le chat non vengono usate per addestrare l\'IA.\n<annotation type="learn_more_link">Scopri di più</annotation></string>
     <string name="duck_chat_visibility_setting">Mostra Duck.ai nel menu del browser</string>
+
+    <string name="duck_chat_download_finished_action_name">Apri</string>
+    <string name="duck_chat_cannot_open_file_error_message">Impossibile aprire il file. Verifica la disponibilità di un\'app compatibile.</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-lt/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-lt/strings-duckchat.xml
@@ -20,4 +20,7 @@
     <string name="duck_chat_title">Duck.ai</string>
     <string name="duck_chat_settings_activity_description">„Duck.ai“ yra pasirenkama funkcija, leidžianti anonimiškai kalbėtis su populiariais trečiųjų šalių DI pokalbių modeliais. Tavo pokalbiai nenaudojami dirbtinio intelekto mokymui.\n<annotation type="learn_more_link">Sužinok daugiau</annotation></string>
     <string name="duck_chat_visibility_setting">Rodyti „Duck.ai“ naršyklės meniu</string>
+
+    <string name="duck_chat_download_finished_action_name">Atviras</string>
+    <string name="duck_chat_cannot_open_file_error_message">Nepavyko atidaryti failo. Patikrinkite, ar yra suderinama programa.</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-lv/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-lv/strings-duckchat.xml
@@ -20,4 +20,7 @@
     <string name="duck_chat_title">Duck.ai</string>
     <string name="duck_chat_settings_activity_description">Duck.ai ir papildu līdzeklis, kas ļauj anonīmi tērzēt ar populāriem trešo pušu Ml tērzēšanas modeļiem. Tavas tērzēšanas sarunas netiek izmantotas AMI apmācībai.\n<annotation type="learn_more_link">Uzzini vairāk</annotation></string>
     <string name="duck_chat_visibility_setting">Rādīt Duck.ai pārlūka izvēlnē</string>
+
+    <string name="duck_chat_download_finished_action_name">Atvērt</string>
+    <string name="duck_chat_cannot_open_file_error_message">Nevar atvērt failu. Pārbaudīt saderīgu lietotni.</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-nb/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-nb/strings-duckchat.xml
@@ -20,4 +20,7 @@
     <string name="duck_chat_title">Duck.ai</string>
     <string name="duck_chat_settings_activity_description">Duck.ai er en valgfri funksjon der du kan chatte anonymt med populære tredjeparts AI-chat-modeller. Chattene dine brukes ikke til å trene AI.\n<annotation type="learn_more_link">Les mer</annotation></string>
     <string name="duck_chat_visibility_setting">Vis Duck.ai i nettlesermenyen</string>
+
+    <string name="duck_chat_download_finished_action_name">Åpne</string>
+    <string name="duck_chat_cannot_open_file_error_message">Kan ikke åpne filen. Se etter kompatibel app.</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-nl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-nl/strings-duckchat.xml
@@ -20,4 +20,7 @@
     <string name="duck_chat_title">Duck.ai</string>
     <string name="duck_chat_settings_activity_description">Duck.ai is een optionele functie waarmee je anoniem kunt chatten met populaire AI-chatmodellen van derden. Je chats worden niet gebruikt om AI te trainen.\n<annotation type="learn_more_link">Meer informatie</annotation></string>
     <string name="duck_chat_visibility_setting">Duck.ai weergeven in browsermenu</string>
+
+    <string name="duck_chat_download_finished_action_name">Openen</string>
+    <string name="duck_chat_cannot_open_file_error_message">Kan bestand niet openen. Kijk of er een compatibele app is.</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-pl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-pl/strings-duckchat.xml
@@ -20,4 +20,7 @@
     <string name="duck_chat_title">Duck.ai</string>
     <string name="duck_chat_settings_activity_description">Duck.ai to opcjonalna funkcja, która umożliwia prowadzenie anonimowych rozmów z popularnymi modelami czatu AI innych firm. Twoje czaty nie są używane do trenowania AI.\n<annotation type="learn_more_link">Dowiedz się więcej</annotation></string>
     <string name="duck_chat_visibility_setting">Pokaż Duck.ai w menu przeglądarki</string>
+
+    <string name="duck_chat_download_finished_action_name">Otwórz</string>
+    <string name="duck_chat_cannot_open_file_error_message">Nie można otworzyć pliku. Poszukaj zgodnej aplikacji.</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-pt/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-pt/strings-duckchat.xml
@@ -20,4 +20,7 @@
     <string name="duck_chat_title">Duck.ai</string>
     <string name="duck_chat_settings_activity_description">O Duck.ai é uma funcionalidade opcional que te permite conversar anonimamente com modelos de chat de IA populares de terceiros. As tuas conversas não são utilizadas para treinar a IA.\n<annotation type="learn_more_link">Sabe mais</annotation></string>
     <string name="duck_chat_visibility_setting">Mostrar Duck.ai no menu do navegador</string>
+
+    <string name="duck_chat_download_finished_action_name">Abrir</string>
+    <string name="duck_chat_cannot_open_file_error_message">Não é possível abrir o ficheiro. Verificar se a aplicação é compatível.</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-ro/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-ro/strings-duckchat.xml
@@ -20,4 +20,7 @@
     <string name="duck_chat_title">Duck.ai</string>
     <string name="duck_chat_settings_activity_description">Duck.ai este o caracteristică opțională care îți permite să discuți anonim cu modele populare de chat AI de la terțe părți. Chaturile tale nu sunt folosite pentru a antrena AI.\n<annotation type="learn_more_link">Află mai multe</annotation></string>
     <string name="duck_chat_visibility_setting">Afișează Duck.ai în meniul browserului</string>
+
+    <string name="duck_chat_download_finished_action_name">Deschide</string>
+    <string name="duck_chat_cannot_open_file_error_message">Nu se poate deschide fișierul. Caută o aplicație compatibilă.</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-ru/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-ru/strings-duckchat.xml
@@ -20,4 +20,7 @@
     <string name="duck_chat_title">Duck.ai</string>
     <string name="duck_chat_settings_activity_description">Duck.ai — дополнительная функция, позволяющая анонимно беседовать с популярными сторонними чат-моделями на базе искусственного интеллекта. Содержимое чатов не применяется для обучения ИИ.\n<annotation type="learn_more_link">Подробнее...</annotation></string>
     <string name="duck_chat_visibility_setting">Показывать Duck.ai в меню браузера</string>
+
+    <string name="duck_chat_download_finished_action_name">Открыть</string>
+    <string name="duck_chat_cannot_open_file_error_message">Не удается открыть файл. Попробуйте найти совместимое приложение.</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-sk/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sk/strings-duckchat.xml
@@ -20,4 +20,7 @@
     <string name="duck_chat_title">Duck.ai</string>
     <string name="duck_chat_settings_activity_description">Duck.ai je voliteľná funkcia, ktorá ti umožňuje anonymne chatovať s obľúbenými modelmi chatu s umelou inteligenciou tretích strán. Tvoje chaty sa nepoužívajú na trénovanie AI.\n<annotation type="learn_more_link">Viac informácií</annotation></string>
     <string name="duck_chat_visibility_setting">Zobraziť Duck.ai v ponuke prehliadača</string>
+
+    <string name="duck_chat_download_finished_action_name">Otvorené</string>
+    <string name="duck_chat_cannot_open_file_error_message">Súbor sa nedá otvoriť. Vyhľadajte kompatibilnú aplikáciu.</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-sl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sl/strings-duckchat.xml
@@ -20,4 +20,7 @@
     <string name="duck_chat_title">Duck.ai</string>
     <string name="duck_chat_settings_activity_description">Duck.ai je izbirna funkcija, ki vam omogoča anonimen klepet s priljubljenimi modeli za klepet z umetno inteligenco drugih ponudnikov. Vaši klepeti se ne uporabljajo za usposabljanje umetne inteligence.\n<annotation type="learn_more_link">Več o tem</annotation></string>
     <string name="duck_chat_visibility_setting">Prikaži Duck.ai v meniju brskalnika</string>
+
+    <string name="duck_chat_download_finished_action_name">Odpri</string>
+    <string name="duck_chat_cannot_open_file_error_message">Datoteke ni mogoče odpreti. Poiščite združljivo aplikacijo.</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-sv/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sv/strings-duckchat.xml
@@ -20,4 +20,7 @@
     <string name="duck_chat_title">Duck.ai</string>
     <string name="duck_chat_settings_activity_description">Duck.ai är en valfri funktion som låter dig chatta anonymt med populära AI-chattmodeller från tredje part. Dina chattar används inte för att träna AI.\n<annotation type="learn_more_link">Läs mer</annotation></string>
     <string name="duck_chat_visibility_setting">Visa Duck.ai i webbläsarmenyn</string>
+
+    <string name="duck_chat_download_finished_action_name">Öppna</string>
+    <string name="duck_chat_cannot_open_file_error_message">Det går inte att öppna filen. Sök efter en kompatibel app.</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-tr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-tr/strings-duckchat.xml
@@ -20,4 +20,7 @@
     <string name="duck_chat_title">Duck.ai</string>
     <string name="duck_chat_settings_activity_description">Duck.ai, popüler 3. taraf yapay zeka sohbet modelleriyle anonim olarak sohbet etmenizi sağlayan isteğe bağlı bir özelliktir. Sohbetler yapay zekayı eğitmek için kullanılmaz.\n<annotation type="learn_more_link">Daha Fazla Bilgi</annotation></string>
     <string name="duck_chat_visibility_setting">Tarayıcı Menüsünde Duck.ai\'yi Göster</string>
+
+    <string name="duck_chat_download_finished_action_name">Aç</string>
+    <string name="duck_chat_cannot_open_file_error_message">Dosya açılamıyor. Uyumlu uygulama arayın.</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
@@ -20,6 +20,6 @@
     <string name="duck_chat_settings_activity_description">Duck.ai is an optional feature that lets you chat anonymously with popular 3rd-party Al chat models. Your chats are not used to train AI.\n<annotation type="learn_more_link">Learn More</annotation></string>
     <string name="duck_chat_visibility_setting">Show Duck.ai in Browser Menu</string>
 
-    <string name="downloadsDownloadFinishedActionName">Open</string>
-    <string name="downloadsCannotOpenFileErrorMessage">Can\'t open file. Check for compatible app.</string>
+    <string name="duck_chat_download_finished_action_name">Open</string>
+    <string name="duck_chat_cannot_open_file_error_message">Can\'t open file. Check for compatible app.</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
@@ -19,4 +19,7 @@
     <string name="duck_chat_title">Duck.ai</string>
     <string name="duck_chat_settings_activity_description">Duck.ai is an optional feature that lets you chat anonymously with popular 3rd-party Al chat models. Your chats are not used to train AI.\n<annotation type="learn_more_link">Learn More</annotation></string>
     <string name="duck_chat_visibility_setting">Show Duck.ai in Browser Menu</string>
+
+    <string name="downloadsDownloadFinishedActionName">Open</string>
+    <string name="downloadsCannotOpenFileErrorMessage">Can\'t open file. Check for compatible app.</string>
 </resources>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1200204095367872/1209525858701077/f

### Description

- Fixes downloading of Duck.ai chats

### Steps to test this PR

- [x] Open Duck.ai and send a prompt
- [x] Go to chat history
- [x] Tap the overflow and export
- [x] Verify that the chat is downloaded successfully (The format should be “duck.ai_\<timestamp\>.txt”)
