### PR TITLE
Add pixel where auth indicates a hardware missing error

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.autofill.impl.pixel
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_DECLINE_PROMPT_TO_DISABLE_AUTOFILL_SNACKBAR_OPEN_SETTINGS
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_DECLINE_PROMPT_TO_DISABLE_AUTOFILL_SNACKBAR_SHOWN
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_DEVICE_AUTH_ERROR_HARDWARE_UNAVAILABLE
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENGAGEMENT_ACTIVE_USER
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENGAGEMENT_ENABLED_USER
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENGAGEMENT_ONBOARDED_USER
@@ -145,6 +146,7 @@ enum class AutofillPixelNames(override val pixelName: String) : Pixel.PixelName 
         "m_autofill_device_capability_secure_storage_unavailable_and_device_auth_disabled",
     ),
     AUTOFILL_DEVICE_CAPABILITY_UNKNOWN_ERROR("m_autofill_device_capability_unknown"),
+    AUTOFILL_DEVICE_AUTH_ERROR_HARDWARE_UNAVAILABLE("autofill_device_auth_error_hardware_unavailable"),
 
     AUTOFILL_SURVEY_AVAILABLE_PROMPT_DISPLAYED("m_autofill_management_screen_visit_survey_available"),
 
@@ -256,6 +258,8 @@ object AutofillPixelsRequiringDataCleaning : PixelParamRemovalPlugin {
             AUTOFILL_SERVICE_PASSWORDS_SEARCH.pixelName to PixelParameter.removeAtb(),
             AUTOFILL_SERVICE_PASSWORDS_SEARCH_INPUT.pixelName to PixelParameter.removeAtb(),
             AUTOFILL_SERVICE_CRASH.pixelName to PixelParameter.removeAtb(),
+
+            AUTOFILL_DEVICE_AUTH_ERROR_HARDWARE_UNAVAILABLE.pixelName to PixelParameter.removeAtb(),
         )
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1209519141368890?focus=true 

### Description
Pixels the scenario whereby auth library returns that the required hardware isn’t present. We expected this not to happen because we check hardware in advance but we’ve seen a few reports indicating this might be happening still and we want to understand it more.

Since it’s not an error that’s possible to reproduce naturally, there is a patch that will map user-cancellations of the auth dialog to act as `ERROR_HW_NOT_PRESENT` errors for testing.

### Steps to test this PR

- [ ] Apply patch (defined below)
- [ ] Add one or more passwords
- [ ] Visit the Password management screen
- [ ] When prompted to authenticate, **cancel instead**. Note, this triggers the patch’s changes simulating this error scenario occurring. 
- [ ] Verify you see `autofill_device_auth_error_hardware_unavailable` in the logs
- [ ] Repeat, and verify `autofill_device_auth_error_hardware_unavailable` isn’t sent again


### Patch to apply for testing

```
Index: autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/deviceauth/AuthLauncher.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/deviceauth/AuthLauncher.kt b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/deviceauth/AuthLauncher.kt
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/deviceauth/AuthLauncher.kt	(revision Staged)
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/deviceauth/AuthLauncher.kt	(date 1745844684704)
@@ -103,6 +103,9 @@
 
             if (errorCode == BiometricPrompt.ERROR_USER_CANCELED) {
                 onResult(UserCancelled)
+
+                // hardcoded for testing
+                sendErrorPixel(12)
             } else {
                 onResult(Error(String.format("(%d) %s", errorCode, errString)))
                 sendErrorPixel(errorCode)

```
