### PR TITLE
Fix privacy pro not launching from ppro url

### DIFF
--- a/.maestro/ppro/launch_privacy_pro_from_special_url.yaml
+++ b/.maestro/ppro/launch_privacy_pro_from_special_url.yaml
@@ -15,7 +15,19 @@ tags:
           text: "search or type URL"
       - inputText: "https://duckduckgo.com/pro"
       - pressKey: Enter
-      - assertVisible:
-          text: "Privacy Pro"
-      - assertVisible:
-          text: "Subscribe to Privacy Pro"
+      - runFlow:
+          when:
+            visible:
+              text: "Privacy Pro"
+          commands:
+            - assertVisible:
+                text: "Subscribe to Privacy Pro"
+      - runFlow:
+          when:
+            visible:
+              id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+          commands:
+            - copyTextFrom:
+                id: "omnibarTextInput"
+            - assertTrue: ${maestro.copiedText == "https://duckduckgo.com/pro"}
+

--- a/.maestro/ppro/launch_privacy_pro_from_special_url.yaml
+++ b/.maestro/ppro/launch_privacy_pro_from_special_url.yaml
@@ -1,0 +1,21 @@
+appId: com.duckduckgo.mobile.android
+name: "ReleaseTest: Launch Privacy Pro from special URL is working"
+tags:
+  - releaseTest
+---
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
+
+      - runFlow: ../shared/skip_all_onboarding.yaml
+
+      - tapOn:
+          text: "search or type URL"
+      - inputText: "https://duckduckgo.com/pro"
+      - pressKey: Enter
+      - assertVisible:
+          text: "Privacy Pro"
+      - assertVisible:
+          text: "Subscribe to Privacy Pro"

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -85,6 +85,7 @@ import com.duckduckgo.app.tabs.ui.TabSwitcherSnackbar
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.autofill.api.emailprotection.EmailProtectionLinkVerifier
 import com.duckduckgo.browser.api.ui.BrowserScreens.BookmarksScreenNoParams
+import com.duckduckgo.browser.api.ui.BrowserScreens.SettingsScreenNoParams
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.experiments.visual.store.VisualDesignExperimentDataStore
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
@@ -698,7 +699,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
     }
 
     fun launchSettings() {
-        startActivity(SettingsActivity.intent(this))
+        globalActivityStarter.start(this, SettingsScreenNoParams)
     }
 
     fun launchSitePermissionsSettings() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -76,7 +76,6 @@ import com.duckduckgo.app.global.view.renderIfChanged
 import com.duckduckgo.app.onboarding.ui.page.DefaultBrowserPage
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.pixels.AppPixelName.FIRE_DIALOG_CANCEL
-import com.duckduckgo.app.settings.SettingsActivity
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.TabManagerFeatureFlags

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
@@ -24,6 +24,7 @@ import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.about.AboutScreenNoParams
 import com.duckduckgo.app.about.FeedbackContract
@@ -70,6 +71,7 @@ import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.autoconsent.impl.ui.AutoconsentSettingsActivity
 import com.duckduckgo.autofill.api.AutofillScreens.AutofillSettingsScreen
 import com.duckduckgo.autofill.api.AutofillSettingsLaunchSource
+import com.duckduckgo.browser.api.ui.BrowserScreens.SettingsScreenNoParams
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.listitem.DaxListItem.IconSize.Small
@@ -98,6 +100,7 @@ import timber.log.Timber
 private const val OTHER_PLATFORMS_URL = "https://duckduckgo.com/app"
 
 @InjectWith(ActivityScope::class)
+@ContributeToActivityStarter(SettingsScreenNoParams::class, screenName = "settings")
 class SettingsActivity : DuckDuckGoActivity() {
 
     private val viewModel: SettingsViewModel by bindViewModel()


### PR DESCRIPTION
### Description

This PR adds the missing SettingsScreenNoParams annotation to enable launching the Settings screen with the GlobalActivityStarter. 

A release Maestro test has been added to verify that launching Privacy Pro from a special URL works correctly.

I've also moved to using GlobalActivityStarter to launch Settings via the Browser screen so this becomes more obvious if it happens again.

### Steps to test this PR

_Privacy Pro URL Test_
- [x] Use a playRelease build
- [x] Launch the app and navigate to the search bar
- [x] Enter "https://duckduckgo.com/pro" and press Enter
- [x] Verify that the Privacy Pro page appears with "Privacy Pro" and "Subscribe to Privacy Pro" text visible
- [x] Click back

_Open settings_
- [x] Click browser overflow menu button
- [x] Click "Settings"
- [x] Settings screen should open

_Maestro test_
- [x] Run `maestro test .maestro/ppro/launch_privacy_pro_from_special_url.yaml`
- [x] Test should pass

### UI changes
No UI changes in this PR.