### PR TITLE
Fix: IllegalStateException crash

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -206,9 +206,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
 
     private val tabPagerAdapter by lazy {
         TabPagerAdapter(
-            fragmentManager = supportFragmentManager,
-            lifecycleOwner = this,
-            activityIntent = intent,
+            activity = this,
             swipingTabsFeature = swipingTabsFeature,
         )
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -874,10 +874,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
             tabPager.setPageTransformer(MarginPageTransformer(resources.getDimension(com.duckduckgo.mobile.android.R.dimen.keyline_1).toPx().toInt()))
 
             savedInstanceState?.getBundle(KEY_TAB_PAGER_STATE)?.let {
-                // state is only useful when there are fragments to restore (also avoids a crash)
-                if (supportFragmentManager.fragments.isNotEmpty()) {
-                    tabPagerAdapter.restoreState(it)
-                }
+                tabPagerAdapter.restore(it)
             }
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -876,7 +876,10 @@ open class BrowserActivity : DuckDuckGoActivity() {
             tabPager.setPageTransformer(MarginPageTransformer(resources.getDimension(com.duckduckgo.mobile.android.R.dimen.keyline_1).toPx().toInt()))
 
             savedInstanceState?.getBundle(KEY_TAB_PAGER_STATE)?.let {
-                tabPagerAdapter.restoreState(it)
+                // state is only useful when there are fragments to restore (also avoids a crash)
+                if (supportFragmentManager.fragments.isNotEmpty()) {
+                    tabPagerAdapter.restoreState(it)
+                }
             }
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/DefaultTabManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/DefaultTabManager.kt
@@ -31,7 +31,6 @@ import timber.log.Timber
 interface TabManager {
     companion object {
         const val MAX_ACTIVE_TABS = 20
-        const val NEW_TAB_CREATION_TIMEOUT_LIMIT = 2 // seconds
     }
 
     fun registerCallbacks(onTabsUpdated: (List<TabModel>) -> Unit)

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/FragmentStateAdapter.java
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/FragmentStateAdapter.java
@@ -29,6 +29,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
 import android.widget.FrameLayout;
+
 import androidx.annotation.CallSuper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -47,8 +48,8 @@ import androidx.recyclerview.widget.RecyclerView;
 import androidx.viewpager2.adapter.StatefulAdapter;
 import androidx.viewpager2.widget.ViewPager2;
 
-import com.duckduckgo.common.ui.tabs.SwipingTabsFeatureProvider;
 import com.duckduckgo.app.browser.tabs.TabManager;
+import com.duckduckgo.common.ui.tabs.SwipingTabsFeatureProvider;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -57,6 +58,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+
 import timber.log.Timber;
 
 /**
@@ -133,7 +135,9 @@ public abstract class FragmentStateAdapter extends RecyclerView.Adapter<Fragment
     public FragmentStateAdapter(
             @NonNull FragmentActivity fragmentActivity,
             SwipingTabsFeatureProvider swipingTabsFeature) {
-        this(fragmentActivity.getSupportFragmentManager(), fragmentActivity.getLifecycle(), swipingTabsFeature);
+        this(fragmentActivity.getSupportFragmentManager(),
+                fragmentActivity.getLifecycle(),
+                swipingTabsFeature);
     }
 
     /**
@@ -637,7 +641,8 @@ public abstract class FragmentStateAdapter extends RecyclerView.Adapter<Fragment
                     Fragment fragment = mFragmentManager.getFragment(bundle, key);
                     mFragments.put(itemId, fragment);
                 } catch (IllegalStateException e) {
-                    Timber.w("FragmentManager is in a bad state, unable to restore fragment %d", itemId);
+                    Timber.w("FragmentManager is in a bad state, unable to restore fragment %d",
+                            itemId);
                 }
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/FragmentStateAdapter.java
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/FragmentStateAdapter.java
@@ -676,8 +676,13 @@ public abstract class FragmentStateAdapter extends RecyclerView.Adapter<Fragment
         for (String key : bundle.keySet()) {
             if (isValidKey(key, KEY_PREFIX_FRAGMENT)) {
                 long itemId = parseIdFromKey(key, KEY_PREFIX_FRAGMENT);
-                Fragment fragment = mFragmentManager.getFragment(bundle, key);
-                mFragments.put(itemId, fragment);
+                try {
+                    Fragment fragment = mFragmentManager.getFragment(bundle, key);
+                    mFragments.put(itemId, fragment);
+                } catch (IllegalStateException e) {
+                    Timber.w("FragmentManager is in a bad state, unable to restore fragment %d", itemId);
+                    continue;
+                }
                 continue;
             }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/FragmentStateAdapter.java
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/FragmentStateAdapter.java
@@ -130,42 +130,18 @@ public abstract class FragmentStateAdapter extends RecyclerView.Adapter<Fragment
     /**
      * @param fragmentActivity if the {@link ViewPager2} lives directly in a {@link
      *     FragmentActivity} subclass.
-     * @see FragmentStateAdapter#FragmentStateAdapter(Fragment)
-     * @see FragmentStateAdapter#FragmentStateAdapter(FragmentManager, Lifecycle)
-     */
-    public FragmentStateAdapter(@NonNull FragmentActivity fragmentActivity) {
-        this(fragmentActivity.getSupportFragmentManager(), fragmentActivity.getLifecycle());
-    }
-
-    /**
-     * @param fragment if the {@link ViewPager2} lives directly in a {@link Fragment} subclass.
-     * @see FragmentStateAdapter#FragmentStateAdapter(FragmentActivity)
-     * @see FragmentStateAdapter#FragmentStateAdapter(FragmentManager, Lifecycle)
-     */
-    public FragmentStateAdapter(@NonNull Fragment fragment) {
-        this(fragment.getChildFragmentManager(), fragment.getLifecycle());
-    }
-
-    /**
-     * @param fragmentManager of {@link ViewPager2}'s host
-     * @param lifecycle of {@link ViewPager2}'s host
-     * @see FragmentStateAdapter#FragmentStateAdapter(FragmentActivity)
-     * @see FragmentStateAdapter#FragmentStateAdapter(Fragment)
+     * @param swipingTabsFeature Feature flag to enable swiping tabs fixes
      */
     public FragmentStateAdapter(
-            @NonNull FragmentManager fragmentManager, @NonNull Lifecycle lifecycle) {
-        mFragmentManager = fragmentManager;
-        mLifecycle = lifecycle;
-        mSwipingTabsFeature = null;
-        super.setHasStableIds(true);
+            @NonNull FragmentActivity fragmentActivity,
+            SwipingTabsFeatureProvider swipingTabsFeature) {
+        this(fragmentActivity.getSupportFragmentManager(), fragmentActivity.getLifecycle(), swipingTabsFeature);
     }
 
     /**
      * @param fragmentManager of {@link ViewPager2}'s host
      * @param lifecycle of {@link ViewPager2}'s host
      * @param swipingTabsFeature Feature flag to enable swiping tabs fixes
-     * @see FragmentStateAdapter#FragmentStateAdapter(FragmentActivity)
-     * @see FragmentStateAdapter#FragmentStateAdapter(Fragment)
      */
     public FragmentStateAdapter(
             @NonNull FragmentManager fragmentManager,

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/FragmentStateAdapter.java
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/FragmentStateAdapter.java
@@ -638,12 +638,8 @@ public abstract class FragmentStateAdapter extends RecyclerView.Adapter<Fragment
                     mFragments.put(itemId, fragment);
                 } catch (IllegalStateException e) {
                     Timber.w("FragmentManager is in a bad state, unable to restore fragment %d", itemId);
-                    continue;
                 }
-                continue;
             }
-
-            throw new IllegalArgumentException("Unexpected key in savedState: " + key);
         }
 
         if (!mFragments.isEmpty()) {

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabPagerAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabPagerAdapter.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.browser.tabs.adapter
 
 import android.annotation.SuppressLint
 import android.content.Intent
+import android.os.Bundle
 import android.os.Message
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
@@ -60,6 +61,13 @@ class TabPagerAdapter(
             }
         } else {
             BrowserTabFragment.newInstance(tab.tabId, tab.url, tab.skipHome, isExternal)
+        }
+    }
+
+    fun restore(state: Bundle) {
+        // state is only useful when there are fragments to restore (also avoids a crash)
+        if (activity.supportFragmentManager.fragments.isNotEmpty()) {
+            restoreState(state)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabPagerAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabPagerAdapter.kt
@@ -17,12 +17,9 @@
 package com.duckduckgo.app.browser.tabs.adapter
 
 import android.annotation.SuppressLint
-import android.content.Intent
 import android.os.Bundle
 import android.os.Message
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentManager
-import androidx.lifecycle.LifecycleOwner
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.duckduckgo.app.browser.BrowserActivity

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabPagerAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabPagerAdapter.kt
@@ -30,11 +30,9 @@ import com.duckduckgo.app.browser.tabs.TabManager.TabModel
 import com.duckduckgo.common.ui.tabs.SwipingTabsFeatureProvider
 
 class TabPagerAdapter(
-    lifecycleOwner: LifecycleOwner,
-    fragmentManager: FragmentManager,
-    private val activityIntent: Intent?,
+    private val activity: BrowserActivity,
     swipingTabsFeature: SwipingTabsFeatureProvider,
-) : FragmentStateAdapter(fragmentManager, lifecycleOwner.lifecycle, swipingTabsFeature) {
+) : FragmentStateAdapter(activity, swipingTabsFeature) {
     private val tabs = mutableListOf<TabModel>()
     private var messageForNewFragment: Message? = null
 
@@ -52,7 +50,7 @@ class TabPagerAdapter(
 
     override fun createFragment(position: Int): Fragment {
         val tab = tabs[position]
-        val isExternal = activityIntent?.getBooleanExtra(BrowserActivity.LAUNCH_FROM_EXTERNAL_EXTRA, false) == true
+        val isExternal = activity.intent?.getBooleanExtra(BrowserActivity.LAUNCH_FROM_EXTERNAL_EXTRA, false) == true
 
         return if (messageForNewFragment != null) {
             val message = messageForNewFragment


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1210250194815685?focus=true

### Description

This PR fixes a crash caused by `FragmentStateAdapter` attempting to restore fragment state when `FragmentManager` loses its fragments after activity recreation.

### Steps to test this PR

- [x] Enable Don't keep activities
- [x] Set DDG as a default browser
- [x] Enable tab swiping
- [x] Open DDG → Open a few tabs
- [x] Go to tab manager
- [x] Switch to an app that can open links (like Twitter)
- [x] Tap on a link
- [x] Notice DDG opens the link and doesn't crash
