### PR TITLE
Translations for AppTP Privacy Pro entry points

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/res/values-bg/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-bg/strings-vpn.xml
@@ -421,4 +421,11 @@
     <string name="appTrackingProtectionNotifyMeTitle">Следете блокираните тракери</string>
     <string name="appTrackingProtectionNotifyMeSubtitle">Получавайте актуализации за блокирани опити за проследяване в чекмеджето за известия.</string>
 
+    <!-- Privacy pro upsell -->
+    <string name="apptp_PproUpsellInfoDisabled">Не можете да използвате App Tracking Protection заради VPN-а си? Преминете към DuckDuckGo VPN — единственият съвместим VPN. <annotation type="ppro_upsell_link">Научете повече</annotation>.</string>
+    <string name="apptp_PproUpsellInfoRevoked"><b>App Tracking Protection е деактивирана</b>\nВашата VPN услуга ли деактивира App Tracking Protection? Използвайте превключвателя по-горе, за да го активирате отново.\n\nВземете DuckDuckGo VPN — единствената VPN, която работи с App Tracking Protection. <annotation type="ppro_upsell_link">Научете повече</annotation>.</string>
+    <string name="apptp_PproUpsellBannerTitle">Издигнете поверителността си на по-високо ниво</string>
+    <string name="apptp_PproUpsellBannerMessage">DuckDuckGo има единствената VPN услуга, която е съвместима с App Tracking Protection. Активирайте с платен абонамент за Privacy Pro.</string>
+    <string name="apptp_PproUpsellBannerAction">Научете повече</string>
+
 </resources>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-cs/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-cs/strings-vpn.xml
@@ -441,4 +441,11 @@
     <string name="appTrackingProtectionNotifyMeTitle">Měj přehled o zablokovaných trackerech</string>
     <string name="appTrackingProtectionNotifyMeSubtitle">Nech si posílat aktualizace o zablokovaných pokusech o sledování na lištu s oznámeními.</string>
 
+    <!-- Privacy pro upsell -->
+    <string name="apptp_PproUpsellInfoDisabled">Nemůžeš používat funkci App Tracking Protection kvůli své VPN? Přejdi na DuckDuckGo VPN – jedinou kompatibilní VPN. <annotation type="ppro_upsell_link">Další informace</annotation></string>
+    <string name="apptp_PproUpsellInfoRevoked"><b>Funkce App Tracking Protection je zakázaná</b>\nZakázala tvoje VPN funkci App Tracking Protection? Přepínačem nahoře ji znovu zapneš.\n\nPořiď si DuckDuckGo VPN – jedinou VPN, která funguje s funkcí App Tracking Protection. <annotation type="ppro_upsell_link">Další informace</annotation>.</string>
+    <string name="apptp_PproUpsellBannerTitle">Posuň ochranu svého soukromí na vyšší úroveň</string>
+    <string name="apptp_PproUpsellBannerMessage">Jedinou VPN, která je kompatibilní s funkcí App Tracking Protection, má DuckDuckGo. Aktivovat ji můžeš s předplatným Privacy Pro.</string>
+    <string name="apptp_PproUpsellBannerAction">Více informací</string>
+
 </resources>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-da/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-da/strings-vpn.xml
@@ -421,4 +421,11 @@
     <string name="appTrackingProtectionNotifyMeTitle">Hold øje med blokerede trackere</string>
     <string name="appTrackingProtectionNotifyMeSubtitle">Få opdateringer om blokerede sporingsforsøg i din meddelelsesskuffe.</string>
 
+    <!-- Privacy pro upsell -->
+    <string name="apptp_PproUpsellInfoDisabled">Kan du ikke bruge App Tracking Protection på grund af din VPN? Skift til DuckDuckGo VPN – den eneste VPN, der er kompatibel. <annotation type="ppro_upsell_link">Læs mere</annotation>.</string>
+    <string name="apptp_PproUpsellInfoRevoked"><b>App Tracking Protection er deaktiveret</b>\nHar din VPN deaktiveret App Tracking Protection? Brug til/fra-knappen ovenfor til at genaktivere.\n\nFå DuckDuckGo VPN – den eneste VPN, der fungerer med App Tracking Protection. <annotation type="ppro_upsell_link">Læs mere</annotation>.</string>
+    <string name="apptp_PproUpsellBannerTitle">Tag dit privatliv til det næste niveau</string>
+    <string name="apptp_PproUpsellBannerMessage">DuckDuckGo har den eneste VPN, der er kompatibel med App Tracking Protection. Aktivér med et betalt Privacy Pro-abonnement.</string>
+    <string name="apptp_PproUpsellBannerAction">Mere info</string>
+
 </resources>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-de/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-de/strings-vpn.xml
@@ -421,4 +421,11 @@
     <string name="appTrackingProtectionNotifyMeTitle">Behalte blockierte Tracker im Auge</string>
     <string name="appTrackingProtectionNotifyMeSubtitle">Erhalte Updates zu blockierten Tracking-Versuchen in deinem Benachrichtigungsfach.</string>
 
