### PR TITLE
Android: FAB button looks different on different OS versions

### DIFF
--- a/app/src/main/res/layout/include_onboarding_bubble_dax_dialog.xml
+++ b/app/src/main/res/layout/include_onboarding_bubble_dax_dialog.xml
@@ -36,6 +36,7 @@
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/daxDialogDismissButton"
+        style="@style/Widget.DuckDuckGo.FloatingActionButton.Circular"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="68dp"
@@ -46,7 +47,6 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:srcCompat="@drawable/ic_close_24"
-        app:style="@style/Widget.DuckDuckGo.FloatingActionButton.Circular"
         app:tint="?attr/daxColorPrimaryIcon" />
 
     <com.duckduckgo.common.ui.view.shape.DaxOnboardingBubbleCardView

--- a/app/src/main/res/layout/include_onboarding_bubble_dax_dialog.xml
+++ b/app/src/main/res/layout/include_onboarding_bubble_dax_dialog.xml
@@ -46,6 +46,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:srcCompat="@drawable/ic_close_24"
+        app:style="@style/Widget.DuckDuckGo.FloatingActionButton.Circular"
         app:tint="?attr/daxColorPrimaryIcon" />
 
     <com.duckduckgo.common.ui.view.shape.DaxOnboardingBubbleCardView

--- a/app/src/main/res/layout/include_onboarding_in_context_dax_dialog.xml
+++ b/app/src/main/res/layout/include_onboarding_in_context_dax_dialog.xml
@@ -60,6 +60,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:srcCompat="@drawable/ic_close_24"
+            app:style="@style/Widget.DuckDuckGo.FloatingActionButton.Circular"
             app:tint="?attr/daxColorPrimaryIcon" />
 
         <com.duckduckgo.common.ui.view.shape.DaxOnboardingBubbleCardView

--- a/app/src/main/res/layout/include_onboarding_in_context_dax_dialog.xml
+++ b/app/src/main/res/layout/include_onboarding_in_context_dax_dialog.xml
@@ -50,6 +50,7 @@
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/daxDialogDismissButton"
+            style="@style/Widget.DuckDuckGo.FloatingActionButton.Circular"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/keyline_0"
@@ -60,7 +61,6 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:srcCompat="@drawable/ic_close_24"
-            app:style="@style/Widget.DuckDuckGo.FloatingActionButton.Circular"
             app:tint="?attr/daxColorPrimaryIcon" />
 
         <com.duckduckgo.common.ui.view.shape.DaxOnboardingBubbleCardView

--- a/common/common-ui/src/main/res/values/widgets.xml
+++ b/common/common-ui/src/main/res/values/widgets.xml
@@ -233,6 +233,10 @@
         <item name="cornerSize">@dimen/keyline_3</item>
     </style>
 
+    <style name="Widget.DuckDuckGo.FloatingActionButton.Circular" parent="Widget.MaterialComponents.FloatingActionButton">
+        <item name="shapeAppearanceOverlay">@style/ShapeAppearanceOverlay.MaterialComponents.FloatingActionButton</item>
+    </style>
+
     <!-- List Items -->
     <style name="Widget.DuckDuckGo.OneLineListItem">
         <item name="android:layout_width">match_parent</item>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1210045609366338?focus=true

### Description
Added a circular style to the close button in onboarding dialogs by applying the `Widget.DuckDuckGo.FloatingActionButton.Circular` style to the FAB in both bubble and in-context DAX dialog layouts. Created a new style in widgets.xml that uses the Material Components circular shape appearance overlay.

### Steps to test this PR

_Verify close button appearance_
- [x] Open the onboarding bubble DAX dialog and verify the close button has a circular shape
- [x] Open the in-context DAX dialog and verify the close button has a circular shape

### UI changes
| Before (context dialog) | After (context dialog) | After (in-context dialog)|
| ------ | ----- | ----- |
|![Screenshot 2025-04-22](https://github.com/user-attachments/assets/88788640-3f2c-42fd-9bd0-de157f447f4d)|![Screenshot_20250422_185631](https://github.com/user-attachments/assets/4abd7f1d-4f87-4b1f-a286-499c35557d11)|![Screenshot_20250422_185648](https://github.com/user-attachments/assets/335fbcdd-d64d-4161-b230-a3bc3ff5136d)|
