### PR TITLE
Add WebView dev settings screen for internal builds

### DIFF
--- a/app/src/internal/AndroidManifest.xml
+++ b/app/src/internal/AndroidManifest.xml
@@ -1,8 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools"
-          package="com.duckduckgo.app.browser">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.duckduckgo.app.browser">
 
     <application>
+        <activity
+            android:name=".webview.WebViewDevSettingsActivity"
+            android:exported="true"
+            android:parentActivityName="com.duckduckgo.app.settings.SettingsActivity"
+            android:label="@string/webview_dev_settings_label"
+            />
         <activity
             android:name="com.duckduckgo.app.dev.settings.DevSettingsActivity"
             android:label="@string/devSettingsTitle"

--- a/app/src/internal/java/com/duckduckgo/app/browser/webview/WebViewDevSettings.kt
+++ b/app/src/internal/java/com/duckduckgo/app/browser/webview/WebViewDevSettings.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.webview
+
+/*
+ * Copyright (c) 2023 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import android.content.Context
+import com.duckduckgo.anvil.annotations.PriorityKey
+import com.duckduckgo.app.browser.R
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.internal.features.api.InternalFeaturePlugin
+import com.duckduckgo.internal.features.api.InternalFeaturePlugin.Companion.WEB_VIEW_DEV_SETTINGS_PRIO_KEY
+import com.duckduckgo.navigation.api.GlobalActivityStarter
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+@PriorityKey(WEB_VIEW_DEV_SETTINGS_PRIO_KEY)
+class WebViewDevSettings @Inject constructor(
+    private val globalActivityStarter: GlobalActivityStarter,
+    private val context: Context,
+) : InternalFeaturePlugin {
+
+    override fun internalFeatureTitle(): String {
+        return context.getString(R.string.webview_internal_feature_title)
+    }
+
+    override fun internalFeatureSubtitle(): String {
+        return context.getString(R.string.webview_internal_feature_subtitle)
+    }
+
+    override fun onInternalFeatureClicked(activityContext: Context) {
+        globalActivityStarter.start(activityContext, WebViewDevSettingsScreen)
+    }
+}

--- a/app/src/internal/java/com/duckduckgo/app/browser/webview/WebViewDevSettingsActivity.kt
+++ b/app/src/internal/java/com/duckduckgo/app/browser/webview/WebViewDevSettingsActivity.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.webview
+
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.net.toUri
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.databinding.ActivityWebViewDevSettingsBinding
+import com.duckduckgo.app.browser.webview.WebViewDevSettingsViewModel.ViewState
+import com.duckduckgo.app.clipboard.ClipboardInteractor
+import com.duckduckgo.common.ui.DuckDuckGoActivity
+import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.playstore.PlayStoreAndroidUtils.Companion.PLAY_STORE_PACKAGE
+import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.navigation.api.GlobalActivityStarter
+import javax.inject.Inject
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+
+@InjectWith(ActivityScope::class)
+@ContributeToActivityStarter(WebViewDevSettingsScreen::class)
+class WebViewDevSettingsActivity : DuckDuckGoActivity() {
+
+    @Inject
+    lateinit var viewModel: WebViewDevSettingsViewModel
+
+    @Inject
+    lateinit var clipboardManager: ClipboardInteractor
+
+    private val binding: ActivityWebViewDevSettingsBinding by viewBinding()
+
+    private lateinit var webViewDebugLauncher: ActivityResultLauncher<Intent>
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(binding.root)
+        setupToolbar(binding.includeToolbar.toolbar)
+        registerActivityResultLauncher()
+        configureListeners()
+        observeViewModel()
+    }
+
+    private fun observeViewModel() {
+        viewModel.viewState()
+            .flowWithLifecycle(lifecycle, Lifecycle.State.CREATED)
+            .onEach { viewState ->
+                updateViews(viewState)
+            }.launchIn(lifecycleScope)
+    }
+
+    private fun updateViews(viewState: ViewState) {
+        binding.webViewPackage.setSecondaryText(viewState.webViewPackage)
+        binding.webViewVersion.setSecondaryText(viewState.webViewVersion)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        viewModel.start()
+    }
+
+    private fun configureListeners() {
+        binding.webViewDevTools.setOnClickListener {
+            launchExternalIntentForAction(Intent(WEBVIEW_DEV_TOOLS_INTENT_ACTION), getString(R.string.webview_dev_ui_not_available))
+        }
+        binding.webViewVersion.setClickListener {
+            clipboardManager.copyToClipboard(viewModel.viewState().value.webViewVersion, false)
+        }
+        binding.webViewPackage.setClickListener {
+            clipboardManager.copyToClipboard(viewModel.viewState().value.webViewPackage, false)
+        }
+        binding.webViewPlayStore.setClickListener {
+            val intent = Intent(Intent.ACTION_VIEW).also {
+                it.setData(PLAYSTORE_WEBVIEW_INTENT_URI.toUri())
+                it.setPackage(PLAY_STORE_PACKAGE)
+            }
+            launchExternalIntentForAction(intent, getString(R.string.webview_play_store_unavailable))
+        }
+    }
+
+    private fun registerActivityResultLauncher() {
+        webViewDebugLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+        }
+    }
+
+    private fun launchExternalIntentForAction(intent: Intent, errorIfCannotLaunch: String) {
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+
+        if (intent.resolveActivity(packageManager) != null) {
+            startActivity(intent)
+        } else {
+            Toast.makeText(this, errorIfCannotLaunch, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    companion object {
+        private const val PLAYSTORE_WEBVIEW_INTENT_URI = "market://details?id=com.google.android.webview"
+        private const val WEBVIEW_DEV_TOOLS_INTENT_ACTION = "com.android.webview.SHOW_DEV_UI"
+        private const val PLAY_STORE_PACKAGE = "com.android.vending"
+    }
+}
+
+data object WebViewDevSettingsScreen : GlobalActivityStarter.ActivityParams {
+    private fun readResolve(): Any = WebViewDevSettingsScreen
+}

--- a/app/src/internal/java/com/duckduckgo/app/browser/webview/WebViewDevSettingsViewModel.kt
+++ b/app/src/internal/java/com/duckduckgo/app/browser/webview/WebViewDevSettingsViewModel.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.webview
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.di.scopes.ActivityScope
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+@ContributesViewModel(ActivityScope::class)
+class WebViewDevSettingsViewModel @Inject constructor(
+    private val webViewInformationExtractor: WebViewInformationExtractor,
+) : ViewModel() {
+
+    data class ViewState(
+        val webViewVersion: String = "unknown",
+        val webViewPackage: String = "unknown",
+    )
+
+    private val viewState = MutableStateFlow(ViewState())
+
+    fun viewState(): StateFlow<ViewState> {
+        return viewState
+    }
+
+    fun start() {
+        viewModelScope.launch {
+            val webViewData = webViewInformationExtractor.extract()
+
+            viewState.emit(
+                currentViewState().copy(
+                    webViewVersion = webViewData.webViewVersion,
+                    webViewPackage = webViewData.webViewPackageName,
+                ),
+            )
+        }
+    }
+
+    private fun currentViewState(): ViewState {
+        return viewState.value
+    }
+}

--- a/app/src/internal/java/com/duckduckgo/app/browser/webview/WebViewInformationExtractor.kt
+++ b/app/src/internal/java/com/duckduckgo/app/browser/webview/WebViewInformationExtractor.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.webview
+
+import android.content.Context
+import androidx.webkit.WebViewCompat
+import com.duckduckgo.app.browser.webview.WebViewInformationExtractor.WebViewData
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface WebViewInformationExtractor {
+
+    data class WebViewData(
+        val webViewVersion: String,
+        val webViewPackageName: String,
+    )
+
+    fun extract(): WebViewData
+}
+
+@ContributesBinding(AppScope::class)
+class InternalWebViewInformationExtractor @Inject constructor(
+    private val context: Context,
+) : WebViewInformationExtractor {
+
+    override fun extract(): WebViewData {
+        return WebViewCompat.getCurrentWebViewPackage(context)?.let {
+            WebViewData(
+                webViewVersion = it.versionName ?: UNKNOWN,
+                webViewPackageName = it.packageName ?: UNKNOWN,
+            )
+        } ?: unknownWebView
+    }
+
+    companion object {
+        private const val UNKNOWN = "unknown"
+
+        private val unknownWebView = WebViewData(
+            webViewVersion = UNKNOWN,
+            webViewPackageName = UNKNOWN,
+        )
+    }
+}

--- a/app/src/internal/res/layout/activity_web_view_dev_settings.xml
+++ b/app/src/internal/res/layout/activity_web_view_dev_settings.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2021 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context="com.duckduckgo.app.dev.settings.notifications.NotificationsActivity">
+
+    <include
+        android:id="@+id/includeToolbar"
+        layout="@layout/include_default_toolbar" />
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:orientation="vertical"
+            android:layout_height="wrap_content">
+
+            <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:primaryText="@string/webview_about" />
+
+            <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+                android:id="@+id/webViewVersion"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="@string/webview_version" />
+
+            <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+                android:id="@+id/webViewPackage"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="@string/webview_package" />
+
+            <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:primaryText="@string/webview_utilities" />
+
+            <com.duckduckgo.common.ui.view.listitem.OneLineListItem
+                android:id="@+id/webViewDevTools"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="@string/webview_dev_tools" />
+
+            <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+                android:id="@+id/webViewPlayStore"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="@string/webview_update_play_store"
+                app:secondaryText="@string/webview_requires_play_store"
+                />
+
+        </LinearLayout>
+
+    </ScrollView>
+</LinearLayout>
+

--- a/app/src/internal/res/values/donottranslate.xml
+++ b/app/src/internal/res/values/donottranslate.xml
@@ -103,4 +103,17 @@
     <string name="devSettingsNotificationsScheduledTitle">Scheduled Notifications</string>
     <string name="devSettingsNotificationsVPNTitle">VPN Notifications</string>
 
+    <!-- WebView Dev Settings -->
+    <string name="webview_about">About WebView</string>
+    <string name="webview_version">WebView Version (tap to copy)</string>
+    <string name="webview_package">WebView Package (tap to copy)</string>
+    <string name="webview_utilities">WebView utilities</string>
+    <string name="webview_dev_tools">Launch WebView DevTools</string>
+    <string name="webview_update_play_store">Update WebView through Play store</string>
+    <string name="webview_requires_play_store">Requires Play Store to be installed</string>
+    <string name="webview_dev_settings_label">WebView Dev Settings</string>
+    <string name="webview_internal_feature_title">System WebView</string>
+    <string name="webview_internal_feature_subtitle">WebView dev settings and tools</string>
+    <string name="webview_dev_ui_not_available">WebView Developer UI is not available.</string>
+    <string name="webview_play_store_unavailable">Play Store unavailable on this device</string>
 </resources>

--- a/internal-features/internal-features-api/src/main/java/com/duckduckgo/internal/features/api/InternalFeaturePlugin.kt
+++ b/internal-features/internal-features-api/src/main/java/com/duckduckgo/internal/features/api/InternalFeaturePlugin.kt
@@ -47,5 +47,6 @@ interface InternalFeaturePlugin {
         const val AUDIT_SETTINGS_PRIO_KEY = 700
         const val ADS_SETTINGS_PRIO_KEY = 800
         const val CRASH_ANR_SETTINGS_PRIO_KEY = 900
+        const val WEB_VIEW_DEV_SETTINGS_PRIO_KEY = 1_000
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1209643196618443?focus=true 

### Description
Adds an internal dev settings screen for `WebView` debug info and accessing tooling.

### Steps to test this PR

- [x] Install `internal` variant
- [x] Visit `Settings -> System WebView`
- [x] Check things work as you'd expect (e.g., no crashes even when Play Store not installed)