### PR TITLE
Handle experiment metadata from subscriptionSelected message

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
@@ -224,18 +224,26 @@ class SubscriptionWebViewViewModel @Inject constructor(
         viewModelScope.launch(dispatcherProvider.io()) {
             val id = runCatching { data?.getString("id") }.getOrNull()
             val offerId = runCatching { data?.getString("offerId") }.getOrNull()
+            val experimentName = runCatching { data?.getJSONObject("experiment")?.getString("name") }.getOrNull()
+            val experimentCohort = runCatching { data?.getJSONObject("experiment")?.getString("cohort") }.getOrNull()
             if (id.isNullOrBlank()) {
                 pixelSender.reportPurchaseFailureOther()
                 _currentPurchaseViewState.emit(currentPurchaseViewState.value.copy(purchaseState = Failure))
             } else {
-                command.send(SubscriptionSelected(id, offerId))
+                command.send(SubscriptionSelected(id, offerId, experimentName, experimentCohort))
             }
         }
     }
 
-    fun purchaseSubscription(activity: Activity, planId: String, offerId: String?) {
+    fun purchaseSubscription(
+        activity: Activity,
+        planId: String,
+        offerId: String?,
+        experimentName: String?,
+        experimentCohort: String?,
+    ) {
         viewModelScope.launch(dispatcherProvider.io()) {
-            subscriptionsManager.purchase(activity, planId, offerId)
+            subscriptionsManager.purchase(activity, planId, offerId, experimentName, experimentCohort)
         }
     }
 
@@ -411,6 +419,8 @@ class SubscriptionWebViewViewModel @Inject constructor(
         data class SubscriptionSelected(
             val id: String,
             val offerId: String?,
+            val experimentName: String?,
+            val experimentCohort: String?,
         ) : Command()
         data object RestoreSubscription : Command()
         data object GoToITR : Command()

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
@@ -417,7 +417,7 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
             is BackToSettings, BackToSettingsActivateSuccess -> backToSettings()
             is SendJsEvent -> sendJsEvent(command.event)
             is SendResponseToJs -> sendResponseToJs(command.data)
-            is SubscriptionSelected -> selectSubscription(command.id, command.offerId)
+            is SubscriptionSelected -> selectSubscription(command.id, command.offerId, command.experimentName, command.experimentCohort)
             is RestoreSubscription -> restoreSubscription()
             is GoToITR -> goToITR()
             is GoToPIR -> goToPIR()
@@ -517,8 +517,13 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
             .show()
     }
 
-    private fun selectSubscription(id: String, offerId: String?) {
-        viewModel.purchaseSubscription(this, id, offerId)
+    private fun selectSubscription(
+        id: String,
+        offerId: String?,
+        experimentName: String?,
+        experimentCohort: String?,
+    ) {
+        viewModel.purchaseSubscription(this, id, offerId, experimentName, experimentCohort)
     }
 
     private fun sendResponseToJs(data: JsCallbackData) {

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
@@ -319,7 +319,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         givenCreateAccountSucceeds()
         val accountExternalId = authDataStore.externalId
 
-        subscriptionsManager.purchase(activity = mock(), planId = "", offerId = null)
+        purchase()
 
         if (authApiV2Enabled) {
             verify(authClient).authorize(any())
@@ -337,7 +337,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         givenUserIsNotSignedIn()
         givenCreateAccountSucceeds()
 
-        subscriptionsManager.purchase(mock(), planId = "", offerId = null)
+        purchase()
 
         if (authApiV2Enabled) {
             verify(authClient).authorize(any())
@@ -355,7 +355,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         whenever(emailManager.getToken()).thenReturn("emailToken")
         givenUserIsNotSignedIn()
 
-        subscriptionsManager.purchase(mock(), planId = "", offerId = null)
+        purchase()
 
         verify(authService).createAccount("Bearer emailToken")
     }
@@ -366,7 +366,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         givenCreateAccountFails()
 
         subscriptionsManager.currentPurchaseState.test {
-            subscriptionsManager.purchase(mock(), planId = "", offerId = null)
+            purchase()
             assertTrue(awaitItem() is CurrentPurchase.PreFlowInProgress)
             assertTrue(awaitItem() is CurrentPurchase.Failure)
             cancelAndConsumeRemainingEvents()
@@ -380,7 +380,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         givenValidateTokenSucceedsNoEntitlements()
         givenAccessTokenSucceeds()
 
-        subscriptionsManager.purchase(mock(), planId = "", offerId = null)
+        purchase()
 
         verify(playBillingManager).launchBillingFlow(any(), any(), externalId = eq("1234"), isNull())
     }
@@ -393,7 +393,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         givenSubscriptionSucceedsWithoutEntitlements(status = "Expired")
         givenAccessTokenSucceeds()
 
-        subscriptionsManager.purchase(mock(), "", null)
+        purchase()
 
         verify(playBillingManager).launchBillingFlow(any(), any(), externalId = eq("1234"), isNull())
     }
@@ -407,7 +407,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         givenAccessTokenSucceeds()
 
         subscriptionsManager.currentPurchaseState.test {
-            subscriptionsManager.purchase(mock(), planId = "", offerId = null)
+            purchase()
             assertTrue(awaitItem() is CurrentPurchase.PreFlowInProgress)
             verify(playBillingManager, never()).launchBillingFlow(any(), any(), any(), isNull())
             assertTrue(awaitItem() is CurrentPurchase.Recovered)
@@ -423,7 +423,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         givenStoreLoginFails()
 
         subscriptionsManager.currentPurchaseState.test {
-            subscriptionsManager.purchase(mock(), planId = "", offerId = null)
+            purchase()
             assertTrue(awaitItem() is CurrentPurchase.PreFlowInProgress)
             assertTrue(awaitItem() is CurrentPurchase.Failure)
             cancelAndConsumeRemainingEvents()
@@ -436,7 +436,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
 
         givenUserIsSignedIn()
 
-        subscriptionsManager.purchase(mock(), planId = "", offerId = null)
+        purchase()
 
         verify(authService).validateToken(any())
     }
@@ -447,7 +447,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         givenSubscriptionSucceedsWithoutEntitlements(status = "Expired")
 
         subscriptionsManager.currentPurchaseState.test {
-            subscriptionsManager.purchase(mock(), planId = "", offerId = null)
+            purchase()
             assertTrue(awaitItem() is CurrentPurchase.PreFlowInProgress)
             verify(playBillingManager).launchBillingFlow(any(), any(), externalId = eq("1234"), isNull())
             assertTrue(awaitItem() is CurrentPurchase.PreFlowFinished)
@@ -461,7 +461,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         givenCreateAccountFails()
 
         subscriptionsManager.currentPurchaseState.test {
-            subscriptionsManager.purchase(mock(), planId = "", offerId = null)
+            purchase()
             assertTrue(awaitItem() is CurrentPurchase.PreFlowInProgress)
             assertTrue(awaitItem() is CurrentPurchase.Failure)
             cancelAndConsumeRemainingEvents()
@@ -473,7 +473,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         givenUserIsSignedIn()
         givenValidateTokenFails("failure")
 
-        subscriptionsManager.purchase(mock(), "", null)
+        purchase()
 
         verify(authService, never()).createAccount(any())
     }
@@ -485,7 +485,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         givenSubscriptionSucceedsWithoutEntitlements()
         givenAccessTokenSucceeds()
 
-        subscriptionsManager.purchase(mock(), planId = "", offerId = null)
+        purchase()
         if (authApiV2Enabled) {
             assertEquals(FAKE_ACCESS_TOKEN_V2, authDataStore.accessTokenV2)
             assertEquals(FAKE_REFRESH_TOKEN_V2, authDataStore.refreshTokenV2)
@@ -507,7 +507,8 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         givenSubscriptionSucceedsWithoutEntitlements()
         givenAccessTokenSucceeds()
 
-        subscriptionsManager.purchase(mock(), planId = "", offerId = null)
+        purchase()
+
         subscriptionsManager.isSignedIn.test {
             assertTrue(awaitItem())
             if (authApiV2Enabled) {
@@ -530,7 +531,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         givenUserIsSignedIn()
         givenSubscriptionFails(httpResponseCode = 400)
 
-        subscriptionsManager.purchase(mock(), planId = "", offerId = null)
+        purchase()
 
         verify(playBillingManager).launchBillingFlow(any(), any(), any(), isNull())
     }
@@ -540,7 +541,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         givenUserIsSignedIn()
         givenSubscriptionFails(httpResponseCode = 404)
 
-        subscriptionsManager.purchase(mock(), planId = "", offerId = null)
+        purchase()
 
         verify(playBillingManager).launchBillingFlow(any(), any(), any(), isNull())
     }
@@ -1171,7 +1172,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         givenAccessTokenSucceeds()
 
         subscriptionsManager.currentPurchaseState.test {
-            subscriptionsManager.purchase(mock(), planId = "", offerId = null)
+            purchase()
             assertTrue(awaitItem() is CurrentPurchase.PreFlowInProgress)
             assertTrue(awaitItem() is CurrentPurchase.Recovered)
 
@@ -1197,7 +1198,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         whenever(playBillingManager.purchaseState).thenReturn(purchaseState)
 
         subscriptionsManager.currentPurchaseState.test {
-            subscriptionsManager.purchase(mock(), planId = "", offerId = null)
+            purchase()
             assertTrue(awaitItem() is CurrentPurchase.PreFlowInProgress)
             assertTrue(awaitItem() is CurrentPurchase.PreFlowFinished)
 
@@ -1241,7 +1242,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         givenCreateAccountFails()
 
         subscriptionsManager.currentPurchaseState.test {
-            subscriptionsManager.purchase(mock(), planId = "", offerId = null)
+            purchase()
             assertTrue(awaitItem() is CurrentPurchase.PreFlowInProgress)
             assertTrue(awaitItem() is CurrentPurchase.Failure)
 
@@ -1756,6 +1757,21 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         }
 
         whenever(playBillingManager.products).thenReturn(listOf(productDetails))
+    }
+
+    private suspend fun purchase(
+        planId: String = "",
+        offerId: String? = null,
+        experimentName: String? = null,
+        experimentCohort: String? = null,
+    ) {
+        subscriptionsManager.purchase(
+            mock(),
+            planId = planId,
+            offerId = offerId,
+            experimentCohort = experimentCohort,
+            experimentName = experimentName,
+        )
     }
 
     @SuppressLint("DenyListedApi")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1209917212981563?focus=true

### Description
Handle experiment metadata and pass to `/confirm` endpoint for a future Front End experiment. For the moment, this change shouldn't make any difference in the paywall

### Steps to test this PR

_Pre steps_
- [x] Make sure you are Privacy Pro eligible

_Regression check: Paywall unaffected_
- [x] Install from branch
- [x] Go to Settings > Privacy Pro
- [x] Make sure paywall opens and works as expected

_Experiment integration (tratment A)_

- [x] Use a VPN connected to US
- [x] Apply patch attached in https://app.asana.com/1/137249556945/task/1210050331055612?focus=true
- [x] Fresh install
- [x] Go to Settings > Privacy Pro
- [x] Check you see a new paywall design for free trials
- [x] Subscribe to a monthly or yearly product
- [x] Check logs to confirm that experimentName and experimentCohort are sent to in `purchase/confirm` request. (Filter by `/confirm body` in logs)

### No UI changes