+    <!-- Privacy pro upsell -->
+    <string name="apptp_PproUpsellInfoDisabled">Kannst du die App Tracking Protection aufgrund deines VPN nicht nutzen? Wechsle zu DuckDuckGo VPN – dem einzigen VPN, das kompatibel ist. <annotation type="ppro_upsell_link">Mehr erfahren</annotation>.</string>
+    <string name="apptp_PproUpsellInfoRevoked"><b>App Tracking Protection deaktiviert</b>\nHat dein VPN die App Tracking Protection deaktiviert? Verwende den Schalter oben, um sie wieder zu aktivieren.\n\nHol dir DuckDuckGo VPN – das einzige VPN, das mit App Tracking Protection funktioniert. <annotation type="ppro_upsell_link">Mehr erfahren</annotation>.</string>
+    <string name="apptp_PproUpsellBannerTitle">Bring deine Privatsphäre auf das nächste Level</string>
+    <string name="apptp_PproUpsellBannerMessage">DuckDuckGo hat das einzige VPN, das mit App Tracking Protection kompatibel ist. Aktiviere es mit einem bezahlten Privacy Pro-Abonnement.</string>
+    <string name="apptp_PproUpsellBannerAction">Mehr erfahren</string>
+
 </resources>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-el/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-el/strings-vpn.xml
@@ -421,4 +421,11 @@
     <string name="appTrackingProtectionNotifyMeTitle">Έχετε τον νου σας στις αποκλεισμένες εφαρμογές παρακολούθησης</string>
     <string name="appTrackingProtectionNotifyMeSubtitle">Λάβετε ενημερώσεις σχετικά με μπλοκαρισμένες προσπάθειες παρακολούθησης στην ενότητα ειδοποιήσεων.</string>
 
+    <!-- Privacy pro upsell -->
+    <string name="apptp_PproUpsellInfoDisabled">Δεν μπορείτε να χρησιμοποιήσετε το App Tracking Protection λόγω του VPN σας; Μεταβείτε στο DuckDuckGo VPN, το μόνο συμβατό VPN. <annotation type="ppro_upsell_link">Μάθετε περισσότερα</annotation>.</string>
+    <string name="apptp_PproUpsellInfoRevoked">Το <b>App Tracking Protection απενεργοποιήθηκε</b>\nΑπενεργοποίησε το VPN σας το App Tracking Protection; Χρησιμοποιήστε τον διακόπτη πιο πάνω για να το ενεργοποιήσετε ξανά.\n\nΑποκτήστε το DuckDuckGo VPN — το μοναδικό VPN που λειτουργεί με το App Tracking Protection. <annotation type="ppro_upsell_link">Μάθετε περισσότερα</annotation>.</string>
+    <string name="apptp_PproUpsellBannerTitle">Πηγαίνετε την ιδιωτικότητά σας στο επόμενο επίπεδο</string>
+    <string name="apptp_PproUpsellBannerMessage">Το DuckDuckGo έχει το μοναδικό VPN που είναι συμβατό με το App Tracking Protection. Ενεργοποιήστε το με μια επί πληρωμή συνδρομή Privacy Pro.</string>
+    <string name="apptp_PproUpsellBannerAction">Μάθετε περισσότερα</string>
+
 </resources>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-es/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-es/strings-vpn.xml
@@ -421,4 +421,11 @@
     <string name="appTrackingProtectionNotifyMeTitle">Vigila los rastreadores bloqueados</string>
     <string name="appTrackingProtectionNotifyMeSubtitle">Recibe actualizaciones sobre intentos de rastreo bloqueados en tu cajón de notificaciones.</string>
 
+    <!-- Privacy pro upsell -->
+    <string name="apptp_PproUpsellInfoDisabled">¿No puedes usar App Tracking Protection debido a tu VPN? Cámbiate a DuckDuckGo VPN, la única VPN compatible. <annotation type="ppro_upsell_link">Más información</annotation>.</string>
+    <string name="apptp_PproUpsellInfoRevoked"><b>App Tracking Protection desactivada</b>\n¿Tu VPN ha desactivado App Tracking Protection? Usa el botón de arriba para volver a activarla.\n\nHazte con DuckDuckGo VPN: la única VPN que funciona con App Tracking Protection. <annotation type="ppro_upsell_link">Más información</annotation>.</string>
+    <string name="apptp_PproUpsellBannerTitle">Lleva la privacidad al siguiente nivel</string>
+    <string name="apptp_PproUpsellBannerMessage">DuckDuckGo tiene la única VPN que es compatible con App Tracking Protection. Actívala con una suscripción de pago a Privacy Pro.</string>
+    <string name="apptp_PproUpsellBannerAction">Más información</string>
+
 </resources>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-et/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-et/strings-vpn.xml
@@ -421,4 +421,11 @@
     <string name="appTrackingProtectionNotifyMeTitle">Hoia blokeeritud jälguritel silm peal</string>
     <string name="appTrackingProtectionNotifyMeSubtitle">Saad uuendusi blokeeritud jälgimiskatsete kohta oma teavituste sahtlis.</string>
 
