### PR TITLE
Improve Duck.ai bang handling

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
@@ -63,7 +63,7 @@ class SpecialUrlDetectorImpl(
             null -> {
                 if (subscriptions.shouldLaunchPrivacyProForUrl("https://$uriString")) {
                     UrlType.ShouldLaunchPrivacyProLink
-                } else if (duckChat.isDuckChatUrl(uri) && aiChatQueryDetectionFeature.self().isEnabled()) {
+                } else if (aiChatQueryDetectionFeature.self().isEnabled() && duckChat.isDuckChatUrl(uri)) {
                     UrlType.ShouldLaunchDuckChatLink
                 } else {
                     UrlType.SearchQuery(uriString)

--- a/app/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
@@ -61,6 +61,8 @@ class SpecialUrlDetectorImpl(
             null -> {
                 if (subscriptions.shouldLaunchPrivacyProForUrl("https://$uriString")) {
                     UrlType.ShouldLaunchPrivacyProLink
+                } else if (duckChat.isDuckChatUrl(uri)) {
+                    UrlType.ShouldLaunchDuckChatLink
                 } else {
                     UrlType.SearchQuery(uriString)
                 }

--- a/app/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
@@ -26,6 +26,7 @@ import android.net.Uri
 import androidx.core.net.toUri
 import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType
 import com.duckduckgo.app.browser.applinks.ExternalAppIntentFlagsFeature
+import com.duckduckgo.app.browser.duckchat.AIChatQueryDetectionFeature
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckplayer.api.DuckPlayer
 import com.duckduckgo.privacy.config.api.AmpLinkType
@@ -43,6 +44,7 @@ class SpecialUrlDetectorImpl(
     private val externalAppIntentFlagsFeature: ExternalAppIntentFlagsFeature,
     private val duckPlayer: DuckPlayer,
     private val duckChat: DuckChat,
+    private val aiChatQueryDetectionFeature: AIChatQueryDetectionFeature,
 ) : SpecialUrlDetector {
 
     override fun determineType(initiatingUrl: String?, uri: Uri): UrlType {
@@ -61,7 +63,7 @@ class SpecialUrlDetectorImpl(
             null -> {
                 if (subscriptions.shouldLaunchPrivacyProForUrl("https://$uriString")) {
                     UrlType.ShouldLaunchPrivacyProLink
-                } else if (duckChat.isDuckChatUrl(uri)) {
+                } else if (duckChat.isDuckChatUrl(uri) && aiChatQueryDetectionFeature.self().isEnabled()) {
                     UrlType.ShouldLaunchDuckChatLink
                 } else {
                     UrlType.SearchQuery(uriString)

--- a/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
@@ -36,6 +36,7 @@ import com.duckduckgo.app.browser.cookies.db.AuthCookiesAllowedDomainsRepository
 import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
 import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserObserver
 import com.duckduckgo.app.browser.downloader.*
+import com.duckduckgo.app.browser.duckchat.AIChatQueryDetectionFeature
 import com.duckduckgo.app.browser.favicon.FaviconPersister
 import com.duckduckgo.app.browser.favicon.FileBasedFaviconPersister
 import com.duckduckgo.app.browser.httpauth.WebViewHttpAuthStore
@@ -179,6 +180,7 @@ class BrowserModule {
         externalAppIntentFlagsFeature: ExternalAppIntentFlagsFeature,
         duckPlayer: DuckPlayer,
         duckChat: DuckChat,
+        aiChatQueryDetectionFeature: AIChatQueryDetectionFeature,
     ): SpecialUrlDetector = SpecialUrlDetectorImpl(
         packageManager,
         ampLinks,
@@ -187,6 +189,7 @@ class BrowserModule {
         externalAppIntentFlagsFeature,
         duckPlayer,
         duckChat,
+        aiChatQueryDetectionFeature,
     )
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/browser/duckchat/AIChatQueryDetectionFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/duckchat/AIChatQueryDetectionFeature.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.duckchat
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "aiChatQueryDetectionFeature",
+)
+
+interface AIChatQueryDetectionFeature {
+
+    @Toggle.DefaultValue(true)
+    fun self(): Toggle
+}

--- a/app/src/test/java/com/duckduckgo/app/browser/SpecialUrlDetectorImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/SpecialUrlDetectorImplTest.kt
@@ -307,6 +307,20 @@ class SpecialUrlDetectorImplTest {
     }
 
     @Test
+    fun whenUrlIsNotDuckChatUrlThenSearchQueryTypeDetected() {
+        whenever(mockDuckChat.isDuckChatUrl(any())).thenReturn(false)
+        val result = testee.determineType("duckduckgo.com")
+        assertTrue(result is SearchQuery)
+    }
+
+    @Test
+    fun whenUrlIsDuckChatUrlThenDuckChatTypeDetected() {
+        whenever(mockDuckChat.isDuckChatUrl(any())).thenReturn(true)
+        val result = testee.determineType("duckduckgo.com")
+        assertTrue(result is ShouldLaunchDuckChatLink)
+    }
+
+    @Test
     fun whenUrlIsParametrizedQueryThenSearchQueryTypeDetected() {
         val type = testee.determineType("foo site:duckduckgo.com") as SearchQuery
         assertEquals("foo site:duckduckgo.com", type.query)

--- a/app/src/test/java/com/duckduckgo/app/browser/SpecialUrlDetectorImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/SpecialUrlDetectorImplTest.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.app.browser.SpecialUrlDetectorImpl.Companion.EMAIL_MAX_LEN
 import com.duckduckgo.app.browser.SpecialUrlDetectorImpl.Companion.PHONE_MAX_LENGTH
 import com.duckduckgo.app.browser.SpecialUrlDetectorImpl.Companion.SMS_MAX_LENGTH
 import com.duckduckgo.app.browser.applinks.ExternalAppIntentFlagsFeature
+import com.duckduckgo.app.browser.duckchat.AIChatQueryDetectionFeature
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckplayer.api.DuckPlayer
 import com.duckduckgo.feature.toggles.api.Toggle
@@ -68,6 +69,8 @@ class SpecialUrlDetectorImplTest {
 
     val mockDuckChat: DuckChat = mock()
 
+    val mockAIChatQueryDetectionFeature: AIChatQueryDetectionFeature = mock()
+
     @Before
     fun setup() = runTest {
         testee = SpecialUrlDetectorImpl(
@@ -78,6 +81,7 @@ class SpecialUrlDetectorImplTest {
             externalAppIntentFlagsFeature = externalAppIntentFlagsFeature,
             duckPlayer = mockDuckPlayer,
             duckChat = mockDuckChat,
+            aiChatQueryDetectionFeature = mockAIChatQueryDetectionFeature,
         )
         whenever(mockPackageManager.queryIntentActivities(any(), anyInt())).thenReturn(emptyList())
         whenever(mockDuckPlayer.willNavigateToDuckPlayer(any())).thenReturn(false)
@@ -308,16 +312,29 @@ class SpecialUrlDetectorImplTest {
 
     @Test
     fun whenUrlIsNotDuckChatUrlThenSearchQueryTypeDetected() {
+        whenever(mockToggle.isEnabled()).thenReturn(true)
+        whenever(mockAIChatQueryDetectionFeature.self()).thenReturn(mockToggle)
         whenever(mockDuckChat.isDuckChatUrl(any())).thenReturn(false)
         val result = testee.determineType("duckduckgo.com")
         assertTrue(result is SearchQuery)
     }
 
     @Test
-    fun whenUrlIsDuckChatUrlThenDuckChatTypeDetected() {
+    fun whenUrlIsDuckChatUrlAndFeatureIsEnabledThenDuckChatTypeDetected() {
+        whenever(mockToggle.isEnabled()).thenReturn(true)
+        whenever(mockAIChatQueryDetectionFeature.self()).thenReturn(mockToggle)
         whenever(mockDuckChat.isDuckChatUrl(any())).thenReturn(true)
         val result = testee.determineType("duckduckgo.com")
         assertTrue(result is ShouldLaunchDuckChatLink)
+    }
+
+    @Test
+    fun whenUrlIsDuckChatUrlAndFeatureIsDisabledThenSearchQueryTypeDetected() {
+        whenever(mockToggle.isEnabled()).thenReturn(false)
+        whenever(mockAIChatQueryDetectionFeature.self()).thenReturn(mockToggle)
+        whenever(mockDuckChat.isDuckChatUrl(any())).thenReturn(true)
+        val result = testee.determineType("duckduckgo.com")
+        assertTrue(result is SearchQuery)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/SpecialUrlDetectorImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/SpecialUrlDetectorImplTest.kt
@@ -71,6 +71,8 @@ class SpecialUrlDetectorImplTest {
 
     val mockAIChatQueryDetectionFeature: AIChatQueryDetectionFeature = mock()
 
+    val mockAIChatQueryDetectionFeatureToggle: Toggle = mock()
+
     @Before
     fun setup() = runTest {
         testee = SpecialUrlDetectorImpl(
@@ -85,6 +87,8 @@ class SpecialUrlDetectorImplTest {
         )
         whenever(mockPackageManager.queryIntentActivities(any(), anyInt())).thenReturn(emptyList())
         whenever(mockDuckPlayer.willNavigateToDuckPlayer(any())).thenReturn(false)
+        whenever(mockAIChatQueryDetectionFeatureToggle.isEnabled()).thenReturn(false)
+        whenever(mockAIChatQueryDetectionFeature.self()).thenReturn(mockAIChatQueryDetectionFeatureToggle)
     }
 
     @Test
@@ -312,8 +316,8 @@ class SpecialUrlDetectorImplTest {
 
     @Test
     fun whenUrlIsNotDuckChatUrlAndFeatureIsEnabledThenSearchQueryTypeDetected() {
-        whenever(mockToggle.isEnabled()).thenReturn(true)
-        whenever(mockAIChatQueryDetectionFeature.self()).thenReturn(mockToggle)
+        whenever(mockAIChatQueryDetectionFeatureToggle.isEnabled()).thenReturn(true)
+        whenever(mockAIChatQueryDetectionFeature.self()).thenReturn(mockAIChatQueryDetectionFeatureToggle)
         whenever(mockDuckChat.isDuckChatUrl(any())).thenReturn(false)
         val result = testee.determineType("duckduckgo.com")
         assertTrue(result is SearchQuery)
@@ -321,8 +325,8 @@ class SpecialUrlDetectorImplTest {
 
     @Test
     fun whenUrlIsDuckChatUrlAndFeatureIsEnabledThenDuckChatTypeDetected() {
-        whenever(mockToggle.isEnabled()).thenReturn(true)
-        whenever(mockAIChatQueryDetectionFeature.self()).thenReturn(mockToggle)
+        whenever(mockAIChatQueryDetectionFeatureToggle.isEnabled()).thenReturn(true)
+        whenever(mockAIChatQueryDetectionFeature.self()).thenReturn(mockAIChatQueryDetectionFeatureToggle)
         whenever(mockDuckChat.isDuckChatUrl(any())).thenReturn(true)
         val result = testee.determineType("duckduckgo.com")
         assertTrue(result is ShouldLaunchDuckChatLink)
@@ -330,8 +334,8 @@ class SpecialUrlDetectorImplTest {
 
     @Test
     fun whenUrlIsDuckChatUrlAndFeatureIsDisabledThenSearchQueryTypeDetected() {
-        whenever(mockToggle.isEnabled()).thenReturn(false)
-        whenever(mockAIChatQueryDetectionFeature.self()).thenReturn(mockToggle)
+        whenever(mockAIChatQueryDetectionFeatureToggle.isEnabled()).thenReturn(false)
+        whenever(mockAIChatQueryDetectionFeature.self()).thenReturn(mockAIChatQueryDetectionFeatureToggle)
         whenever(mockDuckChat.isDuckChatUrl(any())).thenReturn(true)
         val result = testee.determineType("duckduckgo.com")
         assertTrue(result is SearchQuery)

--- a/app/src/test/java/com/duckduckgo/app/browser/SpecialUrlDetectorImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/SpecialUrlDetectorImplTest.kt
@@ -317,7 +317,6 @@ class SpecialUrlDetectorImplTest {
     @Test
     fun whenUrlIsNotDuckChatUrlAndFeatureIsEnabledThenSearchQueryTypeDetected() {
         whenever(mockAIChatQueryDetectionFeatureToggle.isEnabled()).thenReturn(true)
-        whenever(mockAIChatQueryDetectionFeature.self()).thenReturn(mockAIChatQueryDetectionFeatureToggle)
         whenever(mockDuckChat.isDuckChatUrl(any())).thenReturn(false)
         val result = testee.determineType("duckduckgo.com")
         assertTrue(result is SearchQuery)
@@ -326,7 +325,6 @@ class SpecialUrlDetectorImplTest {
     @Test
     fun whenUrlIsDuckChatUrlAndFeatureIsEnabledThenDuckChatTypeDetected() {
         whenever(mockAIChatQueryDetectionFeatureToggle.isEnabled()).thenReturn(true)
-        whenever(mockAIChatQueryDetectionFeature.self()).thenReturn(mockAIChatQueryDetectionFeatureToggle)
         whenever(mockDuckChat.isDuckChatUrl(any())).thenReturn(true)
         val result = testee.determineType("duckduckgo.com")
         assertTrue(result is ShouldLaunchDuckChatLink)
@@ -334,8 +332,6 @@ class SpecialUrlDetectorImplTest {
 
     @Test
     fun whenUrlIsDuckChatUrlAndFeatureIsDisabledThenSearchQueryTypeDetected() {
-        whenever(mockAIChatQueryDetectionFeatureToggle.isEnabled()).thenReturn(false)
-        whenever(mockAIChatQueryDetectionFeature.self()).thenReturn(mockAIChatQueryDetectionFeatureToggle)
         whenever(mockDuckChat.isDuckChatUrl(any())).thenReturn(true)
         val result = testee.determineType("duckduckgo.com")
         assertTrue(result is SearchQuery)

--- a/app/src/test/java/com/duckduckgo/app/browser/SpecialUrlDetectorImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/SpecialUrlDetectorImplTest.kt
@@ -311,7 +311,7 @@ class SpecialUrlDetectorImplTest {
     }
 
     @Test
-    fun whenUrlIsNotDuckChatUrlThenSearchQueryTypeDetected() {
+    fun whenUrlIsNotDuckChatUrlAndFeatureIsEnabledThenSearchQueryTypeDetected() {
         whenever(mockToggle.isEnabled()).thenReturn(true)
         whenever(mockAIChatQueryDetectionFeature.self()).thenReturn(mockToggle)
         whenever(mockDuckChat.isDuckChatUrl(any())).thenReturn(false)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -172,7 +172,7 @@ class RealDuckChat @Inject constructor(
         val parameters = query?.let {
             mutableMapOf(QUERY to it).apply {
                 if (isDuckChatBang(it.toUri())) {
-                    put(BANG_QUERY_NAME, "true")
+                    put(BANG_QUERY_NAME, BANG_QUERY_VALUE)
                 }
             }
         } ?: emptyMap()
@@ -276,5 +276,6 @@ class RealDuckChat @Inject constructor(
         private const val PROMPT_QUERY_NAME = "prompt"
         private const val PROMPT_QUERY_VALUE = "1"
         private const val BANG_QUERY_NAME = "bang"
+        private const val BANG_QUERY_VALUE = "true"
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -176,9 +176,12 @@ class RealDuckChat @Inject constructor(
             } else {
                 originalQuery
             }
-            mutableMapOf(QUERY to cleanedQuery).apply {
-                if (hasDuckChatBang) {
-                    put(BANG_QUERY_NAME, BANG_QUERY_VALUE)
+            mutableMapOf<String, String>().apply {
+                if (cleanedQuery.isNotEmpty()) {
+                    put(QUERY, cleanedQuery)
+                    if (hasDuckChatBang) {
+                        put(BANG_QUERY_NAME, BANG_QUERY_VALUE)
+                    }
                 }
             }
         } ?: emptyMap()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -170,7 +170,11 @@ class RealDuckChat @Inject constructor(
 
     override fun openDuckChat(query: String?) {
         val parameters = query?.let {
-            mapOf(QUERY to it)
+            mutableMapOf(QUERY to it).apply {
+                if (isDuckChatBang(it.toUri())) {
+                    put(BANG_QUERY_NAME, "true")
+                }
+            }
         } ?: emptyMap()
         openDuckChat(parameters)
     }
@@ -271,5 +275,6 @@ class RealDuckChat @Inject constructor(
         private const val CHAT_QUERY_VALUE = "chat"
         private const val PROMPT_QUERY_NAME = "prompt"
         private const val PROMPT_QUERY_VALUE = "1"
+        private const val BANG_QUERY_NAME = "bang"
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -267,10 +267,11 @@ class RealDuckChat @Inject constructor(
                 runCatching { jsonAdapter.fromJson(it) }.getOrNull()
             }
             duckChatLink = settingsJson?.aiChatURL ?: DUCK_CHAT_WEB_LINK
-            settingsJson?.aiChatBangs?.let { bangs ->
-                val bangAlternation = bangs.joinToString("|") { it }
-                bangRegex = settingsJson.aiChatBangRegex?.replace("{bangs}", bangAlternation)?.toRegex()
-            }
+            settingsJson?.aiChatBangs?.takeIf { it.isNotEmpty() }
+                ?.let { bangs ->
+                    val bangAlternation = bangs.joinToString("|") { it }
+                    bangRegex = settingsJson.aiChatBangRegex?.replace("{bangs}", bangAlternation)?.toRegex()
+                }
             cacheShowInBrowser()
         }
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -79,7 +79,9 @@ interface DuckChatInternal : DuckChat {
 }
 
 data class DuckChatSettingJson(
-    val aiChatURL: String,
+    val aiChatURL: String?,
+    val aiChatBangs: List<String>?,
+    val aiChatBangRegex: String?,
 )
 
 @SingleInstanceIn(AppScope::class)
@@ -105,25 +107,19 @@ class RealDuckChat @Inject constructor(
         moshi.adapter(DuckChatSettingJson::class.java)
     }
 
-    /** Cached DuckChat is enabled flag */
     private var isDuckChatEnabled = false
-
-    /** Cached value of whether we should show DuckChat in the menu or not */
     private var showInBrowserMenu = false
-
-    /** Cached DuckChat web link */
     private var duckChatLink = DUCK_CHAT_WEB_LINK
+    private var bangRegex: Regex? = null
 
     init {
         if (isMainProcess) {
-            cacheDuckChatLink()
-            cacheShowInBrowser()
+            cacheConfig()
         }
     }
 
     override fun onPrivacyConfigDownloaded() {
-        cacheDuckChatLink()
-        cacheShowInBrowser()
+        cacheConfig()
     }
 
     override suspend fun setShowInBrowserMenuUserSetting(showDuckChat: Boolean) = withContext(dispatchers.io()) {
@@ -228,6 +224,8 @@ class RealDuckChat @Inject constructor(
     }
 
     override fun isDuckChatUrl(uri: Uri): Boolean {
+        if (isDuckChatBang(uri)) return true
+
         if (uri.host != DUCKDUCKGO_HOST) {
             return false
         }
@@ -237,30 +235,36 @@ class RealDuckChat @Inject constructor(
         }.getOrDefault(false)
     }
 
+    private fun isDuckChatBang(uri: Uri): Boolean {
+        return bangRegex?.containsMatchIn(uri.toString()) == true
+    }
+
     override suspend fun wasOpenedBefore(): Boolean {
         return duckChatFeatureRepository.wasOpenedBefore()
     }
 
-    private fun cacheDuckChatLink() {
+    private fun cacheConfig() {
         appCoroutineScope.launch(dispatchers.io()) {
-            duckChatLink = duckChatFeature.self().getSettings()?.let {
-                runCatching {
-                    val settingsJson = jsonAdapter.fromJson(it)
-                    settingsJson?.aiChatURL
-                }.getOrDefault(DUCK_CHAT_WEB_LINK)
-            } ?: DUCK_CHAT_WEB_LINK
+            isDuckChatEnabled = duckChatFeature.self().isEnabled()
+
+            val settingsString = duckChatFeature.self().getSettings()
+            val settingsJson = settingsString?.let {
+                runCatching { jsonAdapter.fromJson(it) }.getOrNull()
+            }
+            duckChatLink = settingsJson?.aiChatURL ?: DUCK_CHAT_WEB_LINK
+            settingsJson?.aiChatBangs?.let { bangs ->
+                val bangAlternation = bangs.joinToString("|") { it }
+                bangRegex = settingsJson.aiChatBangRegex?.replace("{bangs}", bangAlternation)?.toRegex()
+            }
+            cacheShowInBrowser()
         }
     }
 
     private fun cacheShowInBrowser() {
-        appCoroutineScope.launch(dispatchers.io()) {
-            isDuckChatEnabled = duckChatFeature.self().isEnabled()
-            showInBrowserMenu = duckChatFeatureRepository.shouldShowInBrowserMenu() && isDuckChatEnabled
-        }
+        showInBrowserMenu = duckChatFeatureRepository.shouldShowInBrowserMenu() && isDuckChatEnabled
     }
 
     companion object {
-        /** Default link to DuckChat that identifies Android as the source */
         private const val DUCK_CHAT_WEB_LINK = "https://duckduckgo.com/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=5"
         private const val DUCKDUCKGO_HOST = "duckduckgo.com"
         private const val CHAT_QUERY_NAME = "ia"

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -169,14 +169,25 @@ class RealDuckChat @Inject constructor(
     }
 
     override fun openDuckChat(query: String?) {
-        val parameters = query?.let {
-            mutableMapOf(QUERY to it).apply {
-                if (isDuckChatBang(it.toUri())) {
+        val parameters = query?.let { originalQuery ->
+            val hasDuckChatBang = isDuckChatBang(originalQuery.toUri())
+            val cleanedQuery = if (hasDuckChatBang) {
+                stripBang(originalQuery)
+            } else {
+                originalQuery
+            }
+            mutableMapOf(QUERY to cleanedQuery).apply {
+                if (hasDuckChatBang) {
                     put(BANG_QUERY_NAME, BANG_QUERY_VALUE)
                 }
             }
         } ?: emptyMap()
         openDuckChat(parameters)
+    }
+
+    private fun stripBang(query: String): String {
+        val bangPattern = Regex("!\\w+")
+        return query.replace(bangPattern, "").trim()
     }
 
     override fun openDuckChatWithAutoPrompt(query: String) {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.duckchat.impl
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import androidx.core.net.toUri
@@ -53,6 +54,7 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
+@SuppressLint("DenyListedApi")
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
 class RealDuckChatTest {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -169,14 +169,7 @@ class RealDuckChatTest {
 
     @Test
     fun whenOpenDuckChatCalledWithBangQueryThenActivityStartedWithBangQuery() = runTest {
-        val settingsJson = """
-        {
-            "aiChatBangs": ["!ai","!aichat","!chat","!duckai"],
-            "aiChatBangRegex": "^(?!({bangs})${'$'}).*(?:{bangs}).*${'$'}"
-        }
-        """.trimIndent()
-
-        duckChatFeature.self().setRawStoredState(State(enable = true, settings = settingsJson))
+        duckChatFeature.self().setRawStoredState(State(enable = true, settings = SETTINGS_JSON))
         testee.onPrivacyConfigDownloaded()
 
         testee.openDuckChat(query = "example !ai")
@@ -192,14 +185,7 @@ class RealDuckChatTest {
 
     @Test
     fun whenIsDuckChatUrlCalledWithBangQueryThenReturnTrue() = runTest {
-        val settingsJson = """
-        {
-            "aiChatBangs": ["!ai","!aichat","!chat","!duckai"],
-            "aiChatBangRegex": "^(?!({bangs})${'$'}).*(?:{bangs}).*${'$'}"
-        }
-        """.trimIndent()
-
-        duckChatFeature.self().setRawStoredState(State(enable = true, settings = settingsJson))
+        duckChatFeature.self().setRawStoredState(State(enable = true, settings = SETTINGS_JSON))
         testee.onPrivacyConfigDownloaded()
 
         assertTrue(testee.isDuckChatUrl(uri = "example !ai".toUri()))
@@ -278,5 +264,14 @@ class RealDuckChatTest {
     private fun setFeatureToggle(enabled: Boolean) {
         duckChatFeature.self().setRawStoredState(State(enabled))
         testee.onPrivacyConfigDownloaded()
+    }
+
+    companion object {
+        val SETTINGS_JSON = """
+        {
+            "aiChatBangs": ["!ai","!aichat","!chat","!duckai"],
+            "aiChatBangRegex": "^(?!({bangs})${'$'}).*(?:{bangs}).*${'$'}"
+        }
+        """.trimIndent()
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -178,7 +178,7 @@ class RealDuckChatTest {
         verify(mockGlobalActivityStarter).startIntent(
             mockContext,
             DuckChatWebViewActivityWithParams(
-                url = "https://duckduckgo.com/?q=example%20!ai&bang=true&ia=chat&duckai=5",
+                url = "https://duckduckgo.com/?q=example&bang=true&ia=chat&duckai=5",
             ),
         )
         verify(mockContext).startActivity(any())

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -185,6 +185,22 @@ class RealDuckChatTest {
     }
 
     @Test
+    fun whenOpenDuckChatCalledWithBangsButNoQueryThenActivityStartedWithoutPrompt() = runTest {
+        duckChatFeature.self().setRawStoredState(State(enable = true, settings = SETTINGS_JSON))
+        testee.onPrivacyConfigDownloaded()
+
+        testee.openDuckChat(query = "!ai !image")
+        verify(mockGlobalActivityStarter).startIntent(
+            mockContext,
+            DuckChatWebViewActivityWithParams(
+                url = "https://duckduckgo.com/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=5",
+            ),
+        )
+        verify(mockContext).startActivity(any())
+        verify(mockDuckPlayerFeatureRepository).registerOpened()
+    }
+
+    @Test
     fun whenIsDuckChatUrlCalledWithBangQueryThenReturnTrue() = runTest {
         duckChatFeature.self().setRawStoredState(State(enable = true, settings = SETTINGS_JSON))
         testee.onPrivacyConfigDownloaded()

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -62,8 +62,7 @@ class RealDuckChatTest {
     @get:org.junit.Rule
     var coroutineRule = com.duckduckgo.common.test.CoroutineTestRule()
 
-    private val mockDuckPlayerFeatureRepository: DuckChatFeatureRepository =
-        mock()
+    private val mockDuckPlayerFeatureRepository: DuckChatFeatureRepository = mock()
     private val duckChatFeature = FakeFeatureToggleFactory.create(DuckChatFeature::class.java)
     private val moshi: Moshi = Moshi.Builder().build()
     private val dispatcherProvider = coroutineRule.testDispatcherProvider
@@ -194,6 +193,30 @@ class RealDuckChatTest {
     }
 
     @Test
+    fun whenIsDuckChatUrlCalledWithBangQueryWithEmptyBangsThenReturnFalse() = runTest {
+        duckChatFeature.self().setRawStoredState(State(enable = true, settings = SETTINGS_JSON_EMPTY_BANGS))
+        testee.onPrivacyConfigDownloaded()
+
+        assertFalse(testee.isDuckChatUrl(uri = "example !ai".toUri()))
+    }
+
+    @Test
+    fun whenIsDuckChatUrlCalledWithBangQueryWithNoBangsThenReturnFalse() = runTest {
+        duckChatFeature.self().setRawStoredState(State(enable = true, settings = SETTINGS_JSON_NO_BANGS))
+        testee.onPrivacyConfigDownloaded()
+
+        assertFalse(testee.isDuckChatUrl(uri = "example !ai".toUri()))
+    }
+
+    @Test
+    fun whenIsDuckChatUrlCalledWithBangQueryWithNoRegexThenReturnFalse() = runTest {
+        duckChatFeature.self().setRawStoredState(State(enable = true, settings = SETTINGS_JSON_NO_REGEX))
+        testee.onPrivacyConfigDownloaded()
+
+        assertFalse(testee.isDuckChatUrl(uri = "example !ai".toUri()))
+    }
+
+    @Test
     fun whenOpenDuckChatCalledWithQueryAndAutoPromptThenActivityStartedWithQueryAndAutoPrompt() = runTest {
         testee.openDuckChatWithAutoPrompt(query = "example")
         verify(mockGlobalActivityStarter).startIntent(
@@ -271,8 +294,27 @@ class RealDuckChatTest {
     companion object {
         val SETTINGS_JSON = """
         {
-            "aiChatBangs": ["!ai","!aichat","!chat","!duckai"],
-            "aiChatBangRegex": "^(?!({bangs})${'$'}).*(?:{bangs}).*${'$'}"
+            "aiChatBangs": ["!ai", "!aichat", "!chat", "!duckai"],
+            "aiChatBangRegex": "^(?!({bangs})${'$'})(?=.*({bangs})(?=${'$'}|\\s)).+${'$'}"
+        }
+        """.trimIndent()
+
+        val SETTINGS_JSON_EMPTY_BANGS = """
+        {
+            "aiChatBangs": [],
+            "aiChatBangRegex": "^(?!({bangs})${'$'})(?=.*({bangs})(?=${'$'}|\\s)).+${'$'}"
+        }
+        """.trimIndent()
+
+        val SETTINGS_JSON_NO_BANGS = """
+        {
+            "aiChatBangRegex": "^(?!({bangs})${'$'})(?=.*({bangs})(?=${'$'}|\\s)).+${'$'}"
+        }
+        """.trimIndent()
+
+        val SETTINGS_JSON_NO_REGEX = """
+        {
+            "aiChatBangs": ["!ai", "!aichat", "!chat", "!duckai"],
         }
         """.trimIndent()
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1209440300063888/f

### Description

- Improves handling of Duck.ai bangs in order to prevent a blank screen upon launch.
- Bang regex and list of supported bangs is set in the config.

### Steps to test this PR
_Load the config linked in the task_

- [x] Check out this branch 
- [x] Type `bread recipe !ai`
- [x] Verify that Duck.ai is launched with “bread recipe” pre-filled
- [x] Go back
- [x] Verify that the screen is not blank
- [x] Type only `!ai`
- [x] Verify that SERP is loaded and not Duck.ai
- [x] Bonus: Try the other supported bangs: `!aichat`, `!chat`, `!duckai`

### UI changes
<table>
  <tr>
    <td align="center">
      <strong>Before</strong><br>
      <img src="https://github.com/user-attachments/assets/98dcd559-a19a-4dc4-94ce-2c4905543182" alt="Before Image" />
    </td>
    <td align="center">
      <strong>After</strong><br>
      <img src="https://github.com/user-attachments/assets/3f10d7d1-bb4b-4d43-a0a9-7005cec0967c" alt="After Image"/>
    </td>
  </tr>
</table>
