### PR TITLE
Add Subscriptions SERP integration

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -277,6 +277,8 @@ import com.duckduckgo.site.permissions.api.SitePermissionsManager.LocationPermis
 import com.duckduckgo.site.permissions.api.SitePermissionsManager.SitePermissionQueryResponse
 import com.duckduckgo.site.permissions.api.SitePermissionsManager.SitePermissions
 import com.duckduckgo.subscriptions.api.Subscriptions
+import com.duckduckgo.subscriptions.impl.messaging.RealSubscriptionsJSHelper.Companion.SUBSCRIPTIONS_FEATURE_NAME
+import com.duckduckgo.subscriptions.impl.messaging.SubscriptionsJSHelper
 import com.duckduckgo.sync.api.favicons.FaviconsFetchingPrompt
 import com.duckduckgo.voice.api.VoiceSearchAvailability
 import com.duckduckgo.voice.api.VoiceSearchAvailabilityPixelLogger
@@ -550,6 +552,7 @@ class BrowserTabViewModelTest {
     private val mockSiteErrorHandlerKillSwitchToggle: Toggle = mock { on { it.isEnabled() } doReturn true }
     private val mockSiteErrorHandler: StringSiteErrorHandler = mock()
     private val mockSiteHttpErrorHandler: HttpCodeSiteErrorHandler = mock()
+    private val mockSubscriptionsJSHelper: SubscriptionsJSHelper = mock()
 
     private val selectedTab = TabEntity("TAB_ID", "https://example.com", position = 0, sourceTabId = "TAB_ID_SOURCE")
 
@@ -742,6 +745,7 @@ class BrowserTabViewModelTest {
             siteErrorHandler = mockSiteErrorHandler,
             siteHttpErrorHandler = mockSiteHttpErrorHandler,
             senseOfProtectionExperiment = mockSenseOfProtectionExperiment,
+            subscriptionsJSHelper = mockSubscriptionsJSHelper,
         )
 
         testee.loadData("abc", null, false, false)
@@ -6292,6 +6296,33 @@ class BrowserTabViewModelTest {
 
         verify(mockDuckChat).openDuckChatWithAutoPrompt(query)
         verify(mockDuckChat, never()).openDuckChat()
+    }
+
+    @Test
+    fun whenProcessJsCallbackMessageForSubscriptionsThenSendCommand() = runTest {
+        val jsCallbackData = JsCallbackData(JSONObject(), "", "", "")
+        whenever(mockSubscriptionsJSHelper.processJsCallbackMessage(anyString(), anyString(), anyOrNull(), anyOrNull())).thenReturn(jsCallbackData)
+        testee.processJsCallbackMessage(
+            featureName = SUBSCRIPTIONS_FEATURE_NAME,
+            method = "method",
+            id = "id",
+            data = null,
+        ) { "someUrl" }
+        verify(mockSubscriptionsJSHelper).processJsCallbackMessage(SUBSCRIPTIONS_FEATURE_NAME, "method", "id", null)
+        assertCommandIssued<Command.SendResponseToJs>()
+    }
+
+    @Test
+    fun whenProcessJsCallbackMessageForSubscriptionsAndResponseIsNullThenDoNotSendCommand() = runTest {
+        whenever(mockDuckChatJSHelper.processJsCallbackMessage(anyString(), anyString(), anyOrNull(), anyOrNull())).thenReturn(null)
+        testee.processJsCallbackMessage(
+            featureName = SUBSCRIPTIONS_FEATURE_NAME,
+            method = "method",
+            id = "id",
+            data = null,
+        ) { "someUrl" }
+        verify(mockSubscriptionsJSHelper).processJsCallbackMessage(SUBSCRIPTIONS_FEATURE_NAME, "method", "id", null)
+        assertCommandNotIssued<Command.SendResponseToJs>()
     }
 
     private fun aCredential(): LoginCredentials {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -342,6 +342,8 @@ import com.duckduckgo.site.permissions.api.SitePermissionsManager.LocationPermis
 import com.duckduckgo.site.permissions.api.SitePermissionsManager.SitePermissionQueryResponse
 import com.duckduckgo.site.permissions.api.SitePermissionsManager.SitePermissions
 import com.duckduckgo.subscriptions.api.Subscriptions
+import com.duckduckgo.subscriptions.impl.messaging.RealDuckChatJSHelper.Companion.SUBSCRIPTIONS_FEATURE_NAME
+import com.duckduckgo.subscriptions.impl.messaging.SubscriptionsJSHelper
 import com.duckduckgo.sync.api.favicons.FaviconsFetchingPrompt
 import dagger.Lazy
 import io.reactivex.schedulers.Schedulers
@@ -479,6 +481,7 @@ class BrowserTabViewModel @Inject constructor(
     private val siteErrorHandler: StringSiteErrorHandler,
     private val siteHttpErrorHandler: HttpCodeSiteErrorHandler,
     private val senseOfProtectionExperiment: SenseOfProtectionExperiment,
+    private val subscriptionsJSHelper: SubscriptionsJSHelper,
 ) : WebViewClientListener,
     EditSavedSiteListener,
     DeleteBookmarkListener,
@@ -3571,6 +3574,7 @@ class BrowserTabViewModel @Inject constructor(
         isActiveCustomTab: Boolean = false,
         getWebViewUrl: () -> String?,
     ) {
+        Timber.e("NOELIA processJsCallbackMessage(), featureName: $featureName, method: $method, id: $id")
         when (method) {
             "webShare" -> if (id != null && data != null) {
                 webShare(featureName, method, id, data)
@@ -3611,6 +3615,17 @@ class BrowserTabViewModel @Inject constructor(
             DUCK_CHAT_FEATURE_NAME -> {
                 viewModelScope.launch(dispatchers.io()) {
                     val response = duckChatJSHelper.processJsCallbackMessage(featureName, method, id, data)
+                    withContext(dispatchers.main()) {
+                        response?.let {
+                            command.value = SendResponseToJs(it)
+                        }
+                    }
+                }
+            }
+
+            SUBSCRIPTIONS_FEATURE_NAME -> {
+                viewModelScope.launch(dispatchers.io()) {
+                    val response = subscriptionsJSHelper.processJsCallbackMessage(featureName, method, id, data)
                     withContext(dispatchers.main()) {
                         response?.let {
                             command.value = SendResponseToJs(it)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -3574,7 +3574,6 @@ class BrowserTabViewModel @Inject constructor(
         isActiveCustomTab: Boolean = false,
         getWebViewUrl: () -> String?,
     ) {
-        Timber.e("NOELIA processJsCallbackMessage(), featureName: $featureName, method: $method, id: $id")
         when (method) {
             "webShare" -> if (id != null && data != null) {
                 webShare(featureName, method, id, data)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -342,7 +342,7 @@ import com.duckduckgo.site.permissions.api.SitePermissionsManager.LocationPermis
 import com.duckduckgo.site.permissions.api.SitePermissionsManager.SitePermissionQueryResponse
 import com.duckduckgo.site.permissions.api.SitePermissionsManager.SitePermissions
 import com.duckduckgo.subscriptions.api.Subscriptions
-import com.duckduckgo.subscriptions.impl.messaging.RealDuckChatJSHelper.Companion.SUBSCRIPTIONS_FEATURE_NAME
+import com.duckduckgo.subscriptions.impl.messaging.RealSubscriptionsJSHelper.Companion.SUBSCRIPTIONS_FEATURE_NAME
 import com.duckduckgo.subscriptions.impl.messaging.SubscriptionsJSHelper
 import com.duckduckgo.sync.api.favicons.FaviconsFetchingPrompt
 import dagger.Lazy

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessaging.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessaging.kt
@@ -62,7 +62,13 @@ class ContentScopeScriptsJsMessaging @Inject constructor(
     override val secret: String = coreContentScopeScripts.secret
     override val allowedDomains: List<String> = emptyList()
 
-    private val handlers: List<JsMessageHandler> = listOf(ContentScopeHandler(), breakageHandler, DuckPlayerHandler(), DuckChatHandler())
+    private val handlers: List<JsMessageHandler> = listOf(
+        ContentScopeHandler(),
+        breakageHandler,
+        DuckPlayerHandler(),
+        DuckChatHandler(),
+        SubscriptionsHandler(),
+    )
 
     @JavascriptInterface
     override fun process(message: String, secret: String) {
@@ -164,6 +170,22 @@ class ContentScopeScriptsJsMessaging @Inject constructor(
             "openAIChat",
             "closeAIChat",
             "openAIChatSettings",
+        )
+    }
+
+    inner class SubscriptionsHandler : JsMessageHandler {
+        override fun process(jsMessage: JsMessage, secret: String, jsMessageCallback: JsMessageCallback?) {
+            jsMessageCallback?.process(featureName, jsMessage.method, jsMessage.id ?: "", jsMessage.params)
+        }
+
+        override val allowedDomains: List<String> = listOf(
+            AppUrl.Url.HOST,
+        )
+
+        override val featureName: String = "subscriptions"
+        override val methods: List<String> = listOf(
+            "handshake",
+            "subscriptionDetails",
         )
     }
 }

--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessagingTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessagingTest.kt
@@ -278,6 +278,76 @@ class ContentScopeScriptsJsMessagingTest {
         assertEquals(0, callback.counter)
     }
 
+    @Test
+    fun whenProcessSubscriptionsMessageWithHandshakeMethodThenCallbackExecuted() = runTest {
+        givenInterfaceIsRegistered()
+        whenever(mockWebView.url).thenReturn("https://duckduckgo.com")
+
+        val message = """
+        {"context":"contentScopeScripts","featureName":"subscriptions","id":"myId","method":"handshake"}
+        """.trimIndent()
+
+        contentScopeScriptsJsMessaging.process(message, contentScopeScriptsJsMessaging.secret)
+
+        assertEquals(1, callback.counter)
+    }
+
+    @Test
+    fun whenProcessSubscriptionsMessageWithSubscriptionDetailsMethodThenCallbackExecuted() = runTest {
+        givenInterfaceIsRegistered()
+        whenever(mockWebView.url).thenReturn("https://duckduckgo.com")
+
+        val message = """
+        {"context":"contentScopeScripts","featureName":"subscriptions","id":"myId","method":"subscriptionDetails"}
+        """.trimIndent()
+
+        contentScopeScriptsJsMessaging.process(message, contentScopeScriptsJsMessaging.secret)
+
+        assertEquals(1, callback.counter)
+    }
+
+    @Test
+    fun whenProcessSubscriptionsMessageWithUnknownMethodThenDoNothing() = runTest {
+        givenInterfaceIsRegistered()
+        whenever(mockWebView.url).thenReturn("https://duckduckgo.com")
+
+        val message = """
+        {"context":"contentScopeScripts","featureName":"subscriptions","id":"myId","method":"unknownMethod"}
+        """.trimIndent()
+
+        contentScopeScriptsJsMessaging.process(message, contentScopeScriptsJsMessaging.secret)
+
+        assertEquals(0, callback.counter)
+    }
+
+    @Test
+    fun whenProcessSubscriptionsMessageWithInvalidFeatureNameThenDoNothing() = runTest {
+        givenInterfaceIsRegistered()
+        whenever(mockWebView.url).thenReturn("https://duckduckgo.com")
+
+        val message = """
+        {"context":"contentScopeScripts","featureName":"invalidFeature","id":"myId","method":"handshake"}
+        """.trimIndent()
+
+        contentScopeScriptsJsMessaging.process(message, contentScopeScriptsJsMessaging.secret)
+
+        assertEquals(0, callback.counter)
+    }
+
+    @Test
+    fun whenProcessSubscriptionsMessageWithInvalidDomainThenDoNothing() = runTest {
+        givenInterfaceIsRegistered()
+        whenever(mockWebView.url).thenReturn("https://invalid-domain.com")
+
+        val message = """
+        {"context":"contentScopeScripts","featureName":"subscriptions","id":"myId","method":"subscriptionDetails"}
+        """.trimIndent()
+
+        contentScopeScriptsJsMessaging.process(message, contentScopeScriptsJsMessaging.secret)
+
+        assertEquals(0, callback.counter)
+    }
+
     private val callback = object : JsMessageCallback() {
         var counter = 0
         override fun process(featureName: String, method: String, id: String?, data: JSONObject?) {

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionsJSHelper.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionsJSHelper.kt
@@ -34,7 +34,7 @@ interface SubscriptionsJSHelper {
 }
 
 @ContributesBinding(AppScope::class)
-class RealDuckChatJSHelper @Inject constructor(
+class RealSubscriptionsJSHelper @Inject constructor(
     private val subscriptionsManager: SubscriptionsManager,
 ) : SubscriptionsJSHelper {
 

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionsJSHelper.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionsJSHelper.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.js.messaging.api.JsCallbackData
 import com.duckduckgo.subscriptions.impl.SubscriptionsManager
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
+import org.json.JSONArray
 import org.json.JSONObject
 
 interface SubscriptionsJSHelper {
@@ -45,7 +46,7 @@ class RealDuckChatJSHelper @Inject constructor(
     ): JsCallbackData? = when (method) {
         METHOD_HANDSHAKE -> id?.let {
             val jsonPayload = JSONObject().apply {
-                put(AVAILABLE_MESSAGES, arrayOf(SUBSCRIPTION_DETAILS))
+                put(AVAILABLE_MESSAGES, JSONArray().put(SUBSCRIPTION_DETAILS))
                 put(PLATFORM, ANDROID)
             }
             return JsCallbackData(jsonPayload, featureName, method, id)
@@ -61,7 +62,7 @@ class RealDuckChatJSHelper @Inject constructor(
     private suspend fun getSubscriptionDetailsData(featureName: String, method: String, id: String): JsCallbackData {
         val jsonPayload = subscriptionsManager.getSubscription()?.let { userSubscription ->
             JSONObject().apply {
-                put(IS_SUBSCRIBED, true)
+                put(IS_SUBSCRIBED, userSubscription.isActive())
                 put(BILLING_PERIOD, userSubscription.billingPeriod)
                 put(STARTED_AT, userSubscription.startedAt)
                 put(EXPIRES_OR_RENEWS_AT, userSubscription.expiresOrRenewsAt)

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionsJSHelper.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionsJSHelper.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.messaging
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.js.messaging.api.JsCallbackData
+import com.duckduckgo.subscriptions.impl.SubscriptionsManager
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+import org.json.JSONObject
+
+interface SubscriptionsJSHelper {
+    suspend fun processJsCallbackMessage(
+        featureName: String,
+        method: String,
+        id: String?,
+        data: JSONObject?,
+    ): JsCallbackData?
+}
+
+@ContributesBinding(AppScope::class)
+class RealDuckChatJSHelper @Inject constructor(
+    private val subscriptionsManager: SubscriptionsManager,
+) : SubscriptionsJSHelper {
+
+    override suspend fun processJsCallbackMessage(
+        featureName: String,
+        method: String,
+        id: String?,
+        data: JSONObject?,
+    ): JsCallbackData? = when (method) {
+        METHOD_HANDSHAKE -> id?.let {
+            val jsonPayload = JSONObject().apply {
+                put(AVAILABLE_MESSAGES, arrayOf(SUBSCRIPTION_DETAILS))
+                put(PLATFORM, ANDROID)
+            }
+            return JsCallbackData(jsonPayload, featureName, method, id)
+        }
+
+        METHOD_SUBSCRIPTION_DETAILS -> id?.let {
+            getSubscriptionDetailsData(featureName, method, it)
+        }
+
+        else -> null
+    }
+
+    private suspend fun getSubscriptionDetailsData(featureName: String, method: String, id: String): JsCallbackData {
+        val jsonPayload = subscriptionsManager.getSubscription()?.let { userSubscription ->
+            JSONObject().apply {
+                put(IS_SUBSCRIBED, true)
+                put(BILLING_PERIOD, userSubscription.billingPeriod)
+                put(STARTED_AT, userSubscription.startedAt)
+                put(EXPIRES_OR_RENEWS_AT, userSubscription.expiresOrRenewsAt)
+                put(PAYMENT_PLATFORM, userSubscription.platform)
+                put(STATUS, userSubscription.status.statusName)
+            }
+        } ?: JSONObject().apply {
+            put(IS_SUBSCRIBED, false)
+        }
+
+        return JsCallbackData(jsonPayload, featureName, method, id)
+    }
+
+    companion object {
+        const val SUBSCRIPTIONS_FEATURE_NAME = "subscriptions"
+        private const val METHOD_HANDSHAKE = "handshake"
+        private const val METHOD_SUBSCRIPTION_DETAILS = "subscriptionDetails"
+        private const val AVAILABLE_MESSAGES = "availableMessages"
+        private const val SUBSCRIPTION_DETAILS = "subscriptionDetails"
+        private const val PLATFORM = "platform"
+        private const val ANDROID = "android"
+        private const val IS_SUBSCRIBED = "isSubscribed"
+        private const val BILLING_PERIOD = "billingPeriod"
+        private const val STARTED_AT = "startedAt"
+        private const val EXPIRES_OR_RENEWS_AT = "expiresOrRenewsAt"
+        private const val PAYMENT_PLATFORM = "paymentPlatform"
+        private const val STATUS = "status"
+    }
+}

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/messaging/RealSubscriptionsJSHelperTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/messaging/RealSubscriptionsJSHelperTest.kt
@@ -1,0 +1,167 @@
+package com.duckduckgo.subscriptions.impl.messaging
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.js.messaging.api.JsCallbackData
+import com.duckduckgo.subscriptions.api.SubscriptionStatus.AUTO_RENEWABLE
+import com.duckduckgo.subscriptions.api.SubscriptionStatus.EXPIRED
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.MONTHLY
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.YEARLY
+import com.duckduckgo.subscriptions.impl.SubscriptionsManager
+import com.duckduckgo.subscriptions.impl.repository.Subscription
+import kotlinx.coroutines.test.runTest
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class RealSubscriptionsJSHelperTest {
+
+    @get:Rule
+    var coroutineRule = CoroutineTestRule()
+
+    private val mockSubscriptionsManager: SubscriptionsManager = mock()
+
+    private val testee = RealSubscriptionsJSHelper(mockSubscriptionsManager)
+
+    private val featureName = "subscriptions"
+
+    @Test
+    fun whenMethodIsUnknownThenReturnNull() = runTest {
+        val method = "unknownMethod"
+        val id = "123"
+
+        val result = testee.processJsCallbackMessage(featureName, method, id, null)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun whenHandshakeRequestAndIdIsNullThenReturnNull() = runTest {
+        val method = "handshake"
+
+        val result = testee.processJsCallbackMessage(featureName, method, null, null)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun whenHandshakeRequestThenReturnJsCallbackDataWithAvailableMessages() = runTest {
+        val method = "handshake"
+        val id = "123"
+
+        val result = testee.processJsCallbackMessage(featureName, method, id, null)
+
+        val jsonPayload = JSONObject().apply {
+            put("availableMessages", JSONArray().put("subscriptionDetails"))
+            put("platform", "android")
+        }
+
+        val expected = JsCallbackData(jsonPayload, featureName, method, id)
+
+        assertEquals(expected.id, result!!.id)
+        assertEquals(expected.method, result.method)
+        assertEquals(expected.featureName, result.featureName)
+        assertEquals(expected.params.toString(), result.params.toString())
+    }
+
+    @Test
+    fun givenAnActiveSubscriptionWhenSubscriptionDetailsRequestThenReturnJsCallbackDataWithIsSubscribedFalse() = runTest {
+        val method = "subscriptionDetails"
+        val id = "123"
+
+        whenever(mockSubscriptionsManager.getSubscription()).thenReturn(
+            Subscription(
+                productId = SubscriptionsConstants.YEARLY_PLAN_US,
+                billingPeriod = MONTHLY,
+                startedAt = 1709052033000L,
+                expiresOrRenewsAt = 1711557633000L,
+                status = AUTO_RENEWABLE,
+                platform = "Google",
+                activeOffers = listOf(),
+            ),
+        )
+
+        val result = testee.processJsCallbackMessage(featureName, method, id, null)
+
+        val jsonPayload = JSONObject().apply {
+            put("isSubscribed", true)
+            put("billingPeriod", "Monthly")
+            put("startedAt", 1709052033000L)
+            put("expiresOrRenewsAt", 1711557633000L)
+            put("paymentPlatform", "Google")
+            put("status", "Auto-Renewable")
+        }
+
+        val expected = JsCallbackData(jsonPayload, featureName, method, id)
+
+        assertEquals(expected.id, result!!.id)
+        assertEquals(expected.method, result.method)
+        assertEquals(expected.featureName, result.featureName)
+        assertEquals(expected.params.toString(), result.params.toString())
+    }
+
+    @Test
+    fun givenNoSubscriptionWhenSubscriptionDetailsRequestThenReturnJsCallbackDataWithSubscriptionDetails() = runTest {
+        val method = "subscriptionDetails"
+        val id = "123"
+
+        whenever(mockSubscriptionsManager.getSubscription()).thenReturn(null)
+
+        val result = testee.processJsCallbackMessage(featureName, method, id, null)
+
+        val jsonPayload = JSONObject().apply {
+            put("isSubscribed", false)
+        }
+
+        val expected = JsCallbackData(jsonPayload, featureName, method, id)
+
+        assertEquals(expected.id, result!!.id)
+        assertEquals(expected.method, result.method)
+        assertEquals(expected.featureName, result.featureName)
+        assertEquals(expected.params.toString(), result.params.toString())
+    }
+
+    @Test
+    fun givenAnExpiredSubscriptionWhenSubscriptionDetailsRequestThenReturnJsCallbackDataWithSubscriptionDetails() = runTest {
+        val method = "subscriptionDetails"
+        val id = "123"
+
+        whenever(mockSubscriptionsManager.getSubscription()).thenReturn(
+            Subscription(
+                productId = SubscriptionsConstants.YEARLY_PLAN_US,
+                billingPeriod = YEARLY,
+                startedAt = 1709052033000L,
+                expiresOrRenewsAt = 1711557633000L,
+                status = EXPIRED,
+                platform = "stripe",
+                activeOffers = listOf(),
+            ),
+        )
+
+        val result = testee.processJsCallbackMessage(featureName, method, id, null)
+
+        val jsonPayload = JSONObject().apply {
+            put("isSubscribed", false)
+            put("billingPeriod", "Yearly")
+            put("startedAt", 1709052033000L)
+            put("expiresOrRenewsAt", 1711557633000L)
+            put("paymentPlatform", "stripe")
+            put("status", "Expired")
+        }
+
+        val expected = JsCallbackData(jsonPayload, featureName, method, id)
+
+        assertEquals(expected.id, result!!.id)
+        assertEquals(expected.method, result.method)
+        assertEquals(expected.featureName, result.featureName)
+        assertEquals(expected.params.toString(), result.params.toString())
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201807753394693/task/1210023557524902?focus=true

### Description

- Uses the C-S-S navigatorInterface + messageBridge to request information about the subscription status.
- The functionality is disabled when aiChat is disabled in the config.

### Steps to test this PR

_Pre steps_

- [x] Change remote config URL to https://jsonblob.com/api/1371926095833784320
- [x] Add logs to see the JS messages requests and responses within `fun processJsCallbackMessage()`
     - In line _3577_  log JS request `Timber.d("JsRequestMessage, featureName: $featureName, method: $method, id: $id")`
     - In line _3631_  log JS response `Timber.e("JS response: $it")`
- [x] Use a VPN to set your location to US
- [x] Apply patch to be privacy pro eligible

_Subscriptions message non US_
- [x] Install from branch
- [x] Perform a search
- [x] Check you don't get any messages for featureName _subscriptions_ as you are not in US

_Handshake request_
- [x] Set a VPN to US
- [x] Install from branch
- [x] Perform a search
- [x] Verify you see in the logs the message request: `featureName: subscriptions, method: handshake`
- [x] Verify you see in the logs the message response: `JsCallbackData(params={"availableMessages":["subscriptionDetails"],"platform":"android"}, featureName=subscriptions, method=handshake`
...

_subscriptionDetails request with no Subscription_
- [x] Verify you see in the logs the message request: `featureName: subscriptions, method: subscriptionDetails`
- [x] Verify you see in the logs the message response: `{"isSubscribed":false}`
...

_subscriptionDetails request with active Subscription_
- [x] from previous test, go to Settings > Privacy Pro
- [x] Purchase a subscription
- [x] Perform a search
- [x] Verify you see in the logs the message request: `featureName: subscriptions, method: subscriptionDetails`
- [x] Verify you see in the logs the message response: `{"isSubscribed":true,"billingPeriod":"Monthly or Yearly","startedAt":...,"expiresOrRenewsAt":...,"paymentPlatform":"google","status":"Auto-Renewable"}`
...

_subscriptionDetails request with expired Subscription_
- [x] from previous test, go to Settings > Privacy Pro Settings
- [x] Cancel the subscription
- [x] Wait until subscription expires
- [x] Perform a search
- [x] Verify you see in the logs the message request: `featureName: subscriptions, method: subscriptionDetails`
- [x] Verify you see in the logs the message response: `{"isSubscribed":false,"billingPeriod":"Monthly or Yearly","startedAt":...,"expiresOrRenewsAt":...,"paymentPlatform":"google","status":"Expired"}`

### No UI changes