+    <!-- Privacy pro upsell -->
+    <string name="apptp_PproUpsellInfoDisabled">Kas te ei saa oma VPN-i tõttu kasutada App Tracking Protectionit? Kasutage DuckDuckGo VPN-i — see on ainus VPN, mis ühildub. <annotation type="ppro_upsell_link">Lisateave</annotation>.</string>
+    <string name="apptp_PproUpsellInfoRevoked"><b>App Tracking Protection on inaktiveeritud</b>\nKas teie VPN keelas App Tracking Protectioni? Taasaktiveerimiseks kasutage ülaltoodud lülitit.\n\nHankige DuckDuckGo VPN — ainus VPN, mis töötab koos App Tracking Protectioniga. <annotation type="ppro_upsell_link">Lisateave</annotation>.</string>
+    <string name="apptp_PproUpsellBannerTitle">Viige oma privaatsus järgmisele tasemele</string>
+    <string name="apptp_PproUpsellBannerMessage">DuckDuckGol on ainus VPN, mis ühildub App Tracking Protectioniga. Aktiveerige tasulise Privacy Pro tellimusega.</string>
+    <string name="apptp_PproUpsellBannerAction">Loe edasi</string>
+
 </resources>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-fi/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-fi/strings-vpn.xml
@@ -421,4 +421,11 @@
     <string name="appTrackingProtectionNotifyMeTitle">Pidä silmällä estettyjä seurantaohjelmia</string>
     <string name="appTrackingProtectionNotifyMeSubtitle">Saat päivityksiä estetyistä seurantayrityksistä ilmoituslaatikkoosi.</string>
 
+    <!-- Privacy pro upsell -->
+    <string name="apptp_PproUpsellInfoDisabled">Etkö pysty käyttämään App Tracking Protectionia VPN:n takia? Vaihda DuckDuckGo VPN:ään – ainoaan yhteensopivaan VPN:ään. <annotation type="ppro_upsell_link">Lue lisää</annotation>.</string>
+    <string name="apptp_PproUpsellInfoRevoked"><b>App Tracking Protection poistettu käytöstä</b>\nPoistiko VPN:si App Tracking Protectionin käytöstä? Ota se uudelleen käyttöön yllä olevalla valitsimella.\n\nHanki DuckDuckGo VPN – ainoa VPN, joka toimii App Tracking Protectionin kanssa. <annotation type="ppro_upsell_link">Lue lisää</annotation>.</string>
+    <string name="apptp_PproUpsellBannerTitle">Vie tietosuojasi uudelle tasolle</string>
+    <string name="apptp_PproUpsellBannerMessage">DuckDuckGolla on ainoa VPN, joka on yhteensopiva App Tracking Protectionin kanssa. Aktivoi maksullisella Privacy Pro -tilauksella.</string>
+    <string name="apptp_PproUpsellBannerAction">Lue lisää</string>
+
 </resources>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-fr/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-fr/strings-vpn.xml
@@ -421,4 +421,11 @@
     <string name="appTrackingProtectionNotifyMeTitle">Gardez un œil sur les traqueurs bloqués</string>
     <string name="appTrackingProtectionNotifyMeSubtitle">Recevez des mises à jour sur les tentatives de pistage bloquées dans votre volet notifications.</string>
 
+    <!-- Privacy pro upsell -->
+    <string name="apptp_PproUpsellInfoDisabled">Vous ne pouvez pas l\'utiliser App Tracking Protection à cause de votre VPN ? Passez à DuckDuckGo VPN, le seul VPN compatible. <annotation type="ppro_upsell_link">En savoir plus</annotation>.</string>
+    <string name="apptp_PproUpsellInfoRevoked"><b>App Tracking Protection désactivée</b>\nVotre VPN a désactivé App Tracking Protection ? Faites basculer le bouton ci-dessus pour la réactiver.\n\nProcurez-vous DuckDuckGo VPN, le seul VPN qui fonctionne avec App Tracking Protection. <annotation type="ppro_upsell_link">En savoir plus</annotation>.</string>
+    <string name="apptp_PproUpsellBannerTitle">Renforcez votre confidentialité</string>
+    <string name="apptp_PproUpsellBannerMessage">DuckDuckGo dispose du seul VPN compatible avec App Tracking Protection. Activez-le grâce à un abonnement Privacy Pro payant.</string>
+    <string name="apptp_PproUpsellBannerAction">En savoir plus</string>
+
 </resources>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-hr/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-hr/strings-vpn.xml
@@ -441,4 +441,11 @@
     <string name="appTrackingProtectionNotifyMeTitle">Pripazi na blokirane alate za praćenje</string>
     <string name="appTrackingProtectionNotifyMeSubtitle">Primaj ažuriranja o blokiranim pokušajima praćenja u svoju ladicu s obavijestima.</string>
 
+    <!-- Privacy pro upsell -->
+    <string name="apptp_PproUpsellInfoDisabled">Ne možeš koristiti App Tracking Protection zbog svog VPN-a? Prebaci se na DuckDuckGo VPN – jedini VPN koji je kompatibilan. <annotation type="ppro_upsell_link">Saznaj više</annotation>.</string>
+    <string name="apptp_PproUpsellInfoRevoked"><b>Zaštita App Tracking Protection je onemogućena</b>\nJe li tvoj VPN onemogućio App Tracking Protection? Koristi gornji gumb za ponovno uključivanje.\n\nNabavi DuckDuckGo VPN — jedini VPN koji radi s uslugom za zaštitu App Tracking Protection. <annotation type="ppro_upsell_link">Saznaj više</annotation>.</string>
+    <string name="apptp_PproUpsellBannerTitle">Podigni svoju privatnost na višu razinu</string>
+    <string name="apptp_PproUpsellBannerMessage">DuckDuckGo ima jedini VPN koji je kompatibilan s uslugom App Tracking Protection. Aktiviraj uz plaćenu pretplatu na Privacy Pro.</string>
+    <string name="apptp_PproUpsellBannerAction">Saznajte više</string>
+
 </resources>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-hu/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-hu/strings-vpn.xml
