### PR TITLE
Update content scope scripts to version 8.24.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
@@ -493,6 +493,7 @@
       "cookie",
       "messageBridge",
       "duckPlayer",
+      "duckPlayerNative",
       "harmfulApis",
       "webCompat",
       "windowsPermissionUsage",
@@ -504,8 +505,16 @@
     ]
   );
   var platformSupport = {
-    apple: ["webCompat", ...baseFeatures],
-    "apple-isolated": ["duckPlayer", "brokerProtection", "performanceMetrics", "clickToLoad", "messageBridge", "favicon"],
+    apple: ["webCompat", "duckPlayerNative", ...baseFeatures],
+    "apple-isolated": [
+      "duckPlayer",
+      "duckPlayerNative",
+      "brokerProtection",
+      "performanceMetrics",
+      "clickToLoad",
+      "messageBridge",
+      "favicon"
+    ],
     android: [...baseFeatures, "webCompat", "breakageReporting", "duckPlayer", "messageBridge"],
     "android-broker-protection": ["brokerProtection"],
     "android-autofill-password-import": ["autofillPasswordImport"],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -1992,6 +1992,7 @@
       "cookie",
       "messageBridge",
       "duckPlayer",
+      "duckPlayerNative",
       "harmfulApis",
       "webCompat",
       "windowsPermissionUsage",
@@ -2003,8 +2004,16 @@
     ]
   );
   var platformSupport = {
-    apple: ["webCompat", ...baseFeatures],
-    "apple-isolated": ["duckPlayer", "brokerProtection", "performanceMetrics", "clickToLoad", "messageBridge", "favicon"],
+    apple: ["webCompat", "duckPlayerNative", ...baseFeatures],
+    "apple-isolated": [
+      "duckPlayer",
+      "duckPlayerNative",
+      "brokerProtection",
+      "performanceMetrics",
+      "clickToLoad",
+      "messageBridge",
+      "favicon"
+    ],
     android: [...baseFeatures, "webCompat", "breakageReporting", "duckPlayer", "messageBridge"],
     "android-broker-protection": ["brokerProtection"],
     "android-autofill-password-import": ["autofillPasswordImport"],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -1321,6 +1321,7 @@
       "cookie",
       "messageBridge",
       "duckPlayer",
+      "duckPlayerNative",
       "harmfulApis",
       "webCompat",
       "windowsPermissionUsage",
@@ -1332,8 +1333,16 @@
     ]
   );
   var platformSupport = {
-    apple: ["webCompat", ...baseFeatures],
-    "apple-isolated": ["duckPlayer", "brokerProtection", "performanceMetrics", "clickToLoad", "messageBridge", "favicon"],
+    apple: ["webCompat", "duckPlayerNative", ...baseFeatures],
+    "apple-isolated": [
+      "duckPlayer",
+      "duckPlayerNative",
+      "brokerProtection",
+      "performanceMetrics",
+      "clickToLoad",
+      "messageBridge",
+      "favicon"
+    ],
     android: [...baseFeatures, "webCompat", "breakageReporting", "duckPlayer", "messageBridge"],
     "android-broker-protection": ["brokerProtection"],
     "android-autofill-password-import": ["autofillPasswordImport"],
@@ -6848,7 +6857,7 @@
   var DuckPlayerOverlayMessages = class {
     /**
      * @param {Messaging} messaging
-     * @param {import('./overlays.js').Environment} environment
+     * @param {import('./environment.js').Environment} environment
      * @internal
      */
     constructor(messaging, environment) {
@@ -7082,9 +7091,11 @@
     }
     /**
      * Remove elements, event listeners etc
+     * @param {string} [name]
      */
-    destroy() {
-      for (const cleanup of this._cleanups) {
+    destroy(name) {
+      const cleanups = name ? this._cleanups.filter((c) => c.name === name) : this._cleanups;
+      for (const cleanup of cleanups) {
         if (typeof cleanup.fn === "function") {
           try {
             if (this.debug) {
@@ -7098,7 +7109,11 @@
           throw new Error("invalid cleanup");
         }
       }
-      this._cleanups = [];
+      if (name) {
+        this._cleanups = this._cleanups.filter((c) => c.name !== name);
+      } else {
+        this._cleanups = [];
+      }
     }
   };
   var _VideoParams = class _VideoParams {
@@ -7119,6 +7134,15 @@
         duckUrl.searchParams.set("t", this.time);
       }
       return duckUrl.href;
+    }
+    /**
+     * Get the large thumbnail URL for the current video id
+     *
+     * @returns {string}
+     */
+    toLargeThumbnailUrl() {
+      const url = new URL(`/vi/${this.id}/maxresdefault.jpg`, "https://i.ytimg.com");
+      return url.href;
     }
     /**
      * Create a VideoParams instance from a href, only if it's on the watch page
@@ -7574,6 +7598,109 @@
     }
   };
 
+  // src/features/duckplayer/environment.js
+  init_define_import_meta_trackerLookup();
+
+  // ../build/locales/duckplayer-locales.js
+  init_define_import_meta_trackerLookup();
+  var duckplayer_locales_default = `{"bg":{"overlays.json":{"videoOverlayTitle2":"\u0412\u043A\u043B\u044E\u0447\u0435\u0442\u0435 Duck Player, \u0437\u0430 \u0434\u0430 \u0433\u043B\u0435\u0434\u0430\u0442\u0435 \u0431\u0435\u0437 \u043D\u0430\u0441\u043E\u0447\u0435\u043D\u0438 \u0440\u0435\u043A\u043B\u0430\u043C\u0438","videoButtonOpen2":"\u0412\u043A\u043B\u044E\u0447\u0432\u0430\u043D\u0435 \u043D\u0430 Duck Player","videoButtonOptOut2":"\u041D\u0435, \u0431\u043B\u0430\u0433\u043E\u0434\u0430\u0440\u044F","rememberLabel":"\u0417\u0430\u043F\u043E\u043C\u043D\u0438 \u043C\u043E\u044F \u0438\u0437\u0431\u043E\u0440"}},"cs":{"overlays.json":{"videoOverlayTitle2":"Zapn\u011Bte si Duck Player a\xA0sledujte videa bez c\xEDlen\xFDch reklam","videoButtonOpen2":"Zapni si Duck Player","videoButtonOptOut2":"Ne, d\u011Bkuji","rememberLabel":"Zapamatovat mou volbu"}},"da":{"overlays.json":{"videoOverlayTitle2":"Sl\xE5 Duck Player til for at se indhold uden m\xE5lrettede reklamer","videoButtonOpen2":"Sl\xE5 Duck Player til","videoButtonOptOut2":"Nej tak.","rememberLabel":"Husk mit valg"}},"de":{"overlays.json":{"videoOverlayTitle2":"Aktiviere den Duck Player, um ohne gezielte Werbung zu schauen","videoButtonOpen2":"Duck Player aktivieren","videoButtonOptOut2":"Nein, danke","rememberLabel":"Meine Auswahl merken"}},"el":{"overlays.json":{"videoOverlayTitle2":"\u0395\u03BD\u03B5\u03C1\u03B3\u03BF\u03C0\u03BF\u03B9\u03AE\u03C3\u03C4\u03B5 \u03C4\u03BF Duck Player \u03B3\u03B9\u03B1 \u03C0\u03B1\u03C1\u03B1\u03BA\u03BF\u03BB\u03BF\u03CD\u03B8\u03B7\u03C3\u03B7 \u03C7\u03C9\u03C1\u03AF\u03C2 \u03C3\u03C4\u03BF\u03C7\u03B5\u03C5\u03BC\u03AD\u03BD\u03B5\u03C2 \u03B4\u03B9\u03B1\u03C6\u03B7\u03BC\u03AF\u03C3\u03B5\u03B9\u03C2","videoButtonOpen2":"\u0395\u03BD\u03B5\u03C1\u03B3\u03BF\u03C0\u03BF\u03AF\u03B7\u03C3\u03B7 \u03C4\u03BF\u03C5 Duck Player","videoButtonOptOut2":"\u038C\u03C7\u03B9, \u03B5\u03C5\u03C7\u03B1\u03C1\u03B9\u03C3\u03C4\u03CE","rememberLabel":"\u0398\u03C5\u03BC\u03B7\u03B8\u03B5\u03AF\u03C4\u03B5 \u03C4\u03B7\u03BD \u03B5\u03C0\u03B9\u03BB\u03BF\u03B3\u03AE \u03BC\u03BF\u03C5"}},"en":{"native.json":{"blockedVideoErrorHeading":"YouTube won\u2019t let Duck Player load this video","blockedVideoErrorMessage1":"YouTube doesn\u2019t allow this video to be viewed outside of YouTube.","blockedVideoErrorMessage2":"You can still watch this video on YouTube, but without the added privacy of Duck Player.","signInRequiredErrorMessage1":"YouTube is blocking this video from loading. If you\u2019re using a VPN, try turning it off and reloading this page.","signInRequiredErrorMessage2":"If this doesn\u2019t work, you can still watch this video on YouTube, but without the added privacy of Duck Player."},"overlays.json":{"videoOverlayTitle2":"Turn on Duck Player to watch without targeted ads","videoButtonOpen2":"Turn On Duck Player","videoButtonOptOut2":"No Thanks","rememberLabel":"Remember my choice"}},"es":{"overlays.json":{"videoOverlayTitle2":"Activa Duck Player para ver sin anuncios personalizados","videoButtonOpen2":"Activar Duck Player","videoButtonOptOut2":"No, gracias","rememberLabel":"Recordar mi elecci\xF3n"}},"et":{"overlays.json":{"videoOverlayTitle2":"Sihitud reklaamideta vaatamiseks l\xFClita sisse Duck Player","videoButtonOpen2":"L\xFClita Duck Player sisse","videoButtonOptOut2":"Ei ait\xE4h","rememberLabel":"J\xE4ta mu valik meelde"}},"fi":{"overlays.json":{"videoOverlayTitle2":"Jos haluat katsoa ilman kohdennettuja mainoksia, ota Duck Player k\xE4ytt\xF6\xF6n","videoButtonOpen2":"Ota Duck Player k\xE4ytt\xF6\xF6n","videoButtonOptOut2":"Ei kiitos","rememberLabel":"Muista valintani"}},"fr":{"overlays.json":{"videoOverlayTitle2":"Activez Duck Player pour une vid\xE9o sans publicit\xE9s cibl\xE9es","videoButtonOpen2":"Activez Duck Player","videoButtonOptOut2":"Non merci","rememberLabel":"M\xE9moriser mon choix"}},"hr":{"overlays.json":{"videoOverlayTitle2":"Uklju\u010Di Duck Player za gledanje bez ciljanih oglasa","videoButtonOpen2":"Uklju\u010Di Duck Player","videoButtonOptOut2":"Ne, hvala","rememberLabel":"Zapamti moj izbor"}},"hu":{"overlays.json":{"videoOverlayTitle2":"Kapcsold be a Duck Playert, hogy c\xE9lzott hirdet\xE9sek n\xE9lk\xFCl vide\xF3zhass","videoButtonOpen2":"Duck Player bekapcsol\xE1sa","videoButtonOptOut2":"Nem, k\xF6sz\xF6n\xF6m","rememberLabel":"V\xE1lasztott be\xE1ll\xEDt\xE1s megjegyz\xE9se"}},"it":{"overlays.json":{"videoOverlayTitle2":"Attiva Duck Player per guardare senza annunci personalizzati","videoButtonOpen2":"Attiva Duck Player","videoButtonOptOut2":"No, grazie","rememberLabel":"Ricorda la mia scelta"}},"lt":{"overlays.json":{"videoOverlayTitle2":"\u012Ejunkite \u201EDuck Player\u201C, kad gal\u0117tum\u0117te \u017Ei\u016Br\u0117ti be tikslini\u0173 reklam\u0173","videoButtonOpen2":"\u012Ejunkite \u201EDuck Player\u201C","videoButtonOptOut2":"Ne, d\u0117koju","rememberLabel":"\u012Esiminti mano pasirinkim\u0105"}},"lv":{"overlays.json":{"videoOverlayTitle2":"Iesl\u0113dz Duck Player, lai skat\u012Btos bez m\u0113r\u0137\u0113t\u0101m rekl\u0101m\u0101m","videoButtonOpen2":"Iesl\u0113gt Duck Player","videoButtonOptOut2":"N\u0113, paldies","rememberLabel":"Atcer\u0113ties manu izv\u0113li"}},"nb":{"overlays.json":{"videoOverlayTitle2":"Sl\xE5 p\xE5 Duck Player for \xE5 se p\xE5 uten m\xE5lrettede annonser","videoButtonOpen2":"Sl\xE5 p\xE5 Duck Player","videoButtonOptOut2":"Nei takk","rememberLabel":"Husk valget mitt"}},"nl":{"overlays.json":{"videoOverlayTitle2":"Zet Duck Player aan om te kijken zonder gerichte advertenties","videoButtonOpen2":"Duck Player aanzetten","videoButtonOptOut2":"Nee, bedankt","rememberLabel":"Mijn keuze onthouden"}},"pl":{"overlays.json":{"videoOverlayTitle2":"W\u0142\u0105cz Duck Player, aby ogl\u0105da\u0107 bez reklam ukierunkowanych","videoButtonOpen2":"W\u0142\u0105cz Duck Player","videoButtonOptOut2":"Nie, dzi\u0119kuj\u0119","rememberLabel":"Zapami\u0119taj m\xF3j wyb\xF3r"}},"pt":{"overlays.json":{"videoOverlayTitle2":"Ativa o Duck Player para ver sem an\xFAncios personalizados","videoButtonOpen2":"Ligar o Duck Player","videoButtonOptOut2":"N\xE3o, obrigado","rememberLabel":"Memorizar a minha op\xE7\xE3o"}},"ro":{"overlays.json":{"videoOverlayTitle2":"Activeaz\u0103 Duck Player pentru a viziona f\u0103r\u0103 reclame direc\u021Bionate","videoButtonOpen2":"Activeaz\u0103 Duck Player","videoButtonOptOut2":"Nu, mul\u021Bumesc","rememberLabel":"Re\u021Bine alegerea mea"}},"ru":{"overlays.json":{"videoOverlayTitle2":"Duck Player\xA0\u2014 \u043F\u0440\u043E\u0441\u043C\u043E\u0442\u0440 \u0431\u0435\u0437 \u0446\u0435\u043B\u0435\u0432\u043E\u0439 \u0440\u0435\u043A\u043B\u0430\u043C\u044B","videoButtonOpen2":"\u0412\u043A\u043B\u044E\u0447\u0438\u0442\u044C Duck Player","videoButtonOptOut2":"\u041D\u0435\u0442, \u0441\u043F\u0430\u0441\u0438\u0431\u043E","rememberLabel":"\u0417\u0430\u043F\u043E\u043C\u043D\u0438\u0442\u044C \u0432\u044B\u0431\u043E\u0440"}},"sk":{"overlays.json":{"videoOverlayTitle2":"Zapnite Duck Player a pozerajte bez cielen\xFDch rekl\xE1m","videoButtonOpen2":"Zapn\xFA\u0165 prehr\xE1va\u010D Duck Player","videoButtonOptOut2":"Nie, \u010Fakujem","rememberLabel":"Zapam\xE4ta\u0165 si moju vo\u013Ebu"}},"sl":{"overlays.json":{"videoOverlayTitle2":"Vklopite predvajalnik Duck Player za gledanje brez ciljanih oglasov","videoButtonOpen2":"Vklopi predvajalnik Duck Player","videoButtonOptOut2":"Ne, hvala","rememberLabel":"Zapomni si mojo izbiro"}},"sv":{"overlays.json":{"videoOverlayTitle2":"Aktivera Duck Player f\xF6r att titta utan riktade annonser","videoButtonOpen2":"Aktivera Duck Player","videoButtonOptOut2":"Nej tack","rememberLabel":"Kom ih\xE5g mitt val"}},"tr":{"overlays.json":{"videoOverlayTitle2":"Hedeflenmi\u015F reklamlar olmadan izlemek i\xE7in Duck Player'\u0131 a\xE7\u0131n","videoButtonOpen2":"Duck Player'\u0131 A\xE7","videoButtonOptOut2":"Hay\u0131r Te\u015Fekk\xFCrler","rememberLabel":"Se\xE7imimi hat\u0131rla"}}}`;
+
+  // src/features/duckplayer/environment.js
+  var Environment = class {
+    /**
+     * @param {object} params
+     * @param {{name: string}} params.platform
+     * @param {boolean|null|undefined} [params.debug]
+     * @param {ImportMeta['injectName']} params.injectName
+     * @param {string} params.locale
+     */
+    constructor(params) {
+      __publicField(this, "allowedProxyOrigins", ["duckduckgo.com"]);
+      __publicField(this, "_strings", JSON.parse(duckplayer_locales_default));
+      this.debug = Boolean(params.debug);
+      this.injectName = params.injectName;
+      this.platform = params.platform;
+      this.locale = params.locale;
+    }
+    /**
+     * @param {"overlays.json" | "native.json"} named
+     * @returns {Record<string, string>}
+     */
+    strings(named) {
+      const matched = this._strings[this.locale];
+      if (matched) return matched[named];
+      return this._strings.en[named];
+    }
+    /**
+     * This is the URL of the page that the user is currently on
+     * It's abstracted so that we can mock it in tests
+     * @return {string}
+     */
+    getPlayerPageHref() {
+      if (this.debug) {
+        const url = new URL(window.location.href);
+        if (url.hostname === "www.youtube.com") return window.location.href;
+        if (url.searchParams.has("v")) {
+          const base = new URL("/watch", "https://youtube.com");
+          base.searchParams.set("v", url.searchParams.get("v") || "");
+          return base.toString();
+        }
+        return "https://youtube.com/watch?v=123";
+      }
+      return window.location.href;
+    }
+    getLargeThumbnailSrc(videoId) {
+      const url = new URL(`/vi/${videoId}/maxresdefault.jpg`, "https://i.ytimg.com");
+      return url.href;
+    }
+    setHref(href) {
+      window.location.href = href;
+    }
+    hasOneTimeOverride() {
+      try {
+        if (window.location.hash !== "#ddg-play") return false;
+        if (typeof document.referrer !== "string") return false;
+        if (document.referrer.length === 0) return false;
+        const { hostname } = new URL(document.referrer);
+        const isAllowed = this.allowedProxyOrigins.includes(hostname);
+        return isAllowed;
+      } catch (e) {
+        console.error(e);
+      }
+      return false;
+    }
+    isIntegrationMode() {
+      return this.debug === true && this.injectName === "integration";
+    }
+    isTestMode() {
+      return this.debug === true;
+    }
+    get opensVideoOverlayLinksViaMessage() {
+      return this.platform.name !== "windows";
+    }
+    /**
+     * @return {boolean}
+     */
+    get isMobile() {
+      return this.platform.name === "ios" || this.platform.name === "android";
+    }
+    /**
+     * @return {boolean}
+     */
+    get isDesktop() {
+      return !this.isMobile;
+    }
+    /**
+     * @return {'desktop' | 'mobile'}
+     */
+    get layout() {
+      if (this.platform.name === "ios" || this.platform.name === "android") {
+        return "mobile";
+      }
+      return "desktop";
+    }
+  };
+
   // src/features/duckplayer/thumbnails.js
   var Thumbnails = class {
     /**
@@ -7745,7 +7872,7 @@
   var DDGVideoOverlay = class extends HTMLElement {
     /**
      * @param {object} options
-     * @param {import("../overlays.js").Environment} options.environment
+     * @param {import("../environment.js").Environment} options.environment
      * @param {import("../util").VideoParams} options.params
      * @param {import("../../duck-player.js").UISettings} options.ui
      * @param {VideoOverlay} options.manager
@@ -8287,7 +8414,7 @@
      * @param {object} options
      * @param {import("../duck-player.js").UserValues} options.userValues
      * @param {import("../duck-player.js").OverlaysFeatureSettings} options.settings
-     * @param {import("./overlays.js").Environment} options.environment
+     * @param {import("./environment.js").Environment} options.environment
      * @param {import("./overlay-messages.js").DuckPlayerOverlayMessages} options.messages
      * @param {import("../duck-player.js").UISettings} options.ui
      */
@@ -8437,7 +8564,7 @@
           document.createElement(DDGVideoOverlayMobile.CUSTOM_TAG_NAME)
         );
         elem.testMode = this.environment.isTestMode();
-        elem.text = mobileStrings(this.environment.strings);
+        elem.text = mobileStrings(this.environment.strings("overlays.json"));
         elem.addEventListener(DDGVideoOverlayMobile.OPEN_INFO, () => this.messages.openInfo());
         elem.addEventListener(DDGVideoOverlayMobile.OPT_OUT, (e) => {
           return this.mobileOptOut(e.detail.remember).catch(console.error);
@@ -8472,7 +8599,7 @@
             document.createElement(DDGVideoDrawerMobile.CUSTOM_TAG_NAME)
           );
           drawer.testMode = this.environment.isTestMode();
-          drawer.text = mobileStrings(this.environment.strings);
+          drawer.text = mobileStrings(this.environment.strings("overlays.json"));
           drawer.addEventListener(DDGVideoDrawerMobile.OPEN_INFO, () => this.messages.openInfo());
           drawer.addEventListener(DDGVideoDrawerMobile.OPT_OUT, (e) => {
             return this.mobileOptOut(e.detail.remember).catch(console.error);
@@ -8672,10 +8799,6 @@
     }
   }
 
-  // ../build/locales/duckplayer-locales.js
-  init_define_import_meta_trackerLookup();
-  var duckplayer_locales_default = `{"bg":{"overlays.json":{"videoOverlayTitle2":"\u0412\u043A\u043B\u044E\u0447\u0435\u0442\u0435 Duck Player, \u0437\u0430 \u0434\u0430 \u0433\u043B\u0435\u0434\u0430\u0442\u0435 \u0431\u0435\u0437 \u043D\u0430\u0441\u043E\u0447\u0435\u043D\u0438 \u0440\u0435\u043A\u043B\u0430\u043C\u0438","videoButtonOpen2":"\u0412\u043A\u043B\u044E\u0447\u0432\u0430\u043D\u0435 \u043D\u0430 Duck Player","videoButtonOptOut2":"\u041D\u0435, \u0431\u043B\u0430\u0433\u043E\u0434\u0430\u0440\u044F","rememberLabel":"\u0417\u0430\u043F\u043E\u043C\u043D\u0438 \u043C\u043E\u044F \u0438\u0437\u0431\u043E\u0440"}},"cs":{"overlays.json":{"videoOverlayTitle2":"Zapn\u011Bte si Duck Player a\xA0sledujte videa bez c\xEDlen\xFDch reklam","videoButtonOpen2":"Zapni si Duck Player","videoButtonOptOut2":"Ne, d\u011Bkuji","rememberLabel":"Zapamatovat mou volbu"}},"da":{"overlays.json":{"videoOverlayTitle2":"Sl\xE5 Duck Player til for at se indhold uden m\xE5lrettede reklamer","videoButtonOpen2":"Sl\xE5 Duck Player til","videoButtonOptOut2":"Nej tak.","rememberLabel":"Husk mit valg"}},"de":{"overlays.json":{"videoOverlayTitle2":"Aktiviere den Duck Player, um ohne gezielte Werbung zu schauen","videoButtonOpen2":"Duck Player aktivieren","videoButtonOptOut2":"Nein, danke","rememberLabel":"Meine Auswahl merken"}},"el":{"overlays.json":{"videoOverlayTitle2":"\u0395\u03BD\u03B5\u03C1\u03B3\u03BF\u03C0\u03BF\u03B9\u03AE\u03C3\u03C4\u03B5 \u03C4\u03BF Duck Player \u03B3\u03B9\u03B1 \u03C0\u03B1\u03C1\u03B1\u03BA\u03BF\u03BB\u03BF\u03CD\u03B8\u03B7\u03C3\u03B7 \u03C7\u03C9\u03C1\u03AF\u03C2 \u03C3\u03C4\u03BF\u03C7\u03B5\u03C5\u03BC\u03AD\u03BD\u03B5\u03C2 \u03B4\u03B9\u03B1\u03C6\u03B7\u03BC\u03AF\u03C3\u03B5\u03B9\u03C2","videoButtonOpen2":"\u0395\u03BD\u03B5\u03C1\u03B3\u03BF\u03C0\u03BF\u03AF\u03B7\u03C3\u03B7 \u03C4\u03BF\u03C5 Duck Player","videoButtonOptOut2":"\u038C\u03C7\u03B9, \u03B5\u03C5\u03C7\u03B1\u03C1\u03B9\u03C3\u03C4\u03CE","rememberLabel":"\u0398\u03C5\u03BC\u03B7\u03B8\u03B5\u03AF\u03C4\u03B5 \u03C4\u03B7\u03BD \u03B5\u03C0\u03B9\u03BB\u03BF\u03B3\u03AE \u03BC\u03BF\u03C5"}},"en":{"overlays.json":{"videoOverlayTitle2":"Turn on Duck Player to watch without targeted ads","videoButtonOpen2":"Turn On Duck Player","videoButtonOptOut2":"No Thanks","rememberLabel":"Remember my choice"}},"es":{"overlays.json":{"videoOverlayTitle2":"Activa Duck Player para ver sin anuncios personalizados","videoButtonOpen2":"Activar Duck Player","videoButtonOptOut2":"No, gracias","rememberLabel":"Recordar mi elecci\xF3n"}},"et":{"overlays.json":{"videoOverlayTitle2":"Sihitud reklaamideta vaatamiseks l\xFClita sisse Duck Player","videoButtonOpen2":"L\xFClita Duck Player sisse","videoButtonOptOut2":"Ei ait\xE4h","rememberLabel":"J\xE4ta mu valik meelde"}},"fi":{"overlays.json":{"videoOverlayTitle2":"Jos haluat katsoa ilman kohdennettuja mainoksia, ota Duck Player k\xE4ytt\xF6\xF6n","videoButtonOpen2":"Ota Duck Player k\xE4ytt\xF6\xF6n","videoButtonOptOut2":"Ei kiitos","rememberLabel":"Muista valintani"}},"fr":{"overlays.json":{"videoOverlayTitle2":"Activez Duck Player pour une vid\xE9o sans publicit\xE9s cibl\xE9es","videoButtonOpen2":"Activez Duck Player","videoButtonOptOut2":"Non merci","rememberLabel":"M\xE9moriser mon choix"}},"hr":{"overlays.json":{"videoOverlayTitle2":"Uklju\u010Di Duck Player za gledanje bez ciljanih oglasa","videoButtonOpen2":"Uklju\u010Di Duck Player","videoButtonOptOut2":"Ne, hvala","rememberLabel":"Zapamti moj izbor"}},"hu":{"overlays.json":{"videoOverlayTitle2":"Kapcsold be a Duck Playert, hogy c\xE9lzott hirdet\xE9sek n\xE9lk\xFCl vide\xF3zhass","videoButtonOpen2":"Duck Player bekapcsol\xE1sa","videoButtonOptOut2":"Nem, k\xF6sz\xF6n\xF6m","rememberLabel":"V\xE1lasztott be\xE1ll\xEDt\xE1s megjegyz\xE9se"}},"it":{"overlays.json":{"videoOverlayTitle2":"Attiva Duck Player per guardare senza annunci personalizzati","videoButtonOpen2":"Attiva Duck Player","videoButtonOptOut2":"No, grazie","rememberLabel":"Ricorda la mia scelta"}},"lt":{"overlays.json":{"videoOverlayTitle2":"\u012Ejunkite \u201EDuck Player\u201C, kad gal\u0117tum\u0117te \u017Ei\u016Br\u0117ti be tikslini\u0173 reklam\u0173","videoButtonOpen2":"\u012Ejunkite \u201EDuck Player\u201C","videoButtonOptOut2":"Ne, d\u0117koju","rememberLabel":"\u012Esiminti mano pasirinkim\u0105"}},"lv":{"overlays.json":{"videoOverlayTitle2":"Iesl\u0113dz Duck Player, lai skat\u012Btos bez m\u0113r\u0137\u0113t\u0101m rekl\u0101m\u0101m","videoButtonOpen2":"Iesl\u0113gt Duck Player","videoButtonOptOut2":"N\u0113, paldies","rememberLabel":"Atcer\u0113ties manu izv\u0113li"}},"nb":{"overlays.json":{"videoOverlayTitle2":"Sl\xE5 p\xE5 Duck Player for \xE5 se p\xE5 uten m\xE5lrettede annonser","videoButtonOpen2":"Sl\xE5 p\xE5 Duck Player","videoButtonOptOut2":"Nei takk","rememberLabel":"Husk valget mitt"}},"nl":{"overlays.json":{"videoOverlayTitle2":"Zet Duck Player aan om te kijken zonder gerichte advertenties","videoButtonOpen2":"Duck Player aanzetten","videoButtonOptOut2":"Nee, bedankt","rememberLabel":"Mijn keuze onthouden"}},"pl":{"overlays.json":{"videoOverlayTitle2":"W\u0142\u0105cz Duck Player, aby ogl\u0105da\u0107 bez reklam ukierunkowanych","videoButtonOpen2":"W\u0142\u0105cz Duck Player","videoButtonOptOut2":"Nie, dzi\u0119kuj\u0119","rememberLabel":"Zapami\u0119taj m\xF3j wyb\xF3r"}},"pt":{"overlays.json":{"videoOverlayTitle2":"Ativa o Duck Player para ver sem an\xFAncios personalizados","videoButtonOpen2":"Ligar o Duck Player","videoButtonOptOut2":"N\xE3o, obrigado","rememberLabel":"Memorizar a minha op\xE7\xE3o"}},"ro":{"overlays.json":{"videoOverlayTitle2":"Activeaz\u0103 Duck Player pentru a viziona f\u0103r\u0103 reclame direc\u021Bionate","videoButtonOpen2":"Activeaz\u0103 Duck Player","videoButtonOptOut2":"Nu, mul\u021Bumesc","rememberLabel":"Re\u021Bine alegerea mea"}},"ru":{"overlays.json":{"videoOverlayTitle2":"Duck Player\xA0\u2014 \u043F\u0440\u043E\u0441\u043C\u043E\u0442\u0440 \u0431\u0435\u0437 \u0446\u0435\u043B\u0435\u0432\u043E\u0439 \u0440\u0435\u043A\u043B\u0430\u043C\u044B","videoButtonOpen2":"\u0412\u043A\u043B\u044E\u0447\u0438\u0442\u044C Duck Player","videoButtonOptOut2":"\u041D\u0435\u0442, \u0441\u043F\u0430\u0441\u0438\u0431\u043E","rememberLabel":"\u0417\u0430\u043F\u043E\u043C\u043D\u0438\u0442\u044C \u0432\u044B\u0431\u043E\u0440"}},"sk":{"overlays.json":{"videoOverlayTitle2":"Zapnite Duck Player a pozerajte bez cielen\xFDch rekl\xE1m","videoButtonOpen2":"Zapn\xFA\u0165 prehr\xE1va\u010D Duck Player","videoButtonOptOut2":"Nie, \u010Fakujem","rememberLabel":"Zapam\xE4ta\u0165 si moju vo\u013Ebu"}},"sl":{"overlays.json":{"videoOverlayTitle2":"Vklopite predvajalnik Duck Player za gledanje brez ciljanih oglasov","videoButtonOpen2":"Vklopi predvajalnik Duck Player","videoButtonOptOut2":"Ne, hvala","rememberLabel":"Zapomni si mojo izbiro"}},"sv":{"overlays.json":{"videoOverlayTitle2":"Aktivera Duck Player f\xF6r att titta utan riktade annonser","videoButtonOpen2":"Aktivera Duck Player","videoButtonOptOut2":"Nej tack","rememberLabel":"Kom ih\xE5g mitt val"}},"tr":{"overlays.json":{"videoOverlayTitle2":"Hedeflenmi\u015F reklamlar olmadan izlemek i\xE7in Duck Player'\u0131 a\xE7\u0131n","videoButtonOpen2":"Duck Player'\u0131 A\xE7","videoButtonOptOut2":"Hay\u0131r Te\u015Fekk\xFCrler","rememberLabel":"Se\xE7imimi hat\u0131rla"}}}`;
-
   // src/features/duckplayer/overlays.js
   async function initOverlays(settings, environment, messages) {
     const domState = new DomState();
@@ -8683,11 +8806,11 @@
     try {
       initialSetup = await messages.initialSetup();
     } catch (e) {
-      console.error(e);
+      console.warn(e);
       return;
     }
     if (!initialSetup) {
-      console.error("cannot continue without user settings");
+      console.warn("cannot continue without user settings");
       return;
     }
     let { userValues, ui } = initialSetup;
@@ -8767,96 +8890,6 @@
     if (settings.videoOverlays.state !== "enabled") return void 0;
     return new VideoOverlay({ userValues, settings, environment, messages, ui });
   }
-  var Environment = class {
-    /**
-     * @param {object} params
-     * @param {{name: string}} params.platform
-     * @param {boolean|null|undefined} [params.debug]
-     * @param {ImportMeta['injectName']} params.injectName
-     * @param {string} params.locale
-     */
-    constructor(params) {
-      __publicField(this, "allowedProxyOrigins", ["duckduckgo.com"]);
-      __publicField(this, "_strings", JSON.parse(duckplayer_locales_default));
-      this.debug = Boolean(params.debug);
-      this.injectName = params.injectName;
-      this.platform = params.platform;
-      this.locale = params.locale;
-    }
-    get strings() {
-      const matched = this._strings[this.locale];
-      if (matched) return matched["overlays.json"];
-      return this._strings.en["overlays.json"];
-    }
-    /**
-     * This is the URL of the page that the user is currently on
-     * It's abstracted so that we can mock it in tests
-     * @return {string}
-     */
-    getPlayerPageHref() {
-      if (this.debug) {
-        const url = new URL(window.location.href);
-        if (url.hostname === "www.youtube.com") return window.location.href;
-        if (url.searchParams.has("v")) {
-          const base = new URL("/watch", "https://youtube.com");
-          base.searchParams.set("v", url.searchParams.get("v") || "");
-          return base.toString();
-        }
-        return "https://youtube.com/watch?v=123";
-      }
-      return window.location.href;
-    }
-    getLargeThumbnailSrc(videoId) {
-      const url = new URL(`/vi/${videoId}/maxresdefault.jpg`, "https://i.ytimg.com");
-      return url.href;
-    }
-    setHref(href) {
-      window.location.href = href;
-    }
-    hasOneTimeOverride() {
-      try {
-        if (window.location.hash !== "#ddg-play") return false;
-        if (typeof document.referrer !== "string") return false;
-        if (document.referrer.length === 0) return false;
-        const { hostname } = new URL(document.referrer);
-        const isAllowed = this.allowedProxyOrigins.includes(hostname);
-        return isAllowed;
-      } catch (e) {
-        console.error(e);
-      }
-      return false;
-    }
-    isIntegrationMode() {
-      return this.debug === true && this.injectName === "integration";
-    }
-    isTestMode() {
-      return this.debug === true;
-    }
-    get opensVideoOverlayLinksViaMessage() {
-      return this.platform.name !== "windows";
-    }
-    /**
-     * @return {boolean}
-     */
-    get isMobile() {
-      return this.platform.name === "ios" || this.platform.name === "android";
-    }
-    /**
-     * @return {boolean}
-     */
-    get isDesktop() {
-      return !this.isMobile;
-    }
-    /**
-     * @return {'desktop' | 'mobile'}
-     */
-    get layout() {
-      if (this.platform.name === "ios" || this.platform.name === "android") {
-        return "mobile";
-      }
-      return "desktop";
-    }
-  };
 
   // src/features/duck-player.js
   var DuckPlayerFeature = class extends ContentFeature {

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
@@ -2865,6 +2865,15 @@
       return duckUrl.href;
     }
     /**
+     * Get the large thumbnail URL for the current video id
+     *
+     * @returns {string}
+     */
+    toLargeThumbnailUrl() {
+      const url = new URL(`/vi/${this.id}/maxresdefault.jpg`, "https://i.ytimg.com");
+      return url.href;
+    }
+    /**
      * Create a VideoParams instance from a href, only if it's on the watch page
      *
      * @param {string} href

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^12.20.1",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.1.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.23.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.24.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1746537866"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#8c0378dfe85790d25ee5800845bc8ddcbed0faec",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#53975299db5319b0a3e6811086d7b848f1b62abe",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -181,46 +181,46 @@
       }
     },
     "node_modules/@remusao/guess-url-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@remusao/guess-url-type/-/guess-url-type-2.0.0.tgz",
-      "integrity": "sha512-L98gV/X/GESt5Tgqq/PxpZYClVqeq6/5InrRKl4elq4qXbdZjHlNTgRhXb1xIaUBkikzv410sXw3QaBUYyXt8g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@remusao/guess-url-type/-/guess-url-type-2.1.0.tgz",
+      "integrity": "sha512-zI3dlTUxpjvx2GCxp9nLOSK5yEIqDCpxlAVGwb2Y49RKkS72oeNaxxo+VWS5+XQ5+Mf8Zfp9ZXIlk+G5eoEN8A==",
       "license": "MPL-2.0"
     },
     "node_modules/@remusao/small": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@remusao/small/-/small-2.0.0.tgz",
-      "integrity": "sha512-1ksGCbl1hSeO4CV/uk0qv2vUdZ1ZRdIMzSn0HFsHTJnmWSDk2li+T5eCI9BtweYe0uVQhCvbMjk/3qwsN6fuYg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@remusao/small/-/small-2.1.0.tgz",
+      "integrity": "sha512-Y1kyjZp7JU7dXdyOdxHVNfoTr1XLZJTyQP36/esZUU/WRWq9XY0PV2HsE3CsIHuaTf4pvgWv2pvzvnZ//UHIJQ==",
       "license": "MPL-2.0"
     },
     "node_modules/@remusao/smaz": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@remusao/smaz/-/smaz-2.1.0.tgz",
-      "integrity": "sha512-hTn/ZuBY4LYaqvprTdW3U+uU4xrw5JusxqHIhUzroQlrT6l4LFQRi+aJE/SOv09iS7eO/pqg6Ec3Go+gKiWH8A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@remusao/smaz/-/smaz-2.2.0.tgz",
+      "integrity": "sha512-eSd3Qs0ELP/e7tU1SI5RWXcCn9KjDgvBY+KtWbL4i2QvvHhJOfdIt4v0AA3S5BbLWAr5dCEC7C4LUfogDm6q/Q==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@remusao/smaz-compress": "^2.1.0",
-        "@remusao/smaz-decompress": "^2.1.0"
+        "@remusao/smaz-compress": "^2.2.0",
+        "@remusao/smaz-decompress": "^2.2.0"
       }
     },
     "node_modules/@remusao/smaz-compress": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@remusao/smaz-compress/-/smaz-compress-2.1.0.tgz",
-      "integrity": "sha512-IyuzXxd5F1p5WAvA6Td9ny+wh3sj9szMmdZtQ8Fb5/yE4lIwujXCz0e702u62r3XU47qsQcR/CjSRaw65u7iGA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@remusao/smaz-compress/-/smaz-compress-2.2.0.tgz",
+      "integrity": "sha512-TXpTPgILRUYOt2rEe0+9PC12xULPvBqeMpmipzB9A7oM4fa9Ztvy9lLYzPTd7tiQEeoNa1pmxihpKfJtsxnM/w==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@remusao/trie": "^2.0.0"
+        "@remusao/trie": "^2.1.0"
       }
     },
     "node_modules/@remusao/smaz-decompress": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@remusao/smaz-decompress/-/smaz-decompress-2.1.0.tgz",
-      "integrity": "sha512-TlM/ibBOMiCRniuBjv4x4nIcVbOb1o6DdK+p5OM+zHNndEu9za2C1Bd+PSqnsVCn15Fv2HcLVWGpqh2hKs9uuw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@remusao/smaz-decompress/-/smaz-decompress-2.2.0.tgz",
+      "integrity": "sha512-ERAPwxPaA0/yg4hkNU7T2S+lnp9jj1sApcQMtOyROvOQyo+Zuh6Hn/oRcXr8mmjlYzyRaC7E6r3mT1nrdHR6pg==",
       "license": "MPL-2.0"
     },
     "node_modules/@remusao/trie": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@remusao/trie/-/trie-2.0.0.tgz",
-      "integrity": "sha512-YmVfZrd+igKXJMuAvsNdDnUAyoNw7M+9e2ij6UsaZFZGQzLd75pbxhiuFmdphEXi/s3uXe25+wtFRWjLA2Ho0Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@remusao/trie/-/trie-2.1.0.tgz",
+      "integrity": "sha512-Er3Q8q0/2OcCJPQYJOPLmCuqO0wu7cav3SPtpjlxSbjFi1x+A1pZkkLD6c9q2rGEkGW/tkrRzfrhNMt8VQjzXg==",
       "license": "MPL-2.0"
     },
     "node_modules/@rollup/plugin-json": {
@@ -283,9 +283,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.18.tgz",
-      "integrity": "sha512-v1DKRfUdyW+jJhZNEI1PYy29S2YRxMV5AOO/x/SjKmW0acCIOqmbj6Haf9eHAhsPmrhlHSxEhv/1WszcLWV4cg==",
+      "version": "22.15.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.19.tgz",
+      "integrity": "sha512-3vMNr4TzNQyjHcRZadojpRaD9Ofr6LsonZAoQ+HMUa/9ORTPoxVIw0e0mpqWpdjj8xybyCM+oKOUH2vwFu/oEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^12.20.1",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.1.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.23.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.24.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1746537866"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass