### PR TITLE
Fix RMF promo_single_action layout when vertical space is constrained

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/BottomAppBarBehavior.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/BottomAppBarBehavior.kt
@@ -54,7 +54,7 @@ class BottomAppBarBehavior<V : View>(
     private val viewIDsExemptedFromForceOffset = setOf(
         R.id.webViewFullScreenContainer,
         R.id.browserLayout,
-        R.id.newTabLayout,
+        R.id.includeNewBrowserTab,
     )
 
     @SuppressLint("RestrictedApi")

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/BottomAppBarBehavior.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/BottomAppBarBehavior.kt
@@ -46,18 +46,24 @@ class BottomAppBarBehavior<V : View>(
     private var lastStartedType: Int = 0
     private var offsetAnimator: ValueAnimator? = null
 
+    /**
+     * We don't want any offset when in full screen.
+     *
+     * The browser, new tab page, etc padding management, to avoid omnibar overlapping with the content, is handled in [BottomOmnibarBrowserContainerLayoutBehavior].
+     */
+    private val viewIDsExemptedFromForceOffset = setOf(
+        R.id.webViewFullScreenContainer,
+        R.id.browserLayout,
+        R.id.newTabLayout,
+    )
+
     @SuppressLint("RestrictedApi")
     override fun layoutDependsOn(parent: CoordinatorLayout, child: V, dependency: View): Boolean {
         if (dependency is Snackbar.SnackbarLayout) {
             updateSnackbar(child, dependency)
         }
 
-        /**
-         * We don't want any offset when in full screen.
-         *
-         * The browser padding management, to avoid omnibar overlapping with the browser content, is handled in [BottomOmnibarBrowserContainerLayoutBehavior].
-         */
-        if (dependency.id != R.id.webViewFullScreenContainer && dependency.id != R.id.browserLayout) {
+        if (!viewIDsExemptedFromForceOffset.contains(dependency.id)) {
             offsetBottomByToolbar(dependency)
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
@@ -207,9 +207,12 @@ class Omnibar(
     private fun adjustCoordinatorLayoutBehaviorForBottomOmnibar() {
         removeAppBarBehavior(binding.autoCompleteSuggestionsList)
         removeAppBarBehavior(binding.focusedView)
-        removeAppBarBehavior(binding.includeNewBrowserTab.newTabLayout)
 
         binding.browserLayout.updateLayoutParams<CoordinatorLayout.LayoutParams> {
+            behavior = BottomOmnibarBrowserContainerLayoutBehavior()
+        }
+
+        binding.includeNewBrowserTab.newTabLayout.updateLayoutParams<CoordinatorLayout.LayoutParams> {
             behavior = BottomOmnibarBrowserContainerLayoutBehavior()
         }
     }

--- a/app/src/main/res/layout/include_new_browser_tab.xml
+++ b/app/src/main/res/layout/include_new_browser_tab.xml
@@ -22,7 +22,7 @@
     android:layout_height="match_parent"
     android:clipChildren="false"
     android:fillViewport="true"
-    app:layout_behavior="@string/appbar_scrolling_view_behavior"
+    app:layout_behavior="com.duckduckgo.app.browser.webview.TopOmnibarBrowserContainerLayoutBehavior"
     tools:context="com.duckduckgo.app.browser.BrowserActivity"
     tools:showIn="@layout/fragment_browser_tab">
 

--- a/common/common-ui/src/main/res/layout/view_promo_message_cta.xml
+++ b/common/common-ui/src/main/res/layout/view_promo_message_cta.xml
@@ -70,12 +70,11 @@
         app:typography="body1"
         tools:text="Body text goes here. This component can be used with one or two buttons." />
 
-    <com.duckduckgo.common.ui.view.button.DaxButtonGhost
+    <com.duckduckgo.common.ui.view.button.DaxButtonSecondary
         android:id="@+id/actionButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/keyline_2"
-        app:icon="@drawable/ic_share_android_16"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1210194248346098

### Description
The RMF `promo_single_action` was squished and misaligned in horizontal orientation because it lacked the vertical space to fit all of its elements in correct sizes.

To resolve that issue, we primarily need to make the new tab content page scrollable, which coincidentally is already happening in https://github.com/duckduckgo/Android/pull/6035, so I'm basing this PR on top it.

Additionally:
 1. I'm making sure that the new tab page uses the correct behaviors to ensure that content is not clipped by the bottom navigation bar (when the UI experiment is enabled).
 2. I'm updating the action button to `DaxButtonSecondary`.

### Steps to test this PR

Apply this diff to show a promo message:
```diff
diff --git a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/network/RemoteMessagingService.kt b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/network/RemoteMessagingService.kt
index 7c0e619ba4..7a374edf59 100644
--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/network/RemoteMessagingService.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/network/RemoteMessagingService.kt
@@ -23,6 +23,7 @@ import retrofit2.http.GET
 
 @ContributesServiceApi(AppScope::class)
 interface RemoteMessagingService {
-    @GET("https://staticcdn.duckduckgo.com/remotemessaging/config/v1/android-config.json")
+    @GET("http://www.jsonblob.com/api/1371418004029628416")
+    // @GET("https://staticcdn.duckduckgo.com/remotemessaging/config/v1/android-config.json")
     suspend fun config(): JsonRemoteMessagingConfig
 }
```

- [x] Ensure that the promo message can be scrolled when it doesn't fit on screen (typical in horizontal orientation).
- [x] Test that there's no clipping with both top and bottom omnibars.
- [ ] Retest with top and bottom omnibars and the O-A experimental UI flag enabled.
- [ ] Test that favorites can be scrolled to the bottom and aren't clipped. 

### UI changes
_before_

https://github.com/user-attachments/assets/1eb267a7-5bb8-43a5-909e-be2d5a33acd3

_after_

https://github.com/user-attachments/assets/b3ce2078-6696-481e-8c87-fe609d109b28
