### PR TITLE
always complete omnibar/minibar transitions with an animation

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2751,11 +2751,12 @@ class BrowserTabFragment :
                 }
             }
 
-            it.setOnTouchListener { _, _ ->
+            it.setOnTouchListener { webView, event ->
                 if (omnibar.omnibarTextInput.isFocused) {
                     binding.focusDummy.requestFocus()
                 }
                 dismissAppLinkSnackBar()
+                omnibar.onScrollViewMotionEvent(scrollableView = webView, motionEvent = event)
                 false
             }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
@@ -456,6 +456,30 @@ class Omnibar(
         }
     }
 
+    fun onScrollViewMotionEvent(scrollableView: View, motionEvent: MotionEvent) {
+        when (omnibarPosition) {
+            OmnibarPosition.TOP -> {
+                when (omnibarType) {
+                    SCROLLING -> {
+                        // no-op
+                    }
+
+                    FADE -> binding.fadeOmnibar.onScrollViewMotionEvent(scrollableView, motionEvent)
+                }
+            }
+
+            OmnibarPosition.BOTTOM -> {
+                when (omnibarType) {
+                    SCROLLING -> {
+                        // no-op
+                    }
+
+                    FADE -> binding.fadeOmnibarBottom.onScrollViewMotionEvent(scrollableView, motionEvent)
+                }
+            }
+        }
+    }
+
     fun resetScrollPosition() {
         if (omnibarType == FADE) {
             when (omnibarPosition) {

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/FadeOmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/FadeOmnibarLayout.kt
@@ -261,8 +261,10 @@ class FadeOmnibarLayout @JvmOverloads constructor(
     }
 
     private fun evaluateTransition(progress: Float) {
-        if (maximumTextInputWidth == 0) {
+        if (transitionProgress == 0f) {
             // the maximum input text width is only available after the layout is evaluated because it occupies all available space on screen
+            // on top of that, icons in the toolbar can show/hide dynamically depending on the state and enabled features
+            // to work around this problem, we re-measure the maximum width whenever the toolbar is fully visible
             maximumTextInputWidth = omnibarTextInput.width
         }
 
@@ -285,8 +287,7 @@ class FadeOmnibarLayout @JvmOverloads constructor(
         // hide toolbar views
         val toolbarViewsAlpha = 1f - transitionInterpolation
         omnibarTextInput.alpha = toolbarViewsAlpha
-        aiChatDivider.alpha = toolbarViewsAlpha
-        aiChat.alpha = toolbarViewsAlpha
+        endIconsContainer.alpha = toolbarViewsAlpha
 
         // show minibar views
         minibarText.alpha = transitionInterpolation


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1209754552084246

### Description
Adds logic to always complete the omnibar/minibar transition.

The behavior is as follows:
- If user scrolls down, we always immediately start transitioning to minibar.
- If user scrolls up, we only start transitioning back to omnibar after a scroll threshold since the start of last gesture is reached. This is done so that as users scroll back-and-forth around the page we don't switch between omnibar/minibar all the time - only significant scroll gestures and flings, hitting top of the page, or clicking the minibar, will reveal the omnibar back.
- If gesture has any velocity, we complete the transition in the direction of the gesture.

Known issues:
- If we're near the bottom of the page, and **omnibar** is visible, scrolling very slowly until hitting the bottom of the page might cause a little bit of a bounce while we're force-transitioning to the minibar.

### Steps to test this PR

1. Toggle the feature option on: "Experimental UI Setting" -> "Enable all changes".
2. Play around with the transitions in both top and bottom omnibar positions.

### UI changes

_Before_

https://github.com/user-attachments/assets/401aafbb-2d62-4361-873b-838aacbef755

_After_

https://github.com/user-attachments/assets/7c0d2bc0-29db-4ba0-b2d2-299b3de87312
