### PR TITLE
Tab swiping: Improve state handling in the pager adapter

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -106,7 +106,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import timber.log.Timber
 
 // open class so that we can test BrowserApplicationStateInfo

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -179,7 +179,10 @@ open class BrowserActivity : DuckDuckGoActivity() {
     private var currentTab: BrowserTabFragment?
         get() {
             return if (swipingTabsFeature.isEnabled) {
-                tabPagerAdapter.currentFragment
+                val selectedTabId = tabManager.getSelectedTabId()
+                supportFragmentManager.fragments
+                    .filterIsInstance<BrowserTabFragment>()
+                    .firstOrNull { it.tabId == selectedTabId }
             } else {
                 _currentTab
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -1002,7 +1002,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
         }
     }
 
-    private fun onTabsUpdated(updatedTabIds: List<String>) {
+    private fun onTabsUpdated(updatedTabIds: List<TabModel>) {
         tabPagerAdapter.onTabsUpdated(updatedTabIds)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -55,6 +55,7 @@ import com.duckduckgo.app.browser.omnibar.model.OmnibarPosition.BOTTOM
 import com.duckduckgo.app.browser.omnibar.model.OmnibarPosition.TOP
 import com.duckduckgo.app.browser.shortcut.ShortcutBuilder
 import com.duckduckgo.app.browser.tabs.TabManager
+import com.duckduckgo.app.browser.tabs.TabManager.TabModel
 import com.duckduckgo.app.browser.tabs.adapter.TabPagerAdapter
 import com.duckduckgo.app.browser.webview.RealMaliciousSiteBlockerWebViewIntegration
 import com.duckduckgo.app.di.AppCoroutineScope
@@ -206,9 +207,6 @@ open class BrowserActivity : DuckDuckGoActivity() {
             fragmentManager = supportFragmentManager,
             lifecycleOwner = this,
             activityIntent = intent,
-            getSelectedTabId = tabManager::getSelectedTabId,
-            getTabById = ::getTabById,
-            requestAndWaitForNewTab = ::requestAndWaitForNewTab,
             swipingTabsFeature = swipingTabsFeature,
         )
     }
@@ -1004,14 +1002,6 @@ open class BrowserActivity : DuckDuckGoActivity() {
 
     private fun onTabsUpdated(updatedTabIds: List<TabModel>) {
         tabPagerAdapter.onTabsUpdated(updatedTabIds)
-    }
-
-    private fun getTabById(tabId: String): TabEntity? = runBlocking {
-        return@runBlocking tabManager.getTabById(tabId)
-    }
-
-    private fun requestAndWaitForNewTab(): TabEntity = runBlocking {
-        return@runBlocking tabManager.requestAndWaitForNewTab()
     }
 
     fun launchNewTab(query: String? = null, sourceTabId: String? = null, skipHome: Boolean = false) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -72,19 +72,13 @@ import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.launch
 import timber.log.Timber
 

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/DefaultTabManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/DefaultTabManager.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.browser.tabs
 import com.duckduckgo.app.browser.SkipUrlConversionOnNewTabFeature
 import com.duckduckgo.app.browser.omnibar.OmnibarEntryConverter
 import com.duckduckgo.app.browser.tabs.TabManager.Companion.NEW_TAB_CREATION_TIMEOUT_LIMIT
+import com.duckduckgo.app.browser.tabs.TabManager.TabModel
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.common.utils.DispatcherProvider
@@ -41,15 +42,21 @@ interface TabManager {
         const val NEW_TAB_CREATION_TIMEOUT_LIMIT = 2 // seconds
     }
 
-    fun registerCallbacks(onTabsUpdated: (List<String>) -> Unit)
+    fun registerCallbacks(onTabsUpdated: (List<TabModel>) -> Unit)
     fun getSelectedTabId(): String?
     fun onSelectedTabChanged(tabId: String)
 
-    suspend fun onTabsChanged(updatedTabIds: List<String>)
+    suspend fun onTabsChanged(updatedTabIds: List<TabModel>)
     suspend fun switchToTab(tabId: String)
     suspend fun requestAndWaitForNewTab(): TabEntity
     suspend fun openNewTab(query: String? = null, sourceTabId: String? = null, skipHome: Boolean = false): String
     suspend fun getTabById(tabId: String): TabEntity?
+
+    data class TabModel(
+        val tabId: String,
+        val url: String?,
+        val skipHome: Boolean,
+    )
 }
 
 @ContributesBinding(ActivityScope::class)
@@ -59,10 +66,10 @@ class DefaultTabManager @Inject constructor(
     private val queryUrlConverter: OmnibarEntryConverter,
     private val skipUrlConversionOnNewTabFeature: SkipUrlConversionOnNewTabFeature,
 ) : TabManager {
-    private lateinit var onTabsUpdated: (List<String>) -> Unit
+    private lateinit var onTabsUpdated: (List<TabModel>) -> Unit
     private var selectedTabId: String? = null
 
-    override fun registerCallbacks(onTabsUpdated: (List<String>) -> Unit) {
+    override fun registerCallbacks(onTabsUpdated: (List<TabModel>) -> Unit) {
         this.onTabsUpdated = onTabsUpdated
     }
 
@@ -72,7 +79,7 @@ class DefaultTabManager @Inject constructor(
         selectedTabId = tabId
     }
 
-    override suspend fun onTabsChanged(updatedTabIds: List<String>) {
+    override suspend fun onTabsChanged(updatedTabIds: List<TabModel>) {
         onTabsUpdated(updatedTabIds)
 
         if (updatedTabIds.isEmpty()) {

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/FragmentStateAdapter.java
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/FragmentStateAdapter.java
@@ -535,7 +535,6 @@ public abstract class FragmentStateAdapter extends RecyclerView.Adapter<Fragment
 
         if (!fragment.isAdded()) {
             mFragments.remove(itemId);
-            Timber.d("$$$ Fragment (not added) removed: %s", itemId);
             return;
         }
 
@@ -557,7 +556,6 @@ public abstract class FragmentStateAdapter extends RecyclerView.Adapter<Fragment
         try {
             mFragmentManager.beginTransaction().remove(fragment).commitNow();
             mFragments.remove(itemId);
-            Timber.d("$$$ Fragment removed (after transaction): %s", itemId);
         } finally {
             mFragmentEventDispatcher.dispatchPostEvents(onPost);
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabPagerAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabPagerAdapter.kt
@@ -64,7 +64,6 @@ class TabPagerAdapter(
                 this.messageFromPreviousTab = message
             }
         } else {
-            Timber.d("$$$ TABS creating fragment for ${tab.tabId} with url ${tab.url}")
             BrowserTabFragment.newInstance(tab.tabId, tab.url, tab.skipHome, isExternal)
         }
     }
@@ -76,13 +75,13 @@ class TabPagerAdapter(
     @SuppressLint("NotifyDataSetChanged")
     fun onTabsUpdated(newTabs: List<TabModel>) {
         if (tabs.map { it.tabId } != newTabs.map { it.tabId }) {
+            // we only want to notify the adapter if the tab IDs change
             val diff = DiffUtil.calculateDiff(PagerDiffUtil(tabs, newTabs))
-            Timber.d("$$$ TABS updated\nOLD: ${tabs.joinToString { it.tabId }}\nNEW: ${newTabs.joinToString { it.tabId }}")
             tabs.clear()
             tabs.addAll(newTabs)
             diff.dispatchUpdatesTo(this)
         } else {
-            Timber.d("$$$ TABS content updated\nOLD: ${tabs.joinToString { it.url.toString() }}\nNEW: ${newTabs.joinToString { it.url.toString() }}")
+            // the state of tabs is managed separately, so we don't need to notify the adapter, but we need URL and skipHome to create new fragments
             tabs.clear()
             tabs.addAll(newTabs)
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabPagerAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabPagerAdapter.kt
@@ -94,15 +94,15 @@ class TabPagerAdapter(
     }
 
     inner class PagerDiffUtil(
-        private val oldList: List<String>,
-        private val newList: List<String>,
+        private val oldList: List<TabModel>,
+        private val newList: List<TabModel>,
     ) : DiffUtil.Callback() {
         override fun getOldListSize() = oldList.size
 
         override fun getNewListSize() = newList.size
 
         override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-            return oldList[oldItemPosition] == newList[newItemPosition]
+            return oldList[oldItemPosition].tabId == newList[newItemPosition].tabId
         }
 
         override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabPagerAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabPagerAdapter.kt
@@ -51,10 +51,6 @@ class TabPagerAdapter(
         }
     }
 
-    val currentFragment: BrowserTabFragment?
-        get() = fragmentManager.fragments
-            .filterIsInstance<BrowserTabFragment>()
-            .firstOrNull { it.tabId == getSelectedTabId() }
     override fun containsItem(itemId: Long) = tabs.any { it.tabId.hashCode().toLong() == itemId }
 
     override fun createFragment(position: Int): Fragment {

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabPagerAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabPagerAdapter.kt
@@ -27,10 +27,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.BrowserTabFragment
 import com.duckduckgo.app.browser.tabs.TabManager.TabModel
-import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.common.ui.tabs.SwipingTabsFeatureProvider
-import timber.log.Timber
-import timber.log.Timber.Forest
 
 class TabPagerAdapter(
     lifecycleOwner: LifecycleOwner,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1210226097518220?focus=true

### Description

This PR updates the `TabPagerAdapter` to keep all data required for tab fragment creation within the adapter and avoid DB lookups. Whenever tabs are updated in the DB, the adapter data is updated.

It requires to keep some extra data besides the tab ID but eliminates the chance for a race condition when the adapter requests a new fragment and a tab is deleted before it has a chance get data.

### Steps to test this PR

Smoke testing tab swiping should be enough, as the race condition is not easy to reproduce.
