### PR TITLE
Omnibar outline and transition adjustments

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/FadeOmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/FadeOmnibarLayout.kt
@@ -47,6 +47,7 @@ import com.duckduckgo.app.browser.omnibar.model.OmnibarPosition
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.hide
 import com.duckduckgo.common.ui.view.show
+import com.duckduckgo.common.ui.view.toDp
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.mobile.android.R as CommonR
 import com.google.android.material.card.MaterialCardView
@@ -118,6 +119,8 @@ class FadeOmnibarLayout @JvmOverloads constructor(
         val navBar = rootContainer.findViewById<BrowserNavigationBarView>(R.id.omnibarNavigationBar)
         if (omnibarPosition == OmnibarPosition.TOP) {
             rootContainer.removeView(navBar)
+
+            omnibarCard.elevation = 1f.toDp(context)
         } else {
             navigationBar = navBar
 
@@ -125,11 +128,12 @@ class FadeOmnibarLayout @JvmOverloads constructor(
             toolbarContainer.updatePadding(
                 top = toolbarContainerPaddingTopWhenAtBottom,
             )
-
             // at the same time, we remove that space from the navigation bar which now sits below the omnibar
             navBar.findViewById<LinearLayout>(R.id.rootView).updatePadding(
                 top = 0,
             )
+
+            omnibarCard.elevation = 0.5f.toDp(context)
         }
     }
 

--- a/app/src/main/res/layout/view_fade_omnibar.xml
+++ b/app/src/main/res/layout/view_fade_omnibar.xml
@@ -58,7 +58,6 @@
                     android:layout_marginTop="@dimen/experimentalOmnibarCardMarginTop"
                     android:layout_marginBottom="@dimen/experimentalOmnibarCardMarginBottom"
                     app:strokeColor="?daxColorAccentBlue"
-                    app:contentPadding="@dimen/experimentalOmnibarContentPadding"
                     app:strokeWidth="@dimen/experimentalOmnibarOutlineWidth">
 
                     <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/view_fade_omnibar.xml
+++ b/app/src/main/res/layout/view_fade_omnibar.xml
@@ -64,7 +64,8 @@
                     <androidx.constraintlayout.widget.ConstraintLayout
                         android:id="@+id/omniBarContentContainer"
                         android:layout_width="match_parent"
-                        android:layout_height="match_parent">
+                        android:layout_height="match_parent"
+                        android:layout_gravity="center">
 
                         <ProgressBar
                             android:id="@+id/pageLoadingIndicator"

--- a/common/common-ui/src/main/res/values/design-experiments-dimens.xml
+++ b/common/common-ui/src/main/res/values/design-experiments-dimens.xml
@@ -26,9 +26,9 @@
     <dimen name="experimentalOmnibarCardMarginHorizontal">16dp</dimen>
     <dimen name="experimentalOmnibarCardMarginTop">4dp</dimen>
     <dimen name="experimentalOmnibarCardMarginBottom">12dp</dimen>
-    <dimen name="experimentalOmnibarCardFocusedMarginHorizontal">12dp</dimen>
-    <dimen name="experimentalOmnibarCardFocusedMarginTop">0dp</dimen>
-    <dimen name="experimentalOmnibarCardFocusedMarginBottom">8dp</dimen>
+    <dimen name="experimentalOmnibarCardFocusedMarginHorizontal">14dp</dimen>
+    <dimen name="experimentalOmnibarCardFocusedMarginTop">2dp</dimen>
+    <dimen name="experimentalOmnibarCardFocusedMarginBottom">10dp</dimen>
     <dimen name="experimentalOmnibarOutlineWidth">0dp</dimen>
     <dimen name="experimentalOmnibarOutlineFocusedWidth">2dp</dimen>
 </resources>

--- a/common/common-ui/src/main/res/values/design-experiments-dimens.xml
+++ b/common/common-ui/src/main/res/values/design-experiments-dimens.xml
@@ -29,9 +29,6 @@
     <dimen name="experimentalOmnibarCardFocusedMarginHorizontal">12dp</dimen>
     <dimen name="experimentalOmnibarCardFocusedMarginTop">0dp</dimen>
     <dimen name="experimentalOmnibarCardFocusedMarginBottom">8dp</dimen>
-    <dimen name="experimentalOmnibarContentPadding">0dp</dimen>
-    <dimen name="experimentalOmnibarContentFocusedPaddingHorizontal">4dp</dimen>
-    <dimen name="experimentalOmnibarContentFocusedPaddingVertical">@dimen/experimentalOmnibarOutlineFocusedWidth</dimen>
     <dimen name="experimentalOmnibarOutlineWidth">0dp</dimen>
     <dimen name="experimentalOmnibarOutlineFocusedWidth">2dp</dimen>
 </resources>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1210095910664825?focus=true

### Description
This PR makes 3 small changes to the omnibar.

1. Stop the contents of the omnibar "wiggling" when transitioning between focus and unfocused state. Below videos are in slow motion:

| Before  | After |
| ------ | ----- |
![wiggle_before](https://github.com/user-attachments/assets/88ca3705-635d-4380-998f-2703f9067362)|![wiggle_after](https://github.com/user-attachments/assets/8d419bd3-bfe9-4da0-aa05-b74688f99f28)|

2. Do not visually enlarge the omnibar's card when focus, only resize enough for the stroke to appear outside:

| Before  | After |
| ------ | ----- |
![outline_before](https://github.com/user-attachments/assets/b9c784eb-857d-4abc-9de9-521cac454ba4)|![outline_after](https://github.com/user-attachments/assets/5d120e35-5ea0-41b7-b0b7-407bf111b9f8)|

3. Decrease the bottom omnibar card's shadow and get it closer aligned with the shadow visible on the top omnibar card:

| Before  | After |
| ------ | ----- |
![shadow_before](https://github.com/user-attachments/assets/4f5716be-e6be-464f-a3b5-f3a28a4e752a)|![shadow_after](https://github.com/user-attachments/assets/438cd6fa-d49b-4d35-90c9-565c3f089c14)|