### PR TITLE
Bump C-S-S to 8.19.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
@@ -1820,6 +1820,7 @@
       }
       url.searchParams.set("rel", "0");
       url.searchParams.set("modestbranding", "1");
+      url.searchParams.set("color", "white");
       if (this.timestamp && this.timestamp.seconds > 0) {
         url.searchParams.set("start", String(this.timestamp.seconds));
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^12.18.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.1.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.18.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.19.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1745528586"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#1ff1e5bfa99ad4f9ab679481395b2400b8263f6f",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#1d5f27d5167e4bdcaedebe67086cea3bab8d7f94",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^12.18.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.1.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.18.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.19.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1745528586"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1210128066798031?focus=true

### Description

Bumps C-S-S to version 8.19.0, which adds the `color=white` to Duck Player embedded URLs. This forces the classic YouTube player UI to display.

### Steps to test this PR

- Open Duck Player on any video
- Use Chrome to inspect the Duck Player window
- Confirm that the iframe has a src attribute that includes the query param `color=white` . You can run this on the console to confirm `document.querySelector('iframe').src.includes('color=white');`
- Confirm that the player interface looks like this

<img width="404" alt="image" src="https://github.com/user-attachments/assets/48e3fede-cf1c-4ff3-8d96-9288f74d69b2" />

and not like this

<img width="399" alt="image" src="https://github.com/user-attachments/assets/bfc94120-5c41-418d-a805-9e4d180edae5" />

