### PR TITLE
Improve handling of the unknown_account error during token refresh

### DIFF
--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
@@ -787,7 +787,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
 
         givenUserIsSignedIn()
         givenAccessTokenIsExpired()
-        givenV2AccessTokenRefreshFails(invalidTokenError = true)
+        givenV2AccessTokenRefreshFails(errorCode = "invalid_token")
         givenPurchaseStored()
         givenStoreLoginSucceeds(newAccessToken = "new access token")
 
@@ -806,7 +806,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         givenUserIsSignedIn()
         givenSubscriptionExists()
         givenAccessTokenIsExpired()
-        givenV2AccessTokenRefreshFails(invalidTokenError = true)
+        givenV2AccessTokenRefreshFails(errorCode = "invalid_token")
         givenPurchaseStored()
         givenStoreLoginFails()
 
@@ -1630,9 +1630,9 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         givenValidateV2TokensSucceeds()
     }
 
-    private suspend fun givenV2AccessTokenRefreshFails(invalidTokenError: Boolean = false) {
-        val exception = if (invalidTokenError) {
-            val responseBody = "failure".toResponseBody("text/json".toMediaTypeOrNull())
+    private suspend fun givenV2AccessTokenRefreshFails(errorCode: String? = null) {
+        val exception = if (errorCode != null) {
+            val responseBody = """{"error":"$errorCode"}""".toResponseBody("text/json".toMediaTypeOrNull())
             HttpException(Response.error<Void>(400, responseBody))
         } else {
             RuntimeException()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1209740252113712/f

### Description

This PR fixes unnecessary pixel reporting and redundant store login attempts when a token refresh fails due to an account being deleted (indicated by the unknown_account error).

### Steps to test this PR

QA-optional

### No UI changes
