### PR TITLE
Fix: Tap swiping after changing tabs not working

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -967,9 +967,7 @@ class BrowserTabFragment :
     private fun configureEditModeChangeDetection() {
         if (swipingTabsFeature.isEnabled) {
             omnibar.isInEditMode.onEach { isInEditMode ->
-                if (isActiveTab) {
-                    browserActivity?.onEditModeChanged(isInEditMode)
-                }
+                browserActivity?.onEditModeChanged(isInEditMode)
             }.launchIn(lifecycleScope)
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
@@ -64,6 +64,7 @@ import com.duckduckgo.common.utils.extractDomain
 import com.duckduckgo.common.utils.text.TextChangedWatcher
 import com.google.android.material.appbar.AppBarLayout.GONE
 import com.google.android.material.appbar.AppBarLayout.VISIBLE
+import kotlinx.coroutines.flow.distinctUntilChanged
 import timber.log.Timber
 
 @SuppressLint("ClickableViewAccessibility")
@@ -230,7 +231,7 @@ class Omnibar(
         newOmnibar.omnibarTextInput.rootView
     }
 
-    val isInEditMode = newOmnibar.isEditingFlow
+    val isInEditMode = newOmnibar.isEditingFlow.distinctUntilChanged()
 
     var isScrollingEnabled: Boolean
         get() =


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1202552961248957/1209940913386671/f

### Description

This PR fixes a bug when tab swiping is not working after switching tabs from NTP to a regular website.

### Steps to test this PR

- [ ] Enable tab swiping
- [ ] Prepare 2 tabs -> 1 NTP and 1 with a loaded website
- [ ] Start with a regular website tab and wipe to NTP
- [ ] Notice the swiping is disabled when the address bar is in focus
- [ ] Tap on the tab manager button to open it
- [ ] Select the regular website tab
- [ ] Verify that swiping works again on the website tab

