### PR TITLE
fix an issue where omnibar would be stuck in wrong width after orientation change

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -185,7 +185,7 @@ open class OmnibarLayout @JvmOverloads constructor(
 
     private var previousTransitionState: TransitionState? = null
 
-    private val lifecycleOwner: LifecycleOwner by lazy {
+    protected val lifecycleOwner: LifecycleOwner by lazy {
         requireNotNull(findViewTreeLifecycleOwner())
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -185,7 +185,7 @@ open class OmnibarLayout @JvmOverloads constructor(
 
     private var previousTransitionState: TransitionState? = null
 
-    protected val lifecycleOwner: LifecycleOwner by lazy {
+    private val lifecycleOwner: LifecycleOwner by lazy {
         requireNotNull(findViewTreeLifecycleOwner())
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/FadeOmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/FadeOmnibarLayout.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.browser.omnibar.experiments
 
 import android.animation.ValueAnimator
 import android.content.Context
+import android.content.res.Configuration
 import android.util.AttributeSet
 import android.view.View
 import android.view.ViewGroup
@@ -33,6 +34,9 @@ import androidx.core.view.marginStart
 import androidx.core.view.marginTop
 import androidx.core.view.updateLayoutParams
 import androidx.core.view.updatePadding
+import androidx.lifecycle.findViewTreeLifecycleOwner
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.IncludeFadeOmnibarFindInPageBinding
@@ -47,10 +51,19 @@ import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.hide
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.view.toDp
+import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.mobile.android.R as CommonR
 import com.google.android.material.card.MaterialCardView
 import dagger.android.support.AndroidSupportInjection
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import timber.log.Timber
 
 @InjectWith(FragmentScope::class)
 class FadeOmnibarLayout @JvmOverloads constructor(
@@ -58,6 +71,8 @@ class FadeOmnibarLayout @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyle: Int = 0,
 ) : OmnibarLayout(context, attrs, defStyle) {
+
+    private val conflatedFocusStateJob = ConflatedJob()
 
     private val aiChatDivider: View by lazy { findViewById(R.id.verticalDivider) }
     private val omnibarCard: MaterialCardView by lazy { findViewById(R.id.omniBarContainer) }
@@ -68,17 +83,9 @@ class FadeOmnibarLayout @JvmOverloads constructor(
     override val findInPage: FindInPage by lazy {
         FindInPageImpl(IncludeFadeOmnibarFindInPageBinding.bind(findViewById(R.id.findInPage)))
     }
-    private var isFindInPageVisible = false
+    private var isFindInPageVisible = MutableStateFlow(false)
     private val findInPageLayoutVisibilityChangeListener = OnGlobalLayoutListener {
-        val isVisible = findInPage.findInPageContainer.isVisible
-        if (isFindInPageVisible != isVisible) {
-            isFindInPageVisible = isVisible
-            if (isVisible) {
-                onFindInPageShown()
-            } else {
-                onFindInPageHidden()
-            }
-        }
+        isFindInPageVisible.value = findInPage.findInPageContainer.isVisible
     }
 
     /**
@@ -142,14 +149,38 @@ class FadeOmnibarLayout @JvmOverloads constructor(
     }
 
     override fun onAttachedToWindow() {
+        Timber.d("lp_test; onAttachedToWindow")
         super.onAttachedToWindow()
         findInPage.findInPageContainer.viewTreeObserver.addOnGlobalLayoutListener(findInPageLayoutVisibilityChangeListener)
+
+        val coroutineScope = requireNotNull(findViewTreeLifecycleOwner()?.lifecycleScope)
+        conflatedFocusStateJob += coroutineScope.launch {
+            isFindInPageVisible.collect {
+                if (it) {
+                    onFindInPageShown()
+                } else {
+                    onFindInPageHidden()
+                }
+            }
+        }
+        conflatedFocusStateJob += coroutineScope.launch {
+            viewModel.viewState.flowWithLifecycle(lifecycleOwner.lifecycle)
+                .map { it.hasFocus }
+                .combine(isFindInPageVisible) { hasFocus, isFindInPageVisible ->
+                    hasFocus || isFindInPageVisible
+                }.distinctUntilChanged().collectLatest {
+                    animateOmnibarFocusedState(it)
+                }
+        }
     }
 
     override fun onDetachedFromWindow() {
+        Timber.d("lp_test; onDetachedFromWindow")
         super.onDetachedFromWindow()
+        conflatedFocusStateJob.cancel()
         focusAnimator?.cancel()
         findInPage.findInPageContainer.viewTreeObserver.removeOnGlobalLayoutListener(findInPageLayoutVisibilityChangeListener)
+        unlockContentDimensions()
     }
 
     override fun onSizeChanged(
@@ -169,18 +200,12 @@ class FadeOmnibarLayout @JvmOverloads constructor(
         super.render(viewState)
 
         renderShadows(viewState.showShadows)
-
-        if (viewState.hasFocus || isFindInPageVisible) {
-            animateOmnibarFocusedState(focused = true)
-        } else {
-            animateOmnibarFocusedState(focused = false)
-        }
     }
 
     override fun renderButtons(viewState: ViewState) {
         tabsMenu.isVisible = false
         fireIconMenu.isVisible = false
-        browserMenu.isVisible = viewState.viewMode is ViewMode.CustomTab && viewState.showBrowserMenu && !isFindInPageVisible
+        browserMenu.isVisible = viewState.viewMode is ViewMode.CustomTab && viewState.showBrowserMenu && !isFindInPageVisible.value
         browserMenuHighlight.isVisible = false
         clearTextButton.isVisible = viewState.showClearButton
         voiceSearchButton.isVisible = viewState.showVoiceSearch
@@ -290,6 +315,7 @@ class FadeOmnibarLayout @JvmOverloads constructor(
      * When focused, we resize the wrapping card to make the stroke appear "outside" but we don't want the content to expand with it.
      */
     private fun lockContentDimensions() {
+        Timber.d("lp_test ${this.hashCode()}; lock")
         omniBarContentContainer.updateLayoutParams {
             width = omniBarContentContainer.measuredWidth
             height = omniBarContentContainer.measuredHeight
@@ -301,6 +327,7 @@ class FadeOmnibarLayout @JvmOverloads constructor(
      * like resizing the app window or changing device orientation.
      */
     private fun unlockContentDimensions() {
+        Timber.d("lp_test ${this.hashCode()}; unlock")
         omniBarContentContainer.updateLayoutParams {
             width = ViewGroup.LayoutParams.MATCH_PARENT
             height = ViewGroup.LayoutParams.MATCH_PARENT
@@ -314,7 +341,6 @@ class FadeOmnibarLayout @JvmOverloads constructor(
             omniBarContainer.show()
             browserMenu.gone()
         }
-        animateOmnibarFocusedState(focused = true)
     }
 
     private fun onFindInPageHidden() {
@@ -323,9 +349,6 @@ class FadeOmnibarLayout @JvmOverloads constructor(
         if (viewModel.viewState.value.viewMode is ViewMode.CustomTab) {
             omniBarContainer.hide()
             browserMenu.isVisible = viewModel.viewState.value.showBrowserMenu
-        }
-        if (!viewModel.viewState.value.hasFocus) {
-            animateOmnibarFocusedState(focused = false)
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1157893581871903/task/1210317910216891?focus=true

### Description
Fixes an issue where omnibar would be stuck in wrong width after orientation change.

Initially, I thought this is because of the state update which occurs right after `onSizeChanged` and re-locks the dimensions but after refactoring the code to ensure animation is started only when needed, I realized that the issue was due to some race condition within the Android framework while the layout params were being updated directly in the `onSizeChanged` loop.

With the layout inspector, this is what I found out:
1. We are in an unfocused state, the card's content is `match_parent`, as expected:
![Screenshot from 2025-05-21 11-36-51](https://github.com/user-attachments/assets/a8a463bb-b6f7-433b-b616-7f1dedf61a1f)
2. We click into the omnibar and grab focus, the card's contents get locked so that they don't move while the card animates:
![Screenshot from 2025-05-21 11-37-05](https://github.com/user-attachments/assets/2f4d1685-7ac8-447a-833b-c98578cb86cb)
3. We rotate the screen and the dimensions get unlocked (they are `match_parent` now) but they view doesn't adjust to the new size.
![Screenshot from 2025-05-21 11-37-15](https://github.com/user-attachments/assets/99c1d55c-b794-4b13-9755-94bbcc606b2b)
4. Only after requesting another layout change by dropping focus (or by typing in another letter, or interacting with the omnibar in any other way) the view adjusts to the new width:
![Screenshot from 2025-05-21 11-37-26](https://github.com/user-attachments/assets/9ff1a126-b714-4422-b60f-b1c1a77d6884)

I found it reliable to wait for the first render loop to finish before unlocking the view, without having to refactor any animation state.

### Steps to test this PR

- [ ] Enable visual design flag.
- [ ] Focus on the omnibar and rotate the screen.
- [ ] Verify that the omnibar adjusts to the new width without needing to drop focus.
- [ ] Open "find in page" and rotate the screen.
- [ ] Verify that the "find in page" layout adjusts to the new width without needing to drop focus.
- [ ] When focus is dropped, the address bar shows without content jumping significantly.