### PR TITLE
Multi-selection: Ship review change requests

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -36,8 +36,10 @@ import androidx.annotation.VisibleForTesting
 import androidx.core.view.isVisible
 import androidx.core.view.postDelayed
 import androidx.lifecycle.Lifecycle.State.RESUMED
+import androidx.lifecycle.Lifecycle.State.STARTED
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.viewpager2.widget.MarginPageTransformer
 import androidx.viewpager2.widget.ViewPager2
 import androidx.webkit.ServiceWorkerClientCompat
@@ -313,20 +315,24 @@ open class BrowserActivity : DuckDuckGoActivity() {
     private fun configureFlowCollectors() {
         if (swipingTabsFeature.isEnabled) {
             lifecycleScope.launch {
-                viewModel.tabsFlow.flowWithLifecycle(lifecycle).collectLatest {
-                    tabManager.onTabsChanged(it)
-                }
-            }
+                repeatOnLifecycle(STARTED) {
+                    launch {
+                        viewModel.tabsFlow.collectLatest {
+                            tabManager.onTabsChanged(it)
+                        }
+                    }
 
-            lifecycleScope.launch {
-                viewModel.selectedTabFlow.flowWithLifecycle(lifecycle).collectLatest {
-                    tabManager.onSelectedTabChanged(it)
-                }
-            }
+                    launch {
+                        viewModel.selectedTabFlow.collectLatest {
+                            tabManager.onSelectedTabChanged(it)
+                        }
+                    }
 
-            lifecycleScope.launch {
-                viewModel.selectedTabIndex.flowWithLifecycle(lifecycle).collectLatest {
-                    onMoveToTabRequested(it)
+                    launch {
+                        viewModel.selectedTabIndex.collectLatest {
+                            onMoveToTabRequested(it)
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -648,7 +648,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
             is Command.ShowSystemDefaultAppsActivity -> showSystemDefaultAppsActivity(command.intent)
             is Command.ShowSystemDefaultBrowserDialog -> showSystemDefaultBrowserDialog(command.intent)
             is Command.ShowUndoDeleteTabsMessage -> showTabsDeletedSnackbar(command.tabIds)
-            Command.LaunchTabSwitcherAfterTabsUndeleted -> currentTab?.launchTabSwitcherAfterTabsUndeleted()
+            Command.LaunchTabSwitcher -> currentTab?.launchTabSwitcherAfterTabsUndeleted()
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -4330,6 +4330,10 @@ class BrowserTabFragment :
     fun onTabSwipedAway() {
         viewModel.onTabSwipedAway()
     }
+
+    fun launchTabSwitcherAfterTabsUndeleted() {
+        viewModel.onLaunchTabSwitcherAfterTabsUndeletedRequest()
+    }
 }
 
 private class JsOrientationHandler {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2973,6 +2973,10 @@ class BrowserTabViewModel @Inject constructor(
         onUserDismissedCta(ctaViewState.value?.cta)
     }
 
+    fun onLaunchTabSwitcherAfterTabsUndeletedRequest() {
+        command.value = LaunchTabSwitcher
+    }
+
     private fun fireDailyLaunchPixel() {
         val tabCount = viewModelScope.async(dispatchers.io()) { tabStatsBucketing.getNumberOfOpenTabs() }
         val activeTabCount = viewModelScope.async(dispatchers.io()) { tabStatsBucketing.getTabsActiveLastWeek() }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -81,6 +81,8 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
+private const val DELETABLE_TABS_CHECK_DELAY = 200L
+
 @OptIn(FlowPreview::class)
 @ContributesViewModel(ActivityScope::class)
 class BrowserViewModel @Inject constructor(
@@ -451,7 +453,7 @@ class BrowserViewModel @Inject constructor(
 
     private fun checkIfAnyDeletableTabsExist() {
         viewModelScope.launch {
-            delay() // delayed so that a potential DB operation has time to mark tabs as deletable
+            delay(DELETABLE_TABS_CHECK_DELAY) // delayed so that a potential DB operation has time to mark tabs as deletable
             val deletableTabIds = tabRepository.getDeletableTabIds()
             if (deletableTabIds.isNotEmpty()) {
                 command.value = ShowUndoDeleteTabsMessage(deletableTabIds)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -25,7 +25,7 @@ import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.browser.BrowserViewModel.Command.DismissSetAsDefaultBrowserDialog
-import com.duckduckgo.app.browser.BrowserViewModel.Command.LaunchTabSwitcherAfterTabsUndeleted
+import com.duckduckgo.app.browser.BrowserViewModel.Command.LaunchTabSwitcher
 import com.duckduckgo.app.browser.BrowserViewModel.Command.ShowUndoDeleteTabsMessage
 import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
 import com.duckduckgo.app.browser.defaultbrowsing.prompts.DefaultBrowserPromptsExperiment
@@ -114,7 +114,7 @@ class BrowserViewModel @Inject constructor(
         data class Query(val query: String) : Command()
         data object LaunchPlayStore : Command()
         data object LaunchFeedbackView : Command()
-        data object LaunchTabSwitcherAfterTabsUndeleted : Command()
+        data object LaunchTabSwitcher : Command()
         data class ShowAppEnjoymentPrompt(val promptCount: PromptCount) : Command()
         data class ShowAppRatingPrompt(val promptCount: PromptCount) : Command()
         data class ShowAppFeedbackPrompt(val promptCount: PromptCount) : Command()
@@ -452,7 +452,7 @@ class BrowserViewModel @Inject constructor(
     fun undoDeletableTabs(tabIds: List<String>) {
         viewModelScope.launch {
             tabRepository.undoDeletable(tabIds, moveActiveTabToEnd = true)
-            command.value = LaunchTabSwitcherAfterTabsUndeleted
+            command.value = LaunchTabSwitcher
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -446,7 +446,7 @@ class BrowserViewModel @Inject constructor(
     // user has tapped the Undo action -> restore the closed tabs
     fun undoDeletableTabs(tabIds: List<String>) {
         viewModelScope.launch {
-            tabRepository.undoDeletable(tabIds)
+            tabRepository.undoDeletable(tabIds, moveActiveTabToEnd = true)
             command.value = LaunchTabSwitcherAfterTabsUndeleted
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDao.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDao.kt
@@ -108,11 +108,17 @@ abstract class TabsDao {
     }
 
     @Transaction
-    open fun undoDeletableTabs(tabIds: List<String>) {
+    open fun undoDeletableTabs(tabIds: List<String>, moveActiveTabToEnd: Boolean) {
         // ensure the tab is in the DB
         tabIds.forEach { tabId ->
             tab(tabId)?.let { tab ->
                 updateTab(tab.copy(deletable = false))
+            }
+        }
+
+        if (moveActiveTabToEnd) {
+            selectedTab()?.let { activeTab ->
+                updateTab(activeTab.copy(position = tabIds.size))
             }
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDao.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/db/TabsDao.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.common.utils.swap
 import com.duckduckgo.di.scopes.AppScope
 import dagger.SingleInstanceIn
 import java.time.LocalDateTime
+import kotlin.math.max
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -110,15 +111,17 @@ abstract class TabsDao {
     @Transaction
     open fun undoDeletableTabs(tabIds: List<String>, moveActiveTabToEnd: Boolean) {
         // ensure the tab is in the DB
+        var lastTabPosition = selectedTab()?.position ?: 0
         tabIds.forEach { tabId ->
             tab(tabId)?.let { tab ->
                 updateTab(tab.copy(deletable = false))
+                lastTabPosition = max(lastTabPosition, tab.position)
             }
         }
 
         if (moveActiveTabToEnd) {
             selectedTab()?.let { activeTab ->
-                updateTab(activeTab.copy(position = tabIds.size))
+                updateTab(activeTab.copy(position = lastTabPosition + 1))
             }
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
@@ -27,7 +27,6 @@ import com.duckduckgo.app.browser.tabpreview.WebViewPreviewPersister
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.global.model.Site
 import com.duckduckgo.app.global.model.SiteFactory
-import com.duckduckgo.app.tabs.TabManagerFeatureFlags
 import com.duckduckgo.app.tabs.db.TabsDao
 import com.duckduckgo.app.tabs.model.TabSwitcherData.LayoutType
 import com.duckduckgo.app.tabs.model.TabSwitcherData.UserState

--- a/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/model/TabDataRepository.kt
@@ -62,7 +62,6 @@ class TabDataRepository @Inject constructor(
     private val timeProvider: CurrentTimeProvider,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val dispatchers: DispatcherProvider,
-    private val tabManagerFeatureFlags: TabManagerFeatureFlags,
     private val adClickManager: AdClickManager,
     private val webViewSessionStorage: WebViewSessionStorage,
 ) : TabRepository {
@@ -312,9 +311,9 @@ class TabDataRepository @Inject constructor(
         }
     }
 
-    override suspend fun undoDeletable(tabIds: List<String>) {
+    override suspend fun undoDeletable(tabIds: List<String>, moveActiveTabToEnd: Boolean) {
         databaseExecutor().scheduleDirect {
-            tabsDao.undoDeletableTabs(tabIds)
+            tabsDao.undoDeletableTabs(tabIds, moveActiveTabToEnd)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -684,7 +684,9 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
     }
 
     override fun onNewTabRequested(fromOverflowMenu: Boolean) {
-        clearObserversEarlyToStopViewUpdates()
+        // clear observers early to stop view updates
+        removeObservers()
+
         viewModel.onNewTabRequested(fromOverflowMenu)
     }
 
@@ -816,14 +818,13 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
     }
 
     override fun finish() {
-        clearObserversEarlyToStopViewUpdates()
+        removeObservers()
         super.finish()
     }
 
     override fun onDestroy() {
         super.onDestroy()
-        viewModel.tabSwitcherItems.removeObservers(this)
-        viewModel.deletableTabs.removeObservers(this)
+        removeObservers()
 
         // we don't want to purge during device rotation
         if (isFinishing) {
@@ -835,7 +836,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
         }
     }
 
-    private fun clearObserversEarlyToStopViewUpdates() {
+    private fun removeObservers() {
         viewModel.tabItemsLiveData.removeObservers(this)
         viewModel.deletableTabs.removeObservers(this)
     }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -608,6 +608,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
 
     private fun initMenuClickListeners() {
         popupMenu.onMenuItemClicked(popupMenu.contentView.findViewById(R.id.newTabMenuItem)) { onNewTabRequested(fromOverflowMenu = true) }
+        popupMenu.onMenuItemClicked(popupMenu.contentView.findViewById(R.id.duckChatMenuItem)) { viewModel.onDuckChatMenuClicked() }
         popupMenu.onMenuItemClicked(popupMenu.contentView.findViewById(R.id.selectAllMenuItem)) { viewModel.onSelectAllTabs() }
         popupMenu.onMenuItemClicked(popupMenu.contentView.findViewById(R.id.deselectAllMenuItem)) { viewModel.onDeselectAllTabs() }
         popupMenu.onMenuItemClicked(popupMenu.contentView.findViewById(R.id.shareSelectedLinksMenuItem)) { viewModel.onShareSelectedTabs() }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -335,7 +335,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
         )
     }
 
-    private fun updateToolbarTitle(mode: Mode, tabCount: Int) {
+    private fun updateToolbarTitle(mode: Mode) {
         toolbar.title = if (mode is Selection) {
             if (mode.selectedTabs.isEmpty()) {
                 getString(R.string.selectTabsMenuItem)
@@ -343,7 +343,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
                 getString(R.string.tabSelectionTitle, mode.selectedTabs.size)
             }
         } else {
-            resources.getQuantityString(R.plurals.tabSwitcherTitle, tabCount, tabCount)
+            getString(R.string.tabActivityTitle)
         }
     }
 
@@ -385,7 +385,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
                     tabsRecycler.invalidateItemDecorations()
                     tabsAdapter.updateData(it.tabItems)
 
-                    updateToolbarTitle(it.mode, it.tabItems.size)
+                    updateToolbarTitle(it.mode)
                     updateTabGridItemDecorator()
 
                     tabTouchHelper.mode = it.mode

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -380,7 +380,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
     private fun configureObservers() {
         if (tabManagerFeatureFlags.multiSelection().isEnabled()) {
             lifecycleScope.launch {
-                viewModel.selectionViewState.flowWithLifecycle(lifecycle, Lifecycle.State.STARTED).collectLatest {
+                viewModel.selectionViewState.flowWithLifecycle(lifecycle).collectLatest {
                     tabsRecycler.invalidateItemDecorations()
                     tabsAdapter.updateData(it.tabItems)
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherMenuExt.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherMenuExt.kt
@@ -40,6 +40,7 @@ fun Menu.createDynamicInterface(
     dynamicMenu: DynamicInterface,
 ) {
     popupMenu.newTabMenuItem.isVisible = dynamicMenu.isNewTabVisible
+    popupMenu.duckChatMenuItem.isVisible = dynamicMenu.isDuckChatVisible
     popupMenu.selectAllMenuItem.isVisible = dynamicMenu.isSelectAllVisible
     popupMenu.deselectAllMenuItem.isVisible = dynamicMenu.isDeselectAllVisible
     popupMenu.selectionActionsDivider.isVisible = dynamicMenu.isSelectionActionsDividerVisible

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -620,6 +620,7 @@ class TabSwitcherViewModel @Inject constructor(
                 DynamicInterface(
                     isFireButtonVisible = true,
                     isNewTabVisible = true,
+                    isDuckChatVisible = true,
                     isSelectAllVisible = false,
                     isDeselectAllVisible = false,
                     isSelectionActionsDividerVisible = false,
@@ -652,6 +653,7 @@ class TabSwitcherViewModel @Inject constructor(
                 DynamicInterface(
                     isFireButtonVisible = false,
                     isNewTabVisible = false,
+                    isDuckChatVisible = false,
                     isSelectAllVisible = !areAllTabsSelected,
                     isDeselectAllVisible = areAllTabsSelected,
                     isSelectionActionsDividerVisible = isSelectionActionable,
@@ -675,6 +677,7 @@ class TabSwitcherViewModel @Inject constructor(
         data class DynamicInterface(
             val isFireButtonVisible: Boolean,
             val isNewTabVisible: Boolean,
+            val isDuckChatVisible: Boolean,
             val isSelectAllVisible: Boolean,
             val isDeselectAllVisible: Boolean,
             val isSelectionActionsDividerVisible: Boolean,

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -206,7 +206,7 @@ class TabSwitcherViewModel @Inject constructor(
     }
 
     suspend fun onUndoDeleteSnackbarDismissed(tabIds: List<String>) {
-        // delete only recently deleted tabs, because others may need to be preserved for undeleting
+        // delete only recently deleted tabs, because others may need to be preserved for restoring
         deleteTabs(tabIds)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -608,7 +608,7 @@ class TabSwitcherViewModel @Inject constructor(
     }
 
     data class SelectionViewState(
-        val tabItems: List<Tab> = emptyList(),
+        val tabItems: List<TabSwitcherItem> = emptyList(),
         val mode: Mode = Normal,
         val layoutType: LayoutType? = null,
     ) {
@@ -616,7 +616,7 @@ class TabSwitcherViewModel @Inject constructor(
 
         val dynamicInterface = when (mode) {
             is Normal -> {
-                val isThereOnlyNewTabPage = tabItems.size == 1 && tabItems.any { it.isNewTabPage }
+                val isThereOnlyNewTabPage = tabItems.size == 1 && tabItems.mapNotNull { it as? Tab }.any { it.isNewTabPage }
                 DynamicInterface(
                     isFireButtonVisible = true,
                     isNewTabVisible = true,

--- a/app/src/main/res/layout/popup_tabs_menu.xml
+++ b/app/src/main/res/layout/popup_tabs_menu.xml
@@ -52,12 +52,12 @@
         app:defaultPadding="false" />
 
     <com.duckduckgo.common.ui.view.PopupMenuItemView
-        android:id="@+id/shareSelectedLinksMenuItem"
+        android:id="@+id/bookmarkSelectedTabsMenuItem"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 
     <com.duckduckgo.common.ui.view.PopupMenuItemView
-        android:id="@+id/bookmarkSelectedTabsMenuItem"
+        android:id="@+id/shareSelectedLinksMenuItem"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 

--- a/app/src/main/res/layout/popup_tabs_menu.xml
+++ b/app/src/main/res/layout/popup_tabs_menu.xml
@@ -28,6 +28,12 @@
         app:primaryText="@string/newTabMenuItem" />
 
     <com.duckduckgo.common.ui.view.PopupMenuItemView
+        android:id="@+id/duckChatMenuItem"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:primaryText="@string/duckChatMenuItem" />
+
+    <com.duckduckgo.common.ui.view.PopupMenuItemView
         android:id="@+id/selectAllMenuItem"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -730,11 +730,6 @@
         <item quantity="other">%1$d tabs closed</item>
     </plurals>
 
-    <plurals name="tabSwitcherTitle" tools:ignore="ImpliedQuantity,MissingInstruction">
-        <item quantity="one">1 Private Tab</item>
-        <item quantity="other">%1$d Private Tabs</item>
-    </plurals>
-
     <!-- Private voice search -->
     <string name="accessibilityVoiceSearchSubtitle">Add Private Voice Search option to the address bar. Audio is not stored or shared with anyone, including DuckDuckGo.</string>
     <string name="accessibilityVoiceSearchTitle">Private Voice Search</string>

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandlerImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchOptionHandlerImplTest.kt
@@ -820,7 +820,7 @@ class ShowOnAppLaunchOptionHandlerImplTest {
             TODO("Not yet implemented")
         }
 
-        override suspend fun undoDeletable(tabIds: List<String>) {
+        override suspend fun undoDeletable(tabIds: List<String>, moveActiveTabToEnd: Boolean) {
             TODO("Not yet implemented")
         }
 

--- a/app/src/test/java/com/duckduckgo/tabs/db/TabsDaoTest.kt
+++ b/app/src/test/java/com/duckduckgo/tabs/db/TabsDaoTest.kt
@@ -422,10 +422,29 @@ class TabsDaoTest {
 
         testee.insertTab(tab1)
         testee.insertTab(tab2)
-        testee.undoDeletableTabs(listOf(tab1.tabId, tab2.tabId))
+        testee.undoDeletableTabs(listOf(tab1.tabId, tab2.tabId), false)
 
         assertEquals(tab1.copy(deletable = false), testee.tab(tab1.tabId))
         assertEquals(tab2.copy(deletable = false), testee.tab(tab2.tabId))
+    }
+
+    @Test
+    fun whenUndoDeletableTabsAndMoveActiveToEndThenModifyDeletableColumnAndMoveActiveToEnd() {
+        val tab1 = TabEntity(tabId = "TAB_ID1", url = "www.duckduckgo.com", position = 0, deletable = false)
+        val tab2 = TabEntity(tabId = "TAB_ID2", url = "www.duckduckgo.com", position = 0, deletable = true)
+        val tab3 = TabEntity(tabId = "TAB_ID3", url = "www.duckduckgo.com", position = 1, deletable = true)
+
+        testee.insertTab(tab1)
+        testee.insertTab(tab2)
+        testee.insertTab(tab3)
+        testee.insertTabSelection(TabSelectionEntity(tabId = tab1.tabId))
+        testee.undoDeletableTabs(listOf(tab2.tabId, tab3.tabId), true)
+
+        val tabs = testee.tabs()
+        assertEquals(tab2.copy(deletable = false), testee.tab(tab2.tabId))
+        assertEquals(tab3.copy(deletable = false), testee.tab(tab3.tabId))
+        assertEquals(tab1.copy(position = 2), testee.tab(tab1.tabId))
+        assertEquals(tab1.tabId, tabs.last().tabId)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/tabs/model/TabDataRepositoryTest.kt
+++ b/app/src/test/java/com/duckduckgo/tabs/model/TabDataRepositoryTest.kt
@@ -614,6 +614,8 @@ class TabDataRepositoryTest {
 
     @Test
     fun whenPurgeDeletableTabsThenPurgeDeletableTabsAndClearData() = runTest {
+        tabManagerFeatureFlags.multiSelection().setRawStoredState(State(enable = true))
+
         val testee = tabDataRepository()
         val tabIds = listOf("tabid1", "tabid2")
         whenever(mockDao.getDeletableTabIds()).thenReturn(tabIds)

--- a/app/src/test/java/com/duckduckgo/tabs/model/TabDataRepositoryTest.kt
+++ b/app/src/test/java/com/duckduckgo/tabs/model/TabDataRepositoryTest.kt
@@ -660,6 +660,7 @@ class TabDataRepositoryTest {
             coroutinesTestRule.testDispatcherProvider,
             mockAdClickManager,
             mockWebViewSessionStorage,
+            tabManagerFeatureFlags,
         )
     }
 

--- a/browser-api/src/main/java/com/duckduckgo/app/tabs/model/TabRepository.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/tabs/model/TabRepository.kt
@@ -88,7 +88,7 @@ interface TabRepository {
 
     suspend fun undoDeletable(tab: TabEntity)
 
-    suspend fun undoDeletable(tabIds: List<String>)
+    suspend fun undoDeletable(tabIds: List<String>, moveActiveTabToEnd: Boolean = false)
 
     suspend fun deleteTabs(tabIds: List<String>)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1209846575622288/f

### Description

This PR implements the following changes:

- Implement undo snackbar after tab deletion in the browser screen
- Add the AI chat back to the normal mode menu
- Reverse the order of share/bookmark tabs in selection mode
- Revert the tab switcher title back to "Tabs"

### Steps to test this PR

_Undo snackbar_
- [x] Go to the tab switcher
- [x] Make sure you have multiple tabs
- [x] Tap on the more menu -> Close all tabs
- [x] Verify a snackbar with the Undo button appears in the browser
- [x] Tap on the Undo button
- [x] Verify the closed tabs are all restored
- [x] Verify the NTP is at the last position

_AI chat_
- [x] Go to the tab switcher
- [x] Verify the AI chat menu item is visible and works

_Selection mode menu_
- [x] Go to the tab switcher
- [x] Tap on the more menu
- [x] Tap on the Select tabs
- [x] Select some tabs
- [x] Tap on the more menu
- [x] Verify the Bookmark menu item is above Share menu item

_Tab switcher screen title_
- [x] Go to the tab switcher
- [x] Verify the title says "Tabs"
