### PR TITLE
Support internal FF default value

### DIFF
--- a/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/remoteconfig/AdClickAttributionFeature.kt
+++ b/ad-click/ad-click-impl/src/main/java/com/duckduckgo/adclick/impl/remoteconfig/AdClickAttributionFeature.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.adclick.impl.remoteconfig
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
@@ -33,13 +34,13 @@ interface AdClickAttributionFeature {
      * @return `true` when the remote config has the global "adClickAttribution" feature flag enabled
      * If the remote feature is not present defaults to `false`
      */
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 
     /**
      * @return `true` when the remote config has the global "persistExemptions" adClickAttribution sub-feature flag enabled
      * If the remote feature is not present defaults to `false`
      */
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun persistExemptions(): Toggle
 }

--- a/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/ndk/NativeCrashFeature.kt
+++ b/anrs/anrs-impl/src/main/java/com/duckduckgo/app/anr/ndk/NativeCrashFeature.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.RemoteFeatureStoreNamed
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.moshi.JsonAdapter
@@ -41,14 +42,14 @@ import kotlinx.coroutines.launch
     toggleStore = NativeCrashFeatureMultiProcessStore::class,
 )
 interface NativeCrashFeature {
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     @Toggle.InternalAlwaysEnabled
     fun self(): Toggle
 
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun nativeCrashHandling(): Toggle
 
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun nativeCrashHandlingSecondaryProcess(): Toggle
 }
 

--- a/anvil/anvil-annotations/src/main/java/com/duckduckgo/anvil/annotations/ContributesActivePlugin.kt
+++ b/anvil/anvil-annotations/src/main/java/com/duckduckgo/anvil/annotations/ContributesActivePlugin.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.anvil.annotations
 
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import kotlin.reflect.KClass
 
 /**
@@ -50,7 +51,7 @@ annotation class ContributesActivePlugin(
      * The default value of remote feature flag.
      * Default is true (ie. enabled)
      */
