### PR TITLE
Ensure blocklist is updated always

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/blocklist/AppTrackerListUpdateWorker.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/blocklist/AppTrackerListUpdateWorker.kt
@@ -73,12 +73,7 @@ class AppTrackerListUpdateWorker(context: Context, workerParameters: WorkerParam
                     vpnDatabase.vpnAppTrackerBlockingDao().getTrackerBlocklistMetadata()?.eTag
                 val updatedEtag = blocklist.etag.value
 
-                if (updatedEtag == currentEtag) {
-                    logcat { "Downloaded blocklist has same eTag, noop" }
-                    return Result.success()
-                }
-
-                logcat { "Updating the app tracker blocklist, eTag: ${blocklist.etag.value}" }
+                logcat { "Updating the app tracker blocklist, previous/new eTag: $currentEtag / $updatedEtag}" }
 
                 vpnDatabase
                     .vpnAppTrackerBlockingDao()

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/blocklist/AppTrackerListUpdateWorker.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/blocklist/AppTrackerListUpdateWorker.kt
@@ -73,7 +73,7 @@ class AppTrackerListUpdateWorker(context: Context, workerParameters: WorkerParam
                     vpnDatabase.vpnAppTrackerBlockingDao().getTrackerBlocklistMetadata()?.eTag
                 val updatedEtag = blocklist.etag.value
 
-                logcat { "Updating the app tracker blocklist, previous/new eTag: $currentEtag / $updatedEtag}" }
+                logcat { "Updating the app tracker blocklist, previous/new eTag: $currentEtag / $updatedEtag" }
 
                 vpnDatabase
                     .vpnAppTrackerBlockingDao()

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/feature/settings/ExceptionListsSettingStore.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/feature/settings/ExceptionListsSettingStore.kt
@@ -50,9 +50,7 @@ class ExceptionListsSettingStore @Inject constructor(
     override fun store(jsonString: String) {
         logcat { "Received configuration: $jsonString" }
         runCatching {
-            jsonAdapter.fromJson(jsonString)?.let { model ->
-
-                val exceptionLists = model.exceptionLists
+            jsonAdapter.fromJson(jsonString)?.exceptionLists?.let { exceptionLists ->
 
                 val appTrackerExceptionRuleList = exceptionLists.appTrackerAllowList.map { appTrackerAllowRule ->
                     AppTrackerExceptionRule(
@@ -78,7 +76,7 @@ class ExceptionListsSettingStore @Inject constructor(
     }
 
     private data class JsonConfigModel(
-        val exceptionLists: JsonExceptionListsModel,
+        val exceptionLists: JsonExceptionListsModel?,
     )
 
     private data class JsonExceptionListsModel(

--- a/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/feature/settings/ExceptionListsSettingStoreTest.kt
+++ b/app-tracking-protection/vpn-impl/src/test/java/com/duckduckgo/mobile/android/vpn/feature/settings/ExceptionListsSettingStoreTest.kt
@@ -96,6 +96,12 @@ class ExceptionListsSettingStoreTest {
 
     @Test
     fun whenEmptyJsonStoreNothing() {
+        exceptionListsSettingStore.store("{}")
+        verifyNoInteractions(mockVpnDatabase)
+    }
+
+    @Test
+    fun whenInvalidJsonStoreNothingAndDoNotCrash() {
         exceptionListsSettingStore.store("")
         verifyNoInteractions(mockVpnDatabase)
     }

--- a/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/dao/VpnAppTrackerBlockingDao.kt
+++ b/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/dao/VpnAppTrackerBlockingDao.kt
@@ -38,6 +38,9 @@ interface VpnAppTrackerBlockingDao {
     @Insert
     fun setTrackerBlocklistMetadata(appTrackerMetadata: AppTrackerMetadata)
 
+    @Query("DELETE from vpn_app_tracker_blocking_list_metadata")
+    fun deleteTrackerBlocklistMetadata()
+
     @Query("DELETE from vpn_app_tracker_blocking_list")
     fun deleteTrackerBlockList()
 
@@ -63,6 +66,7 @@ interface VpnAppTrackerBlockingDao {
         metadata: AppTrackerMetadata,
         entities: List<AppTrackerEntity>,
     ) {
+        deleteTrackerBlocklistMetadata()
         setTrackerBlocklistMetadata(metadata)
 
         deleteTrackerBlockList()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202279501986195/task/1210112806879953?focus=true

### Description
Remove the eTag checks to ensure blocklist is always stored

### Steps to test this PR

_Test 1_
- [x] build and install internal debug build
- [x] launch the app
- [x] verify `Updating the app tracker blocklist, previous/new eTag:...` appears in logs

_Test 2_
- [x] Change from `ExistingPeriodicWorkPolicy.KEEP` to `ExistingPeriodicWorkPolicy.REPLACE` in  `AppTrackerListUpdateWorkerScheduler`
- [x] build and install internal debug build
- [x] launch the app
- [x] verify `Updating the app tracker blocklist, previous/new eTag:...` appears in logs
- [x] force close and reopen the app
- [x] verify `Updating the app tracker blocklist, previous/new eTag:...` appears in logs