### PR TITLE
Re-enable Privacy Test cases

### DIFF
--- a/.github/workflows/privacy.yml
+++ b/.github/workflows/privacy.yml
@@ -1,10 +1,20 @@
 name: Privacy Tests
 
 on:
-  pull_request:
+  pull_request_target:
     types: [ labeled ]
+
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    paths:
+      - 'node_modules/@duckduckgo/content-scope-scripts/**'
+
   schedule:
     - cron: '0 3 * * *' # run at 3 AM UTC
+
   workflow_dispatch:
 
 concurrency:
@@ -13,7 +23,7 @@ concurrency:
 
 jobs:
   privacy_tests:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'content scope scripts') || github.event.schedule == '0 3 * * *' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'content scope scripts')) || github.event_name == 'pull_request' }}
     name: Privacy Tests
     runs-on: ubuntu-latest
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -201,7 +201,6 @@ fladle {
     configs {
         privacyTests {
             async.set(false)
-            variant.set("playDebug")
             flankVersion.set("21.+")
             useOrchestrator.set(true)
             environmentVariables.set([
@@ -211,7 +210,7 @@ fladle {
                     "annotation com.duckduckgo.espresso.PrivacyTest"
             ])
             devices.set([
-                    ["model": "redfin", "version": "30"]
+                    ["model": "MediumPhone.arm", "version": "34"],
             ])
             localResultsDir.set("fladleResults")
             flakyTestAttempts.set(2)

--- a/app/src/androidTest/java/com/duckduckgo/espresso/JsObjectIdlingResource.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/JsObjectIdlingResource.kt
@@ -19,10 +19,8 @@ package com.duckduckgo.espresso
 import android.os.Handler
 import android.os.Looper
 import android.os.SystemClock
-import android.util.Log
 import android.webkit.WebView
 import androidx.test.espresso.IdlingResource
-import androidx.test.espresso.IdlingResource.ResourceCallback
 
 class JsObjectIdlingResource(
     private val webView: WebView,
@@ -36,7 +34,7 @@ class JsObjectIdlingResource(
 
     private val handler = Handler(Looper.getMainLooper())
     private val checkInterval = 100L // milliseconds
-    private val timeoutMillis = 10_000L // 10 seconds
+    private val timeoutMillis = 20_000L // 20 seconds
     private val startTime = SystemClock.elapsedRealtime()
 
     override fun getName(): String = "JsObjectIdlingResource for $objectName"
@@ -50,9 +48,9 @@ class JsObjectIdlingResource(
 
     private fun pollForJsObject() {
         if (SystemClock.elapsedRealtime() - startTime > timeoutMillis) {
-            Log.w("JsObjectIdlingResource", "Timeout waiting for JS object: $objectName")
             isIdle = true
             callback?.onTransitionToIdle()
+            // fail test if the object is not found within the timeout
             throw AssertionError("JS object '$objectName' did not appear within timeout.")
         }
 

--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/GpcTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/GpcTest.kt
@@ -31,6 +31,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.espresso.JsObjectIdlingResource
+import com.duckduckgo.espresso.PrivacyTest
 import com.duckduckgo.espresso.WebViewIdlingResource
 import com.duckduckgo.privacy.config.impl.network.JSONObjectAdapter
 import com.squareup.moshi.JsonAdapter
@@ -38,6 +39,7 @@ import com.squareup.moshi.Moshi
 import org.hamcrest.CoreMatchers.containsString
 import org.junit.Assert.assertTrue
 import org.junit.Rule
+import org.junit.Test
 
 class GpcTest {
 
@@ -49,8 +51,8 @@ class GpcTest {
         ),
     )
 
-    // @Test @PrivacyTest
     // Temporarily disabled; see https://app.asana.com/1/137249556945/project/414730916066338/task/1210131499379055?focus=true
+    @Test @PrivacyTest
     fun whenProtectionsAreEnableGpcSetCorrectly() {
         preparationsForPrivacyTest()
 

--- a/build.gradle
+++ b/build.gradle
@@ -180,7 +180,7 @@ fladle {
                     "notAnnotation com.duckduckgo.espresso.UserJourney",
             ])
             devices.set([
-                    ["model": "MediumPhone.arm", "version": "30"],
+                    ["model": "MediumPhone.arm", "version": "34"],
                     ["model": "Pixel2.arm", "version": "28"]
             ])
             localResultsDir.set("fladleResults")

--- a/build.gradle
+++ b/build.gradle
@@ -180,7 +180,7 @@ fladle {
                     "notAnnotation com.duckduckgo.espresso.UserJourney",
             ])
             devices.set([
-                    ["model": "MediumPhone.arm", "version": "34"],
+                    ["model": "MediumPhone.arm", "version": "30"],
                     ["model": "Pixel2.arm", "version": "28"]
             ])
             localResultsDir.set("fladleResults")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1210170077557891?focus=true 

### Description
Tries to fix issues on privacy tests so we can re-enable them again.
Also updates workflow triggers so they run if CSS path changes.


### Steps to test this PR

Should pass -> https://github.com/duckduckgo/Android/actions/runs/14960434017

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
