### PR TITLE
Update content scope scripts to version 8.13.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
@@ -49,6 +49,9 @@
   function registerMessageSecret(secret) {
     messageSecret = secret;
   }
+  function getGlobal() {
+    return globalObj;
+  }
   var exemptionLists = {};
   function shouldExemptUrl(type, url) {
     for (const regex of exemptionLists[type]) {
@@ -1719,7 +1722,7 @@
   };
 
   // src/trackers.js
-  function isTrackerOrigin(trackerLookup, originHostname = document.location.hostname) {
+  function isTrackerOrigin(trackerLookup, originHostname = getGlobal().document.location.hostname) {
     const parts = originHostname.split(".").reverse();
     let node = trackerLookup;
     for (const sub of parts) {

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -1573,6 +1573,9 @@
   function registerMessageSecret(secret) {
     messageSecret = secret;
   }
+  function getGlobal() {
+    return globalObj;
+  }
   var exemptionLists = {};
   var debug = false;
   function initStringExemptionLists(args) {
@@ -3093,7 +3096,7 @@
 
   // src/trackers.js
   init_define_import_meta_trackerLookup();
-  function isTrackerOrigin(trackerLookup, originHostname = document.location.hostname) {
+  function isTrackerOrigin(trackerLookup, originHostname = getGlobal().document.location.hostname) {
     const parts = originHostname.split(".").reverse();
     let node = trackerLookup;
     for (const sub of parts) {

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -885,6 +885,9 @@
     const style = createStyleElement(css);
     getInjectionElement().appendChild(style);
   }
+  function getGlobal() {
+    return globalObj;
+  }
   function nextRandom(v) {
     return Math.abs(v >> 1 | (v << 62 ^ v << 61) & ~(~0 << 63) << 62);
   }
@@ -3089,7 +3092,7 @@
 
   // src/trackers.js
   init_define_import_meta_trackerLookup();
-  function isTrackerOrigin(trackerLookup, originHostname = document.location.hostname) {
+  function isTrackerOrigin(trackerLookup, originHostname = getGlobal().document.location.hostname) {
     const parts = originHostname.split(".").reverse();
     let node = trackerLookup;
     for (const sub of parts) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^12.16.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.12.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.13.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.4.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1743747763"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#15523c9a752060fd139874b2033fab407210116c",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#d26d4a628cbd50dd765984de6feab44cff66f85f",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^12.16.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.0.1",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.12.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.13.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#8.4.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1743747763"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1209918883790892/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass