### PR TITLE
RMF: do not dismiss promo_single_action on share action click

### DIFF
--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/RealRemoteMessageModel.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/RealRemoteMessageModel.kt
@@ -70,10 +70,13 @@ class RealRemoteMessageModel @Inject constructor(
 
     override suspend fun onActionClicked(remoteMessage: RemoteMessage): Action? {
         remoteMessagingPixels.fireRemoteMessageActionClickedPixel(remoteMessage)
-        withContext(dispatchers.io()) {
-            remoteMessagingRepository.dismissMessage(remoteMessage.id)
+        val action = remoteMessage.content.getAction()
+        if (action !is Action.Share) {
+            withContext(dispatchers.io()) {
+                remoteMessagingRepository.dismissMessage(remoteMessage.id)
+            }
         }
-        return remoteMessage.content.getAction()
+        return action
     }
 
     private fun Content.getPrimaryAction(): Action? {

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/RemoteMessagingModelTests.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/RemoteMessagingModelTests.kt
@@ -17,7 +17,9 @@
 package com.duckduckgo.remote.messaging.impl
 
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.remote.messaging.api.Action
 import com.duckduckgo.remote.messaging.api.Content
+import com.duckduckgo.remote.messaging.api.Content.Placeholder.VISUAL_DESIGN_UPDATE
 import com.duckduckgo.remote.messaging.api.RemoteMessage
 import com.duckduckgo.remote.messaging.api.RemoteMessagingRepository
 import com.duckduckgo.remote.messaging.impl.pixels.RemoteMessagingPixels
@@ -27,6 +29,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 
 class RemoteMessagingModelTests {
@@ -86,5 +89,30 @@ class RemoteMessagingModelTests {
         verify(remoteMessagingPixels).fireRemoteMessageActionClickedPixel(remoteMessage)
         verify(remoteMessagingRepository).dismissMessage(remoteMessage.id)
         assertEquals(action, null)
+    }
+
+    @Test
+    fun onActionClickedThenPixelFiredAndMessageNotDismissedIfActionShare() = runTest {
+        val action = Action.Share(
+            value = "",
+            additionalParameters = null,
+        )
+        val remoteMessage = RemoteMessage(
+            id = "id1",
+            Content.PromoSingleAction(
+                titleText = "",
+                descriptionText = "",
+                placeholder = VISUAL_DESIGN_UPDATE,
+                actionText = "",
+                action = action,
+            ),
+            matchingRules = emptyList(),
+            exclusionRules = emptyList(),
+        )
+        val result = testee.onActionClicked(remoteMessage)
+
+        verify(remoteMessagingPixels).fireRemoteMessageActionClickedPixel(remoteMessage)
+        verify(remoteMessagingRepository, never()).dismissMessage(remoteMessage.id)
+        assertEquals(action, result)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1210248635492286

### Description
Don't dismiss `promo_single_action` remote message on action click, if the action is of type "share". 

### Steps to test this PR

Apply this diff to get an RMF config with the message:
```diff
diff --git a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/network/RemoteMessagingService.kt b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/network/RemoteMessagingService.kt
index 7c0e619ba..cc34cfa5d 100644
--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/network/RemoteMessagingService.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/network/RemoteMessagingService.kt
@@ -23,6 +23,6 @@ import retrofit2.http.GET
 
 @ContributesServiceApi(AppScope::class)
 interface RemoteMessagingService {
-    @GET("https://staticcdn.duckduckgo.com/remotemessaging/config/v1/android-config.json")
+    @GET("https://www.jsonblob.com/api/1372187606078644224")
     suspend fun config(): JsonRemoteMessagingConfig
 }
```

- [x] Verify that clicking the action does not dismiss the message.
- [x] (optional) Update the JSON blob to a different action, update the version, save, restart the app and verify that clicking the button dismisses the message.