### PR TITLE
Disable Paste button while processing request

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
@@ -84,14 +84,17 @@ class EnterCodeActivity : DuckDuckGoActivity() {
             AuthState.Error -> {
                 binding.loadingIndicatorContainer.hide()
                 binding.errorAuthStateHint.show()
+                binding.pasteCodeButton.isEnabled = true
             }
             Idle -> {
                 binding.loadingIndicatorContainer.hide()
                 binding.errorAuthStateHint.hide()
+                binding.pasteCodeButton.isEnabled = true
             }
             Loading -> {
                 binding.loadingIndicatorContainer.show()
                 binding.errorAuthStateHint.hide()
+                binding.pasteCodeButton.isEnabled = false
             }
         }
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
@@ -177,6 +177,7 @@ class EnterCodeViewModel @Inject constructor(
                 INVALID_CODE.code -> R.string.sync_invalid_code_error
                 else -> null
             }?.let { message ->
+                viewState.value = viewState.value.copy(authState = AuthState.Idle)
                 command.send(
                     ShowError(
                         message = message,
@@ -204,6 +205,7 @@ class EnterCodeViewModel @Inject constructor(
                         ShowError(message = message, reason = result.reason),
                     )
                 }
+                viewState.value = viewState.value.copy(authState = AuthState.Idle)
             } else {
                 syncPixels.fireUserSwitchedAccount()
                 command.send(SwitchAccountSuccess)
@@ -212,7 +214,10 @@ class EnterCodeViewModel @Inject constructor(
     }
 
     fun onUserCancelledJoiningNewAccount() {
-        syncPixels.fireUserCancelledSwitchingAccount()
+        viewModelScope.launch(dispatchers.io()) {
+            syncPixels.fireUserCancelledSwitchingAccount()
+            viewState.value = viewState.value.copy(authState = AuthState.Idle)
+        }
     }
 
     fun onUserAskedToSwitchAccount() {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
@@ -228,7 +228,7 @@ internal class EnterCodeViewModelTest {
     }
 
     @Test
-    fun whenProcessCodeAndLoginFailsThenShowError() = runTest {
+    fun whenProcessCodeAndLoginFailsThenShowErrorAndUpdateState() = runTest {
         whenever(syncAccountRepository.getAccountInfo()).thenReturn(noAccount)
         whenever(clipboard.pasteFromClipboard()).thenReturn(jsonRecoveryKeyEncoded)
         whenever(syncAccountRepository.processCode(jsonRecoveryKeyEncoded)).thenReturn(Error(code = LOGIN_FAILED.code))
@@ -238,6 +238,20 @@ internal class EnterCodeViewModelTest {
         testee.commands().test {
             val command = awaitItem()
             assertTrue(command is ShowError)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenProcessCodeAndLoginFailsThenUpdateStateToIdle() = runTest {
+        whenever(syncAccountRepository.getAccountInfo()).thenReturn(noAccount)
+        whenever(clipboard.pasteFromClipboard()).thenReturn(jsonRecoveryKeyEncoded)
+        whenever(syncAccountRepository.processCode(jsonRecoveryKeyEncoded)).thenReturn(Error(code = LOGIN_FAILED.code))
+
+        testee.onPasteCodeClicked()
+
+        testee.viewState().test {
+            assertTrue(awaitItem().authState == Idle)
             cancelAndIgnoreRemainingEvents()
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203822806345703/task/1210183822217249?focus=true 

### Description
Disables paste button while processing request.
Includes fix: update viewstate to idle after error.

### Steps to test this PR

Disables paste button while processing request.
Includes fix: update viewstate to idle after error.

_Test the connect device sync flow (manually enter code) under the following scenarios_
- [x] using an invalid code 
- [x] using the recovery code of an deleted account (you can create one, copy code, and delete before testing)
- [ ] using a valid recovery code / exchange code / connect code
-> ensure in all of them, button is disabled while processing, enabled once finished (error or success)

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
