### PR TITLE
update find in page feature in FadeOmnibarLayout

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/FindInPage.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/FindInPage.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.omnibar
+
+import android.view.ViewGroup
+import android.widget.EditText
+import android.widget.ImageView
+import com.duckduckgo.app.browser.databinding.IncludeFadeOmnibarFindInPageBinding
+import com.duckduckgo.app.browser.databinding.IncludeFindInPageBinding
+import com.duckduckgo.common.ui.view.text.DaxTextView
+
+/**
+ * Compatibility interface for accessing [IncludeFindInPageBinding] or [IncludeFadeOmnibarFindInPageBinding], depending on which omnibar is used.
+ */
+interface FindInPage {
+    val findInPageContainer: ViewGroup
+    val findInPageInput: EditText
+    val findInPageMatches: DaxTextView
+    val previousSearchTermButton: ImageView
+    val nextSearchTermButton: ImageView
+    val closeFindInPagePanel: ImageView
+}
+
+class FindInPageImpl(
+    override val findInPageContainer: ViewGroup,
+    override val findInPageInput: EditText,
+    override val findInPageMatches: DaxTextView,
+    override val previousSearchTermButton: ImageView,
+    override val nextSearchTermButton: ImageView,
+    override val closeFindInPagePanel: ImageView,
+) : FindInPage {
+
+    constructor(binding: IncludeFindInPageBinding) : this(
+        findInPageContainer = binding.findInPageContainer,
+        findInPageInput = binding.findInPageInput,
+        findInPageMatches = binding.findInPageMatches,
+        previousSearchTermButton = binding.previousSearchTermButton,
+        nextSearchTermButton = binding.nextSearchTermButton,
+        closeFindInPagePanel = binding.closeFindInPagePanel,
+    )
+
+    constructor(binding: IncludeFadeOmnibarFindInPageBinding) : this(
+        findInPageContainer = binding.findInPageContainer,
+        findInPageInput = binding.findInPageInput,
+        findInPageMatches = binding.findInPageMatches,
+        previousSearchTermButton = binding.previousSearchTermButton,
+        nextSearchTermButton = binding.nextSearchTermButton,
+        closeFindInPagePanel = binding.closeFindInPagePanel,
+    )
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
@@ -28,7 +28,6 @@ import com.airbnb.lottie.LottieAnimationView
 import com.duckduckgo.app.browser.BrowserTabFragment.Companion.KEYBOARD_DELAY
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.FragmentBrowserTabBinding
-import com.duckduckgo.app.browser.databinding.IncludeFindInPageBinding
 import com.duckduckgo.app.browser.navigation.bar.view.BrowserNavigationBarView
 import com.duckduckgo.app.browser.omnibar.Omnibar.ViewMode.CustomTab
 import com.duckduckgo.app.browser.omnibar.Omnibar.ViewMode.Error
@@ -62,8 +61,6 @@ import com.duckduckgo.common.ui.view.showKeyboard
 import com.duckduckgo.common.utils.extensions.replaceTextChangedListener
 import com.duckduckgo.common.utils.extractDomain
 import com.duckduckgo.common.utils.text.TextChangedWatcher
-import com.google.android.material.appbar.AppBarLayout.GONE
-import com.google.android.material.appbar.AppBarLayout.VISIBLE
 import kotlinx.coroutines.flow.distinctUntilChanged
 import timber.log.Timber
 
@@ -208,7 +205,7 @@ class Omnibar(
         }
     }
 
