### PR TITLE
Update DataStore to 1.1.4 to hopefully prevent a race condition

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -39,7 +39,7 @@ version.androidx.biometric=1.1.0
 
 version.androidx.core-splashscreen=1.0.1
 
-version.androidx.datastore=1.1.1
+version.androidx.datastore=1.1.4
 
 version.androidx.localbroadcastmanager=1.1.0
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1210142390986838?focus=true 

### Description
We saw a crash in `DataStore` code which looks like a race condition that is fixed in `DataStore 1.1.3`. There is a newer `1.1.4` and `1.1.5` both improving the same kinds of issues
- `1.1.5` is a broken release though so I'm pretending that doesn't exist
- this PR updates `DataStore` to use `1.1.4` (currently `1.1.1`)

### Steps to test this PR
- [x] Start with `develop` and run the app, generally use it to hopefully populate some `DataStores` 
- [x] Upgrade to this branch. Re-launch the app and smoke test
- [x] Smoke test a fresh install on this branch

