### PR TITLE
Add separate worker for scam, so it can handle RC updates immediately

### DIFF
--- a/malicious-site-protection/malicious-site-protection-api/src/main/kotlin/com/duckduckgo/malicioussiteprotection/api/MaliciousSiteProtection.kt
+++ b/malicious-site-protection/malicious-site-protection-api/src/main/kotlin/com/duckduckgo/malicioussiteprotection/api/MaliciousSiteProtection.kt
@@ -34,6 +34,17 @@ interface MaliciousSiteProtection {
         PHISHING,
         MALWARE,
         SCAM,
+        ;
+
+        companion object {
+            fun fromString(name: String): Feed? {
+                return try {
+                    valueOf(name)
+                } catch (e: IllegalArgumentException) {
+                    null
+                }
+            }
+        }
     }
 
     sealed class IsMaliciousResult {

--- a/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionFeature.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionFeature.kt
@@ -45,6 +45,7 @@ interface MaliciousSiteProtectionFeature {
     @Toggle.DefaultValue(true)
     fun canUpdateDatasets(): Toggle
 
+    @Toggle.InternalAlwaysEnabled
     @Toggle.DefaultValue(false)
     fun scamProtection(): Toggle
 }

--- a/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionFiltersUpdateWorker.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionFiltersUpdateWorker.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import androidx.lifecycle.LifecycleOwner
 import androidx.work.BackoffPolicy
 import androidx.work.CoroutineWorker
+import androidx.work.Data
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
@@ -28,6 +29,10 @@ import com.duckduckgo.anvil.annotations.ContributesWorker
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed
+import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed.MALWARE
+import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed.PHISHING
+import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed.SCAM
 import com.duckduckgo.malicioussiteprotection.impl.data.MaliciousSiteRepository
 import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -35,6 +40,8 @@ import dagger.SingleInstanceIn
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import kotlinx.coroutines.withContext
+
+private const val TYPE = "type"
 
 @ContributesWorker(AppScope::class)
 class MaliciousSiteProtectionFiltersUpdateWorker(
@@ -55,7 +62,13 @@ class MaliciousSiteProtectionFiltersUpdateWorker(
             if (maliciousSiteProtectionFeature.isFeatureEnabled().not() || maliciousSiteProtectionFeature.canUpdateDatasets().not()) {
                 return@withContext Result.success()
             }
-            return@withContext if (maliciousSiteRepository.loadFilters().isSuccess) {
+
+            val feeds = inputData.getStringArray(TYPE)
+                ?.mapNotNull { Feed.fromString(it) }
+                ?.filter { it != SCAM || maliciousSiteProtectionFeature.scamProtectionEnabled() }
+                ?.toTypedArray() ?: return@withContext Result.failure()
+
+            return@withContext if (maliciousSiteRepository.loadFilters(*feeds).isSuccess) {
                 Result.success()
             } else {
                 Result.retry()
@@ -81,10 +94,12 @@ class MaliciousSiteProtectionFiltersUpdateWorkerScheduler @Inject constructor(
 
     override fun onCreate(owner: LifecycleOwner) {
         enqueuePeriodicWork()
+        enqueuePeriodicScamWork()
     }
 
     override fun onPrivacyConfigDownloaded() {
         enqueuePeriodicWork()
+        enqueuePeriodicScamWork()
     }
 
     private fun enqueuePeriodicWork() {
@@ -92,21 +107,35 @@ class MaliciousSiteProtectionFiltersUpdateWorkerScheduler @Inject constructor(
             workManager.cancelUniqueWork(MALICIOUS_SITE_PROTECTION_FILTERS_UPDATE_WORKER_TAG)
             return
         }
-        val workerRequest = PeriodicWorkRequestBuilder<MaliciousSiteProtectionFiltersUpdateWorker>(
+        enqueueWorker(PHISHING, MALWARE, tag = MALICIOUS_SITE_PROTECTION_FILTERS_UPDATE_WORKER_TAG)
+    }
+
+    private fun enqueuePeriodicScamWork() {
+        if (maliciousSiteProtectionFeature.isFeatureEnabled().not() || maliciousSiteProtectionFeature.canUpdateDatasets().not() || maliciousSiteProtectionFeature.scamProtectionEnabled().not()) {
+            workManager.cancelUniqueWork(MALICIOUS_SITE_PROTECTION_FILTERS_UPDATE_WORKER_SCAM_TAG)
+            return
+        }
+        enqueueWorker(SCAM, tag = MALICIOUS_SITE_PROTECTION_FILTERS_UPDATE_WORKER_SCAM_TAG)
+    }
+
+    private fun enqueueWorker(vararg feeds: Feed, tag: String) {
+        PeriodicWorkRequestBuilder<MaliciousSiteProtectionFiltersUpdateWorker>(
             maliciousSiteProtectionFeature.getFilterSetUpdateFrequency(),
             TimeUnit.MINUTES,
-        )
-            .addTag(MALICIOUS_SITE_PROTECTION_FILTERS_UPDATE_WORKER_TAG)
+        ).addTag(tag)
+            .setInputData(Data.Builder().putStringArray(TYPE, feeds.map { it.name }.toTypedArray()).build())
             .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 1, TimeUnit.MINUTES)
-            .build()
-        workManager.enqueueUniquePeriodicWork(
-            MALICIOUS_SITE_PROTECTION_FILTERS_UPDATE_WORKER_TAG,
-            ExistingPeriodicWorkPolicy.UPDATE,
-            workerRequest,
-        )
+            .build().let {
+                workManager.enqueueUniquePeriodicWork(
+                    tag,
+                    ExistingPeriodicWorkPolicy.UPDATE,
+                    it,
+                )
+            }
     }
 
     companion object {
         private const val MALICIOUS_SITE_PROTECTION_FILTERS_UPDATE_WORKER_TAG = "MALICIOUS_SITE_PROTECTION_FILTERS_UPDATE_WORKER_TAG"
+        private const val MALICIOUS_SITE_PROTECTION_FILTERS_UPDATE_WORKER_SCAM_TAG = "MALICIOUS_SITE_PROTECTION_FILTERS_UPDATE_WORKER_SCAM_TAG"
     }
 }

--- a/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionFiltersUpdateWorker.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionFiltersUpdateWorker.kt
@@ -111,9 +111,11 @@ class MaliciousSiteProtectionFiltersUpdateWorkerScheduler @Inject constructor(
     }
 
     private fun enqueuePeriodicScamWork() {
-        if (maliciousSiteProtectionFeature.isFeatureEnabled().not() || maliciousSiteProtectionFeature.canUpdateDatasets().not() || maliciousSiteProtectionFeature.scamProtectionEnabled().not()) {
-            workManager.cancelUniqueWork(MALICIOUS_SITE_PROTECTION_FILTERS_UPDATE_WORKER_SCAM_TAG)
-            return
+        with(maliciousSiteProtectionFeature) {
+            if (isFeatureEnabled().not() || canUpdateDatasets().not() || scamProtectionEnabled().not()) {
+                workManager.cancelUniqueWork(MALICIOUS_SITE_PROTECTION_FILTERS_UPDATE_WORKER_SCAM_TAG)
+                return
+            }
         }
         enqueueWorker(SCAM, tag = MALICIOUS_SITE_PROTECTION_FILTERS_UPDATE_WORKER_SCAM_TAG)
     }

--- a/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionFiltersUpdateWorker.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionFiltersUpdateWorker.kt
@@ -65,8 +65,15 @@ class MaliciousSiteProtectionFiltersUpdateWorker(
 
             val feeds = inputData.getStringArray(TYPE)
                 ?.mapNotNull { Feed.fromString(it) }
-                ?.filter { it != SCAM || maliciousSiteProtectionFeature.scamProtectionEnabled() }
+                ?.let { feeds ->
+                    if (!maliciousSiteProtectionFeature.scamProtectionEnabled()) {
+                        return@let feeds.filterNot { it == SCAM }
+                    }
+                    feeds
+                }
                 ?.toTypedArray() ?: return@withContext Result.failure()
+
+            if (feeds.isEmpty()) return@withContext Result.success()
 
             return@withContext if (maliciousSiteRepository.loadFilters(*feeds).isSuccess) {
                 Result.success()

--- a/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionHashPrefixesUpdateWorker.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionHashPrefixesUpdateWorker.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import androidx.lifecycle.LifecycleOwner
 import androidx.work.BackoffPolicy
 import androidx.work.CoroutineWorker
+import androidx.work.Data
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
@@ -28,6 +29,10 @@ import com.duckduckgo.anvil.annotations.ContributesWorker
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed
+import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed.MALWARE
+import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed.PHISHING
+import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed.SCAM
 import com.duckduckgo.malicioussiteprotection.impl.data.MaliciousSiteRepository
 import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -35,6 +40,8 @@ import dagger.SingleInstanceIn
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import kotlinx.coroutines.withContext
+
+private const val TYPE = "type"
 
 @ContributesWorker(AppScope::class)
 class MaliciousSiteProtectionHashPrefixesUpdateWorker(
@@ -55,7 +62,13 @@ class MaliciousSiteProtectionHashPrefixesUpdateWorker(
             if (maliciousSiteProtectionFeature.isFeatureEnabled().not() || maliciousSiteProtectionFeature.canUpdateDatasets().not()) {
                 return@withContext Result.success()
             }
-            return@withContext if (maliciousSiteRepository.loadHashPrefixes().isSuccess) {
+
+            val feeds = inputData.getStringArray(TYPE)
+                ?.mapNotNull { Feed.fromString(it) }
+                ?.filter { it != SCAM || maliciousSiteProtectionFeature.scamProtectionEnabled() }
+                ?.toTypedArray() ?: return@withContext Result.failure()
+
+            return@withContext if (maliciousSiteRepository.loadHashPrefixes(*feeds).isSuccess) {
                 Result.success()
             } else {
                 Result.retry()
@@ -81,10 +94,12 @@ class MaliciousSiteProtectionHashPrefixesUpdateWorkerScheduler @Inject construct
 
     override fun onCreate(owner: LifecycleOwner) {
         enqueuePeriodicWork()
+        enqueuePeriodicScamWork()
     }
 
     override fun onPrivacyConfigDownloaded() {
         enqueuePeriodicWork()
+        enqueuePeriodicScamWork()
     }
 
     private fun enqueuePeriodicWork() {
@@ -92,21 +107,36 @@ class MaliciousSiteProtectionHashPrefixesUpdateWorkerScheduler @Inject construct
             workManager.cancelUniqueWork(MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_TAG)
             return
         }
-        val workerRequest = PeriodicWorkRequestBuilder<MaliciousSiteProtectionHashPrefixesUpdateWorker>(
+        enqueueWorker(PHISHING, MALWARE, tag = MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_TAG)
+    }
+
+    private fun enqueuePeriodicScamWork() {
+        if (maliciousSiteProtectionFeature.isFeatureEnabled().not() || maliciousSiteProtectionFeature.canUpdateDatasets().not() || maliciousSiteProtectionFeature.scamProtectionEnabled().not()) {
+            workManager.cancelUniqueWork(MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_SCAM_TAG)
+            return
+        }
+
+        enqueueWorker(SCAM, tag = MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_SCAM_TAG)
+    }
+
+    private fun enqueueWorker(vararg feeds: Feed, tag: String) {
+        PeriodicWorkRequestBuilder<MaliciousSiteProtectionHashPrefixesUpdateWorker>(
             maliciousSiteProtectionFeature.getHashPrefixUpdateFrequency(),
             TimeUnit.MINUTES,
-        )
-            .addTag(MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_TAG)
+        ).addTag(tag)
+            .setInputData(Data.Builder().putStringArray(TYPE, feeds.map { it.name }.toTypedArray()).build())
             .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 1, TimeUnit.MINUTES)
-            .build()
-        workManager.enqueueUniquePeriodicWork(
-            MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_TAG,
-            ExistingPeriodicWorkPolicy.UPDATE,
-            workerRequest,
-        )
+            .build().let {
+                workManager.enqueueUniquePeriodicWork(
+                    tag,
+                    ExistingPeriodicWorkPolicy.UPDATE,
+                    it,
+                )
+            }
     }
 
     companion object {
         private const val MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_TAG = "MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_TAG"
+        private const val MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_SCAM_TAG = "MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_SCAM_TAG"
     }
 }

--- a/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionHashPrefixesUpdateWorker.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionHashPrefixesUpdateWorker.kt
@@ -111,11 +111,12 @@ class MaliciousSiteProtectionHashPrefixesUpdateWorkerScheduler @Inject construct
     }
 
     private fun enqueuePeriodicScamWork() {
-        if (maliciousSiteProtectionFeature.isFeatureEnabled().not() || maliciousSiteProtectionFeature.canUpdateDatasets().not() || maliciousSiteProtectionFeature.scamProtectionEnabled().not()) {
-            workManager.cancelUniqueWork(MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_SCAM_TAG)
-            return
+        with(maliciousSiteProtectionFeature) {
+            if (isFeatureEnabled().not() || canUpdateDatasets().not() || scamProtectionEnabled().not()) {
+                workManager.cancelUniqueWork(MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_SCAM_TAG)
+                return
+            }
         }
-
         enqueueWorker(SCAM, tag = MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_SCAM_TAG)
     }
 
@@ -137,6 +138,7 @@ class MaliciousSiteProtectionHashPrefixesUpdateWorkerScheduler @Inject construct
 
     companion object {
         private const val MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_TAG = "MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_TAG"
-        private const val MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_SCAM_TAG = "MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_SCAM_TAG"
+        private const val MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_SCAM_TAG =
+            "MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_SCAM_TAG"
     }
 }

--- a/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/data/MaliciousSiteRepository.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/data/MaliciousSiteRepository.kt
@@ -155,18 +155,18 @@ class RealMaliciousSiteRepository @Inject constructor(
 
     override suspend fun loadFilters(vararg feeds: Feed): Result<Unit> {
         return loadDataOfType(FILTER_SET) {
-                latestRevision, networkRevision ->
+                localRevisions, networkRevision ->
             feeds.forEach { feed ->
-                loadFilters(latestRevision, networkRevision, feed)
+                loadFilters(localRevisions, networkRevision, feed)
             }
         }
     }
 
     override suspend fun loadHashPrefixes(vararg feeds: Feed): Result<Unit> {
         return loadDataOfType(HASH_PREFIXES) {
-                latestRevision, networkRevision ->
+                localRevisions, networkRevision ->
             feeds.forEach { feed ->
-                loadHashPrefixes(latestRevision, networkRevision, feed)
+                loadHashPrefixes(localRevisions, networkRevision, feed)
             }
         }
     }

--- a/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/data/network/MaliciousSiteDatasetService.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/data/network/MaliciousSiteDatasetService.kt
@@ -20,7 +20,7 @@ import com.duckduckgo.common.utils.AppUrl.Url.API
 import retrofit2.http.GET
 import retrofit2.http.Query
 
-private const val BASE_URL = "$API/api/protection/v1/android"
+private const val BASE_URL = "$API/api/protection/v2/android"
 private const val HASH_PREFIX_PATH = "/hashPrefix"
 private const val FILTER_SET_PATH = "/filterSet"
 private const val CATEGORY = "category"

--- a/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/data/network/MaliciousSiteService.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/data/network/MaliciousSiteService.kt
@@ -21,7 +21,7 @@ import com.squareup.moshi.Json
 import retrofit2.http.GET
 import retrofit2.http.Query
 
-private const val BASE_URL = "$API/api/protection/v1/android"
+private const val BASE_URL = "$API/api/protection/v2/android"
 
 interface MaliciousSiteService {
 

--- a/malicious-site-protection/malicious-site-protection-impl/src/test/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionFiltersUpdateWorkerTest.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/test/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionFiltersUpdateWorkerTest.kt
@@ -2,6 +2,7 @@ package com.duckduckgo.malicioussiteprotection.impl
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import androidx.work.Data
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.ListenableWorker.Result.retry
 import androidx.work.ListenableWorker.Result.success
@@ -9,6 +10,9 @@ import androidx.work.PeriodicWorkRequest
 import androidx.work.WorkManager
 import androidx.work.testing.TestListenableWorkerBuilder
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed.MALWARE
+import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed.PHISHING
+import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed.SCAM
 import com.duckduckgo.malicioussiteprotection.impl.data.MaliciousSiteRepository
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.test.runTest
@@ -20,6 +24,7 @@ import org.junit.runner.RunWith
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
+import org.mockito.kotlin.any
 import org.mockito.kotlin.capture
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
@@ -35,13 +40,28 @@ class MaliciousSiteProtectionFiltersUpdateWorkerTest {
     private val maliciousSiteRepository: MaliciousSiteRepository = mock()
     private val dispatcherProvider = coroutineRule.testDispatcherProvider
     private val maliciousSiteProtectionFeature: MaliciousSiteProtectionRCFeature = mock()
-    private val worker = TestListenableWorkerBuilder<MaliciousSiteProtectionFiltersUpdateWorker>(context = context).build()
+    private val worker = TestListenableWorkerBuilder<MaliciousSiteProtectionFiltersUpdateWorker>(context = context)
+        .setInputData(
+            Data.Builder()
+                .putStringArray("type", arrayOf(PHISHING.name, MALWARE.name))
+                .build(),
+        ).build()
+
+    private val scamWorker = TestListenableWorkerBuilder<MaliciousSiteProtectionFiltersUpdateWorker>(context = context)
+        .setInputData(
+            Data.Builder()
+                .putStringArray("type", arrayOf(SCAM.name))
+                .build(),
+        ).build()
 
     @Before
     fun setup() {
         worker.maliciousSiteRepository = maliciousSiteRepository
+        scamWorker.maliciousSiteRepository = maliciousSiteRepository
         worker.dispatcherProvider = dispatcherProvider
+        scamWorker.dispatcherProvider = dispatcherProvider
         worker.maliciousSiteProtectionFeature = maliciousSiteProtectionFeature
+        scamWorker.maliciousSiteProtectionFeature = maliciousSiteProtectionFeature
         whenever(maliciousSiteProtectionFeature.canUpdateDatasets()).thenReturn(true)
     }
 
@@ -51,7 +71,7 @@ class MaliciousSiteProtectionFiltersUpdateWorkerTest {
 
         val result = worker.doWork()
 
-        verify(maliciousSiteRepository, never()).loadFilters()
+        verify(maliciousSiteRepository, never()).loadFilters(any())
         assertEquals(success(), result)
     }
 
@@ -61,7 +81,7 @@ class MaliciousSiteProtectionFiltersUpdateWorkerTest {
 
         val result = worker.doWork()
 
-        verify(maliciousSiteRepository, never()).loadFilters()
+        verify(maliciousSiteRepository, never()).loadFilters(any())
         assertEquals(success(), result)
     }
 
@@ -72,13 +92,13 @@ class MaliciousSiteProtectionFiltersUpdateWorkerTest {
         val result = worker.doWork()
 
         assertEquals(success(), result)
-        verify(maliciousSiteRepository).loadFilters()
+        verify(maliciousSiteRepository).loadFilters(PHISHING, MALWARE)
     }
 
     @Test
     fun doWork_returnsRetryWhenLoadFiltersFails() = runTest {
         whenever(maliciousSiteProtectionFeature.isFeatureEnabled()).thenReturn(true)
-        whenever(maliciousSiteRepository.loadFilters()).thenReturn(Result.failure(Exception()))
+        whenever(maliciousSiteRepository.loadFilters(PHISHING, MALWARE)).thenReturn(Result.failure(Exception()))
 
         val result = worker.doWork()
 
@@ -93,12 +113,13 @@ class MaliciousSiteProtectionFiltersUpdateWorkerSchedulerTest {
     private val scheduler = MaliciousSiteProtectionFiltersUpdateWorkerScheduler(workManager, maliciousSiteProtectionFeature)
 
     @Test
-    fun onPrivacyConfigDownloadedWithFeatureOn_schedulesWorkerWithUpdateFrequencyFromRCFlagAndUpdatePolicy() {
+    fun onPrivacyConfigDownloadedWithFeatureOnAndScamOff_schedulesPhishingAndMalwareWorkerAndCancelsScamWorker() {
         val updateFrequencyMinutes = 15L
 
         whenever(maliciousSiteProtectionFeature.getFilterSetUpdateFrequency()).thenReturn(updateFrequencyMinutes)
         whenever(maliciousSiteProtectionFeature.isFeatureEnabled()).thenReturn(true)
         whenever(maliciousSiteProtectionFeature.canUpdateDatasets()).thenReturn(true)
+        whenever(maliciousSiteProtectionFeature.scamProtectionEnabled()).thenReturn(false)
 
         scheduler.onPrivacyConfigDownloaded()
 
@@ -109,6 +130,15 @@ class MaliciousSiteProtectionFiltersUpdateWorkerSchedulerTest {
             capture(workRequestCaptor),
         )
 
+        verify(workManager).cancelUniqueWork(
+            eq("MALICIOUS_SITE_PROTECTION_FILTERS_UPDATE_WORKER_SCAM_TAG"),
+        )
+        verify(workManager, never()).enqueueUniquePeriodicWork(
+            eq("MALICIOUS_SITE_PROTECTION_FILTERS_UPDATE_WORKER_SCAM_TAG"),
+            any(),
+            any(),
+        )
+
         val capturedWorkRequest = workRequestCaptor.value
         val repeatInterval = capturedWorkRequest.workSpec.intervalDuration
         val expectedInterval = TimeUnit.MINUTES.toMillis(updateFrequencyMinutes)
@@ -117,7 +147,53 @@ class MaliciousSiteProtectionFiltersUpdateWorkerSchedulerTest {
     }
 
     @Test
-    fun onPrivacyConfigDownloadedWithCanUpdateDatasetOff_cancelsWorker() {
+    fun onPrivacyConfigDownloadedWithFeatureOnAndScamOn_schedulesBothWorkersWithUpdateFrequencyFromRCFlagAndUpdatePolicy() {
+        val updateFrequencyMinutes = 15L
+
+        whenever(maliciousSiteProtectionFeature.getFilterSetUpdateFrequency()).thenReturn(updateFrequencyMinutes)
+        whenever(maliciousSiteProtectionFeature.isFeatureEnabled()).thenReturn(true)
+        whenever(maliciousSiteProtectionFeature.canUpdateDatasets()).thenReturn(true)
+        whenever(maliciousSiteProtectionFeature.scamProtectionEnabled()).thenReturn(true)
+
+        scheduler.onPrivacyConfigDownloaded()
+
+        val workRequestCaptor = ArgumentCaptor.forClass(PeriodicWorkRequest::class.java)
+        verify(workManager).enqueueUniquePeriodicWork(
+            eq("MALICIOUS_SITE_PROTECTION_FILTERS_UPDATE_WORKER_TAG"),
+            eq(ExistingPeriodicWorkPolicy.UPDATE),
+            capture(workRequestCaptor),
+        )
+        var capturedWorkRequest = workRequestCaptor.value
+        var repeatInterval = capturedWorkRequest.workSpec.intervalDuration
+        val expectedInterval = TimeUnit.MINUTES.toMillis(updateFrequencyMinutes)
+        var inputData = capturedWorkRequest.workSpec.input
+
+        assertEquals(expectedInterval, repeatInterval)
+        assertEquals(
+            inputData.getStringArray("type")?.toList(),
+            listOf(PHISHING.name, MALWARE.name),
+        )
+
+        val scamWorkRequestCaptor = ArgumentCaptor.forClass(PeriodicWorkRequest::class.java)
+        verify(workManager).enqueueUniquePeriodicWork(
+            eq("MALICIOUS_SITE_PROTECTION_FILTERS_UPDATE_WORKER_SCAM_TAG"),
+            eq(ExistingPeriodicWorkPolicy.UPDATE),
+            capture(scamWorkRequestCaptor),
+        )
+
+        capturedWorkRequest = scamWorkRequestCaptor.value
+        repeatInterval = capturedWorkRequest.workSpec.intervalDuration
+        inputData = capturedWorkRequest.workSpec.input
+
+        assertEquals(expectedInterval, repeatInterval)
+        assertEquals(
+            inputData.getStringArray("type")?.toList(),
+            listOf(SCAM.name),
+        )
+    }
+
+    @Test
+    fun onPrivacyConfigDownloadedWithCanUpdateDatasetOff_cancelsBothWorkers() {
         val updateFrequencyMinutes = 15L
 
         whenever(maliciousSiteProtectionFeature.getFilterSetUpdateFrequency()).thenReturn(updateFrequencyMinutes)
@@ -128,6 +204,19 @@ class MaliciousSiteProtectionFiltersUpdateWorkerSchedulerTest {
 
         verify(workManager).cancelUniqueWork(
             eq("MALICIOUS_SITE_PROTECTION_FILTERS_UPDATE_WORKER_TAG"),
+        )
+        verify(workManager).cancelUniqueWork(
+            eq("MALICIOUS_SITE_PROTECTION_FILTERS_UPDATE_WORKER_SCAM_TAG"),
+        )
+        verify(workManager, never()).enqueueUniquePeriodicWork(
+            eq("MALICIOUS_SITE_PROTECTION_FILTERS_UPDATE_WORKER_TAG"),
+            any(),
+            any(),
+        )
+        verify(workManager, never()).enqueueUniquePeriodicWork(
+            eq("MALICIOUS_SITE_PROTECTION_FILTERS_UPDATE_WORKER_SCAM_TAG"),
+            any(),
+            any(),
         )
     }
 }

--- a/malicious-site-protection/malicious-site-protection-impl/src/test/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionFiltersUpdateWorkerTest.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/test/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionFiltersUpdateWorkerTest.kt
@@ -104,6 +104,18 @@ class MaliciousSiteProtectionFiltersUpdateWorkerTest {
 
         assertEquals(retry(), result)
     }
+
+    @Test
+    fun doWork_returnsSuccessWhenLoadFiltersWithScamAndRCFlagDisabled() = runTest {
+        whenever(maliciousSiteProtectionFeature.isFeatureEnabled()).thenReturn(true)
+        whenever(maliciousSiteProtectionFeature.canUpdateDatasets()).thenReturn(true)
+        whenever(maliciousSiteProtectionFeature.scamProtectionEnabled()).thenReturn(false)
+
+        val result = scamWorker.doWork()
+
+        assertEquals(success(), result)
+        verify(maliciousSiteRepository, never()).loadFilters(SCAM)
+    }
 }
 
 class MaliciousSiteProtectionFiltersUpdateWorkerSchedulerTest {

--- a/malicious-site-protection/malicious-site-protection-impl/src/test/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionHashPrefixesUpdateWorkerTest.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/test/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionHashPrefixesUpdateWorkerTest.kt
@@ -2,6 +2,7 @@ package com.duckduckgo.malicioussiteprotection.impl
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import androidx.work.Data
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.ListenableWorker.Result.retry
 import androidx.work.ListenableWorker.Result.success
@@ -9,6 +10,9 @@ import androidx.work.PeriodicWorkRequest
 import androidx.work.WorkManager
 import androidx.work.testing.TestListenableWorkerBuilder
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed.MALWARE
+import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed.PHISHING
+import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed.SCAM
 import com.duckduckgo.malicioussiteprotection.impl.data.MaliciousSiteRepository
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.test.runTest
@@ -20,6 +24,7 @@ import org.junit.runner.RunWith
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
+import org.mockito.kotlin.any
 import org.mockito.kotlin.capture
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
@@ -35,13 +40,28 @@ class MaliciousSiteProtectionHashPrefixesUpdateWorkerTest {
     private val maliciousSiteRepository: MaliciousSiteRepository = mock()
     private val dispatcherProvider = coroutineRule.testDispatcherProvider
     private val maliciousSiteProtectionFeature: MaliciousSiteProtectionRCFeature = mock()
-    private val worker = TestListenableWorkerBuilder<MaliciousSiteProtectionHashPrefixesUpdateWorker>(context = context).build()
+    private val worker = TestListenableWorkerBuilder<MaliciousSiteProtectionHashPrefixesUpdateWorker>(context = context)
+        .setInputData(
+            Data.Builder()
+                .putStringArray("type", arrayOf(PHISHING.name, MALWARE.name))
+                .build(),
+        ).build()
+
+    private val scamWorker = TestListenableWorkerBuilder<MaliciousSiteProtectionHashPrefixesUpdateWorker>(context = context)
+        .setInputData(
+            Data.Builder()
+                .putStringArray("type", arrayOf(SCAM.name))
+                .build(),
+        ).build()
 
     @Before
     fun setup() {
         worker.maliciousSiteRepository = maliciousSiteRepository
+        scamWorker.maliciousSiteRepository = maliciousSiteRepository
         worker.dispatcherProvider = dispatcherProvider
+        scamWorker.dispatcherProvider = dispatcherProvider
         worker.maliciousSiteProtectionFeature = maliciousSiteProtectionFeature
+        scamWorker.maliciousSiteProtectionFeature = maliciousSiteProtectionFeature
         whenever(maliciousSiteProtectionFeature.canUpdateDatasets()).thenReturn(true)
     }
 
@@ -51,7 +71,7 @@ class MaliciousSiteProtectionHashPrefixesUpdateWorkerTest {
 
         val result = worker.doWork()
 
-        verify(maliciousSiteRepository, never()).loadHashPrefixes()
+        verify(maliciousSiteRepository, never()).loadHashPrefixes(any())
         assertEquals(success(), result)
     }
 
@@ -61,7 +81,7 @@ class MaliciousSiteProtectionHashPrefixesUpdateWorkerTest {
 
         val result = worker.doWork()
 
-        verify(maliciousSiteRepository, never()).loadHashPrefixes()
+        verify(maliciousSiteRepository, never()).loadHashPrefixes(any())
         assertEquals(success(), result)
     }
 
@@ -72,13 +92,13 @@ class MaliciousSiteProtectionHashPrefixesUpdateWorkerTest {
         val result = worker.doWork()
 
         assertEquals(success(), result)
-        verify(maliciousSiteRepository).loadHashPrefixes()
+        verify(maliciousSiteRepository).loadHashPrefixes(PHISHING, MALWARE)
     }
 
     @Test
     fun doWork_returnsRetryWhenLoadHashPrefixesFails() = runTest {
         whenever(maliciousSiteProtectionFeature.isFeatureEnabled()).thenReturn(true)
-        whenever(maliciousSiteRepository.loadHashPrefixes()).thenReturn(Result.failure(Exception()))
+        whenever(maliciousSiteRepository.loadHashPrefixes(PHISHING, MALWARE)).thenReturn(Result.failure(Exception()))
 
         val result = worker.doWork()
 
@@ -93,12 +113,13 @@ class MaliciousSiteProtectionHashPrefixesUpdateWorkerSchedulerTest {
     private val scheduler = MaliciousSiteProtectionHashPrefixesUpdateWorkerScheduler(workManager, maliciousSiteProtectionFeature)
 
     @Test
-    fun onPrivacyConfigDownloaded_schedulesWorkerWithUpdateFrequencyFromRCFlag() {
+    fun onPrivacyConfigDownloadedWithFeatureOnAndScamOff_schedulesPhishingAndMalwareWorkerAndCancelsScamWorker() {
         val updateFrequencyMinutes = 15L
 
         whenever(maliciousSiteProtectionFeature.getHashPrefixUpdateFrequency()).thenReturn(updateFrequencyMinutes)
         whenever(maliciousSiteProtectionFeature.isFeatureEnabled()).thenReturn(true)
         whenever(maliciousSiteProtectionFeature.canUpdateDatasets()).thenReturn(true)
+        whenever(maliciousSiteProtectionFeature.scamProtectionEnabled()).thenReturn(false)
 
         scheduler.onPrivacyConfigDownloaded()
 
@@ -109,6 +130,15 @@ class MaliciousSiteProtectionHashPrefixesUpdateWorkerSchedulerTest {
             capture(workRequestCaptor),
         )
 
+        verify(workManager).cancelUniqueWork(
+            eq("MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_SCAM_TAG"),
+        )
+        verify(workManager, never()).enqueueUniquePeriodicWork(
+            eq("MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_SCAM_TAG"),
+            any(),
+            any(),
+        )
+
         val capturedWorkRequest = workRequestCaptor.value
         val repeatInterval = capturedWorkRequest.workSpec.intervalDuration
         val expectedInterval = TimeUnit.MINUTES.toMillis(updateFrequencyMinutes)
@@ -117,7 +147,53 @@ class MaliciousSiteProtectionHashPrefixesUpdateWorkerSchedulerTest {
     }
 
     @Test
-    fun onPrivacyConfigDownloadedWithCanUpdateDatasetOff_cancelsWorker() {
+    fun onPrivacyConfigDownloadedWithFeatureOnAndScamOn_schedulesBothWorkersWithUpdateFrequencyFromRCFlagAndUpdatePolicy() {
+        val updateFrequencyMinutes = 15L
+
+        whenever(maliciousSiteProtectionFeature.getHashPrefixUpdateFrequency()).thenReturn(updateFrequencyMinutes)
+        whenever(maliciousSiteProtectionFeature.isFeatureEnabled()).thenReturn(true)
+        whenever(maliciousSiteProtectionFeature.canUpdateDatasets()).thenReturn(true)
+        whenever(maliciousSiteProtectionFeature.scamProtectionEnabled()).thenReturn(true)
+
+        scheduler.onPrivacyConfigDownloaded()
+
+        val workRequestCaptor = ArgumentCaptor.forClass(PeriodicWorkRequest::class.java)
+        verify(workManager).enqueueUniquePeriodicWork(
+            eq("MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_TAG"),
+            eq(ExistingPeriodicWorkPolicy.UPDATE),
+            capture(workRequestCaptor),
+        )
+        var capturedWorkRequest = workRequestCaptor.value
+        var repeatInterval = capturedWorkRequest.workSpec.intervalDuration
+        val expectedInterval = TimeUnit.MINUTES.toMillis(updateFrequencyMinutes)
+        var inputData = capturedWorkRequest.workSpec.input
+
+        assertEquals(expectedInterval, repeatInterval)
+        assertEquals(
+            inputData.getStringArray("type")?.toList(),
+            listOf(PHISHING.name, MALWARE.name),
+        )
+
+        val scamWorkRequestCaptor = ArgumentCaptor.forClass(PeriodicWorkRequest::class.java)
+        verify(workManager).enqueueUniquePeriodicWork(
+            eq("MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_SCAM_TAG"),
+            eq(ExistingPeriodicWorkPolicy.UPDATE),
+            capture(scamWorkRequestCaptor),
+        )
+
+        capturedWorkRequest = scamWorkRequestCaptor.value
+        repeatInterval = capturedWorkRequest.workSpec.intervalDuration
+        inputData = capturedWorkRequest.workSpec.input
+
+        assertEquals(expectedInterval, repeatInterval)
+        assertEquals(
+            inputData.getStringArray("type")?.toList(),
+            listOf(SCAM.name),
+        )
+    }
+
+    @Test
+    fun onPrivacyConfigDownloadedWithCanUpdateDatasetOff_cancelsBothWorkers() {
         val updateFrequencyMinutes = 15L
 
         whenever(maliciousSiteProtectionFeature.getFilterSetUpdateFrequency()).thenReturn(updateFrequencyMinutes)
@@ -128,6 +204,19 @@ class MaliciousSiteProtectionHashPrefixesUpdateWorkerSchedulerTest {
 
         verify(workManager).cancelUniqueWork(
             eq("MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_TAG"),
+        )
+        verify(workManager).cancelUniqueWork(
+            eq("MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_SCAM_TAG"),
+        )
+        verify(workManager, never()).enqueueUniquePeriodicWork(
+            eq("MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_TAG"),
+            any(),
+            any(),
+        )
+        verify(workManager, never()).enqueueUniquePeriodicWork(
+            eq("MALICIOUS_SITE_PROTECTION_HASH_PREFIXES_UPDATE_WORKER_SCAM_TAG"),
+            any(),
+            any(),
         )
     }
 }

--- a/malicious-site-protection/malicious-site-protection-impl/src/test/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionHashPrefixesUpdateWorkerTest.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/test/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionHashPrefixesUpdateWorkerTest.kt
@@ -104,6 +104,18 @@ class MaliciousSiteProtectionHashPrefixesUpdateWorkerTest {
 
         assertEquals(retry(), result)
     }
+
+    @Test
+    fun doWork_returnsSuccessWhenLoadHashPrefixesWithScamAndRCFlagDisabled() = runTest {
+        whenever(maliciousSiteProtectionFeature.isFeatureEnabled()).thenReturn(true)
+        whenever(maliciousSiteProtectionFeature.canUpdateDatasets()).thenReturn(true)
+        whenever(maliciousSiteProtectionFeature.scamProtectionEnabled()).thenReturn(false)
+
+        val result = scamWorker.doWork()
+
+        assertEquals(success(), result)
+        verify(maliciousSiteRepository, never()).loadHashPrefixes(SCAM)
+    }
 }
 
 class MaliciousSiteProtectionHashPrefixesUpdateWorkerSchedulerTest {

--- a/malicious-site-protection/malicious-site-protection-impl/src/test/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionReferenceTest.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/test/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionReferenceTest.kt
@@ -21,6 +21,7 @@ import androidx.room.Room
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.test.FileUtilities
+import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed
 import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.IsMaliciousResult.ConfirmedResult
 import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.MaliciousStatus
 import com.duckduckgo.malicioussiteprotection.impl.data.RealMaliciousSiteRepository
@@ -148,8 +149,8 @@ class MaliciousSiteProtectionReferenceTest(private val testCase: TestCase) {
         )
         whenever(mockMaliciousSiteProtectionRCFeature.isFeatureEnabled()).thenReturn(true)
         whenever(mockMaliciousSiteProtectionRCRepository.isExempted(any())).thenReturn(false)
-        repository.loadFilters()
-        repository.loadHashPrefixes()
+        repository.loadFilters(*enumValues<Feed>())
+        repository.loadHashPrefixes(*enumValues<Feed>())
 
         testee = RealMaliciousSiteProtection(
             coroutineRule.testDispatcherProvider,

--- a/malicious-site-protection/malicious-site-protection-impl/src/test/kotlin/com/duckduckgo/malicioussiteprotection/impl/data/RealMaliciousSiteRepositoryTest.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/test/kotlin/com/duckduckgo/malicioussiteprotection/impl/data/RealMaliciousSiteRepositoryTest.kt
@@ -1,6 +1,7 @@
 package com.duckduckgo.malicioussiteprotection.impl.data
 
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed
 import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed.PHISHING
 import com.duckduckgo.malicioussiteprotection.impl.MaliciousSitePixelName.MALICIOUS_SITE_CLIENT_TIMEOUT
 import com.duckduckgo.malicioussiteprotection.impl.MaliciousSiteProtectionRCFeature
@@ -63,7 +64,7 @@ class RealMaliciousSiteRepositoryTest {
         whenever(maliciousSiteDao.getLatestRevision()).thenReturn(latestRevision)
         whenever(maliciousSiteDatasetService.getPhishingFilterSet(any())).thenReturn(phishingFilterSetResponse)
 
-        repository.loadFilters()
+        repository.loadFilters(*enumValues<Feed>())
 
         verify(maliciousSiteDatasetService).getPhishingFilterSet(latestRevision.first().revision)
         verify(maliciousSiteDao).updateFilters(any<PhishingFilterSetWithRevision>())
@@ -77,7 +78,7 @@ class RealMaliciousSiteRepositoryTest {
         whenever(maliciousSiteService.getRevision()).thenReturn(RevisionResponse(networkRevision))
         whenever(maliciousSiteDao.getLatestRevision()).thenReturn(latestRevision)
 
-        repository.loadFilters()
+        repository.loadFilters(*enumValues<Feed>())
 
         verify(maliciousSiteDatasetService, never()).getPhishingFilterSet(any())
         verify(maliciousSiteDao, never()).updateFilters(any())
@@ -93,7 +94,7 @@ class RealMaliciousSiteRepositoryTest {
         whenever(maliciousSiteDao.getLatestRevision()).thenReturn(latestRevision)
         whenever(maliciousSiteDatasetService.getPhishingHashPrefixes(any())).thenReturn(phishingHashPrefixResponse)
 
-        repository.loadHashPrefixes()
+        repository.loadHashPrefixes(*enumValues<Feed>())
 
         verify(maliciousSiteDatasetService).getPhishingHashPrefixes(latestRevision.first().revision)
         verify(maliciousSiteDao).updateHashPrefixes(any<PhishingHashPrefixesWithRevision>())
@@ -107,7 +108,7 @@ class RealMaliciousSiteRepositoryTest {
         whenever(maliciousSiteService.getRevision()).thenReturn(RevisionResponse(networkRevision))
         whenever(maliciousSiteDao.getLatestRevision()).thenReturn(latestRevision)
 
-        repository.loadHashPrefixes()
+        repository.loadHashPrefixes(*enumValues<Feed>())
 
         verify(maliciousSiteDatasetService, never()).getPhishingHashPrefixes(any())
         verify(maliciousSiteDao, never()).updateHashPrefixes(any())


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1209893469792815/f 

### Description

### Steps to test this PR

_Feature 1_
- [ ] Fresh install the app
- [ ] Using the app inspector, check that only phishing and malware datasets are present. Data needs to be downloaded, so it might take a few seconds to complete. The easiest way is to check the `revisions` table in `malicious_sites` db
- [ ] Open https://privacy-test-pages.site/security/badware/phishing.html and check it's blocked
- [ ] Open https://privacy-test-pages.site/security/badware/malware.html and check it's blocked
- [ ] Open https://privacy-test-pages.site/security/badware/scam.html and check it's not blocked

_Feature 2_
- [ ] Without reinstalling the app, enable `scamProtection` under Feature Flag Inventory and restart the app
- [ ] Using the app inspector, check that phishing, malware and scam datasets are present. Data needs to be downloaded, so it might take a few seconds to complete. The easiest way is to check the `revisions` table in `malicious_sites` db
- [ ] Open https://privacy-test-pages.site/security/badware/scam.html and check it's blocked.
- [ ] Disable `scamProtection` under Feature Flag Inventory and restart the app
- [ ] Open https://privacy-test-pages.site/security/badware/scam.html and check it's not blocked


### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
