### PR TITLE
Send pixel when existing account is restored during successful purchase

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
@@ -269,6 +269,7 @@ class RealSubscriptionsManager @Inject constructor(
     private var purchaseStateJob: Job? = null
 
     private var removeExpiredSubscriptionOnCancelledPurchase: Boolean = false
+    private var purchaseFlowStartedUsingRestoredAccount: Boolean = false
 
     override suspend fun isSignedIn(): Boolean {
         return isSignedInV1() || isSignedInV2()
@@ -469,6 +470,11 @@ class RealSubscriptionsManager @Inject constructor(
                 }
                 pixelSender.reportPurchaseSuccess()
                 pixelSender.reportSubscriptionActivated()
+                if (purchaseFlowStartedUsingRestoredAccount) {
+                    purchaseFlowStartedUsingRestoredAccount = false
+                    val hasEmail = !authRepository.getAccount()?.email.isNullOrBlank()
+                    pixelSender.reportPurchaseWithRestoredAccount(hasEmail)
+                }
                 emitEntitlementsValues()
                 _currentPurchaseState.emit(CurrentPurchase.Success)
             } else {
@@ -484,6 +490,7 @@ class RealSubscriptionsManager @Inject constructor(
     }
 
     private suspend fun handlePurchaseFailed() {
+        purchaseFlowStartedUsingRestoredAccount = false
         authRepository.purchaseToWaitingStatus()
         pixelSender.reportPurchaseFailureBackend()
         _currentPurchaseState.emit(CurrentPurchase.Waiting)
@@ -819,16 +826,20 @@ class RealSubscriptionsManager @Inject constructor(
                 isSignedInV1() -> fetchAndStoreAllData()
             }
 
+            var restoredAccount = false
+
             if (!isSignedIn()) {
                 recoverSubscriptionFromStore()
+                restoredAccount = isSignedIn()
             } else {
                 authRepository.getSubscription()?.run {
                     if (status.isExpired() && platform == "google") {
                         // re-authenticate in case previous subscription was bought using different google account
                         val accountId = authRepository.getAccount()?.externalId
                         recoverSubscriptionFromStore()
-                        removeExpiredSubscriptionOnCancelledPurchase =
-                            accountId != null && accountId != authRepository.getAccount()?.externalId
+                        val accountIdChanged = accountId != null && accountId != authRepository.getAccount()?.externalId
+                        removeExpiredSubscriptionOnCancelledPurchase = accountIdChanged
+                        restoredAccount = accountIdChanged
                     }
                 }
             }
@@ -849,6 +860,8 @@ class RealSubscriptionsManager @Inject constructor(
                 }
             }
 
+            purchaseFlowStartedUsingRestoredAccount = restoredAccount
+
             logcat(LogPriority.DEBUG) { "Subs: external id is ${authRepository.getAccount()!!.externalId}" }
             _currentPurchaseState.emit(CurrentPurchase.PreFlowFinished)
             playBillingManager.launchBillingFlow(
@@ -862,6 +875,7 @@ class RealSubscriptionsManager @Inject constructor(
             logcat(LogPriority.ERROR) { "Subs: $error" }
             pixelSender.reportPurchaseFailureOther()
             _currentPurchaseState.emit(CurrentPurchase.Failure(error))
+            purchaseFlowStartedUsingRestoredAccount = false
         }
     }
 

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixel.kt
@@ -201,6 +201,11 @@ enum class SubscriptionPixel(
         type = Count,
         includedParameters = setOf(ATB, APP_VERSION),
     ),
+    SUBSCRIPTION_PURCHASE_WITH_RESTORED_ACCOUNT(
+        baseName = "m_privacy-pro_app_purchase_with_restored_account",
+        type = Count,
+        includedParameters = setOf(APP_VERSION),
+    ),
     AUTH_V2_INVALID_REFRESH_TOKEN_DETECTED(
         baseName = "m_privacy-pro_auth_invalid_refresh_token_detected",
         types = setOf(Count, Daily()),

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelSender.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelSender.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.subscriptions.impl.pixels
 
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.common.utils.extensions.toBinaryString
 import com.duckduckgo.common.utils.extensions.toSanitizedLanguageTag
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.subscriptions.impl.freetrial.FreeTrialPrivacyProPixelsPlugin
@@ -66,6 +67,7 @@ import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.SUBSCRIPTION_O
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.SUBSCRIPTION_PRICE_MONTHLY_CLICK
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.SUBSCRIPTION_PRICE_YEARLY_CLICK
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.SUBSCRIPTION_PRIVACY_PRO_REDIRECT
+import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.SUBSCRIPTION_PURCHASE_WITH_RESTORED_ACCOUNT
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.SUBSCRIPTION_SETTINGS_CHANGE_PLAN_OR_BILLING_CLICK
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.SUBSCRIPTION_SETTINGS_REMOVE_FROM_DEVICE_CLICK
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.SUBSCRIPTION_SETTINGS_SHOWN
@@ -107,6 +109,7 @@ interface SubscriptionPixelSender {
     fun reportOnboardingFaqClick()
     fun reportAddEmailSuccess()
     fun reportPrivacyProRedirect()
+    fun reportPurchaseWithRestoredAccount(hasEmail: Boolean)
     fun reportAuthV2InvalidRefreshTokenDetected()
     fun reportAuthV2InvalidRefreshTokenSignedOut()
     fun reportAuthV2InvalidRefreshTokenRecovered()
@@ -238,6 +241,9 @@ class SubscriptionPixelSenderImpl @Inject constructor(
 
     override fun reportPrivacyProRedirect() =
         fire(SUBSCRIPTION_PRIVACY_PRO_REDIRECT)
+
+    override fun reportPurchaseWithRestoredAccount(hasEmail: Boolean) =
+        fire(SUBSCRIPTION_PURCHASE_WITH_RESTORED_ACCOUNT, mapOf("hasEmail" to hasEmail.toBinaryString()))
 
     override fun reportAuthV2InvalidRefreshTokenDetected() {
         fire(AUTH_V2_INVALID_REFRESH_TOKEN_DETECTED)

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
@@ -1184,6 +1184,39 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
     }
 
     @Test
+    fun whenPurchaseIsSuccessfulAndAccountWasRestoredThenPixelIsSent() = runTest {
+        givenUserIsNotSignedIn()
+        givenPurchaseStored()
+        givenStoreLoginSucceeds()
+        givenSubscriptionSucceedsWithoutEntitlements(status = EXPIRED.statusName)
+        givenConfirmPurchaseSucceeds()
+        givenAccessTokenSucceeds()
+        givenV2AccessTokenRefreshSucceeds()
+
+        val purchaseState = MutableSharedFlow<PurchaseState>()
+        whenever(playBillingManager.purchaseState).thenReturn(purchaseState)
+
+        subscriptionsManager.currentPurchaseState.test {
+            subscriptionsManager.purchase(mock(), planId = "", offerId = null)
+            assertTrue(awaitItem() is CurrentPurchase.PreFlowInProgress)
+            assertTrue(awaitItem() is CurrentPurchase.PreFlowFinished)
+
+            purchaseState.emit(PurchaseState.Purchased("any", "any"))
+            givenSubscriptionSucceedsWithEntitlements()
+
+            assertTrue(awaitItem() is CurrentPurchase.InProgress)
+            assertTrue(awaitItem() is CurrentPurchase.Success)
+
+            verify(pixelSender).reportPurchaseSuccess()
+            verify(pixelSender).reportPurchaseWithRestoredAccount(any())
+            verify(pixelSender).reportSubscriptionActivated()
+            verifyNoMoreInteractions(pixelSender)
+
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
     fun whenPurchaseFailsThenPixelIsSent() = runTest {
         givenUserIsSignedIn()
         givenValidateTokenFails("failure")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1205648422731273/1209714124375337/f

### Description

This PR adds a temporary pixel to measure how often existing account is restored when purchasing subscription.

### Steps to test this PR

See task

### No UI changes