### PR TITLE
Store initial Duck.ai address bar setting

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/store/DuckChatDataStore.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/store/DuckChatDataStore.kt
@@ -83,12 +83,11 @@ class SharedPreferencesDuckChatDataStore @Inject constructor(
         }
     }
 
-    private fun storeDerivedValues() {
-        appCoroutineScope.launch(dispatchers.io()) {
-            val current = store.data.firstOrNull() ?: return@launch
-            if (current[DUCK_CHAT_SHOW_IN_ADDRESS_BAR] == null) {
-                val initial = current[DUCK_CHAT_SHOW_IN_MENU] ?: true
-                store.edit { it[DUCK_CHAT_SHOW_IN_ADDRESS_BAR] = initial }
+    private fun storeDerivedValues() = appCoroutineScope.launch(dispatchers.io()) {
+        store.data.firstOrNull()?.let { prefs ->
+            if (prefs[DUCK_CHAT_SHOW_IN_ADDRESS_BAR] == null) {
+                val default = prefs[DUCK_CHAT_SHOW_IN_MENU] ?: true
+                store.edit { it[DUCK_CHAT_SHOW_IN_ADDRESS_BAR] = default }
             }
         }
     }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/store/SharedPreferencesDuckChatDataStoreTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/store/SharedPreferencesDuckChatDataStoreTest.kt
@@ -50,7 +50,12 @@ class SharedPreferencesDuckChatDataStoreTest {
         )
 
     private val testee: DuckChatDataStore =
-        SharedPreferencesDuckChatDataStore(testDataStore, coroutineRule.testScope)
+        SharedPreferencesDuckChatDataStore(
+            testDataStore,
+            coroutineRule.testDispatcherProvider,
+            true,
+            coroutineRule.testScope,
+        )
 
     companion object {
         val DUCK_CHAT_USER_PREFERENCES = stringPreferencesKey("DUCK_CHAT_USER_PREFERENCES")
@@ -107,9 +112,14 @@ class SharedPreferencesDuckChatDataStoreTest {
     }
 
     @Test
-    fun whenMenuFlagChangesThenAddressBarDefaultsToMenuValue() = runTest {
+    fun whenMenuFlagChangesLaterThenAddressBarRemainsUnchanged() = runTest {
+        assertTrue(testee.getShowInBrowserMenu())
+        assertTrue(testee.getShowInAddressBar())
+
         testee.setShowInBrowserMenu(false)
-        assertFalse(testee.getShowInAddressBar())
+
+        assertFalse(testee.getShowInBrowserMenu())
+        assertTrue(testee.getShowInAddressBar())
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1210096722341711?focus=true

### Description

- If the Duck.ai menu setting was initially disabled and the user updates, then the address bar setting is also disabled.
- However, if the the menu setting is toggled, then both settings toggle because there is no initial stored value for the address bar setting.
- This fixes that use-case.

### Steps to test this PR

- [ ] Checkout 5.230.1
- [ ] Disable the Duck.ai menu setting
- [ ] Update to this branch
- [ ] Verify that both settings are disabled
- [ ] Toggle the menu setting
- [ ] Verify that only the menu setting is toggled