@@ -421,4 +421,11 @@
     <string name="appTrackingProtectionNotifyMeTitle">Blokkolt nyomkövetők szemmel tartása</string>
     <string name="appTrackingProtectionNotifyMeSubtitle">Az értesítési fiókodban tájékoztatunk a blokkolt nyomkövetési kísérletekről.</string>
 
+    <!-- Privacy pro upsell -->
+    <string name="apptp_PproUpsellInfoDisabled">Nem tudod használni az App Tracking Protection funkciót a VPN-ed miatt? Válts a DuckDuckGo VPN-re – az egyetlen VPN, amely kompatibilis vele. <annotation type="ppro_upsell_link">További információk</annotation>.</string>
+    <string name="apptp_PproUpsellInfoRevoked"><b>Az App Tracking Protection ki van kapcsolva</b>\nA VPN-ed kikapcsolta az App Tracking Protectiont? Az újbóli engedélyezéshez használd a fenti váltógombot.\n\nSzerezd be a DuckDuckGo VPN-t – az egyetlen VPN, amely működik az App Tracking Protection funkcióval. <annotation type="ppro_upsell_link">További információk</annotation>.</string>
+    <string name="apptp_PproUpsellBannerTitle">Magasabb szintű adatvédelem</string>
+    <string name="apptp_PproUpsellBannerMessage">A DuckDuckGo VPN az egyetlen, amely kompatibilis az App Tracking Protectionnel. Aktiváld a fizetős Privacy Pro-előfizetéssel.</string>
+    <string name="apptp_PproUpsellBannerAction">További részletek</string>
+
 </resources>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-it/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-it/strings-vpn.xml
@@ -421,4 +421,11 @@
     <string name="appTrackingProtectionNotifyMeTitle">Tieni d\'occhio i sistemi di tracciamento bloccati</string>
     <string name="appTrackingProtectionNotifyMeSubtitle">Ricevi aggiornamenti sui tentativi di tracciamento bloccati nel cassetto delle notifiche.</string>
 
+    <!-- Privacy pro upsell -->
+    <string name="apptp_PproUpsellInfoDisabled">Non riesci a usare App Tracking Protection a causa della tua VPN? Passa a DuckDuckGo VPN, l\'unica VPN compatibile. <annotation type="ppro_upsell_link">Ulteriori informazioni</annotation>.</string>
+    <string name="apptp_PproUpsellInfoRevoked"><b>App Tracking Protection disattivata</b>\nLa tua VPN ha disattivato App Tracking Protection? Usa l\'opzione in alto per riattivarla.\n\nOttieni DuckDuckGo VPN, l\'unica VPN che funziona con App Tracking Protection. <annotation type="ppro_upsell_link">Ulteriori informazioni</annotation>.</string>
+    <string name="apptp_PproUpsellBannerTitle">Aumenta il livello di privacy</string>
+    <string name="apptp_PproUpsellBannerMessage">DuckDuckGo ha l\'unica VPN compatibile con App Tracking Protection. Attiva con un abbonamento a pagamento a Privacy Pro.</string>
+    <string name="apptp_PproUpsellBannerAction">Ulteriori informazioni</string>
+
 </resources>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-lt/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-lt/strings-vpn.xml
@@ -441,4 +441,11 @@
     <string name="appTrackingProtectionNotifyMeTitle">Stebėkite užblokuotas stebėjimo priemones</string>
     <string name="appTrackingProtectionNotifyMeSubtitle">Gaukite naujienas apie užblokuotus stebėjimo bandymus pranešimų skiltyje.</string>
 
+    <!-- Privacy pro upsell -->
+    <string name="apptp_PproUpsellInfoDisabled">Negali naudoti „App Tracking Protection“ dėl savo VPN? Pereik prie „DuckDuckGo VPN“ – vienintelio suderinamo VPN. <annotation type="ppro_upsell_link">Sužinok daugiau</annotation>.</string>
+    <string name="apptp_PproUpsellInfoRevoked"><b>„App Tracking Protection“ išjungta</b>\nAr jūsų VPN išjungė „App Tracking Protection“? Jei nori jį dar kartą įjungti, naudok aukščiau esantį perjungiklį.\n\nGauk „DuckDuckGo VPN“ – vienintelį VPN, kuris veikia su „App Tracking Protection“. <annotation type="ppro_upsell_link">Sužinok daugiau</annotation>.</string>
+    <string name="apptp_PproUpsellBannerTitle">Perkelkite savo privatumą į kitą lygį</string>
+    <string name="apptp_PproUpsellBannerMessage">„DuckDuckGo“ turi vienintelį VPN, suderinamą su „App Tracking Protection“. Aktyvink su mokama „Privacy Pro“ prenumerata.</string>
+    <string name="apptp_PproUpsellBannerAction">Sužinoti daugiau</string>
+
 </resources>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-lv/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-lv/strings-vpn.xml
