### PR TITLE
fix WebView offset when navigation bar enabled and keyboard visible

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/navigation/bar/BrowserNavigationBarViewIntegration.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/navigation/bar/BrowserNavigationBarViewIntegration.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.utils.keyboardVisibilityFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 
 /**
@@ -88,11 +89,14 @@ class BrowserNavigationBarViewIntegration(
         // we're hiding the navigation bar when keyboard is shown,
         // to prevent it from being "pushed up" within the coordinator layout
         keyboardVisibilityJob = lifecycleScope.launch {
-            omnibar.textInputRootView.keyboardVisibilityFlow().collect { keyboardVisible ->
+            omnibar.textInputRootView.keyboardVisibilityFlow().distinctUntilChanged().collect { keyboardVisible ->
                 if (keyboardVisible) {
                     navigationBarView.gone()
                 } else {
-                    navigationBarView.show()
+                    navigationBarView.postDelayed(
+                        { navigationBarView.show() },
+                        BrowserTabFragment.KEYBOARD_DELAY,
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/navigation/bar/view/BrowserNavigationBarView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/navigation/bar/view/BrowserNavigationBarView.kt
@@ -45,6 +45,7 @@ import com.duckduckgo.app.browser.navigation.bar.view.BrowserNavigationBarViewMo
 import com.duckduckgo.app.browser.navigation.bar.view.BrowserNavigationBarViewModel.ViewState
 import com.duckduckgo.app.browser.omnibar.experiments.FadeOmnibarLayout
 import com.duckduckgo.app.browser.omnibar.model.OmnibarPosition
+import com.duckduckgo.app.browser.webview.BrowserContainerLayoutBehavior
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.ViewViewModelFactory
@@ -61,6 +62,22 @@ class BrowserNavigationBarView @JvmOverloads constructor(
     private val attrs: AttributeSet? = null,
     defStyle: Int = 0,
 ) : FrameLayout(context, attrs, defStyle), AttachedBehavior {
+
+    override fun setVisibility(visibility: Int) {
+        val isVisibilityUpdated = this.visibility != visibility
+
+        super.setVisibility(visibility)
+
+        /**
+         * This notifies all view behaviors that depend on the [BrowserNavigationBarView] to recalculate whenever the bar's visibility changes,
+         * for example, we require that in [BrowserContainerLayoutBehavior] to remove the bottom inset when navigation bar disappears.
+         * The base coordinator behavior doesn't notify dependent views when visibility changes, so we need to do that manually.
+         */
+        val parent = parent
+        if (isVisibilityUpdated && parent is CoordinatorLayout) {
+            parent.dispatchDependentViewsChanged(this)
+        }
+    }
 
     @Inject
     lateinit var viewModelFactory: ViewViewModelFactory

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/BottomAppBarBehavior.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/BottomAppBarBehavior.kt
@@ -23,7 +23,6 @@ import android.util.AttributeSet
 import android.view.Gravity
 import android.view.View
 import android.view.animation.DecelerateInterpolator
-import android.widget.RelativeLayout
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.ViewCompat
 import androidx.core.view.ViewCompat.NestedScrollType
@@ -46,17 +45,13 @@ class BottomAppBarBehavior<V : View>(
     private var lastStartedType: Int = 0
     private var offsetAnimator: ValueAnimator? = null
 
-    private var browserLayout: RelativeLayout? = null
-
     @SuppressLint("RestrictedApi")
     override fun layoutDependsOn(parent: CoordinatorLayout, child: V, dependency: View): Boolean {
         if (dependency is Snackbar.SnackbarLayout) {
             updateSnackbar(child, dependency)
         }
 
-        if (dependency.id == R.id.browserLayout) {
-            browserLayout = dependency as RelativeLayout
-        } else if (dependency.id != R.id.webViewFullScreenContainer) {
+        if (dependency.id != R.id.webViewFullScreenContainer) {
             offsetBottomByToolbar(dependency)
         }
 
@@ -95,7 +90,6 @@ class BottomAppBarBehavior<V : View>(
             // only hide the app bar in the browser layout
             if (target.id == R.id.browserWebView) {
                 toolbar.translationY = max(0f, min(toolbar.height.toFloat(), toolbar.translationY + dy))
-                offsetBottomByToolbar(browserLayout)
             }
         }
     }
@@ -132,7 +126,6 @@ class BottomAppBarBehavior<V : View>(
         } else {
             val targetTranslation = if (expanded) 0f else omnibar.height().toFloat()
             omnibar.setTranslation(targetTranslation)
-            offsetBottomByToolbar(browserLayout)
         }
     }
 
@@ -149,7 +142,6 @@ class BottomAppBarBehavior<V : View>(
         offsetAnimator?.addUpdateListener { animation ->
             val animatedValue = animation.animatedValue as Float
             omnibar.setTranslation(animatedValue)
-            offsetBottomByToolbar(browserLayout)
         }
 
         val targetTranslation = if (isVisible) 0f else omnibar.height().toFloat()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1210010551182684?focus=true

### Description
Fixes an issue where navigation bar, even when gone when keyboard is inflated, would still retain the offset applied to the web view content.

The fix is to notify the coordinator layout that navigation bar changed, when its visibility changes, which doesn't happen by default.

We already have handling of that available in the behavior that adjusts browsers padding:

https://github.com/duckduckgo/Android/blob/c0e22478de53029ceb4f6f80188c97782a74562a/app/src/main/java/com/duckduckgo/app/browser/webview/BrowserContainerLayoutBehavior.kt#L53-L78

### Steps to test this PR

- [x] With experimental UI flag enabled, click on the address bar when on a web page other than SERP. Ensure that there's no visible inset/padding on the bottom of the web view.
- [ ] Try that with both top and bottom omnibar.

### UI changes
1. Before
2. After

| 1  | 2 |
| ------ | ------ |
![Screenshot_20250417_163916](https://github.com/user-attachments/assets/8d48a5d8-1b29-41b7-a00f-93eaaa0b29bb)|![Screenshot_20250417_164016](https://github.com/user-attachments/assets/4e8371b1-47b2-47a1-8100-6ac9e320a75b)|
