### PR TITLE
Tab swiping: Disable swiping on error views

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -978,11 +978,15 @@ class BrowserTabFragment :
 
     @SuppressLint("ClickableViewAccessibility")
     private fun disableSwipingOutsideTheOmnibar() {
-        newBrowserTab.newTabLayout.setOnTouchListener { v, event ->
+        newBrowserTab.newTabLayout.setOnTouchListener { v, _ ->
             v.parent.requestDisallowInterceptTouchEvent(true)
             true
         }
-        binding.autoCompleteSuggestionsList.setOnTouchListener { v, event ->
+        binding.autoCompleteSuggestionsList.setOnTouchListener { v, _ ->
+            v.parent.requestDisallowInterceptTouchEvent(true)
+            false
+        }
+        binding.includeErrorView.root.setOnTouchListener { v, _ ->
             v.parent.requestDisallowInterceptTouchEvent(true)
             false
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/webview/SslWarningLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/webview/SslWarningLayout.kt
@@ -16,11 +16,14 @@
 
 package com.duckduckgo.app.browser.webview
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
+import android.view.MotionEvent
 import android.view.View
 import android.webkit.SslErrorHandler
 import android.widget.FrameLayout
+import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.SSLErrorType
 import com.duckduckgo.app.browser.SSLErrorType.WRONG_HOST
@@ -29,18 +32,26 @@ import com.duckduckgo.app.browser.databinding.ViewSslWarningBinding
 import com.duckduckgo.app.browser.webview.SslWarningLayout.Action.Advance
 import com.duckduckgo.app.browser.webview.SslWarningLayout.Action.LeaveSite
 import com.duckduckgo.app.browser.webview.SslWarningLayout.Action.Proceed
+import com.duckduckgo.common.ui.tabs.SwipingTabsFeatureProvider
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.extensions.applyBoldSpanTo
 import com.duckduckgo.common.utils.extensions.html
 import com.duckduckgo.common.utils.extractDomain
+import com.duckduckgo.di.scopes.ViewScope
+import dagger.android.support.AndroidSupportInjection
+import javax.inject.Inject
 
+@InjectWith(ViewScope::class)
 class SslWarningLayout @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyle: Int = 0,
 ) : FrameLayout(context, attrs, defStyle) {
+
+    @Inject
+    lateinit var swipingTabsFeature: SwipingTabsFeatureProvider
 
     sealed class Action {
 
@@ -64,6 +75,20 @@ class SslWarningLayout @JvmOverloads constructor(
             configureCopy(errorResponse)
             setListeners(handler, actionHandler)
         }
+    }
+
+    override fun onAttachedToWindow() {
+        AndroidSupportInjection.inject(this)
+        super.onAttachedToWindow()
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    override fun dispatchTouchEvent(ev: MotionEvent?): Boolean {
+        if (swipingTabsFeature.isEnabled) {
+            // disable tab swiping on this view
+            parent.requestDisallowInterceptTouchEvent(true)
+        }
+        return super.dispatchTouchEvent(ev)
     }
 
     private fun resetViewState() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1210226097518216?focus=true

### Description

This PR disables the swiping on the following views:

- Loading error view
- Malicious site protection view
- SSL error view

### Steps to test this PR

_Loading error view_

- [x] Enable flight mode
- [x] Start the app
- [x] Verify only the omnibar can swipe tabs, not the error content

_Malicious site error view_

- [x] Apply the patch below
```kotlin
Subject: [PATCH] Malicious site
---
Index: app/src/main/java/com/duckduckgo/app/browser/webview/MaliciousSiteBlockerWebViewIntegration.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/app/src/main/java/com/duckduckgo/app/browser/webview/MaliciousSiteBlockerWebViewIntegration.kt b/app/src/main/java/com/duckduckgo/app/browser/webview/MaliciousSiteBlockerWebViewIntegration.kt
--- a/app/src/main/java/com/duckduckgo/app/browser/webview/MaliciousSiteBlockerWebViewIntegration.kt	(revision e238a9d4a8b58b2e65d5027861f343587589af33)
+++ b/app/src/main/java/com/duckduckgo/app/browser/webview/MaliciousSiteBlockerWebViewIntegration.kt	(date 1747129357867)
@@ -32,6 +32,7 @@
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection
 import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed
+import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed.MALWARE
 import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.IsMaliciousResult
 import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.IsMaliciousResult.ConfirmedResult
 import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.IsMaliciousResult.WaitForConfirmation
@@ -151,6 +152,7 @@
         }
 
         return withContext(dispatchers.io()) {
+            return@withContext IsMaliciousViewData.MaliciousSite(request.url, MALWARE, exempted = false, clientSideHit = true)
             val belongsToCurrentPage = documentUri?.host == request.requestHeaders["Referer"]?.toUri()?.host
             val isForIframe = (isForIframe(request) && belongsToCurrentPage)
 

``` 

- [x] Start the app
- [x] Verify only the omnibar can swipe tabs, not the error content


_SSL error view_

It's difficult to mock this error but it's the same custom view type as malicious site error, so it uses the same approach.