### PR TITLE
Tab swiping: Add a subfeature flag

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -540,6 +540,7 @@ class BrowserTabViewModelTest {
         MockitoAnnotations.openMocks(this)
 
         swipingTabsFeature.self().setRawStoredState(State(enable = true))
+        swipingTabsFeature.onForInternalUsers().setRawStoredState(State(enable = true))
 
         db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
             .allowMainThreadQueries()

--- a/app/src/main/java/com/duckduckgo/app/browser/SwipingTabsFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/SwipingTabsFeature.kt
@@ -25,11 +25,15 @@ import com.duckduckgo.feature.toggles.api.Toggle
     featureName = "swipingTabs",
 )
 interface SwipingTabsFeature {
-    // The flag used to enable the feature for the internal users
+    // The main kill switch for the feature
     @Toggle.DefaultValue(false)
     fun self(): Toggle
 
-    // The toggle used to enable the feature for prod users (during the rollout phase)
+    // The toggle used to enable the feature for internal users
     @Toggle.DefaultValue(false)
-    fun onForExistingUsers(): Toggle
+    fun onForInternalUsers(): Toggle
+
+    // The toggle used to enable the feature for external users
+    @Toggle.DefaultValue(false)
+    fun onForExternalUsers(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/SwipingTabsFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/SwipingTabsFeature.kt
@@ -25,6 +25,11 @@ import com.duckduckgo.feature.toggles.api.Toggle
     featureName = "swipingTabs",
 )
 interface SwipingTabsFeature {
+    // the main kill switch for the feature
     @Toggle.DefaultValue(false)
     fun self(): Toggle
+
+    // This toggle is used to enable the feature for existing users (during the rollout phase)
+    @Toggle.DefaultValue(false)
+    fun onForExistingUsers(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/SwipingTabsFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/SwipingTabsFeature.kt
@@ -25,11 +25,11 @@ import com.duckduckgo.feature.toggles.api.Toggle
     featureName = "swipingTabs",
 )
 interface SwipingTabsFeature {
-    // the main kill switch for the feature
+    // The flag used to enable the feature for the internal users
     @Toggle.DefaultValue(false)
     fun self(): Toggle
 
-    // This toggle is used to enable the feature for existing users (during the rollout phase)
+    // The toggle used to enable the feature for prod users (during the rollout phase)
     @Toggle.DefaultValue(false)
     fun onForExistingUsers(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/SwipingTabsFeatureProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/SwipingTabsFeatureProvider.kt
@@ -25,6 +25,7 @@ class SwipingTabsFeatureProvider @Inject constructor(
     swipingTabsFeature: SwipingTabsFeature,
 ) {
     val isEnabled: Boolean by lazy {
-        swipingTabsFeature.self().isEnabled() || swipingTabsFeature.onForExistingUsers().isEnabled()
+        swipingTabsFeature.self().isEnabled() &&
+            (swipingTabsFeature.onForInternalUsers().isEnabled() || swipingTabsFeature.onForExternalUsers().isEnabled())
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/SwipingTabsFeatureProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/SwipingTabsFeatureProvider.kt
@@ -25,6 +25,6 @@ class SwipingTabsFeatureProvider @Inject constructor(
     swipingTabsFeature: SwipingTabsFeature,
 ) {
     val isEnabled: Boolean by lazy {
-        swipingTabsFeature.self().isEnabled()
+        swipingTabsFeature.self().isEnabled() && swipingTabsFeature.onForExistingUsers().isEnabled()
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/SwipingTabsFeatureProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/SwipingTabsFeatureProvider.kt
@@ -25,6 +25,6 @@ class SwipingTabsFeatureProvider @Inject constructor(
     swipingTabsFeature: SwipingTabsFeature,
 ) {
     val isEnabled: Boolean by lazy {
-        swipingTabsFeature.self().isEnabled() && swipingTabsFeature.onForExistingUsers().isEnabled()
+        swipingTabsFeature.self().isEnabled() || swipingTabsFeature.onForExistingUsers().isEnabled()
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
@@ -111,6 +111,7 @@ class BrowserViewModelTest {
 
         configureSkipUrlConversionInNewTabState(enabled = true)
         swipingTabsFeature.self().setRawStoredState(State(enable = false))
+        swipingTabsFeature.onForInternalUsers().setRawStoredState(State(enable = true))
 
         whenever(mockDefaultBrowserPromptsExperiment.commands).thenReturn(defaultBrowserPromptsExperimentCommandsFlow.receiveAsFlow())
 

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -115,6 +115,7 @@ class TabSwitcherViewModelTest {
         MockitoAnnotations.openMocks(this)
 
         swipingTabsFeature.self().setRawStoredState(State(enable = true))
+        swipingTabsFeature.onForInternalUsers().setRawStoredState(State(enable = true))
 
         whenever(mockTabRepository.flowDeletableTabs)
             .thenReturn(repoDeletableTabs.consumeAsFlow())


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/414730916066338/1209846575622295/f

### Description

This PR adds a subfeature flag `onForInternalUsers` and `onForExternalUsers` (the feature flag for prod users to enable staged rollout).

The flag is used inside a `SwipingTabsFeatureProvider` wrapper so nothing else should be affected. The original flag feature flag will be used to keep the feature enabled for all internal users.

After this, the updated privacy config will look like this:
```
"swipingTabs": {
    "state": "enabled",
    "minSupportedVersion": 52271000,
    "features": {
        "onForInternalUsers": {
            "state": "internal"
        },
        "onForExternalUsers": {
            "state": "enabled",
            "rollout": {
                "steps": [
                    {
                        "percent": 20
                    }
                ]
            }
        }
    }
}
```

### Steps to test this PR

_Internal test_
- [x] Replace the privacy config URL to: `https://jsonblob.com/api/1356597958694592512`
- [x] Run the app using an internal build
- [x] Verify the tab swiping is working