### PR TITLE
use fully opaque ripple mask

### DIFF
--- a/common/common-ui/src/main/res/drawable/selectable_item_experimental_background.xml
+++ b/common/common-ui/src/main/res/drawable/selectable_item_experimental_background.xml
@@ -17,7 +17,18 @@
     android:color="?daxColorControlFillPrimary">
     <item android:id="@android:id/mask">
         <shape android:shape="rectangle">
-            <solid android:color="?attr/daxColorControlFillPrimary" />
+            <!--
+              Use a fully opaque (100% alpha) color for the mask.
+
+              The actual color doesn't matter, but devices handle the alpha channel differently:
+              - On tested devices, a 0% alpha mask makes the ripple effect invisible.
+              - On tested Pixels, any alpha > 0% applies the ripple color correctly.
+              - On tested Samsungs, the ripple alpha is affected by both the mask and the ripple color alpha,
+                summing them up and causing unexpected results.
+
+              To ensure consistent ripple visibility across devices, always use a fully opaque mask.
+            -->
+            <solid android:color="#FF000000" />
             <corners android:radius="14dp" />
         </shape>
     </item>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1210251609451213?focus=true

### Description
Uses a fully opaque (100% alpha) color for the ripple mask.

The actual color doesn't matter, but devices handle the alpha channel differently:
- On tested devices, a 0% alpha mask makes the ripple effect invisible.
- On tested Pixels, any alpha > 0% applies the ripple color correctly.
- On tested Samsungs, the ripple alpha is affected by both the mask and the ripple color alpha, summing them up and causing unexpected results.

To ensure consistent ripple visibility across devices, always use a fully opaque mask.

### Steps to test this PR

- [ ] Enable visual experiment changes.
- [ ] Verify that ripple is fully visible when clicking on buttons in the omnibar or navigation bar.
  - [ ] Test on a Samsung device.
  - [ ] Test on any other device.

### UI changes
| Before  | After |
| ------ | ----- |
![Screenshot_20250519_102345](https://github.com/user-attachments/assets/b32199ab-1ec9-4a17-8e3d-987396d9311d)|![Screenshot_20250519_102420](https://github.com/user-attachments/assets/58756e3d-917f-4d24-9915-3a91e3035fec)|

The screenshots come from a Samsung Tab S9+. You can see that on the _before_ screenshot, the ripple is barely visible because the 9% alpha of the color was summed with the 9% alpha of the mask (which was using the same color).