### PR TITLE
Android: NewTabLegacyPage onboardingComplete logic incomplete

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageViewModel.kt
@@ -25,6 +25,8 @@ import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.browser.remotemessage.CommandActionMapper
 import com.duckduckgo.app.cta.db.DismissedCtaDao
 import com.duckduckgo.app.cta.model.CtaId
+import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.ExtendedOnboardingFeatureToggles
+import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.playstore.PlayStoreUtils
 import com.duckduckgo.di.scopes.ViewScope
@@ -58,6 +60,8 @@ class NewTabLegacyPageViewModel @Inject constructor(
     private val syncEngine: SyncEngine,
     private val commandActionMapper: CommandActionMapper,
     private val dismissedCtaDao: DismissedCtaDao,
+    private val extendedOnboardingFeatureToggles: ExtendedOnboardingFeatureToggles,
+    private val settingsDataStore: SettingsDataStore,
 ) : ViewModel(), DefaultLifecycleObserver {
 
     data class ViewState(
@@ -133,7 +137,11 @@ class NewTabLegacyPageViewModel @Inject constructor(
     // We only want to show New Tab when the Home CTAs from Onboarding has finished
     // https://app.asana.com/0/1157893581871903/1207769731595075/f
     private fun isHomeOnboardingComplete(): Boolean {
-        return dismissedCtaDao.exists(CtaId.DAX_END)
+        val noBrowserCtaExperiment = extendedOnboardingFeatureToggles.noBrowserCtas().isEnabled()
+        return dismissedCtaDao.exists(CtaId.DAX_END) ||
+            noBrowserCtaExperiment ||
+            settingsDataStore.hideTips ||
+            dismissedCtaDao.exists(CtaId.ADD_WIDGET)
     }
 
     fun onMessageShown() {

--- a/app/src/test/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageViewModelTest.kt
@@ -22,8 +22,12 @@ import com.duckduckgo.app.browser.newtab.NewTabLegacyPageViewModel.Command
 import com.duckduckgo.app.browser.remotemessage.CommandActionMapper
 import com.duckduckgo.app.cta.db.DismissedCtaDao
 import com.duckduckgo.app.cta.model.CtaId.DAX_END
+import com.duckduckgo.app.onboarding.store.UserStageStore
+import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.ExtendedOnboardingFeatureToggles
+import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.playstore.PlayStoreUtils
+import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.remote.messaging.api.Action
 import com.duckduckgo.remote.messaging.api.Content
 import com.duckduckgo.remote.messaging.api.RemoteMessage
@@ -38,6 +42,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -54,11 +59,16 @@ class NewTabLegacyPageViewModelTest {
     private var mockPlaystoreUtils: PlayStoreUtils = mock()
     private var mockRemoteMessageModel: RemoteMessageModel = mock()
     private var mockDismissedCtaDao: DismissedCtaDao = mock()
+    private val mockExtendedOnboardingFeatureToggles: ExtendedOnboardingFeatureToggles = mock()
+    private val mockSettingsDataStore: SettingsDataStore = mock()
+    private val mockUserStageStore: UserStageStore = mock()
 
     private lateinit var testee: NewTabLegacyPageViewModel
 
     @Before
     fun setUp() {
+        val mockDisabledToggle: Toggle = mock { on { it.isEnabled() } doReturn false }
+        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
         whenever(mockSavedSitesRepository.getFavorites()).thenReturn(flowOf(emptyList()))
         whenever(mockRemoteMessageModel.getActiveMessages()).thenReturn(flowOf(null))
 
@@ -70,6 +80,8 @@ class NewTabLegacyPageViewModelTest {
             syncEngine = mockSyncEngine,
             commandActionMapper = mockCommandActionMapper,
             dismissedCtaDao = mockDismissedCtaDao,
+            extendedOnboardingFeatureToggles = mockExtendedOnboardingFeatureToggles,
+            settingsDataStore = mockSettingsDataStore,
         )
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200581511062568/task/1209979916234701?focus=true

### Description

Added a few conditions for when onboarding is considered complete in NewTabLegacyPageViewModel: `noBrowserCtas` toggle enabled or tips hidden or add widget dismissed.

### Steps to test this PR

- [x] Fresh install from this branch.
- [x] Skip onboarding.
- [x] You should see the new tab with the Dax icon and no flickering.


### NO UI changes