### PR TITLE
Expand mutex setup to revisions and exceptions

### DIFF
--- a/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/data/MaliciousSiteRepository.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/main/kotlin/com/duckduckgo/malicioussiteprotection/impl/data/MaliciousSiteRepository.kt
@@ -24,7 +24,6 @@ import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed.M
 import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed.PHISHING
 import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed.SCAM
 import com.duckduckgo.malicioussiteprotection.impl.MaliciousSitePixelName.MALICIOUS_SITE_CLIENT_TIMEOUT
-import com.duckduckgo.malicioussiteprotection.impl.MaliciousSiteProtectionRCFeature
 import com.duckduckgo.malicioussiteprotection.impl.data.db.MaliciousSiteDao
 import com.duckduckgo.malicioussiteprotection.impl.data.db.RevisionEntity
 import com.duckduckgo.malicioussiteprotection.impl.data.network.FilterResponse
@@ -83,7 +82,6 @@ class RealMaliciousSiteRepository @Inject constructor(
     private val maliciousSiteDatasetService: MaliciousSiteDatasetService,
     private val dispatcherProvider: DispatcherProvider,
     private val pixels: Pixel,
-    private val maliciousSiteProtectionFeature: MaliciousSiteProtectionRCFeature,
 ) : MaliciousSiteRepository {
 
     private val writeMutex = Mutex()
@@ -177,7 +175,7 @@ class RealMaliciousSiteRepository @Inject constructor(
     ): Result<Unit> {
         return withContext(dispatcherProvider.io()) {
             val networkRevision = maliciousSiteService.getRevision().revision
-            val localRevisions = getLocalRevisions(type)
+            val localRevisions = writeMutex.withLock { getLocalRevisions(type) }
 
             try {
                 loadData(localRevisions, networkRevision)

--- a/malicious-site-protection/malicious-site-protection-impl/src/test/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionReferenceTest.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/test/kotlin/com/duckduckgo/malicioussiteprotection/impl/MaliciousSiteProtectionReferenceTest.kt
@@ -99,7 +99,6 @@ class MaliciousSiteProtectionReferenceTest(private val testCase: TestCase) {
         maliciousSiteDatasetService,
         coroutineRule.testDispatcherProvider,
         mockPixel,
-        mockMaliciousSiteProtectionRCFeature,
     )
 
     @Before
@@ -148,7 +147,6 @@ class MaliciousSiteProtectionReferenceTest(private val testCase: TestCase) {
             ),
         )
         whenever(mockMaliciousSiteProtectionRCFeature.isFeatureEnabled()).thenReturn(true)
-        whenever(mockMaliciousSiteProtectionRCRepository.isExempted(any())).thenReturn(false)
         repository.loadFilters(*enumValues<Feed>())
         repository.loadHashPrefixes(*enumValues<Feed>())
 

--- a/malicious-site-protection/malicious-site-protection-impl/src/test/kotlin/com/duckduckgo/malicioussiteprotection/impl/data/RealMaliciousSiteRepositoryTest.kt
+++ b/malicious-site-protection/malicious-site-protection-impl/src/test/kotlin/com/duckduckgo/malicioussiteprotection/impl/data/RealMaliciousSiteRepositoryTest.kt
@@ -4,7 +4,6 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed
 import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed.PHISHING
 import com.duckduckgo.malicioussiteprotection.impl.MaliciousSitePixelName.MALICIOUS_SITE_CLIENT_TIMEOUT
-import com.duckduckgo.malicioussiteprotection.impl.MaliciousSiteProtectionRCFeature
 import com.duckduckgo.malicioussiteprotection.impl.data.db.FilterEntity
 import com.duckduckgo.malicioussiteprotection.impl.data.db.HashPrefixEntity
 import com.duckduckgo.malicioussiteprotection.impl.data.db.MaliciousSiteDao
@@ -44,14 +43,12 @@ class RealMaliciousSiteRepositoryTest {
     private val maliciousSiteService: MaliciousSiteService = mock()
     private val maliciousSiteDatasetService: MaliciousSiteDatasetService = mock()
     private val mockPixel: Pixel = mock()
-    private val mockMaliciousSiteProtectionRCFeature: MaliciousSiteProtectionRCFeature = mock()
     private val repository = RealMaliciousSiteRepository(
         maliciousSiteDao,
         maliciousSiteService,
         maliciousSiteDatasetService,
         coroutineRule.testDispatcherProvider,
         mockPixel,
-        mockMaliciousSiteProtectionRCFeature,
     )
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1210226116146307?focus=true 

### Description
We still see some ANRs that seem to be related to a database connection not being acquired on first app run. Looking at the logs, it looks like it happens on devices with 1GB RAM, which only allow for 1 simultaneous SQLite connection. 

Add mutex to get revisions, so if another DB operation needs to happen at the same time, it can decide whether to wait for the lock to be acquired or use a default value 

### Steps to test this PR

_Feature 1_
- [ ] Smoke test malicious site protections
