### PR TITLE
Refactor BrowserTabFragment's content offset management

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/navigation/bar/view/BrowserNavigationBarView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/navigation/bar/view/BrowserNavigationBarView.kt
@@ -45,7 +45,7 @@ import com.duckduckgo.app.browser.navigation.bar.view.BrowserNavigationBarViewMo
 import com.duckduckgo.app.browser.navigation.bar.view.BrowserNavigationBarViewModel.ViewState
 import com.duckduckgo.app.browser.omnibar.experiments.FadeOmnibarLayout
 import com.duckduckgo.app.browser.omnibar.model.OmnibarPosition
-import com.duckduckgo.app.browser.webview.BrowserContainerLayoutBehavior
+import com.duckduckgo.app.browser.webview.TopOmnibarBrowserContainerLayoutBehavior
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.ViewViewModelFactory
@@ -70,7 +70,7 @@ class BrowserNavigationBarView @JvmOverloads constructor(
 
         /**
          * This notifies all view behaviors that depend on the [BrowserNavigationBarView] to recalculate whenever the bar's visibility changes,
-         * for example, we require that in [BrowserContainerLayoutBehavior] to remove the bottom inset when navigation bar disappears.
+         * for example, we require that in [TopOmnibarBrowserContainerLayoutBehavior] to remove the bottom inset when navigation bar disappears.
          * The base coordinator behavior doesn't notify dependent views when visibility changes, so we need to do that manually.
          */
         val parent = parent

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/BottomAppBarBehavior.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/BottomAppBarBehavior.kt
@@ -52,15 +52,6 @@ class BottomAppBarBehavior<V : View>(
             updateSnackbar(child, dependency)
         }
 
-        /**
-         * We don't want any offset when in full screen.
-         *
-         * The browser padding management, to avoid omnibar overlapping with the browser content, is handled in [BottomOmnibarBrowserContainerLayoutBehavior].
-         */
-        if (dependency.id != R.id.webViewFullScreenContainer && dependency.id != R.id.browserLayout) {
-            offsetBottomByToolbar(dependency)
-        }
-
         return super.layoutDependsOn(parent, child, dependency)
     }
 
@@ -96,18 +87,6 @@ class BottomAppBarBehavior<V : View>(
             // only hide the app bar in the browser layout
             if (target.id == R.id.browserWebView) {
                 toolbar.translationY = max(0f, min(toolbar.height.toFloat(), toolbar.translationY + dy))
-            }
-        }
-    }
-
-    private fun offsetBottomByToolbar(view: View?) {
-        (view?.layoutParams as? CoordinatorLayout.LayoutParams)?.let { layoutParams ->
-            val newBottomMargin = omnibar.measuredHeight() - omnibar.getTranslation().roundToInt()
-            if (layoutParams.bottomMargin != newBottomMargin) {
-                layoutParams.bottomMargin = newBottomMargin
-                view.postOnAnimation {
-                    view.requestLayout()
-                }
             }
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/BottomAppBarBehavior.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/BottomAppBarBehavior.kt
@@ -27,6 +27,7 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.ViewCompat
 import androidx.core.view.ViewCompat.NestedScrollType
 import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.webview.BottomOmnibarBrowserContainerLayoutBehavior
 import com.google.android.material.snackbar.Snackbar
 import kotlin.math.max
 import kotlin.math.min
@@ -51,7 +52,12 @@ class BottomAppBarBehavior<V : View>(
             updateSnackbar(child, dependency)
         }
 
-        if (dependency.id != R.id.webViewFullScreenContainer) {
+        /**
+         * We don't want any offset when in full screen.
+         *
+         * The browser padding management, to avoid omnibar overlapping with the browser content, is handled in [BottomOmnibarBrowserContainerLayoutBehavior].
+         */
+        if (dependency.id != R.id.webViewFullScreenContainer && dependency.id != R.id.browserLayout) {
             offsetBottomByToolbar(dependency)
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
@@ -50,6 +50,7 @@ import com.duckduckgo.app.browser.viewstate.FindInPageViewState
 import com.duckduckgo.app.browser.viewstate.LoadingViewState
 import com.duckduckgo.app.browser.viewstate.OmnibarViewState
 import com.duckduckgo.app.browser.webview.BottomOmnibarBrowserContainerLayoutBehavior
+import com.duckduckgo.app.browser.webview.TopOmnibarBrowserContainerLayoutBehavior
 import com.duckduckgo.app.global.model.PrivacyShield
 import com.duckduckgo.app.trackerdetection.model.Entity
 import com.duckduckgo.common.ui.experiments.visual.store.VisualDesignExperimentDataStore
@@ -96,6 +97,10 @@ class Omnibar(
                         binding.rootView.removeView(binding.newOmnibarBottom)
                     }
                 }
+
+                binding.browserContentFrame.updateLayoutParams<CoordinatorLayout.LayoutParams> {
+                    behavior = TopOmnibarBrowserContainerLayoutBehavior()
+                }
             }
 
             OmnibarPosition.BOTTOM -> {
@@ -119,7 +124,9 @@ class Omnibar(
                     }
                 }
 
-                adjustCoordinatorLayoutBehaviorForBottomOmnibar()
+                binding.browserContentFrame.updateLayoutParams<CoordinatorLayout.LayoutParams> {
+                    behavior = BottomOmnibarBrowserContainerLayoutBehavior()
+                }
             }
         }
     }
@@ -195,27 +202,6 @@ class Omnibar(
                     FADE -> binding.fadeOmnibarBottom
                 }
             }
-        }
-    }
-
-    /**
-     * When bottom omnibar is used, this function removes the default top app bar behavior as most of the offsets are handled via [BottomAppBarBehavior].
-     *
-     * However, the browser (web view) content offset is managed via [BottomOmnibarBrowserContainerLayoutBehavior].
-     */
-    private fun adjustCoordinatorLayoutBehaviorForBottomOmnibar() {
-        removeAppBarBehavior(binding.autoCompleteSuggestionsList)
-        removeAppBarBehavior(binding.focusedView)
-        removeAppBarBehavior(binding.includeNewBrowserTab.newTabLayout)
-
-        binding.browserLayout.updateLayoutParams<CoordinatorLayout.LayoutParams> {
-            behavior = BottomOmnibarBrowserContainerLayoutBehavior()
-        }
-    }
-
-    private fun removeAppBarBehavior(view: View) {
-        view.updateLayoutParams<CoordinatorLayout.LayoutParams> {
-            behavior = null
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
@@ -49,6 +49,7 @@ import com.duckduckgo.app.browser.viewstate.BrowserViewState
 import com.duckduckgo.app.browser.viewstate.FindInPageViewState
 import com.duckduckgo.app.browser.viewstate.LoadingViewState
 import com.duckduckgo.app.browser.viewstate.OmnibarViewState
+import com.duckduckgo.app.browser.webview.BottomOmnibarBrowserContainerLayoutBehavior
 import com.duckduckgo.app.global.model.PrivacyShield
 import com.duckduckgo.app.trackerdetection.model.Entity
 import com.duckduckgo.common.ui.experiments.visual.store.VisualDesignExperimentDataStore
@@ -118,11 +119,7 @@ class Omnibar(
                     }
                 }
 
-                // remove the default top abb bar behavior
-                removeAppBarBehavior(binding.autoCompleteSuggestionsList)
-                removeAppBarBehavior(binding.browserLayout)
-                removeAppBarBehavior(binding.focusedView)
-                removeAppBarBehavior(binding.includeNewBrowserTab.newTabLayout)
+                adjustCoordinatorLayoutBehaviorForBottomOmnibar()
             }
         }
     }
@@ -198,6 +195,21 @@ class Omnibar(
                     FADE -> binding.fadeOmnibarBottom
                 }
             }
