### PR TITLE
Update autofill to 17.0.1

### DIFF
--- a/node_modules/@duckduckgo/autofill/dist/autofill-debug.js
+++ b/node_modules/@duckduckgo/autofill/dist/autofill-debug.js
@@ -3585,6 +3585,9 @@ Source: "${matchedFrom}"`;
     "americanexpress.com": {
       "password-rules": "minlength: 8; maxlength: 20; max-consecutive: 4; required: lower, upper; required: digit; allowed: [%&_?#=];"
     },
+    "amnh.org": {
+      "password-rules": "minlength: 8; maxlength: 16; required: digit; required: upper,lower; allowed: ascii-printable;"
+    },
     "ana.co.jp": {
       "password-rules": "minlength: 8; maxlength: 16; required: digit; required: upper,lower;"
     },
@@ -3698,6 +3701,9 @@ Source: "${matchedFrom}"`;
     },
     "callofduty.com": {
       "password-rules": "minlength: 8; maxlength: 20; max-consecutive: 2; required: lower, upper; required: digit;"
+    },
+    "candyrect.com": {
+      "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit;"
     },
     "capitalone.com": {
       "password-rules": "minlength: 8; maxlength: 32; required: lower, upper; required: digit; allowed: [-_./\\@$*&!#];"
@@ -4298,6 +4304,9 @@ Source: "${matchedFrom}"`;
     },
     "naver.com": {
       "password-rules": "minlength: 6; maxlength: 16;"
+    },
+    "nekochat.cn": {
+      "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit;"
     },
     "nelnet.net": {
       "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit, [!@#$&*];"
@@ -11139,13 +11148,22 @@ Source: "${matchedFrom}"`;
         return;
       window.performance?.mark?.("scan_shadow:init:start");
       const realTarget = pierceShadowTree(event, HTMLInputElement);
-      if (realTarget instanceof HTMLInputElement && !realTarget.hasAttribute(ATTR_INPUT_TYPE3)) {
+      if (realTarget instanceof HTMLInputElement && realTarget.matches(this.matching.cssSelector("genericTextInputField")) && !realTarget.hasAttribute(ATTR_INPUT_TYPE3)) {
+        if (shouldLog())
+          console.log("scanOnClick executing for target", realTarget);
         const parentForm = this.getParentForm(realTarget);
         if (parentForm instanceof HTMLInputElement)
           return;
         const hasShadowTree = event.target?.shadowRoot != null;
-        const form = new Form(parentForm, realTarget, this.device, this.matching, this.shouldAutoprompt, hasShadowTree);
-        this.forms.set(parentForm, form);
+        const form = this.forms.get(parentForm);
+        if (!form) {
+          this.forms.set(
+            parentForm,
+            new Form(parentForm, realTarget, this.device, this.matching, this.shouldAutoprompt, hasShadowTree)
+          );
+        } else {
+          form.addInput(realTarget);
+        }
         this.findEligibleInputs(parentForm);
       }
       window.performance?.mark?.("scan_shadow:init:end");
@@ -16104,16 +16122,16 @@ Source: "${matchedFrom}"`;
     testMode: false,
     checkVisibility: true,
     hasCaret: false,
+    isTopAutofill: false,
     isIncontextSignupAvailable: () => false
   };
   var HTMLTooltip = class {
     /**
-     * @param config
      * @param inputType
      * @param getPosition
      * @param {HTMLTooltipOptions} options
      */
-    constructor(config, inputType, getPosition, options) {
+    constructor(inputType, getPosition, options) {
       __publicField(this, "isAboveInput", false);
       /** @type {HTMLTooltipOptions} */
       __publicField(this, "options");
@@ -16137,7 +16155,6 @@ Source: "${matchedFrom}"`;
         mode: options.testMode ? "open" : "closed"
       });
       this.host = this.shadow.host;
-      this.config = config;
       this.subtype = getSubtypeFromType(inputType);
       this.variant = getVariantFromType(inputType);
       this.tooltip = null;
