### PR TITLE
Fix: E2E tests

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -685,9 +685,6 @@ open class BrowserActivity : DuckDuckGoActivity() {
             fireButtonStore = fireButtonStore,
             appBuildConfig = appBuildConfig,
         )
-        dialog.clearStarted = {
-            removeObservers()
-        }
         dialog.setOnShowListener { currentTab?.onFireDialogVisibilityChanged(isVisible = true) }
         dialog.setOnCancelListener {
             pixel.fire(FIRE_DIALOG_CANCEL)
@@ -695,6 +692,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
         }
         dialog.clearStarted = {
             isDataClearingInProgress = true
+            removeObservers()
         }
         dialog.show()
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -254,6 +254,8 @@ open class BrowserActivity : DuckDuckGoActivity() {
     @VisibleForTesting
     var destroyedByBackPress: Boolean = false
 
+    var isDataClearingInProgress: Boolean = false
+
     private val startBookmarksActivityForResult =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result: ActivityResult ->
             if (result.resultCode == RESULT_OK) {
@@ -690,6 +692,9 @@ open class BrowserActivity : DuckDuckGoActivity() {
         dialog.setOnCancelListener {
             pixel.fire(FIRE_DIALOG_CANCEL)
             currentTab?.onFireDialogVisibilityChanged(isVisible = false)
+        }
+        dialog.clearStarted = {
+            isDataClearingInProgress = true
         }
         dialog.show()
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1238,6 +1238,11 @@ class BrowserTabFragment :
     override fun onResume() {
         super.onResume()
 
+        // we need to prevent new tab initialization while clearing data, because it can mess up onboarding state after the process is restarted
+        if (swipingTabsFeature.isEnabled && (requireActivity() as? BrowserActivity)?.isDataClearingInProgress == true) {
+            return
+        }
+
         val hasOmnibarPositionChanged = viewModel.hasOmnibarPositionChanged(omnibar.omnibarPosition)
         val hasOmnibarTypeChanged = omnibar.omnibarType != visualDesignExperimentDataStore.getOmnibarType()
         if (hasOmnibarPositionChanged || hasOmnibarTypeChanged) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1209964667726374?focus=true

### Description

This PR fixes one of the E2E tests, which fails because onboarding does not resume correctly after the fire button is used to clear the data.

### Steps to test this PR

#### Manual test
- [x] Start with a fresh installation
- [x] Go through the onboarding until you get the Dax dialog with things to search for
- [x] Load this URL: `https://privacy-test-pages.site`
- [x] Tap on Got it
- [x] When prompted, clear the browsing data using the fire button
- [x] Verify that after the app is restarted you see Dax dialog with `Remember: every time you browse with me a creepy ad loses its wings.`

#### Maestro test (optional, Maestro installation required)
- [ ] Create a release build and install it on a device
- [ ] Run `maestro test .maestro/fire_button/fire_during_onboarding.yaml`

### UI changes
| Before  | After |
| ------ | ----- |
![image](https://github.com/user-attachments/assets/38501329-60a5-4b01-b8c7-3155f0abd9cf)|![image](https://github.com/user-attachments/assets/222a4874-5846-47b6-9a8c-bff109be4aa6)|
