### PR TITLE
Move RMF jsonAdapter to lazy

### DIFF
--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/di/RMFMapperModule.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/di/RMFMapperModule.kt
@@ -34,6 +34,7 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import dagger.Lazy
 import dagger.Module
 import dagger.Provides
 import dagger.SingleInstanceIn
@@ -45,7 +46,7 @@ object RMFMapperModule {
     @Provides
     @SingleInstanceIn(AppScope::class)
     fun providesMessageMapper(
-        messageAdapter: JsonAdapter<RemoteMessage>,
+        messageAdapter: Lazy<JsonAdapter<RemoteMessage>>,
     ): MessageMapper {
         return MessageMapper(messageAdapter)
     }

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/mappers/MessageMapper.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/mappers/MessageMapper.kt
@@ -18,18 +18,19 @@ package com.duckduckgo.remote.messaging.impl.mappers
 
 import com.duckduckgo.remote.messaging.api.RemoteMessage
 import com.squareup.moshi.JsonAdapter
+import dagger.Lazy
 
 class MessageMapper(
-    private val messageAdapter: JsonAdapter<RemoteMessage>,
+    private val messageAdapter: Lazy<JsonAdapter<RemoteMessage>>,
 ) {
 
     fun toString(sitePayload: RemoteMessage): String {
-        return messageAdapter.toJson(sitePayload)
+        return messageAdapter.get().toJson(sitePayload)
     }
 
     fun fromMessage(payload: String): RemoteMessage? {
         return runCatching {
-            messageAdapter.fromJson(payload)
+            messageAdapter.get().fromJson(payload)
         }.getOrNull()
     }
 }

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/fixtures/TestMessageMapper.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/fixtures/TestMessageMapper.kt
@@ -16,7 +16,18 @@
 
 package com.duckduckgo.remote.messaging.fixtures
 
+import com.duckduckgo.remote.messaging.api.RemoteMessage
 import com.duckduckgo.remote.messaging.impl.di.RMFMapperModule
 import com.duckduckgo.remote.messaging.impl.mappers.MessageMapper
+import com.squareup.moshi.JsonAdapter
+import dagger.Lazy
 
-fun getMessageMapper() = MessageMapper(RMFMapperModule.provideMoshiAdapter(messageActionPlugins))
+fun getMessageMapper(): MessageMapper {
+    val lazyAdapter = object : Lazy<JsonAdapter<RemoteMessage>> {
+        override fun get(): JsonAdapter<RemoteMessage> {
+            return RMFMapperModule.provideMoshiAdapter(messageActionPlugins)
+        }
+    }
+
+    return MessageMapper(lazyAdapter)
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1210331622687071?focus=true

### Description
Moves creation of RMF JsonAdapter to lazy so it inits on background thread

### Steps to test this PR

_Feature 1_
- [ ] Put a `Thread.sleep(20_000)` in RMFMapperModule L59 (first line in `provideMoshiAdapter`)
- [ ] Update RemoteMessagingService endpoint to `https://www.jsonblob.com/api/1374757173657264128`
- [ ] Install the app
- [ ] Run the app
- [ ] Should not freeze, you can interact with the app
- [ ] in 20 seconds RMF will appear

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
