### PR TITLE
Update content scope scripts to version 8.22.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
@@ -2767,7 +2767,18 @@
       __privateAdd(this, _bundledConfig);
       /** @type {string} */
       __publicField(this, "name");
-      /** @type {{ debug?: boolean, desktopModeEnabled?: boolean, forcedZoomEnabled?: boolean, featureSettings?: Record<string, unknown>, assets?: import('./content-feature.js').AssetConfig | undefined, site: import('./content-feature.js').Site, messagingConfig?: import('@duckduckgo/messaging').MessagingConfig } | null} */
+      /**
+       * @type {{
+       *   debug?: boolean,
+       *   desktopModeEnabled?: boolean,
+       *   forcedZoomEnabled?: boolean,
+       *   featureSettings?: Record<string, unknown>,
+       *   assets?: import('./content-feature.js').AssetConfig | undefined,
+       *   site: import('./content-feature.js').Site,
+       *   messagingConfig?: import('@duckduckgo/messaging').MessagingConfig,
+       *   currentCohorts?: [{feature: string, cohort: string, subfeature: string}],
+       * } | null}
+       */
       __privateAdd(this, _args);
       this.name = name;
       const { bundledConfig, site, platform } = args;
@@ -2830,6 +2841,9 @@
      * @typedef {object} ConditionBlock
      * @property {string[] | string} [domain]
      * @property {object} [urlPattern]
+     * @property {object} [experiment]
+     * @property {string} [experiment.experimentName]
+     * @property {string} [experiment.cohort]
      */
     /**
      * Takes multiple conditional blocks and returns true if any apply.
@@ -2851,7 +2865,8 @@
     _matchConditionalBlock(conditionBlock) {
       const conditionChecks = {
         domain: this._matchDomainConditional,
-        urlPattern: this._matchUrlPatternConditional
+        urlPattern: this._matchUrlPatternConditional,
+        experiment: this._matchExperimentConditional
       };
       for (const key in conditionBlock) {
         if (!conditionChecks[key]) {
@@ -2861,6 +2876,31 @@
         }
       }
       return true;
+    }
+    /**
+     * Takes a condition block and returns true if the current experiment matches the experimentName and cohort.
+     * Expects:
+     * ```json
+     * {
+     *   "experiment": {
+     *      "experimentName": "experimentName",
+     *      "cohort": "cohort-name"
+     *    }
+     * }
+     * ```
+     * Where featureName "ContentScopeExperiments" has a subfeature "experimentName" and cohort "cohort-name"
+     * @param {ConditionBlock} conditionBlock
+     * @returns {boolean}
+     */
+    _matchExperimentConditional(conditionBlock) {
+      if (!conditionBlock.experiment) return false;
+      const experiment = conditionBlock.experiment;
+      if (!experiment.experimentName || !experiment.cohort) return false;
+      const currentCohorts = this.args?.currentCohorts;
+      if (!currentCohorts) return false;
+      return currentCohorts.some((cohort) => {
+        return cohort.feature === "ContentScopeExperiments" && cohort.subfeature === experiment.experimentName && cohort.cohort === experiment.cohort;
+      });
     }
     /**
      * Takes a condtion block and returns true if the current url matches the urlPattern.

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -4310,7 +4310,18 @@
       __privateAdd(this, _bundledConfig);
       /** @type {string} */
       __publicField(this, "name");
-      /** @type {{ debug?: boolean, desktopModeEnabled?: boolean, forcedZoomEnabled?: boolean, featureSettings?: Record<string, unknown>, assets?: import('./content-feature.js').AssetConfig | undefined, site: import('./content-feature.js').Site, messagingConfig?: import('@duckduckgo/messaging').MessagingConfig } | null} */
+      /**
+       * @type {{
+       *   debug?: boolean,
+       *   desktopModeEnabled?: boolean,
+       *   forcedZoomEnabled?: boolean,
+       *   featureSettings?: Record<string, unknown>,
+       *   assets?: import('./content-feature.js').AssetConfig | undefined,
+       *   site: import('./content-feature.js').Site,
+       *   messagingConfig?: import('@duckduckgo/messaging').MessagingConfig,
+       *   currentCohorts?: [{feature: string, cohort: string, subfeature: string}],
+       * } | null}
+       */
       __privateAdd(this, _args);
       this.name = name;
       const { bundledConfig, site, platform } = args;
@@ -4373,6 +4384,9 @@
      * @typedef {object} ConditionBlock
      * @property {string[] | string} [domain]
      * @property {object} [urlPattern]
