### PR TITLE
fix browser content offset when interacting with web forms

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/navigation/bar/view/BrowserNavigationBarView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/navigation/bar/view/BrowserNavigationBarView.kt
@@ -45,7 +45,7 @@ import com.duckduckgo.app.browser.navigation.bar.view.BrowserNavigationBarViewMo
 import com.duckduckgo.app.browser.navigation.bar.view.BrowserNavigationBarViewModel.ViewState
 import com.duckduckgo.app.browser.omnibar.experiments.FadeOmnibarLayout
 import com.duckduckgo.app.browser.omnibar.model.OmnibarPosition
-import com.duckduckgo.app.browser.webview.BrowserContainerLayoutBehavior
+import com.duckduckgo.app.browser.webview.TopOmnibarBrowserContainerLayoutBehavior
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.ViewViewModelFactory
@@ -70,7 +70,7 @@ class BrowserNavigationBarView @JvmOverloads constructor(
 
         /**
          * This notifies all view behaviors that depend on the [BrowserNavigationBarView] to recalculate whenever the bar's visibility changes,
-         * for example, we require that in [BrowserContainerLayoutBehavior] to remove the bottom inset when navigation bar disappears.
+         * for example, we require that in [TopOmnibarBrowserContainerLayoutBehavior] to remove the bottom inset when navigation bar disappears.
          * The base coordinator behavior doesn't notify dependent views when visibility changes, so we need to do that manually.
          */
         val parent = parent

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/BottomAppBarBehavior.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/BottomAppBarBehavior.kt
@@ -27,6 +27,7 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.ViewCompat
 import androidx.core.view.ViewCompat.NestedScrollType
 import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.webview.BottomOmnibarBrowserContainerLayoutBehavior
 import com.google.android.material.snackbar.Snackbar
 import kotlin.math.max
 import kotlin.math.min
@@ -51,7 +52,12 @@ class BottomAppBarBehavior<V : View>(
             updateSnackbar(child, dependency)
         }
 
-        if (dependency.id != R.id.webViewFullScreenContainer) {
+        /**
+         * We don't want any offset when in full screen.
+         *
+         * The browser padding management, to avoid omnibar overlapping with the browser content, is handled in [BottomOmnibarBrowserContainerLayoutBehavior].
+         */
+        if (dependency.id != R.id.webViewFullScreenContainer && dependency.id != R.id.browserLayout) {
             offsetBottomByToolbar(dependency)
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
@@ -49,6 +49,7 @@ import com.duckduckgo.app.browser.viewstate.BrowserViewState
 import com.duckduckgo.app.browser.viewstate.FindInPageViewState
 import com.duckduckgo.app.browser.viewstate.LoadingViewState
 import com.duckduckgo.app.browser.viewstate.OmnibarViewState
+import com.duckduckgo.app.browser.webview.BottomOmnibarBrowserContainerLayoutBehavior
 import com.duckduckgo.app.global.model.PrivacyShield
 import com.duckduckgo.app.trackerdetection.model.Entity
 import com.duckduckgo.common.ui.experiments.visual.store.VisualDesignExperimentDataStore
@@ -118,11 +119,7 @@ class Omnibar(
                     }
                 }
 
-                // remove the default top abb bar behavior
-                removeAppBarBehavior(binding.autoCompleteSuggestionsList)
-                removeAppBarBehavior(binding.browserLayout)
-                removeAppBarBehavior(binding.focusedView)
-                removeAppBarBehavior(binding.includeNewBrowserTab.newTabLayout)
+                adjustCoordinatorLayoutBehaviorForBottomOmnibar()
             }
         }
     }
@@ -198,6 +195,21 @@ class Omnibar(
                     FADE -> binding.fadeOmnibarBottom
                 }
             }
