### PR TITLE
fix disabled icon colors in the ui experiment

### DIFF
--- a/common/common-ui/src/main/res/values/design-experiments-colors.xml
+++ b/common/common-ui/src/main/res/values/design-experiments-colors.xml
@@ -35,6 +35,7 @@
     <!-- Icons -->
     <color name="icon_primary_dark">#C7FFFFFF</color>
     <color name="icon_secondary_dark">#7AFFFFFF</color>
+    <color name="icon_tertiary_dark">#3DFFFFFF</color>
 
     <!-- Lines-->
     <color name="lines_dark">#1FF9F9F9</color>
@@ -60,6 +61,7 @@
     <!-- Icons -->
     <color name="icon_primary_light">#D61C1F21</color>
     <color name="icon_secondary_light">#991C1F21</color>
+    <color name="icon_tertiary_light">#661C1F21</color>
 
     <!-- Lines-->
     <color name="lines_light">#171C1F21</color>

--- a/common/common-ui/src/main/res/values/design-experiments-theming.xml
+++ b/common/common-ui/src/main/res/values/design-experiments-theming.xml
@@ -30,8 +30,8 @@
 
         <!-- Icons -->
         <item name="daxColorPrimaryIcon">@color/icon_primary_dark</item>
-        <item name="daxColorIconDisabled">@color/text_primary_dark</item>
         <item name="daxColorSecondaryIcon">@color/icon_secondary_dark</item>
+        <item name="daxColorIconDisabled">@color/icon_tertiary_dark</item>
 
         <!-- Lines-->
         <item name="daxColorLines">@color/lines_dark</item>
@@ -63,6 +63,7 @@
         <!-- Icons -->
         <item name="daxColorPrimaryIcon">@color/icon_primary_light</item>
         <item name="daxColorSecondaryIcon">@color/icon_secondary_light</item>
+        <item name="daxColorIconDisabled">@color/icon_tertiary_light</item>
 
         <!-- Lines-->
         <item name="daxColorLines">@color/lines_light</item>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1142021229838617/task/1210010466569435?focus=true

### Description
Adds the missing icon tertiary colors, and applies them in the experimental theme.

### Steps to test this PR

With the experimental flag enabled, try and button that has an enabled and disabled state, whether it's represented correctly. For example, when adding a bookmarks folder.

### UI changes
| Before  | After |
| ------ | ----- |
![Screenshot_20250418_135351](https://github.com/user-attachments/assets/8068ca8d-4cb1-4997-b966-0c9c99f20c3e)|![Screenshot_20250418_135439](https://github.com/user-attachments/assets/adfd6bfb-0b07-4eaa-8dbe-b0845f416d86)|
