### PR TITLE
Add executor for MSP Room transactions

### DIFF
--- a/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteModule.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteModule.kt
@@ -32,6 +32,7 @@ import dagger.Provides
 import dagger.SingleInstanceIn
 import java.io.File
 import java.security.MessageDigest
+import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit.SECONDS
 import javax.inject.Named
 import javax.inject.Qualifier
@@ -56,6 +57,7 @@ class MaliciousSiteModule {
     fun provideMaliciousSiteProtectionDatabase(context: Context): MaliciousSitesDatabase {
         return Room.databaseBuilder(context, MaliciousSitesDatabase::class.java, "malicious_sites.db")
             .addMigrations(*ALL_MIGRATIONS)
+            .setTransactionExecutor(Executors.newSingleThreadExecutor())
             .fallbackToDestructiveMigration()
             .build()
     }

--- a/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteModule.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteModule.kt
@@ -57,6 +57,7 @@ class MaliciousSiteModule {
     fun provideMaliciousSiteProtectionDatabase(context: Context): MaliciousSitesDatabase {
         return Room.databaseBuilder(context, MaliciousSitesDatabase::class.java, "malicious_sites.db")
             .addMigrations(*ALL_MIGRATIONS)
+            .setQueryExecutor(Executors.newFixedThreadPool(4))
             .setTransactionExecutor(Executors.newSingleThreadExecutor())
             .fallbackToDestructiveMigration()
             .build()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1209959841243986?focus=true 

### Description
Use dedicated executor for MSP transactions to prevent thread exhaustion on Room executors

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