+        }
+    }
+
+    /**
+     * When bottom omnibar is used, this function removes the default top app bar behavior as most of the offsets are handled via [BottomAppBarBehavior].
+     *
+     * However, the browser (web view) content offset is managed via [BottomOmnibarBrowserContainerLayoutBehavior].
+     */
+    private fun adjustCoordinatorLayoutBehaviorForBottomOmnibar() {
+        removeAppBarBehavior(binding.autoCompleteSuggestionsList)
+        removeAppBarBehavior(binding.focusedView)
+        removeAppBarBehavior(binding.includeNewBrowserTab.newTabLayout)
+
+        binding.browserLayout.updateLayoutParams<CoordinatorLayout.LayoutParams> {
+            behavior = BottomOmnibarBrowserContainerLayoutBehavior()
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/webview/BrowserContainerLayoutBehavior.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/webview/BrowserContainerLayoutBehavior.kt
@@ -20,23 +20,26 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.View
 import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.coordinatorlayout.widget.CoordinatorLayout.Behavior
 import androidx.core.view.isGone
 import com.duckduckgo.app.browser.navigation.bar.view.BrowserNavigationBarView
 import com.duckduckgo.app.browser.omnibar.OmnibarLayout
 import com.duckduckgo.app.browser.omnibar.model.OmnibarPosition
+import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.appbar.AppBarLayout.ScrollingViewBehavior
 
 /**
- * A [ScrollingViewBehavior] that additionally observes the position of [BrowserNavigationBarView] or bottom [OmnibarLayout], if present,
- * and applies bottom padding to the target view equal to the visible height of the bottom element.
+ * A [ScrollingViewBehavior] that observes [AppBarLayout] (top omnibar) present in the view hierarchy and applies top offset to the child view
+ * equal to the visible height of the omnibar.
  *
- * This prevents the bottom element from overlapping with, for example, content found in the web view.
+ * This extension additionally observes the position of [BrowserNavigationBarView], if present and a sibling of the target child in the [CoordinatorLayout],
+ * and applies bottom padding to the target child equal to the visible height of the navigation bar.
  *
- * Note: [BrowserNavigationBarView] or bottom [OmnibarLayout] will never be children of the coordinator layout at the same time, so they won't be competing for updates:
- * - When top [OmnibarLayout] is used, [BrowserNavigationBarView] is added directly to the coordinator layout.
- * - When bottom [OmnibarLayout] is used, it comes embedded with the [BrowserNavigationBarView].
+ * This prevents the omnibar and the navigation bar from overlapping with, for example, content found in the web view.
+ *
+ * Note: If bottom [OmnibarLayout] is used ([OmnibarPosition.BOTTOM]), [BottomOmnibarBrowserContainerLayoutBehavior] should be set to the target child.
  */
-class BrowserContainerLayoutBehavior(
+class TopOmnibarBrowserContainerLayoutBehavior(
     context: Context,
     attrs: AttributeSet?,
 ) : ScrollingViewBehavior(context, attrs) {
@@ -46,7 +49,7 @@ class BrowserContainerLayoutBehavior(
         child: View,
         dependency: View,
     ): Boolean {
-        return dependency.isBrowserNavigationBar() || dependency.isBottomOmnibar() || super.layoutDependsOn(parent, child, dependency)
+        return dependency.isBrowserNavigationBar() || super.layoutDependsOn(parent, child, dependency)
     }
 
     override fun onDependentViewChanged(
@@ -54,28 +57,71 @@ class BrowserContainerLayoutBehavior(
         child: View,
         dependency: View,
     ): Boolean {
-        return if (dependency.isBrowserNavigationBar() || dependency.isBottomOmnibar()) {
-            val newBottomPadding = if (dependency.isGone) {
-                0
-            } else {
-                dependency.measuredHeight - dependency.translationY.toInt()
-            }
-            if (child.paddingBottom != newBottomPadding) {
-                child.setPadding(
-                    0,
-                    0,
-                    0,
-                    newBottomPadding,
-                )
-                true
-            } else {
-                false
-            }
+        return if (dependency.isBrowserNavigationBar()) {
+            offsetByBottomElementVisibleHeight(child = child, dependency = dependency)
         } else {
             super.onDependentViewChanged(parent, child, dependency)
         }
     }
-
-    private fun View.isBrowserNavigationBar(): Boolean = this is BrowserNavigationBarView
-    private fun View.isBottomOmnibar(): Boolean = this is OmnibarLayout && this.omnibarPosition == OmnibarPosition.BOTTOM
 }
+
+/**
+ * A behavior that observes the position of the bottom [OmnibarLayout] ([OmnibarPosition.BOTTOM]), if present,
+ * and applies bottom padding to the target view equal to the visible height of the omnibar.
+ *
+ * This prevents the omnibar from overlapping with, for example, content found in the web view.
+ *
+ * We can't use the [ScrollingViewBehavior] because it relies on the [AppBarLayout] and always forcefully places the target child _below_ the bar,
+ * which doesn't work if the bar is at the bottom.
+ *
+ * We don't need to additionally observe the position of the [BrowserNavigationBarView] when bottom [OmnibarLayout] is used because it comes pre-embedded with the navigation bar.
+ *
+ * Note: If top [OmnibarLayout] is used ([OmnibarPosition.TOP]), [TopOmnibarBrowserContainerLayoutBehavior] should be set to the target child.
+ */
+class BottomOmnibarBrowserContainerLayoutBehavior : Behavior<View>() {
+
+    override fun layoutDependsOn(
+        parent: CoordinatorLayout,
+        child: View,
+        dependency: View,
+    ): Boolean {
+        return dependency.isBottomOmnibar() || super.layoutDependsOn(parent, child, dependency)
+    }
+
+    override fun onDependentViewChanged(
+        parent: CoordinatorLayout,
+        child: View,
+        dependency: View,
+    ): Boolean {
+        return if (dependency.isBottomOmnibar()) {
+            offsetByBottomElementVisibleHeight(child = child, dependency = dependency)
+        } else {
+            super.onDependentViewChanged(parent, child, dependency)
+        }
+    }
+}
+
+private fun offsetByBottomElementVisibleHeight(
+    child: View,
+    dependency: View,
+): Boolean {
+    val newBottomPadding = if (dependency.isGone) {
+        0
+    } else {
+        dependency.measuredHeight - dependency.translationY.toInt()
+    }
+    return if (child.paddingBottom != newBottomPadding) {
+        child.setPadding(
+            0,
+            0,
+            0,
+            newBottomPadding,
+        )
+        true
+    } else {
+        false
+    }
+}
+
+private fun View.isBrowserNavigationBar(): Boolean = this is BrowserNavigationBarView
+private fun View.isBottomOmnibar(): Boolean = this is OmnibarLayout && this.omnibarPosition == OmnibarPosition.BOTTOM

--- a/app/src/main/res/layout/fragment_browser_tab.xml
+++ b/app/src/main/res/layout/fragment_browser_tab.xml
@@ -84,7 +84,7 @@
         android:layout_height="match_parent"
         android:clipChildren="false"
         android:orientation="vertical"
-        app:layout_behavior="com.duckduckgo.app.browser.webview.BrowserContainerLayoutBehavior"
+        app:layout_behavior="com.duckduckgo.app.browser.webview.TopOmnibarBrowserContainerLayoutBehavior"
         tools:context="com.duckduckgo.app.browser.BrowserActivity">
 
         <FrameLayout


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1210046079393105?focus=true

### Description
Continues building on https://github.com/duckduckgo/Android/pull/5931, where the full intended behavior for the bottom omnibar wasn't actually being applied.

### Steps to test this PR
- [ ] Request and drop omnibar focus multiple times, ensure that web view adjusts to omnibar and keyboard's visibility, and that there's no excess padding.
- [ ] Click a form in the web view and ensure that soft keyboard pushes web view content up. Verify there's no excess padding.
- [ ] Test with both top and bottom omnibars, with experimental feature flag enabled and disabled.

### UI changes
| Before  | After |
| ------ | ----- |
![Screenshot_20250423_114334](https://github.com/user-attachments/assets/dc143f36-4684-4090-8f6a-13d49b1c4577)|![Screenshot_20250423_114446](https://github.com/user-attachments/assets/242198b4-f9cb-4ae1-9f43-9bd5239eaeeb)|