@@ -16409,8 +16426,7 @@ Source: "${matchedFrom}"`;
      */
     render(device, config, items, callbacks) {
       const t = device.t;
-      const { wrapperClass, css } = this.options;
-      const isTopAutofill = wrapperClass?.includes("top-autofill");
+      const { wrapperClass, css, isTopAutofill } = this.options;
       let hasAddedSeparator = false;
       const shouldShowSeparator = (dataId, index) => {
         const shouldShow = ["personalAddress", "privateAddress"].includes(dataId) && !hasAddedSeparator;
@@ -16483,7 +16499,6 @@ ${css}
       return this;
     }
   };
-  var DataHTMLTooltip_default = DataHTMLTooltip;
 
   // src/UI/EmailHTMLTooltip.js
   var EmailHTMLTooltip = class extends HTMLTooltip_default {
@@ -16545,7 +16560,6 @@ ${this.options.css}
       this.device?.selectedDetail({ email: formattedAddress, id }, "email");
     }
   };
-  var EmailHTMLTooltip_default = EmailHTMLTooltip;
 
   // src/UI/EmailSignupHTMLTooltip.js
   var EmailSignupHTMLTooltip = class extends HTMLTooltip_default {
@@ -16590,7 +16604,6 @@ ${this.options.css}
       return this;
     }
   };
-  var EmailSignupHTMLTooltip_default = EmailSignupHTMLTooltip;
 
   // src/UI/CredentialsImportTooltip.js
   var CredentialsImportTooltip = class extends HTMLTooltip_default {
@@ -16603,7 +16616,7 @@ ${this.options.css}
       const t = device.t;
       this.shadow.innerHTML = `
 ${this.options.css}
-<div class="wrapper wrapper--data top-autofill" hidden>
+<div class="wrapper wrapper--data ${this.options.isTopAutofill ? "top-autofill" : ""}" hidden>
     <div class="tooltip tooltip--data">
         <button class="tooltip__button tooltip__button--data tooltip__button--credentials-import js-promo-wrapper">
             <span class="tooltip__button__text-container">
@@ -16633,7 +16646,6 @@ ${this.options.css}
       return this;
     }
   };
