### PR TITLE
Update content scope scripts to version 8.4.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
@@ -2874,12 +2874,15 @@
       trackerLookup: define_import_meta_trackerLookup_default,
       injectName: "android-autofill-password-import"
     };
-    const featureNames = typeof importConfig.injectName === "string" ? platformSupport[importConfig.injectName] : [];
-    for (const featureName of featureNames) {
-      const ContentFeature2 = ddg_platformFeatures_default["ddg_feature_" + featureName];
-      const featureInstance = new ContentFeature2(featureName, importConfig, args);
-      featureInstance.callLoad();
-      features.push({ featureName, featureInstance });
+    const bundledFeatureNames = typeof importConfig.injectName === "string" ? platformSupport[importConfig.injectName] : [];
+    const featuresToLoad = isGloballyDisabled(args) ? platformSpecificFeatures : args.site.enabledFeatures || bundledFeatureNames;
+    for (const featureName of bundledFeatureNames) {
+      if (featuresToLoad.includes(featureName)) {
+        const ContentFeature2 = ddg_platformFeatures_default["ddg_feature_" + featureName];
+        const featureInstance = new ContentFeature2(featureName, importConfig, args);
+        featureInstance.callLoad();
+        features.push({ featureName, featureInstance });
+      }
     }
     mark.end();
   }
@@ -2924,9 +2927,6 @@
     const userUnprotectedDomains = $USER_UNPROTECTED_DOMAINS$;
     const userPreferences = $USER_PREFERENCES$;
     const processedConfig = processConfig(config, userUnprotectedDomains, userPreferences);
-    if (isGloballyDisabled(processedConfig)) {
-      return;
-    }
     const configConstruct = processedConfig;
     const messageCallback = configConstruct.messageCallback;
     const messageSecret2 = configConstruct.messageSecret;

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -7151,12 +7151,15 @@
       trackerLookup: define_import_meta_trackerLookup_default,
       injectName: "android-broker-protection"
     };
-    const featureNames = typeof importConfig.injectName === "string" ? platformSupport[importConfig.injectName] : [];
-    for (const featureName of featureNames) {
-      const ContentFeature2 = ddg_platformFeatures_default["ddg_feature_" + featureName];
-      const featureInstance = new ContentFeature2(featureName, importConfig, args);
-      featureInstance.callLoad();
-      features.push({ featureName, featureInstance });
+    const bundledFeatureNames = typeof importConfig.injectName === "string" ? platformSupport[importConfig.injectName] : [];
+    const featuresToLoad = isGloballyDisabled(args) ? platformSpecificFeatures : args.site.enabledFeatures || bundledFeatureNames;
+    for (const featureName of bundledFeatureNames) {
+      if (featuresToLoad.includes(featureName)) {
+        const ContentFeature2 = ddg_platformFeatures_default["ddg_feature_" + featureName];
+        const featureInstance = new ContentFeature2(featureName, importConfig, args);
+        featureInstance.callLoad();
+        features.push({ featureName, featureInstance });
+      }
     }
     mark.end();
   }
@@ -7201,9 +7204,6 @@
     const userUnprotectedDomains = $USER_UNPROTECTED_DOMAINS$;
     const userPreferences = $USER_PREFERENCES$;
     const processedConfig = processConfig(config, userUnprotectedDomains, userPreferences);
-    if (isGloballyDisabled(processedConfig)) {
-      return;
-    }
     const configConstruct = processedConfig;
     const messageCallback = configConstruct.messageCallback;
     const messageSecret2 = configConstruct.messageSecret;

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -7749,12 +7749,15 @@
       trackerLookup: define_import_meta_trackerLookup_default,
       injectName: "android"
     };
-    const featureNames = typeof importConfig.injectName === "string" ? platformSupport[importConfig.injectName] : [];
-    for (const featureName of featureNames) {
-      const ContentFeature2 = ddg_platformFeatures_default["ddg_feature_" + featureName];
-      const featureInstance2 = new ContentFeature2(featureName, importConfig, args);
-      featureInstance2.callLoad();
-      features.push({ featureName, featureInstance: featureInstance2 });
+    const bundledFeatureNames = typeof importConfig.injectName === "string" ? platformSupport[importConfig.injectName] : [];
+    const featuresToLoad = isGloballyDisabled(args) ? platformSpecificFeatures : args.site.enabledFeatures || bundledFeatureNames;
+    for (const featureName of bundledFeatureNames) {
+      if (featuresToLoad.includes(featureName)) {
+        const ContentFeature2 = ddg_platformFeatures_default["ddg_feature_" + featureName];
+        const featureInstance2 = new ContentFeature2(featureName, importConfig, args);
+        featureInstance2.callLoad();
+        features.push({ featureName, featureInstance: featureInstance2 });
+      }
     }
     mark.end();
   }
@@ -7799,9 +7802,6 @@
     const userUnprotectedDomains = $USER_UNPROTECTED_DOMAINS$;
     const userPreferences = $USER_PREFERENCES$;
     const processedConfig = processConfig(config, userUnprotectedDomains, userPreferences);
-    if (isGloballyDisabled(processedConfig)) {
-      return;
-    }
     const configConstruct = processedConfig;
     const messageCallback = configConstruct.messageCallback;
     const messageSecret2 = configConstruct.messageSecret;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^12.14.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.3.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.4.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.4.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1741215780"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#079350dbc0b9780feeacd0c7baf50ab6d80e1000",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#eb11d8809f41ba8bc320f5f0c4028122a7ce8cd4",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^12.14.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.3.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.4.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.4.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1741215780"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass