### PR TITLE
Add error and message to privacy config download error pixel

### DIFF
--- a/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/RealPrivacyConfigDownloaderTest.kt
+++ b/privacy-config/privacy-config-impl/src/test/java/com/duckduckgo/privacy/config/impl/RealPrivacyConfigDownloaderTest.kt
@@ -69,7 +69,7 @@ class RealPrivacyConfigDownloaderTest {
                 pixel,
             )
         assertTrue(testee.download() is Error)
-        verify(pixel).fire("m_privacy_config_download_error")
+        verify(pixel).fire("m_privacy_config_download_error", mapOf("code" to "unknown", "message" to "unknown"))
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1210365417691801?focus=true 

### Description
This PR adds an error code and message to the privacy config download error pixel

### Steps to test this PR

- [x] Throw an exception in the `RealPrivacyConfigDownloader` when downloading the remote config and check the pixel has the message
- [ ] You can also change the privacy config url for this.

