### PR TITLE
Tile experiment text edge case

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
@@ -152,9 +152,15 @@ class TabSwitcherAdapter(
             is TabSwitcherViewHolder.TrackerAnimationInfoPanelViewHolder -> {
                 val trackerAnimationInfoPanel = list[position] as TabSwitcherItem.TrackerAnimationInfoPanel
 
+                val stringRes = if (trackerAnimationInfoPanel.trackerCount == 1) {
+                    R.string.trackerBlockedInTheLast7days
+                } else {
+                    R.string.trackersBlockedInTheLast7days
+                }
+
                 trackerCountAnimator.animateTrackersBlockedCountView(
                     context = holder.binding.root.context,
-                    stringRes = R.string.trackersBlockedInTheLast7days,
+                    stringRes = stringRes,
                     totalTrackerCount = trackerAnimationInfoPanel.trackerCount,
                     trackerTextView = holder.binding.infoPanelText,
                 )

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -54,4 +54,6 @@
     <!-- Skip Onboarding (not user-facing) -->
     <string name="skipOnboarding">Skip Onboarding</string>"
 
+    <!-- Trackers blocked animation-->
+    <string name="trackerBlockedInTheLast7days" instruction="Placeholder is 1 tracker blocked" >&lt;b&gt;%1$s tracker blocked &lt;/b&gt; in the last 7 days</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,7 +118,6 @@
     <string name="tabSwitcherGridViewMenu">Grid view</string>
 
     <!--Tab Switcher Animation-->
-    <!-- Trackers blocked animation-->
     <string name="trackersBlockedInTheLast7days" instruction="Placeholder is the number of trackers blocked > 1">&lt;b&gt;%1$s trackers blocked &lt;/b&gt; in the last 7 days</string>
     <string name="trackersBlocked" instruction="Placeholder is the number of trackers blocked">&lt;b&gt;%1$s trackers blocked &lt;/b&gt;</string>
     <string name="inTheLast7Days">in the last 7 days</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,7 +120,6 @@
     <!--Tab Switcher Animation-->
     <!-- Trackers blocked animation-->
     <string name="trackersBlockedInTheLast7days" instruction="Placeholder is the number of trackers blocked > 1">&lt;b&gt;%1$s trackers blocked &lt;/b&gt; in the last 7 days</string>
-    <string name="trackerBlockedInTheLast7days" instruction="Placeholder is 1 tracker blocked" >&lt;b&gt;%1$s tracker blocked &lt;/b&gt; in the last 7 days</string>
     <string name="trackersBlocked" instruction="Placeholder is the number of trackers blocked">&lt;b&gt;%1$s trackers blocked &lt;/b&gt;</string>
     <string name="inTheLast7Days">in the last 7 days</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,7 +118,9 @@
     <string name="tabSwitcherGridViewMenu">Grid view</string>
 
     <!--Tab Switcher Animation-->
-    <string name="trackersBlockedInTheLast7days" instruction="Placeholder is the number of trackers blocked">&lt;b&gt;%1$s trackers blocked &lt;/b&gt; in the last 7 days</string>
+    <!-- Trackers blocked animation-->
+    <string name="trackersBlockedInTheLast7days" instruction="Placeholder is the number of trackers blocked > 1">&lt;b&gt;%1$s trackers blocked &lt;/b&gt; in the last 7 days</string>
+    <string name="trackerBlockedInTheLast7days" instruction="Placeholder is 1 tracker blocked" >&lt;b&gt;%1$s tracker blocked &lt;/b&gt; in the last 7 days</string>
     <string name="trackersBlocked" instruction="Placeholder is the number of trackers blocked">&lt;b&gt;%1$s trackers blocked &lt;/b&gt;</string>
     <string name="inTheLast7Days">in the last 7 days</string>
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1210140687033716

### Description
This PR fixes and edge case where only 1 tracker has been blocked and we display the tile animation.
This only applies to English, other languages in this edge case will see the english text.

Instructions - [instructions.mp4](https://app.asana.com/app/asana/-/get_asset?asset_id=1210103609702441)
Install apk and open Settings / Experimental UI Settings
Enable any of the O-10 Experiments. Restart the app to ensure it works as expected.
Note: This is not compatible with the O-A Experiment, please disable it for proper testing

### Steps to test this PR

_1 tracker blocked_
- [ ] Fresh install and enable the Variant 2 in the O-10 experiment
- [ ] Visit a site that blocks 1 tracker
- [ ] Open the Tab Manager screen
- [ ] Tile should read “1 tracker blocked in the last 7 days"

### UI changes
| Before  | After |
| ------ | ----- |
![Screenshot_20250502_143738](https://github.com/user-attachments/assets/ff030e9a-adcc-4643-ba16-ba6098ad6ddf)|![Screenshot_20250502_144324](https://github.com/user-attachments/assets/0c3349f8-75b5-4de6-882c-1d5cb461bd40)|

