### PR TITLE
Update reference tests to version 1743047884

### DIFF
--- a/malicious-site-protection/malicious-site-protection-impl/src/test/resources/reference_tests/canonicalization/canonicalization_tests.json
+++ b/malicious-site-protection/malicious-site-protection-impl/src/test/resources/reference_tests/canonicalization/canonicalization_tests.json
@@ -115,19 +115,19 @@
                 "name": "Decode any %XX escapes present in the hostname",
                 "siteURL": "http://www.%73ome%73ite.com",
                 "expectDomain": "www.somesite.com",
-                "exceptPlatforms": []
+                "exceptPlatforms": ["windows-browser"]
             },
             {
                 "name": "Discard any leading and/or trailing full-stops",
                 "siteURL": "http://.www.somesite.com.",
                 "expectDomain": "www.somesite.com",
-                "exceptPlatforms": []
+                "exceptPlatforms": ["windows-browser"]
             },
             {
                 "name": "Replace sequences of two or more full-stops with a single full-stop.",
                 "siteURL": "http://www..example...com",
                 "expectDomain": "www.example.com",
-                "exceptPlatforms": []
+                "exceptPlatforms": ["windows-browser"]
             },
             {
                 "name": "If the hostname is a numeric IPv4 address, reduce it to the canonical dotted quad form.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.9.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.4.0",
-        "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1741215780"
+        "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1743047884"
       },
       "devDependencies": {
         "@rollup/plugin-json": "^4.1.0",
@@ -84,7 +84,7 @@
       }
     },
     "node_modules/@duckduckgo/privacy-reference-tests": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#49a9f735391a35c6d1bebd88c77035ea4a81a346",
+      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#773618d410399d4da7cef18fe8d6ac30cd7b0280",
       "license": "Apache-2.0"
     },
     "node_modules/@ghostery/adblocker": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.0",
     "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.9.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.4.0",
-    "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1741215780"
+    "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1743047884"
   }
 }


### PR DESCRIPTION
- Automated reference tests dependency update

This PR updates the reference tests dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/0/1203766026095653/f for further information on what to do next.

- [ ] All tests must pass