### PR TITLE
disable design experiment by default

### DIFF
--- a/.github/workflows/ads-end-to-end.yml
+++ b/.github/workflows/ads-end-to-end.yml
@@ -48,7 +48,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
 
       - name: Assemble the project
-        run: ./gradlew assembleInternalRelease -Pforce-default-variant -Pdisable-visual-design-experiment
+        run: ./gradlew assembleInternalRelease -Pforce-default-variant
 
       - name: Move APK to new folder
         if: always()

--- a/.github/workflows/custom-tabs-nightly.yml
+++ b/.github/workflows/custom-tabs-nightly.yml
@@ -48,7 +48,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
 
       - name: Assemble internal release APK
-        run: ./gradlew assembleInternalRelease -Pforce-default-variant -Pdisable-visual-design-experiment -x lint
+        run: ./gradlew assembleInternalRelease -Pforce-default-variant -x lint
 
       - name: Move APK to new folder
         if: always()

--- a/.github/workflows/sync-critical-path.yml
+++ b/.github/workflows/sync-critical-path.yml
@@ -55,7 +55,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
 
       - name: Assemble internal release APK
-        run: ./gradlew assembleInternalRelease -Pforce-default-variant -Psync-disable-auth-requirement -Pdisable-visual-design-experiment -x lint
+        run: ./gradlew assembleInternalRelease -Pforce-default-variant -Psync-disable-auth-requirement -x lint
 
       - name: Move APK to new folder
         if: always()

