### PR TITLE
Update content scope scripts to version 8.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^12.16.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.11.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.12.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.4.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1743047884"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#1ed51c1731b072b1042303887539b2382448fe4d",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#15523c9a752060fd139874b2033fab407210116c",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^12.16.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.11.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.12.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.4.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1743047884"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1209900850846011/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [x] All tests must pass