### PR TITLE
Remove FeatureExceptions.Store

### DIFF
--- a/anvil/anvil-annotations/src/main/java/com/duckduckgo/anvil/annotations/ContributesRemoteFeature.kt
+++ b/anvil/anvil-annotations/src/main/java/com/duckduckgo/anvil/annotations/ContributesRemoteFeature.kt
@@ -58,10 +58,6 @@ annotation class ContributesRemoteFeature(
     @Deprecated("Not needed anymore. Settings is now supported in top-level and sub-features and Toggle#getSettings returns it")
     val settingsStore: KClass<*> = Unit::class,
 
-    /** The class that implements the [FeatureExceptions.Store] interface */
-    @Deprecated("Not needed anymore. Exceptions is now supported in top-level and sub-features and Toggle#getExceptions returns it")
-    val exceptionsStore: KClass<*> = Unit::class,
-
     /** The class that implements the [Toggle.Store] interface */
     val toggleStore: KClass<*> = Unit::class,
 )

--- a/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesRemoteFeatureCodeGenerator.kt
+++ b/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesRemoteFeatureCodeGenerator.kt
@@ -1088,7 +1088,7 @@ class ContributesRemoteFeatureCodeGenerator : CodeGenerator {
         BOUND_TYPE,
         FEATURE_NAME,
         SETTINGS_STORE,
-        TOGGLE_STORE
+        TOGGLE_STORE,
     }
 
     private fun AnnotationReference.remoteFeatureStoreValueOrNull(): ClassReference? {

--- a/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesRemoteFeatureCodeGenerator.kt
+++ b/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesRemoteFeatureCodeGenerator.kt
@@ -152,27 +152,6 @@ class ContributesRemoteFeatureCodeGenerator : CodeGenerator {
                                     .build(),
                             )
                         }
-                        if (!customStorePresence.exceptionStorePresent) {
-                            addFunction(
-                                FunSpec.builder("providesNoopExceptionsStore")
-                                    .addAnnotation(Provides::class.asClassName())
-                                    .addAnnotation(
-                                        AnnotationSpec.builder(RemoteFeatureStoreNamed::class.asClassName())
-                                            .addMember("value = %T::class", boundType.asClassName())
-                                            .build(),
-                                    )
-                                    .addCode(
-                                        CodeBlock.of(
-                                            """
-                                                return %T.EMPTY_STORE
-                                            """.trimIndent(),
-                                            FeatureExceptions::class.asClassName(),
-                                        ),
-                                    )
-                                    .returns(FeatureExceptions.Store::class.asClassName())
-                                    .build(),
-                            )
-                        }
                         addFunction(
                             FunSpec.builder("provides${boundType.shortName}Inventory")
                                 .addAnnotation(Provides::class.asClassName())
@@ -267,20 +246,6 @@ class ContributesRemoteFeatureCodeGenerator : CodeGenerator {
                             .addParameter(
                                 ParameterSpec
                                     .builder(
-                                        "exceptionStore",
-                                        FeatureExceptions.Store::class,
-                                    )
-                                    .addAnnotation(
-                                        AnnotationSpec
-                                            .builder(RemoteFeatureStoreNamed::class).addMember("value = %T::class", boundType.asClassName())
-                                            .build(),
-
-                                    )
-                                    .build(),
-                            )
-                            .addParameter(
-                                ParameterSpec
-                                    .builder(
                                         "settingsStore",
                                         FeatureSettings.Store::class,
                                     )
@@ -296,16 +261,6 @@ class ContributesRemoteFeatureCodeGenerator : CodeGenerator {
                             .addParameter("appBuildConfig", appBuildConfig.asClassName(module))
                             .addParameter("variantManager", variantManager.asClassName(module))
                             .addParameter("context", context.asClassName(module))
-                            .build(),
-                    )
-                    .addProperty(
-                        PropertySpec
-                            .builder(
-                                "exceptionStore",
-                                FeatureExceptions.Store::class,
-                                KModifier.PRIVATE,
-                            )
-                            .initializer("exceptionStore")
                             .build(),
                     )
                     .addProperty(
@@ -400,18 +355,6 @@ class ContributesRemoteFeatureCodeGenerator : CodeGenerator {
                             .returns(FeatureSettings.Store::class.java.asClassName())
                             .build(),
                     )
-                    .addFunction(
-                        FunSpec.builder("bindOptionalExceptionsStore")
-                            .addModifiers(KModifier.ABSTRACT)
-                            .addAnnotation(BindsOptionalOf::class.asClassName())
-                            .addAnnotation(
-                                AnnotationSpec.builder(RemoteFeatureStoreNamed::class.asClassName())
-                                    .addMember("value = %T::class", boundType.asClassName())
-                                    .build(),
-                            )
-                            .returns(FeatureExceptions.Store::class.java.asClassName())
-                            .build(),
-                    )
                     .build(),
             )
         }
@@ -487,8 +430,6 @@ class ContributesRemoteFeatureCodeGenerator : CodeGenerator {
                     }
         
                     val exceptions = parseExceptions(feature.exceptions)
-                    // TODO: Remove once migrating everything to getExceptions()
-                    exceptionStore.insertAll(exceptions)
         
                     val isEnabled = (feature.state == "enabled") || (appBuildConfig.flavor == %T && feature.state == "internal")
                     this.feature.get().invokeMethod("self").setRawStoredState(
@@ -1025,7 +966,6 @@ class ContributesRemoteFeatureCodeGenerator : CodeGenerator {
             }
         }
 
-        var exceptionStore = false
         var settingsStore = false
         var toggleStore = false
 
@@ -1077,20 +1017,6 @@ class ContributesRemoteFeatureCodeGenerator : CodeGenerator {
                     )
                 }
 
-                requireFeatureAndStoreCrossReference(vmClass, this)
-            }
-        }
-        with(annotation.exceptionsStoreOrNull()) {
-            exceptionStore = this != null
-            if (this != null) {
-                if (this.directSuperTypeReferences()
-                    .none { it.asClassReferenceOrNull()?.fqName == FeatureExceptions.Store::class.fqName }
-                ) {
-                    throw AnvilCompilationException(
-                        "${vmClass.fqName} [exceptionsStore] must extend [FeatureExceptions.Store]",
-                        element = vmClass.clazz.identifyingElement,
-                    )
-                }
                 requireFeatureAndStoreCrossReference(vmClass, this)
             }
         }
@@ -1152,30 +1078,33 @@ class ContributesRemoteFeatureCodeGenerator : CodeGenerator {
         }
 
         return CustomStorePresence(
-            exceptionStorePresent = exceptionStore,
             toggleStorePresent = toggleStore,
             settingsStorePresent = settingsStore,
         )
     }
 
+    private enum class ContributesRemoteFeatureValues {
+        SCOPE,
+        BOUND_TYPE,
+        FEATURE_NAME,
+        SETTINGS_STORE,
+        TOGGLE_STORE
+    }
+
     private fun AnnotationReference.remoteFeatureStoreValueOrNull(): ClassReference? {
-        return argumentAt("value", 0)?.value()
+        return argumentAt("value", ContributesRemoteFeatureValues.SCOPE.ordinal)?.value()
     }
 
     private fun AnnotationReference.featureNameOrNull(): String? {
-        return argumentAt("featureName", 2)?.value()
+        return argumentAt("featureName", ContributesRemoteFeatureValues.FEATURE_NAME.ordinal)?.value()
     }
 
     private fun AnnotationReference.settingsStoreOrNull(): ClassReference? {
-        return argumentAt("settingsStore", 3)?.value()
-    }
-
-    private fun AnnotationReference.exceptionsStoreOrNull(): ClassReference? {
-        return argumentAt("exceptionsStore", 4)?.value()
+        return argumentAt("settingsStore", ContributesRemoteFeatureValues.SETTINGS_STORE.ordinal)?.value()
     }
 
     private fun AnnotationReference.toggleStoreOrNull(): ClassReference? {
-        return argumentAt("toggleStore", 5)?.value()
+        return argumentAt("toggleStore", ContributesRemoteFeatureValues.TOGGLE_STORE.ordinal)?.value()
     }
 
     private fun ClassReference.declaredFunctions(): List<MemberFunctionReference> {
@@ -1208,6 +1137,5 @@ class ContributesRemoteFeatureCodeGenerator : CodeGenerator {
 
 private data class CustomStorePresence(
     val settingsStorePresent: Boolean = false,
-    val exceptionStorePresent: Boolean = false,
     val toggleStorePresent: Boolean = false,
 )

--- a/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesRemoteFeatureCodeGenerator.kt
+++ b/anvil/anvil-compiler/src/main/java/com/duckduckgo/anvil/compiler/ContributesRemoteFeatureCodeGenerator.kt
@@ -597,11 +597,11 @@ class ContributesRemoteFeatureCodeGenerator : CodeGenerator {
                             }
                             return featureExceptions.toList()
                         """.trimIndent(),
-                        FeatureExceptions.FeatureException::class.fqName.asClassName(module),
-                        FeatureExceptions.FeatureException::class.fqName.asClassName(module),
+                        FeatureException::class.fqName.asClassName(module),
+                        FeatureException::class.fqName.asClassName(module),
                     ).build(),
             )
-            .returns(List::class.asClassName().parameterizedBy(FeatureExceptions.FeatureException::class.asClassName()))
+            .returns(List::class.asClassName().parameterizedBy(FeatureException::class.asClassName()))
             .build()
     }
 

--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/FirstPartyCookiesReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/FirstPartyCookiesReferenceTest.kt
@@ -37,7 +37,7 @@ import com.duckduckgo.cookies.store.CookieExceptionEntity
 import com.duckduckgo.cookies.store.CookiesRepository
 import com.duckduckgo.cookies.store.FirstPartyCookiePolicyEntity
 import com.duckduckgo.cookies.store.toFeatureException
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.privacy.config.impl.models.JsonPrivacyConfig
 import com.duckduckgo.privacy.config.impl.network.JSONObjectAdapter

--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/HttpsReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/HttpsReferenceTest.kt
@@ -27,7 +27,7 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.test.FileUtilities
 import com.duckduckgo.common.utils.isHttps
 import com.duckduckgo.common.utils.store.BinaryDataStore
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.httpsupgrade.api.HttpsEmbeddedDataPersister
 import com.duckduckgo.httpsupgrade.api.HttpsUpgrader

--- a/app/src/androidTest/java/com/duckduckgo/cookies/impl/features/firstparty/RealFirstPartyCookiesModifierTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/cookies/impl/features/firstparty/RealFirstPartyCookiesModifierTest.kt
@@ -29,7 +29,7 @@ import com.duckduckgo.common.utils.DefaultDispatcherProvider
 import com.duckduckgo.cookies.impl.SQLCookieRemover
 import com.duckduckgo.cookies.store.CookiesRepository
 import com.duckduckgo.cookies.store.FirstPartyCookiePolicyEntity
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import java.time.Instant
 import java.time.ZoneOffset

--- a/app/src/main/java/com/duckduckgo/app/browser/mediaplayback/store/MediaPlaybackRepository.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/mediaplayback/store/MediaPlaybackRepository.kt
@@ -21,7 +21,7 @@ import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.di.IsMainProcess
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.feature.toggles.api.FeatureExceptions
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -32,7 +32,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 interface MediaPlaybackRepository {
-    val exceptions: CopyOnWriteArrayList<FeatureExceptions.FeatureException>
+    val exceptions: CopyOnWriteArrayList<FeatureException>
 }
 
 @ContributesBinding(
@@ -51,7 +51,7 @@ class RealMediaPlaybackRepository @Inject constructor(
     @IsMainProcess private val isMainProcess: Boolean,
 ) : MediaPlaybackRepository, PrivacyConfigCallbackPlugin {
 
-    override val exceptions = CopyOnWriteArrayList<FeatureExceptions.FeatureException>()
+    override val exceptions = CopyOnWriteArrayList<FeatureException>()
 
     init {
         loadToMemory()

--- a/app/src/test/java/com/duckduckgo/app/browser/mediaplayback/store/RealMediaPlaybackRepositoryTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/mediaplayback/store/RealMediaPlaybackRepositoryTest.kt
@@ -3,7 +3,7 @@ package com.duckduckgo.app.browser.mediaplayback.store
 import com.duckduckgo.app.browser.mediaplayback.MediaPlaybackFeature
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.feature.toggles.api.Toggle
 import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.test.TestScope

--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/remoteconfig/AutoconsentExceptionsRepository.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/remoteconfig/AutoconsentExceptionsRepository.kt
@@ -20,7 +20,7 @@ import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.di.IsMainProcess
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding

--- a/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/Fakes.kt
+++ b/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/Fakes.kt
@@ -24,7 +24,7 @@ import com.duckduckgo.autoconsent.api.AutoconsentCallback
 import com.duckduckgo.autoconsent.impl.store.AutoconsentSettingsRepository
 import com.duckduckgo.common.utils.domain
 import com.duckduckgo.common.utils.plugins.PluginPoint
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf

--- a/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/RealAutoconsentTest.kt
+++ b/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/RealAutoconsentTest.kt
@@ -21,7 +21,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.autoconsent.impl.remoteconfig.AutoconsentExceptionsRepository
 import com.duckduckgo.autoconsent.impl.remoteconfig.AutoconsentFeature
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.feature.toggles.api.Toggle
 import java.util.concurrent.CopyOnWriteArrayList
 import org.junit.Assert.*

--- a/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/remoteconfig/RealAutoconsentExceptionsRepositoryTest.kt
+++ b/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/remoteconfig/RealAutoconsentExceptionsRepositoryTest.kt
@@ -19,7 +19,7 @@ package com.duckduckgo.autoconsent.impl.remoteconfig
 import android.annotation.SuppressLint
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.feature.toggles.api.Toggle
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/feature/plugin/AutofillFeatureRepository.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/feature/plugin/AutofillFeatureRepository.kt
@@ -21,7 +21,7 @@ import com.duckduckgo.app.di.IsMainProcess
 import com.duckduckgo.autofill.api.AutofillFeature
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/RealAutofillTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/RealAutofillTest.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.autofill.impl
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.autofill.impl.feature.plugin.AutofillFeatureRepository
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import java.util.concurrent.CopyOnWriteArrayList
 import org.junit.Assert.*

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/email/remoteconfig/RealEmailProtectionInContextFeatureRepositoryTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/email/remoteconfig/RealEmailProtectionInContextFeatureRepositoryTest.kt
@@ -4,7 +4,7 @@ import android.annotation.SuppressLint
 import com.duckduckgo.autofill.impl.email.incontext.EmailProtectionInContextSignupFeature
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.feature.toggles.api.Toggle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/feature/plugin/RealAutofillFeatureRepositoryTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/feature/plugin/RealAutofillFeatureRepositoryTest.kt
@@ -4,7 +4,7 @@ import android.annotation.SuppressLint
 import com.duckduckgo.autofill.api.AutofillFeature
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.feature.toggles.api.Toggle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/reporting/remoteconfig/AutofillSiteBreakageReportingFeatureRepositoryImplTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/reporting/remoteconfig/AutofillSiteBreakageReportingFeatureRepositoryImplTest.kt
@@ -3,7 +3,7 @@ package com.duckduckgo.autofill.impl.reporting.remoteconfig
 import android.annotation.SuppressLint
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.feature.toggles.api.Toggle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/store/RealAutofillServiceFeatureRepositoryTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/store/RealAutofillServiceFeatureRepositoryTest.kt
@@ -21,7 +21,7 @@ import com.duckduckgo.autofill.impl.service.AutofillServiceFeature
 import com.duckduckgo.autofill.impl.service.store.RealAutofillServiceFeatureRepository
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.feature.toggles.api.Toggle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScripts.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScripts.kt
@@ -22,7 +22,7 @@ import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.contentscopescripts.api.ContentScopeConfigPlugin
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.fingerprintprotection.api.FingerprintProtectionManager
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.squareup.anvil.annotations.ContributesBinding

--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScriptsTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScriptsTest.kt
@@ -22,7 +22,7 @@ import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.contentscopescripts.api.ContentScopeConfigPlugin
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.fingerprintprotection.api.FingerprintProtectionManager
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary

--- a/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/features/CookiesFeature.kt
+++ b/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/features/CookiesFeature.kt
@@ -16,7 +16,7 @@
 
 package com.duckduckgo.cookies.impl.features
 
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 
 data class CookiesFeature(
     val state: String,

--- a/cookies/cookies-store/src/main/java/com/duckduckgo/cookies/store/CookiesDatabaseModels.kt
+++ b/cookies/cookies-store/src/main/java/com/duckduckgo/cookies/store/CookiesDatabaseModels.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.cookies.store
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 
 @Entity(tableName = "first_party_cookie_policy")
 data class FirstPartyCookiePolicyEntity(

--- a/cookies/cookies-store/src/main/java/com/duckduckgo/cookies/store/CookiesRepository.kt
+++ b/cookies/cookies-store/src/main/java/com/duckduckgo/cookies/store/CookiesRepository.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.cookies.store
 
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.cookies.store.thirdpartycookienames.ThirdPartyCookieNamesDao
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch

--- a/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureException.kt
+++ b/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureException.kt
@@ -15,6 +15,4 @@
  */
 package com.duckduckgo.feature.toggles.api
 
-object FeatureExceptions {
-    data class FeatureException(val domain: String, val reason: String?)
-}
+data class FeatureException(val domain: String, val reason: String?)

--- a/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureExceptions.kt
+++ b/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureExceptions.kt
@@ -16,13 +16,5 @@
 package com.duckduckgo.feature.toggles.api
 
 object FeatureExceptions {
-    interface Store {
-        fun insertAll(exception: List<FeatureException>)
-    }
-
     data class FeatureException(val domain: String, val reason: String?)
-
-    val EMPTY_STORE = object : Store {
-        override fun insertAll(exception: List<FeatureException>) {}
-    }
 }

--- a/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureToggles.kt
+++ b/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureToggles.kt
@@ -16,7 +16,6 @@
 
 package com.duckduckgo.feature.toggles.api
 
-import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.feature.toggles.api.Toggle.FeatureName
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.feature.toggles.api.Toggle.State.Cohort

--- a/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureToggles.kt
+++ b/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureToggles.kt
@@ -16,7 +16,7 @@
 
 package com.duckduckgo.feature.toggles.api
 
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.feature.toggles.api.Toggle.FeatureName
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.feature.toggles.api.Toggle.State.Cohort

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorBucketAssignmentTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorBucketAssignmentTest.kt
@@ -22,7 +22,6 @@ import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.appbuildconfig.api.BuildFlavor.PLAY
 import com.duckduckgo.experiments.api.VariantManager
 import com.duckduckgo.feature.toggles.api.FakeToggleStore
-import com.duckduckgo.feature.toggles.api.FeatureExceptions
 import com.duckduckgo.feature.toggles.api.FeatureSettings
 import com.duckduckgo.feature.toggles.api.FeatureToggles
 import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorBucketAssignmentTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorBucketAssignmentTest.kt
@@ -125,14 +125,12 @@ class ContributesRemoteFeatureCodeGeneratorBucketAssignmentTest(private val test
         return Class
             .forName("com.duckduckgo.feature.toggles.codegen.TestTriggerFeature_RemoteFeature")
             .getConstructor(
-                FeatureExceptions.Store::class.java,
                 FeatureSettings.Store::class.java,
                 dagger.Lazy::class.java as Class<*>,
                 AppBuildConfig::class.java,
                 VariantManager::class.java,
                 Context::class.java,
             ).newInstance(
-                FeatureExceptions.EMPTY_STORE,
                 FeatureSettings.EMPTY_STORE,
                 Lazy { testFeature },
                 appBuildConfig,

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt
@@ -24,8 +24,8 @@ import com.duckduckgo.appbuildconfig.api.BuildFlavor.*
 import com.duckduckgo.experiments.api.VariantConfig
 import com.duckduckgo.experiments.api.VariantManager
 import com.duckduckgo.feature.toggles.api.FakeToggleStore
-import com.duckduckgo.feature.toggles.api.FeatureExceptions
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.feature.toggles.api.FeatureSettings
 import com.duckduckgo.feature.toggles.api.FeatureToggles
 import com.duckduckgo.feature.toggles.api.RemoteFeatureStoreNamed

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt
@@ -25,7 +25,6 @@ import com.duckduckgo.experiments.api.VariantConfig
 import com.duckduckgo.experiments.api.VariantManager
 import com.duckduckgo.feature.toggles.api.FakeToggleStore
 import com.duckduckgo.feature.toggles.api.FeatureException
-import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.feature.toggles.api.FeatureSettings
 import com.duckduckgo.feature.toggles.api.FeatureToggles
 import com.duckduckgo.feature.toggles.api.RemoteFeatureStoreNamed

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt
@@ -321,14 +321,12 @@ class ContributesRemoteFeatureCodeGeneratorTest {
             return Class
                 .forName("com.duckduckgo.feature.toggles.codegen.AnotherTestTriggerFeature_RemoteFeature")
                 .getConstructor(
-                    FeatureExceptions.Store::class.java,
                     FeatureSettings.Store::class.java,
                     dagger.Lazy::class.java as Class<*>,
                     AppBuildConfig::class.java,
                     VariantManager::class.java,
                     Context::class.java,
                 ).newInstance(
-                    FeatureExceptions.EMPTY_STORE,
                     FeatureSettings.EMPTY_STORE,
                     Lazy { anotherTestFeature },
                     appBuildConfig,
@@ -4206,14 +4204,12 @@ class ContributesRemoteFeatureCodeGeneratorTest {
         return Class
             .forName("com.duckduckgo.feature.toggles.codegen.TestTriggerFeature_RemoteFeature")
             .getConstructor(
-                FeatureExceptions.Store::class.java,
                 FeatureSettings.Store::class.java,
                 dagger.Lazy::class.java as Class<*>,
                 AppBuildConfig::class.java,
                 VariantManager::class.java,
                 Context::class.java,
             ).newInstance(
-                FeatureExceptions.EMPTY_STORE,
                 FeatureSettings.EMPTY_STORE,
                 Lazy { testFeature },
                 appBuildConfig,

--- a/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/remoteconfig/MaliciousSiteProtectionRCRepository.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/remoteconfig/MaliciousSiteProtectionRCRepository.kt
@@ -20,7 +20,7 @@ import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.di.IsMainProcess
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.malicioussiteprotection.impl.MaliciousSiteProtectionFeature
 import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
 import com.squareup.anvil.annotations.ContributesBinding

--- a/malicious-site-protection/malicious-site-protection-impl/src/test/kotlin/com/duckduckgo/malicioussiteprotection/impl/remoteconfig/RealMaliciousSiteProtectionRCRepositoryTest.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/test/kotlin/com/duckduckgo/malicioussiteprotection/impl/remoteconfig/RealMaliciousSiteProtectionRCRepositoryTest.kt
@@ -3,7 +3,7 @@ package com.duckduckgo.malicioussiteprotection.impl.remoteconfig
 import android.annotation.SuppressLint
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.malicioussiteprotection.impl.MaliciousSiteProtectionFeature
 import kotlinx.coroutines.test.runTest

--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/UnprotectedTemporary.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/UnprotectedTemporary.kt
@@ -16,7 +16,7 @@
 
 package com.duckduckgo.privacy.config.api
 
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 
 /** Public interface for the Unprotected Temporary feature */
 interface UnprotectedTemporary {

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/amplinks/AmpLinksFeature.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/amplinks/AmpLinksFeature.kt
@@ -16,7 +16,7 @@
 
 package com.duckduckgo.privacy.config.impl.features.amplinks
 
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 
 data class AmpLinksFeature(
     val state: String,

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/contentblocking/ContentBlockingFeature.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/contentblocking/ContentBlockingFeature.kt
@@ -16,7 +16,7 @@
 
 package com.duckduckgo.privacy.config.impl.features.contentblocking
 
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 
 data class ContentBlockingFeature(
     val state: String,

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/drm/DrmFeature.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/drm/DrmFeature.kt
@@ -16,7 +16,7 @@
 
 package com.duckduckgo.privacy.config.impl.features.drm
 
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 
 data class DrmFeature(
     val state: String,

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/https/HttpsFeature.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/https/HttpsFeature.kt
@@ -16,7 +16,7 @@
 
 package com.duckduckgo.privacy.config.impl.features.https
 
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 
 data class HttpsFeature(
     val state: String,

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/trackingparameters/TrackingParametersFeature.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/trackingparameters/TrackingParametersFeature.kt
@@ -16,7 +16,7 @@
 
 package com.duckduckgo.privacy.config.impl.features.trackingparameters
 
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 
 data class TrackingParametersFeature(
     val state: String,

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/unprotectedtemporary/RealUnprotectedTemporary.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/unprotectedtemporary/RealUnprotectedTemporary.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.privacy.config.impl.features.unprotectedtemporary
 
 import com.duckduckgo.app.browser.UriString
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.UnprotectedTemporaryRepository
 import com.squareup.anvil.annotations.ContributesBinding

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/models/JsonPrivacyConfig.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/models/JsonPrivacyConfig.kt
@@ -16,7 +16,7 @@
 
 package com.duckduckgo.privacy.config.impl.models
 
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import org.json.JSONObject
 
 data class JsonPrivacyConfig(

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/RealPrivacyConfigDownloaderTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/RealPrivacyConfigDownloaderTest.kt
@@ -19,7 +19,7 @@ package com.duckduckgo.privacy.config.impl
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.test.CoroutineTestRule
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.privacy.config.impl.PrivacyConfigDownloader.ConfigDownloadResult.Error
 import com.duckduckgo.privacy.config.impl.PrivacyConfigDownloader.ConfigDownloadResult.Success
 import com.duckduckgo.privacy.config.impl.RealPrivacyConfigPersisterTest.FakeFakePrivacyConfigCallbackPluginPoint

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/RealPrivacyConfigPersisterTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/RealPrivacyConfigPersisterTest.kt
@@ -23,7 +23,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.test.api.InMemorySharedPreferences
 import com.duckduckgo.common.utils.plugins.PluginPoint
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.api.PrivacyFeaturePlugin

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/contentblocking/RealContentBlockingTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/contentblocking/RealContentBlockingTest.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.privacy.config.impl.features.contentblocking
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/drm/RealDrmTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/drm/RealDrmTest.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.privacy.config.impl.features.drm
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/https/RealHttpsTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/https/RealHttpsTest.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.privacy.config.impl.features.https
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.privacy.config.store.features.https.HttpsRepository
 import java.util.concurrent.CopyOnWriteArrayList

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/trackingparameters/RealTrackingParametersTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/trackingparameters/RealTrackingParametersTest.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.privacy.config.impl.features.trackingparameters
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/unprotectedtemporary/RealUnprotectedTemporaryTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/features/unprotectedtemporary/RealUnprotectedTemporaryTest.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.privacy.config.impl.features.unprotectedtemporary
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.privacy.config.store.features.unprotectedtemporary.UnprotectedTemporaryRepository
 import java.util.concurrent.CopyOnWriteArrayList
 import org.junit.Assert.*

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/amplinks/AmpFormatReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/amplinks/AmpFormatReferenceTest.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.privacy.config.impl.referencetests.amplinks
 
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.common.test.FileUtilities
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.AmpLinkType
 import com.duckduckgo.privacy.config.api.AmpLinks

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/amplinks/AmpKeywordReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/amplinks/AmpKeywordReferenceTest.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.privacy.config.impl.referencetests.amplinks
 
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.common.test.FileUtilities
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.AmpLinks
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName

--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/trackingparameters/TrackingParameterReferenceTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/referencetests/trackingparameters/TrackingParameterReferenceTest.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.privacy.config.impl.referencetests.trackingparameters
 
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.common.test.FileUtilities
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
 import com.duckduckgo.privacy.config.api.TrackingParameters

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabaseModels.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/PrivacyConfigDatabaseModels.kt
@@ -19,7 +19,7 @@ package com.duckduckgo.privacy.config.store
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import androidx.room.TypeConverter
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.privacy.config.api.GpcException
 import com.duckduckgo.privacy.config.api.GpcHeaderEnabledSite
 import com.duckduckgo.privacy.config.api.PrivacyConfigData

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/amplinks/AmpLinksRepository.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/amplinks/AmpLinksRepository.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.privacy.config.store.features.amplinks
 
 import com.duckduckgo.common.utils.DispatcherProvider
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.privacy.config.store.*
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlinx.coroutines.CoroutineScope

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/contentblocking/ContentBlockingRepository.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/contentblocking/ContentBlockingRepository.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.privacy.config.store.features.contentblocking
 
 import com.duckduckgo.common.utils.DispatcherProvider
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.privacy.config.store.ContentBlockingExceptionEntity
 import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
 import com.duckduckgo.privacy.config.store.toFeatureException

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/drm/DrmRepository.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/drm/DrmRepository.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.privacy.config.store.features.drm
 
 import com.duckduckgo.common.utils.DispatcherProvider
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.privacy.config.store.DrmExceptionEntity
 import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
 import com.duckduckgo.privacy.config.store.toFeatureException

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/https/HttpsRepository.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/https/HttpsRepository.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.privacy.config.store.features.https
 
 import com.duckduckgo.common.utils.DispatcherProvider
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.privacy.config.store.HttpsExceptionEntity
 import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
 import com.duckduckgo.privacy.config.store.toFeatureException

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/trackingparameters/TrackingParametersRepository.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/trackingparameters/TrackingParametersRepository.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.privacy.config.store.features.trackingparameters
 
 import com.duckduckgo.common.utils.DispatcherProvider
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.privacy.config.store.*
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlinx.coroutines.CoroutineScope

--- a/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/unprotectedtemporary/UnprotectedTemporaryRepository.kt
+++ b/privacy-config/privacy-config-store/src/main/java/com/duckduckgo/privacy/config/store/features/unprotectedtemporary/UnprotectedTemporaryRepository.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.privacy.config.store.features.unprotectedtemporary
 
 import com.duckduckgo.common.utils.DispatcherProvider
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.privacy.config.store.PrivacyConfigDatabase
 import com.duckduckgo.privacy.config.store.UnprotectedTemporaryEntity
 import com.duckduckgo.privacy.config.store.toFeatureException

--- a/request-filterer/request-filterer-impl/src/main/java/com/duckduckgo/request/filterer/impl/RequestFiltererFeature.kt
+++ b/request-filterer/request-filterer-impl/src/main/java/com/duckduckgo/request/filterer/impl/RequestFiltererFeature.kt
@@ -16,7 +16,7 @@
 
 package com.duckduckgo.request.filterer.impl
 
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 
 data class RequestFiltererFeature(
     val state: String,

--- a/request-filterer/request-filterer-impl/src/test/java/com/duckduckgo/request/filterer/impl/RequestFiltererImplTest.kt
+++ b/request-filterer/request-filterer-impl/src/test/java/com/duckduckgo/request/filterer/impl/RequestFiltererImplTest.kt
@@ -19,7 +19,7 @@ package com.duckduckgo.request.filterer.impl
 import android.webkit.WebResourceRequest
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.common.test.CoroutineTestRule
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.request.filterer.api.RequestFiltererFeatureName

--- a/request-filterer/request-filterer-store/src/main/java/com/duckduckgo/request/filterer/store/RequestFiltererDatabaseModels.kt
+++ b/request-filterer/request-filterer-store/src/main/java/com/duckduckgo/request/filterer/store/RequestFiltererDatabaseModels.kt
@@ -19,7 +19,7 @@ package com.duckduckgo.request.filterer.store
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 
 @Entity(tableName = "settings_entity")
 data class SettingsEntity(

--- a/request-filterer/request-filterer-store/src/main/java/com/duckduckgo/request/filterer/store/RequestFiltererRepository.kt
+++ b/request-filterer/request-filterer-store/src/main/java/com/duckduckgo/request/filterer/store/RequestFiltererRepository.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.request.filterer.store
 
 import com.duckduckgo.common.utils.DispatcherProvider
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch

--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/drmblock/DrmBlockRepository.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/drmblock/DrmBlockRepository.kt
@@ -20,7 +20,7 @@ import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.di.IsMainProcess
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding

--- a/site-permissions/site-permissions-impl/src/test/java/com/duckduckgo/site/permissions/impl/drmblock/RealDrmBlockRepositoryTest.kt
+++ b/site-permissions/site-permissions-impl/src/test/java/com/duckduckgo/site/permissions/impl/drmblock/RealDrmBlockRepositoryTest.kt
@@ -3,7 +3,7 @@ package com.duckduckgo.site.permissions.impl.drmblock
 import android.annotation.SuppressLint
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.feature.toggles.api.Toggle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals

--- a/site-permissions/site-permissions-impl/src/test/java/com/duckduckgo/site/permissions/impl/drmblock/RealDrmBlockTest.kt
+++ b/site-permissions/site-permissions-impl/src/test/java/com/duckduckgo/site/permissions/impl/drmblock/RealDrmBlockTest.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.site.permissions.impl.drmblock
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.nhaarman.mockitokotlin2.any

--- a/user-agent/user-agent-impl/src/main/java/com/duckduckgo/user/agent/impl/UserAgentFeature.kt
+++ b/user-agent/user-agent-impl/src/main/java/com/duckduckgo/user/agent/impl/UserAgentFeature.kt
@@ -16,7 +16,7 @@
 
 package com.duckduckgo.user.agent.impl
 
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 
 data class UserAgentFeature(
     val state: String,

--- a/user-agent/user-agent-impl/src/test/java/com/duckduckgo/user/agent/impl/RealUserAgentTest.kt
+++ b/user-agent/user-agent-impl/src/test/java/com/duckduckgo/user/agent/impl/RealUserAgentTest.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.user.agent.impl
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.user.agent.store.UserAgentRepository
 import java.util.concurrent.CopyOnWriteArrayList

--- a/user-agent/user-agent-store/src/main/java/com/duckduckgo/user/agent/store/UserAgentDatabaseModels.kt
+++ b/user-agent/user-agent-store/src/main/java/com/duckduckgo/user/agent/store/UserAgentDatabaseModels.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.user.agent.store
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 
 @Entity(tableName = "user_agent_exceptions")
 data class UserAgentExceptionEntity(

--- a/user-agent/user-agent-store/src/main/java/com/duckduckgo/user/agent/store/UserAgentRepository.kt
+++ b/user-agent/user-agent-store/src/main/java/com/duckduckgo/user/agent/store/UserAgentRepository.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.user.agent.store
 
 import com.duckduckgo.common.utils.DispatcherProvider
-import com.duckduckgo.feature.toggles.api.FeatureExceptions.FeatureException
+import com.duckduckgo.feature.toggles.api.FeatureException
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch


### PR DESCRIPTION
Task/Issue URL: 

### Description
Stacked onto https://github.com/duckduckgo/Android/pull/5877. Use this one for testing.


FeatureExceptions.Store interface as it's no longer necessary after adding getExceptions()
We'll need to remove the following classes
* AutoconsentExceptionsStore
* AutofillServiceExceptionsStore
* MediaPlaybackStore
* DrmBlockFeatureExceptionStore
* MaliciousSiteProtectionExceptionsStore
* AutofillSiteBreakageReportingExceptionsPersister
* AutofillFeatureExceptionStore
* EmailProtectionInContextRemoteExceptionsPersister

We'll need to refactor repositories associated to classes above

### Steps to test this PR
Smoke test all features related to the stores above
