### PR TITLE
Visual update:Adjust the end autocomplete item paddings

### DIFF
--- a/app/src/main/res/layout/item_autocomplete_bookmark_suggestion.xml
+++ b/app/src/main/res/layout/item_autocomplete_bookmark_suggestion.xml
@@ -24,7 +24,8 @@
     android:layout_marginTop="6dp"
     android:background="?attr/selectableItemBackground"
     android:paddingVertical="@dimen/keyline_2"
-    android:paddingHorizontal="?attr/autocompleteListItemHorizontalPadding">
+    android:paddingStart="?attr/autocompleteListItemStartPadding"
+    android:paddingEnd="?attr/autocompleteListItemWithoutTrailIconEndPadding">
 
     <ImageView
         android:id="@+id/bookmarkIndicator"

--- a/app/src/main/res/layout/item_autocomplete_history_search_suggestion.xml
+++ b/app/src/main/res/layout/item_autocomplete_history_search_suggestion.xml
@@ -23,7 +23,8 @@
     android:layout_marginBottom="8dp"
     android:background="?attr/selectableItemBackground"
     android:paddingVertical="@dimen/keyline_2"
-    android:paddingHorizontal="?attr/autocompleteListItemHorizontalPadding">
+    android:paddingStart="?attr/autocompleteListItemStartPadding"
+    android:paddingEnd="?attr/autocompleteListItemWithoutTrailIconEndPadding">
 
     <ImageView
         android:id="@+id/phraseOrUrlIndicator"

--- a/app/src/main/res/layout/item_autocomplete_history_suggestion.xml
+++ b/app/src/main/res/layout/item_autocomplete_history_suggestion.xml
@@ -24,7 +24,8 @@
     android:layout_marginTop="6dp"
     android:background="?attr/selectableItemBackground"
     android:paddingVertical="@dimen/keyline_2"
-    android:paddingHorizontal="?attr/autocompleteListItemHorizontalPadding">
+    android:paddingStart="?attr/autocompleteListItemStartPadding"
+    android:paddingEnd="?attr/autocompleteListItemWithoutTrailIconEndPadding">
 
     <ImageView
         android:id="@+id/historyIndicator"

--- a/app/src/main/res/layout/item_autocomplete_switch_to_tab_suggestion.xml
+++ b/app/src/main/res/layout/item_autocomplete_switch_to_tab_suggestion.xml
@@ -22,7 +22,8 @@
     android:layout_marginTop="6dp"
     android:layout_marginBottom="8dp"
     android:background="?attr/selectableItemBackground"
-    android:paddingHorizontal="?attr/autocompleteListItemHorizontalPadding"
+    android:paddingStart="?attr/autocompleteListItemStartPadding"
+    android:paddingEnd="?attr/autocompleteListItemWithoutTrailIconEndPadding"
     android:paddingVertical="@dimen/keyline_2">
 
     <ImageView

--- a/common/common-ui/src/main/res/values/design-experiments-theming.xml
+++ b/common/common-ui/src/main/res/values/design-experiments-theming.xml
@@ -87,6 +87,7 @@
         <item name="autocompleteListItemHorizontalPadding">26dp</item>
         <item name="autocompleteListItemStartPadding">26dp</item>
         <item name="autocompleteListItemEndPadding">22dp</item>
+        <item name="autocompleteListItemWithoutTrailIconEndPadding">46dp</item>
         <item name="autocompleteListItemIconMargin">@dimen/keyline_2</item>
     </style>
 

--- a/common/common-ui/src/main/res/values/design-system-attrs.xml
+++ b/common/common-ui/src/main/res/values/design-system-attrs.xml
@@ -23,4 +23,5 @@
     <attr name="autocompleteListItemStartPadding" format="dimension"/>
     <attr name="autocompleteListItemEndPadding" format="dimension"/>
     <attr name="autocompleteListItemIconMargin" format="dimension"/>
+    <attr name="autocompleteListItemWithoutTrailIconEndPadding" format="dimension"/>
 </resources>

--- a/common/common-ui/src/main/res/values/design-system-theming.xml
+++ b/common/common-ui/src/main/res/values/design-system-theming.xml
@@ -137,6 +137,7 @@
         <item name="autocompleteListItemStartPadding">18dp</item>
         <item name="autocompleteListItemEndPadding">@dimen/keyline_2</item>
         <item name="autocompleteListItemIconMargin">10dp</item>
+        <item name="autocompleteListItemWithoutTrailIconEndPadding">@dimen/keyline_4</item>
     </style>
 
     <!-- The app theme will mostly contain values for colour attributes -->


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1210187246401092?focus=true

### Description

This PR updates the end paddings for the autocomplete suggestion items that don't have a trailing icon, as requested by design.

### UI changes
| Old  | New |
| ------ | ----- |
![image](https://github.com/user-attachments/assets/6d46c8f2-2879-482f-85c6-6f4e6972d3d0)|![image](https://github.com/user-attachments/assets/89c1b5b1-6ba3-402a-9d7e-7cb7a1da53df)|
