### PR TITLE
VPN/AppTP: Fix incorrect reporting for motogFix

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
@@ -45,6 +45,7 @@ import com.duckduckgo.di.scopes.VpnScope
 import com.duckduckgo.library.loader.LibraryLoader
 import com.duckduckgo.mobile.android.vpn.dao.VpnServiceStateStatsDao
 import com.duckduckgo.mobile.android.vpn.feature.AppTpRemoteFeatures
+import com.duckduckgo.mobile.android.vpn.integration.NgVpnNetworkStack
 import com.duckduckgo.mobile.android.vpn.integration.VpnNetworkStackProvider
 import com.duckduckgo.mobile.android.vpn.model.AlwaysOnState
 import com.duckduckgo.mobile.android.vpn.model.VpnServiceState
@@ -406,9 +407,8 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope(), V
         // see https://app.asana.com/0/488551667048375/1203410036713941/f for more info
         tunnelConfig?.let { config ->
             // TODO this is temporary hack until we know this approach works for moto g. If it does we'll spend time making it better/more permanent
-            if (config.dns.map { it.hostAddress }.contains("10.11.12.1")) {
-                // noop whenever NetP is enabled
-            } else if (config.dns.isNotEmpty()) {
+            if (vpnNetworkStack is NgVpnNetworkStack && config.dns.isNotEmpty()) {
+                // This solution is only relevant for AppTP
                 // just temporary pixel to know quantify how many users would be impacted
                 deviceShieldPixels.reportMotoGFix()
                 dnsChangeCallback.register()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208589375218614/task/1210288585414843?focus=true

### Description
The motog workaround is executed in the NgVpnNetworkStack.
We only need to report the fix when it is actually implemented.

### Steps to test this PR

- [ ] Fresh install app on a [valid device](https://github.com/duckduckgo/Android/blob/782de178cf0c950fea42df07a9fc6bfab65fbbb8/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/integration/NgVpnNetworkStack.kt#L105-L113) if you don’t have, modify code to include your device’s model 
- [ ] Obtain a Privacy Pro subscription
- [ ] Filter logcat ”m_vpn_ev_moto_g_fix_d”
- [ ] Enable VPN
- [ ] Verify that logcat doesn’t show anything.
- [ ] Enable AppTP
- [ ] Verify that logcat doesn’t show anything.
- [ ] Disable VPN
- [ ] Verify that logcat shows an entry for m_vpn_ev_moto_g_fix_d

