### PR TITLE
Add onboarding design experiment feature toggles

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboardingdesignexperiment/OnboardingDesignExperiment.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboardingdesignexperiment/OnboardingDesignExperiment.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboardingdesignexperiment
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
+
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "onboardingDesignExperiment",
+)
+interface OnboardingDesignExperimentToggles {
+
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun self(): Toggle
+
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun buckOnboarding(): Toggle
+}

--- a/app/src/main/java/com/duckduckgo/app/onboardingdesignexperiment/OnboardingDesignExperiment.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboardingdesignexperiment/OnboardingDesignExperiment.kt
@@ -25,11 +25,23 @@ import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
     scope = AppScope::class,
     featureName = "onboardingDesignExperiment",
 )
+/**
+ * Interface defining feature toggles for the onboarding design experiment.
+ * These toggles control specific features related to the onboarding process.
+ */
 interface OnboardingDesignExperimentToggles {
 
+    /**
+     * Toggle for enabling or disabling the "self" onboarding design experiment.
+     * Default value: false (disabled).
+     */
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 
+    /**
+     * Toggle for enabling or disabling the "buckOnboarding" design experiment.
+     * Default value: false (disabled).
+     */
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun buckOnboarding(): Toggle
 }


### PR DESCRIPTION
### Description

This PR adds a new remote feature toggle for the onboarding design experiment. The feature includes two toggles:
- `self()`: Main toggle for the entire experiment (default: OFF)
- `buckOnboarding()`: Toggle for the buck onboarding variant (default: OFF)

### Steps to test this PR

_Onboarding Design Experiment_
- [x] Confirm the default values for both toggles are set to FALSE