### PR TITLE
Sense of Protection Experiment: Add new experiments

### DIFF
--- a/app/src/internal/java/experiments/trackersblocking/TrackersBlockingExperimentViewModel.kt
+++ b/app/src/internal/java/experiments/trackersblocking/TrackersBlockingExperimentViewModel.kt
@@ -58,7 +58,7 @@ class TrackersBlockingExperimentViewModel @Inject constructor(
         viewModelScope.launch(dispatchers.io()) {
             val enrollmentDateET = ZonedDateTime.now(ZoneId.of("America/New_York")).toString()
             if (checked) {
-                senseOfProtectionToggles.senseOfProtectionExistingUserExperimentApr25().setRawStoredState(
+                senseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().setRawStoredState(
                     State(
                         remoteEnableState = true,
                         enable = true,
@@ -71,7 +71,7 @@ class TrackersBlockingExperimentViewModel @Inject constructor(
                     ),
                 )
             } else {
-                senseOfProtectionToggles.senseOfProtectionExistingUserExperimentApr25().setRawStoredState(
+                senseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().setRawStoredState(
                     State(
                         remoteEnableState = false,
                         enable = false,
@@ -93,7 +93,7 @@ class TrackersBlockingExperimentViewModel @Inject constructor(
         viewModelScope.launch(dispatchers.io()) {
             val enrollmentDateET = ZonedDateTime.now(ZoneId.of("America/New_York")).toString()
             if (checked) {
-                senseOfProtectionToggles.senseOfProtectionExistingUserExperimentApr25().setRawStoredState(
+                senseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().setRawStoredState(
                     State(
                         remoteEnableState = true,
                         enable = true,
@@ -106,7 +106,7 @@ class TrackersBlockingExperimentViewModel @Inject constructor(
                     ),
                 )
             } else {
-                senseOfProtectionToggles.senseOfProtectionExistingUserExperimentApr25().setRawStoredState(
+                senseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().setRawStoredState(
                     State(
                         remoteEnableState = false,
                         enable = false,
@@ -128,7 +128,7 @@ class TrackersBlockingExperimentViewModel @Inject constructor(
         viewModelScope.launch(dispatchers.io()) {
             val enrollmentDateET = ZonedDateTime.now(ZoneId.of("America/New_York")).toString()
             if (checked) {
-                senseOfProtectionToggles.senseOfProtectionExistingUserExperimentApr25().setRawStoredState(
+                senseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().setRawStoredState(
                     State(
                         remoteEnableState = true,
                         enable = true,
@@ -141,7 +141,7 @@ class TrackersBlockingExperimentViewModel @Inject constructor(
                     ),
                 )
             } else {
-                senseOfProtectionToggles.senseOfProtectionExistingUserExperimentApr25().setRawStoredState(
+                senseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().setRawStoredState(
                     State(
                         remoteEnableState = false,
                         enable = false,

--- a/app/src/main/java/com/duckduckgo/app/browser/senseofprotection/SenseOfProtectionExperimentImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/senseofprotection/SenseOfProtectionExperimentImpl.kt
@@ -28,9 +28,9 @@ import com.duckduckgo.feature.toggles.api.MetricsPixel
 import com.duckduckgo.feature.toggles.api.Toggle.State.CohortName
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
+import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 private const val EXISTING_USER_DAY_COUNT_THRESHOLD = 28
 

--- a/app/src/main/java/com/duckduckgo/app/browser/senseofprotection/SenseOfProtectionExperimentImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/senseofprotection/SenseOfProtectionExperimentImpl.kt
@@ -136,7 +136,7 @@ class SenseOfProtectionExperimentImpl @Inject constructor(
     }
 
     private fun enrollInExistingUserExperiment(cohortName: CohortName): Boolean {
-        return senseOfProtectionToggles.senseOfProtectionExistingUserExperimentApr25().isEnabled(cohortName)
+        return senseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().isEnabled(cohortName)
     }
 
     private fun isUserEnrolledInNewUserExperimentModifiedControlCohortAndExperimentEnabled(): Boolean =
@@ -175,7 +175,7 @@ class SenseOfProtectionExperimentImpl @Inject constructor(
         senseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25().isEnrolledAndEnabled(cohortName)
 
     private fun isExistingUserExperimentEnabled(cohortName: CohortName): Boolean =
-        senseOfProtectionToggles.senseOfProtectionExistingUserExperimentApr25().isEnrolledAndEnabled(cohortName)
+        senseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().isEnrolledAndEnabled(cohortName)
 
     private fun getNewUserExperimentCohortName(): String? =
         senseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25().getCohort()?.name
@@ -184,10 +184,10 @@ class SenseOfProtectionExperimentImpl @Inject constructor(
         senseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25().featureName().name
 
     private fun getExistingUserExperimentCohortName(): String? =
-        senseOfProtectionToggles.senseOfProtectionExistingUserExperimentApr25().getCohort()?.name
+        senseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().getCohort()?.name
 
     private fun getExistingUserExperimentName(): String =
-        senseOfProtectionToggles.senseOfProtectionExistingUserExperimentApr25().featureName().name
+        senseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().featureName().name
 
     private fun MetricsPixel.fire() = getPixelDefinitions().forEach {
         pixel.fire(it.pixelName, it.params)

--- a/app/src/main/java/com/duckduckgo/app/browser/senseofprotection/SenseOfProtectionExperimentImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/senseofprotection/SenseOfProtectionExperimentImpl.kt
@@ -28,9 +28,9 @@ import com.duckduckgo.feature.toggles.api.MetricsPixel
 import com.duckduckgo.feature.toggles.api.Toggle.State.CohortName
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
-import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 private const val EXISTING_USER_DAY_COUNT_THRESHOLD = 28
 
@@ -132,7 +132,7 @@ class SenseOfProtectionExperimentImpl @Inject constructor(
     }
 
     private fun enrollInNewUserExperiment(cohortName: CohortName): Boolean {
-        return senseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25().isEnabled(cohortName)
+        return senseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().isEnabled(cohortName)
     }
 
     private fun enrollInExistingUserExperiment(cohortName: CohortName): Boolean {
@@ -172,16 +172,16 @@ class SenseOfProtectionExperimentImpl @Inject constructor(
     }
 
     private fun isNewUserExperimentEnabled(cohortName: CohortName): Boolean =
-        senseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25().isEnrolledAndEnabled(cohortName)
+        senseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().isEnrolledAndEnabled(cohortName)
 
     private fun isExistingUserExperimentEnabled(cohortName: CohortName): Boolean =
         senseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().isEnrolledAndEnabled(cohortName)
 
     private fun getNewUserExperimentCohortName(): String? =
-        senseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25().getCohort()?.name
+        senseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().getCohort()?.name
 
     private fun getNewUserExperimentName(): String =
-        senseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25().featureName().name
+        senseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().featureName().name
 
     private fun getExistingUserExperimentCohortName(): String? =
         senseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().getCohort()?.name

--- a/app/src/main/java/com/duckduckgo/app/browser/senseofprotection/SenseOfProtectionExperimentToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/senseofprotection/SenseOfProtectionExperimentToggles.kt
@@ -43,7 +43,7 @@ interface SenseOfProtectionToggles {
     fun senseOfProtectionNewUserExperimentApr25(): Toggle
 
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
-    fun senseOfProtectionExistingUserExperimentApr25(): Toggle
+    fun senseOfProtectionExistingUserExperimentMay25(): Toggle
 
     enum class Cohorts(override val cohortName: String) : CohortName {
         MODIFIED_CONTROL("modifiedControl"), // without grey tracker logos from original animation

--- a/app/src/main/java/com/duckduckgo/app/browser/senseofprotection/SenseOfProtectionExperimentToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/senseofprotection/SenseOfProtectionExperimentToggles.kt
@@ -40,7 +40,7 @@ interface SenseOfProtectionToggles {
     fun self(): Toggle
 
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
-    fun senseOfProtectionNewUserExperimentApr25(): Toggle
+    fun senseOfProtectionNewUserExperimentMay25(): Toggle
 
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun senseOfProtectionExistingUserExperimentMay25(): Toggle

--- a/app/src/main/java/com/duckduckgo/app/survey/rmf/TemporaryDefaultSurveyParameters.kt
+++ b/app/src/main/java/com/duckduckgo/app/survey/rmf/TemporaryDefaultSurveyParameters.kt
@@ -29,5 +29,5 @@ class SenseOfProtectionCohortSurveyParameterPlugin @Inject constructor(
 ) : SurveyParameterPlugin {
     override val surveyParamKey: String = "senseProtectionCohort"
 
-    override suspend fun evaluate(): String = senseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25().getCohort()?.name.orEmpty()
+    override suspend fun evaluate(): String = senseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().getCohort()?.name.orEmpty()
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/senseofprotection/SenseOfProtectionExperimentImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/senseofprotection/SenseOfProtectionExperimentImplTest.kt
@@ -77,7 +77,7 @@ class SenseOfProtectionExperimentImplTest {
     @Test
     fun `when user is new and enrolUserInNewExperimentIfEligible then user is in enrolled`() {
         fakeUserBrowserProperties.setDaysSinceInstalled(28)
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -94,7 +94,7 @@ class SenseOfProtectionExperimentImplTest {
     @Test
     fun `when user is new and experiment is enabled but for different cohort then isEnabled returns false`() {
         fakeUserBrowserProperties.setDaysSinceInstalled(20)
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -109,7 +109,7 @@ class SenseOfProtectionExperimentImplTest {
     @Test
     fun `when user is new and experiment is disabled then isEnabled returns false`() {
         fakeUserBrowserProperties.setDaysSinceInstalled(10)
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
             State(
                 remoteEnableState = false,
                 enable = false,
@@ -123,7 +123,7 @@ class SenseOfProtectionExperimentImplTest {
 
     @Test
     fun `when user is enrolled in new user experiment then getTabManagerPixelParams returns new user experiment params`() {
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -135,12 +135,12 @@ class SenseOfProtectionExperimentImplTest {
         val params = testee.getTabManagerPixelParams()
 
         assertEquals(VARIANT_1.cohortName, params["cohort"])
-        assertEquals(fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25().featureName().name, params["experiment"])
+        assertEquals(fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().featureName().name, params["experiment"])
     }
 
     @Test
     fun `when user is enrolled in new user experiment but experiment is disabled then getTabManagerPixelParams returns empty map`() {
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
             State(
                 remoteEnableState = false,
                 enable = false,
@@ -190,7 +190,7 @@ class SenseOfProtectionExperimentImplTest {
     @Test
     fun `when user is not enrolled in any experiment then getTabManagerPixelParams returns empty map`() {
         fakeUserBrowserProperties.setDaysSinceInstalled(30)
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
             State(
                 remoteEnableState = false,
                 enable = false,
@@ -214,7 +214,7 @@ class SenseOfProtectionExperimentImplTest {
 
     @Test
     fun `when user is enrolled in modified control variant then we can detect it`() {
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -232,7 +232,7 @@ class SenseOfProtectionExperimentImplTest {
 
     @Test
     fun `when user is enrolled in variant 1 then other variants are not enabled`() {
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -250,7 +250,7 @@ class SenseOfProtectionExperimentImplTest {
 
     @Test
     fun `when user is enrolled in variant 2 then other variants are not enabled`() {
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -269,7 +269,7 @@ class SenseOfProtectionExperimentImplTest {
     @Test
     fun `when user is enrolled in modified control then legacy privacy shield is shown`() {
         fakeUserBrowserProperties.setDaysSinceInstalled(20)
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -284,7 +284,7 @@ class SenseOfProtectionExperimentImplTest {
     @Test
     fun `when user is not enrolled in any variant`() {
         fakeUserBrowserProperties.setDaysSinceInstalled(20)
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -298,7 +298,7 @@ class SenseOfProtectionExperimentImplTest {
     @Test
     fun `when user is enrolled in variant 1 then new privacy shield is shown`() {
         fakeUserBrowserProperties.setDaysSinceInstalled(20)
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -313,7 +313,7 @@ class SenseOfProtectionExperimentImplTest {
     @Test
     fun `when user is enrolled in variant 2 then new privacy shield is shown`() {
         fakeUserBrowserProperties.setDaysSinceInstalled(20)
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,

--- a/app/src/test/java/com/duckduckgo/app/browser/senseofprotection/SenseOfProtectionExperimentImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/senseofprotection/SenseOfProtectionExperimentImplTest.kt
@@ -156,7 +156,7 @@ class SenseOfProtectionExperimentImplTest {
 
     @Test
     fun `when user is enrolled in existing user experiment then getTabManagerPixelParams returns existing user experiment params`() {
-        fakeSenseOfProtectionToggles.senseOfProtectionExistingUserExperimentApr25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -168,12 +168,12 @@ class SenseOfProtectionExperimentImplTest {
         val params = testee.getTabManagerPixelParams()
 
         assertEquals(VARIANT_2.cohortName, params["cohort"])
-        assertEquals(fakeSenseOfProtectionToggles.senseOfProtectionExistingUserExperimentApr25().featureName().name, params["experiment"])
+        assertEquals(fakeSenseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().featureName().name, params["experiment"])
     }
 
     @Test
     fun `when user is enrolled in existing user experiment but experiment is disabled then getTabManagerPixelParams returns empty map`() {
-        fakeSenseOfProtectionToggles.senseOfProtectionExistingUserExperimentApr25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().setRawStoredState(
             State(
                 remoteEnableState = false,
                 enable = false,
@@ -198,7 +198,7 @@ class SenseOfProtectionExperimentImplTest {
                 cohorts = emptyList(),
             ),
         )
-        fakeSenseOfProtectionToggles.senseOfProtectionExistingUserExperimentApr25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().setRawStoredState(
             State(
                 remoteEnableState = false,
                 enable = false,

--- a/app/src/test/java/com/duckduckgo/app/survey/rmf/TemporaryDefaultSurveyParametersPluginTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/survey/rmf/TemporaryDefaultSurveyParametersPluginTest.kt
@@ -22,7 +22,7 @@ class TemporaryDefaultSurveyParametersPluginTest {
             on { it.isEnabled() } doReturn true
             on { it.getCohort() } doReturn modifiedControlCohort
         }
-        whenever(mockSenseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25()).thenReturn(mockToggle)
+        whenever(mockSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25()).thenReturn(mockToggle)
 
         val plugin = SenseOfProtectionCohortSurveyParameterPlugin(mockSenseOfProtectionToggles)
 
@@ -36,7 +36,7 @@ class TemporaryDefaultSurveyParametersPluginTest {
             on { it.isEnabled() } doReturn true
             on { it.getCohort() } doReturn modifiedControlCohort
         }
-        whenever(mockSenseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25()).thenReturn(mockToggle)
+        whenever(mockSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25()).thenReturn(mockToggle)
 
         val plugin = SenseOfProtectionCohortSurveyParameterPlugin(mockSenseOfProtectionToggles)
 
@@ -50,7 +50,7 @@ class TemporaryDefaultSurveyParametersPluginTest {
             on { it.isEnabled() } doReturn true
             on { it.getCohort() } doReturn modifiedControlCohort
         }
-        whenever(mockSenseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25()).thenReturn(mockToggle)
+        whenever(mockSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25()).thenReturn(mockToggle)
 
         val plugin = SenseOfProtectionCohortSurveyParameterPlugin(mockSenseOfProtectionToggles)
 
@@ -63,7 +63,7 @@ class TemporaryDefaultSurveyParametersPluginTest {
             on { it.isEnabled() } doReturn false
             on { it.getCohort() } doReturn null
         }
-        whenever(mockSenseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25()).thenReturn(mockToggle)
+        whenever(mockSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25()).thenReturn(mockToggle)
 
         val plugin = SenseOfProtectionCohortSurveyParameterPlugin(mockSenseOfProtectionToggles)
 

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -1400,7 +1400,7 @@ class TabSwitcherViewModelTest {
     @Test
     fun `when animated info panel clicked then tapped pixel fired`() = runTest {
         whenever(mockWebTrackersBlockedAppRepository.getTrackerCountForLast7Days()).thenReturn(15)
-        fakeSenseOfProtectionToggles.senseOfProtectionExistingUserExperimentApr25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -1417,7 +1417,7 @@ class TabSwitcherViewModelTest {
             pixel = AppPixelName.TAB_MANAGER_INFO_PANEL_TAPPED,
             parameters = mapOf(
                 "cohort" to VARIANT_2.cohortName,
-                "experiment" to fakeSenseOfProtectionToggles.senseOfProtectionExistingUserExperimentApr25().featureName().name,
+                "experiment" to fakeSenseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().featureName().name,
             ),
         )
     }
@@ -1450,7 +1450,7 @@ class TabSwitcherViewModelTest {
 
     @Test
     fun `when user is in modified control of sense of protection experiment then animated tile is not shown`() = runTest {
-        fakeSenseOfProtectionToggles.senseOfProtectionExistingUserExperimentApr25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -1245,7 +1245,7 @@ class TabSwitcherViewModelTest {
 
     @Test
     fun `when animated info panel then tab switcher items include animation tile and tabs`() = runTest {
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -1274,7 +1274,7 @@ class TabSwitcherViewModelTest {
 
     @Test
     fun `when animated info panel not visible then tab switcher items contain only tabs`() = runTest {
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -1321,7 +1321,7 @@ class TabSwitcherViewModelTest {
 
     @Test
     fun `when animated info panel positive button clicked then animated info panel is still visible`() = runTest {
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -1350,7 +1350,7 @@ class TabSwitcherViewModelTest {
     fun `when animated info panel negative button clicked then animated info panel is removed`() = runTest {
         initializeViewModel(FakeTabSwitcherDataStore())
 
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -1374,7 +1374,7 @@ class TabSwitcherViewModelTest {
 
     @Test
     fun `when animated info panel visible then impressions pixel fired`() = runTest {
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -1392,7 +1392,7 @@ class TabSwitcherViewModelTest {
             pixel = AppPixelName.TAB_MANAGER_INFO_PANEL_IMPRESSIONS,
             parameters = mapOf(
                 "cohort" to VARIANT_2.cohortName,
-                "experiment" to fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25().featureName().name,
+                "experiment" to fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().featureName().name,
             ),
         )
     }
@@ -1424,7 +1424,7 @@ class TabSwitcherViewModelTest {
 
     @Test
     fun `when animated info panel negative button clicked then dismiss pixel fired`() = runTest {
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -1443,7 +1443,7 @@ class TabSwitcherViewModelTest {
             parameters = mapOf(
                 "trackerCount" to "15",
                 "cohort" to VARIANT_2.cohortName,
-                "experiment" to fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25().featureName().name,
+                "experiment" to fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().featureName().name,
             ),
         )
     }
@@ -1468,7 +1468,7 @@ class TabSwitcherViewModelTest {
 
     @Test
     fun `when user is in variant 1 of sense of protection experiment then animated tile is not shown`() = runTest {
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentApr25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207908166761516/task/1210235542874003

### Description
Update the Sense of Protection experiment toggle names from April to May, changing all references from `senseOfProtectionNewUserExperimentApr25()` to `senseOfProtectionNewUserExperimentMay25()` and `senseOfProtectionExistingUserExperimentApr25()` to `senseOfProtectionExistingUserExperimentMay25()`.

### Steps to test this PR

_Sense of Protection Experiment_
- [ ] Verify that the experiment toggles work correctly in the internal app
- [ ] Check that the experiment enrollment works as expected for both new and existing users
- [ ] Confirm that the survey parameters still function properly with the updated toggle names

### UI changes
No UI changes in this PR.