### PR TITLE
Fix PreferencesFlipperPlugin crash upon app launch

### DIFF
--- a/app-tracking-protection/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/flipper/PreferencesFlipperPlugin.kt
+++ b/app-tracking-protection/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/flipper/PreferencesFlipperPlugin.kt
@@ -48,7 +48,8 @@ class PreferencesFlipperPlugin @Inject constructor(
     private var connection: FlipperConnection? = null
 
     private val onSharedPreferenceChangeListener = SharedPreferences.OnSharedPreferenceChangeListener { sharedPreferences, key ->
-        val descriptor = this.sharedPreferences[sharedPreferences] ?: return@OnSharedPreferenceChangeListener
+        // We assume it could happen sharedPreferences are not initialised here, but not anywhere else in this file
+        val descriptor = runCatching { this.sharedPreferences[sharedPreferences] }.getOrNull() ?: return@OnSharedPreferenceChangeListener
 
         connection?.send(
             "sharedPreferencesChange",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202552961248957/1209831319132189/f

### Description
Guard against shared prefs not being initialised in the onSharedPreferenceChangeListener

### Steps to test this PR
N/A or test that flipper works