@@ -431,4 +431,11 @@
     <string name="appTrackingProtectionNotifyMeTitle">Pieskati bloķētos izsekotājus</string>
     <string name="appTrackingProtectionNotifyMeSubtitle">Paziņojumu panelī saņem atjauninājumus par bloķētajiem izsekošanas mēģinājumiem.</string>
 
+    <!-- Privacy pro upsell -->
+    <string name="apptp_PproUpsellInfoDisabled">Nevari izmantot App Tracking Protection sava VPN dēļ? Pārslēdzies uz DuckDuckGo VPN — vienīgo saderīgo VPN. <annotation type="ppro_upsell_link">Uzzini vairāk</annotation>.</string>
+    <string name="apptp_PproUpsellInfoRevoked"><b>App Tracking Protection ir atspējota</b>\nVai jūsu VPN atspējoja App Tracking Protection? Izmanto augstāk redzamo slēdzi, lai to no jauna iespējotu.\n\nIegūsti DuckDuckGo VPN — vienīgais VPN, kas darbojas ar App Tracking Protection. <annotation type="ppro_upsell_link">Uzzini vairāk</annotation>.</string>
+    <string name="apptp_PproUpsellBannerTitle">Pacel savu privātumu nākamajā līmenī</string>
+    <string name="apptp_PproUpsellBannerMessage">DuckDuckGo ir vienīgais VPN, kas ir saderīgs ar App Tracking Protection. Aktivizē ar apmaksātu Privacy Pro abonementu.</string>
+    <string name="apptp_PproUpsellBannerAction">Uzzināt vairāk</string>
+
 </resources>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-nb/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-nb/strings-vpn.xml
@@ -421,4 +421,11 @@
     <string name="appTrackingProtectionNotifyMeTitle">Hold øye med blokkerte sporere</string>
     <string name="appTrackingProtectionNotifyMeSubtitle">Få oppdateringer om blokkerte sporingsforsøk i varselskuffen din.</string>
 
+    <!-- Privacy pro upsell -->
+    <string name="apptp_PproUpsellInfoDisabled">Kan du ikke bruke App Tracking Protection på grunn av VPN-en din? Bytt til DuckDuckGo VPN – den eneste VPN-løsningen som er kompatibel. <annotation type="ppro_upsell_link">Finn ut mer</annotation>.</string>
+    <string name="apptp_PproUpsellInfoRevoked"><b>App Tracking Protection er deaktivert</b>\nHar VPN-en din deaktivert App Tracking Protection? Bruk bryteren ovenfor for å aktivere det igjen.\n\nFå DuckDuckGo VPN – den eneste VPN-løsningen som fungerer med App Tracking Protection. <annotation type="ppro_upsell_link">Finn ut mer</annotation>.</string>
+    <string name="apptp_PproUpsellBannerTitle">Ta personvernet til neste nivå</string>
+    <string name="apptp_PproUpsellBannerMessage">DuckDuckGo VPN er den eneste som er kompatibel med App Tracking Protection. Aktiver med et abonnement på Privacy Pro.</string>
+    <string name="apptp_PproUpsellBannerAction">Finn ut mer</string>
+
 </resources>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-nl/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-nl/strings-vpn.xml
@@ -421,4 +421,11 @@
     <string name="appTrackingProtectionNotifyMeTitle">Houd geblokkeerde trackers in de gaten</string>
     <string name="appTrackingProtectionNotifyMeSubtitle">Ontvang meldingen over geblokkeerde trackingpogingen.</string>
 
+    <!-- Privacy pro upsell -->
+    <string name="apptp_PproUpsellInfoDisabled">Kun je App Tracking Protection niet gebruiken vanwege je VPN? Stap over op DuckDuckGo VPN - de enige compatibele VPN. <annotation type="ppro_upsell_link">Meer informatie</annotation>.</string>
+    <string name="apptp_PproUpsellInfoRevoked"><b>App Tracking Protection uitgeschakeld</b>\nHeeft je VPN App Tracking Protection uitgeschakeld? Gebruik de schakelaar hierboven om de functie weer in te schakelen.\n\nKies voor DuckDuckGo VPN — de enige VPN die werkt met App Tracking Protection. <annotation type="ppro_upsell_link">Meer informatie</annotation>.</string>
+    <string name="apptp_PproUpsellBannerTitle">Til je privacy naar een hoger niveau</string>
+    <string name="apptp_PproUpsellBannerMessage">DuckDuckGo heeft de enige VPN die compatibel is met App Tracking Protection. Activeer met een betaald Privacy Pro-abonnement.</string>
+    <string name="apptp_PproUpsellBannerAction">Meer informatie</string>
+
 </resources>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-pl/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-pl/strings-vpn.xml
@@ -441,4 +441,11 @@
     <string name="appTrackingProtectionNotifyMeTitle">Obserwuj zablokowane trackery</string>
     <string name="appTrackingProtectionNotifyMeSubtitle">Otrzymuj bieżące powiadomienia o zablokowanych próbach śledzenia w szufladzie powiadomień.</string>
 
