### PR TITLE
Restore idling for script in privacy tests

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/FingerprintProtectionTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/FingerprintProtectionTest.kt
@@ -69,8 +69,8 @@ class FingerprintProtectionTest {
             .check(webMatches(getText(), containsString("Start the test")))
             .perform(webClick())
 
-        val jsIdlingResourceForResult = JsObjectIdlingResource(webView, "window.results.results")
-        IdlingRegistry.getInstance().register(jsIdlingResourceForResult)
+        val idlingResourceForScript = WebViewIdlingResource(webView!!)
+        IdlingRegistry.getInstance().register(idlingResourceForScript)
 
         val results = onWebView()
             .perform(script(SCRIPT))
@@ -84,7 +84,7 @@ class FingerprintProtectionTest {
                 assertEquals(sortProperties(expected), sortProperties(actual))
             }
         }
-        IdlingRegistry.getInstance().unregister(idlingResourceForDisableProtections, jsIdlingResource, jsIdlingResourceForResult)
+        IdlingRegistry.getInstance().unregister(idlingResourceForDisableProtections, jsIdlingResource, idlingResourceForScript)
     }
 
     private fun getTestJson(jsonString: String): TestJson? {

--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/GpcTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/GpcTest.kt
@@ -71,8 +71,8 @@ class GpcTest {
             .check(webMatches(getText(), containsString("Start test")))
             .perform(webClick())
 
-        val jsIdlingResourceForResult = JsObjectIdlingResource(webView, "window.results.results")
-        IdlingRegistry.getInstance().register(jsIdlingResourceForResult)
+        val idlingResourceForScript = WebViewIdlingResource(webView!!)
+        IdlingRegistry.getInstance().register(idlingResourceForScript)
 
         val results = onWebView()
             .perform(script(SCRIPT))
@@ -84,7 +84,7 @@ class GpcTest {
                 assertTrue("Value ${it.id} should be true", it.value.toString() == "true")
             }
         }
-        IdlingRegistry.getInstance().unregister(idlingResourceForDisableProtections, jsIdlingResource, jsIdlingResourceForResult)
+        IdlingRegistry.getInstance().unregister(idlingResourceForDisableProtections, jsIdlingResource, idlingResourceForScript)
     }
 
     private fun getTestJson(jsonString: String): TestJson? {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1210131369202191?focus=true

### Description

Restore part of: https://github.com/duckduckgo/Android/pull/5994 as it wasn't what we were aiming to resolve first anyway.

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
