### PR TITLE
fix Omnibar's content jump when Custom Tab's title becomes available

### DIFF
--- a/app/src/main/res/layout/include_custom_tab_toolbar.xml
+++ b/app/src/main/res/layout/include_custom_tab_toolbar.xml
@@ -45,19 +45,19 @@
         android:importantForAccessibility="no"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toEndOf="@id/customTabCloseIcon"
-        app:layout_constraintTop_toTopOf="parent"/>
+        app:layout_constraintTop_toTopOf="parent" />
 
     <ImageView
         android:id="@+id/customTabDuckPlayerIcon"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:importantForAccessibility="no"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toEndOf="@id/customTabCloseIcon"
-        app:layout_constraintEnd_toStartOf="@+id/customTabTitle"
-        app:layout_constraintTop_toTopOf="parent"
         android:src="@drawable/ic_duckplayer"
-        android:visibility="gone"/>
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/customTabTitle"
+        app:layout_constraintStart_toEndOf="@id/customTabCloseIcon"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <com.duckduckgo.common.ui.view.text.DaxTextView
         android:id="@+id/customTabTitle"
@@ -69,7 +69,7 @@
         android:includeFontPadding="false"
         android:maxLines="1"
         android:paddingTop="10dp"
-        android:visibility="gone"
+        android:visibility="invisible"
         app:layout_constraintBottom_toTopOf="@id/customTabDomain"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -80,14 +80,12 @@
 
     <com.duckduckgo.common.ui.view.text.DaxTextView
         android:id="@+id/customTabDomain"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="86dp"
-        android:layout_marginEnd="@dimen/keyline_2"
         android:ellipsize="end"
         android:includeFontPadding="false"
         android:maxLines="1"
-        android:visibility="gone"
+        android:visibility="invisible"
         app:layout_constraintEnd_toEndOf="@id/customTabTitle"
         app:layout_constraintStart_toStartOf="@id/customTabTitle"
         app:layout_constraintTop_toBottomOf="@id/customTabTitle"
@@ -97,16 +95,17 @@
 
     <com.duckduckgo.common.ui.view.text.DaxTextView
         android:id="@+id/customTabDomainOnly"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="86dp"
         android:layout_marginEnd="@dimen/keyline_2"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
+        android:paddingTop="10dp"
+        android:visibility="invisible"
+        app:layout_constraintBottom_toTopOf="@id/customTabDomain"
+        app:layout_constraintEnd_toEndOf="@id/customTabTitle"
         app:layout_constraintStart_toStartOf="@id/customTabTitle"
         app:layout_constraintTop_toTopOf="parent"
         app:typography="body2"
         tools:text="www.example.com"
-        tools:visibility="gone" />
+        tools:visibility="visible" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1209987826470158?focus=true

### Description

All the of the text views are anchored to the title, so to fix the content jump I'm making sure that the title view is always present in the layout and hidden instead of removed when title text is not available.

### Steps to test this PR

- [ ] Open a Custom Tab and make sure that once content loads, there's no position shift in text views.

### UI changes

_before_

https://github.com/user-attachments/assets/acafa3cf-6e11-4c8d-bca2-3520562b9e75

_after_

https://github.com/user-attachments/assets/3267bda7-0e83-4853-8cf4-1e9936ae127a
