### PR TITLE
Update content scope scripts to version 8.23.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
@@ -2888,7 +2888,7 @@
      *    }
      * }
      * ```
-     * Where featureName "ContentScopeExperiments" has a subfeature "experimentName" and cohort "cohort-name"
+     * Where featureName "contentScopeExperiments" has a subfeature "experimentName" and cohort "cohort-name"
      * @param {ConditionBlock} conditionBlock
      * @returns {boolean}
      */
@@ -2899,7 +2899,7 @@
       const currentCohorts = this.args?.currentCohorts;
       if (!currentCohorts) return false;
       return currentCohorts.some((cohort) => {
-        return cohort.feature === "ContentScopeExperiments" && cohort.subfeature === experiment.experimentName && cohort.cohort === experiment.cohort;
+        return cohort.feature === "contentScopeExperiments" && cohort.subfeature === experiment.experimentName && cohort.cohort === experiment.cohort;
       });
     }
     /**

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -4431,7 +4431,7 @@
      *    }
      * }
      * ```
-     * Where featureName "ContentScopeExperiments" has a subfeature "experimentName" and cohort "cohort-name"
+     * Where featureName "contentScopeExperiments" has a subfeature "experimentName" and cohort "cohort-name"
      * @param {ConditionBlock} conditionBlock
      * @returns {boolean}
      */
@@ -4442,7 +4442,7 @@
       const currentCohorts = this.args?.currentCohorts;
       if (!currentCohorts) return false;
       return currentCohorts.some((cohort) => {
-        return cohort.feature === "ContentScopeExperiments" && cohort.subfeature === experiment.experimentName && cohort.cohort === experiment.cohort;
+        return cohort.feature === "contentScopeExperiments" && cohort.subfeature === experiment.experimentName && cohort.cohort === experiment.cohort;
       });
     }
     /**

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -4271,7 +4271,7 @@
      *    }
      * }
      * ```
-     * Where featureName "ContentScopeExperiments" has a subfeature "experimentName" and cohort "cohort-name"
+     * Where featureName "contentScopeExperiments" has a subfeature "experimentName" and cohort "cohort-name"
      * @param {ConditionBlock} conditionBlock
      * @returns {boolean}
      */
@@ -4282,7 +4282,7 @@
       const currentCohorts = this.args?.currentCohorts;
       if (!currentCohorts) return false;
       return currentCohorts.some((cohort) => {
-        return cohort.feature === "ContentScopeExperiments" && cohort.subfeature === experiment.experimentName && cohort.cohort === experiment.cohort;
+        return cohort.feature === "contentScopeExperiments" && cohort.subfeature === experiment.experimentName && cohort.cohort === experiment.cohort;
       });
     }
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^12.19.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.1.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.22.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.23.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1746537866"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#f4b2f625c4db638ae392794d91782e17e2a43566",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#8c0378dfe85790d25ee5800845bc8ddcbed0faec",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -651,14 +651,14 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.39.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.1.tgz",
-      "integrity": "sha512-Mm6+uad0ZuDtcV8/4uOZQDQ8RuiC5Pu+iZRedJtF7yA/27sPL7d++In/AJKpWZlU3SYMPPkVfwetn6sgZ66pUA==",
+      "version": "5.39.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.2.tgz",
+      "integrity": "sha512-yEPUmWve+VA78bI71BW70Dh0TuV4HHd+I5SHOAfS1+QBOmvmCiiffgjR8ryyEd3KIfvPGFqoADt8LdQ6XpXIvg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.8.2",
+        "acorn": "^8.14.0",
         "commander": "^2.20.0",
         "source-map-support": "~0.5.20"
       },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^12.19.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.1.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.22.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.23.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1746537866"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass