### PR TITLE
Onboarding: Auto complete temporary pixel

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -591,6 +591,7 @@ class BrowserTabViewModelTest {
         whenever(mockAutocompleteTabsFeature.self().isEnabled()).thenReturn(true)
         whenever(mockSitePermissionsManager.hasSitePermanentPermission(any(), any())).thenReturn(false)
         whenever(mockToggleReports.shouldPrompt()).thenReturn(false)
+        whenever(subscriptions.isEligible()).thenReturn(false)
 
         remoteMessagingModel = givenRemoteMessagingModel(mockRemoteMessagingRepository, mockPixel, coroutineRule.testDispatcherProvider)
 
@@ -607,7 +608,7 @@ class BrowserTabViewModelTest {
             dispatchers = coroutineRule.testDispatcherProvider,
             duckDuckGoUrlDetector = DuckDuckGoUrlDetectorImpl(),
             extendedOnboardingFeatureToggles = mockExtendedOnboardingFeatureToggles,
-            subscriptions = mock(),
+            subscriptions = subscriptions,
             duckPlayer = mockDuckPlayer,
             brokenSitePrompt = mockBrokenSitePrompt,
             userBrowserProperties = mockUserBrowserProperties,

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -2527,7 +2527,7 @@ class BrowserTabViewModelTest {
         whenever(mockDismissedCtaDao.exists(DAX_DIALOG_TRACKERS_FOUND)).thenReturn(true)
         testee.refreshCta()
         assertNull(testee.ctaViewState.value!!.cta)
-        assertTrue(testee.ctaViewState.value!!.daxOnboardingComplete)
+        assertTrue(testee.ctaViewState.value!!.isOnboardingCompleteInNewTabPage)
         assertFalse(testee.ctaViewState.value!!.isBrowserShowing)
     }
 
@@ -2541,7 +2541,7 @@ class BrowserTabViewModelTest {
         whenever(mockDismissedCtaDao.exists(DAX_DIALOG_NETWORK)).thenReturn(true)
         testee.refreshCta()
         assertNull(testee.ctaViewState.value!!.cta)
-        assertTrue(testee.ctaViewState.value!!.daxOnboardingComplete)
+        assertTrue(testee.ctaViewState.value!!.isOnboardingCompleteInNewTabPage)
         assertTrue(testee.ctaViewState.value!!.isBrowserShowing)
     }
 

--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -812,6 +812,73 @@ class CtaViewModelTest {
         assertNull(value)
     }
 
+    @Test
+    fun givenPrivacyProEligibleWhenRefreshCtaIfNotAllRequiredCtasShownThenNotCompleteOnboarding() = runTest {
+        givenDaxOnboardingActive()
+        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockEnabledToggle)
+        whenever(mockExtendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockEnabledToggle)
+        whenever(mockSubscriptions.isEligible()).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_DIALOG_SERP)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO_VISIT_SITE)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_END)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO_PRIVACY_PRO)).thenReturn(false)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_DIALOG_TRACKERS_FOUND)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.ADD_WIDGET)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_FIRE_BUTTON)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_FIRE_BUTTON_PULSE)).thenReturn(true)
+
+        testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false)
+
+        verify(mockPixel, never()).fire(ONBOARDING_AUTO_COMPLETE)
+        verify(mockUserStageStore, never()).stageCompleted(AppStage.DAX_ONBOARDING)
+    }
+
+    @Test
+    fun givenPrivacyProEligibleWhenRefreshCtaIfOnboardingActiveAndAllRequiredCtasShownThenCompleteOnboardingAndSendAutoCompletePixel() = runTest {
+        givenDaxOnboardingActive()
+        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockEnabledToggle)
+        whenever(mockExtendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockEnabledToggle)
+        whenever(mockSubscriptions.isEligible()).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_DIALOG_SERP)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO_VISIT_SITE)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_END)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO_PRIVACY_PRO)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_DIALOG_TRACKERS_FOUND)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.ADD_WIDGET)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_FIRE_BUTTON)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_FIRE_BUTTON_PULSE)).thenReturn(true)
+
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false)
+        assertNull(value)
+
+        verify(mockPixel).fire(ONBOARDING_AUTO_COMPLETE)
+        verify(mockUserStageStore).stageCompleted(AppStage.DAX_ONBOARDING)
+    }
+
+    @Test
+    fun givenPrivacyProNotEligibleWhenRefreshCtaIfOnboardingActiveAndAllRequiredCtasShownThenCompleteOnboardingAndSendAutoCompletePixel() = runTest {
+        givenDaxOnboardingActive()
+        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockEnabledToggle)
+        whenever(mockExtendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockEnabledToggle)
+        whenever(mockSubscriptions.isEligible()).thenReturn(false)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_DIALOG_SERP)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO_VISIT_SITE)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_END)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_DIALOG_TRACKERS_FOUND)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.ADD_WIDGET)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_FIRE_BUTTON)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_FIRE_BUTTON_PULSE)).thenReturn(true)
+
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false)
+        assertNull(value)
+
+        verify(mockPixel).fire(ONBOARDING_AUTO_COMPLETE)
+        verify(mockUserStageStore).stageCompleted(AppStage.DAX_ONBOARDING)
+    }
+
     private suspend fun givenDaxOnboardingActive() {
         whenever(mockUserStageStore.getUserAppStage()).thenReturn(AppStage.DAX_ONBOARDING)
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -4092,7 +4092,7 @@ class BrowserTabFragment :
                         hideNewTab()
                     }
 
-                    viewState.daxOnboardingComplete && !viewState.isErrorShowing -> {
+                    viewState.isOnboardingCompleteInNewTabPage && !viewState.isErrorShowing -> {
                         hideDaxBubbleCta()
                         showNewTab()
                     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2765,13 +2765,13 @@ class BrowserTabViewModel @Inject constructor(
                     siteLiveData.value,
                 )
             }
-            val isOnboardingComplete = withContext(dispatchers.io()) {
+            val contextDaxDialogsShown = withContext(dispatchers.io()) {
                 ctaViewModel.areBubbleDaxDialogsCompleted()
             }
             if (isBrowserShowing && cta != null) hasCtaBeenShownForCurrentPage.set(true)
             ctaViewState.value = currentCtaViewState().copy(
                 cta = cta,
-                daxOnboardingComplete = isOnboardingComplete,
+                isOnboardingCompleteInNewTabPage = contextDaxDialogsShown,
                 isBrowserShowing = isBrowserShowing,
                 isErrorShowing = isErrorShowing,
             )

--- a/app/src/main/java/com/duckduckgo/app/browser/viewstate/CtaViewState.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/viewstate/CtaViewState.kt
@@ -20,7 +20,7 @@ import com.duckduckgo.app.cta.ui.Cta
 
 data class CtaViewState(
     val cta: Cta? = null,
-    val daxOnboardingComplete: Boolean = false,
+    val isOnboardingCompleteInNewTabPage: Boolean = false,
     val isBrowserShowing: Boolean = true,
     val isErrorShowing: Boolean = false,
 )

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -219,7 +219,7 @@ class CtaViewModel @Inject constructor(
         if (daxOnboardingActive() && allOnboardingCtasShown()) {
             Timber.d("Auto completing DAX ONBOARDING")
             userStageStore.stageCompleted(AppStage.DAX_ONBOARDING)
-            pixel.fire(AppPixelName.ONBOARDING_AUTO_COMPLETED)
+            pixel.fire(AppPixelName.ONBOARDING_AUTO_COMPLETE)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -205,11 +205,21 @@ class CtaViewModel @Inject constructor(
         site: Site? = null,
     ): Cta? {
         return withContext(dispatcher) {
+            markOnboardingAsCompletedIfRequiredCtasShown()
             if (isBrowserShowing) {
                 getBrowserCta(site)
             } else {
                 getHomeCta()
             }
+        }
+    }
+
+    // Temporary function to complete onboarding if all CTAs were shown
+    private suspend fun markOnboardingAsCompletedIfRequiredCtasShown() {
+        if (daxOnboardingActive() && allOnboardingCtasShown()) {
+            Timber.d("Auto completing DAX ONBOARDING")
+            userStageStore.stageCompleted(AppStage.DAX_ONBOARDING)
+            pixel.fire(AppPixelName.ONBOARDING_AUTO_COMPLETED)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -50,6 +50,9 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     ONBOARDING_DAX_CTA_DISMISS_BUTTON("m_onboarding_dax_cta_dismiss"),
     ONBOARDING_VISIT_SITE_CTA_SHOWN("onboarding_visit_site_cta_shown"),
 
+    // Temporary Pixel
+    ONBOARDING_AUTO_COMPLETE("onboarding_auto_complete"),
+
     BROWSER_MENU_ALLOWLIST_ADD("mb_wla"),
     BROWSER_MENU_ALLOWLIST_REMOVE("mb_wlr"),
     BROWSER_PULL_TO_REFRESH("m_browser_pull_to_refresh"),

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/OnboardingDaxDialogTests.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/OnboardingDaxDialogTests.kt
@@ -42,6 +42,7 @@ import com.duckduckgo.browser.api.UserBrowserProperties
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckplayer.api.DuckPlayer
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.subscriptions.api.Subscriptions
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -78,13 +79,16 @@ class OnboardingDaxDialogTests {
     private val mockDuckPlayer: DuckPlayer = mock()
     private val mockBrokenSitePrompt: BrokenSitePrompt = mock()
     private val mockUserBrowserProperties: UserBrowserProperties = mock()
+    private val mockSubscriptions: Subscriptions = mock()
 
     val mockEnabledToggle: Toggle = org.mockito.kotlin.mock { on { it.isEnabled() } doReturn true }
     val mockDisabledToggle: Toggle = org.mockito.kotlin.mock { on { it.isEnabled() } doReturn false }
 
     @Before
-    fun before() {
+    fun before() = runTest {
         whenever(extendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
+        whenever(extendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockDisabledToggle)
+        whenever(mockSubscriptions.isEligible()).thenReturn(false)
 
         testee = CtaViewModel(
             appInstallStore,
@@ -99,7 +103,7 @@ class OnboardingDaxDialogTests {
             coroutineRule.testDispatcherProvider,
             duckDuckGoUrlDetector,
             extendedOnboardingFeatureToggles,
-            subscriptions = mock(),
+            mockSubscriptions,
             mockDuckPlayer,
             mockBrokenSitePrompt,
             mockUserBrowserProperties,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1209868780091258

### Description

- Added a temporary pixel to catch an edge case where onboarding remains active even after all dialogs have been shown. 
- Also included logic to complete onboarding in that scenario, and 
- renamed a few variables for clarity

### Steps to test this PR

_Onboarding_
- [x] Smoke test onboarding

_Temporary pixel (Optional)_
- [x] Fresh install
- [x] Complete onboarding
- [x] Go to 'App Inspection' > `userStage` db
- [x] Edit `appStage` to `DAX_ONBOARDING`
- [x] Trigger `refreshCta()` in the browser (refresh site, or open a new tab, etc.)
- [x] Check in logcat that pixel `onboarding_auto_complete` is fired

### No UI changes
