### PR TITLE
Fix custom tab mode:

### DIFF
--- a/.maestro/custom_tabs/custom_tabs_navigation.yaml
+++ b/.maestro/custom_tabs/custom_tabs_navigation.yaml
@@ -48,6 +48,18 @@ tags:
       - inputText: "https://www.search-company.site"
       - tapOn:
           text: "load custom tab"
+      - assertNotVisible:
+          id: "com.duckduckgo.mobile.android:id/fireIconImageView"
+      - assertNotVisible:
+          id: "com.duckduckgo.mobile.android:id/tabsMenu"
+      - assertVisible:
+          id: "com.duckduckgo.mobile.android:id/customTabCloseIcon"
+      - assertVisible:
+          id: "com.duckduckgo.mobile.android:id/customTabShieldIcon"
+      - assertVisible:
+          id: "com.duckduckgo.mobile.android:id/customTabTitle"
+      - assertVisible:
+          id: "com.duckduckgo.mobile.android:id/customTabDomain"
       - tapOn:
           id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
       - assertVisible:

--- a/app/src/main/java/com/duckduckgo/app/browser/menu/BrowserPopupMenu.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/menu/BrowserPopupMenu.kt
@@ -30,7 +30,6 @@ import com.duckduckgo.app.browser.omnibar.model.OmnibarPosition.TOP
 import com.duckduckgo.app.browser.viewstate.BrowserViewState
 import com.duckduckgo.common.ui.menu.PopupMenu
 import com.duckduckgo.common.ui.view.MenuItemView