--- a/app-build-config/app-build-config-api/src/main/java/com/duckduckgo/appbuildconfig/api/AppBuildConfig.kt
+++ b/app-build-config/app-build-config-api/src/main/java/com/duckduckgo/appbuildconfig/api/AppBuildConfig.kt
@@ -34,7 +34,6 @@ interface AppBuildConfig {
     val isDefaultVariantForced: Boolean
     val buildDateTimeMillis: Long
     val canSkipOnboarding: Boolean
-    val visualDesignExperimentEnabledByDefault: Boolean
 
     /**
      * You should call [variantName] in a background thread

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,11 +67,6 @@ android {
         } else {
             buildConfigField "long", "BUILD_DATE_MILLIS", "0"
         }
-        if (project.hasProperty('disable-visual-design-experiment')) {
-            buildConfigField "boolean", "VISUAL_DESIGN_EXPERIMENT_ENABLED_BY_DEFAULT", "false"
-        } else {
-            buildConfigField "boolean", "VISUAL_DESIGN_EXPERIMENT_ENABLED_BY_DEFAULT", "true"
-        }
 
         namespace 'com.duckduckgo.app.browser'
     }

--- a/app/src/main/java/com/duckduckgo/app/buildconfig/RealAppBuildConfig.kt
+++ b/app/src/main/java/com/duckduckgo/app/buildconfig/RealAppBuildConfig.kt
@@ -109,9 +109,6 @@ class RealAppBuildConfig @Inject constructor(
     override val canSkipOnboarding: Boolean
         get() = BuildConfig.CAN_SKIP_ONBOARDING || isInternalBuild()
 
-    override val visualDesignExperimentEnabledByDefault: Boolean
-        get() = BuildConfig.VISUAL_DESIGN_EXPERIMENT_ENABLED_BY_DEFAULT
-
     private fun getDownloadsDirectory(): File {
         val downloadDirectory = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
         if (!downloadDirectory.exists()) {

--- a/common/common-ui-internal/src/main/java/com/duckduckgo/common/ui/internal/experiments/visual/VisualDesignExperimentViewModel.kt
+++ b/common/common-ui-internal/src/main/java/com/duckduckgo/common/ui/internal/experiments/visual/VisualDesignExperimentViewModel.kt
@@ -81,8 +81,4 @@ class VisualDesignExperimentViewModel @Inject constructor(
     fun onExperimentalUIModeChanged(checked: Boolean) {
         visualDesignExperimentDataStore.setExperimentStateUserPreference(checked)
     }
-
-    fun onNavigationBarPrefChanged(checked: Boolean) {
-        visualDesignExperimentDataStore.setNavigationBarStateUserPreference(checked)
-    }
 }

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/experiments/visual/store/VisualDesignExperimentDataStore.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/experiments/visual/store/VisualDesignExperimentDataStore.kt
@@ -24,7 +24,6 @@ interface VisualDesignExperimentDataStore {
     val navigationBarState: StateFlow<FeatureState>
 
     fun setExperimentStateUserPreference(enabled: Boolean)
-    fun setNavigationBarStateUserPreference(enabled: Boolean)
 
     /**
      * @param isAvailable returns `true` if the flag for this feature is enabled in the config.

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/experiments/visual/store/VisualDesignExperimentDataStoreImpl.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/experiments/visual/store/VisualDesignExperimentDataStoreImpl.kt
@@ -21,7 +21,6 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import com.duckduckgo.app.di.AppCoroutineScope
-import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.ui.experiments.visual.ExperimentalUIThemingFeature
 import com.duckduckgo.common.ui.experiments.visual.store.VisualDesignExperimentDataStore.FeatureState
 import com.duckduckgo.di.scopes.AppScope
@@ -51,13 +50,14 @@ import kotlinx.coroutines.runBlocking
 class VisualDesignExperimentDataStoreImpl @Inject constructor(
     @VisualDesignExperiment private val store: DataStore<Preferences>,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
-    appBuildConfig: AppBuildConfig,
     experimentalUIThemingFeature: ExperimentalUIThemingFeature,
 ) : VisualDesignExperimentDataStore, PrivacyConfigCallbackPlugin {
     private companion object {
 
         private const val KEY_EXPERIMENT_ENABLED = "KEY_EXPERIMENT_ENABLED"
         private const val KEY_NAVIGATION_BAR_ENABLED = "KEY_NAVIGATION_BAR_ENABLED"
+
+        private const val EXPERIMENT_ENABLED_BY_DEFAULT = false
 
         private val NO_PARENT_FEATURE = flowOf(FeatureState(isAvailable = true, isEnabled = true))
     }
@@ -67,7 +67,7 @@ class VisualDesignExperimentDataStoreImpl @Inject constructor(
         coroutineScope = appCoroutineScope,
         targetToggle = experimentalUIThemingFeature.self(),
         prefsKey = KEY_EXPERIMENT_ENABLED,
-        prefsDefault = appBuildConfig.visualDesignExperimentEnabledByDefault,
+        prefsDefault = EXPERIMENT_ENABLED_BY_DEFAULT,
     )
     override val experimentState: StateFlow<FeatureState> = _experimentState.state
 
@@ -77,7 +77,7 @@ class VisualDesignExperimentDataStoreImpl @Inject constructor(
         parentStateFlow = experimentState,
         targetToggle = experimentalUIThemingFeature.browserNavigationBar(),
         prefsKey = KEY_NAVIGATION_BAR_ENABLED,
-        prefsDefault = appBuildConfig.visualDesignExperimentEnabledByDefault,
+        prefsDefault = true, // for now, navigation bar always enabled when the whole experiment enabled
     )
     override val navigationBarState: StateFlow<FeatureState> = _navigationBarState.state
 
@@ -91,10 +91,6 @@ class VisualDesignExperimentDataStoreImpl @Inject constructor(
 
     override fun setExperimentStateUserPreference(enabled: Boolean) {
         _experimentState.setUserPreference(enabled)
-    }
-
-    override fun setNavigationBarStateUserPreference(enabled: Boolean) {
-        _navigationBarState.setUserPreference(enabled)
     }
 
     private fun updateFeatureState() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1208671518894266/1209736451015483/f

### Description

Disables experimental UI changes by default.

### Steps to test this PR

- [x] Reinstall previous version of the internal app (or clear caches), the experimental UI should be enabled by default.
- [x] Install the updated version from this branch, the experimental UI should automatically be disabled.

Note, the experimental UI will stay enabled if you've previously manually interacted with the settings toggle. It will only automatically switch off if you relied on the default behavior.