-    val defaultActiveValue: Boolean = true,
+    val defaultActiveValue: DefaultFeatureValue = DefaultFeatureValue.TRUE,
 
     /**
      * The priority for the plugin.

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/feature/AppTpLocalFeature.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/feature/AppTpLocalFeature.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.mobile.android.vpn.feature
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 /**
  * Local feature/settings - they will never be in remote config
@@ -28,9 +29,9 @@ import com.duckduckgo.feature.toggles.api.Toggle
     featureName = "appTpLocalFeature",
 )
 interface AppTpLocalFeature {
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun verboseLogging(): Toggle
 }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/feature/AppTpRemoteFeatures.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/feature/AppTpRemoteFeatures.kt
@@ -31,6 +31,7 @@ import com.duckduckgo.feature.toggles.api.MetricsPixel
 import com.duckduckgo.feature.toggles.api.MetricsPixelPlugin
 import com.duckduckgo.feature.toggles.api.RemoteFeatureStoreNamed
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.feature.toggles.api.Toggle.DefaultValue
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.feature.toggles.api.Toggle.State.CohortName
@@ -54,43 +55,43 @@ import kotlinx.coroutines.withContext
     settingsStore = ExceptionListsSettingStore::class,
 )
 interface AppTpRemoteFeatures {
-    @Toggle.DefaultValue(true)
+    @DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 
-    @Toggle.DefaultValue(true)
+    @DefaultValue(DefaultFeatureValue.TRUE)
     fun restartOnConnectivityLoss(): Toggle
 
-    @DefaultValue(true)
+    @DefaultValue(DefaultFeatureValue.TRUE)
     fun setSearchDomains(): Toggle // kill switch
 
-    @DefaultValue(false)
+    @DefaultValue(DefaultFeatureValue.FALSE)
     fun atpTdsExperiment001(): Toggle
 
-    @DefaultValue(false)
+    @DefaultValue(DefaultFeatureValue.FALSE)
     fun atpTdsExperiment002(): Toggle
 
-    @DefaultValue(false)
+    @DefaultValue(DefaultFeatureValue.FALSE)
     fun atpTdsExperiment003(): Toggle
 
-    @DefaultValue(false)
+    @DefaultValue(DefaultFeatureValue.FALSE)
     fun atpTdsExperiment004(): Toggle
 
-    @DefaultValue(false)
+    @DefaultValue(DefaultFeatureValue.FALSE)
     fun atpTdsExperiment005(): Toggle
 
-    @DefaultValue(false)
+    @DefaultValue(DefaultFeatureValue.FALSE)
     fun atpTdsExperiment006(): Toggle
 
-    @DefaultValue(false)
+    @DefaultValue(DefaultFeatureValue.FALSE)
     fun atpTdsExperiment007(): Toggle
 
-    @DefaultValue(false)
+    @DefaultValue(DefaultFeatureValue.FALSE)
     fun atpTdsExperiment008(): Toggle
 
-    @DefaultValue(false)
+    @DefaultValue(DefaultFeatureValue.FALSE)
     fun atpTdsExperiment009(): Toggle
 
-    @DefaultValue(false)
+    @DefaultValue(DefaultFeatureValue.FALSE)
     fun atpTdsExperiment010(): Toggle
 
     enum class Cohorts(override val cohortName: String) : CohortName {

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/newtab/AppTrackingProtectionNewTabSettingView.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/newtab/AppTrackingProtectionNewTabSettingView.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.mobile.android.vpn.databinding.ViewApptpSettingsItemBinding
 import com.duckduckgo.mobile.android.vpn.feature.removal.VpnFeatureRemover
 import com.duckduckgo.mobile.android.vpn.ui.newtab.AppTrackingProtectionNewTabSettingsViewModel.ViewState
@@ -119,6 +120,6 @@ class AppTrackingProtectionNewTabSettingViewPlugin @Inject constructor(
     featureName = "newTabAppTPSectionSetting",
 )
 interface NewTabAppTrackingProtectionSectionSetting {
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 }

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/blocklist/AppTPBlockListInterceptorApiPluginTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/blocklist/AppTPBlockListInterceptorApiPluginTest.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.feature.toggles.api.FakeToggleStore
 import com.duckduckgo.feature.toggles.api.FeatureToggles
 import com.duckduckgo.feature.toggles.api.FeatureTogglesInventory
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.feature.toggles.api.Toggle.DefaultValue
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.mobile.android.app.tracking.AppTrackingProtection
@@ -272,15 +273,15 @@ abstract class TriggerTestScope private constructor()
     featureName = "appTrackerProtection",
 )
 interface TestBlockListFeature {
-    @DefaultValue(false)
+    @DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @DefaultValue(DefaultFeatureValue.FALSE)
     fun atpTdsNextExperimentTest(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @DefaultValue(DefaultFeatureValue.FALSE)
     fun atpTdsNextExperimentAnotherTest(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @DefaultValue(DefaultFeatureValue.FALSE)
     fun nonMatchingFeatureName(): Toggle
 }

--- a/app/src/internal/java/com/duckduckgo/app/browser/webview/InternalWebContentDebugging.kt
+++ b/app/src/internal/java/com/duckduckgo/app/browser/webview/InternalWebContentDebugging.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.browser.webview
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 
@@ -39,9 +40,9 @@ class InternalWebContentDebugging @Inject constructor(
     featureName = "InternalWebContentDebuggingFlag",
 )
 interface WebContentDebuggingFeature {
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun webContentDebugging(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/autocomplete/AutocompleteTabsFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/AutocompleteTabsFeature.kt
@@ -19,12 +19,13 @@ package com.duckduckgo.app.autocomplete
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
     featureName = "autocompleteTabs",
 )
 interface AutocompleteTabsFeature {
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -65,6 +65,7 @@ import com.duckduckgo.common.utils.SingleLiveEvent
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
@@ -456,6 +457,6 @@ class BrowserViewModel @Inject constructor(
     featureName = "androidSkipUrlConversionOnNewTab",
 )
 interface SkipUrlConversionOnNewTabFeature {
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/SwipingTabsFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/SwipingTabsFeature.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.browser
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.feature.toggles.api.Toggle.InternalAlwaysEnabled
 
 @ContributesRemoteFeature(
@@ -27,20 +28,20 @@ import com.duckduckgo.feature.toggles.api.Toggle.InternalAlwaysEnabled
 )
 interface SwipingTabsFeature {
     // The main kill switch for the feature
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     @InternalAlwaysEnabled
     fun self(): Toggle
 
     // The toggle used for staged rollout to external users
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     @InternalAlwaysEnabled
     fun enabledForUsers(): Toggle
 
     // The toggle used to enable a potential fix for https://app.asana.com/0/1207418217763355/1209914129786590/f
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun tabSwipingFix1(): Toggle
 
     // The toggle used to enable a potential fix for https://app.asana.com/0/1207418217763355/1209914129786590/f
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun tabSwipingFix2(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/applinks/ExternalAppIntentFlagsFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/applinks/ExternalAppIntentFlagsFeature.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.browser.applinks
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
@@ -28,6 +29,6 @@ import com.duckduckgo.feature.toggles.api.Toggle
 // A safeguard for this fix: https://app.asana.com/0/0/1207374732742336/1207383486029585/f
 interface ExternalAppIntentFlagsFeature {
 
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/certificates/remoteconfig/SSLCertificatesFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/certificates/remoteconfig/SSLCertificatesFeature.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.RemoteFeatureStoreNamed
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.moshi.JsonAdapter
@@ -46,14 +47,14 @@ interface SSLCertificatesFeature {
      * @return `true` when the remote config has the global "sslCertificates" feature flag enabled
      * If the remote feature is not present defaults to `true`
      */
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 
     /**
      * @return `true` when the remote config has the "allowBypass" flag enabled
      * If the remote feature is not present defaults to `false`
      */
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun allowBypass(): Toggle
 }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/DefaultBrowserPromptsFeatureToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/DefaultBrowserPromptsFeatureToggles.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.browser.defaultbrowsing.prompts
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.feature.toggles.api.Toggle.State.CohortName
 
 @ContributesRemoteFeature(
@@ -27,10 +28,10 @@ import com.duckduckgo.feature.toggles.api.Toggle.State.CohortName
 )
 interface DefaultBrowserPromptsFeatureToggles {
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun defaultBrowserAdditionalPrompts202501(): Toggle
 
     enum class AdditionalPromptsCohortName(override val cohortName: String) : CohortName {

--- a/app/src/main/java/com/duckduckgo/app/browser/duckchat/AIChatQueryDetectionFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/duckchat/AIChatQueryDetectionFeature.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.browser.duckchat
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
@@ -27,6 +28,6 @@ import com.duckduckgo.feature.toggles.api.Toggle
 
 interface AIChatQueryDetectionFeature {
 
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/httperrors/SiteErrorHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/httperrors/SiteErrorHandler.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.app.browser.BrowserTabViewModel
 import com.duckduckgo.app.global.model.Site
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import javax.inject.Inject
 
 interface SiteErrorHandler<T> {
@@ -90,6 +91,6 @@ class HttpCodeSiteErrorHandlerImpl @Inject constructor() : HttpCodeSiteErrorHand
 )
 interface SiteErrorHandlerKillSwitch {
 
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/mediaplayback/MediaPlaybackFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/mediaplayback/MediaPlaybackFeature.kt
@@ -17,8 +17,9 @@
 package com.duckduckgo.app.browser.mediaplayback
 
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 interface MediaPlaybackFeature {
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/ChangeOmnibarPositionFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/ChangeOmnibarPositionFeature.kt
@@ -19,16 +19,17 @@ package com.duckduckgo.app.browser.omnibar
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
     featureName = "changeOmnibarPosition",
 )
 interface ChangeOmnibarPositionFeature {
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     @Toggle.InternalAlwaysEnabled
     fun self(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun refactor(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/senseofprotection/SenseOfProtectionExperimentToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/senseofprotection/SenseOfProtectionExperimentToggles.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.feature.toggles.api.FeatureTogglesInventory
 import com.duckduckgo.feature.toggles.api.MetricsPixel
 import com.duckduckgo.feature.toggles.api.MetricsPixelPlugin
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.feature.toggles.api.Toggle.State.CohortName
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
@@ -35,13 +36,13 @@ import javax.inject.Inject
 )
 interface SenseOfProtectionToggles {
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun senseOfProtectionNewUserExperimentApr25(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun senseOfProtectionExistingUserExperimentApr25(): Toggle
 
     enum class Cohorts(override val cohortName: String) : CohortName {

--- a/app/src/main/java/com/duckduckgo/app/browser/uriloaded/UriLoadedPixelFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/uriloaded/UriLoadedPixelFeature.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.browser.uriloaded
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
@@ -26,6 +27,6 @@ import com.duckduckgo.feature.toggles.api.Toggle
 )
 interface UriLoadedPixelFeature {
 
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/webview/WebViewBlobDownloadFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/webview/WebViewBlobDownloadFeature.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.browser.webview
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
@@ -26,6 +27,6 @@ import com.duckduckgo.feature.toggles.api.Toggle
 )
 interface WebViewBlobDownloadFeature {
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/webview/safewebview/SafeWebViewFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/webview/safewebview/SafeWebViewFeature.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.browser.webview.safewebview
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
@@ -27,6 +28,6 @@ import com.duckduckgo.feature.toggles.api.Toggle
 
 interface SafeWebViewFeature {
 
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/downloads/DownloadsNewTabShortcutPlugin.kt
+++ b/app/src/main/java/com/duckduckgo/app/downloads/DownloadsNewTabShortcutPlugin.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.downloads.DownloadsScreens.DownloadsScreenNoParams
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.newtabpage.api.NewTabPageShortcutPlugin
 import com.duckduckgo.newtabpage.api.NewTabShortcut
@@ -73,6 +74,6 @@ class DownloadsNewTabShortcutPlugin @Inject constructor(
     featureName = "downloadsNewTabShortcutSetting",
 )
 interface DownloadsNewTabShortcutSetting {
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchFeature.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.generalsettings.showonapplaunch
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
@@ -26,6 +27,6 @@ import com.duckduckgo.feature.toggles.api.Toggle
 )
 interface ShowOnAppLaunchFeature {
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/extendedonboarding/ExtendedOnboardingFeatureToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/extendedonboarding/ExtendedOnboardingFeatureToggles.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.onboarding.ui.page.extendedonboarding
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.feature.toggles.api.Toggle.Experiment
 
 @ContributesRemoteFeature(
@@ -27,16 +28,16 @@ import com.duckduckgo.feature.toggles.api.Toggle.Experiment
 )
 interface ExtendedOnboardingFeatureToggles {
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun noBrowserCtas(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun privacyProCta(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     @Experiment
     fun highlights(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/pixels/campaign/AdditionalPixelParamsFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/campaign/AdditionalPixelParamsFeature.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.pixels.campaign
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
@@ -30,6 +31,6 @@ interface AdditionalPixelParamsFeature {
     /**
      * @return `true` to enable the privacy pro promo feature of appending a random subset of additional pixel parameters
      */
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.pixels.remoteconfig
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 /**
  * This is the class that represents the browser feature flags
@@ -33,7 +34,7 @@ interface AndroidBrowserConfigFeature {
      * @return `true` when the remote config has the global "androidBrowserConfig" feature flag enabled
      * If the remote feature is not present defaults to `false`
      */
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 
     /**
@@ -41,7 +42,7 @@ interface AndroidBrowserConfigFeature {
      * sub-feature flag enabled
      * If the remote feature is not present defaults to `false`
      */
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun collectFullWebViewVersion(): Toggle
 
     /**
@@ -49,7 +50,7 @@ interface AndroidBrowserConfigFeature {
      * sub-feature flag enabled
      * If the remote feature is not present defaults to `false`
      */
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun screenLock(): Toggle
 
     /**
@@ -57,7 +58,7 @@ interface AndroidBrowserConfigFeature {
      * sub-feature flag enabled
      * If the remote feature is not present defaults to `false`
      */
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun optimizeTrackerEvaluationV2(): Toggle
 
     /**
@@ -65,7 +66,7 @@ interface AndroidBrowserConfigFeature {
      * sub-feature flag enabled
      * If the remote feature is not present defaults to `true`
      */
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun errorPagePixel(): Toggle
 
     /**
@@ -73,7 +74,7 @@ interface AndroidBrowserConfigFeature {
      * sub-feature flag enabled
      * If the remote feature is not present defaults to `false`
      */
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun featuresRequestHeader(): Toggle
 
     /**
@@ -81,7 +82,7 @@ interface AndroidBrowserConfigFeature {
      * sub-feature flag enabled
      * If the remote feature is not present defaults to `false`
      */
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun webLocalStorage(): Toggle
 
     /**
@@ -89,7 +90,7 @@ interface AndroidBrowserConfigFeature {
      * sub-feature flag enabled
      * If the remote feature is not present defaults to `false`
      */
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun enableMaliciousSiteProtection(): Toggle
 
     /**
@@ -97,7 +98,7 @@ interface AndroidBrowserConfigFeature {
      * sub-feature flag enabled
      * If the remote feature is not present defaults to `false`
      */
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun fireproofedWebLocalStorage(): Toggle
 
     /**
@@ -105,10 +106,10 @@ interface AndroidBrowserConfigFeature {
      * sub-feature flag enabled
      * If the remote feature is not present defaults to `false`
      */
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun httpError5xxPixel(): Toggle
 
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun glideSuspend(): Toggle
 
     /**
@@ -116,6 +117,6 @@ interface AndroidBrowserConfigFeature {
      * sub-feature flag enabled
      * If the remote feature is not present defaults to `false`
      */
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun omnibarAnimation(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsNewTabShortcutPlugin.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsNewTabShortcutPlugin.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.app.browser.R
 import com.duckduckgo.browser.api.ui.BrowserScreens.SettingsScreenNoParams
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.newtabpage.api.NewTabPageShortcutPlugin
 import com.duckduckgo.newtabpage.api.NewTabShortcut
@@ -73,6 +74,6 @@ class SettingsNewTabShortcutPlugin @Inject constructor(
     featureName = "settingsNewTabShortcutSetting",
 )
 interface SettingsNewTabShortcutSetting {
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/tabs/TabFeatureFlags.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/TabFeatureFlags.kt
@@ -19,16 +19,17 @@ package com.duckduckgo.app.tabs
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
     featureName = "tabManager",
 )
 interface TabManagerFeatureFlags {
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     @Toggle.InternalAlwaysEnabled
     fun self(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun multiSelection(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/tabs/TabSwitcherAnimationFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/TabSwitcherAnimationFeature.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.tabs
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
@@ -26,6 +27,6 @@ import com.duckduckgo.feature.toggles.api.Toggle
 )
 interface TabSwitcherAnimationFeature {
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/blocklist/BlockList.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/blocklist/BlockList.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.feature.toggles.api.FeatureTogglesInventory
 import com.duckduckgo.feature.toggles.api.MetricsPixel
 import com.duckduckgo.feature.toggles.api.MetricsPixelPlugin
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.feature.toggles.api.Toggle.State.CohortName
 import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -42,34 +43,34 @@ import timber.log.Timber
     featureName = "blockList",
 )
 interface BlockList {
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun tdsNextExperimentBaselineBackup6(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun tdsNextExperimentBaselineBackup7(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun tdsNextExperimentBaselineBackup8(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun tdsNextExperimentBaselineBackup9(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun tdsNextExperimentBaselineBackup10(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun tdsNextExperimentMar25(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun tdsNextExperimentApr25(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun tdsNextExperimentMay25(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun tdsNextExperimentJun25(): Toggle
 
     enum class Cohorts(override val cohortName: String) : CohortName {

--- a/app/src/test/java/com/duckduckgo/app/trackerdetection/blocklist/BlockListInterceptorApiPluginTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/trackerdetection/blocklist/BlockListInterceptorApiPluginTest.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.feature.toggles.api.FakeToggleStore
 import com.duckduckgo.feature.toggles.api.FeatureToggles
 import com.duckduckgo.feature.toggles.api.FeatureTogglesInventory
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.feature.toggles.api.Toggle.DefaultValue
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.feature.toggles.impl.RealFeatureTogglesInventory
@@ -271,15 +272,15 @@ abstract class TriggerTestScope private constructor()
     featureName = "blockList",
 )
 interface TestBlockListFeature {
-    @DefaultValue(false)
+    @DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun tdsNextExperimentTest(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun tdsNextExperimentAnotherTest(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun nonMatchingFeatureName(): Toggle
 }

--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/remoteconfig/AutoconsentFeature.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/remoteconfig/AutoconsentFeature.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.autoconsent.impl.remoteconfig
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
@@ -34,9 +35,9 @@ interface AutoconsentFeature {
      * @return `true` when the remote config has the global "voiceSearch" feature flag enabled
      * If the remote feature is not present defaults to `true`
      */
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun onByDefault(): Toggle
 }

--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillFeature.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillFeature.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.autofill.api
 
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.feature.toggles.api.Toggle.InternalAlwaysEnabled
 
 /**
@@ -27,7 +28,7 @@ interface AutofillFeature {
      * @return `true` when the remote config has the global "autofill" feature flag enabled
      * If the remote feature is not present defaults to `true`
      */
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 
     /**
@@ -36,49 +37,49 @@ interface AutofillFeature {
      * @return `true` when the remote config has the global "canIntegrateAutofillInWebView" autofill sub-feature flag enabled
      * If the remote feature is not present defaults to `true`
      */
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun canIntegrateAutofillInWebView(): Toggle
 
     /**
      * @return `true` when the remote config has the global "canInjectCredentials" autofill sub-feature flag enabled
      * If the remote feature is not present defaults to `false`
      */
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun canInjectCredentials(): Toggle
 
     /**
      * @return `true` when the remote config has the global "canSaveCredentials" autofill sub-feature flag enabled
      * If the remote feature is not present defaults to `false`
      */
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun canSaveCredentials(): Toggle
 
     /**
      * @return `true` when the remote config has the global "canGeneratePasswords" autofill sub-feature flag enabled
      * If the remote feature is not present defaults to `false`
      */
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun canGeneratePasswords(): Toggle
 
     /**
      * @return `true` when the remote config has the global "canAccessCredentialManagement" autofill sub-feature flag enabled
      * If the remote feature is not present defaults to `false`
      */
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun canAccessCredentialManagement(): Toggle
 
     /**
      * @return `true` when the remote config has the global "canCategorizeUnknownUsername" autofill sub-feature flag enabled
      * If the remote feature is not present defaults to `false`
      */
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun canCategorizeUnknownUsername(): Toggle
 
     /**
      * @return `true` when the remote config has the global "onByDefault" autofill sub-feature flag enabled
      * If the remote feature is not present defaults to `false`
      */
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun onByDefault(): Toggle
 
     /**
@@ -86,7 +87,7 @@ interface AutofillFeature {
      * @return `true` when the remote config has the global "onForExistingUsers" autofill sub-feature flag enabled
      * If the remote feature is not present defaults to `false`
      */
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     @InternalAlwaysEnabled
     fun onForExistingUsers(): Toggle
 
@@ -95,7 +96,7 @@ interface AutofillFeature {
      * @return `true` when the remote config has the global "allowToDisableAutofill" autofill sub-feature flag enabled
      * If the remote feature is not present defaults to `false`
      */
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun showDisableDialogAutofillPrompt(): Toggle
 
     /**
@@ -104,7 +105,7 @@ interface AutofillFeature {
      * If the remote feature is not present defaults to `false`
      */
     @InternalAlwaysEnabled
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun canImportFromGooglePasswordManager(): Toggle
 
     /**
@@ -112,7 +113,7 @@ interface AutofillFeature {
      *  - a multi-step login form where username and password are entered on separate pages
      *  - password reset flow
      */
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun partialFormSaves(): Toggle
 
     /**
@@ -120,24 +121,24 @@ interface AutofillFeature {
      * We want to limit times we save duplicates, and we can do that with a deeper comparison of domains to decide if we already have a matching cred.
      * By deeper, this means comparing using E-TLD+1
      */
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun deepDomainComparisonsOnExistingCredentialsChecks(): Toggle
 
     /**
      * Kill switch for the new layout of list mode where everything is inside the recycler view
      */
-    @Toggle.DefaultValue(defaultValue = true)
+    @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.TRUE)
     fun newScrollBehaviourInPasswordManagementScreen(): Toggle
 
     /**
      * Kill switch for making case insensitive checks on existing username matches
      */
-    @Toggle.DefaultValue(defaultValue = true)
+    @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.TRUE)
     fun ignoreCaseOnUsernameComparisons(): Toggle
 
-    @Toggle.DefaultValue(defaultValue = false)
+    @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.FALSE)
     fun siteSpecificFixes(): Toggle
 
-    @Toggle.DefaultValue(defaultValue = true)
+    @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.TRUE)
     fun createAsyncPreferences(): Toggle
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/email/incontext/EmailProtectionInContextSignupFeature.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/email/incontext/EmailProtectionInContextSignupFeature.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.autofill.impl.email.incontext
 
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 /**
  * This is the class that represents the feature flag  for Email Protection in-context signup flow
@@ -27,6 +28,6 @@ interface EmailProtectionInContextSignupFeature {
      * If the remote feature is not present defaults to `true`
      */
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/newtab/AutofillNewTabShortcut.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/newtab/AutofillNewTabShortcut.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.autofill.api.AutofillSettingsLaunchSource
 import com.duckduckgo.autofill.impl.R
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.newtabpage.api.NewTabPageShortcutPlugin
 import com.duckduckgo.newtabpage.api.NewTabShortcut
@@ -74,6 +75,6 @@ class AutofillNewTabShortcutPlugin @Inject constructor(
     featureName = "autofillNewTabShortcutSetting",
 )
 interface AutofillNewTabShortcutSetting {
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/reporting/remoteconfig/AutofillSiteBreakageReportingFeature.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/reporting/remoteconfig/AutofillSiteBreakageReportingFeature.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.autofill.impl.reporting.remoteconfig
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
@@ -38,6 +39,6 @@ interface AutofillSiteBreakageReportingFeature {
      */
 
     @Toggle.InternalAlwaysEnabled
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/AutofillServiceFeature.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/AutofillServiceFeature.kt
@@ -20,6 +20,7 @@ import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.autofill.impl.service.store.AutofillServiceExceptionsStore
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.feature.toggles.api.Toggle.InternalAlwaysEnabled
 
 @ContributesRemoteFeature(
@@ -29,22 +30,22 @@ import com.duckduckgo.feature.toggles.api.Toggle.InternalAlwaysEnabled
 )
 interface AutofillServiceFeature {
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     @InternalAlwaysEnabled
     fun self(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     @InternalAlwaysEnabled
     fun canUpdateAppToDomainDataset(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     @InternalAlwaysEnabled
     fun canMapAppToDomain(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     @InternalAlwaysEnabled
     fun canAutofillInsideDDG(): Toggle
 
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun canProcessSystemFillRequests(): Toggle
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/survey/AutofillSurveyFeature.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/survey/AutofillSurveyFeature.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.FeatureSettings
 import com.duckduckgo.feature.toggles.api.RemoteFeatureStoreNamed
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.feature.toggles.api.Toggle.InternalAlwaysEnabled
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
@@ -46,7 +47,7 @@ interface AutofillSurveysFeature {
      */
 
     @InternalAlwaysEnabled
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/provider/CredentialsSyncLocalValidationFeature.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/provider/CredentialsSyncLocalValidationFeature.kt
@@ -19,12 +19,13 @@ package com.duckduckgo.autofill.sync.provider
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
     featureName = "credentialsLocalFieldValidation",
 )
 interface CredentialsSyncLocalValidationFeature {
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 }

--- a/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSitePromptRCFeature.kt
+++ b/broken-site/broken-site-impl/src/main/java/com/duckduckgo/brokensite/impl/BrokenSitePromptRCFeature.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.FeatureSettings
 import com.duckduckgo.feature.toggles.api.RemoteFeatureStoreNamed
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.feature.toggles.api.Toggle.DefaultValue
 import com.duckduckgo.feature.toggles.api.Toggle.InternalAlwaysEnabled
 import com.squareup.anvil.annotations.ContributesBinding
@@ -40,7 +41,7 @@ import kotlinx.coroutines.launch
 )
 interface BrokenSitePromptRCFeature {
     @InternalAlwaysEnabled
-    @DefaultValue(false)
+    @DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 }
 

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/experiments/visual/ExperimentalUIThemingFeature.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/experiments/visual/ExperimentalUIThemingFeature.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.common.ui.experiments.visual
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.feature.toggles.api.Toggle.InternalAlwaysEnabled
 
 @ContributesRemoteFeature(
@@ -26,11 +27,11 @@ import com.duckduckgo.feature.toggles.api.Toggle.InternalAlwaysEnabled
     featureName = "experimentalUITheming",
 )
 interface ExperimentalUIThemingFeature {
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     @InternalAlwaysEnabled
     fun self(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     @InternalAlwaysEnabled
     fun browserNavigationBar(): Toggle
 }

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/ContentScopeScriptsFeature.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/ContentScopeScriptsFeature.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.contentscopescripts.impl
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
@@ -26,6 +27,6 @@ import com.duckduckgo.feature.toggles.api.Toggle
 )
 
 interface ContentScopeScriptsFeature {
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/AIChatDownloadFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/AIChatDownloadFeature.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.duckchat.impl.feature
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
@@ -27,6 +28,6 @@ import com.duckduckgo.feature.toggles.api.Toggle
 
 interface AIChatDownloadFeature {
 
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.duckchat.impl.feature
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
@@ -32,6 +33,6 @@ interface DuckChatFeature {
      * @return `true` when the remote config has the global "aiChat" feature flag enabled
      * If the remote feature is not present defaults to `false`
      */
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 }

--- a/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerFeature.kt
+++ b/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerFeature.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.duckplayer.impl
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
@@ -33,27 +34,27 @@ interface DuckPlayerFeature {
      * @return `true` when the remote config has the global "duckPlayer" feature flag enabled
      * If the remote feature is not present defaults to `false`
      */
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 
     /**
      * @return `true` when the remote config has the "enableDuckPlayer" feature flag enabled
      * If the remote feature is not present defaults to `false`
      */
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun enableDuckPlayer(): Toggle
 
     /**
      * @return `true` when the remote config has the "openInNewTab" feature flag enabled
      * If the remote feature is not present defaults to `false`
      */
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun openInNewTab(): Toggle
 
     /**
      * @return `true` when the remote config has the "customError" feature flag enabled
      * If the remote feature is not present defaults to `false`
      */
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun customError(): Toggle
 }

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.feature.toggles.api
 import com.duckduckgo.appbuildconfig.api.BuildFlavor
 import com.duckduckgo.feature.toggles.api.Cohorts.CONTROL
 import com.duckduckgo.feature.toggles.api.Cohorts.TREATMENT
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.feature.toggles.api.Toggle.FeatureName
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.feature.toggles.api.Toggle.State.CohortName
@@ -558,34 +559,34 @@ class FeatureTogglesTest {
 }
 
 interface TestFeature {
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun disableByDefault(): Toggle
 
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun enabledByDefault(): Toggle
     fun noDefaultValue(): Toggle
 
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun wrongReturnValue(): Boolean
 
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun methodWithArguments(arg: String)
 
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     suspend fun suspendFun(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     @Toggle.InternalAlwaysEnabled
     fun internal(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     @Toggle.Experiment
     fun experimentDisabledByDefault(): Toggle
 
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     @Toggle.Experiment
     fun experimentEnabledByDefault(): Toggle
 }

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/api/FeatureTogglesTest.kt
@@ -34,7 +34,6 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import org.mockito.kotlin.times
 
 class FeatureTogglesTest {
 
@@ -68,6 +67,29 @@ class FeatureTogglesTest {
     @Test
     fun assertSubFeatureName() {
         assertEquals(FeatureName(parentName = "test", name = "disableByDefault"), feature.disableByDefault().featureName())
+    }
+
+    @Test
+    fun whenInternalByDefaultAndInternalBuildReturnTrue() {
+        provider.flavorName = BuildFlavor.INTERNAL.name
+        assertTrue(feature.internalByDefault().isEnabled())
+    }
+
+    @Test
+    fun whenInternalByDefaultAndPlayBuildReturnFalse() {
+        provider.flavorName = BuildFlavor.PLAY.name
+        assertFalse(feature.internalByDefault().isEnabled())
+    }
+
+    @Test
+    fun whenInternalByDefaultAndFdroidBuildReturnFalse() {
+        provider.flavorName = BuildFlavor.FDROID.name
+        assertFalse(feature.internalByDefault().isEnabled())
+    }
+
+    @Test
+    fun whenInternalByDefaultAndNoFlavourBuildReturnFalse() {
+        assertFalse(feature.internalByDefault().isEnabled())
     }
 
     @Test
@@ -561,6 +583,9 @@ class FeatureTogglesTest {
 interface TestFeature {
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
+
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun internalByDefault(): Toggle
 
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun disableByDefault(): Toggle

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesActivePluginPointCodeGeneratorTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesActivePluginPointCodeGeneratorTest.kt
@@ -119,7 +119,9 @@ class ContributesActivePluginPointCodeGeneratorTest {
         )
         assertEquals(
             Toggle.DefaultFeatureValue.INTERNAL,
-            clazzInternal.kotlin.java.methods.find { it.name == "pluginFooActiveInternalPlugin" }!!.getAnnotation(Toggle.DefaultValue::class.java)!!.defaultValue,
+            clazzInternal.kotlin.java.methods.find {
+                it.name == "pluginFooActiveInternalPlugin"
+            }!!.getAnnotation(Toggle.DefaultValue::class.java)!!.defaultValue,
         )
 
         val featureAnnotation = clazz.kotlin.java.getAnnotation(ContributesRemoteFeature::class.java)!!

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesActivePluginPointCodeGeneratorTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesActivePluginPointCodeGeneratorTest.kt
@@ -33,7 +33,6 @@ import kotlin.reflect.KClass
 import kotlin.reflect.full.functions
 import kotlinx.coroutines.CoroutineScope
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -76,8 +75,12 @@ class ContributesActivePluginPointCodeGeneratorTest {
             clazz.kotlin.functions.firstOrNull { it.name == "pluginBarActivePlugin" }!!.annotations
                 .firstOrNull { it.annotationClass == Toggle.DefaultValue::class },
         )
-        assertTrue(clazz.kotlin.java.methods.find { it.name == "self" }!!.getAnnotation(Toggle.DefaultValue::class.java)!!.defaultValue)
-        assertTrue(
+        assertEquals(
+            Toggle.DefaultFeatureValue.TRUE,
+            clazz.kotlin.java.methods.find { it.name == "self" }!!.getAnnotation(Toggle.DefaultValue::class.java)!!.defaultValue,
+        )
+        assertEquals(
+            Toggle.DefaultFeatureValue.TRUE,
             clazz.kotlin.java.methods.find { it.name == "pluginBarActivePlugin" }!!.getAnnotation(Toggle.DefaultValue::class.java)!!.defaultValue,
         )
 
@@ -93,6 +96,8 @@ class ContributesActivePluginPointCodeGeneratorTest {
     fun `test generated foo remote features`() {
         val clazz = Class
             .forName("com.duckduckgo.feature.toggles.codegen.FooActivePlugin_ActivePlugin_RemoteFeature")
+        val clazzInternal = Class
+            .forName("com.duckduckgo.feature.toggles.codegen.FooActiveInternalPlugin_ActivePlugin_RemoteFeature")
 
         assertNotNull(clazz.methods.find { it.name == "self" && it.returnType.kotlin == Toggle::class })
         assertNotNull(clazz.methods.find { it.name == "pluginFooActivePlugin" && it.returnType.kotlin == Toggle::class })
@@ -104,9 +109,17 @@ class ContributesActivePluginPointCodeGeneratorTest {
             clazz.kotlin.functions.firstOrNull { it.name == "pluginFooActivePlugin" }!!.annotations
                 .firstOrNull { it.annotationClass == Toggle.DefaultValue::class },
         )
-        assertTrue(clazz.kotlin.java.methods.find { it.name == "self" }!!.getAnnotation(Toggle.DefaultValue::class.java)!!.defaultValue)
-        assertFalse(
+        assertEquals(
+            Toggle.DefaultFeatureValue.TRUE,
+            clazz.kotlin.java.methods.find { it.name == "self" }!!.getAnnotation(Toggle.DefaultValue::class.java)!!.defaultValue,
+        )
+        assertEquals(
+            Toggle.DefaultFeatureValue.FALSE,
             clazz.kotlin.java.methods.find { it.name == "pluginFooActivePlugin" }!!.getAnnotation(Toggle.DefaultValue::class.java)!!.defaultValue,
+        )
+        assertEquals(
+            Toggle.DefaultFeatureValue.INTERNAL,
+            clazzInternal.kotlin.java.methods.find { it.name == "pluginFooActiveInternalPlugin" }!!.getAnnotation(Toggle.DefaultValue::class.java)!!.defaultValue,
         )
 
         val featureAnnotation = clazz.kotlin.java.getAnnotation(ContributesRemoteFeature::class.java)!!
@@ -147,8 +160,12 @@ class ContributesActivePluginPointCodeGeneratorTest {
             clazz.kotlin.functions.firstOrNull { it.name == "pluginExperimentActivePlugin" }!!.annotations
                 .firstOrNull { it.annotationClass == Toggle.InternalAlwaysEnabled::class },
         )
-        assertTrue(clazz.kotlin.java.methods.find { it.name == "self" }!!.getAnnotation(Toggle.DefaultValue::class.java)!!.defaultValue)
-        assertTrue(
+        assertEquals(
+            Toggle.DefaultFeatureValue.TRUE,
+            clazz.kotlin.java.methods.find { it.name == "self" }!!.getAnnotation(Toggle.DefaultValue::class.java)!!.defaultValue,
+        )
+        assertEquals(
+            Toggle.DefaultFeatureValue.TRUE,
             clazz.kotlin.java.methods.find { it.name == "pluginExperimentActivePlugin" }!!
                 .getAnnotation(Toggle.DefaultValue::class.java)!!.defaultValue,
         )
@@ -191,8 +208,12 @@ class ContributesActivePluginPointCodeGeneratorTest {
             clazz.kotlin.functions.firstOrNull { it.name == "pluginInternalAlwaysEnabledActivePlugin" }!!.annotations
                 .firstOrNull { it.annotationClass == Toggle.InternalAlwaysEnabled::class },
         )
-        assertTrue(clazz.kotlin.java.methods.find { it.name == "self" }!!.getAnnotation(Toggle.DefaultValue::class.java)!!.defaultValue)
-        assertTrue(
+        assertEquals(
+            Toggle.DefaultFeatureValue.TRUE,
+            clazz.kotlin.java.methods.find { it.name == "self" }!!.getAnnotation(Toggle.DefaultValue::class.java)!!.defaultValue,
+        )
+        assertEquals(
+            Toggle.DefaultFeatureValue.TRUE,
             clazz.kotlin.java.methods.find { it.name == "pluginInternalAlwaysEnabledActivePlugin" }!!
                 .getAnnotation(Toggle.DefaultValue::class.java)!!.defaultValue,
         )
@@ -225,7 +246,10 @@ class ContributesActivePluginPointCodeGeneratorTest {
         assertNotNull(
             clazz.kotlin.functions.firstOrNull { it.name == "self" }!!.annotations.firstOrNull { it.annotationClass == Toggle.DefaultValue::class },
         )
-        assertTrue(clazz.kotlin.java.methods.find { it.name == "self" }!!.getAnnotation(Toggle.DefaultValue::class.java)!!.defaultValue)
+        assertEquals(
+            Toggle.DefaultFeatureValue.TRUE,
+            clazz.kotlin.java.methods.find { it.name == "self" }!!.getAnnotation(Toggle.DefaultValue::class.java)!!.defaultValue,
+        )
 
         val featureAnnotation = clazz.kotlin.java.getAnnotation(ContributesRemoteFeature::class.java)!!
         assertEquals(AppScope::class, featureAnnotation.scope)
@@ -255,7 +279,10 @@ class ContributesActivePluginPointCodeGeneratorTest {
         assertNotNull(
             clazz.kotlin.functions.firstOrNull { it.name == "self" }!!.annotations.firstOrNull { it.annotationClass == Toggle.DefaultValue::class },
         )
-        assertTrue(clazz.kotlin.java.methods.find { it.name == "self" }!!.getAnnotation(Toggle.DefaultValue::class.java)!!.defaultValue)
+        assertEquals(
+            Toggle.DefaultFeatureValue.TRUE,
+            clazz.kotlin.java.methods.find { it.name == "self" }!!.getAnnotation(Toggle.DefaultValue::class.java)!!.defaultValue,
+        )
 
         val featureAnnotation = clazz.kotlin.java.getAnnotation(ContributesRemoteFeature::class.java)!!
         assertEquals(AppScope::class, featureAnnotation.scope)
@@ -277,8 +304,12 @@ class ContributesActivePluginPointCodeGeneratorTest {
             clazz.kotlin.functions.firstOrNull { it.name == "pluginFooActiveTriggeredMyPlugin" }!!.annotations
                 .firstOrNull { it.annotationClass == Toggle.DefaultValue::class },
         )
-        assertTrue(clazz.kotlin.java.methods.find { it.name == "self" }!!.getAnnotation(Toggle.DefaultValue::class.java)!!.defaultValue)
-        assertFalse(
+        assertEquals(
+            Toggle.DefaultFeatureValue.TRUE,
+            clazz.kotlin.java.methods.find { it.name == "self" }!!.getAnnotation(Toggle.DefaultValue::class.java)!!.defaultValue,
+        )
+        assertEquals(
+            Toggle.DefaultFeatureValue.FALSE,
             clazz.kotlin.java.methods.find { it.name == "pluginFooActiveTriggeredMyPlugin" }!!
                 .getAnnotation(Toggle.DefaultValue::class.java)!!.defaultValue,
         )

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/ContributesRemoteFeatureCodeGeneratorTest.kt
@@ -512,6 +512,7 @@ class ContributesRemoteFeatureCodeGeneratorTest {
         assertTrue(testFeature.defaultTrue().isEnabled())
         assertFalse(testFeature.internalDefaultFalse().isEnabled())
         assertFalse(testFeature.defaultFalse().isEnabled())
+        assertFalse(testFeature.defaultValueInternal().isEnabled())
 
         whenever(appBuildConfig.flavor).thenReturn(INTERNAL)
         assertTrue(privacyPlugin.store("testFeature", jsonString))
@@ -519,6 +520,8 @@ class ContributesRemoteFeatureCodeGeneratorTest {
         assertTrue(testFeature.defaultTrue().isEnabled())
         assertTrue(testFeature.internalDefaultFalse().isEnabled())
         assertFalse(testFeature.defaultFalse().isEnabled())
+        // the default value doesn't get re-evaluated, it's assigned when toggle is first created. That's why this returns FALSE
+        assertFalse(testFeature.defaultValueInternal().isEnabled())
 
         jsonString = """
                 {
@@ -534,6 +537,9 @@ class ContributesRemoteFeatureCodeGeneratorTest {
                             "state": "enabled"
                         }, 
                         "defaultFalse": {
+                            "state": "enabled"
+                        }, 
+                        "defaultValueInternal": {
                             "state": "enabled"
                         }
                     }
@@ -546,6 +552,7 @@ class ContributesRemoteFeatureCodeGeneratorTest {
         assertTrue(testFeature.defaultTrue().isEnabled())
         assertTrue(testFeature.internalDefaultFalse().isEnabled())
         assertTrue(testFeature.defaultFalse().isEnabled())
+        assertTrue(testFeature.defaultValueInternal().isEnabled())
 
         whenever(appBuildConfig.flavor).thenReturn(INTERNAL)
         assertTrue(privacyPlugin.store("testFeature", jsonString))
@@ -553,6 +560,7 @@ class ContributesRemoteFeatureCodeGeneratorTest {
         assertTrue(testFeature.defaultTrue().isEnabled())
         assertTrue(testFeature.internalDefaultFalse().isEnabled())
         assertTrue(testFeature.defaultFalse().isEnabled())
+        assertTrue(testFeature.defaultValueInternal().isEnabled())
 
         jsonString = """
                 {
@@ -569,39 +577,9 @@ class ContributesRemoteFeatureCodeGeneratorTest {
                         }, 
                         "defaultFalse": {
                             "state": "disabled"
-                        }
-                    }
-                }
-        """.trimIndent()
-        whenever(appBuildConfig.flavor).thenReturn(PLAY)
-        assertTrue(privacyPlugin.store("testFeature", jsonString))
-        assertFalse(testFeature.internalDefaultTrue().isEnabled())
-        assertFalse(testFeature.defaultTrue().isEnabled())
-        assertFalse(testFeature.internalDefaultFalse().isEnabled())
-        assertFalse(testFeature.defaultFalse().isEnabled())
-
-        whenever(appBuildConfig.flavor).thenReturn(INTERNAL)
-        assertTrue(privacyPlugin.store("testFeature", jsonString))
-        assertTrue(testFeature.internalDefaultTrue().isEnabled())
-        assertFalse(testFeature.defaultTrue().isEnabled())
-        assertTrue(testFeature.internalDefaultFalse().isEnabled())
-        assertFalse(testFeature.defaultFalse().isEnabled())
-
-        jsonString = """
-                {
-                    "state": "disabled",
-                    "features": {
-                        "internalDefaultTrue": {
-                            "state": "internal"
                         }, 
-                        "defaultTrue": {
-                            "state": "internal"
-                        },
-                        "internalDefaultFalse": {
-                            "state": "internal"
-                        }, 
-                        "defaultFalse": {
-                            "state": "internal"
+                        "defaultValueInternal": {
+                            "state": "disabled"
                         }
                     }
                 }
@@ -612,6 +590,45 @@ class ContributesRemoteFeatureCodeGeneratorTest {
         assertFalse(testFeature.defaultTrue().isEnabled())
         assertFalse(testFeature.internalDefaultFalse().isEnabled())
         assertFalse(testFeature.defaultFalse().isEnabled())
+        assertFalse(testFeature.defaultValueInternal().isEnabled())
+
+        whenever(appBuildConfig.flavor).thenReturn(INTERNAL)
+        assertTrue(privacyPlugin.store("testFeature", jsonString))
+        assertTrue(testFeature.internalDefaultTrue().isEnabled())
+        assertFalse(testFeature.defaultTrue().isEnabled())
+        assertTrue(testFeature.internalDefaultFalse().isEnabled())
+        assertFalse(testFeature.defaultFalse().isEnabled())
+        assertFalse(testFeature.defaultValueInternal().isEnabled())
+
+        jsonString = """
+                {
+                    "state": "disabled",
+                    "features": {
+                        "internalDefaultTrue": {
+                            "state": "internal"
+                        }, 
+                        "defaultTrue": {
+                            "state": "internal"
+                        },
+                        "internalDefaultFalse": {
+                            "state": "internal"
+                        }, 
+                        "defaultFalse": {
+                            "state": "internal"
+                        }, 
+                        "defaultValueInternal": {
+                            "state": "internal"
+                        }
+                    }
+                }
+        """.trimIndent()
+        whenever(appBuildConfig.flavor).thenReturn(PLAY)
+        assertTrue(privacyPlugin.store("testFeature", jsonString))
+        assertFalse(testFeature.internalDefaultTrue().isEnabled())
+        assertFalse(testFeature.defaultTrue().isEnabled())
+        assertFalse(testFeature.internalDefaultFalse().isEnabled())
+        assertFalse(testFeature.defaultFalse().isEnabled())
+        assertFalse(testFeature.defaultValueInternal().isEnabled())
 
         whenever(appBuildConfig.flavor).thenReturn(INTERNAL)
         assertTrue(privacyPlugin.store("testFeature", jsonString))
@@ -619,6 +636,64 @@ class ContributesRemoteFeatureCodeGeneratorTest {
         assertTrue(testFeature.defaultTrue().isEnabled())
         assertTrue(testFeature.internalDefaultFalse().isEnabled())
         assertTrue(testFeature.defaultFalse().isEnabled())
+        assertTrue(testFeature.defaultValueInternal().isEnabled())
+    }
+
+    @Test
+    fun `test default value set to internal`() {
+        val feature = generatedFeatureNewInstance()
+        val privacyPlugin = (feature as PrivacyFeaturePlugin)
+
+        // Order matters, we need to start with the config that does not have any features
+        var jsonString = """
+                {
+                    "state": "disabled",
+                    "features": {}
+                }
+        """.trimIndent()
+
+        assertTrue(privacyPlugin.store("testFeature", jsonString))
+        whenever(appBuildConfig.flavor).thenReturn(INTERNAL)
+        assertTrue(testFeature.defaultValueInternal().isEnabled())
+
+        jsonString = """
+                {
+                    "state": "disabled",
+                    "features": {
+                        "defaultValueInternal": {
+                            "state": "enabled"
+                        }
+                    }
+                }
+        """.trimIndent()
+        assertTrue(privacyPlugin.store("testFeature", jsonString))
+        assertTrue(testFeature.defaultValueInternal().isEnabled())
+
+        jsonString = """
+                {
+                    "state": "disabled",
+                    "features": {
+                        "defaultValueInternal": {
+                            "state": "disabled"
+                        }
+                    }
+                }
+        """.trimIndent()
+        assertTrue(privacyPlugin.store("testFeature", jsonString))
+        assertFalse(testFeature.defaultValueInternal().isEnabled())
+
+        jsonString = """
+                {
+                    "state": "disabled",
+                    "features": {
+                        "defaultValueInternal": {
+                            "state": "internal"
+                        }
+                    }
+                }
+        """.trimIndent()
+        assertTrue(privacyPlugin.store("testFeature", jsonString))
+        assertTrue(testFeature.defaultValueInternal().isEnabled())
     }
 
     @Test

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/TestActivePlugins.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/TestActivePlugins.kt
@@ -63,6 +63,16 @@ class FooActivePlugin @Inject constructor() : MyPlugin {
 @ContributesActivePlugin(
     scope = AppScope::class,
     boundType = MyPlugin::class,
+    defaultActiveValue = DefaultFeatureValue.INTERNAL,
+)
+class FooActiveInternalPlugin @Inject constructor() : MyPlugin {
+    override fun doSomething() {
+    }
+}
+
+@ContributesActivePlugin(
+    scope = AppScope::class,
+    boundType = MyPlugin::class,
     priority = 1000,
 )
 class BarActivePlugin @Inject constructor() : MyPlugin {

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/TestActivePlugins.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/TestActivePlugins.kt
@@ -20,6 +20,7 @@ import com.duckduckgo.anvil.annotations.ContributesActivePlugin
 import com.duckduckgo.anvil.annotations.ContributesActivePluginPoint
 import com.duckduckgo.common.utils.plugins.ActivePlugin
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import javax.inject.Inject
 
 @ContributesActivePluginPoint(
@@ -42,7 +43,7 @@ private interface TriggeredMyPluginTrigger
 @ContributesActivePlugin(
     scope = AppScope::class,
     boundType = TriggeredMyPlugin::class,
-    defaultActiveValue = false,
+    defaultActiveValue = DefaultFeatureValue.FALSE,
 )
 class FooActiveTriggeredMyPlugin @Inject constructor() : TriggeredMyPlugin {
     override fun doSomething() {
@@ -52,7 +53,7 @@ class FooActiveTriggeredMyPlugin @Inject constructor() : TriggeredMyPlugin {
 @ContributesActivePlugin(
     scope = AppScope::class,
     boundType = MyPlugin::class,
-    defaultActiveValue = false,
+    defaultActiveValue = DefaultFeatureValue.FALSE,
 )
 class FooActivePlugin @Inject constructor() : MyPlugin {
     override fun doSomething() {

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/TestTriggerFeature.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/TestTriggerFeature.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.feature.toggles.codegen
 
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.feature.toggles.api.Toggle.DefaultValue
 import com.duckduckgo.feature.toggles.api.Toggle.Experiment
 import com.duckduckgo.feature.toggles.api.Toggle.InternalAlwaysEnabled
@@ -29,34 +30,34 @@ abstract class TriggerTestScope private constructor()
     featureName = "testFeature",
 )
 interface TestTriggerFeature {
-    @DefaultValue(false)
+    @DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 
-    @DefaultValue(false)
+    @DefaultValue(DefaultFeatureValue.FALSE)
     fun fooFeature(): Toggle
 
-    @DefaultValue(false)
+    @DefaultValue(DefaultFeatureValue.FALSE)
     @Experiment
     fun experimentFooFeature(): Toggle
 
-    @DefaultValue(true)
+    @DefaultValue(DefaultFeatureValue.TRUE)
     @InternalAlwaysEnabled
     fun internalDefaultTrue(): Toggle
 
-    @DefaultValue(false)
+    @DefaultValue(DefaultFeatureValue.FALSE)
     @InternalAlwaysEnabled
     fun internalDefaultFalse(): Toggle
 
-    @DefaultValue(true)
+    @DefaultValue(DefaultFeatureValue.TRUE)
     fun defaultTrue(): Toggle
 
-    @DefaultValue(false)
+    @DefaultValue(DefaultFeatureValue.FALSE)
     fun defaultFalse(): Toggle
 
-    @DefaultValue(false)
+    @DefaultValue(DefaultFeatureValue.FALSE)
     fun variantFeature(): Toggle
 
-    @DefaultValue(false)
+    @DefaultValue(DefaultFeatureValue.FALSE)
     @Experiment
     fun experimentDisabledByDefault(): Toggle
 }
@@ -66,12 +67,12 @@ interface TestTriggerFeature {
     featureName = "testFeature",
 )
 interface AnotherTestTriggerFeature {
-    @DefaultValue(false)
+    @DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 
-    @DefaultValue(false)
+    @DefaultValue(DefaultFeatureValue.FALSE)
     fun fooFeature(): Toggle
 
-    @DefaultValue(false)
+    @DefaultValue(DefaultFeatureValue.FALSE)
     fun newFooFeature(): Toggle
 }

--- a/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/TestTriggerFeature.kt
+++ b/feature-toggles/feature-toggles-impl/src/test/java/com/duckduckgo/feature/toggles/codegen/TestTriggerFeature.kt
@@ -48,6 +48,9 @@ interface TestTriggerFeature {
     @InternalAlwaysEnabled
     fun internalDefaultFalse(): Toggle
 
+    @DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun defaultValueInternal(): Toggle
+
     @DefaultValue(DefaultFeatureValue.TRUE)
     fun defaultTrue(): Toggle
 

--- a/history/history-impl/src/main/java/com/duckduckgo/history/impl/remoteconfig/HistoryRemoteFeature.kt
+++ b/history/history-impl/src/main/java/com/duckduckgo/history/impl/remoteconfig/HistoryRemoteFeature.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.history.impl.remoteconfig
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.feature.toggles.api.Toggle.InternalAlwaysEnabled
 
 @ContributesRemoteFeature(
@@ -26,11 +27,11 @@ import com.duckduckgo.feature.toggles.api.Toggle.InternalAlwaysEnabled
     featureName = "history",
 )
 interface HistoryRemoteFeature {
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     @InternalAlwaysEnabled
     fun self(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     @InternalAlwaysEnabled
     fun storeHistory(): Toggle
 }

--- a/installation/installation-impl/src/main/java/com/duckduckgo/installation/impl/installer/aura/AuraExperimentFeature.kt
+++ b/installation/installation-impl/src/main/java/com/duckduckgo/installation/impl/installer/aura/AuraExperimentFeature.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.installation.impl.installer.aura
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
@@ -26,6 +27,6 @@ import com.duckduckgo.feature.toggles.api.Toggle
 )
 interface AuraExperimentFeature {
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 }

--- a/installation/installation-impl/src/main/java/com/duckduckgo/installation/impl/installer/fullpackage/feature/InstallSourceFullPackageFeature.kt
+++ b/installation/installation-impl/src/main/java/com/duckduckgo/installation/impl/installer/fullpackage/feature/InstallSourceFullPackageFeature.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.FeatureSettings
 import com.duckduckgo.feature.toggles.api.RemoteFeatureStoreNamed
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.installation.impl.installer.fullpackage.InstallSourceFullPackageStore
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
@@ -47,7 +48,7 @@ interface InstallSourceFullPackageFeature {
      * If the remote feature is not present defaults to `false`
      */
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 }
 

--- a/macos/macos-impl/src/main/java/com/duckduckgo/macos/impl/MacOsDownloadLinkOrigin.kt
+++ b/macos/macos-impl/src/main/java/com/duckduckgo/macos/impl/MacOsDownloadLinkOrigin.kt
@@ -19,12 +19,13 @@ package com.duckduckgo.macos.impl
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
     featureName = "macOsDownloadLinkOrigin",
 )
 interface MacOsDownloadLinkOrigin {
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 }

--- a/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionFeature.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionFeature.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.malicioussiteprotection.impl
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.malicioussiteprotection.impl.remoteconfig.MaliciousSiteProtectionExceptionsStore
 
 @ContributesRemoteFeature(
@@ -35,17 +36,17 @@ interface MaliciousSiteProtectionFeature {
      * If the remote feature is not present defaults to `false`
      */
     @Toggle.InternalAlwaysEnabled
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 
     @Toggle.InternalAlwaysEnabled
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun visibleAndOnByDefault(): Toggle
 
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun canUpdateDatasets(): Toggle
 
     @Toggle.InternalAlwaysEnabled
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun scamProtection(): Toggle
 }

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/VpnRemoteFeatures.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/VpnRemoteFeatures.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.RemoteFeatureStoreNamed
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.feature.toggles.api.Toggle.DefaultValue
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.squareup.anvil.annotations.ContributesBinding
@@ -43,16 +44,16 @@ import kotlinx.coroutines.launch
     settingsStore = VpnRemoteSettingsStore::class,
 )
 interface VpnRemoteFeatures {
-    @Toggle.DefaultValue(true)
+    @DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 
-    @DefaultValue(true)
+    @DefaultValue(DefaultFeatureValue.TRUE)
     fun showExcludeAppPrompt(): Toggle // kill switch
 
-    @DefaultValue(false)
+    @DefaultValue(DefaultFeatureValue.FALSE)
     fun allowDnsBlockMalware(): Toggle
 
-    @DefaultValue(false)
+    @DefaultValue(DefaultFeatureValue.FALSE)
     fun localVpnControllerDns(): Toggle
 }
 

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/settings/NetPSettingsLocalConfig.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/settings/NetPSettingsLocalConfig.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.RemoteFeatureStoreNamed
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.networkprotection.impl.di.ProdNetPConfigTogglesDao
 import com.duckduckgo.networkprotection.store.remote_config.NetPConfigToggle
 import com.duckduckgo.networkprotection.store.remote_config.NetPConfigTogglesDao
@@ -41,43 +42,43 @@ import kotlinx.coroutines.launch
     toggleStore = NetPSettingsLocalConfigStore::class,
 )
 interface NetPSettingsLocalConfig {
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun vpnNotificationAlerts(): Toggle
 
     /**
      * When `true` the VPN routes will exclude local networks
      */
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun vpnExcludeLocalNetworkRoutes(): Toggle
 
     /**
      * When `true` the VPN will automatically pause when a call is started and will automatically restart after.
      */
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun vpnPauseDuringCalls(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun excludeSystemAppsCommunication(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun excludeSystemAppsNetworking(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun excludeSystemAppsMedia(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun excludeSystemAppsOthers(): Toggle
 
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun blockMalware(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun permanentRemoveExcludeAppPrompt(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun autoExcludeBrokenApps(): Toggle
 }
 

--- a/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/feature/NetPInternalFeatureToggles.kt
+++ b/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/feature/NetPInternalFeatureToggles.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.networkprotection.internal.feature
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
@@ -27,15 +28,15 @@ import com.duckduckgo.feature.toggles.api.Toggle
     toggleStore = NetPInternalFeatureToggleStore::class,
 )
 interface NetPInternalFeatureToggles {
-    @Toggle.DefaultValue(defaultValue = true)
+    @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.TRUE)
     fun self(): Toggle
 
-    @Toggle.DefaultValue(defaultValue = false)
+    @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.FALSE)
     fun excludeSystemApps(): Toggle
 
-    @Toggle.DefaultValue(defaultValue = false)
+    @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.FALSE)
     fun enablePcapRecording(): Toggle
 
-    @Toggle.DefaultValue(defaultValue = false)
+    @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.FALSE)
     fun useVpnStagingEnvironment(): Toggle
 }

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/NewTabPage.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/NewTabPage.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.view.View
 import com.duckduckgo.anvil.annotations.ContributesActivePlugin
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.newtabpage.api.NewTabPagePlugin
 import com.duckduckgo.newtabpage.impl.view.NewTabPageView
 import javax.inject.Inject
@@ -28,7 +29,7 @@ import javax.inject.Inject
     scope = AppScope::class,
     boundType = NewTabPagePlugin::class,
     priority = NewTabPagePlugin.PRIORITY_LEGACY_NTP,
-    defaultActiveValue = false,
+    defaultActiveValue = DefaultFeatureValue.FALSE,
     supportExperiments = true,
     internalAlwaysEnabled = false,
 )

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/shortcuts/NewTabShortcuts.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/shortcuts/NewTabShortcuts.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.app.tabs.BrowserNav
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.newtabpage.api.NewTabPageShortcutPlugin
 import com.duckduckgo.newtabpage.api.NewTabShortcut
 import com.duckduckgo.newtabpage.impl.R
@@ -76,6 +77,6 @@ class AIChatNewTabShortcutPlugin @Inject constructor(
     featureName = "aIChatNewTabShortcutSetting",
 )
 interface AIChatNewTabShortcutSetting {
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 }

--- a/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/PirRemoteFeatures.kt
+++ b/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/PirRemoteFeatures.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.pir.internal
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.feature.toggles.api.Toggle.DefaultValue
 
 @ContributesRemoteFeature(
@@ -26,9 +27,9 @@ import com.duckduckgo.feature.toggles.api.Toggle.DefaultValue
     featureName = "pir",
 )
 interface PirRemoteFeatures {
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 
-    @DefaultValue(false)
+    @DefaultValue(DefaultFeatureValue.FALSE)
     fun allowPirRun(): Toggle
 }

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ToggleReportsFeature.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ToggleReportsFeature.kt
@@ -19,12 +19,13 @@ package com.duckduckgo.privacy.dashboard.impl
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
     featureName = "toggleReports",
 )
 interface ToggleReportsFeature {
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 }

--- a/privacy-protections-popup/privacy-protections-popup-impl/src/main/java/com/duckduckgo/privacyprotectionspopup/impl/PrivacyProtectionsPopupFeature.kt
+++ b/privacy-protections-popup/privacy-protections-popup-impl/src/main/java/com/duckduckgo/privacyprotectionspopup/impl/PrivacyProtectionsPopupFeature.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.privacyprotectionspopup.impl
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.feature.toggles.api.Toggle.DefaultValue
 
 @ContributesRemoteFeature(
@@ -26,7 +27,7 @@ import com.duckduckgo.feature.toggles.api.Toggle.DefaultValue
     featureName = "privacyProtectionsPopup",
 )
 interface PrivacyProtectionsPopupFeature {
-    @DefaultValue(false)
+    @DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 }
 

--- a/remote-messaging/remote-messaging-internal/src/main/java/com/duckduckgo/remote/messaging/internal/setting/RmfInternalSettings.kt
+++ b/remote-messaging/remote-messaging-internal/src/main/java/com/duckduckgo/remote/messaging/internal/setting/RmfInternalSettings.kt
@@ -19,15 +19,16 @@ package com.duckduckgo.remote.messaging.internal.setting
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
     featureName = "internalRmfSettings", // will never appear in production
 )
 interface RmfInternalSettings {
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun useStatingEndpoint(): Toggle
 }

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/BookmarksSortingFeature.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/BookmarksSortingFeature.kt
@@ -19,13 +19,14 @@ package com.duckduckgo.savedsites.impl
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
     featureName = "bookmarksSorting",
 )
 interface BookmarksSortingFeature {
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     @Toggle.InternalAlwaysEnabled
     fun self(): Toggle
 }

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/BookmarksShortcut.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/BookmarksShortcut.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.browser.api.ui.BrowserScreens.BookmarksScreenNoParams
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.newtabpage.api.NewTabPageShortcutPlugin
 import com.duckduckgo.newtabpage.api.NewTabShortcut
@@ -78,6 +79,6 @@ class BookmarksNewTabShortcutPlugin @Inject constructor(
     featureName = "bookmarksNewTabShortcutSetting",
 )
 interface BookmarksNewTabShortcutSetting {
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 }

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSettingView.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSettingView.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.newtabpage.api.NewTabPageSection
 import com.duckduckgo.newtabpage.api.NewTabPageSectionSettingsPlugin
 import com.duckduckgo.saved.sites.impl.databinding.ViewFavouritesSettingsItemBinding
@@ -112,6 +113,6 @@ class FavouritesNewTabSectionSettingsPlugin @Inject constructor() : NewTabPageSe
     featureName = "newTabFavouritesSectionSetting",
 )
 interface NewTabFavouritesSectionSetting {
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 }

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/BookmarksSyncLocalValidationFeature.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/BookmarksSyncLocalValidationFeature.kt
@@ -19,12 +19,13 @@ package com.duckduckgo.savedsites.impl.sync
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
     featureName = "bookmarksLocalFieldValidation",
 )
 interface BookmarksSyncLocalValidationFeature {
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 }

--- a/settings/settings-api/src/main/java/com/duckduckgo/settings/api/SettingsPageFeature.kt
+++ b/settings/settings-api/src/main/java/com/duckduckgo/settings/api/SettingsPageFeature.kt
@@ -17,10 +17,11 @@
 package com.duckduckgo.settings.api
 
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 interface SettingsPageFeature {
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     @Toggle.InternalAlwaysEnabled
     fun self(): Toggle
 }

--- a/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/drmblock/DrmBlockFeature.kt
+++ b/site-permissions/site-permissions-impl/src/main/java/com/duckduckgo/site/permissions/impl/drmblock/DrmBlockFeature.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.site.permissions.impl.drmblock
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
@@ -26,6 +27,6 @@ import com.duckduckgo.feature.toggles.api.Toggle
     exceptionsStore = DrmBlockFeatureExceptionStore::class,
 )
 interface DrmBlockFeature {
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.RemoteFeatureStoreNamed
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.feature.toggles.api.Toggle.State.CohortName
 import com.duckduckgo.navigation.api.GlobalActivityStarter
@@ -134,33 +135,33 @@ class RealSubscriptions @Inject constructor(
     toggleStore = PrivacyProFeatureStore::class,
 )
 interface PrivacyProFeature {
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun allowPurchase(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun useUnifiedFeedback(): Toggle
 
     // Kill switch
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun allowEmailFeedback(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun serpPromoCookie(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun authApiV2(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun isLaunchedROW(): Toggle
 
     // Kill switch
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun featuresApi(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun privacyProFreeTrialJan25(): Toggle
 
     enum class Cohorts(override val cohortName: String) : CohortName {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.sync.impl
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.feature.toggles.api.Toggle.InternalAlwaysEnabled
 
 @ContributesRemoteFeature(
@@ -26,31 +27,31 @@ import com.duckduckgo.feature.toggles.api.Toggle.InternalAlwaysEnabled
     featureName = "sync",
 )
 interface SyncFeature {
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     @Toggle.InternalAlwaysEnabled
     fun self(): Toggle
 
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun level0ShowSync(): Toggle
 
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun level1AllowDataSyncing(): Toggle
 
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun level2AllowSetupFlows(): Toggle
 
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun level3AllowCreateAccount(): Toggle
 
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun gzipPatchRequests(): Toggle
 
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun seamlessAccountSwitching(): Toggle
 
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun exchangeKeysToSyncWithAnotherDevice(): Toggle
 
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun automaticallyUpdateSyncSettings(): Toggle
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/SyncPromotionFeature.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/SyncPromotionFeature.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.sync.impl.promotion
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
@@ -33,14 +34,14 @@ import com.duckduckgo.feature.toggles.api.Toggle
 interface SyncPromotionFeature {
 
     @Toggle.InternalAlwaysEnabled
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 
     @Toggle.InternalAlwaysEnabled
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun bookmarks(): Toggle
 
     @Toggle.InternalAlwaysEnabled
-    @Toggle.DefaultValue(false)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun passwords(): Toggle
 }

--- a/user-agent/user-agent-impl/src/main/java/com/duckduckgo/user/agent/impl/remoteconfig/ClientBrandHintFeature.kt
+++ b/user-agent/user-agent-impl/src/main/java/com/duckduckgo/user/agent/impl/remoteconfig/ClientBrandHintFeature.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.user.agent.impl.remoteconfig
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
@@ -27,6 +28,6 @@ import com.duckduckgo.feature.toggles.api.Toggle
 )
 
 interface ClientBrandHintFeature {
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 }

--- a/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/remoteconfig/VoiceSearchFeature.kt
+++ b/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/remoteconfig/VoiceSearchFeature.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.voice.impl.remoteconfig
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
@@ -33,6 +34,6 @@ interface VoiceSearchFeature {
      * @return `true` when the remote config has the global "voiceSearch" feature flag enabled
      * If the remote feature is not present defaults to `true`
      */
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 }

--- a/windows/windows-impl/src/main/java/com/duckduckgo/windows/impl/WindowsDownloadLinkOrigin.kt
+++ b/windows/windows-impl/src/main/java/com/duckduckgo/windows/impl/WindowsDownloadLinkOrigin.kt
@@ -19,12 +19,13 @@ package com.duckduckgo.windows.impl
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
     featureName = "windowsDownloadLinkOrigin",
 )
 interface WindowsDownloadLinkOrigin {
-    @Toggle.DefaultValue(true)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1210096516271365?focus=true

### Description
Add support for "internal" default value in Toggle.DefaultValue.

### Steps to test this PR
Code review that all changed values are correct (even if they were changed with find/replace)
Smoke tests the app
Take one feature that is not in remote config:
- [x] change its default value to INTERNAL
- [x] intall play version of the app
- [x] verify feature is not enabled
- [x] install internal version of the app
- [x] verify feature is enabled
- [x] while in internal build, override the remote config (using override config in dev settings) and disable the feature
- [x] verify the feature is disabled
- [x] enable the feature in the remote config
- [x] verify the feature is enabled
