### PR TITLE
Changed elevation and color of Paywall Toolbar

### DIFF
--- a/common/common-ui/src/main/res/values/design-system-colors.xml
+++ b/common/common-ui/src/main/res/values/design-system-colors.xml
@@ -69,6 +69,7 @@
     <!-- Component Specific Colors -->
     <attr name="daxColorToolbar" format="color"/>
     <attr name="daxColorBrowserOverlay" format="color"/>
+    <attr name="daxColorPaywallToolbar" format="color"/>
 
     <!-- Visual Design Specific Colors -->
     <attr name="daxColorControlFillPrimary" format="color"/>

--- a/common/common-ui/src/main/res/values/design-system-theming.xml
+++ b/common/common-ui/src/main/res/values/design-system-theming.xml
@@ -159,6 +159,9 @@
         <!-- App Tracking Protection -->
         <item name="appTPHeaderBackground">@color/black</item>
 
+        <!-- Privacy Pro -->
+        <item name="daxColorPaywallToolbar">@color/gray100</item>
+
         <!-- Design System Reference Colors Dark -->
         <item name="daxColorBackground">@color/gray100</item>
         <item name="daxColorBackgroundInverted">@color/gray0</item>
@@ -261,6 +264,9 @@
 
         <!-- App Tracking Protection -->
         <item name="appTPHeaderBackground">@color/white_60</item>
+
+        <!-- Privacy Pro -->
+        <item name="daxColorPaywallToolbar">@color/white</item>
 
         <!-- Design System Reference Colors Light -->
         <item name="daxColorBackground">@color/gray0</item>

--- a/subscriptions/subscriptions-impl/src/main/res/layout/privacy_pro_toolbar.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/layout/privacy_pro_toolbar.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (c) 2024 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,38 +14,39 @@
   ~ limitations under the License.
   -->
 
-<com.google.android.material.appbar.AppBarLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        android:id="@+id/appBarLayout"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:theme="@style/Widget.DuckDuckGo.ToolbarTheme">
+<com.google.android.material.appbar.AppBarLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/appBarLayout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:elevation="0dp"
+    android:stateListAnimator="@null"
+    android:theme="@style/Widget.DuckDuckGo.ToolbarTheme">
 
     <androidx.appcompat.widget.Toolbar
-            android:id="@+id/toolbar"
-            android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
-            android:background="?attr/daxColorToolbar"
-            android:theme="@style/Widget.DuckDuckGo.ToolbarTheme"
-            app:popupTheme="@style/Widget.DuckDuckGo.PopUpOverflowMenu">
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/daxColorPaywallToolbar"
+        android:theme="@style/Widget.DuckDuckGo.ToolbarTheme"
+        app:popupTheme="@style/Widget.DuckDuckGo.PopUpOverflowMenu">
 
         <androidx.appcompat.widget.AppCompatImageView
-                android:id="@+id/logoToolbar"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                app:srcCompat="@drawable/ic_subs_toolbar_logo"/>
+            android:id="@+id/logoToolbar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            app:srcCompat="@drawable/ic_subs_toolbar_logo" />
+
         <com.duckduckgo.common.ui.view.text.DaxTextView
-                android:id="@+id/titleToolbar"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:typography="h2"
-                android:layout_gravity="center"
-                android:layout_marginStart="@dimen/keyline_5"
-                app:textType="primary"
-                android:text="@string/privacyPro"
-        />
+            android:id="@+id/titleToolbar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginStart="@dimen/keyline_5"
+            android:text="@string/privacyPro"
+            app:textType="primary"
+            app:typography="h2" />
     </androidx.appcompat.widget.Toolbar>
 
 </com.google.android.material.appbar.AppBarLayout>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1210327090176041?focus=true

### Description
Change color and elevation of Paywall Toolbar so header and content match

### Steps to test this PR

_Light mode_
- [ ] Apply patch to be Privacy Pro eligible
- [ ] Set light mode
- [ ] Install from branch
- [ ] Go to Settings > Privacy Pro
- [ ] Check paywall toolbar matches updated specs and there is no difference between header and background

_Dark mode_
- [ ] Set dark mode
- [ ] Go to Settings > Privacy Pro
- [ ] Check paywall toolbar matches updated specs and there is no difference between header and background

### UI changes
| Before  | After |
| ------ | ----- |
![old-paywall-dark](https://github.com/user-attachments/assets/4ee2cfab-3686-4e05-a6b6-f9479202bffe)|![paywall-dark-mode](https://github.com/user-attachments/assets/66eafd7a-b02a-47fc-ac1d-ef72d8699b86)|
![old-paywall-light](https://github.com/user-attachments/assets/a6310bb1-03eb-44a4-a74f-a29fe34dfeb5)|![paywall-light-mode](https://github.com/user-attachments/assets/5f0d74dd-142e-4a81-ba53-177a626612b2)|