-    private val findInPage: IncludeFindInPageBinding by lazy {
+    private val findInPage: FindInPage by lazy {
         newOmnibar.findInPage
     }
 
@@ -325,17 +322,17 @@ class Omnibar(
     }
 
     fun hideFindInPage() {
-        if (findInPage.findInPageContainer.visibility != GONE) {
+        if (newOmnibar.isFindInPageVisible()) {
             binding.focusDummy.requestFocus()
-            findInPage.findInPageContainer.gone()
+            newOmnibar.hideFindInPage()
             findInPage.findInPageInput.hideKeyboard()
             findInPage.findInPageInput.text.clear()
         }
     }
 
     fun showFindInPageView(viewState: FindInPageViewState) {
-        if (findInPage.findInPageContainer.visibility != VISIBLE) {
-            findInPage.findInPageContainer.show()
+        if (!newOmnibar.isFindInPageVisible()) {
+            newOmnibar.showFindInPage()
             findInPage.findInPageInput.postDelayed(KEYBOARD_DELAY) {
                 findInPage.findInPageInput.showKeyboard()
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
@@ -61,6 +61,8 @@ import com.duckduckgo.common.ui.view.showKeyboard
 import com.duckduckgo.common.utils.extensions.replaceTextChangedListener
 import com.duckduckgo.common.utils.extractDomain
 import com.duckduckgo.common.utils.text.TextChangedWatcher
+import com.google.android.material.appbar.AppBarLayout.GONE
+import com.google.android.material.appbar.AppBarLayout.VISIBLE
 import kotlinx.coroutines.flow.distinctUntilChanged
 import timber.log.Timber
 
@@ -322,17 +324,17 @@ class Omnibar(
     }
 
     fun hideFindInPage() {
-        if (newOmnibar.isFindInPageVisible()) {
+        if (findInPage.findInPageContainer.visibility != GONE) {
             binding.focusDummy.requestFocus()
-            newOmnibar.hideFindInPage()
+            findInPage.findInPageContainer.gone()
             findInPage.findInPageInput.hideKeyboard()
             findInPage.findInPageInput.text.clear()
         }
     }
 
     fun showFindInPageView(viewState: FindInPageViewState) {
-        if (!newOmnibar.isFindInPageVisible()) {
-            newOmnibar.showFindInPage()
+        if (findInPage.findInPageContainer.visibility != VISIBLE) {
+            findInPage.findInPageContainer.show()
             findInPage.findInPageInput.postDelayed(KEYBOARD_DELAY) {
                 findInPage.findInPageInput.showKeyboard()
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -440,7 +440,6 @@ open class OmnibarLayout @JvmOverloads constructor(
             lastSeenPrivacyShield = null
         }
         renderButtons(viewState)
-        renderFindInPage(viewState)
     }
 
     open fun processCommand(command: OmnibarLayoutViewModel.Command) {
@@ -651,20 +650,6 @@ open class OmnibarLayout @JvmOverloads constructor(
             Timber.d("Omnibar: reduce not attached saving $stateChange")
             this.stateBuffer.add(stateChange)
         }
-    }
-
-    private fun renderFindInPage(viewState: ViewState) {
-        findInPage.findInPageContainer.isVisible = viewState.findInPageVisible
-    }
-
-    fun isFindInPageVisible(): Boolean = viewModel.viewState.value.findInPageVisible
-
-    fun showFindInPage() {
-        viewModel.showFindInPage()
-    }
-
-    fun hideFindInPage() {
-        viewModel.hideFindInPage()
     }
 
     private fun reduceDeferred(stateChange: StateChange) {

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -57,7 +57,6 @@ import com.duckduckgo.app.browser.omnibar.OmnibarLayout.Decoration.HighlightOmni
 import com.duckduckgo.app.browser.omnibar.OmnibarLayout.Decoration.LaunchCookiesAnimation
 import com.duckduckgo.app.browser.omnibar.OmnibarLayout.Decoration.LaunchTrackersAnimation
 import com.duckduckgo.app.browser.omnibar.OmnibarLayout.Decoration.Mode
-import com.duckduckgo.app.browser.omnibar.OmnibarLayout.Decoration.Outline
 import com.duckduckgo.app.browser.omnibar.OmnibarLayout.Decoration.PrivacyShieldChanged
 import com.duckduckgo.app.browser.omnibar.OmnibarLayout.Decoration.QueueCookiesAnimation
 import com.duckduckgo.app.browser.omnibar.OmnibarLayoutViewModel.Command
@@ -125,7 +124,6 @@ open class OmnibarLayout @JvmOverloads constructor(
             val privacyShield: Boolean,
         ) : Decoration()
 
-        data class Outline(val enabled: Boolean) : Decoration()
         data class DisableVoiceSearch(val url: String) : Decoration()
     }
 
@@ -167,7 +165,9 @@ open class OmnibarLayout @JvmOverloads constructor(
     private var lastViewMode: Mode? = null
     private var stateBuffer: MutableList<StateChange> = mutableListOf()
 
-    internal val findInPage by lazy { IncludeFindInPageBinding.bind(findViewById(R.id.findInPage)) }
+    internal open val findInPage: FindInPage by lazy {
+        FindInPageImpl(IncludeFindInPageBinding.bind(findViewById(R.id.findInPage)))
+    }
     internal val omnibarTextInput: KeyboardAwareEditText by lazy { findViewById(R.id.omnibarTextInput) }
     internal val tabsMenu: TabSwitcherButton by lazy { findViewById(R.id.tabsMenu) }
     internal val fireIconMenu: FrameLayout by lazy { findViewById(R.id.fireIconMenu) }
@@ -440,6 +440,7 @@ open class OmnibarLayout @JvmOverloads constructor(
             lastSeenPrivacyShield = null
         }
         renderButtons(viewState)
+        renderFindInPage(viewState)
     }
 
     open fun processCommand(command: OmnibarLayoutViewModel.Command) {
@@ -613,10 +614,6 @@ open class OmnibarLayout @JvmOverloads constructor(
                 viewModel.onPrivacyShieldChanged(decoration.privacyShield)
             }
 
-            is Outline -> {
-                viewModel.onOutlineEnabled(decoration.enabled)
-            }
-
             Decoration.CancelAnimations -> {
                 cancelTrackersAnimation()
             }
@@ -654,6 +651,20 @@ open class OmnibarLayout @JvmOverloads constructor(
             Timber.d("Omnibar: reduce not attached saving $stateChange")
             this.stateBuffer.add(stateChange)
         }
+    }
+
+    private fun renderFindInPage(viewState: ViewState) {
+        findInPage.findInPageContainer.isVisible = viewState.findInPageVisible
+    }
+
+    fun isFindInPageVisible(): Boolean = viewModel.viewState.value.findInPageVisible
+
+    fun showFindInPage() {
+        viewModel.showFindInPage()
+    }
+
+    fun hideFindInPage() {
+        viewModel.hideFindInPage()
     }
 
     private fun reduceDeferred(stateChange: StateChange) {

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -145,11 +145,7 @@ class OmnibarLayoutViewModel @Inject constructor(
         val experimentalIconsEnabled: Boolean = false,
         val trackersBlocked: Int = 0,
         val previouslyTrackersBlocked: Int = 0,
-        val findInPageVisible: Boolean = false,
     ) {
-
-        val outlineVisible: Boolean = hasFocus || findInPageVisible
-
         fun shouldUpdateOmnibarText(): Boolean {
             return this.viewMode is Browser || this.viewMode is MaliciousSiteWarning
         }
@@ -700,18 +696,6 @@ class OmnibarLayoutViewModel @Inject constructor(
                     viewMode = customTabMode.copy(title = decoration.title),
                 )
             }
-        }
-    }
-
-    fun showFindInPage() {
-        _viewState.update {
-            it.copy(findInPageVisible = true)
-        }
-    }
-
-    fun hideFindInPage() {
-        _viewState.update {
-            it.copy(findInPageVisible = false)
         }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -145,7 +145,11 @@ class OmnibarLayoutViewModel @Inject constructor(
         val experimentalIconsEnabled: Boolean = false,
         val trackersBlocked: Int = 0,
         val previouslyTrackersBlocked: Int = 0,
+        val findInPageVisible: Boolean = false,
     ) {
+
+        val outlineVisible: Boolean = hasFocus || findInPageVisible
+
         fun shouldUpdateOmnibarText(): Boolean {
             return this.viewMode is Browser || this.viewMode is MaliciousSiteWarning
         }
@@ -370,15 +374,6 @@ class OmnibarLayoutViewModel @Inject constructor(
         _viewState.update {
             it.copy(
                 privacyShield = privacyShield,
-            )
-        }
-    }
-
-    fun onOutlineEnabled(enabled: Boolean) {
-        Timber.d("Omnibar: onOutlineEnabled")
-        _viewState.update {
-            it.copy(
-                hasFocus = enabled,
             )
         }
     }
@@ -705,6 +700,18 @@ class OmnibarLayoutViewModel @Inject constructor(
                     viewMode = customTabMode.copy(title = decoration.title),
                 )
             }
+        }
+    }
+
+    fun showFindInPage() {
+        _viewState.update {
+            it.copy(findInPageVisible = true)
+        }
+    }
+
+    fun hideFindInPage() {
+        _viewState.update {
+            it.copy(findInPageVisible = false)
         }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/FadeOmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/FadeOmnibarLayout.kt
@@ -32,7 +32,10 @@ import androidx.core.view.marginTop
 import androidx.core.view.updatePadding
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.databinding.IncludeFadeOmnibarFindInPageBinding
 import com.duckduckgo.app.browser.navigation.bar.view.BrowserNavigationBarView
+import com.duckduckgo.app.browser.omnibar.FindInPage
+import com.duckduckgo.app.browser.omnibar.FindInPageImpl
 import com.duckduckgo.app.browser.omnibar.Omnibar.ViewMode
 import com.duckduckgo.app.browser.omnibar.OmnibarLayout
 import com.duckduckgo.app.browser.omnibar.OmnibarLayoutViewModel.ViewState
@@ -56,6 +59,10 @@ class FadeOmnibarLayout @JvmOverloads constructor(
     private val omnibarCard: MaterialCardView by lazy { findViewById(R.id.omniBarContainer) }
     private val omniBarContentContainer: View by lazy { findViewById(R.id.omniBarContentContainer) }
     private val backIcon: ImageView by lazy { findViewById(R.id.backIcon) }
+
+    override val findInPage: FindInPage by lazy {
+        FindInPageImpl(IncludeFadeOmnibarFindInPageBinding.bind(findViewById(R.id.findInPage)))
+    }
 
     /**
      * Returns the [BrowserNavigationBarView] reference if it's embedded inside of this omnibar layout, otherwise, returns null.
@@ -158,8 +165,9 @@ class FadeOmnibarLayout @JvmOverloads constructor(
             backIcon.gone()
         }
 
-        omniBarContainer.isPressed = viewState.hasFocus
-        if (viewState.hasFocus) {
+        omniBarContentContainer.isVisible = !viewState.findInPageVisible
+
+        if (viewState.outlineVisible) {
             animateOmnibarFocusedState(focused = true)
         } else {
             animateOmnibarFocusedState(focused = false)
@@ -182,10 +190,10 @@ class FadeOmnibarLayout @JvmOverloads constructor(
         val startCardMarginBottom = omnibarCard.marginBottom
         val startCardMarginStart = omnibarCard.marginStart
         val startCardMarginEnd = omnibarCard.marginEnd
-        val startContentPaddingTop = omniBarContentContainer.paddingTop
-        val startContentPaddingBottom = omniBarContentContainer.paddingBottom
-        val startContentPaddingStart = omniBarContentContainer.paddingStart
-        val startContentPaddingEnd = omniBarContentContainer.paddingEnd
+        val startContentPaddingTop = omnibarCard.contentPaddingTop
+        val startContentPaddingBottom = omnibarCard.contentPaddingBottom
+        val startContentPaddingStart = omnibarCard.contentPaddingLeft
+        val startContentPaddingEnd = omnibarCard.contentPaddingRight
         val startCardStrokeWidth = omnibarCard.strokeWidth
 
         val endCardMarginTop: Int
@@ -243,7 +251,7 @@ class FadeOmnibarLayout @JvmOverloads constructor(
             params.bottomMargin = animatedCardMarginBottom
             omnibarCard.setLayoutParams(params)
 
-            omniBarContentContainer.setPadding(
+            omnibarCard.setContentPadding(
                 animatedContentPaddingStart,
                 animatedContentPaddingTop,
                 animatedContentPaddingEnd,

--- a/app/src/main/res/drawable/ic_chevron_down_24e.xml
+++ b/app/src/main/res/drawable/ic_chevron_down_24e.xml
@@ -1,0 +1,26 @@
+<!--
+  ~ Copyright (c) 2025 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M3.22,8.22C2.927,8.513 2.927,8.987 3.22,9.28L10.232,16.293C11.208,17.269 12.792,17.269 13.768,16.293L20.905,9.155C21.198,8.862 21.198,8.388 20.905,8.095C20.612,7.802 20.138,7.802 19.845,8.095L12.707,15.232C12.317,15.623 11.683,15.623 11.293,15.232L4.28,8.22C3.987,7.927 3.513,7.927 3.22,8.22Z"
+      android:fillColor="?attr/daxColorSecondaryIcon"
+      android:fillType="evenOdd"/>
+</vector>

--- a/app/src/main/res/drawable/ic_chevron_up_24e.xml
+++ b/app/src/main/res/drawable/ic_chevron_up_24e.xml
@@ -1,0 +1,26 @@
+<!--
+  ~ Copyright (c) 2025 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M3.22,15.78C2.927,15.487 2.927,15.013 3.22,14.72L10.232,7.707C11.208,6.731 12.792,6.731 13.768,7.707L20.905,14.845C21.198,15.138 21.198,15.612 20.905,15.905C20.612,16.198 20.138,16.198 19.845,15.905L12.707,8.768C12.317,8.377 11.683,8.377 11.293,8.768L4.28,15.78C3.987,16.073 3.513,16.073 3.22,15.78Z"
+      android:fillColor="?attr/daxColorSecondaryIcon"
+      android:fillType="evenOdd"/>
+</vector>

--- a/app/src/main/res/drawable/ic_close_24e.xml
+++ b/app/src/main/res/drawable/ic_close_24e.xml
@@ -1,0 +1,30 @@
+<!--
+  ~ Copyright (c) 2025 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M18.78,5.22C19.073,5.513 19.073,5.987 18.78,6.28L6.28,18.78C5.987,19.073 5.513,19.073 5.22,18.78C4.927,18.487 4.927,18.013 5.22,17.72L17.72,5.22C18.013,4.927 18.487,4.927 18.78,5.22Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M5.22,5.22C5.513,4.927 5.987,4.927 6.28,5.22L18.78,17.72C19.073,18.013 19.073,18.487 18.78,18.78C18.487,19.073 18.013,19.073 17.72,18.78L5.22,6.28C4.927,5.987 4.927,5.513 5.22,5.22Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"
+      android:fillType="evenOdd"/>
+</vector>

--- a/app/src/main/res/drawable/ic_find_in_page_24e.xml
+++ b/app/src/main/res/drawable/ic_find_in_page_24e.xml
@@ -1,0 +1,29 @@
+<!--
+  ~ Copyright (c) 2025 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M8,1.969C5.221,1.969 2.969,4.221 2.969,7V17C2.969,19.779 5.221,22.031 8,22.031H15C15.089,22.031 15.179,22.032 15.269,22.032C15.95,22.038 16.223,21.192 15.752,20.699C15.609,20.549 15.411,20.469 15.203,20.469H8C6.084,20.469 4.531,18.916 4.531,17V7C4.531,5.084 6.084,3.531 8,3.531H16C17.916,3.531 19.469,5.084 19.469,7V15.947C19.469,16.159 19.552,16.361 19.704,16.508C20.204,16.989 21.031,16.693 21.031,16V7C21.031,4.221 18.779,1.969 16,1.969H8Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"/>
+  <path
+      android:pathData="M16.119,15.889C16.694,15.072 17.031,14.075 17.031,13C17.031,10.221 14.779,7.969 12,7.969C9.221,7.969 6.969,10.221 6.969,13C6.969,15.779 9.221,18.031 12,18.031C13.139,18.031 14.191,17.652 15.034,17.014L18.166,20.146C18.471,20.451 18.966,20.451 19.271,20.146C19.576,19.841 19.576,19.346 19.271,19.041L16.119,15.889ZM8.531,13C8.531,11.084 10.084,9.531 12,9.531C13.916,9.531 15.469,11.084 15.469,13C15.469,14.916 13.916,16.469 12,16.469C10.084,16.469 8.531,14.916 8.531,13Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"
+      android:fillType="evenOdd"/>
+</vector>

--- a/app/src/main/res/layout/include_fade_omnibar_find_in_page.xml
+++ b/app/src/main/res/layout/include_fade_omnibar_find_in_page.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2018 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/findInPageContainer"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_gravity="center_vertical"
+    android:gravity="center"
+    android:orientation="horizontal"
+    android:paddingHorizontal="2dp"
+    tools:ignore="KeyboardInaccessibleWidget"
+    tools:layout_height="@dimen/experimentalToolbarSize">
+
+    <!-- The expected horizontal padding for content is 6dp but we're applying only 2dp
+    because the remaining 4dp are added by the omnibar selection animation -->
+
+    <ImageView
+        android:layout_width="@dimen/toolbarIcon"
+        android:layout_height="@dimen/toolbarIcon"
+        android:gravity="center"
+        android:importantForAccessibility="no"
+        android:scaleType="center"
+        android:src="@drawable/ic_find_in_page_24e" />
+
+    <EditText
+        android:id="@+id/findInPageInput"
+        style="@style/Widget.DuckDuckGo.SearchInput"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:hint="@string/findInPageHint" />
+
+    <com.duckduckgo.common.ui.view.text.DaxTextView
+        android:id="@+id/findInPageMatches"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
+        app:textType="secondary"
+        app:typography="body2"
+        tools:text="1/10" />
+
+    <ImageView
+        android:id="@+id/previousSearchTermButton"
+        android:layout_width="@dimen/toolbarIcon"
+        android:layout_height="@dimen/toolbarIcon"
+        android:background="@drawable/selectable_item_experimental_background"
+        android:contentDescription="@string/previousSearchTermDescription"
+        android:scaleType="center"
+        android:src="@drawable/ic_chevron_up_24e" />
+
+    <ImageView
+        android:id="@+id/nextSearchTermButton"
+        android:layout_width="@dimen/toolbarIcon"
+        android:layout_height="@dimen/toolbarIcon"
+        android:background="@drawable/selectable_item_experimental_background"
+        android:contentDescription="@string/nextSearchTermDescription"
+        android:scaleType="center"
+        android:src="@drawable/ic_chevron_down_24e" />
+
+    <ImageView
+        android:id="@+id/closeFindInPagePanel"
+        android:layout_width="@dimen/toolbarIcon"
+        android:layout_height="@dimen/toolbarIcon"
+        android:background="@drawable/selectable_item_experimental_background"
+        android:contentDescription="@string/closeFindInPageButtonDescription"
+        android:scaleType="center"
+        android:src="@drawable/ic_close_24e" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/view_fade_omnibar.xml
+++ b/app/src/main/res/layout/view_fade_omnibar.xml
@@ -58,13 +58,13 @@
                     android:layout_marginTop="@dimen/experimentalOmnibarCardMarginTop"
                     android:layout_marginBottom="@dimen/experimentalOmnibarCardMarginBottom"
                     app:strokeColor="?daxColorAccentBlue"
+                    app:contentPadding="@dimen/experimentalOmnibarContentPadding"
                     app:strokeWidth="@dimen/experimentalOmnibarOutlineWidth">
 
                     <androidx.constraintlayout.widget.ConstraintLayout
                         android:id="@+id/omniBarContentContainer"
                         android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:padding="@dimen/experimentalOmnibarContentPadding">
+                        android:layout_height="match_parent">
 
                         <ProgressBar
                             android:id="@+id/pageLoadingIndicator"
@@ -319,6 +319,13 @@
 
                     </androidx.constraintlayout.widget.ConstraintLayout>
 
+                    <include
+                        android:id="@+id/findInPage"
+                        layout="@layout/include_fade_omnibar_find_in_page"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:visibility="gone" />
+
                 </com.google.android.material.card.MaterialCardView>
 
             </androidx.appcompat.widget.Toolbar>
@@ -404,16 +411,6 @@
                     android:contentDescription="@string/browserPopupMenu"
                     android:src="@drawable/ic_fire" />
             </FrameLayout>
-
-            <include
-                android:id="@+id/findInPage"
-                layout="@layout/include_find_in_page"
-                android:layout_width="0dp"
-                android:layout_height="?attr/actionBarSize"
-                android:visibility="gone"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
 
             <com.airbnb.lottie.LottieAnimationView
                 android:id="@+id/shieldIconExperiment"

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -1072,57 +1072,6 @@ class OmnibarLayoutViewModelTest {
         }
     }
 
-    @Test
-    fun `when showFindInPage and hideFindInPage called, then update the view state`() = runTest {
-        testee.showFindInPage()
-
-        testee.viewState.test {
-            val viewState = awaitItem()
-            assertTrue(viewState.findInPageVisible)
-        }
-
-        testee.hideFindInPage()
-
-        testee.viewState.test {
-            val viewState = awaitItem()
-            assertFalse(viewState.findInPageVisible)
-        }
-    }
-
-    @Test
-    fun `when find in page visible, then outline also visible`() = runTest {
-        testee.showFindInPage()
-
-        testee.viewState.test {
-            val viewState = awaitItem()
-            assertTrue(viewState.outlineVisible)
-        }
-
-        testee.hideFindInPage()
-
-        testee.viewState.test {
-            val viewState = awaitItem()
-            assertFalse(viewState.outlineVisible)
-        }
-    }
-
-    @Test
-    fun `when omnibar focused, then outline visible`() = runTest {
-        testee.onOmnibarFocusChanged(hasFocus = true, "")
-
-        testee.viewState.test {
-            val viewState = awaitItem()
-            assertTrue(viewState.outlineVisible)
-        }
-
-        testee.onOmnibarFocusChanged(hasFocus = false, "")
-
-        testee.viewState.test {
-            val viewState = awaitItem()
-            assertFalse(viewState.outlineVisible)
-        }
-    }
-
     private fun givenSiteLoaded(loadedUrl: String) {
         testee.onViewModeChanged(ViewMode.Browser(loadedUrl))
         testee.onExternalStateChange(

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -521,24 +521,6 @@ class OmnibarLayoutViewModelTest {
     }
 
     @Test
-    fun whenOutlineEnabledThenViewStateCorrect() = runTest {
-        testee.onOutlineEnabled(true)
-        testee.viewState.test {
-            val viewState = awaitItem()
-            assertTrue(viewState.hasFocus)
-        }
-    }
-
-    @Test
-    fun whenOutlineDisabledThenViewStateCorrect() = runTest {
-        testee.onOutlineEnabled(false)
-        testee.viewState.test {
-            val viewState = awaitItem()
-            assertFalse(viewState.hasFocus)
-        }
-    }
-
-    @Test
     fun whenClearTextButtonPressedThenViewStateCorrect() = runTest {
         testee.onClearTextButtonPressed()
         testee.viewState.test {
@@ -1087,6 +1069,57 @@ class OmnibarLayoutViewModelTest {
         testee.viewState.test {
             val viewState = awaitItem()
             assertTrue(viewState.showBrowserMenuHighlight)
+        }
+    }
+
+    @Test
+    fun `when showFindInPage and hideFindInPage called, then update the view state`() = runTest {
+        testee.showFindInPage()
+
+        testee.viewState.test {
+            val viewState = awaitItem()
+            assertTrue(viewState.findInPageVisible)
+        }
+
+        testee.hideFindInPage()
+
+        testee.viewState.test {
+            val viewState = awaitItem()
+            assertFalse(viewState.findInPageVisible)
+        }
+    }
+
+    @Test
+    fun `when find in page visible, then outline also visible`() = runTest {
+        testee.showFindInPage()
+
+        testee.viewState.test {
+            val viewState = awaitItem()
+            assertTrue(viewState.outlineVisible)
+        }
+
+        testee.hideFindInPage()
+
+        testee.viewState.test {
+            val viewState = awaitItem()
+            assertFalse(viewState.outlineVisible)
+        }
+    }
+
+    @Test
+    fun `when omnibar focused, then outline visible`() = runTest {
+        testee.onOmnibarFocusChanged(hasFocus = true, "")
+
+        testee.viewState.test {
+            val viewState = awaitItem()
+            assertTrue(viewState.outlineVisible)
+        }
+
+        testee.onOmnibarFocusChanged(hasFocus = false, "")
+
+        testee.viewState.test {
+            val viewState = awaitItem()
+            assertFalse(viewState.outlineVisible)
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1209874980847232

### Description

Updates the "find in page" design for the `FadeOmnibarLayout`.

Functionally, there’s no change for the production omnibar. But in the experimental omnibar - where the "find in page" UI is moved inside the card - we can now detect when it’s shown and hide other content accordingly. This lets us reuse the omnibar card’s existing design and animations.

This PR keeps the changes minimal, focused on adapting "find in page" for the experimental omnibar. As a follow up, in https://github.com/duckduckgo/Android/pull/5926, I'm attempting to migrate the whole of "find in page" state management out of `BrowserTabViewModel` and into the omnibar, along with further cleanup.

### Steps to test this PR

- [x] Verify that "find in page" for production omnibar is unchanged.
- [x] Enable experimental UI feature flag.
  - [x] Verify that "find in page" for experimental omnibar matches design.
  - [x] Verify that when "find in page" is opened, the omnibar animates to a focused state but content doesn't change position.
  - [x] Verify that using back button/gestures and "X" button closes "find in page" without changing page navigation.

### UI changes
| Before  | After |
| ------ | ----- |
![Screenshot_20250417_115000](https://github.com/user-attachments/assets/fc99be5a-b697-41e7-a085-f44a4279d80b)|![Screenshot_20250417_115143](https://github.com/user-attachments/assets/5c0275b8-aa22-47db-aaa0-0ef83886c6fd)|
