### PR TITLE
Update origins: AppTP entry points to Privacy Pro

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/view/message/PProUpsellBannerPlugin.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/view/message/PProUpsellBannerPlugin.kt
@@ -91,6 +91,6 @@ class PProUpsellBannerPlugin @Inject constructor(
 
     companion object {
         internal const val PRIORITY_PPRO_UPSELL_BANNER = PRIORITY_ACTION_REQUIRED - 1
-        private const val PPRO_UPSELL_URL = "https://duckduckgo.com/pro?origin=funnel_pro_android_apptp_banner"
+        private const val PPRO_UPSELL_URL = "https://duckduckgo.com/pro?origin=funnel_apptrackingprotection_android__banner"
     }
 }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/view/message/PproUpsellDisabledMessagePlugin.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/view/message/PproUpsellDisabledMessagePlugin.kt
@@ -75,6 +75,6 @@ class PproUpsellDisabledMessagePlugin @Inject constructor(
     companion object {
         internal const val PRIORITY_PPRO_DISABLED = PRIORITY_DISABLED - 1
         private const val PPRO_UPSELL_ANNOTATION = "ppro_upsell_link"
-        private const val PPRO_UPSELL_URL = "https://duckduckgo.com/pro?origin=funnel_pro_android_apptp_disabled"
+        private const val PPRO_UPSELL_URL = "https://duckduckgo.com/pro?origin=funnel_apptrackingprotection_android__disabled"
     }
 }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/view/message/PproUpsellRevokedMessagePlugin.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/view/message/PproUpsellRevokedMessagePlugin.kt
@@ -73,6 +73,6 @@ class PproUpsellRevokedMessagePlugin @Inject constructor(
     companion object {
         internal const val PRIORITY_PPRO_REVOKED = PRIORITY_REVOKED - 1
         private const val PPRO_UPSELL_ANNOTATION = "ppro_upsell_link"
-        private const val PPRO_UPSELL_URL = "https://duckduckgo.com/pro?origin=funnel_pro_android_apptp_revoked"
+        private const val PPRO_UPSELL_URL = "https://duckduckgo.com/pro?origin=funnel_apptrackingprotection_android__revoked"
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1209860021472115/f

### Description
Update origins for AppTP entry points to PrivacyPro

### Steps to test this PR

_Pre steps_

- Make sure you are Privacy Pro eligible

_Banner_
- [x] Fresh install
- [x] Go to Settings > App Tracking Protection
- [x] Do AppTP onboarding
- [x] Tap on Privacy Pro banner
- [x] Check paywall origin is updated to `funnel_apptrackingprotection_android__banner`

_Revoked_
- [x] Enable AppTP
- [x] Enable an external VPN on your phone
- [x] Go back to AppTP screen
- [x] Tap on Privacy Pro revoked banner
- [x] Check paywall origin is updated to `funnel_apptrackingprotection_android__revoked`

_Disabled_
- [x] Disable AppTP
- [x] Enable an external VPN on your phone
- [x] Go back to AppTP screen
- [x] Tap on Privacy Pro disabled banner
- [x] Check paywall origin is updated to `funnel_apptrackingprotection_android__disabled`

### No UI changes
