### PR TITLE
Fix toggle pixel fired when entering Duck.ai settings

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatSettingsActivity.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatSettingsActivity.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.duckchat.impl.ui
 
 import android.os.Bundle
 import android.view.View
+import android.widget.CompoundButton
 import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
@@ -47,6 +48,16 @@ class DuckChatSettingsActivity : DuckDuckGoActivity() {
 
     private val viewModel: DuckChatSettingsViewModel by bindViewModel()
     private val binding: ActivityDuckChatSettingsBinding by viewBinding()
+
+    private val menuToggleListener =
+        CompoundButton.OnCheckedChangeListener { _, isChecked ->
+            viewModel.onShowDuckChatInMenuToggled(isChecked)
+        }
+
+    private val addressBarToggleListener =
+        CompoundButton.OnCheckedChangeListener { _, isChecked ->
+            viewModel.onShowDuckChatInAddressBarToggled(isChecked)
+        }
 
     @Inject
     lateinit var globalActivityStarter: GlobalActivityStarter
@@ -81,12 +92,8 @@ class DuckChatSettingsActivity : DuckDuckGoActivity() {
     }
 
     private fun configureUiEventHandlers() {
-        binding.showDuckChatInMenuToggle.setOnCheckedChangeListener { _, isChecked ->
-            viewModel.onShowDuckChatInMenuToggled(isChecked)
-        }
-        binding.showDuckChatInAddressBarToggle.setOnCheckedChangeListener { _, isChecked ->
-            viewModel.onShowDuckChatInAddressBarToggled(isChecked)
-        }
+        binding.showDuckChatInMenuToggle.setOnCheckedChangeListener(menuToggleListener)
+        binding.showDuckChatInAddressBarToggle.setOnCheckedChangeListener(addressBarToggleListener)
     }
 
     private fun observeViewModel() {
@@ -102,8 +109,8 @@ class DuckChatSettingsActivity : DuckDuckGoActivity() {
     }
 
     private fun renderViewState(viewState: ViewState) {
-        binding.showDuckChatInMenuToggle.setIsChecked(viewState.showInBrowserMenu)
-        binding.showDuckChatInAddressBarToggle.setIsChecked(viewState.showInAddressBar)
+        binding.showDuckChatInMenuToggle.quietlySetIsChecked(viewState.showInBrowserMenu, menuToggleListener)
+        binding.showDuckChatInAddressBarToggle.quietlySetIsChecked(viewState.showInAddressBar, addressBarToggleListener)
     }
 
     private fun processCommand(command: DuckChatSettingsViewModel.Command) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1209630328746101?focus=true

### Description

- Fixes `aichat_menu_setting_on` being fired when entering Duck.ai settings.

### Steps to test this PR

- [ ] Open Duck.ai settings
- [ ] Verify that `aichat_menu_setting_on`/`aichat_menu_setting_on` are not fired
- [ ] Toggle the “Show Duck.ai in Browser Menu" setting
- [ ] Verify that `aichat_menu_setting_on`/`aichat_menu_setting_on` are fired