### PR TITLE
Swiping tabs: Save tab pager state

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -295,7 +295,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
 
         setContentView(binding.root)
 
-        initializeTabs()
+        initializeTabs(savedInstanceState)
 
         // LiveData observers are restarted on each showWebContent() call; we want to subscribe to
         // flows only once, so a separate initialization is necessary
@@ -311,6 +311,14 @@ open class BrowserActivity : DuckDuckGoActivity() {
             viewModel.onLaunchedFromNotification(it)
         }
         configureOnBackPressedListener()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+
+        if (swipingTabsFeature.isEnabled) {
+            outState.putParcelable(KEY_TAB_PAGER_STATE, tabPagerAdapter.saveState())
+        }
     }
 
     private fun configureFlowCollectors() {
@@ -803,6 +811,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
         private const val OPEN_DUCK_CHAT = "OPEN_DUCK_CHAT_EXTRA"
 
         private const val MAX_ACTIVE_TABS = 40
+        private const val KEY_TAB_PAGER_STATE = "tabPagerState"
     }
 
     inner class BrowserStateRenderer {
@@ -846,7 +855,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
         }
     }
 
-    private fun initializeTabs() {
+    private fun initializeTabs(savedInstanceState: Bundle?) {
         if (swipingTabsFeature.isEnabled) {
             tabManager.registerCallbacks(
                 onTabsUpdated = ::onTabsUpdated,
@@ -855,6 +864,10 @@ open class BrowserActivity : DuckDuckGoActivity() {
             tabPager.adapter = tabPagerAdapter
             tabPager.registerOnPageChangeCallback(onTabPageChangeListener)
             tabPager.setPageTransformer(MarginPageTransformer(resources.getDimension(com.duckduckgo.mobile.android.R.dimen.keyline_1).toPx().toInt()))
+
+            savedInstanceState?.getBundle(KEY_TAB_PAGER_STATE)?.let {
+                tabPagerAdapter.restoreState(it)
+            }
         }
 
         binding.fragmentContainer.isVisible = !swipingTabsFeature.isEnabled


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1210186654423822?focus=true

### Description

This PR just calls `TabPagerAdapter.saveState()` and `restoreState()` whenever the activity is saved and restored.

### Steps to test this PR

- [ ] Enable Don't keep activities
- [ ] Start the app, add a few tabs
- [ ] Move between the browser and tab switcher a few times
- [ ] Verify everything looks as expected

