### PR TITLE
Update content scope scripts to version 8.21.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
@@ -509,7 +509,7 @@
     android: [...baseFeatures, "webCompat", "breakageReporting", "duckPlayer", "messageBridge"],
     "android-broker-protection": ["brokerProtection"],
     "android-autofill-password-import": ["autofillPasswordImport"],
-    windows: ["cookie", ...baseFeatures, "windowsPermissionUsage", "duckPlayer", "brokerProtection", "breakageReporting"],
+    windows: ["cookie", ...baseFeatures, "windowsPermissionUsage", "duckPlayer", "brokerProtection", "breakageReporting", "messageBridge"],
     firefox: ["cookie", ...baseFeatures, "clickToLoad"],
     chrome: ["cookie", ...baseFeatures, "clickToLoad"],
     "chrome-mv3": ["cookie", ...baseFeatures, "clickToLoad"],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -2008,7 +2008,7 @@
     android: [...baseFeatures, "webCompat", "breakageReporting", "duckPlayer", "messageBridge"],
     "android-broker-protection": ["brokerProtection"],
     "android-autofill-password-import": ["autofillPasswordImport"],
-    windows: ["cookie", ...baseFeatures, "windowsPermissionUsage", "duckPlayer", "brokerProtection", "breakageReporting"],
+    windows: ["cookie", ...baseFeatures, "windowsPermissionUsage", "duckPlayer", "brokerProtection", "breakageReporting", "messageBridge"],
     firefox: ["cookie", ...baseFeatures, "clickToLoad"],
     chrome: ["cookie", ...baseFeatures, "clickToLoad"],
     "chrome-mv3": ["cookie", ...baseFeatures, "clickToLoad"],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -1337,7 +1337,7 @@
     android: [...baseFeatures, "webCompat", "breakageReporting", "duckPlayer", "messageBridge"],
     "android-broker-protection": ["brokerProtection"],
     "android-autofill-password-import": ["autofillPasswordImport"],
-    windows: ["cookie", ...baseFeatures, "windowsPermissionUsage", "duckPlayer", "brokerProtection", "breakageReporting"],
+    windows: ["cookie", ...baseFeatures, "windowsPermissionUsage", "duckPlayer", "brokerProtection", "breakageReporting", "messageBridge"],
     firefox: ["cookie", ...baseFeatures, "clickToLoad"],
     chrome: ["cookie", ...baseFeatures, "clickToLoad"],
     "chrome-mv3": ["cookie", ...baseFeatures, "clickToLoad"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^12.19.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.1.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.19.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.21.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1746537866"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#1d5f27d5167e4bdcaedebe67086cea3bab8d7f94",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#c5dc2cf80de232a158b16d4d648f4fa326341665",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -283,9 +283,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.14.tgz",
-      "integrity": "sha512-BL1eyu/XWsFGTtDWOYULQEs4KR0qdtYfCxYAUYRoB7JP7h9ETYLgQTww6kH8Sj2C0pFGgrpM0XKv6/kbIzYJ1g==",
+      "version": "22.15.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.17.tgz",
+      "integrity": "sha512-wIX2aSZL5FE+MR0JlvF87BNVrtFWf6AE6rxSE9X7OwnVvoyCQjpzSRJ+M87se/4QCkCiebQAqrJ0y6fwIyi7nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -670,18 +670,18 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.6.tgz",
-      "integrity": "sha512-HZeeJrplG9y+sJx6VNcMKfbpY9UEq+JI0JRqE66Dm81QmclDgygaKOIwkeX8atmiQraJV2w4JbYI3wfCbw319w==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.7.tgz",
+      "integrity": "sha512-ECqb8imSroX1UmUuhRBNPkkmtZ8mHEenieim80UVxG0M5wXVjY2Fp2tYXCPvk+nLy1geOhFpeD5YQhM/gF63Jg==",
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.6.tgz",
-      "integrity": "sha512-aetoYSqSsxUPBBMuQGc0b3g/q1auci10DrndrzyzPscOHleL+f/Yh2SMVp90vJGc0Q+I/KBfp62xjTwiHHgzNQ==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.7.tgz",
+      "integrity": "sha512-V055ViO8G6PbTBfaiL1Utq/MLUqFZKhJ1c9+T8t+c1uPmVSAl7rR6ib8y0lleN18niKV6f1/zmMlAhpFEaPY9w==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.6"
+        "tldts-core": "^7.0.7"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^12.19.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.1.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.19.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.21.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1746537866"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1210232911000167/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass