### PR TITLE
fix web view container to shift content up when bottom navigation bar is visible

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/navigation/bar/view/BrowserNavigationBarView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/navigation/bar/view/BrowserNavigationBarView.kt
@@ -55,8 +55,8 @@ import kotlinx.coroutines.flow.onEach
 
 @InjectWith(ViewScope::class)
 class BrowserNavigationBarView @JvmOverloads constructor(
-    context: Context,
-    attrs: AttributeSet? = null,
+    private val context: Context,
+    private val attrs: AttributeSet? = null,
     defStyle: Int = 0,
 ) : FrameLayout(context, attrs, defStyle), AttachedBehavior {
 
@@ -152,7 +152,7 @@ class BrowserNavigationBarView @JvmOverloads constructor(
     }
 
     override fun getBehavior(): Behavior<*> {
-        return BottomViewBehavior()
+        return BottomViewBehavior(context, attrs)
     }
 
     private fun renderView(viewState: ViewState) {
@@ -197,7 +197,10 @@ class BrowserNavigationBarView @JvmOverloads constructor(
      *
      * This practically applies only when paired with the top omnibar because if the bottom omnibar is used, it comes with the navigation bar embedded.
      */
-    private class BottomViewBehavior : Behavior<View>() {
+    private class BottomViewBehavior(
+        context: Context,
+        attrs: AttributeSet?,
+    ) : Behavior<View>(context, attrs) {
 
         override fun layoutDependsOn(
             parent: CoordinatorLayout,

--- a/app/src/main/java/com/duckduckgo/app/browser/webview/BrowserContainerLayoutBehavior.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/webview/BrowserContainerLayoutBehavior.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.webview
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.view.isVisible
+import com.duckduckgo.app.browser.navigation.bar.view.BrowserNavigationBarView
+import com.google.android.material.appbar.AppBarLayout.ScrollingViewBehavior
+
+/**
+ * A [ScrollingViewBehavior] that additionally observes the position of [BrowserNavigationBarView], if present,
+ * and applies bottom padding to the target view equal to the visible height of the navigation bar.
+ *
+ * This prevents the navigation bar from overlapping with, for example, content found in the web view.
+ *
+ * Note: This behavior is intended for use with the top omnibar. When the bottom omnibar is used,
+ * it already includes the navigation bar, so no additional coordination is required.
+ */
+class BrowserContainerLayoutBehavior(
+    context: Context,
+    attrs: AttributeSet?,
+) : ScrollingViewBehavior(context, attrs) {
+
+    override fun layoutDependsOn(
+        parent: CoordinatorLayout,
+        child: View,
+        dependency: View,
+    ): Boolean {
+        return if (dependency is BrowserNavigationBarView) {
+            true
+        } else {
+            super.layoutDependsOn(parent, child, dependency)
+        }
+    }
+
+    override fun onDependentViewChanged(
+        parent: CoordinatorLayout,
+        child: View,
+        dependency: View,
+    ): Boolean {
+        return if (dependency is BrowserNavigationBarView) {
+            val newBottomPadding = if (dependency.isVisible) {
+                dependency.measuredHeight - dependency.translationY.toInt()
+            } else {
+                0
+            }
+            if (child.paddingBottom != newBottomPadding) {
+                child.setPadding(
+                    0,
+                    0,
+                    0,
+                    newBottomPadding,
+                )
+                true
+            } else {
+                false
+            }
+        } else {
+            super.onDependentViewChanged(parent, child, dependency)
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_browser_tab.xml
+++ b/app/src/main/res/layout/fragment_browser_tab.xml
@@ -84,7 +84,7 @@
         android:layout_height="match_parent"
         android:clipChildren="false"
         android:orientation="vertical"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        app:layout_behavior="com.duckduckgo.app.browser.webview.BrowserContainerLayoutBehavior"
         tools:context="com.duckduckgo.app.browser.BrowserActivity">
 
         <FrameLayout


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/0/1209897414427802

### Description
Adds to the browser container a behavioral dependency on the navigation bar, so that the content of the browser doesn't overlap with the bar.

### Steps to test this PR

- [ ] Verify that in production there's no unexpected content padding on the bottom of the web view, both in top and bottom omnibar positions.
- [ ] Enable the experimental UI feature flag, open a page like YouTube or any other page that has persistent element at the bottom (which is easiest to test with), and ensure that all page content is always visible.

### UI changes

_before_

https://github.com/user-attachments/assets/d6c73985-b667-4c85-a29d-e7381e2fd44d

_after_

https://github.com/user-attachments/assets/c48f8c3c-3641-4b72-89ab-ca920287d36a
