### PR TITLE
Update DataStore to 1.1.6

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -39,7 +39,7 @@ version.androidx.biometric=1.1.0
 
 version.androidx.core-splashscreen=1.0.1
 
-version.androidx.datastore=1.1.4
+version.androidx.datastore=1.1.6
 
 version.androidx.localbroadcastmanager=1.1.0
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1210239213905771?focus=true 

### Description
Updates `DataStore` to the latest stable version: [`1.1.6`](https://developer.android.com/jetpack/androidx/releases/datastore#1.1.6). 

### Steps to test this PR
Smoke test, especially anything you know touches `DataStore`. 