-import com.duckduckgo.mobile.android.R.dimen
 import com.duckduckgo.mobile.android.R.drawable
 
 class BrowserPopupMenu(
@@ -276,7 +275,7 @@ class BrowserPopupMenu(
 
         printPageMenuItem.isEnabled = browserShowing
 
-        newTabMenuItem.isVisible = browserShowing && !displayedInCustomTabScreen
+        newTabMenuItem.isVisible = !displayedInCustomTabScreen
         duckChatMenuItem.isVisible = viewState.showDuckChatOption && !displayedInCustomTabScreen
         sharePageMenuItem.isVisible = viewState.canSharePage
 
@@ -348,13 +347,14 @@ class BrowserPopupMenu(
         openInDdgBrowserMenuItem.isVisible = displayedInCustomTabScreen
         customTabsMenuDivider.isVisible = displayedInCustomTabScreen
         runningInDdgBrowserMenuItem.isVisible = displayedInCustomTabScreen
-        overrideForSSlError(viewState)
+        overrideForSSlError(viewState, displayedInCustomTabScreen)
     }
 
     private fun overrideForSSlError(
         viewState: BrowserViewState,
+        displayedInCustomTabScreen: Boolean,
     ) {
-        if (viewState.sslError != NONE) {
+        if (viewState.sslError != NONE && !displayedInCustomTabScreen) {
             newTabMenuItem.isVisible = true
             siteOptionsMenuDivider.isVisible = true
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
@@ -85,6 +85,7 @@ class Omnibar(
                         binding.rootView.removeView(binding.fadeOmnibar)
                         binding.rootView.removeView(binding.fadeOmnibarBottom)
                     }
+
                     FADE -> {
                         // remove bottom variant
                         binding.rootView.removeView(binding.fadeOmnibarBottom)
@@ -106,6 +107,7 @@ class Omnibar(
                         binding.rootView.removeView(binding.fadeOmnibar)
                         binding.rootView.removeView(binding.fadeOmnibarBottom)
                     }
+
                     FADE -> {
                         // remove top variant
                         binding.rootView.removeView(binding.fadeOmnibar)
@@ -174,6 +176,7 @@ class Omnibar(
         data class Browser(val url: String?) : ViewMode()
         data class CustomTab(
             val toolbarColor: Int,
+            val title: String?,
             val domain: String?,
             val showDuckPlayerIcon: Boolean = false,
         ) : ViewMode()
@@ -237,6 +240,7 @@ class Omnibar(
         }
 
     fun setViewMode(viewMode: ViewMode) {
+        Timber.d("Omnibar: setViewMode $viewMode")
         when (viewMode) {
             Error -> {
                 newOmnibar.decorate(Mode(viewMode))
@@ -389,7 +393,7 @@ class Omnibar(
         customTabToolbarColor: Int,
         customTabDomainText: String?,
     ) {
-        newOmnibar.decorate(Mode(CustomTab(customTabToolbarColor, customTabDomainText)))
+        newOmnibar.decorate(Mode(CustomTab(toolbarColor = customTabToolbarColor, title = null, domain = customTabDomainText)))
     }
 
     fun showWebPageTitleInCustomTab(
@@ -427,6 +431,7 @@ class Omnibar(
                     SCROLLING -> {
                         // no-op
                     }
+
                     FADE -> binding.fadeOmnibar.onScrollChanged(
                         scrollableView = v,
                         scrollY = scrollY,
@@ -440,6 +445,7 @@ class Omnibar(
                     SCROLLING -> {
                         // no-op
                     }
+
                     FADE -> binding.fadeOmnibarBottom.onScrollChanged(
                         scrollableView = v,
                         scrollY = scrollY,

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -547,16 +547,10 @@ open class OmnibarLayout @JvmOverloads constructor(
              */
             if (decoration is Mode) {
                 val lastMode = lastViewMode?.viewMode
-                when (lastMode) {
-                    is CustomTab -> {
-                        this.decoration = null
-                    }
-
-                    else -> {
-                        lastViewMode = decoration
-                        this.decoration = null
-                    }
+                if (lastMode !is CustomTab) {
+                    lastViewMode = decoration
                 }
+                this.decoration = null
             } else if (this.decoration == null) {
                 this.decoration = decoration
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -256,11 +256,13 @@ open class OmnibarLayout @JvmOverloads constructor(
         }
 
         if (lastViewMode != null) {
+            Timber.d("Omnibar: onAttachedToWindow lastViewMode $lastViewMode")
             decorateDeferred(lastViewMode!!)
             lastViewMode = null
         }
 
         if (decoration != null) {
+            Timber.d("Omnibar: onAttachedToWindow decoration $decoration")
             decorateDeferred(decoration!!)
             decoration = null
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -547,10 +547,15 @@ open class OmnibarLayout @JvmOverloads constructor(
              */
             if (decoration is Mode) {
                 val lastMode = lastViewMode?.viewMode
-                if (lastMode is CustomTab) {
-                    this.decoration = null
-                } else {
-                    lastViewMode = decoration
+                when (lastMode) {
+                    is CustomTab -> {
+                        this.decoration = null
+                    }
+
+                    else -> {
+                        lastViewMode = decoration
+                        this.decoration = null
+                    }
                 }
             } else if (this.decoration == null) {
                 this.decoration = decoration

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -31,6 +31,7 @@ import com.duckduckgo.app.browser.omnibar.Omnibar.ViewMode.MaliciousSiteWarning
 import com.duckduckgo.app.browser.omnibar.Omnibar.ViewMode.NewTab
 import com.duckduckgo.app.browser.omnibar.Omnibar.ViewMode.SSLWarning
 import com.duckduckgo.app.browser.omnibar.OmnibarLayout.Decoration
+import com.duckduckgo.app.browser.omnibar.OmnibarLayout.Decoration.ChangeCustomTabTitle
 import com.duckduckgo.app.browser.omnibar.OmnibarLayout.Decoration.LaunchCookiesAnimation
 import com.duckduckgo.app.browser.omnibar.OmnibarLayout.Decoration.LaunchTrackersAnimation
 import com.duckduckgo.app.browser.omnibar.OmnibarLayout.StateChange
@@ -652,6 +653,17 @@ class OmnibarLayoutViewModel @Inject constructor(
                     urlLoaded = url,
                 ),
             )
+        }
+    }
+
+    fun onCustomTabTitleUpdate(decoration: ChangeCustomTabTitle) {
+        val customTabMode = viewState.value.viewMode
+        if (customTabMode is CustomTab) {
+            _viewState.update {
+                it.copy(
+                    viewMode = customTabMode.copy(title = decoration.title),
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -294,46 +294,51 @@ class OmnibarLayoutViewModel @Inject constructor(
     }
 
     fun onViewModeChanged(viewMode: ViewMode) {
+        val currentViewMode = _viewState.value.viewMode
         Timber.d("Omnibar: onViewModeChanged $viewMode")
-        when (viewMode) {
-            is CustomTab -> {
-                _viewState.update {
-                    it.copy(
-                        viewMode = viewMode,
-                        showClearButton = false,
-                        showVoiceSearch = false,
-                        showBrowserMenu = true,
-                        showTabsMenu = false,
-                        showFireIcon = false,
-                    )
-                }
-            }
-
-            else -> {
-                val scrollingEnabled = viewMode != NewTab
-                val hasFocus = _viewState.value.hasFocus
-                val leadingIcon = if (hasFocus) {
-                    LeadingIconState.SEARCH
-                } else {
-                    when (viewMode) {
-                        Error, SSLWarning, MaliciousSiteWarning -> GLOBE
-                        NewTab -> SEARCH
-                        else -> SEARCH
+        if (currentViewMode is CustomTab) {
+            Timber.d("Omnibar: custom tab mode enabled, sending updates there")
+        } else {
+            when (viewMode) {
+                is CustomTab -> {
+                    _viewState.update {
+                        it.copy(
+                            viewMode = viewMode,
+                            showClearButton = false,
+                            showVoiceSearch = false,
+                            showBrowserMenu = true,
+                            showTabsMenu = false,
+                            showFireIcon = false,
+                        )
                     }
                 }
 
-                _viewState.update {
-                    it.copy(
-                        viewMode = viewMode,
-                        leadingIconState = leadingIcon,
-                        scrollingEnabled = scrollingEnabled,
-                        showVoiceSearch = shouldShowVoiceSearch(
-                            hasFocus = _viewState.value.hasFocus,
-                            query = _viewState.value.omnibarText,
-                            hasQueryChanged = false,
-                            urlLoaded = _viewState.value.url,
-                        ),
-                    )
+                else -> {
+                    val scrollingEnabled = viewMode != NewTab
+                    val hasFocus = _viewState.value.hasFocus
+                    val leadingIcon = if (hasFocus) {
+                        LeadingIconState.SEARCH
+                    } else {
+                        when (viewMode) {
+                            Error, SSLWarning, MaliciousSiteWarning -> GLOBE
+                            NewTab -> SEARCH
+                            else -> SEARCH
+                        }
+                    }
+
+                    _viewState.update {
+                        it.copy(
+                            viewMode = viewMode,
+                            leadingIconState = leadingIcon,
+                            scrollingEnabled = scrollingEnabled,
+                            showVoiceSearch = shouldShowVoiceSearch(
+                                hasFocus = _viewState.value.hasFocus,
+                                query = _viewState.value.omnibarText,
+                                hasQueryChanged = false,
+                                urlLoaded = _viewState.value.url,
+                            ),
+                        )
+                    }
                 }
             }
         }

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -287,7 +287,7 @@ class OmnibarLayoutViewModelTest {
 
     @Test
     fun whenViewModeChangedToCustomTabThenViewStateCorrect() = runTest {
-        testee.onViewModeChanged(ViewMode.CustomTab(0, "example.com", false))
+        testee.onViewModeChanged(ViewMode.CustomTab(0, "example", "example.com", false))
 
         testee.viewState.test {
             val viewState = awaitItem()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1157893581871903/1209822654738726/f

### Description
The custom tab mode wasn’t rendering properly. This PR fixes it

### Steps to test this PR

_Custom Tab_
- [x] Fresh install app and set it as default browser
- [x] Go to an app that will allow you to open a link (Reddit)
- [x] Tap on a link
- [x] Verify Custom Tab is displayed properly (tabs button is not visible, X is visible)
- [x] Open overflow menu and tap on “Open in DuckDuckGo"
- [x] Verify that the omnibar is displayed with the tabs button and without the X

_Malicious site protection_
- [x] Open https://privacy-test-pages.site/security/badware/
- [x] Navigate to https://privacy-test-pages.site/security/badware/phishing-iframe-loader.html
- [x] Once the error page is shown, open a new tab and load [wikipedia.org](https://wikipedia.org/)
- [x] While on the wikipedia tab, close and kill the app
- [x] Reopen the app, and wait for wikipedia to load
- [x] Switch to the previous tab
- [x] Check globe icon is shown