### PR TITLE
Remove Blocking Free Trial Experiment Code

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
@@ -428,12 +428,9 @@ class RealSubscriptionsManager @Inject constructor(
         packageName: String,
         purchaseToken: String,
     ): Boolean {
-        var experimentName: String? = null
-        var cohort: String? = null
-        experimentAssigned?.let { // FE experiment details
-            cohort = it.cohort
-            experimentName = it.name
-        }
+        // FE experiment details
+        val experimentName: String? = experimentAssigned?.name
+        val cohort: String? = experimentAssigned?.cohort
         return try {
             val confirmationResponse = subscriptionsService.confirm(
                 ConfirmationBody(

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
@@ -429,14 +429,10 @@ class RealSubscriptionsManager @Inject constructor(
         purchaseToken: String,
     ): Boolean {
         var experimentName: String? = null
-        var cohort: String? = privacyProFeature.get().privacyProFreeTrialJan25().getCohort()?.name
-        if (cohort != null) { // Android experiment
-            experimentName = "privacyProFreeTrialJan25"
-        } else {
-            experimentAssigned?.let { // FE experiment details
-                cohort = it.cohort
-                experimentName = it.name
-            }
+        var cohort: String? = null
+        experimentAssigned?.let { // FE experiment details
+            cohort = it.cohort
+            experimentName = it.name
         }
         return try {
             val confirmationResponse = subscriptionsService.confirm(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1210331174511735

### Description
Remove logic for sending Free trials experiment details to BE metrics

### Steps to test this PR

_Pre steps_
- [ ] Make sure you are Privacy Pro eligible
- [ ] Use a VPN connected to US

_Experiment data sent to BE_
- [ ] Apply patch attached in https://app.asana.com/1/137249556945/task/1210050331055612?focus=true
- [ ] Fresh install
- [ ] Go to Settings > Privacy Pro
- [ ] Check you see Free Trials Paywall
- [ ] Subscribe to a monthly or yearly product
- [ ] Check logs to confirm that experimentName is **not** `privacyProFreeTrialJan25` in `purchase/confirm` request. (Filter by `/confirm body` in logs)

### No UI changes
