### PR TITLE
Renamed tests to avoid Robin errors due to name conflict.

### DIFF
--- a/.maestro/onboarding/onboarding_dismiss_all_dialogs.yaml
+++ b/.maestro/onboarding/onboarding_dismiss_all_dialogs.yaml
@@ -1,5 +1,5 @@
 appId: com.duckduckgo.mobile.android
-name: "Onboarding: Ensuring we can navigate through pre-onboarding flow"
+name: "Onboarding: Ensuring we can navigate through pre-onboarding flow and dismissing all dialogs"
 tags:
   - onboardingTest
 ---

--- a/.maestro/onboarding/onboarding_dismiss_try_a_search_dialog.yaml
+++ b/.maestro/onboarding/onboarding_dismiss_try_a_search_dialog.yaml
@@ -1,5 +1,5 @@
 appId: com.duckduckgo.mobile.android
-name: "Onboarding: Ensuring we can navigate through pre-onboarding flow"
+name: "Onboarding: Ensuring we can navigate through pre-onboarding flow and dismissing the fire dialog"
 tags:
   - onboardingTest
 ---


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200581511062568/task/1209976250734772?focus=true

### Description

Updated the names of two Maestro test files to better reflect their purpose:
- Changed `onboarding_dismiss_all_dialogs.yaml` test name to "Onboarding: Ensuring we can navigate through pre-onboarding flow and dismissing all dialogs"
- Changed `onboarding_dismiss_try_a_search_dialog.yaml` test name to "Onboarding: Ensuring we can navigate through pre-onboarding flow and dismissing the fire dialog"

### Steps to test this PR

_Maestro Tests_
Tests are passing -> https://github.com/duckduckgo/Android/actions/runs/14444800539/job/40502769051
