### PR TITLE
show the same omnibar hint on pages and NTP

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -696,7 +696,7 @@ open class OmnibarLayout @JvmOverloads constructor(
     }
 
     private fun renderHint(viewState: ViewState) {
-        if (viewState.viewMode is NewTab && duckChat.showInAddressBar.value) {
+        if (!viewState.isVisualDesignExperimentEnabled && viewState.viewMode is NewTab && duckChat.showInAddressBar.value) {
             omnibarTextInput.hint = context.getString(R.string.search)
         } else {
             omnibarTextInput.hint = context.getString(R.string.omnibarInputHint)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1210251609451227?focus=true

### Description
When new visual design enabled, show the same hint in the omnibar when both text cleared on a page or NTP opened.

### Steps to test this PR

- [x] Enable visual design experiment.
- [x] Open new tab page.
- [x] Verify that text in the omnibar is "Search or type URL".
- [x] Disable visual design experiment.
- [x] Verify that text in the omnibar is "Search".

### UI changes
| Before  | After |
| ------ | ----- |
![Screenshot_20250515_124644](https://github.com/user-attachments/assets/b8f5f62d-9126-4101-a595-8cd08f0b4598)|![Screenshot_20250515_124748](https://github.com/user-attachments/assets/f520d38a-75cf-4546-afff-31a9e8f43fdf)|
