### PR TITLE
Ensure the webview content is always rendered when fragment is resumed

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -891,16 +891,28 @@ class BrowserTabFragment :
         Timber.d("Resuming webview: $tabId")
         webView?.let { webView ->
             if (webView.isShown) {
+                webView.ensureVisible()
                 webView.onResume()
             } else if (swipingTabsFeature.isEnabled) {
-                // Sometimes the tab is brought back from the background but the WebView is not visible yet due to
-                // ViewPager page change delay; this fixes an issue when a tab was blank.
+                // Sometimes a tab is brought back from the background but the WebView is not shown yet due to
+                // ViewPager page change delay; this makes sure the WebView is resumed when it is shown.
                 webView.post {
                     if (webView.isShown) {
+                        webView.ensureVisible()
                         webView.onResume()
                     }
                 }
+            } else {
+                Timber.d("WebView is not shown, not resuming")
             }
+        }
+    }
+
+    // This is a hack to make sure the WebView content is always rendered when the fragment is resumed
+    private fun DuckDuckGoWebView.ensureVisible() = postDelayed(100) {
+        if (swipingTabsFeature.isEnabled) {
+            scrollBy(0, 1)
+            scrollBy(0, -1)
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1209581454593298?focus=true

### Description

This PR fixes an issue when the WebView content is not rendered in the browser.

### Steps to test this PR

- [ ] Create 4 tabs and move to the 1st one
- [ ] Restart the app to start fresh
- [ ] Swipe to the 2nd, 3rd and 4th tab, one by one
- [ ] Open the tab switcher and select the 1st tab
- [ ] Notice the web content is correctly rendered
- [ ] Repeat the previous 3 steps to make sure

### UI changes

Before

https://github.com/user-attachments/assets/c5a0fcf0-3ac9-446f-8a81-d61bf74fae4e

After

https://github.com/user-attachments/assets/ca0bc4e0-ec20-4304-b30c-5154c4b11e41

