### PR TITLE
Android Crash: [Not fixed in 5.230.0] java.util.NoSuchElementException - kotlinx.coroutines.flow.FlowKt__ReduceKt.first(Reduce.kt:92)

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsViewModel.kt
@@ -117,6 +117,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
@@ -670,7 +671,7 @@ class AutofillSettingsViewModel @Inject constructor(
             Timber.v("Opened autofill management screen from from %s", launchSource)
 
             val source = launchSource.asString()
-            val hasCredentialsSaved = autofillStore.getCredentialCount().first() > 0
+            val hasCredentialsSaved = (autofillStore.getCredentialCount().firstOrNull() ?: 0) > 0
             pixel.fire(AUTOFILL_MANAGEMENT_SCREEN_OPENED, mapOf("source" to source, "has_credentials_saved" to hasCredentialsSaved.toBinaryString()))
         }
     }

--- a/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSitePomptDataStore.kt
+++ b/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSitePomptDataStore.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 
 interface BrokenSitePromptDataStore {
@@ -149,7 +150,7 @@ class SharedPreferencesDuckPlayerDataStore @Inject constructor(
     ): Int {
         val allDismissEvents = store.data.map { prefs ->
             prefs[DISMISS_EVENTS]?.toSet() ?: emptySet()
-        }.first()
+        }.firstOrNull() ?: emptySet()
 
         return allDismissEvents.count { dateString: String ->
             try {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1210012823537208?focus=true

### Description
This PR replaces usages of `first()` with `firstOrNull()` in two locations to prevent potential crashes when collecting from empty flows.

### Steps to test this PR

N/A