-  var CredentialsImportTooltip_default = CredentialsImportTooltip;
 
   // src/UI/controllers/HTMLTooltipUIController.js
   var HTMLTooltipUIController = class extends UIController {
@@ -16709,29 +16721,26 @@ ${this.options.css}
       const hasNoCredentialsData = this._options.device.getLocalCredentials().length === 0;
       if (topContextData.credentialsImport && hasNoCredentialsData) {
         this._options.device.firePixel({ pixelName: "autofill_import_credentials_prompt_shown" });
-        return new CredentialsImportTooltip_default(config, topContextData.inputType, getPosition, tooltipOptions).render(
-          this._options.device,
-          {
-            onStarted: () => {
-              this._options.device.credentialsImport.started();
-            },
-            onDismissed: () => {
-              this._options.device.credentialsImport.dismissed();
-            }
+        return new CredentialsImportTooltip(topContextData.inputType, getPosition, tooltipOptions).render(this._options.device, {
+          onStarted: () => {
+            this._options.device.credentialsImport.started();
+          },
+          onDismissed: () => {
+            this._options.device.credentialsImport.dismissed();
           }
-        );
+        });
       }
       if (this._options.tooltipKind === "legacy") {
         this._options.device.firePixel({ pixelName: "autofill_show" });
-        return new EmailHTMLTooltip_default(config, topContextData.inputType, getPosition, tooltipOptions).render(this._options.device);
+        return new EmailHTMLTooltip(topContextData.inputType, getPosition, tooltipOptions).render(this._options.device);
       }
       if (this._options.tooltipKind === "emailsignup") {
         this._options.device.firePixel({ pixelName: "incontext_show" });
-        return new EmailSignupHTMLTooltip_default(config, topContextData.inputType, getPosition, tooltipOptions).render(this._options.device);
+        return new EmailSignupHTMLTooltip(topContextData.inputType, getPosition, tooltipOptions).render(this._options.device);
       }
       const data = this._dataForAutofill(config, topContextData.inputType, topContextData);
       const asRenderers = data.map((d) => config.tooltipItem(d));
-      return new DataHTMLTooltip_default(config, topContextData.inputType, getPosition, tooltipOptions).render(
+      return new DataHTMLTooltip(topContextData.inputType, getPosition, tooltipOptions).render(
         this._options.device,
         config,
         asRenderers,
@@ -16757,7 +16766,7 @@ ${this.options.css}
       const config = getInputConfigFromType(this._activeInputType);
       const asRenderers = data.map((d) => config.tooltipItem(d));
       const activeTooltip = this.getActiveTooltip();
-      if (activeTooltip instanceof DataHTMLTooltip_default) {
+      if (activeTooltip instanceof DataHTMLTooltip) {
         activeTooltip?.render(this._options.device, config, asRenderers, {
           onSelect: (id) => {
             this._onSelect(this._activeInputType, data, id);
@@ -17704,6 +17713,7 @@ ${this.options.css}
         },
         {
           wrapperClass: "top-autofill",
+          isTopAutofill: true,
           tooltipPositionClass: () => ".wrapper { transform: none; }",
           setSize: (details) => this.deviceApi.notify(createNotification("setSize", details)),
           remove: async () => this._closeAutofillParent(),
@@ -17930,6 +17940,7 @@ ${this.options.css}
         },
         {
           wrapperClass: "top-autofill",
+          isTopAutofill: true,
           tooltipPositionClass: () => ".wrapper { transform: none; }",
           setSize: (details) => this.deviceApi.notify(new SetSizeCall(details)),
           remove: async () => this._closeAutofillParent(),

--- a/node_modules/@duckduckgo/autofill/dist/autofill.js
+++ b/node_modules/@duckduckgo/autofill/dist/autofill.js
@@ -3585,6 +3585,9 @@ Source: "${matchedFrom}"`;
     "americanexpress.com": {
       "password-rules": "minlength: 8; maxlength: 20; max-consecutive: 4; required: lower, upper; required: digit; allowed: [%&_?#=];"
     },
+    "amnh.org": {
+      "password-rules": "minlength: 8; maxlength: 16; required: digit; required: upper,lower; allowed: ascii-printable;"
+    },
     "ana.co.jp": {
       "password-rules": "minlength: 8; maxlength: 16; required: digit; required: upper,lower;"
     },
@@ -3698,6 +3701,9 @@ Source: "${matchedFrom}"`;
     },
     "callofduty.com": {
       "password-rules": "minlength: 8; maxlength: 20; max-consecutive: 2; required: lower, upper; required: digit;"
+    },
+    "candyrect.com": {
+      "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit;"
     },
     "capitalone.com": {
       "password-rules": "minlength: 8; maxlength: 32; required: lower, upper; required: digit; allowed: [-_./\\@$*&!#];"
@@ -4298,6 +4304,9 @@ Source: "${matchedFrom}"`;
     },
     "naver.com": {
       "password-rules": "minlength: 6; maxlength: 16;"
+    },
+    "nekochat.cn": {
+      "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit;"
     },
     "nelnet.net": {
       "password-rules": "minlength: 8; maxlength: 15; required: lower; required: upper; required: digit, [!@#$&*];"
@@ -6844,13 +6853,22 @@ Source: "${matchedFrom}"`;
         return;
       window.performance?.mark?.("scan_shadow:init:start");
       const realTarget = pierceShadowTree(event, HTMLInputElement);
-      if (realTarget instanceof HTMLInputElement && !realTarget.hasAttribute(ATTR_INPUT_TYPE3)) {
+      if (realTarget instanceof HTMLInputElement && realTarget.matches(this.matching.cssSelector("genericTextInputField")) && !realTarget.hasAttribute(ATTR_INPUT_TYPE3)) {
+        if (shouldLog())
+          console.log("scanOnClick executing for target", realTarget);
         const parentForm = this.getParentForm(realTarget);
         if (parentForm instanceof HTMLInputElement)
           return;
         const hasShadowTree = event.target?.shadowRoot != null;
-        const form = new Form(parentForm, realTarget, this.device, this.matching, this.shouldAutoprompt, hasShadowTree);
-        this.forms.set(parentForm, form);
+        const form = this.forms.get(parentForm);
+        if (!form) {
+          this.forms.set(
+            parentForm,
+            new Form(parentForm, realTarget, this.device, this.matching, this.shouldAutoprompt, hasShadowTree)
+          );
+        } else {
+          form.addInput(realTarget);
+        }
         this.findEligibleInputs(parentForm);
       }
       window.performance?.mark?.("scan_shadow:init:end");
@@ -11813,16 +11831,16 @@ Source: "${matchedFrom}"`;
     testMode: false,
     checkVisibility: true,
     hasCaret: false,
+    isTopAutofill: false,
     isIncontextSignupAvailable: () => false
   };
   var HTMLTooltip = class {
     /**
-     * @param config
      * @param inputType
      * @param getPosition
      * @param {HTMLTooltipOptions} options
      */
-    constructor(config, inputType, getPosition, options) {
+    constructor(inputType, getPosition, options) {
       __publicField(this, "isAboveInput", false);
       /** @type {HTMLTooltipOptions} */
       __publicField(this, "options");
@@ -11846,7 +11864,6 @@ Source: "${matchedFrom}"`;
         mode: options.testMode ? "open" : "closed"
       });
       this.host = this.shadow.host;
-      this.config = config;
       this.subtype = getSubtypeFromType(inputType);
       this.variant = getVariantFromType(inputType);
       this.tooltip = null;
@@ -12118,8 +12135,7 @@ Source: "${matchedFrom}"`;
      */
     render(device, config, items, callbacks) {
       const t = device.t;
-      const { wrapperClass, css } = this.options;
-      const isTopAutofill = wrapperClass?.includes("top-autofill");
+      const { wrapperClass, css, isTopAutofill } = this.options;
       let hasAddedSeparator = false;
       const shouldShowSeparator = (dataId, index) => {
         const shouldShow = ["personalAddress", "privateAddress"].includes(dataId) && !hasAddedSeparator;
@@ -12192,7 +12208,6 @@ ${css}
       return this;
     }
   };
-  var DataHTMLTooltip_default = DataHTMLTooltip;
 
   // src/UI/EmailHTMLTooltip.js
   var EmailHTMLTooltip = class extends HTMLTooltip_default {
@@ -12254,7 +12269,6 @@ ${this.options.css}
       this.device?.selectedDetail({ email: formattedAddress, id }, "email");
     }
   };
-  var EmailHTMLTooltip_default = EmailHTMLTooltip;
 
   // src/UI/EmailSignupHTMLTooltip.js
   var EmailSignupHTMLTooltip = class extends HTMLTooltip_default {
@@ -12299,7 +12313,6 @@ ${this.options.css}
       return this;
     }
   };
-  var EmailSignupHTMLTooltip_default = EmailSignupHTMLTooltip;
 
   // src/UI/CredentialsImportTooltip.js
   var CredentialsImportTooltip = class extends HTMLTooltip_default {
@@ -12312,7 +12325,7 @@ ${this.options.css}
       const t = device.t;
       this.shadow.innerHTML = `
 ${this.options.css}
-<div class="wrapper wrapper--data top-autofill" hidden>
+<div class="wrapper wrapper--data ${this.options.isTopAutofill ? "top-autofill" : ""}" hidden>
     <div class="tooltip tooltip--data">
         <button class="tooltip__button tooltip__button--data tooltip__button--credentials-import js-promo-wrapper">
             <span class="tooltip__button__text-container">
@@ -12342,7 +12355,6 @@ ${this.options.css}
       return this;
     }
   };
-  var CredentialsImportTooltip_default = CredentialsImportTooltip;
 
   // src/UI/controllers/HTMLTooltipUIController.js
   var HTMLTooltipUIController = class extends UIController {
@@ -12418,29 +12430,26 @@ ${this.options.css}
       const hasNoCredentialsData = this._options.device.getLocalCredentials().length === 0;
       if (topContextData.credentialsImport && hasNoCredentialsData) {
         this._options.device.firePixel({ pixelName: "autofill_import_credentials_prompt_shown" });
-        return new CredentialsImportTooltip_default(config, topContextData.inputType, getPosition, tooltipOptions).render(
-          this._options.device,
-          {
-            onStarted: () => {
-              this._options.device.credentialsImport.started();
-            },
-            onDismissed: () => {
-              this._options.device.credentialsImport.dismissed();
-            }
+        return new CredentialsImportTooltip(topContextData.inputType, getPosition, tooltipOptions).render(this._options.device, {
+          onStarted: () => {
+            this._options.device.credentialsImport.started();
+          },
+          onDismissed: () => {
+            this._options.device.credentialsImport.dismissed();
           }
-        );
+        });
       }
       if (this._options.tooltipKind === "legacy") {
         this._options.device.firePixel({ pixelName: "autofill_show" });
-        return new EmailHTMLTooltip_default(config, topContextData.inputType, getPosition, tooltipOptions).render(this._options.device);
+        return new EmailHTMLTooltip(topContextData.inputType, getPosition, tooltipOptions).render(this._options.device);
       }
       if (this._options.tooltipKind === "emailsignup") {
         this._options.device.firePixel({ pixelName: "incontext_show" });
-        return new EmailSignupHTMLTooltip_default(config, topContextData.inputType, getPosition, tooltipOptions).render(this._options.device);
+        return new EmailSignupHTMLTooltip(topContextData.inputType, getPosition, tooltipOptions).render(this._options.device);
       }
       const data = this._dataForAutofill(config, topContextData.inputType, topContextData);
       const asRenderers = data.map((d) => config.tooltipItem(d));
-      return new DataHTMLTooltip_default(config, topContextData.inputType, getPosition, tooltipOptions).render(
+      return new DataHTMLTooltip(topContextData.inputType, getPosition, tooltipOptions).render(
         this._options.device,
         config,
         asRenderers,
@@ -12466,7 +12475,7 @@ ${this.options.css}
       const config = getInputConfigFromType(this._activeInputType);
       const asRenderers = data.map((d) => config.tooltipItem(d));
       const activeTooltip = this.getActiveTooltip();
-      if (activeTooltip instanceof DataHTMLTooltip_default) {
+      if (activeTooltip instanceof DataHTMLTooltip) {
         activeTooltip?.render(this._options.device, config, asRenderers, {
           onSelect: (id) => {
             this._onSelect(this._activeInputType, data, id);
@@ -13417,6 +13426,7 @@ ${this.options.css}
         },
         {
           wrapperClass: "top-autofill",
+          isTopAutofill: true,
           tooltipPositionClass: () => ".wrapper { transform: none; }",
           setSize: (details) => this.deviceApi.notify(createNotification("setSize", details)),
           remove: async () => this._closeAutofillParent(),
@@ -13643,6 +13653,7 @@ ${this.options.css}
         },
         {
           wrapperClass: "top-autofill",
+          isTopAutofill: true,
           tooltipPositionClass: () => ".wrapper { transform: none; }",
           setSize: (details) => this.deviceApi.notify(new SetSizeCall(details)),
           remove: async () => this._closeAutofillParent(),

--- a/node_modules/@duckduckgo/autofill/dist/shared-credentials.json
+++ b/node_modules/@duckduckgo/autofill/dist/shared-credentials.json
@@ -138,6 +138,12 @@
   },
   {
     "shared": [
+      "candyrect.com",
+      "nekochat.cn"
+    ]
+  },
+  {
+    "shared": [
       "centralfcu.org",
       "centralfcu.com"
     ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@duckduckgo/autoconsent": "^12.16.0",
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.0",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.9.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.4.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1743047884"
@@ -58,7 +58,7 @@
       }
     },
     "node_modules/@duckduckgo/autofill": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#2bc93bec9cbe6d916e84b42346b925c6c057bfa5",
+      "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#8e89de49b4003d449b65faef19254ed5aaaf7def",
       "hasInstallScript": true,
       "license": "Apache-2.0"
     },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@duckduckgo/autoconsent": "^12.16.0",
-    "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.0",
+    "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
     "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.9.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.4.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1743047884"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1209843505405123/1209843505405123
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/17.0.1


## Description
Updates Autofill to version [17.0.1](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/17.0.1).

### Autofill 17.0.1 release notes
## What's Changed
* Update password-related json files (2025-03-17) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/779
* display all Autofill UI elements in 1 HTML page by @shakyShane in https://github.com/duckduckgo/duckduckgo-autofill/pull/781
* [Scanner] add form only when it's not available by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/782
* Update Apple BSK path by @samsymons in https://github.com/duckduckgo/duckduckgo-autofill/pull/784
* Update password-related json files (2025-03-28) by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/787


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/17.0.0...17.0.1

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).