### PR TITLE
RMF: dismiss promo_single_action message on button interaction

### DIFF
--- a/app/src/test/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageViewModelTest.kt
@@ -204,7 +204,7 @@ class NewTabLegacyPageViewModelTest {
     }
 
     @Test
-    fun whenRemoteMessageActionButtonClickedThenFirePixelAndDontDismiss() = runTest {
+    fun whenRemoteMessageActionButtonClickedThenFirePixelAndDismiss() = runTest {
         val remoteMessage = RemoteMessage("id1", Content.Small("", ""), emptyList(), emptyList())
         whenever(mockRemoteMessageModel.getActiveMessages()).thenReturn(flowOf(remoteMessage))
 

--- a/remote-messaging/remote-messaging-api/src/main/java/com/duckduckgo/remote/messaging/api/RemoteMessageModel.kt
+++ b/remote-messaging/remote-messaging-api/src/main/java/com/duckduckgo/remote/messaging/api/RemoteMessageModel.kt
@@ -32,5 +32,5 @@ interface RemoteMessageModel {
 
     suspend fun onSecondaryActionClicked(remoteMessage: RemoteMessage): Action?
 
-    fun onActionClicked(remoteMessage: RemoteMessage): Action?
+    suspend fun onActionClicked(remoteMessage: RemoteMessage): Action?
 }

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/RealRemoteMessageModel.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/RealRemoteMessageModel.kt
@@ -68,8 +68,11 @@ class RealRemoteMessageModel @Inject constructor(
         return remoteMessage.content.getSecondaryAction()
     }
 
-    override fun onActionClicked(remoteMessage: RemoteMessage): Action? {
+    override suspend fun onActionClicked(remoteMessage: RemoteMessage): Action? {
         remoteMessagingPixels.fireRemoteMessageActionClickedPixel(remoteMessage)
+        withContext(dispatchers.io()) {
+            remoteMessagingRepository.dismissMessage(remoteMessage.id)
+        }
         return remoteMessage.content.getAction()
     }
 

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/RemoteMessagingModelTests.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/RemoteMessagingModelTests.kt
@@ -80,10 +80,11 @@ class RemoteMessagingModelTests {
     }
 
     @Test
-    fun onActionClickedThenPixelFired() = runTest {
+    fun onActionClickedThenPixelFiredAndMessageDismissed() = runTest {
         val action = testee.onActionClicked(remoteMessage)
 
         verify(remoteMessagingPixels).fireRemoteMessageActionClickedPixel(remoteMessage)
+        verify(remoteMessagingRepository).dismissMessage(remoteMessage.id)
         assertEquals(action, null)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207619243206445/task/1210224059296246?focus=true

### Description
Fixes an issue where `promo_single_action` message wasn't dismissed on action button click.

### Steps to test this PR
Apply this diff:
```diff
diff --git a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/network/RemoteMessagingService.kt b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/network/RemoteMessagingService.kt
index 7c0e619ba4..c4e5e607d1 100644
--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/network/RemoteMessagingService.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/network/RemoteMessagingService.kt
@@ -23,6 +23,6 @@ import retrofit2.http.GET
 
 @ContributesServiceApi(AppScope::class)
 interface RemoteMessagingService {
-    @GET("https://staticcdn.duckduckgo.com/remotemessaging/config/v1/android-config.json")
+    @GET("http://www.jsonblob.com/api/1371418004029628416")
     suspend fun config(): JsonRemoteMessagingConfig
 }
```

- [ ] Launch the app, you should see a remote message, click dismiss and ensure that the message disappears.
- [ ] Relaunch the app, the message shouldn't show again.