### PR TITLE
Quick win: Skip the current tab in switch-to-tab suggestions

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -553,6 +553,8 @@ class BrowserTabViewModelTest {
     private val fakeAppPersonalityFeature = FakeFeatureToggleFactory.create(AppPersonalityFeature::class.java)
     private val mockPrivacyDashboardExternalPixelParams: PrivacyDashboardExternalPixelParams = mock()
 
+    private val selectedTab = TabEntity("TAB_ID", "https://example.com", position = 0, sourceTabId = "TAB_ID_SOURCE")
+
     @Before
     fun before() = runTest {
         MockitoAnnotations.openMocks(this)
@@ -586,6 +588,7 @@ class BrowserTabViewModelTest {
         whenever(mockDismissedCtaDao.dismissedCtas()).thenReturn(dismissedCtaDaoChannel.consumeAsFlow())
         whenever(mockTabRepository.flowTabs).thenReturn(flowOf(emptyList()))
         whenever(mockTabRepository.getTabs()).thenReturn(emptyList())
+        whenever(mockTabRepository.flowSelectedTab).thenReturn(flowOf(selectedTab))
         whenever(mockTabRepository.liveTabs).thenReturn(tabsLiveData)
         whenever(mockEmailManager.signedInFlow()).thenReturn(emailStateFlow.asStateFlow())
         whenever(mockSavedSitesRepository.getFavorites()).thenReturn(favoriteListFlow.consumeAsFlow())

--- a/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
@@ -290,7 +290,7 @@ class AutoCompleteApi @Inject constructor(
             if (autocompleteTabsEnabled) {
                 combine(
                     tabRepository.flowTabs,
-                    tabRepository.flowSelectedTab
+                    tabRepository.flowSelectedTab,
                 ) { tabs, selectedTab ->
                     rankTabs(query, tabs.filter { it.tabId != selectedTab?.tabId })
                 }.distinctUntilChanged()

--- a/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
@@ -288,9 +288,12 @@ class AutoCompleteApi @Inject constructor(
     private fun getAutocompleteSwitchToTabResults(query: String): Flow<List<RankedSuggestion<AutoCompleteSwitchToTabSuggestion>>> =
         runCatching {
             if (autocompleteTabsEnabled) {
-                tabRepository.flowTabs
-                    .map { rankTabs(query, it) }
-                    .distinctUntilChanged()
+                combine(
+                    tabRepository.flowTabs,
+                    tabRepository.flowSelectedTab
+                ) { tabs, selectedTab ->
+                    rankTabs(query, tabs.filter { it.tabId != selectedTab?.tabId })
+                }.distinctUntilChanged()
             } else {
                 flowOf(emptyList())
             }

--- a/app/src/test/java/com/duckduckgo/app/autocomplete/api/AutoCompleteApiTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/autocomplete/api/AutoCompleteApiTest.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteSuggestion.A
 import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteSuggestion.AutoCompleteHistoryRelatedSuggestion.AutoCompleteHistorySearchSuggestion
 import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteSuggestion.AutoCompleteHistoryRelatedSuggestion.AutoCompleteHistorySuggestion
 import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteSuggestion.AutoCompleteHistoryRelatedSuggestion.AutoCompleteInAppMessageSuggestion
+import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteSuggestion.AutoCompleteHistoryRelatedSuggestion.AutoCompleteInAppMessageSuggestion.phrase
 import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteSuggestion.AutoCompleteSearchSuggestion
 import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteSuggestion.AutoCompleteUrlSuggestion.AutoCompleteBookmarkSuggestion
 import com.duckduckgo.app.autocomplete.api.AutoComplete.AutoCompleteSuggestion.AutoCompleteUrlSuggestion.AutoCompleteSwitchToTabSuggestion
@@ -34,6 +35,7 @@ import com.duckduckgo.app.onboarding.store.UserStageStore
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.UrlScheme.Companion.https
 import com.duckduckgo.common.utils.formatters.time.DatabaseDateFormatter
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.history.api.HistoryEntry.VisitedPage
@@ -93,6 +95,7 @@ class AutoCompleteApiTest {
     @Before
     fun before() {
         MockitoAnnotations.openMocks(this)
+        whenever(mockTabRepository.flowSelectedTab).thenReturn(flowOf(TabEntity("0", position = 0)))
         whenever(mockTabRepository.flowTabs).thenReturn(flowOf(listOf(TabEntity("1", position = 1))))
         whenever(mockNavigationHistory.getHistory()).thenReturn(flowOf(emptyList()))
         runTest {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1208855331182033?focus=true

### Description

This PR filters out the current tab from the switch-to-tab suggestion list.

### Steps to test this PR

- [x] Clear tabs, so there is only 1 active tab
- [x] Visit a page (i.e. [nike.com](https://nike.com/))
- [x] In that same tab, tap into the address bar and type nike
- [x] Verify that only the history suggestion is displayed for the Nike website, not a switch-to-tab suggestion
