### PR TITLE
Update content scope scripts to version 8.11.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -23,10 +23,6 @@
   var __commonJS = (cb, mod) => function __require2() {
     return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
   };
-  var __export = (target, all) => {
-    for (var name in all)
-      __defProp(target, name, { get: all[name], enumerable: true });
-  };
   var __copyProps = (to, from, except, desc) => {
     if (from && typeof from === "object" || typeof from === "function") {
       for (let key of __getOwnPropNames(from))
@@ -6439,12 +6435,6 @@
   init_define_import_meta_trackerLookup();
 
   // src/features/broker-protection/captcha-services/captcha.service.js
-  var captcha_service_exports = {};
-  __export(captcha_service_exports, {
-    getCaptchaInfo: () => getCaptchaInfo2,
-    getSupportingCodeToInject: () => getSupportingCodeToInject,
-    solveCaptcha: () => solveCaptcha2
-  });
   init_define_import_meta_trackerLookup();
 
   // src/features/broker-protection/utils/url.js
@@ -6754,11 +6744,6 @@
   }
 
   // src/features/broker-protection/actions/captcha-deprecated.js
-  var captcha_deprecated_exports = {};
-  __export(captcha_deprecated_exports, {
-    getCaptchaInfo: () => getCaptchaInfo,
-    solveCaptcha: () => solveCaptcha
-  });
   init_define_import_meta_trackerLookup();
   function getCaptchaInfo(action, root = document) {
     const pageUrl = window.location.href;
@@ -6965,45 +6950,24 @@
     return new SuccessResponse({ actionID, actionType, response });
   }
 
-  // src/features/broker-protection/actions/actions.js
-  function resolveActionHandlers({ useEnhancedCaptchaSystem }) {
-    return {
-      extract,
-      fillForm,
-      click,
-      expectation,
-      ...useEnhancedCaptchaSystem ? {
-        navigate,
-        ...captcha_service_exports
-      } : {
-        navigate: buildUrl,
-        ...captcha_deprecated_exports
-      }
-    };
-  }
-
   // src/features/broker-protection/execute.js
-  async function execute(action, inputData, root = document, options = {}) {
+  async function execute(action, inputData, root = document) {
     try {
-      const { useEnhancedCaptchaSystem = false } = options;
-      const { navigate: navigate2, extract: extract2, click: click2, expectation: expectation2, fillForm: fillForm2, getCaptchaInfo: getCaptchaInfo3, solveCaptcha: solveCaptcha3 } = resolveActionHandlers({
-        useEnhancedCaptchaSystem
-      });
       switch (action.actionType) {
         case "navigate":
-          return navigate2(action, data(action, inputData, "userProfile"));
+          return navigate(action, data(action, inputData, "userProfile"));
         case "extract":
-          return await extract2(action, data(action, inputData, "userProfile"), root);
+          return await extract(action, data(action, inputData, "userProfile"), root);
         case "click":
-          return click2(action, data(action, inputData, "userProfile"), root);
+          return click(action, data(action, inputData, "userProfile"), root);
         case "expectation":
-          return expectation2(action, root);
+          return expectation(action, root);
         case "fillForm":
-          return fillForm2(action, data(action, inputData, "extractedProfile"), root);
+          return fillForm(action, data(action, inputData, "extractedProfile"), root);
         case "getCaptchaInfo":
-          return getCaptchaInfo3(action, root);
+          return getCaptchaInfo2(action, root);
         case "solveCaptcha":
-          return solveCaptcha3(action, data(action, inputData, "token"), root);
+          return solveCaptcha2(action, data(action, inputData, "token"), root);
         default: {
           return new ErrorResponse({
             actionID: action.id,
@@ -7091,8 +7055,7 @@
      */
     async exec(action, data2) {
       const retryConfig = this.retryConfigFor(action);
-      const options = { useEnhancedCaptchaSystem: this.getFeatureSettingEnabled("useEnhancedCaptchaSystem") };
-      const { result, exceptions } = await retry(() => execute(action, data2, document, options), retryConfig);
+      const { result, exceptions } = await retry(() => execute(action, data2, document), retryConfig);
       if (result) {
         if ("success" in result && Array.isArray(result.success.next)) {
           const nextResults = [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^12.16.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.9.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.11.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.4.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1743047884"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#f0104543e4c16874588fca1bf089cf048ba40053",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#1ed51c1731b072b1042303887539b2382448fe4d",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -283,13 +283,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.14.tgz",
-      "integrity": "sha512-Zs/Ollc1SJ8nKUAgc7ivOEdIBM8JAKgrqqUYi2J997JuKO7/tpQC+WCetQ1sypiKCQWHdvdg9wBNpUPEWZae7w==",
+      "version": "22.14.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.0.tgz",
+      "integrity": "sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/resolve": {
@@ -685,9 +685,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^12.16.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.9.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.11.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.4.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1743047884"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1209891408682992/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [x] All tests must pass