### PR TITLE
fix an issue where Custom Tab URL or icon wouldn't update according to page redirects

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -708,7 +708,11 @@ class OmnibarLayoutViewModel @Inject constructor(
         if (customTabMode is CustomTab) {
             _viewState.update {
                 it.copy(
-                    viewMode = customTabMode.copy(title = decoration.title),
+                    viewMode = customTabMode.copy(
+                        title = decoration.title,
+                        domain = decoration.domain,
+                        showDuckPlayerIcon = decoration.showDuckPlayerIcon,
+                    ),
                 )
             }
         }

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -8,6 +8,7 @@ import com.duckduckgo.app.browser.DuckDuckGoUrlDetectorImpl
 import com.duckduckgo.app.browser.defaultbrowsing.prompts.DefaultBrowserPromptsExperiment
 import com.duckduckgo.app.browser.omnibar.Omnibar.ViewMode
 import com.duckduckgo.app.browser.omnibar.OmnibarLayout.Decoration
+import com.duckduckgo.app.browser.omnibar.OmnibarLayout.Decoration.ChangeCustomTabTitle
 import com.duckduckgo.app.browser.omnibar.OmnibarLayout.StateChange
 import com.duckduckgo.app.browser.omnibar.OmnibarLayoutViewModel.Command
 import com.duckduckgo.app.browser.omnibar.OmnibarLayoutViewModel.LeadingIconState
@@ -298,16 +299,67 @@ class OmnibarLayoutViewModelTest {
 
     @Test
     fun whenViewModeChangedToCustomTabThenViewStateCorrect() = runTest {
-        testee.onViewModeChanged(ViewMode.CustomTab(0, "example", "example.com", false))
+        val expectedToolbarColor = 100
+        val expectedTitle = "example"
+        val expectedDomain = "example.com"
+        val expectedShowDuckPlayerIcon = false
+        testee.onViewModeChanged(
+            ViewMode.CustomTab(
+                toolbarColor = expectedToolbarColor,
+                title = expectedTitle,
+                domain = expectedDomain,
+                showDuckPlayerIcon = expectedShowDuckPlayerIcon,
+            ),
+        )
 
         testee.viewState.test {
             val viewState = awaitItem()
-            assertTrue(viewState.viewMode is ViewMode.CustomTab)
             assertFalse(viewState.showClearButton)
             assertFalse(viewState.showVoiceSearch)
             assertFalse(viewState.showTabsMenu)
             assertFalse(viewState.showFireIcon)
             assertTrue(viewState.showBrowserMenu)
+
+            assertTrue(viewState.viewMode is ViewMode.CustomTab)
+            val customTabMode = viewState.viewMode as ViewMode.CustomTab
+            assertEquals(expectedToolbarColor, customTabMode.toolbarColor)
+            assertEquals(expectedTitle, customTabMode.title)
+            assertEquals(expectedDomain, customTabMode.domain)
+            assertEquals(expectedShowDuckPlayerIcon, customTabMode.showDuckPlayerIcon)
+        }
+    }
+
+    @Test
+    fun `when custom tab title updates, update view mode state`() = runTest {
+        val expectedTitle = "newTitle"
+        val expectedDomain = "newDomain"
+        val expectedShowDuckPlayerIcon = true
+        val decoration = ChangeCustomTabTitle(
+            title = expectedTitle,
+            domain = expectedDomain,
+            showDuckPlayerIcon = expectedShowDuckPlayerIcon,
+        )
+
+        testee.onViewModeChanged(ViewMode.CustomTab(100, "example", "example.com", showDuckPlayerIcon = false))
+        testee.viewState.test {
+            // skipping initial update
+            skipItems(1)
+            // this function needs to be called only when the flow is consumed,
+            // otherwise, the values are not produced and the internal check for custom tab state fails
+            testee.onCustomTabTitleUpdate(decoration)
+            val viewState = awaitItem()
+            assertFalse(viewState.showClearButton)
+            assertFalse(viewState.showVoiceSearch)
+            assertFalse(viewState.showTabsMenu)
+            assertFalse(viewState.showFireIcon)
+            assertTrue(viewState.showBrowserMenu)
+
+            assertTrue(viewState.viewMode is ViewMode.CustomTab)
+            val customTabMode = viewState.viewMode as ViewMode.CustomTab
+            assertEquals(100, customTabMode.toolbarColor)
+            assertEquals(expectedTitle, customTabMode.title)
+            assertEquals(expectedDomain, customTabMode.domain)
+            assertEquals(expectedShowDuckPlayerIcon, customTabMode.showDuckPlayerIcon)
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1210137390470561?focus=true

### Description
Adds a missing change to https://github.com/duckduckgo/Android/pull/5829 and ensures that the domain and/or duck chat icon are updated when Custom Tab page loads and redirects.

### Steps to test this PR

- [x] Set DDG as the default browser.
- [x] Open a link from Gmail or any other source that would redirect.
- [ ] Ensure that the domain is correct after the page fully loads.