### PR TITLE
Fix: Ensure the scrollbars are always restored

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/tabpreview/WebViewPreviewGenerator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabpreview/WebViewPreviewGenerator.kt
@@ -33,13 +33,17 @@ interface WebViewPreviewGenerator {
 class FileBasedWebViewPreviewGenerator(private val dispatchers: DispatcherProvider) : WebViewPreviewGenerator {
 
     override suspend fun generatePreview(webView: WebView): Bitmap {
-        disableScrollbars(webView)
-        val fullSizeBitmap = createBitmap(webView)
+        val scaledBitmap: Bitmap
+        try {
+            disableScrollbars(webView)
+            val fullSizeBitmap = createBitmap(webView)
 
-        val scaledHeight = webView.context.resources.getDimension(R.dimen.gridItemPreviewHeight).toPx()
-        val scaledWidth = scaledHeight / fullSizeBitmap.height * fullSizeBitmap.width
-        val scaledBitmap = scaleBitmap(fullSizeBitmap, scaledHeight.roundToInt(), scaledWidth.roundToInt())
-        enableScrollbars(webView)
+            val scaledHeight = webView.context.resources.getDimension(R.dimen.gridItemPreviewHeight).toPx()
+            val scaledWidth = scaledHeight / fullSizeBitmap.height * fullSizeBitmap.width
+            scaledBitmap = scaleBitmap(fullSizeBitmap, scaledHeight.roundToInt(), scaledWidth.roundToInt())
+        } finally {
+            enableScrollbars(webView)
+        }
         return scaledBitmap
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/tabpreview/WebViewPreviewGenerator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabpreview/WebViewPreviewGenerator.kt
@@ -33,18 +33,16 @@ interface WebViewPreviewGenerator {
 class FileBasedWebViewPreviewGenerator(private val dispatchers: DispatcherProvider) : WebViewPreviewGenerator {
 
     override suspend fun generatePreview(webView: WebView): Bitmap {
-        val scaledBitmap: Bitmap
         try {
             disableScrollbars(webView)
             val fullSizeBitmap = createBitmap(webView)
 
             val scaledHeight = webView.context.resources.getDimension(R.dimen.gridItemPreviewHeight).toPx()
             val scaledWidth = scaledHeight / fullSizeBitmap.height * fullSizeBitmap.width
-            scaledBitmap = scaleBitmap(fullSizeBitmap, scaledHeight.roundToInt(), scaledWidth.roundToInt())
+            return scaleBitmap(fullSizeBitmap, scaledHeight.roundToInt(), scaledWidth.roundToInt())
         } finally {
             enableScrollbars(webView)
         }
-        return scaledBitmap
     }
 
     @SuppressLint("AvoidComputationUsage")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1210108991225075?focus=true

### Description

This fixes a bug when the WebView scrollbars would stay hidden if the preview generation threw an exception. This may happen fairly often with tab swiping when you swipe between tabs fast so that the webview doesn't get a chance to get laid out.

### Steps to test this PR

- [ ] Swipe tabs until you notice `Failed to generate WebView preview` in the logcat
- [ ] Swipe back to the last tab
- [ ] Notice the WebView has scrollbars when you scroll it

