### PR TITLE
Narrow down errors when creating null tunnel

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/integration/NgVpnNetworkStack.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/integration/NgVpnNetworkStack.kt
@@ -234,9 +234,15 @@ class NgVpnNetworkStack @Inject constructor(
 
             tunnelThread = Thread {
                 logcat { "Running tunnel in context $jniContext" }
-                vpnNetwork.run(jniContext, tunfd)
-                logcat(LogPriority.WARN) { "Tunnel exited" }
-                tunnelThread = null
+                try {
+                    vpnNetwork.run(jniContext, tunfd)
+                } catch (t: Throwable) {
+                    logcat(LogPriority.ERROR) { "Tunnel thread crashed: ${t.asLog()}" }
+                    deviceShieldPixels.reportTunnelThreadAbnormalCrash()
+                } finally {
+                    tunnelThread = null
+                    logcat(LogPriority.WARN) { "Tunnel exited" }
+                }
             }.also { it.start() }
 
             logcat { "Started tunnel thread" }

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixelNames.kt
@@ -212,6 +212,9 @@ enum class DeviceShieldPixelNames(override val pixelName: String, val enqueue: B
     ATP_REPORT_TUNNEL_THREAD_STOP_TIMEOUT("m_atp_ev_apptp_tunnel_thread_stop_timeout_c", enqueue = true),
     ATP_REPORT_TUNNEL_THREAD_STOP_TIMEOUT_DAILY("m_atp_ev_apptp_tunnel_thread_stop_timeout_d", enqueue = true),
 
+    ATP_REPORT_TUNNEL_THREAD_STOP_CRASH("m_atp_ev_apptp_tunnel_thread_crash_c", enqueue = true),
+    ATP_REPORT_TUNNEL_THREAD_CRASH_DAILY("m_atp_ev_apptp_tunnel_thread_crash_d", enqueue = true),
+
     REPORT_VPN_ALWAYS_ON_TRIGGERED("m_vpn_ev_always_on_triggered_c"),
     REPORT_VPN_ALWAYS_ON_TRIGGERED_DAILY("m_vpn_ev_always_on_triggered_d"),
 

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/pixels/DeviceShieldPixels.kt
@@ -364,6 +364,8 @@ interface DeviceShieldPixels {
 
     fun reportTunnelThreadStopTimeout()
 
+    fun reportTunnelThreadAbnormalCrash()
+
     fun reportVpnAlwaysOnTriggered()
 
     fun notifyStartFailed()
@@ -881,6 +883,11 @@ class RealDeviceShieldPixels @Inject constructor(
     override fun reportTunnelThreadStopTimeout() {
         tryToFireDailyPixel(DeviceShieldPixelNames.ATP_REPORT_TUNNEL_THREAD_STOP_TIMEOUT_DAILY)
         firePixel(DeviceShieldPixelNames.ATP_REPORT_TUNNEL_THREAD_STOP_TIMEOUT)
+    }
+
+    override fun reportTunnelThreadAbnormalCrash() {
+        tryToFireDailyPixel(DeviceShieldPixelNames.ATP_REPORT_TUNNEL_THREAD_CRASH_DAILY)
+        firePixel(DeviceShieldPixelNames.ATP_REPORT_TUNNEL_THREAD_STOP_CRASH)
     }
 
     override fun reportVpnAlwaysOnTriggered() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1210194113621115?focus=true

### Description
Improve crash messaging when creating null tun.
Also add a small delay to give `startForeground` time to "settle".

### Steps to test this PR
Smoke test VPN and AppTP
