### PR TITLE
Fix: Settings toggle is reset on config change

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/generalsettings/GeneralSettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/GeneralSettingsActivity.kt
@@ -100,11 +100,7 @@ class GeneralSettingsActivity : DuckDuckGoActivity() {
     }
 
     private fun configureUiEventHandlers() {
-        binding.autocompleteToggle.setOnCheckedChangeListener(autocompleteToggleListener)
-        binding.autocompleteRecentlyVisitedSitesToggle.setOnCheckedChangeListener(autocompleteRecentlyVisitedSitesToggleListener)
-        binding.voiceSearchToggle.setOnCheckedChangeListener(voiceSearchChangeListener)
         binding.showOnAppLaunchButton.setOnClickListener(showOnAppLaunchClickListener)
-        binding.maliciousToggle.setOnCheckedChangeListener(maliciousSiteProtectionToggleListener)
     }
 
     private fun observeViewModel() {

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/DaxSwitch.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/DaxSwitch.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.common.ui.view
 
 import android.content.Context
-import android.os.Parcelable
 import android.util.AttributeSet
 import android.widget.CompoundButton
 import com.duckduckgo.mobile.android.R

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/DaxSwitch.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/DaxSwitch.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.common.ui.view
 
 import android.content.Context
+import android.os.Parcelable
 import android.util.AttributeSet
 import android.widget.CompoundButton
 import com.duckduckgo.mobile.android.R
@@ -30,7 +31,12 @@ class DaxSwitch @JvmOverloads constructor(
     ctx,
     attrs,
     defStyleAttr,
-)
+) {
+    override fun onSaveInstanceState(): Parcelable? {
+        super.onSaveInstanceState()
+        return null
+    }
+}
 
 fun DaxSwitch.quietlySetIsChecked(
     newCheckedState: Boolean,

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/DaxSwitch.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/DaxSwitch.kt
@@ -31,12 +31,7 @@ class DaxSwitch @JvmOverloads constructor(
     ctx,
     attrs,
     defStyleAttr,
-) {
-    override fun onSaveInstanceState(): Parcelable? {
-        super.onSaveInstanceState()
-        return null
-    }
-}
+)
 
 fun DaxSwitch.quietlySetIsChecked(
     newCheckedState: Boolean,

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatSettingsActivity.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatSettingsActivity.kt
@@ -88,26 +88,19 @@ class DuckChatSettingsActivity : DuckDuckGoActivity() {
 
         setupToolbar(binding.includeToolbar.toolbar)
 
-        configureUiEventHandlers()
         observeViewModel()
 
         pixel.fire(DUCK_CHAT_SETTINGS_DISPLAYED)
     }
 
-    private fun configureUiEventHandlers() {
-        binding.userEnabledDuckChatToggle.setOnCheckedChangeListener(userEnabledDuckChatToggleListener)
-        binding.showDuckChatInMenuToggle.setOnCheckedChangeListener(menuToggleListener)
-        binding.showDuckChatInAddressBarToggle.setOnCheckedChangeListener(addressBarToggleListener)
-    }
-
     private fun observeViewModel() {
         viewModel.viewState
-            .flowWithLifecycle(lifecycle, Lifecycle.State.CREATED)
+            .flowWithLifecycle(lifecycle, Lifecycle.State.RESUMED)
             .onEach { renderViewState(it) }
             .launchIn(lifecycleScope)
 
         viewModel.commands
-            .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
+            .flowWithLifecycle(lifecycle, Lifecycle.State.CREATED)
             .onEach { processCommand(it) }
             .launchIn(lifecycleScope)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1210337463408658?focus=true

### Description

The toggle's view state that gets restored after a configuration change triggers the `OnCheckChanged` listeners and resets the saved values on settings screens that use it. This PR disables the view state saving, which fixes the issue.

### Steps to test this PR

_General settings_
- [x] Go to Settings -> General
- [x] Change one of the toggles
- [x] Rotate the device
- [x] Notice the toggle stays the same

_Duck.AI settings_
- [x] Go to Settings -> Duck.AI
- [x] Change one of the toggles
- [x] Rotate the device
- [x] Notice the toggle stays the same

### UI changes
Before

[Screen_recording_20250521_151134.webm](https://github.com/user-attachments/assets/8745ac50-3e5a-471d-87ab-d026a1a22d31)

After

[Screen_recording_20250521_150543.webm](https://github.com/user-attachments/assets/7b477bec-4ab9-490d-9ae3-2512b6e8a715)

