### PR TITLE
Replace first() with firstOrNull() in BrokenSitePromptDataStore

### DIFF
--- a/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSitePomptDataStore.kt
+++ b/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSitePomptDataStore.kt
@@ -41,9 +41,9 @@ import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
 
 interface BrokenSitePromptDataStore {
     suspend fun setMaxDismissStreak(maxDismissStreak: Int)
@@ -81,24 +81,24 @@ class SharedPreferencesDuckPlayerDataStore @Inject constructor(
 
     private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
     private val maxDismissStreak: Flow<Int> = store.data
-        .map { prefs ->
-            prefs[MAX_DISMISS_STREAK] ?: 3
+        .mapNotNull { prefs ->
+            prefs[MAX_DISMISS_STREAK]
         }
         .distinctUntilChanged()
 
     private val dismissStreakResetDays: Flow<Int> = store.data
-        .map { prefs ->
-            prefs[DISMISS_STREAK_RESET_DAYS] ?: 30
+        .mapNotNull { prefs ->
+            prefs[DISMISS_STREAK_RESET_DAYS]
         }
         .distinctUntilChanged()
 
     private val coolDownDays: Flow<Long> = store.data
-        .map { prefs ->
-            prefs[COOL_DOWN_DAYS] ?: 7
+        .mapNotNull { prefs ->
+            prefs[COOL_DOWN_DAYS]
         }
 
-    private val nextShownDate: Flow<String?> = store.data
-        .map { prefs ->
+    private val nextShownDate: Flow<String> = store.data
+        .mapNotNull { prefs ->
             prefs[NEXT_SHOWN_DATE]
         }
         .distinctUntilChanged()
@@ -107,19 +107,19 @@ class SharedPreferencesDuckPlayerDataStore @Inject constructor(
         store.edit { prefs -> prefs[MAX_DISMISS_STREAK] = maxDismissStreak }
     }
 
-    override suspend fun getMaxDismissStreak(): Int = maxDismissStreak.first()
+    override suspend fun getMaxDismissStreak(): Int = maxDismissStreak.firstOrNull() ?: 3
 
     override suspend fun setDismissStreakResetDays(days: Int) {
         store.edit { prefs -> prefs[DISMISS_STREAK_RESET_DAYS] = days }
     }
 
-    override suspend fun getDismissStreakResetDays(): Int = dismissStreakResetDays.first()
+    override suspend fun getDismissStreakResetDays(): Int = dismissStreakResetDays.firstOrNull() ?: 30
 
     override suspend fun setCoolDownDays(days: Long) {
         store.edit { prefs -> prefs[COOL_DOWN_DAYS] = days }
     }
 
-    override suspend fun getCoolDownDays(): Long = coolDownDays.first()
+    override suspend fun getCoolDownDays(): Long = coolDownDays.firstOrNull() ?: 7
 
     override suspend fun setNextShownDate(nextShownDate: LocalDateTime?) {
         store.edit { prefs ->
@@ -180,6 +180,6 @@ class SharedPreferencesDuckPlayerDataStore @Inject constructor(
     }
 
     override suspend fun getNextShownDate(): LocalDateTime? {
-        return nextShownDate.first()?.let { LocalDateTime.parse(it, formatter) }
+        return nextShownDate.firstOrNull()?.let { LocalDateTime.parse(it, formatter) }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1210033439367731?focus=true 

### Description
Replace first() with firstOrNull() in BrokenSitePromptDataStore
