### PR TITLE
Avoid race condition when pre-populating VPN db

### DIFF
--- a/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/store/VpnDatabase.kt
+++ b/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/store/VpnDatabase.kt
@@ -30,7 +30,7 @@ import java.time.format.DateTimeFormatter
 
 @Database(
     exportSchema = true,
-    version = 33,
+    version = 34,
     entities = [
         VpnTracker::class,
         VpnServiceStateStats::class,
@@ -214,6 +214,12 @@ abstract class VpnDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_33_TO_34: Migration = object : Migration(33, 34) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("DELETE FROM `vpn_app_tracker_blocking_list_metadata`")
+            }
+        }
+
         val ALL_MIGRATIONS: List<Migration>
             get() = listOf(
                 MIGRATION_18_TO_19,
@@ -231,6 +237,7 @@ abstract class VpnDatabase : RoomDatabase() {
                 MIGRATION_30_TO_31,
                 MIGRATION_31_TO_32,
                 MIGRATION_32_TO_33,
+                MIGRATION_33_TO_34,
             )
     }
 }

--- a/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/store/VpnDatabaseCallback.kt
+++ b/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/store/VpnDatabaseCallback.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.mobile.android.vpn.store
 
 import android.content.Context
-import androidx.annotation.VisibleForTesting
 import androidx.room.RoomDatabase
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.duckduckgo.common.utils.DispatcherProvider
@@ -45,14 +44,14 @@ internal class VpnDatabaseCallback(
         super.onCreate(db)
         coroutineScope.launch(dispatcherProvider.io()) {
             mutex.withLock {
-                if (vpnDatabase.get().vpnAppTrackerBlockingDao().getExclusionListMetadata()?.eTag == null) {
-                    logcat { "VPN db onCreate: pre-populating db" }
+                if (vpnDatabase.get().vpnAppTrackerBlockingDao().getTrackerBlocklistMetadata()?.eTag == null) {
+                    logcat { "VPN-db onCreate: pre-populating db" }
                     // only pre-populate when there's no blocklist
                     prepopulateAppTrackerBlockingList()
                     prepopulateAppTrackerExclusionList()
                     prepopulateAppTrackerExceptionRules()
                 } else {
-                    logcat { "VPN db onCreate: SKIP pre-populating db" }
+                    logcat { "VPN-db onCreate: SKIP pre-populating db" }
                 }
             }
         }
@@ -61,7 +60,8 @@ internal class VpnDatabaseCallback(
     override fun onDestructiveMigration(db: SupportSQLiteDatabase) {
         coroutineScope.launch(dispatcherProvider.io()) {
             mutex.withLock {
-                if (vpnDatabase.get().vpnAppTrackerBlockingDao().getExclusionListMetadata()?.eTag == null) {
+                if (vpnDatabase.get().vpnAppTrackerBlockingDao().getTrackerBlocklistMetadata()?.eTag == null) {
+                    logcat { "VPN-db onDestructiveMigration: pre-populating db" }
                     // only pre-populate when there's no blocklist
                     prepopulateAppTrackerBlockingList()
                     prepopulateAppTrackerExclusionList()
@@ -71,8 +71,7 @@ internal class VpnDatabaseCallback(
         }
     }
 
-    @VisibleForTesting
-    internal fun prepopulateAppTrackerBlockingList() {
+    private fun prepopulateAppTrackerBlockingList() {
         context.resources.openRawResource(R.raw.full_app_trackers_blocklist).bufferedReader()
             .use { it.readText() }
             .also {

--- a/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/store/VpnDatabaseCallbackProvider.kt
+++ b/app-tracking-protection/vpn-store/src/main/java/com/duckduckgo/mobile/android/vpn/store/VpnDatabaseCallbackProvider.kt
@@ -18,14 +18,19 @@ package com.duckduckgo.mobile.android.vpn.store
 
 import android.content.Context
 import androidx.room.RoomDatabase
-import com.duckduckgo.common.utils.DefaultDispatcherProvider
+import com.duckduckgo.common.utils.DispatcherProvider
 import javax.inject.Provider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.sync.Mutex
 
 class VpnDatabaseCallbackProvider constructor(
     private val context: Context,
     private val vpnDatabaseProvider: Provider<VpnDatabase>,
+    private val dispatcherProvider: DispatcherProvider,
+    private val coroutineScope: CoroutineScope,
+    private val mutex: Mutex,
 ) {
     fun provideCallbacks(): RoomDatabase.Callback {
-        return VpnDatabaseCallback(context, vpnDatabaseProvider, DefaultDispatcherProvider())
+        return VpnDatabaseCallback(context, vpnDatabaseProvider, dispatcherProvider, coroutineScope, mutex)
     }
 }

--- a/app-tracking-protection/vpn-store/src/test/java/com/duckduckgo/mobile/android/vpn/store/VpnDatabaseCallbackTest.kt
+++ b/app-tracking-protection/vpn-store/src/test/java/com/duckduckgo/mobile/android/vpn/store/VpnDatabaseCallbackTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.mobile.android.vpn.store
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.mobile.android.vpn.trackers.AppTrackerMetadata
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class VpnDatabaseCallbackTest {
+
+    @get:Rule
+    var coroutineRule = CoroutineTestRule()
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+
+    private val vpnDatabase: VpnDatabase = Room.inMemoryDatabaseBuilder(
+        context,
+        VpnDatabase::class.java,
+    ).allowMainThreadQueries().build()
+
+    private val vpnDatabaseCallback = VpnDatabaseCallback(
+        context,
+        { vpnDatabase },
+        coroutineRule.testDispatcherProvider,
+        coroutineRule.testScope,
+        Mutex(),
+    )
+
+    @Test
+    fun whenOnCreateAndNullETagThenPrePopulate() = runTest {
+        assertNull(vpnDatabase.vpnAppTrackerBlockingDao().getTrackerBySubdomain("15.taboola.com"))
+        assertNull(vpnDatabase.vpnAppTrackerBlockingDao().getTrackerBlocklistMetadata())
+
+        vpnDatabaseCallback.onCreate(vpnDatabase.openHelper.writableDatabase)
+
+        assertNotNull(vpnDatabase.vpnAppTrackerBlockingDao().getTrackerBySubdomain("15.taboola.com"))
+        assertEquals(110, vpnDatabase.vpnAppTrackerBlockingDao().getAppExclusionList().size)
+        assertEquals(21, vpnDatabase.vpnAppTrackerBlockingDao().getTrackerExceptionRules().size)
+        // pre-population doesn't set metadata
+        assertNull(vpnDatabase.vpnAppTrackerBlockingDao().getTrackerBlocklistMetadata())
+        assertNull(vpnDatabase.vpnAppTrackerBlockingDao().getExclusionListMetadata())
+        assertNull(vpnDatabase.vpnAppTrackerBlockingDao().getTrackerExceptionRulesMetadata())
+    }
+
+    @Test
+    fun whenOnCreateAndETagNotNullThenSkipPrePopulate() = runTest {
+        assertNull(vpnDatabase.vpnAppTrackerBlockingDao().getTrackerBySubdomain("15.taboola.com"))
+        assertNull(vpnDatabase.vpnAppTrackerBlockingDao().getTrackerBlocklistMetadata())
+
+        vpnDatabase.vpnAppTrackerBlockingDao().setTrackerBlocklistMetadata(AppTrackerMetadata(0, "1"))
+
+        vpnDatabaseCallback.onCreate(vpnDatabase.openHelper.writableDatabase)
+
+        // tracker list continues to be empty
+        assertNull(vpnDatabase.vpnAppTrackerBlockingDao().getTrackerBySubdomain("15.taboola.com"))
+        assertEquals(0, vpnDatabase.vpnAppTrackerBlockingDao().getAppExclusionList().size)
+        assertEquals(0, vpnDatabase.vpnAppTrackerBlockingDao().getTrackerExceptionRules().size)
+        assertNull(vpnDatabase.vpnAppTrackerBlockingDao().getExclusionListMetadata())
+        assertNull(vpnDatabase.vpnAppTrackerBlockingDao().getTrackerExceptionRulesMetadata())
+        assertEquals(
+            "1",
+            vpnDatabase.vpnAppTrackerBlockingDao().getTrackerBlocklistMetadata()?.eTag,
+        )
+    }
+}

--- a/app-tracking-protection/vpn-store/src/test/java/com/duckduckgo/mobile/android/vpn/trackers/AppTrackerRepositoryTest.kt
+++ b/app-tracking-protection/vpn-store/src/test/java/com/duckduckgo/mobile/android/vpn/trackers/AppTrackerRepositoryTest.kt
@@ -46,7 +46,8 @@ class AppTrackerRepositoryTest {
             context,
             VpnDatabase::class.java,
         ).allowMainThreadQueries().build().apply {
-            VpnDatabaseCallback(context, { this }, coroutineRule.testDispatcherProvider, coroutineRule.testScope, Mutex()).prepopulateAppTrackerBlockingList()
+            VpnDatabaseCallback(context, { this }, coroutineRule.testDispatcherProvider, coroutineRule.testScope, Mutex())
+                .onCreate(this.openHelper.writableDatabase)
         }
         appTrackerRepository = RealAppTrackerRepository(vpnDatabase.vpnAppTrackerBlockingDao(), vpnDatabase.vpnSystemAppsOverridesDao())
     }

--- a/app-tracking-protection/vpn-store/src/test/java/com/duckduckgo/mobile/android/vpn/trackers/AppTrackerRepositoryTest.kt
+++ b/app-tracking-protection/vpn-store/src/test/java/com/duckduckgo/mobile/android/vpn/trackers/AppTrackerRepositoryTest.kt
@@ -22,6 +22,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.mobile.android.vpn.store.VpnDatabase
 import com.duckduckgo.mobile.android.vpn.store.VpnDatabaseCallback
+import kotlinx.coroutines.sync.Mutex
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
@@ -45,7 +46,7 @@ class AppTrackerRepositoryTest {
             context,
             VpnDatabase::class.java,
         ).allowMainThreadQueries().build().apply {
-            VpnDatabaseCallback(context, { this }, coroutineRule.testDispatcherProvider).prepopulateAppTrackerBlockingList()
+            VpnDatabaseCallback(context, { this }, coroutineRule.testDispatcherProvider, coroutineRule.testScope, Mutex()).prepopulateAppTrackerBlockingList()
         }
         appTrackerRepository = RealAppTrackerRepository(vpnDatabase.vpnAppTrackerBlockingDao(), vpnDatabase.vpnSystemAppsOverridesDao())
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202279501986195/task/1210212546082973?focus=true

### Description
Fix a race condition that can happen upon first install. Both the vpn db callbacks (onCreate) and the AppTP blocklist worker race to update the db.
It can happen that worker wins, updates db, then callback overrides it. Leaving an inconsistent state

### Steps to test this PR

_Test #1_
- [x] smoke test AppTP


_Test #2_
- [x] fresh install internal build
- [x] filter logcat by `VPN-db` and `tag:AppTrackerListUpdateWorker`
- [x] launch the app
- [x] verify `Updating the app tracker blocklist, previous/new eTag: null / 096e201c66270d520e1e186073c41a64` appears
- [x] verify `VPN-db onCreate: pre-populating db` appears OR `VPN-db onCreate: SKIP pre-populating db` if the worker updates the blocklist before
- [x] verify the `vpn.db` has the correct blocklist in `vpn_app_tracker_block_list` and `vpn_app_tracker_block_list_metadata`
- [x] force closed the app and relaunch
- [x] verify `Downloaded blocklist has same eTag, noop` logcat shows
- [x] verify `VPN-db onCreate: pre-populating db` does NOT show
- [x] using the device inspector, delete the all `vpn.db*` files (this simulates a first launch as vpn db is not created)
- [x] force closed the app and relaunch
- [x] verify `VPN-db onCreate: pre-populating db` appears
- [x] verify `Updating the app tracker blocklist, previous/new eTag: null / 096e201c66270d520e1e186073c41a64` appears

_Test #3_
- [x] fresh install from commit https://github.com/duckduckgo/Android/pull/6040/commits/0f6a1769086d9a0e14790ba3ed05cf9981db525b
- [x] launch app and enable AppTP (you can disable afterwards)
- [x] force close app and re-launch
- [x] verify VPN-db or `tag:AppTrackerListUpdateWorker` logs appear
- [x] checkout commit https://github.com/duckduckgo/Android/pull/6040/commits/e3818ad85bd418f240c9a81b8c5611e70ff1928d
- [x] Change to `ExistingPeriodicWorkPolicy.REPLACE` in `AppTrackerListUpdateWorkerScheduler`
- [x] build and update the app, relaunch
- [x] verify `Updating the app tracker blocklist, previous/new eTag: null / 096e201c66270d520e1e186073c41a64` log appears