+        }
+    }
+
+    /**
+     * When bottom omnibar is used, this function removes the default top app bar behavior as most of the offsets are handled via [BottomAppBarBehavior].
+     *
+     * However, the browser (web view) content offset is managed via [BottomOmnibarBrowserContainerLayoutBehavior].
+     */
+    private fun adjustCoordinatorLayoutBehaviorForBottomOmnibar() {
+        removeAppBarBehavior(binding.autoCompleteSuggestionsList)
+        removeAppBarBehavior(binding.focusedView)
+        removeAppBarBehavior(binding.includeNewBrowserTab.newTabLayout)
+
+        binding.browserLayout.updateLayoutParams<CoordinatorLayout.LayoutParams> {
+            behavior = BottomOmnibarBrowserContainerLayoutBehavior()
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/TopAppBarBehavior.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/TopAppBarBehavior.kt
@@ -33,22 +33,6 @@ class TopAppBarBehavior(
     attrs: AttributeSet? = null,
 ) : AppBarLayout.Behavior(context, attrs) {
 
-    private companion object {
-        private val viewsExemptedFromOffset = setOf(
-            R.id.browserLayout,
-            R.id.webViewFullScreenContainer,
-            R.id.navigationBar,
-        )
-    }
-
-    override fun layoutDependsOn(parent: CoordinatorLayout, child: AppBarLayout, dependency: View): Boolean {
-        if (!viewsExemptedFromOffset.contains(dependency.id)) {
-            offsetBottomByToolbar(dependency)
-        }
-
-        return super.layoutDependsOn(parent, child, dependency)
-    }
-
     override fun onNestedPreScroll(
         coordinatorLayout: CoordinatorLayout,
         child: AppBarLayout,
@@ -61,19 +45,6 @@ class TopAppBarBehavior(
         if (target.id == R.id.browserWebView) {
             if (omnibar.isOmnibarScrollingEnabled()) {
                 super.onNestedPreScroll(coordinatorLayout, child, target, dx, dy, consumed, type)
-            }
-        }
-    }
-
-    private fun offsetBottomByToolbar(view: View?) {
-        val omnibarHeight = omnibar.measuredHeight()
-        if (omnibarHeight > 0 && view is View && view.layoutParams is MarginLayoutParams) {
-            val layoutParams = view.layoutParams as MarginLayoutParams
-            if (layoutParams.bottomMargin != omnibarHeight) {
-                layoutParams.bottomMargin = omnibarHeight
-                view.postOnAnimation {
-                    view.requestLayout()
-                }
             }
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/webview/BrowserContainerLayoutBehavior.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/webview/BrowserContainerLayoutBehavior.kt
@@ -20,23 +20,26 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.View
 import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.coordinatorlayout.widget.CoordinatorLayout.Behavior
 import androidx.core.view.isGone
 import com.duckduckgo.app.browser.navigation.bar.view.BrowserNavigationBarView
 import com.duckduckgo.app.browser.omnibar.OmnibarLayout
 import com.duckduckgo.app.browser.omnibar.model.OmnibarPosition
+import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.appbar.AppBarLayout.ScrollingViewBehavior
 
 /**
- * A [ScrollingViewBehavior] that additionally observes the position of [BrowserNavigationBarView] or bottom [OmnibarLayout], if present,
- * and applies bottom padding to the target view equal to the visible height of the bottom element.
+ * A [ScrollingViewBehavior] that observes [AppBarLayout] (top omnibar) present in the view hierarchy and applies top offset to the child view
+ * equal to the visible height of the omnibar.
  *
- * This prevents the bottom element from overlapping with, for example, content found in the web view.
+ * This extension additionally observes the position of [BrowserNavigationBarView], if present and a sibling of the target child in the [CoordinatorLayout],
+ * and applies bottom padding to the target child equal to the visible height of the navigation bar.
  *
- * Note: [BrowserNavigationBarView] or bottom [OmnibarLayout] will never be children of the coordinator layout at the same time, so they won't be competing for updates:
- * - When top [OmnibarLayout] is used, [BrowserNavigationBarView] is added directly to the coordinator layout.
- * - When bottom [OmnibarLayout] is used, it comes embedded with the [BrowserNavigationBarView].
+ * This prevents the omnibar and the navigation bar from overlapping with, for example, content found in the web view.
+ *
+ * Note: If bottom [OmnibarLayout] is used ([OmnibarPosition.BOTTOM]), [BottomOmnibarBrowserContainerLayoutBehavior] should be set to the target child.
  */
-class BrowserContainerLayoutBehavior(
+class TopOmnibarBrowserContainerLayoutBehavior(
     context: Context,
     attrs: AttributeSet?,
 ) : ScrollingViewBehavior(context, attrs) {
@@ -46,7 +49,7 @@ class BrowserContainerLayoutBehavior(
         child: View,
         dependency: View,
     ): Boolean {
-        return dependency.isBrowserNavigationBar() || dependency.isBottomOmnibar() || super.layoutDependsOn(parent, child, dependency)
+        return dependency.isBrowserNavigationBar() || super.layoutDependsOn(parent, child, dependency)
     }
 
     override fun onDependentViewChanged(
@@ -54,28 +57,71 @@ class BrowserContainerLayoutBehavior(
         child: View,
         dependency: View,
     ): Boolean {
-        return if (dependency.isBrowserNavigationBar() || dependency.isBottomOmnibar()) {
-            val newBottomPadding = if (dependency.isGone) {
-                0
-            } else {
-                dependency.measuredHeight - dependency.translationY.toInt()
-            }
-            if (child.paddingBottom != newBottomPadding) {
-                child.setPadding(
-                    0,
-                    0,
-                    0,
-                    newBottomPadding,
-                )
-                true
-            } else {
-                false
-            }
+        return if (dependency.isBrowserNavigationBar()) {
+            offsetByBottomElementVisibleHeight(child = child, dependency = dependency)
         } else {
             super.onDependentViewChanged(parent, child, dependency)
         }
     }
-
-    private fun View.isBrowserNavigationBar(): Boolean = this is BrowserNavigationBarView
-    private fun View.isBottomOmnibar(): Boolean = this is OmnibarLayout && this.omnibarPosition == OmnibarPosition.BOTTOM
 }
+
+/**
+ * A behavior that observes the position of the bottom [OmnibarLayout] ([OmnibarPosition.BOTTOM]), if present,
+ * and applies bottom padding to the target view equal to the visible height of the omnibar.
+ *
+ * This prevents the omnibar from overlapping with, for example, content found in the web view.
+ *
+ * We can't use the [ScrollingViewBehavior] because it relies on the [AppBarLayout] and always forcefully places the target child _below_ the bar,
+ * which doesn't work if the bar is at the bottom.
+ *
+ * We don't need to additionally observe the position of the [BrowserNavigationBarView] when bottom [OmnibarLayout] is used because it comes pre-embedded with the navigation bar.
+ *
+ * Note: If top [OmnibarLayout] is used ([OmnibarPosition.TOP]), [TopOmnibarBrowserContainerLayoutBehavior] should be set to the target child.
+ */
+class BottomOmnibarBrowserContainerLayoutBehavior : Behavior<View>() {
+
+    override fun layoutDependsOn(
+        parent: CoordinatorLayout,
+        child: View,
+        dependency: View,
+    ): Boolean {
+        return dependency.isBottomOmnibar() || super.layoutDependsOn(parent, child, dependency)
+    }
+
+    override fun onDependentViewChanged(
+        parent: CoordinatorLayout,
+        child: View,
+        dependency: View,
+    ): Boolean {
+        return if (dependency.isBottomOmnibar()) {
+            offsetByBottomElementVisibleHeight(child = child, dependency = dependency)
+        } else {
+            super.onDependentViewChanged(parent, child, dependency)
+        }
+    }
+}
+
+private fun offsetByBottomElementVisibleHeight(
+    child: View,
+    dependency: View,
+): Boolean {
+    val newBottomPadding = if (dependency.isGone) {
+        0
+    } else {
+        dependency.measuredHeight - dependency.translationY.toInt()
+    }
+    return if (child.paddingBottom != newBottomPadding) {
+        child.setPadding(
+            0,
+            0,
+            0,
+            newBottomPadding,
+        )
+        true
+    } else {
+        false
+    }
+}
+
+private fun View.isBrowserNavigationBar(): Boolean = this is BrowserNavigationBarView
+private fun View.isBottomOmnibar(): Boolean = this is OmnibarLayout && this.omnibarPosition == OmnibarPosition.BOTTOM

--- a/app/src/main/java/com/duckduckgo/app/browser/webview/BrowserContainerLayoutBehavior.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/webview/BrowserContainerLayoutBehavior.kt
@@ -16,8 +16,6 @@
 
 package com.duckduckgo.app.browser.webview
 
-import android.content.Context
-import android.util.AttributeSet
 import android.view.View
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.coordinatorlayout.widget.CoordinatorLayout.Behavior
@@ -39,10 +37,7 @@ import com.google.android.material.appbar.AppBarLayout.ScrollingViewBehavior
  *
  * Note: If bottom [OmnibarLayout] is used ([OmnibarPosition.BOTTOM]), [BottomOmnibarBrowserContainerLayoutBehavior] should be set to the target child.
  */
-class TopOmnibarBrowserContainerLayoutBehavior(
-    context: Context,
-    attrs: AttributeSet?,
-) : ScrollingViewBehavior(context, attrs) {
+class TopOmnibarBrowserContainerLayoutBehavior : ScrollingViewBehavior() {
 
     override fun layoutDependsOn(
         parent: CoordinatorLayout,

--- a/app/src/main/res/layout/fragment_browser_tab.xml
+++ b/app/src/main/res/layout/fragment_browser_tab.xml
@@ -40,104 +40,107 @@
         android:elevation="10dp"
         android:visibility="gone" />
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/autoCompleteSuggestionsList"
+    <FrameLayout
+        android:id="@+id/browserContentFrame"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="?attr/daxColorBrowserOverlay"
-        android:clipToPadding="false"
-        android:elevation="2dp"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior"
-        tools:itemCount="3"
-        tools:listitem="@layout/item_autocomplete_search_suggestion"
-        tools:visibility="visible" />
+        android:layout_height="match_parent">
 
-    <com.duckduckgo.app.browser.newtab.FocusedView
-        android:id="@+id/focusedView"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="?attr/daxColorBrowserOverlay"
-        android:elevation="4dp"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior"
-        app:layout_scrollFlags="noScroll" />
-
-    <include
-        android:id="@+id/includeNewBrowserTab"
-        layout="@layout/include_new_browser_tab"
-        android:visibility="gone" />
-
-    <com.duckduckgo.app.browser.webview.SslWarningLayout
-        android:id="@+id/sslErrorWarningLayout"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:visibility="gone" />
-
-    <com.duckduckgo.app.browser.webview.MaliciousSiteBlockedWarningLayout
-        android:id="@+id/maliciousSiteWarningLayout"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:visibility="gone" />
-
-    <RelativeLayout
-        android:id="@+id/browserLayout"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:clipChildren="false"
-        android:orientation="vertical"
-        app:layout_behavior="com.duckduckgo.app.browser.webview.TopOmnibarBrowserContainerLayoutBehavior"
-        tools:context="com.duckduckgo.app.browser.BrowserActivity">
-
-        <FrameLayout
-            android:id="@+id/daxDialogOnboardingCtaContent"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:animateLayoutChanges="true"
-            android:elevation="@dimen/keyline_4">
-
-            <include
-                android:id="@+id/includeOnboardingInContextDaxDialog"
-                layout="@layout/include_onboarding_in_context_dax_dialog"
-                android:visibility="gone" />
-
-            <include
-                android:id="@+id/includeBrokenSitePromptDialog"
-                layout="@layout/prompt_broken_site"
-                android:visibility="gone" />
-        </FrameLayout>
-
-        <com.duckduckgo.app.browser.ui.ScrollAwareRefreshLayout
-            android:id="@+id/swipeRefreshContainer"
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/autoCompleteSuggestionsList"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_below="@id/daxDialogOnboardingCtaContent">
+            android:background="?attr/daxColorBrowserOverlay"
+            android:clipToPadding="false"
+            android:elevation="2dp"
+            tools:itemCount="3"
+            tools:listitem="@layout/item_autocomplete_search_suggestion"
+            tools:visibility="visible" />
+
+        <com.duckduckgo.app.browser.newtab.FocusedView
+            android:id="@+id/focusedView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="?attr/daxColorBrowserOverlay"
+            android:elevation="4dp"
+            app:layout_scrollFlags="noScroll" />
+
+        <include
+            android:id="@+id/includeNewBrowserTab"
+            layout="@layout/include_new_browser_tab"
+            android:visibility="gone" />
+
+        <com.duckduckgo.app.browser.webview.SslWarningLayout
+            android:id="@+id/sslErrorWarningLayout"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:visibility="gone" />
+
+        <com.duckduckgo.app.browser.webview.MaliciousSiteBlockedWarningLayout
+            android:id="@+id/maliciousSiteWarningLayout"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:visibility="gone" />
+
+        <RelativeLayout
+            android:id="@+id/browserLayout"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:clipChildren="false"
+            android:orientation="vertical"
+            tools:context="com.duckduckgo.app.browser.BrowserActivity">
 
             <FrameLayout
+                android:id="@+id/daxDialogOnboardingCtaContent"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:animateLayoutChanges="true">
-
-                <FrameLayout
-                    android:id="@+id/webViewContainer"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    app:layout_behavior="@string/appbar_scrolling_view_behavior"
-                    tools:background="#4F00" />
+                android:animateLayoutChanges="true"
+                android:elevation="@dimen/keyline_4">
 
                 <include
-                    android:id="@+id/includeErrorView"
-                    layout="@layout/include_error_view"
+                    android:id="@+id/includeOnboardingInContextDaxDialog"
+                    layout="@layout/include_onboarding_in_context_dax_dialog"
+                    android:visibility="gone" />
+
+                <include
+                    android:id="@+id/includeBrokenSitePromptDialog"
+                    layout="@layout/prompt_broken_site"
                     android:visibility="gone" />
             </FrameLayout>
-        </com.duckduckgo.app.browser.ui.ScrollAwareRefreshLayout>
 
-        <View
-            android:id="@+id/focusDummy"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_below="@id/daxDialogOnboardingCtaContent"
-            android:focusableInTouchMode="true" />
+            <com.duckduckgo.app.browser.ui.ScrollAwareRefreshLayout
+                android:id="@+id/swipeRefreshContainer"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_below="@id/daxDialogOnboardingCtaContent">
 
-    </RelativeLayout>
+                <FrameLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:animateLayoutChanges="true">
+
+                    <FrameLayout
+                        android:id="@+id/webViewContainer"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        tools:background="#4F00" />
+
+                    <include
+                        android:id="@+id/includeErrorView"
+                        layout="@layout/include_error_view"
+                        android:visibility="gone" />
+                </FrameLayout>
+            </com.duckduckgo.app.browser.ui.ScrollAwareRefreshLayout>
+
+            <View
+                android:id="@+id/focusDummy"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_below="@id/daxDialogOnboardingCtaContent"
+                android:focusableInTouchMode="true" />
+
+        </RelativeLayout>
+
+    </FrameLayout>
 
     <com.duckduckgo.app.browser.omnibar.experiments.ScrollingOmnibarLayout
         android:id="@+id/newOmnibarBottom"

--- a/app/src/main/res/layout/fragment_browser_tab.xml
+++ b/app/src/main/res/layout/fragment_browser_tab.xml
@@ -84,7 +84,7 @@
         android:layout_height="match_parent"
         android:clipChildren="false"
         android:orientation="vertical"
-        app:layout_behavior="com.duckduckgo.app.browser.webview.BrowserContainerLayoutBehavior"
+        app:layout_behavior="com.duckduckgo.app.browser.webview.TopOmnibarBrowserContainerLayoutBehavior"
         tools:context="com.duckduckgo.app.browser.BrowserActivity">
 
         <FrameLayout

--- a/app/src/main/res/layout/include_new_browser_tab.xml
+++ b/app/src/main/res/layout/include_new_browser_tab.xml
@@ -22,7 +22,6 @@
     android:layout_height="match_parent"
     android:clipChildren="false"
     android:fillViewport="true"
-    app:layout_behavior="@string/appbar_scrolling_view_behavior"
     tools:context="com.duckduckgo.app.browser.BrowserActivity"
     tools:showIn="@layout/fragment_browser_tab">
 


### PR DESCRIPTION
Task/Issue URL: 

### Description
Builds on top of https://github.com/duckduckgo/Android/pull/5950 and simplifies main fragment's offset management.

Work in progress. TODO:
- [ ] favorites icons on new tab page are getting clipped at the bottom

### Steps to test this PR

