### PR TITLE
update Custom Tab omnibar and navigation bar behavior/layout

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1038,7 +1038,7 @@ class BrowserTabFragment :
 
     private fun onBrowserMenuButtonPressed() {
         contentScopeScripts.sendSubscriptionEvent(createBreakageReportingEventData())
-        viewModel.onBrowserMenuClicked()
+        viewModel.onBrowserMenuClicked(isCustomTab = isActiveCustomTab())
     }
 
     private fun onOmnibarPrivacyShieldButtonPressed() {
@@ -1074,8 +1074,8 @@ class BrowserTabFragment :
     }
 
     private fun createPopupMenu() {
-        val popupMenuResourceType = if (visualDesignExperimentDataStore.experimentState.value.isEnabled) {
-            // when bottom navigation bar is enabled, we always inflate the popup menu from the bottom
+        val popupMenuResourceType = if (!isActiveCustomTab() && visualDesignExperimentDataStore.experimentState.value.isEnabled) {
+            // when not custom tab and bottom navigation bar is enabled, we always inflate the popup menu from the bottom
             BrowserPopupMenu.ResourceType.BOTTOM
         } else {
             when (settingsDataStore.omnibarPosition) {
@@ -2756,7 +2756,7 @@ class BrowserTabFragment :
 
         binding.daxDialogOnboardingCtaContent.layoutTransition.enableTransitionType(LayoutTransition.CHANGING)
 
-        val webViewLayout = if (visualDesignExperimentDataStore.getOmnibarType() == FADE) {
+        val webViewLayout = if (!isActiveCustomTab() && visualDesignExperimentDataStore.getOmnibarType() == FADE) {
             R.layout.include_duckduckgo_browser_experiment_webview
         } else {
             R.layout.include_duckduckgo_browser_webview

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2720,14 +2720,14 @@ class BrowserTabViewModel @Inject constructor(
         }
     }
 
-    fun onBrowserMenuClicked() {
+    fun onBrowserMenuClicked(isCustomTab: Boolean) {
         val menuHighlighted = currentBrowserViewState().showMenuButton.isHighlighted()
         if (menuHighlighted) {
             browserViewState.value = currentBrowserViewState().copy(
                 showMenuButton = HighlightableButton.Visible(highlighted = false),
             )
         }
-        command.value = LaunchPopupMenu(anchorToNavigationBar = visualDesignExperimentDataStore.navigationBarState.value.isEnabled)
+        command.value = LaunchPopupMenu(anchorToNavigationBar = !isCustomTab && visualDesignExperimentDataStore.navigationBarState.value.isEnabled)
     }
 
     fun onPopupMenuLaunched() {

--- a/app/src/main/java/com/duckduckgo/app/browser/navigation/bar/view/BrowserNavigationBarViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/navigation/bar/view/BrowserNavigationBarViewModel.kt
@@ -66,22 +66,10 @@ class BrowserNavigationBarViewModel @Inject constructor(
         visualDesignExperimentDataStore.navigationBarState,
     ) { state, isCustomTab, tabs, navigationBarState ->
         state.copy(
-            isVisible = navigationBarState.isEnabled,
+            isVisible = navigationBarState.isEnabled && !isCustomTab,
             tabsCount = tabs.size,
             shouldUpdateTabsCount = tabs.size != state.tabsCount && tabs.isNotEmpty(),
-        ).let { newState ->
-            if (isCustomTab) {
-                newState.copy(
-                    newTabButtonVisible = false,
-                    autofillButtonVisible = false,
-                    bookmarksButtonVisible = false,
-                    fireButtonVisible = false,
-                    tabsButtonVisible = false,
-                )
-            } else {
-                newState
-            }
-        }
+        )
     }.flowOn(dispatcherProvider.io()).stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000L), ViewState())
 
     fun onFireButtonClicked() {

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/FadeOmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/FadeOmnibarLayout.kt
@@ -20,6 +20,7 @@ import android.animation.ValueAnimator
 import android.content.Context
 import android.util.AttributeSet
 import android.view.View
+import android.view.ViewOutlineProvider
 import android.view.animation.DecelerateInterpolator
 import android.widget.ImageView
 import android.widget.LinearLayout
@@ -117,8 +118,6 @@ class FadeOmnibarLayout @JvmOverloads constructor(
                 top = 0,
             )
         }
-
-        outlineProvider = null
     }
 
     override fun onDetachedFromWindow() {
@@ -127,12 +126,22 @@ class FadeOmnibarLayout @JvmOverloads constructor(
     }
 
     override fun render(viewState: ViewState) {
-        val experimentalViewState = viewState.copy(
-            showBrowserMenu = false,
-            showFireIcon = false,
-            showTabsMenu = false,
-        )
-        super.render(experimentalViewState)
+        if (viewState.viewMode is ViewMode.CustomTab) {
+            // adds a drop shadow for the AppBarLayout, in case it was removed at any point
+            outlineProvider = ViewOutlineProvider.BACKGROUND
+            super.render(viewState)
+        } else {
+            // removes the drop shadow from the AppBarLayout to make it appear flat in the view hierarchy
+            outlineProvider = null
+
+            // removes the duplicate buttons that are also present in the navigation bar
+            val experimentalViewState = viewState.copy(
+                showBrowserMenu = false,
+                showFireIcon = false,
+                showTabsMenu = false,
+            )
+            super.render(experimentalViewState)
+        }
 
         val showChatMenu = viewState.viewMode !is ViewMode.CustomTab
         aiChat.isVisible = showChatMenu

--- a/app/src/main/java/com/duckduckgo/app/dispatchers/IntentDispatcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/dispatchers/IntentDispatcherActivity.kt
@@ -46,7 +46,7 @@ class IntentDispatcherActivity : DuckDuckGoActivity() {
             dispatch(it)
         }.launchIn(lifecycleScope)
 
-        val surfaceColor = getColorFromAttr(com.duckduckgo.mobile.android.R.attr.daxColorSurface)
+        val surfaceColor = getColorFromAttr(com.duckduckgo.mobile.android.R.attr.daxColorToolbar)
         viewModel.onIntentReceived(intent, surfaceColor, isExternal = true)
     }
 

--- a/app/src/main/res/layout/view_fade_omnibar.xml
+++ b/app/src/main/res/layout/view_fade_omnibar.xml
@@ -49,13 +49,6 @@
                 app:layout_constraintTop_toTopOf="parent"
                 app:popupTheme="@style/Widget.DuckDuckGo.PopUpOverflowMenu">
 
-                <include
-                    android:id="@+id/customTabToolbarContainer"
-                    layout="@layout/include_custom_tab_toolbar"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:visibility="gone" />
-
                 <com.google.android.material.card.MaterialCardView
                     android:id="@+id/omniBarContainer"
                     style="@style/Widget.DuckDuckGo.OmnibarCardView"
@@ -63,9 +56,9 @@
                     android:layout_height="match_parent"
                     android:layout_marginHorizontal="@dimen/experimentalOmnibarCardMarginHorizontal"
                     android:layout_marginTop="@dimen/experimentalOmnibarCardMarginTop"
+                    android:layout_marginBottom="@dimen/experimentalOmnibarCardMarginBottom"
                     app:strokeColor="?daxColorAccentBlue"
-                    app:strokeWidth="@dimen/experimentalOmnibarOutlineWidth"
-                    android:layout_marginBottom="@dimen/experimentalOmnibarCardMarginBottom">
+                    app:strokeWidth="@dimen/experimentalOmnibarOutlineWidth">
 
                     <androidx.constraintlayout.widget.ConstraintLayout
                         android:id="@+id/omniBarContentContainer"
@@ -324,6 +317,24 @@
                 </com.google.android.material.card.MaterialCardView>
 
             </androidx.appcompat.widget.Toolbar>
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="0dp"
+                android:layout_height="@dimen/experimentalToolbarSize"
+                android:layout_marginHorizontal="@dimen/keyline_2"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/browserMenu"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <include
+                    android:id="@+id/customTabToolbarContainer"
+                    layout="@layout/include_custom_tab_toolbar"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:visibility="gone" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
             <com.duckduckgo.app.browser.tabswitcher.ExperimentalTabSwitcherButton
                 android:id="@+id/tabsMenu"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1209703519253563?focus=true

### Description
Updated the behavior of navigation bar to hide when in Custom Tab. Also re-aligned Custom Tab design with production, only with the updated background colors.

I tried reusing as much from the production implementation as possible, since the designs are nearly identical.

### Steps to test this PR
- [ ] With experimental changes flag disabled, ensure that the omnibar's background color in Custom Tab is white when light theme (same as production).
- [ ] With experimental changes flag enabled ensure that:
  - [ ] Omnibar's background color in Custom Tab is warmer white when light theme.
  - [ ] Overflow menu is anchored to the omnibar and navigation buttons are at the top.
  - [ ] There are no rounded corners around the web view.

### UI changes
1. Experiment before
2. Experiment after
3. Production

| 1 | 2 | 3 |
| ------ | ------ | ------ |
|  ![Screenshot_20250414_135544](https://github.com/user-attachments/assets/b56af895-f104-420d-8aa0-843eb42519b1) | ![Screenshot_20250414_164147](https://github.com/user-attachments/assets/641f7784-f02d-4af3-8d9b-8641d3ec17c7) | ![Screenshot_20250414_144119](https://github.com/user-attachments/assets/d6a295fe-c17d-4a73-abd2-73433aa4dcfb) |