+    <!-- Privacy pro upsell -->
+    <string name="apptp_PproUpsellInfoDisabled">Nie możesz korzystać z App Tracking Protection z powodu wykorzystywanej sieci VPN? Przejdź na DuckDuckGo VPN — jedyną zgodną sieć VPN. <annotation type="ppro_upsell_link">Dowiedz się więcej</annotation>.</string>
+    <string name="apptp_PproUpsellInfoRevoked"><b>App Tracking Protection wyłączona</b>\nCzy wykorzystywana sieć VPN wyłączyła App Tracking Protection? Użyj przełącznika powyżej, aby ponownie ją włączyć.\n\nPobierz DuckDuckGo VPN — jedyny VPN, który działa z funkcją App Tracking Protection. <annotation type="ppro_upsell_link">Dowiedz się więcej</annotation>.</string>
+    <string name="apptp_PproUpsellBannerTitle">Przenieś prywatność na wyższy poziom</string>
+    <string name="apptp_PproUpsellBannerMessage">DuckDuckGo oferuje jedyną sieć VPN zgodną z funkcją App Tracking Protection. Można ją aktywować z płatną subskrypcją Privacy Pro.</string>
+    <string name="apptp_PproUpsellBannerAction">Dowiedz się więcej</string>
+
 </resources>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-pt/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-pt/strings-vpn.xml
@@ -421,4 +421,11 @@
     <string name="appTrackingProtectionNotifyMeTitle">Prestar atenção aos rastreadores bloqueados</string>
     <string name="appTrackingProtectionNotifyMeSubtitle">Obtenha atualizações sobre as tentativas de rastreamento bloqueadas na sua gaveta de notificações.</string>
 
+    <!-- Privacy pro upsell -->
+    <string name="apptp_PproUpsellInfoDisabled">Não consegues usar a App Tracking Protection por causa da tua VPN? Muda para VPN DuckDuckGo, a única VPN compatível. <annotation type="ppro_upsell_link">Sabe mais</annotation>.</string>
+    <string name="apptp_PproUpsellInfoRevoked"><b>App Tracking Protection desativada</b>\nA tua VPN desativou a App Tracking Protection? Usa o botão acima para a reativar.\n\nObtém a VPN DuckDuckGo, que é a única VPN que funciona com a App Tracking Protection. <annotation type="ppro_upsell_link">Sabe mais</annotation>.</string>
+    <string name="apptp_PproUpsellBannerTitle">Leva a tua privacidade ao próximo nível</string>
+    <string name="apptp_PproUpsellBannerMessage">O DuckDuckGo tem a única VPN compatível com a App Tracking Protection. Ativa-a com uma subscrição Privacy Pro paga.</string>
+    <string name="apptp_PproUpsellBannerAction">Saiba mais</string>
+
 </resources>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-ro/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-ro/strings-vpn.xml
@@ -431,4 +431,11 @@
     <string name="appTrackingProtectionNotifyMeTitle">Fii cu ochii pe tehnologiile de urmărire blocate</string>
     <string name="appTrackingProtectionNotifyMeSubtitle">Primește actualizări despre încercările de urmărire blocate, în zona de notificare.</string>
 
+    <!-- Privacy pro upsell -->
+    <string name="apptp_PproUpsellInfoDisabled">Nu poți folosi App Tracking Protection din cauza VPN-ului tău? Treci la DuckDuckGo VPN ‑ singurul VPN compatibil. <annotation type="ppro_upsell_link">Află mai multe</annotation>.</string>
+    <string name="apptp_PproUpsellInfoRevoked"><b>App Tracking Protection dezactivată</b>\nVPN-ul tău a dezactivat App Tracking Protection? Folosește comutatorul de mai sus pentru a reactiva.\n\nDescarcă DuckDuckGo VPN – singurul VPN care funcționează cu App Tracking Protection. <annotation type="ppro_upsell_link">Află mai multe</annotation>.</string>
+    <string name="apptp_PproUpsellBannerTitle">Du-ți confidențialitatea la următorul nivel</string>
+    <string name="apptp_PproUpsellBannerMessage">DuckDuckGo pune la dispoziție singurul VPN care este compatibil cu App Tracking Protection. Activează cu un abonament Privacy Pro cu plată.</string>
+    <string name="apptp_PproUpsellBannerAction">Află mai multe</string>
+
 </resources>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-ru/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-ru/strings-vpn.xml
@@ -441,4 +441,11 @@
     <string name="appTrackingProtectionNotifyMeTitle">Всегда в курсе блокировок</string>
     <string name="appTrackingProtectionNotifyMeSubtitle">Уведомления о пресеченных попытках отслеживания в панели уведомлений.</string>
 
+    <!-- Privacy pro upsell -->
+    <string name="apptp_PproUpsellInfoDisabled">Не получается включить защиту от отслеживания в приложениях (App Tracking Protection) из-за VPN? Переходите на DuckDuckGo VPN — единственный совместимый с защитой сервис. <annotation type="ppro_upsell_link">Подробнее...</annotation></string>
+    <string name="apptp_PproUpsellInfoRevoked"><b>Защита App Tracking Protection отключена</b>\nVPN отключил защиту от трекеров в приложениях? Активируйте ее снова с помощью переключателя выше.\n\nИ установите DuckDuckGo VPN — единственный VPN, совместимый с App Tracking Protection. <annotation type="ppro_upsell_link">Подробнее...</annotation></string>
+    <string name="apptp_PproUpsellBannerTitle">Конфиденциальность качественно нового уровня</string>
+    <string name="apptp_PproUpsellBannerMessage">DuckDuckGo предлагает единственный VPN, совместимый с защитой от отслеживания в приложениях (App Tracking Protection). Для его активации необходима платная подписка Privacy Pro.</string>
+    <string name="apptp_PproUpsellBannerAction">Узнать больше</string>
+
 </resources>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-sk/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-sk/strings-vpn.xml