+     * @property {object} [experiment]
+     * @property {string} [experiment.experimentName]
+     * @property {string} [experiment.cohort]
      */
     /**
      * Takes multiple conditional blocks and returns true if any apply.
@@ -4394,7 +4408,8 @@
     _matchConditionalBlock(conditionBlock) {
       const conditionChecks = {
         domain: this._matchDomainConditional,
-        urlPattern: this._matchUrlPatternConditional
+        urlPattern: this._matchUrlPatternConditional,
+        experiment: this._matchExperimentConditional
       };
       for (const key in conditionBlock) {
         if (!conditionChecks[key]) {
@@ -4404,6 +4419,31 @@
         }
       }
       return true;
+    }
+    /**
+     * Takes a condition block and returns true if the current experiment matches the experimentName and cohort.
+     * Expects:
+     * ```json
+     * {
+     *   "experiment": {
+     *      "experimentName": "experimentName",
+     *      "cohort": "cohort-name"
+     *    }
+     * }
+     * ```
+     * Where featureName "ContentScopeExperiments" has a subfeature "experimentName" and cohort "cohort-name"
+     * @param {ConditionBlock} conditionBlock
+     * @returns {boolean}
+     */
+    _matchExperimentConditional(conditionBlock) {
+      if (!conditionBlock.experiment) return false;
+      const experiment = conditionBlock.experiment;
+      if (!experiment.experimentName || !experiment.cohort) return false;
+      const currentCohorts = this.args?.currentCohorts;
+      if (!currentCohorts) return false;
+      return currentCohorts.some((cohort) => {
+        return cohort.feature === "ContentScopeExperiments" && cohort.subfeature === experiment.experimentName && cohort.cohort === experiment.cohort;
+      });
     }
     /**
      * Takes a condtion block and returns true if the current url matches the urlPattern.

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -4150,7 +4150,18 @@
       __privateAdd(this, _bundledConfig);
       /** @type {string} */
       __publicField(this, "name");
-      /** @type {{ debug?: boolean, desktopModeEnabled?: boolean, forcedZoomEnabled?: boolean, featureSettings?: Record<string, unknown>, assets?: import('./content-feature.js').AssetConfig | undefined, site: import('./content-feature.js').Site, messagingConfig?: import('@duckduckgo/messaging').MessagingConfig } | null} */
+      /**
+       * @type {{
+       *   debug?: boolean,
+       *   desktopModeEnabled?: boolean,
+       *   forcedZoomEnabled?: boolean,
+       *   featureSettings?: Record<string, unknown>,
+       *   assets?: import('./content-feature.js').AssetConfig | undefined,
+       *   site: import('./content-feature.js').Site,
+       *   messagingConfig?: import('@duckduckgo/messaging').MessagingConfig,
+       *   currentCohorts?: [{feature: string, cohort: string, subfeature: string}],
+       * } | null}
+       */
       __privateAdd(this, _args);
       this.name = name;
       const { bundledConfig, site, platform } = args;
@@ -4213,6 +4224,9 @@
      * @typedef {object} ConditionBlock
      * @property {string[] | string} [domain]
      * @property {object} [urlPattern]
+     * @property {object} [experiment]
+     * @property {string} [experiment.experimentName]
+     * @property {string} [experiment.cohort]
      */
     /**
      * Takes multiple conditional blocks and returns true if any apply.
@@ -4234,7 +4248,8 @@
     _matchConditionalBlock(conditionBlock) {
       const conditionChecks = {
         domain: this._matchDomainConditional,
-        urlPattern: this._matchUrlPatternConditional
+        urlPattern: this._matchUrlPatternConditional,
+        experiment: this._matchExperimentConditional
       };
       for (const key in conditionBlock) {
         if (!conditionChecks[key]) {
@@ -4244,6 +4259,31 @@
         }
       }
       return true;
+    }
+    /**
+     * Takes a condition block and returns true if the current experiment matches the experimentName and cohort.
+     * Expects:
+     * ```json
+     * {
+     *   "experiment": {
+     *      "experimentName": "experimentName",
+     *      "cohort": "cohort-name"
+     *    }
+     * }
+     * ```
+     * Where featureName "ContentScopeExperiments" has a subfeature "experimentName" and cohort "cohort-name"
+     * @param {ConditionBlock} conditionBlock
+     * @returns {boolean}
+     */
+    _matchExperimentConditional(conditionBlock) {
+      if (!conditionBlock.experiment) return false;
+      const experiment = conditionBlock.experiment;
+      if (!experiment.experimentName || !experiment.cohort) return false;
+      const currentCohorts = this.args?.currentCohorts;
+      if (!currentCohorts) return false;
+      return currentCohorts.some((cohort) => {
+        return cohort.feature === "ContentScopeExperiments" && cohort.subfeature === experiment.experimentName && cohort.cohort === experiment.cohort;
+      });
     }
     /**
      * Takes a condtion block and returns true if the current url matches the urlPattern.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^12.19.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.1.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.21.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.22.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1746537866"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#c5dc2cf80de232a158b16d4d648f4fa326341665",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#f4b2f625c4db638ae392794d91782e17e2a43566",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -283,9 +283,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.17.tgz",
-      "integrity": "sha512-wIX2aSZL5FE+MR0JlvF87BNVrtFWf6AE6rxSE9X7OwnVvoyCQjpzSRJ+M87se/4QCkCiebQAqrJ0y6fwIyi7nw==",
+      "version": "22.15.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.18.tgz",
+      "integrity": "sha512-v1DKRfUdyW+jJhZNEI1PYy29S2YRxMV5AOO/x/SjKmW0acCIOqmbj6Haf9eHAhsPmrhlHSxEhv/1WszcLWV4cg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -651,9 +651,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
-      "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
+      "version": "5.39.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.1.tgz",
+      "integrity": "sha512-Mm6+uad0ZuDtcV8/4uOZQDQ8RuiC5Pu+iZRedJtF7yA/27sPL7d++In/AJKpWZlU3SYMPPkVfwetn6sgZ66pUA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^12.19.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.1.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.21.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.22.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1746537866"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1210257699578837/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass