### PR TITLE
Remove OS_VERSION from PixelParamRemovalPlugin

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/VpnPixelParamRemovalPlugin.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/VpnPixelParamRemovalPlugin.kt
@@ -31,7 +31,6 @@ class VpnPixelParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin
             VPN_PIXEL_PREFIX to PixelParameter.removeAtb(),
             "m_atp_unprotected_apps_bucket_" to PixelParameter.removeAll(),
             "m_vpn_ev_moto_g_fix_" to PixelParameter.removeAll(),
-            ATP_PPRO_UPSELL_PREFIX to PixelParameter.removeOSVersion(),
             ATP_PPRO_UPSELL_PREFIX to PixelParameter.removeAtb(),
         )
     }

--- a/app/src/main/java/com/duckduckgo/app/global/api/PixelParamRemovalInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/PixelParamRemovalInterceptor.kt
@@ -29,7 +29,6 @@ import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin
 import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin.PixelParameter
 import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin.PixelParameter.APP_VERSION
 import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin.PixelParameter.ATB
-import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin.PixelParameter.OS_VERSION
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.site.permissions.impl.SitePermissionsPixelName
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -55,15 +54,11 @@ class PixelParamRemovalInterceptor @Inject constructor(
         val url = chain.request().url.newBuilder().apply {
             val atbs = pixels.filter { it.second.contains(ATB) }.map { it.first }
             val versions = pixels.filter { it.second.contains(APP_VERSION) }.map { it.first }
-            val oses = pixels.filter { it.second.contains(OS_VERSION) }.map { it.first }
             if (atbs.any { pixel.startsWith(it) }) {
                 removeAllQueryParameters(AppUrl.ParamKey.ATB)
             }
             if (versions.any { pixel.startsWith(it) }) {
                 removeAllQueryParameters(Pixel.PixelParameter.APP_VERSION)
-            }
-            if (oses.any { pixel.startsWith(it) }) {
-                removeAllQueryParameters(Pixel.PixelParameter.OS_VERSION)
             }
         }.build()
 

--- a/app/src/test/java/com/duckduckgo/app/global/api/PixelParamRemovalInterceptorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/global/api/PixelParamRemovalInterceptorTest.kt
@@ -66,18 +66,7 @@ class PixelParamRemovalInterceptorTest {
     }
 
     @Test
-    fun whenSendPixelRedactOSVersion() {
-        testPixels.filter { it.second == PixelParameter.removeOSVersion() }.map { it.first }.forEach { pixelName ->
-            val pixelUrl = String.format(PIXEL_TEMPLATE, pixelName)
-            val interceptedUrl = pixelRemovalInterceptor.intercept(FakeChain(pixelUrl)).request.url
-            assertNotNull(interceptedUrl.queryParameter("atb"))
-            assertNotNull(interceptedUrl.queryParameter("appVersion"))
-            assertNull(interceptedUrl.queryParameter("os_version"))
-        }
-    }
-
-    @Test
-    fun whenSendPixelRedactAtbAndAppAndOSVersion() {
+    fun whenSendPixelRedactAtbAndAppVersion() {
         testPixels.filter { it.second.containsAll(PixelParameter.removeAll()) }
             .map { it.first }
             .forEach { pixelName ->
@@ -85,17 +74,15 @@ class PixelParamRemovalInterceptorTest {
                 val interceptedUrl = pixelRemovalInterceptor.intercept(FakeChain(pixelUrl)).request.url
                 assertNull(interceptedUrl.queryParameter("atb"))
                 assertNull(interceptedUrl.queryParameter("appVersion"))
-                assertNull(interceptedUrl.queryParameter("os_version"))
             }
     }
 
     companion object {
         private const val PIXEL_TEMPLATE = "https://improving.duckduckgo.com/t/%s_android_phone?atb=v255-7zu&appVersion=5.74.0&os_version=1.0&test=1"
         private val testPixels = listOf(
-            "atb_and_version_and_os_redacted" to PixelParameter.removeAll(),
+            "atb_and_version_redacted" to PixelParameter.removeAll(),
             "atb_redacted" to PixelParameter.removeAtb(),
             "version_redacted" to PixelParameter.removeVersion(),
-            "os_version_redacted" to PixelParameter.removeOSVersion(),
         )
     }
 }

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/plugins/pixel/PixelParamRemovalPlugin.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/plugins/pixel/PixelParamRemovalPlugin.kt
@@ -31,13 +31,12 @@ interface PixelParamRemovalPlugin {
     fun names(): List<Pair<String, Set<PixelParameter>>>
 
     enum class PixelParameter {
-        ATB, APP_VERSION, OS_VERSION;
+        ATB, APP_VERSION;
 
         companion object {
-            fun removeAll() = setOf(ATB, APP_VERSION, OS_VERSION)
+            fun removeAll() = setOf(ATB, APP_VERSION)
             fun removeAtb() = setOf(ATB)
             fun removeVersion() = setOf(APP_VERSION)
-            fun removeOSVersion() = setOf(OS_VERSION)
         }
     }
 }

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/pixels/DownloadsPixelName.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/pixels/DownloadsPixelName.kt
@@ -17,11 +17,6 @@
 package com.duckduckgo.downloads.impl.pixels
 
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin
-import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin.PixelParameter
-import com.duckduckgo.di.scopes.AppScope
-import com.squareup.anvil.annotations.ContributesMultibinding
-import javax.inject.Inject
 
 internal enum class DownloadsPixelName(override val pixelName: String) : Pixel.PixelName {
     DOWNLOAD_REQUEST_STARTED("m_download_request_started"),
@@ -30,13 +25,4 @@ internal enum class DownloadsPixelName(override val pixelName: String) : Pixel.P
     DOWNLOAD_REQUEST_CANCELLED("m_download_request_cancelled"),
     DOWNLOAD_REQUEST_CANCELLED_BY_USER("m_download_request_cancelled_by_user"),
     DOWNLOAD_REQUEST_RETRIED("m_download_request_retried"),
-}
-
-@ContributesMultibinding(AppScope::class)
-class DownloadPixelsParamRemoval @Inject constructor() : PixelParamRemovalPlugin {
-    override fun names(): List<Pair<String, Set<PixelParameter>>> {
-        return DownloadsPixelName.entries.map {
-            it.pixelName to PixelParameter.removeOSVersion()
-        }
-    }
 }

--- a/statistics/statistics-api/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/statistics/statistics-api/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -50,7 +50,6 @@ interface Pixel {
         const val LAST_USED_DAY = "duck_address_last_used"
         const val WEBVIEW_VERSION = "webview_version"
         const val WEBVIEW_FULL_VERSION = "webview_full_version"
-        const val OS_VERSION = "os_version"
         const val DEFAULT_BROWSER = "default_browser"
         const val EMAIL = "email"
         const val MESSAGE_SHOWN = "message"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1209956345642687?focus=true

### Description

This PR removes an API that is effectively a no-op, as it doesn’t impact pixel behavior. PixelParamRemovalPlugin.OS_VERSION is never added to pixels and thus doesn’t need removal. 

### Steps to test this PR

QA-optional

### No UI changes
