### PR TITLE
use primary icon color for menu icon on the nav bar

### DIFF
--- a/app/src/main/res/layout/view_browser_navigation_bar.xml
+++ b/app/src/main/res/layout/view_browser_navigation_bar.xml
@@ -158,8 +158,7 @@
                 android:layout_gravity="center"
                 android:contentDescription="@string/browserPopupMenu"
                 android:scaleType="center"
-                android:src="@drawable/ic_menu_vertical_24"
-                app:tint="?daxColorPrimaryIcon" />
+                android:src="@drawable/ic_menu_vertical_24" />
         </FrameLayout>
 
     </LinearLayout>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1210248310047072?focus=true

### Description
Use primary icon color for menu icon on the nav bar.

### Steps to test this PR
- [x] Enable visual design.
- [x] Ensure the menu icon color is the same as all the other icons.

### UI changes
| Before  | After |
| ------ | ----- |
![Screenshot_20250515_123653](https://github.com/user-attachments/assets/3ae5569b-09d3-4feb-9e23-2977dcea1dcf)|![Screenshot_20250515_123838](https://github.com/user-attachments/assets/1c8255a7-7383-4e2f-b387-e45951e69e04)|