@@ -441,4 +441,11 @@
     <string name="appTrackingProtectionNotifyMeTitle">Dávajte pozor na zablokované sledovacie zariadenia</string>
     <string name="appTrackingProtectionNotifyMeSubtitle">Získajte aktualizácie o zablokovaných pokusoch o sledovanie v zásuvke oznámení.</string>
 
+    <!-- Privacy pro upsell -->
+    <string name="apptp_PproUpsellInfoDisabled">Nemôžeš používať App Tracking Protection kvôli tvojej VPN? Prejdi na DuckDuckGo VPN – jedinú VPN, ktorá je kompatibilná. <annotation type="ppro_upsell_link">Zistiť viac</annotation>.</string>
+    <string name="apptp_PproUpsellInfoRevoked"><b>App Tracking Protection je vypnutá</b>\nVypla tvoja VPN službu App Tracking Protection? Na opätovné zapnutie použi vyššie uvedený prepínač.\n\nZískaj DuckDuckGo VPN – jedinú VPN, ktorá funguje s App Tracking Protection. <annotation type="ppro_upsell_link">Zisti viac</annotation>.</string>
+    <string name="apptp_PproUpsellBannerTitle">Posuňte svoje súkromie na vyššiu úroveň</string>
+    <string name="apptp_PproUpsellBannerMessage">DuckDuckGo má jedinú VPN, ktorá je kompatibilná s App Tracking Protection. Aktivuj si ju s plateným predplatným Privacy Pro.</string>
+    <string name="apptp_PproUpsellBannerAction">Zistite viac</string>
+
 </resources>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-sl/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-sl/strings-vpn.xml
@@ -441,4 +441,11 @@
     <string name="appTrackingProtectionNotifyMeTitle">Bodite pozorni na blokirane sledilnike</string>
     <string name="appTrackingProtectionNotifyMeSubtitle">Posodobitve o blokiranih poskusih sledenja prejemajte v predal za obvestila.</string>
 
+    <!-- Privacy pro upsell -->
+    <string name="apptp_PproUpsellInfoDisabled">Ne morete uporabljati aplikacije za zaščito App Tracking Protection zaradi vašega VPN-ja? Preklopite na VPN DuckDuckGo –edini združljivi VPN. <annotation type="ppro_upsell_link">Več o tem</annotation>.</string>
+    <string name="apptp_PproUpsellInfoRevoked"><b>Zaščita App Tracking Protection je onemogočena</b>\nAli je vaš VPN onemogočil App Tracking Protection? Z zgornjim stikalom ga lahko znova omogočite.\n\nPridobitev VPN DuckDuckGo – edini VPN, ki deluje z zaščito App Tracking Protection. <annotation type="ppro_upsell_link">Več o tem</annotation>.</string>
+    <string name="apptp_PproUpsellBannerTitle">Dvignite svojo zasebnost na naslednjo raven</string>
+    <string name="apptp_PproUpsellBannerMessage">DuckDuckGo ima edini VPN, ki je združljiv z zaščito App Tracking Protection. Aktiviraj s plačljivo naročnino na Privacy Pro.</string>
+    <string name="apptp_PproUpsellBannerAction">Več</string>
+
 </resources>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-sv/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-sv/strings-vpn.xml
@@ -421,4 +421,11 @@
     <string name="appTrackingProtectionNotifyMeTitle">Håll ett öga på blockerade spårare</string>
     <string name="appTrackingProtectionNotifyMeSubtitle">Få uppdateringar om blockerade spårningsförsök i dina meddelanden.</string>
 
+    <!-- Privacy pro upsell -->
+    <string name="apptp_PproUpsellInfoDisabled">Kan du inte använda App Tracking Protection på grund av din VPN? Byt till DuckDuckGo VPN – den enda VPN-tjänsten som är kompatibel. <annotation type="ppro_upsell_link">Läs mer</annotation>.</string>
+    <string name="apptp_PproUpsellInfoRevoked"><b>App Tracking Protection är inaktiverat</b>\nHar din VPN-tjänst inaktiverat App Tracking Protection? Använd reglaget ovan för att återaktivera det.\n\nSkaffa DuckDuckGo VPN – den enda VPN-tjänsten som fungerar med App Tracking Protection. <annotation type="ppro_upsell_link">Läs mer</annotation>.</string>
+    <string name="apptp_PproUpsellBannerTitle">Ta din integritet till nästa nivå</string>
+    <string name="apptp_PproUpsellBannerMessage">DuckDuckGo har den enda VPN-tjänsten som är kompatibel med App Tracking Protection. Aktivera det med ett betalt abonnemang på Privacy Pro.</string>
+    <string name="apptp_PproUpsellBannerAction">Läs mer</string>
+
 </resources>

--- a/app-tracking-protection/vpn-impl/src/main/res/values-tr/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values-tr/strings-vpn.xml
@@ -421,4 +421,11 @@
     <string name="appTrackingProtectionNotifyMeTitle">Engellenen izleyicilerden haberdar olun</string>
     <string name="appTrackingProtectionNotifyMeSubtitle">Bildirim çekmecenizde engellenen izleme girişimleri hakkında güncellemeler alın.</string>
 
+    <!-- Privacy pro upsell -->
+    <string name="apptp_PproUpsellInfoDisabled">Kullandığınız VPN yüzünden App Tracking Protection\'ı kullanamıyor musunuz? Uyumlu tek VPN olan DuckDuckGo VPN\'e geçin. <annotation type="ppro_upsell_link">Daha fazla bilgi edinin</annotation>.</string>
+    <string name="apptp_PproUpsellInfoRevoked"><b>App Tracking Protection Devre Dışı Bırakıldı</b>\nKullandığınız VPN App Tracking Protection\'ı devre dışı mı bıraktı? Yeniden etkinleştirmek için yukarıdaki düğmeyi kullanın.\n\nApp Tracking Protection ile çalışan tek VPN olan DuckDuckGo VPN\'i edinin. <annotation type="ppro_upsell_link">Daha fazla bilgi edinin</annotation>.</string>
+    <string name="apptp_PproUpsellBannerTitle">Gizliliğinizi bir üst seviyeye taşıyın</string>
+    <string name="apptp_PproUpsellBannerMessage">DuckDuckGo, App Tracking Protection ile uyumlu olan tek VPN\'i sunuyor. Ücretli bir Privacy Pro aboneliğiyle etkinleştirebilirsiniz.</string>
+    <string name="apptp_PproUpsellBannerAction">Daha Fazla Bilgi</string>
+
 </resources>

--- a/app-tracking-protection/vpn-impl/src/main/res/values/donottranslate.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values/donottranslate.xml
@@ -40,11 +40,4 @@
     <!-- New Tab -->
     <string name="vpn_NewTabSectionSettingsTitle">App Tracking Protection Status</string>
 
-    <!-- Privacy pro upsell -->
-    <string name="apptp_PproUpsellInfoDisabled">Unable to use App Tracking Protection because of your VPN? Switch to DuckDuckGo VPN — the only VPN that\’s compatible. <annotation type="ppro_upsell_link">Learn more</annotation>.</string>
-    <string name="apptp_PproUpsellInfoRevoked"><b>App Tracking Protection Disabled</b>\nDid your VPN disable App Tracking Protection? Use the toggle above to re-enable it.\n\nGet DuckDuckGo VPN — the only VPN that works with App Tracking Protection. <annotation type="ppro_upsell_link">Learn more</annotation>.</string>
-    <string name="apptp_PproUpsellBannerTitle">Take Your Privacy to the Next Level</string>
-    <string name="apptp_PproUpsellBannerMessage">DuckDuckGo has the only VPN that\’s compatible with App Tracking Protection. Activate with a paid Privacy Pro subscription.</string>
-    <string name="apptp_PproUpsellBannerAction">Learn More</string>
-
 </resources>

--- a/app-tracking-protection/vpn-impl/src/main/res/values/strings-vpn.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/values/strings-vpn.xml
@@ -424,4 +424,11 @@
     <string name="appTrackingProtectionNotifyMeTitle">Keep an eye on blocked trackers</string>
     <string name="appTrackingProtectionNotifyMeSubtitle">Get updates about blocked tracking attempts in your notification drawer.</string>
 
+    <!-- Privacy pro upsell -->
+    <string name="apptp_PproUpsellInfoDisabled">Unable to use App Tracking Protection because of your VPN? Switch to DuckDuckGo VPN — the only VPN that\’s compatible. <annotation type="ppro_upsell_link">Learn more</annotation>.</string>
+    <string name="apptp_PproUpsellInfoRevoked"><b>App Tracking Protection Disabled</b>\nDid your VPN disable App Tracking Protection? Use the toggle above to re-enable it.\n\nGet DuckDuckGo VPN — the only VPN that works with App Tracking Protection. <annotation type="ppro_upsell_link">Learn more</annotation>.</string>
+    <string name="apptp_PproUpsellBannerTitle">Take Your Privacy to the Next Level</string>
+    <string name="apptp_PproUpsellBannerMessage">DuckDuckGo has the only VPN that\’s compatible with App Tracking Protection. Activate with a paid Privacy Pro subscription.</string>
+    <string name="apptp_PproUpsellBannerAction">Learn More</string>
+
 </resources>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1209734846386434

### Description
Translate AppTP Privacy Pro entry points
- banner
- revoked
- disabled

### Steps to test this PR _(Optional)_

_Pre steps_

- Make sure you are Privacy Pro eligible
- Switch your device language to something other than English

_Banner_
- [ ] Fresh install
- [ ] Go to Settings > App Tracking Protection
- [ ] Do AppTP onboarding
- [ ] Check Privacy Pro banner is translated

_Revoked_
- [ ] Enable AppTP
- [ ] Enable an external VPN on your phone
- [ ] Go back to AppTP screen
- [ ] Check revoked banner is translated

_Disabled_
- [ ] Disable AppTP
- [ ] Enable an external VPN on your phone
- [ ] Go back to AppTP screen
- [ ] Check disabled banner is translated

### No UI changes
