### PR TITLE
adjust DefaultBrowserPromptsExperimentImplTest

### DIFF
--- a/app/src/test/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/DefaultBrowserPromptsExperimentImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/DefaultBrowserPromptsExperimentImplTest.kt
@@ -909,7 +909,7 @@ class DefaultBrowserPromptsExperimentImplTest {
     @Test
     fun `if message dialog shown, then send a pixel`() = runTest {
         val expectedParams = mapOf(
-            PIXEL_PARAM_KEY_VARIANT to "variant_2",
+            PIXEL_PARAM_KEY_VARIANT to "variant2",
             PIXEL_PARAM_KEY_STAGE to "stage_1",
         )
         val dataStoreMock = createDataStoreFake(
@@ -930,7 +930,7 @@ class DefaultBrowserPromptsExperimentImplTest {
     @Test
     fun `if message dialog canceled, then send a pixel`() = runTest {
         val expectedParams = mapOf(
-            PIXEL_PARAM_KEY_VARIANT to "variant_2",
+            PIXEL_PARAM_KEY_VARIANT to "variant2",
             PIXEL_PARAM_KEY_STAGE to "stage_1",
         )
         val dataStoreMock = createDataStoreFake(
@@ -951,7 +951,7 @@ class DefaultBrowserPromptsExperimentImplTest {
     @Test
     fun `if message dialog not now clicked, then send a pixel`() = runTest {
         val expectedParams = mapOf(
-            PIXEL_PARAM_KEY_VARIANT to "variant_2",
+            PIXEL_PARAM_KEY_VARIANT to "variant2",
             PIXEL_PARAM_KEY_STAGE to "stage_1",
         )
         val dataStoreMock = createDataStoreFake(
@@ -972,7 +972,7 @@ class DefaultBrowserPromptsExperimentImplTest {
     @Test
     fun `if message dialog confirmation clicked, then send a pixel`() = runTest {
         val expectedParams = mapOf(
-            PIXEL_PARAM_KEY_VARIANT to "variant_2",
+            PIXEL_PARAM_KEY_VARIANT to "variant2",
             PIXEL_PARAM_KEY_STAGE to "stage_1",
         )
         val dataStoreMock = createDataStoreFake(
@@ -993,7 +993,7 @@ class DefaultBrowserPromptsExperimentImplTest {
     @Test
     fun `if menu item clicked, then send a pixel`() = runTest {
         val expectedParams = mapOf(
-            PIXEL_PARAM_KEY_VARIANT to "variant_2",
+            PIXEL_PARAM_KEY_VARIANT to "variant2",
             PIXEL_PARAM_KEY_STAGE to "stage_1",
         )
         val dataStoreMock = createDataStoreFake(
@@ -1064,7 +1064,7 @@ class DefaultBrowserPromptsExperimentImplTest {
 
     private fun mockActiveCohort(cohortName: AdditionalPromptsCohortName): Cohort {
         val cohort = Cohort(
-            name = cohortName.name,
+            name = cohortName.cohortName,
             weight = 1,
             enrollmentDateET = fakeEnrollmentDateETString,
         )


### PR DESCRIPTION
### Description
Follow-up to https://github.com/duckduckgo/Android/pull/5702 where we renamed the cohort names and they don't match their respective enum names anymore (for example, `VARIANT_1("variant1")` enum). Now I noticed that unit tests were mocking enum name, so fixing that up to avoid potential future confusion. Nothing changes functionally and all tests still pass.