### PR TITLE
Subscriptions: fetch billingPeriod property from BE

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsConstants.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsConstants.kt
@@ -16,11 +16,6 @@
 
 package com.duckduckgo.subscriptions.impl
 
-import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.MONTHLY_PLAN_ROW
-import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.MONTHLY_PLAN_US
-import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.YEARLY_PLAN_ROW
-import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.YEARLY_PLAN_US
-
 object SubscriptionsConstants {
 
     // List of subscriptions
@@ -61,12 +56,4 @@ object SubscriptionsConstants {
     const val FAQS_URL = "https://duckduckgo.com/duckduckgo-help-pages/privacy-pro/"
     const val PRIVACY_PRO_ETLD = "duckduckgo.com"
     const val PRIVACY_PRO_PATH = "pro"
-}
-
-internal fun String.productIdToBillingPeriod(): String? {
-    return when (this) {
-        MONTHLY_PLAN_US, MONTHLY_PLAN_ROW -> "monthly"
-        YEARLY_PLAN_US, YEARLY_PLAN_ROW -> "annual"
-        else -> null
-    }
 }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsConstants.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsConstants.kt
@@ -46,8 +46,8 @@ object SubscriptionsConstants {
     const val PLATFORM = "android"
 
     // Recurrence
-    const val MONTHLY = "monthly"
-    const val YEARLY = "yearly"
+    const val MONTHLY = "Monthly"
+    const val YEARLY = "Yearly"
 
     // URLs
     const val BUY_URL = "https://duckduckgo.com/subscriptions"

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
@@ -450,6 +450,7 @@ class RealSubscriptionsManager @Inject constructor(
 
             val subscription = Subscription(
                 productId = confirmationResponse.subscription.productId,
+                billingPeriod = confirmationResponse.subscription.billingPeriod,
                 startedAt = confirmationResponse.subscription.startedAt,
                 expiresOrRenewsAt = confirmationResponse.subscription.expiresOrRenewsAt,
                 status = confirmationResponse.subscription.status.toStatus(),
@@ -560,6 +561,7 @@ class RealSubscriptionsManager @Inject constructor(
             authRepository.setSubscription(
                 Subscription(
                     productId = subscription.productId,
+                    billingPeriod = subscription.billingPeriod,
                     startedAt = subscription.startedAt,
                     expiresOrRenewsAt = subscription.expiresOrRenewsAt,
                     status = subscription.status.toStatus(),
@@ -635,6 +637,7 @@ class RealSubscriptionsManager @Inject constructor(
         authRepository.setSubscription(
             Subscription(
                 productId = subscription.productId,
+                billingPeriod = subscription.billingPeriod,
                 startedAt = subscription.startedAt,
                 expiresOrRenewsAt = subscription.expiresOrRenewsAt,
                 status = subscription.status.toStatus(),

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/repository/AuthRepository.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/repository/AuthRepository.kt
@@ -163,27 +163,30 @@ internal class RealAuthRepository constructor(
     override suspend fun setSubscription(subscription: Subscription?) = withContext(dispatcherProvider.io()) {
         with(subscriptionsDataStore) {
             productId = subscription?.productId
-            platform = subscription?.platform
+            billingPeriod = subscription?.billingPeriod
             startedAt = subscription?.startedAt
             expiresOrRenewsAt = subscription?.expiresOrRenewsAt
             status = subscription?.status?.statusName
+            platform = subscription?.platform
             freeTrialActive = subscription?.activeOffers?.contains(ActiveOfferType.TRIAL) ?: false
         }
     }
 
     override suspend fun getSubscription(): Subscription? = withContext(dispatcherProvider.io()) {
         val productId = subscriptionsDataStore.productId ?: return@withContext null
-        val platform = subscriptionsDataStore.platform ?: return@withContext null
+        val billingPeriod = subscriptionsDataStore.billingPeriod ?: return@withContext null
         val startedAt = subscriptionsDataStore.startedAt ?: return@withContext null
         val expiresOrRenewsAt = subscriptionsDataStore.expiresOrRenewsAt ?: return@withContext null
         val status = subscriptionsDataStore.status?.toStatus() ?: return@withContext null
+        val platform = subscriptionsDataStore.platform ?: return@withContext null
         val activeOffers = if (subscriptionsDataStore.freeTrialActive) listOf(ActiveOfferType.TRIAL) else listOf()
         Subscription(
             productId = productId,
-            platform = platform,
+            billingPeriod = billingPeriod,
             startedAt = startedAt,
             expiresOrRenewsAt = expiresOrRenewsAt,
             status = status,
+            platform = platform,
             activeOffers = activeOffers,
         )
     }
@@ -249,6 +252,7 @@ data class Account(
 
 data class Subscription(
     val productId: String,
+    val billingPeriod: String,
     val startedAt: Long,
     val expiresOrRenewsAt: Long,
     val status: SubscriptionStatus,

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/rmf/RMFPProBillingPeriodMatchingAttribute.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/rmf/RMFPProBillingPeriodMatchingAttribute.kt
@@ -22,7 +22,6 @@ import com.duckduckgo.remote.messaging.api.JsonMatchingAttribute
 import com.duckduckgo.remote.messaging.api.JsonToMatchingAttributeMapper
 import com.duckduckgo.remote.messaging.api.MatchingAttribute
 import com.duckduckgo.subscriptions.impl.SubscriptionsManager
-import com.duckduckgo.subscriptions.impl.productIdToBillingPeriod
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
 import javax.inject.Inject
@@ -41,8 +40,8 @@ class RMFPProBillingPeriodMatchingAttribute @Inject constructor(
 ) : JsonToMatchingAttributeMapper, AttributeMatcherPlugin {
     override suspend fun evaluate(matchingAttribute: MatchingAttribute): Boolean? {
         if (matchingAttribute is PProBillingPeriodMatchingAttribute) {
-            val productId = subscriptionsManager.getSubscription()?.productId
-            return productId != null && matchingAttribute.value == productId.productIdToBillingPeriod()
+            val subscription = subscriptionsManager.getSubscription()
+            return subscription?.productId != null && matchingAttribute.value == subscription.billingPeriod
         }
         return null
     }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/rmf/RMFPProBillingPeriodMatchingAttribute.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/rmf/RMFPProBillingPeriodMatchingAttribute.kt
@@ -40,8 +40,7 @@ class RMFPProBillingPeriodMatchingAttribute @Inject constructor(
 ) : JsonToMatchingAttributeMapper, AttributeMatcherPlugin {
     override suspend fun evaluate(matchingAttribute: MatchingAttribute): Boolean? {
         if (matchingAttribute is PProBillingPeriodMatchingAttribute) {
-            val subscription = subscriptionsManager.getSubscription()
-            return subscription?.productId != null && matchingAttribute.value == subscription.billingPeriod
+            return matchingAttribute.value == subscriptionsManager.getSubscription()?.billingPeriod
         }
         return null
     }
@@ -64,6 +63,6 @@ internal data class PProBillingPeriodMatchingAttribute(
     val value: String,
 ) : MatchingAttribute {
     companion object {
-        const val KEY = "privacyProBillingPeriod"
+        const val KEY = "pproBillingPeriod"
     }
 }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/services/SubscriptionsService.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/services/SubscriptionsService.kt
@@ -59,6 +59,7 @@ data class PortalResponse(val customerPortalUrl: String)
 
 data class SubscriptionResponse(
     val productId: String,
+    val billingPeriod: String,
     val startedAt: Long,
     val expiresOrRenewsAt: Long,
     val platform: String,

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/store/SubscriptionsDataStore.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/store/SubscriptionsDataStore.kt
@@ -36,6 +36,7 @@ interface SubscriptionsDataStore {
 
     // Subscription
     var expiresOrRenewsAt: Long?
+    var billingPeriod: String?
     var startedAt: Long?
     var platform: String?
     var status: String?
@@ -52,7 +53,7 @@ interface SubscriptionsDataStore {
  * THINK TWICE before using this class directly.
  * Usages of this class should all go through [AuthRepository]
  */
-internal class SubscriptionsEncryptedDataStore constructor(
+internal class SubscriptionsEncryptedDataStore(
     private val sharedPreferencesProvider: SharedPreferencesProvider,
 ) : SubscriptionsDataStore {
     private val encryptedPreferences: SharedPreferences? by lazy { encryptedPreferences() }
@@ -196,6 +197,14 @@ internal class SubscriptionsEncryptedDataStore constructor(
             }
         }
 
+    override var billingPeriod: String?
+        get() = encryptedPreferences?.getString(KEY_BILLING_PERIOD, null)
+        set(value) {
+            encryptedPreferences?.edit(commit = true) {
+                putString(KEY_BILLING_PERIOD, value)
+            }
+        }
+
     override var subscriptionFeatures: String?
         get() = encryptedPreferences?.getString(KEY_SUBSCRIPTION_FEATURES, null)
         set(value) {
@@ -222,6 +231,7 @@ internal class SubscriptionsEncryptedDataStore constructor(
         const val KEY_EXTERNAL_ID = "KEY_EXTERNAL_ID"
         const val KEY_EXPIRES_OR_RENEWS_AT = "KEY_EXPIRES_OR_RENEWS_AT"
         const val KEY_STARTED_AT = "KEY_STARTED_AT"
+        const val KEY_BILLING_PERIOD = "KEY_BILLING_PERIOD"
         const val KEY_ENTITLEMENTS = "KEY_ENTITLEMENTS"
         const val KEY_STATUS = "KEY_STATUS"
         const val KEY_PRODUCT_ID = "KEY_PRODUCT_ID"

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/survey/PproSurveyParameters.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/survey/PproSurveyParameters.kt
@@ -19,7 +19,6 @@ package com.duckduckgo.subscriptions.impl.survey
 import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.subscriptions.impl.SubscriptionsManager
-import com.duckduckgo.subscriptions.impl.productIdToBillingPeriod
 import com.duckduckgo.survey.api.SurveyParameterPlugin
 import com.squareup.anvil.annotations.ContributesMultibinding
 import java.util.concurrent.TimeUnit
@@ -41,8 +40,7 @@ class PproBillingParameterPlugin @Inject constructor(
     override val surveyParamKey: String = "ppro_billing"
 
     override suspend fun evaluate(): String {
-        val productId = subscriptionsManager.getSubscription()?.productId
-        return productId?.productIdToBillingPeriod() ?: ""
+        return subscriptionsManager.getSubscription()?.billingPeriod ?: ""
     }
 }
 

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
@@ -309,8 +309,8 @@ class SubscriptionWebViewViewModel @Inject constructor(
     ): SubscriptionOptionsJson {
         return SubscriptionOptionsJson(
             options = listOf(
-                createOptionsJson(yearlyOffer, YEARLY),
-                createOptionsJson(monthlyOffer, MONTHLY),
+                createOptionsJson(yearlyOffer, YEARLY.lowercase()),
+                createOptionsJson(monthlyOffer, MONTHLY.lowercase()),
             ),
             features = monthlyOffer.features.map(::FeatureJson),
         )

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
@@ -1375,6 +1375,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
 
             SubscriptionResponse(
                 productId = MONTHLY_PLAN_US,
+                billingPeriod = "Monthly",
                 startedAt = 1234,
                 expiresOrRenewsAt = 1234,
                 platform = "android",
@@ -1457,6 +1458,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         whenever(subscriptionsService.subscription()).thenReturn(
             SubscriptionResponse(
                 productId = MONTHLY_PLAN_US,
+                billingPeriod = "Monthly",
                 startedAt = 1234,
                 expiresOrRenewsAt = 1234,
                 platform = "android",
@@ -1471,6 +1473,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         whenever(subscriptionsService.subscription()).thenReturn(
             SubscriptionResponse(
                 productId = MONTHLY_PLAN_US,
+                billingPeriod = "Monthly",
                 startedAt = 1234,
                 expiresOrRenewsAt = 1234,
                 platform = "android",
@@ -1532,6 +1535,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         authDataStore.productId = "productId"
         authDataStore.entitlements = """[{"product":"Network Protection", "name":"subscriber"}]"""
         authDataStore.status = status.statusName
+        authDataStore.billingPeriod = "Monthly"
         authDataStore.startedAt = 1000L
         authDataStore.expiresOrRenewsAt = 1000L
     }
@@ -1675,6 +1679,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
                 ),
                 subscription = SubscriptionResponse(
                     productId = "id",
+                    billingPeriod = "Monthly",
                     platform = "google",
                     status = "Auto-Renewable",
                     startedAt = 1000000L,

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionMessagingInterfaceTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionMessagingInterfaceTest.kt
@@ -749,6 +749,7 @@ class SubscriptionMessagingInterfaceTest {
         whenever(subscriptionsManager.getSubscription()).thenReturn(
             Subscription(
                 productId = "productId",
+                billingPeriod = "Monthly",
                 startedAt = 10000L,
                 expiresOrRenewsAt = 10000L,
                 status = AUTO_RENEWABLE,

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/repository/FakeSubscriptionsDataStore.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/repository/FakeSubscriptionsDataStore.kt
@@ -43,6 +43,7 @@ class FakeSubscriptionsDataStore(
     // Subscription
     override var expiresOrRenewsAt: Long? = 0L
     override var platform: String? = null
+    override var billingPeriod: String? = null
     override var startedAt: Long? = 0L
     override var status: String? = null
     override var entitlements: String? = null

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/repository/RealAuthRepositoryTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/repository/RealAuthRepositoryTest.kt
@@ -50,6 +50,7 @@ class RealAuthRepositoryTest {
     @Test
     fun whenClearSubscriptionThenClearData() = runTest {
         authStore.status = "expired"
+        authStore.billingPeriod = "Monthly"
         authStore.startedAt = 1000L
         authStore.expiresOrRenewsAt = 1000L
         authStore.platform = "google"
@@ -59,6 +60,7 @@ class RealAuthRepositoryTest {
         authRepository.setSubscription(null)
 
         assertNull(authStore.status)
+        assertNull(authStore.billingPeriod)
         assertNull(authStore.startedAt)
         assertNull(authStore.expiresOrRenewsAt)
         assertNull(authStore.platform)

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/rmf/RMFPProBillingPeriodMatchingAttributeTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/rmf/RMFPProBillingPeriodMatchingAttributeTest.kt
@@ -3,6 +3,8 @@ package com.duckduckgo.subscriptions.impl.rmf
 import com.duckduckgo.remote.messaging.api.JsonMatchingAttribute
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.AUTO_RENEWABLE
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.MONTHLY
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.YEARLY
 import com.duckduckgo.subscriptions.impl.SubscriptionsManager
 import com.duckduckgo.subscriptions.impl.repository.Subscription
 import kotlinx.coroutines.test.runTest
@@ -18,15 +20,6 @@ class RMFPProBillingPeriodMatchingAttributeTest {
     private lateinit var subscriptionsManager: SubscriptionsManager
 
     private lateinit var matcher: RMFPProBillingPeriodMatchingAttribute
-    private val testSubscription = Subscription(
-        productId = SubscriptionsConstants.YEARLY_PLAN_US,
-        billingPeriod = "Monthly",
-        startedAt = 10000L,
-        expiresOrRenewsAt = 10000L,
-        status = AUTO_RENEWABLE,
-        platform = "Google",
-        activeOffers = listOf(),
-    )
 
     @Before
     fun setUp() {
@@ -76,8 +69,18 @@ class RMFPProBillingPeriodMatchingAttributeTest {
 
     @Test
     fun whenMatchingAttributeHasAnnualValueAndSubscriptionIsAnnualThenEvaluateToTrue() = runTest {
-        whenever(subscriptionsManager.getSubscription()).thenReturn(testSubscription)
-        val result = matcher.evaluate(PProBillingPeriodMatchingAttribute("annual"))
+        whenever(subscriptionsManager.getSubscription()).thenReturn(
+            Subscription(
+                productId = SubscriptionsConstants.YEARLY_PLAN_US,
+                billingPeriod = YEARLY,
+                startedAt = 10000L,
+                expiresOrRenewsAt = 10000L,
+                status = AUTO_RENEWABLE,
+                platform = "Google",
+                activeOffers = listOf(),
+            ),
+        )
+        val result = matcher.evaluate(PProBillingPeriodMatchingAttribute("yearly"))
 
         assertNotNull(result)
         result?.let {
@@ -87,7 +90,17 @@ class RMFPProBillingPeriodMatchingAttributeTest {
 
     @Test
     fun whenMatchingAttributeHasMonthlyValueAndSubscriptionIsMonthlyThenEvaluateToTrue() = runTest {
-        whenever(subscriptionsManager.getSubscription()).thenReturn(testSubscription.copy(productId = SubscriptionsConstants.MONTHLY_PLAN_US))
+        whenever(subscriptionsManager.getSubscription()).thenReturn(
+            Subscription(
+                productId = SubscriptionsConstants.YEARLY_PLAN_US,
+                billingPeriod = MONTHLY,
+                startedAt = 10000L,
+                expiresOrRenewsAt = 10000L,
+                status = AUTO_RENEWABLE,
+                platform = "Google",
+                activeOffers = listOf(),
+            ),
+        )
         val result = matcher.evaluate(PProBillingPeriodMatchingAttribute("monthly"))
 
         assertNotNull(result)
@@ -98,7 +111,17 @@ class RMFPProBillingPeriodMatchingAttributeTest {
 
     @Test
     fun whenMatchingAttributeHasMonthlyValueButSubscriptionIsAnnualThenEvaluateToFalse() = runTest {
-        whenever(subscriptionsManager.getSubscription()).thenReturn(testSubscription)
+        whenever(subscriptionsManager.getSubscription()).thenReturn(
+            Subscription(
+                productId = SubscriptionsConstants.YEARLY_PLAN_US,
+                billingPeriod = YEARLY,
+                startedAt = 10000L,
+                expiresOrRenewsAt = 10000L,
+                status = AUTO_RENEWABLE,
+                platform = "Google",
+                activeOffers = listOf(),
+            ),
+        )
         val result = matcher.evaluate(PProBillingPeriodMatchingAttribute("monthly"))
 
         assertNotNull(result)
@@ -108,9 +131,9 @@ class RMFPProBillingPeriodMatchingAttributeTest {
     }
 
     @Test
-    fun whenSubscriptionIsNullAnnualThenEvaluateToFalse() = runTest {
+    fun whenSubscriptionIsNullThenAnnualEvaluateToFalse() = runTest {
         whenever(subscriptionsManager.getSubscription()).thenReturn(null)
-        val result = matcher.evaluate(PProBillingPeriodMatchingAttribute("monthly"))
+        val result = matcher.evaluate(PProBillingPeriodMatchingAttribute("yearly"))
 
         assertNotNull(result)
         result?.let {
@@ -120,7 +143,17 @@ class RMFPProBillingPeriodMatchingAttributeTest {
 
     @Test
     fun whenMatchingAttributeIsUnsupportedValueThenEvaluateToFalse() = runTest {
-        whenever(subscriptionsManager.getSubscription()).thenReturn(testSubscription)
+        whenever(subscriptionsManager.getSubscription()).thenReturn(
+            Subscription(
+                productId = SubscriptionsConstants.YEARLY_PLAN_US,
+                billingPeriod = MONTHLY,
+                startedAt = 10000L,
+                expiresOrRenewsAt = 10000L,
+                status = AUTO_RENEWABLE,
+                platform = "Google",
+                activeOffers = listOf(),
+            ),
+        )
         val result = matcher.evaluate(PProBillingPeriodMatchingAttribute("quarterly"))
 
         assertNotNull(result)
@@ -130,19 +163,18 @@ class RMFPProBillingPeriodMatchingAttributeTest {
     }
 
     @Test
-    fun whenSubscriptionHasInvalidProductIdThenEvaluateToFalse() = runTest {
-        whenever(subscriptionsManager.getSubscription()).thenReturn(testSubscription.copy(productId = "invalid"))
-        val result = matcher.evaluate(PProBillingPeriodMatchingAttribute("annual"))
-
-        assertNotNull(result)
-        result?.let {
-            assertFalse(it)
-        }
-    }
-
-    @Test
     fun whenMatcherHasEmptyValueThenEvaluateToFalse() = runTest {
-        whenever(subscriptionsManager.getSubscription()).thenReturn(testSubscription)
+        whenever(subscriptionsManager.getSubscription()).thenReturn(
+            Subscription(
+                productId = SubscriptionsConstants.YEARLY_PLAN_US,
+                billingPeriod = MONTHLY,
+                startedAt = 10000L,
+                expiresOrRenewsAt = 10000L,
+                status = AUTO_RENEWABLE,
+                platform = "Google",
+                activeOffers = listOf(),
+            ),
+        )
         val result = matcher.evaluate(PProBillingPeriodMatchingAttribute(value = ""))
 
         assertNotNull(result)

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/rmf/RMFPProBillingPeriodMatchingAttributeTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/rmf/RMFPProBillingPeriodMatchingAttributeTest.kt
@@ -20,6 +20,7 @@ class RMFPProBillingPeriodMatchingAttributeTest {
     private lateinit var matcher: RMFPProBillingPeriodMatchingAttribute
     private val testSubscription = Subscription(
         productId = SubscriptionsConstants.YEARLY_PLAN_US,
+        billingPeriod = "Monthly",
         startedAt = 10000L,
         expiresOrRenewsAt = 10000L,
         status = AUTO_RENEWABLE,

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/rmf/RMFPProBillingPeriodMatchingAttributeTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/rmf/RMFPProBillingPeriodMatchingAttributeTest.kt
@@ -29,7 +29,7 @@ class RMFPProBillingPeriodMatchingAttributeTest {
 
     @Test
     fun whenKeyIsNotBillingPeriodThenMappersMapsToNull() {
-        val jsonMatchingAttribute = JsonMatchingAttribute(value = "annual")
+        val jsonMatchingAttribute = JsonMatchingAttribute(value = "Yearly")
         val result = matcher.map("somethingelse", jsonMatchingAttribute)
 
         assertNull(result)
@@ -37,7 +37,7 @@ class RMFPProBillingPeriodMatchingAttributeTest {
 
     @Test
     fun whenKeyIsBillingPeriodWithInvalidValueTypeThenMappersMapsToNull() {
-        val jsonMatchingAttribute = JsonMatchingAttribute(value = listOf("annual"))
+        val jsonMatchingAttribute = JsonMatchingAttribute(value = listOf("Yearly"))
         val result = matcher.map("privacyProBillingPeriod", jsonMatchingAttribute)
 
         assertNull(result)
@@ -54,17 +54,17 @@ class RMFPProBillingPeriodMatchingAttributeTest {
     @Test
     fun whenKeyIsBillingPeriodWithNullValueThenMappersMapsToNull() {
         val jsonMatchingAttribute = JsonMatchingAttribute(value = null)
-        val result = matcher.map("privacyProBillingPeriod", jsonMatchingAttribute)
+        val result = matcher.map("pproBillingPeriod", jsonMatchingAttribute)
 
         assertNull(result)
     }
 
     @Test
     fun whenKeyIsBillingPeriodValidThenMappersMapsToAttribute() {
-        val jsonMatchingAttribute = JsonMatchingAttribute(value = "annual")
-        val result = matcher.map("privacyProBillingPeriod", jsonMatchingAttribute)
+        val jsonMatchingAttribute = JsonMatchingAttribute(value = "Yearly")
+        val result = matcher.map("pproBillingPeriod", jsonMatchingAttribute)
 
-        assertEquals(PProBillingPeriodMatchingAttribute("annual"), result)
+        assertEquals(PProBillingPeriodMatchingAttribute(YEARLY), result)
     }
 
     @Test
@@ -80,7 +80,7 @@ class RMFPProBillingPeriodMatchingAttributeTest {
                 activeOffers = listOf(),
             ),
         )
-        val result = matcher.evaluate(PProBillingPeriodMatchingAttribute("yearly"))
+        val result = matcher.evaluate(PProBillingPeriodMatchingAttribute("Yearly"))
 
         assertNotNull(result)
         result?.let {
@@ -101,7 +101,7 @@ class RMFPProBillingPeriodMatchingAttributeTest {
                 activeOffers = listOf(),
             ),
         )
-        val result = matcher.evaluate(PProBillingPeriodMatchingAttribute("monthly"))
+        val result = matcher.evaluate(PProBillingPeriodMatchingAttribute("Monthly"))
 
         assertNotNull(result)
         result?.let {

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/rmf/RMFPProDaysSinceSubscribedMatchingAttributeTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/rmf/RMFPProDaysSinceSubscribedMatchingAttributeTest.kt
@@ -81,6 +81,7 @@ class RMFPProDaysSinceSubscribedMatchingAttributeTest {
         whenever(subscriptionsManager.getSubscription()).thenReturn(
             Subscription(
                 productId = "productId",
+                billingPeriod = "Monthly",
                 startedAt = 10000L,
                 expiresOrRenewsAt = 10000L,
                 status = AUTO_RENEWABLE,
@@ -111,6 +112,7 @@ class RMFPProDaysSinceSubscribedMatchingAttributeTest {
         whenever(subscriptionsManager.getSubscription()).thenReturn(
             Subscription(
                 productId = "productId",
+                billingPeriod = "Monthly",
                 startedAt = TimeUnit.DAYS.toMillis(1),
                 expiresOrRenewsAt = 10000L,
                 status = AUTO_RENEWABLE,
@@ -131,6 +133,7 @@ class RMFPProDaysSinceSubscribedMatchingAttributeTest {
         whenever(subscriptionsManager.getSubscription()).thenReturn(
             Subscription(
                 productId = "productId",
+                billingPeriod = "Monthly",
                 startedAt = TimeUnit.DAYS.toMillis(1),
                 expiresOrRenewsAt = 10000L,
                 status = AUTO_RENEWABLE,
@@ -151,6 +154,7 @@ class RMFPProDaysSinceSubscribedMatchingAttributeTest {
         whenever(subscriptionsManager.getSubscription()).thenReturn(
             Subscription(
                 productId = "productId",
+                billingPeriod = "Monthly",
                 startedAt = TimeUnit.DAYS.toMillis(1),
                 expiresOrRenewsAt = 10000L,
                 status = AUTO_RENEWABLE,
@@ -171,6 +175,7 @@ class RMFPProDaysSinceSubscribedMatchingAttributeTest {
         whenever(subscriptionsManager.getSubscription()).thenReturn(
             Subscription(
                 productId = "productId",
+                billingPeriod = "Monthly",
                 startedAt = TimeUnit.DAYS.toMillis(1),
                 expiresOrRenewsAt = 10000L,
                 status = AUTO_RENEWABLE,
@@ -191,6 +196,7 @@ class RMFPProDaysSinceSubscribedMatchingAttributeTest {
         whenever(subscriptionsManager.getSubscription()).thenReturn(
             Subscription(
                 productId = "productId",
+                billingPeriod = "Monthly",
                 startedAt = TimeUnit.DAYS.toMillis(1),
                 expiresOrRenewsAt = 10000L,
                 status = AUTO_RENEWABLE,
@@ -211,6 +217,7 @@ class RMFPProDaysSinceSubscribedMatchingAttributeTest {
         whenever(subscriptionsManager.getSubscription()).thenReturn(
             Subscription(
                 productId = "productId",
+                billingPeriod = "Monthly",
                 startedAt = TimeUnit.DAYS.toMillis(1),
                 expiresOrRenewsAt = 10000L,
                 status = AUTO_RENEWABLE,
@@ -231,6 +238,7 @@ class RMFPProDaysSinceSubscribedMatchingAttributeTest {
         whenever(subscriptionsManager.getSubscription()).thenReturn(
             Subscription(
                 productId = "productId",
+                billingPeriod = "Monthly",
                 startedAt = TimeUnit.DAYS.toMillis(1),
                 expiresOrRenewsAt = 10000L,
                 status = AUTO_RENEWABLE,

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/rmf/RMFPProDaysUntilExpiryRenewalMatchingAttributeTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/rmf/RMFPProDaysUntilExpiryRenewalMatchingAttributeTest.kt
@@ -31,6 +31,7 @@ class RMFPProDaysUntilExpiryRenewalMatchingAttributeTest {
 
     private val testSubscription = Subscription(
         productId = "productId",
+        billingPeriod = "Monthly",
         startedAt = DAYS.toMillis(1),
         expiresOrRenewsAt = DAYS.toMillis(10),
         status = AUTO_RENEWABLE,

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/rmf/RMFPProPurchasePlatformMatchingAttributeTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/rmf/RMFPProPurchasePlatformMatchingAttributeTest.kt
@@ -68,6 +68,7 @@ class RMFPProPurchasePlatformMatchingAttributeTest {
         whenever(subscriptionsManager.getSubscription()).thenReturn(
             Subscription(
                 productId = "productId",
+                billingPeriod = "Monthly",
                 startedAt = 10000L,
                 expiresOrRenewsAt = 10000L,
                 status = AUTO_RENEWABLE,
@@ -88,6 +89,7 @@ class RMFPProPurchasePlatformMatchingAttributeTest {
         whenever(subscriptionsManager.getSubscription()).thenReturn(
             Subscription(
                 productId = "productId",
+                billingPeriod = "Monthly",
                 startedAt = 10000L,
                 expiresOrRenewsAt = 10000L,
                 status = AUTO_RENEWABLE,
@@ -119,6 +121,7 @@ class RMFPProPurchasePlatformMatchingAttributeTest {
         whenever(subscriptionsManager.getSubscription()).thenReturn(
             Subscription(
                 productId = "productId",
+                billingPeriod = "Monthly",
                 startedAt = 10000L,
                 expiresOrRenewsAt = 10000L,
                 status = AUTO_RENEWABLE,

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/rmf/RMFPProSubscriptionStatusMatchingAttributeTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/rmf/RMFPProSubscriptionStatusMatchingAttributeTest.kt
@@ -9,6 +9,7 @@ import com.duckduckgo.subscriptions.api.SubscriptionStatus.NOT_AUTO_RENEWABLE
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.UNKNOWN
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.WAITING
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.MONTHLY
 import com.duckduckgo.subscriptions.impl.SubscriptionsManager
 import com.duckduckgo.subscriptions.impl.repository.Subscription
 import kotlinx.coroutines.test.runTest
@@ -26,7 +27,7 @@ class RMFPProSubscriptionStatusMatchingAttributeTest {
     private lateinit var matcher: RMFPProSubscriptionStatusMatchingAttribute
     private val testSubscription = Subscription(
         productId = SubscriptionsConstants.YEARLY_PLAN_US,
-        billingPeriod = "Monthly",
+        billingPeriod = MONTHLY,
         startedAt = 10000L,
         expiresOrRenewsAt = 10000L,
         status = AUTO_RENEWABLE,

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/rmf/RMFPProSubscriptionStatusMatchingAttributeTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/rmf/RMFPProSubscriptionStatusMatchingAttributeTest.kt
@@ -26,6 +26,7 @@ class RMFPProSubscriptionStatusMatchingAttributeTest {
     private lateinit var matcher: RMFPProSubscriptionStatusMatchingAttribute
     private val testSubscription = Subscription(
         productId = SubscriptionsConstants.YEARLY_PLAN_US,
+        billingPeriod = "Monthly",
         startedAt = 10000L,
         expiresOrRenewsAt = 10000L,
         status = AUTO_RENEWABLE,

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/survey/PproSurveyParameterPluginsTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/survey/PproSurveyParameterPluginsTest.kt
@@ -6,6 +6,8 @@ import com.duckduckgo.subscriptions.api.SubscriptionStatus.GRACE_PERIOD
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.INACTIVE
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.NOT_AUTO_RENEWABLE
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.MONTHLY
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.YEARLY
 import com.duckduckgo.subscriptions.impl.SubscriptionsManager
 import com.duckduckgo.subscriptions.impl.repository.Subscription
 import kotlinx.coroutines.test.runTest
@@ -25,7 +27,7 @@ class PproSurveyParameterPluginTest {
 
     private val testSubscription = Subscription(
         productId = SubscriptionsConstants.MONTHLY_PLAN_US,
-        billingPeriod = "Monthly",
+        billingPeriod = MONTHLY,
         startedAt = 1717797600000, // June 07 UTC
         expiresOrRenewsAt = 1719525600000, // June 27 UTC
         status = AUTO_RENEWABLE,
@@ -62,33 +64,26 @@ class PproSurveyParameterPluginTest {
 
         val plugin = PproBillingParameterPlugin(subscriptionsManager)
 
-        assertEquals("monthly", plugin.evaluate())
+        assertEquals("Monthly", plugin.evaluate())
     }
 
     @Test
     fun whenSubscriptionIsYearlyThenBillingParamEvaluatesToSubscriptionBilling() = runTest {
         whenever(subscriptionsManager.getSubscription()).thenReturn(
-            testSubscription.copy(
-                productId = SubscriptionsConstants.YEARLY_PLAN_US,
+            Subscription(
+                productId = SubscriptionsConstants.MONTHLY_PLAN_US,
+                billingPeriod = YEARLY,
+                startedAt = 1717797600000, // June 07 UTC
+                expiresOrRenewsAt = 1719525600000, // June 27 UTC
+                status = AUTO_RENEWABLE,
+                platform = "android",
+                activeOffers = listOf(),
             ),
         )
 
         val plugin = PproBillingParameterPlugin(subscriptionsManager)
 
-        assertEquals("annual", plugin.evaluate())
-    }
-
-    @Test
-    fun whenSubscriptionHasInvalidProductIdThenBillingParamEvaluatesToEmpty() = runTest {
-        whenever(subscriptionsManager.getSubscription()).thenReturn(
-            testSubscription.copy(
-                productId = "some invalid product id",
-            ),
-        )
-
-        val plugin = PproBillingParameterPlugin(subscriptionsManager)
-
-        assertEquals("", plugin.evaluate())
+        assertEquals("Yearly", plugin.evaluate())
     }
 
     @Test

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/survey/PproSurveyParameterPluginsTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/survey/PproSurveyParameterPluginsTest.kt
@@ -25,6 +25,7 @@ class PproSurveyParameterPluginTest {
 
     private val testSubscription = Subscription(
         productId = SubscriptionsConstants.MONTHLY_PLAN_US,
+        billingPeriod = "Monthly",
         startedAt = 1717797600000, // June 07 UTC
         expiresOrRenewsAt = 1719525600000, // June 27 UTC
         status = AUTO_RENEWABLE,

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/RestoreSubscriptionViewModelTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/RestoreSubscriptionViewModelTest.kt
@@ -193,6 +193,7 @@ class RestoreSubscriptionViewModelTest {
     private fun subscriptionActive(): Subscription {
         return Subscription(
             productId = "productId",
+            billingPeriod = "Monthly",
             startedAt = 10000L,
             expiresOrRenewsAt = 10000L,
             status = AUTO_RENEWABLE,

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionSettingsViewModelTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionSettingsViewModelTest.kt
@@ -62,6 +62,7 @@ class SubscriptionSettingsViewModelTest {
         whenever(subscriptionsManager.getSubscription()).thenReturn(
             Subscription(
                 productId = SubscriptionsConstants.MONTHLY_PLAN_US,
+                billingPeriod = "Monthly",
                 startedAt = 1234,
                 expiresOrRenewsAt = 1701694623000,
                 status = AUTO_RENEWABLE,
@@ -90,6 +91,7 @@ class SubscriptionSettingsViewModelTest {
         whenever(subscriptionsManager.getSubscription()).thenReturn(
             Subscription(
                 productId = SubscriptionsConstants.MONTHLY_PLAN_US,
+                billingPeriod = "Monthly",
                 startedAt = 1234,
                 expiresOrRenewsAt = 1701694623000,
                 status = AUTO_RENEWABLE,
@@ -118,6 +120,7 @@ class SubscriptionSettingsViewModelTest {
         whenever(subscriptionsManager.getSubscription()).thenReturn(
             Subscription(
                 productId = SubscriptionsConstants.MONTHLY_PLAN_US,
+                billingPeriod = "Monthly",
                 startedAt = 1234,
                 expiresOrRenewsAt = 1701694623000,
                 status = AUTO_RENEWABLE,
@@ -146,6 +149,7 @@ class SubscriptionSettingsViewModelTest {
         whenever(subscriptionsManager.getSubscription()).thenReturn(
             Subscription(
                 productId = SubscriptionsConstants.YEARLY_PLAN_US,
+                billingPeriod = "Monthly",
                 startedAt = 1234,
                 expiresOrRenewsAt = 1701694623000,
                 status = AUTO_RENEWABLE,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1210199014409745?focus=true

### Description
Parse `billingPeriod` from ConfirmResponse request and add it to Subscription Object

### Steps to test this PR

_Existing PPro user_
- [x] Make sure you are PPro subscription
- [x] Install from branch
- [x] Go to Settings
- [x] Check all PPro items in menu are showing and work as expected
- [x] Check in Subscription Settings option you see the correct subscription billing period

_Purchase yearly subscription_
- [x] Make sure you are PPro eligible
- [x] Fresh install from branch
- [x] Go to Settings > Privacy Pro
- [x] Check paywall looks as expected
- [x] Purchase a yearly membership
- [x] Check we parse correctly `billingPeriod` and add it to the Subscription object

_Purchase yearly subscription (Optional)_
- [x] Make sure you are PPro eligible
- [x] Fresh install from branch
- [x] Go to Settings > Privacy Pro
- [x] Check paywall looks as expected
- [x] Purchase a monthly membership
- [x] Check we parse correctly `billingPeriod` and add it to the Subscription object

### No UI changes
