### PR TITLE
Fix Duck.ai settings race condition

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -152,7 +152,7 @@ class RealDuckChat @Inject constructor(
         cacheUserSettings()
     }
 
-    override suspend fun setShowInAddressBarUserSetting(showDuckChat: Boolean) {
+    override suspend fun setShowInAddressBarUserSetting(showDuckChat: Boolean) = withContext(dispatchers.io()) {
         duckChatFeatureRepository.setShowInAddressBar(showDuckChat)
         cacheUserSettings()
     }
@@ -316,7 +316,7 @@ class RealDuckChat @Inject constructor(
         }
     }
 
-    private fun cacheUserSettings() {
+    private suspend fun cacheUserSettings() = withContext(dispatchers.io()) {
         showInBrowserMenu = duckChatFeatureRepository.shouldShowInBrowserMenu() && isDuckChatEnabled
         showInAddressBar = duckChatFeatureRepository.shouldShowInAddressBar() && isDuckChatEnabled
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/repository/DuckChatFeatureRepository.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/repository/DuckChatFeatureRepository.kt
@@ -28,8 +28,8 @@ interface DuckChatFeatureRepository {
     suspend fun setShowInAddressBar(showDuckChat: Boolean)
     fun observeShowInBrowserMenu(): Flow<Boolean>
     fun observeShowInAddressBar(): Flow<Boolean>
-    fun shouldShowInBrowserMenu(): Boolean
-    fun shouldShowInAddressBar(): Boolean
+    suspend fun shouldShowInBrowserMenu(): Boolean
+    suspend fun shouldShowInAddressBar(): Boolean
     suspend fun registerOpened()
     suspend fun wasOpenedBefore(): Boolean
 }
@@ -56,11 +56,11 @@ class RealDuckChatFeatureRepository @Inject constructor(
         return duckChatDataStore.observeShowInAddressBar()
     }
 
-    override fun shouldShowInBrowserMenu(): Boolean {
+    override suspend fun shouldShowInBrowserMenu(): Boolean {
         return duckChatDataStore.getShowInBrowserMenu()
     }
 
-    override fun shouldShowInAddressBar(): Boolean {
+    override suspend fun shouldShowInAddressBar(): Boolean {
         return duckChatDataStore.getShowInAddressBar()
     }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/repository/DuckChatFeatureRepositoryTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/repository/DuckChatFeatureRepositoryTest.kt
@@ -50,7 +50,7 @@ class DuckChatFeatureRepositoryTest {
     }
 
     @Test
-    fun whenShouldShowInBrowserMenuThenGetFromDatabase() {
+    fun whenShouldShowInBrowserMenuThenGetFromDatabase() = runTest {
         whenever(mockDatabase.getShowInBrowserMenu()).thenReturn(true)
 
         assertTrue(testee.shouldShowInBrowserMenu())

--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
@@ -27,4 +27,4 @@ enum class PrivacyFeatureName(val value: String) {
     TrackingParametersFeatureName("trackingParameters"),
 }
 
-const val PRIVACY_REMOTE_CONFIG_URL = "https://staticcdn.duckduckgo.com/trackerblocking/config/v4/android-config.json"
+const val PRIVACY_REMOTE_CONFIG_URL = "https://www.jsonblob.com/api/1361681328311033856"

--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
@@ -27,4 +27,4 @@ enum class PrivacyFeatureName(val value: String) {
     TrackingParametersFeatureName("trackingParameters"),
 }
 
-const val PRIVACY_REMOTE_CONFIG_URL = "https://www.jsonblob.com/api/1361681328311033856"
+const val PRIVACY_REMOTE_CONFIG_URL = "https://staticcdn.duckduckgo.com/trackerblocking/config/v4/android-config.json"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1210070864871955?focus=true

### Description

- Fixes a race condition where Duck.ai settings are accessed before they are initialized.

### Steps to test this PR

_Point at the config linked in the task_
- [ ] Enable/disable Duck.ai settings
- [ ] Verify that they reflect as intended
- [ ] Kill and reopen the app
- [ ] Verify that the correct settings are reflected
