### PR TITLE
Update reference tests to version 1747996876

### DIFF
--- a/malicious-site-protection/malicious-site-protection-impl/src/test/resources/reference_tests/canonicalization/canonicalization_tests.json
+++ b/malicious-site-protection/malicious-site-protection-impl/src/test/resources/reference_tests/canonicalization/canonicalization_tests.json
@@ -74,6 +74,15 @@
                     "web-extension",
                     "safari-extension"
                 ]
+            },
+            {
+                "name": "multiple encoded slashes in path with www. prefix",
+                "siteURL": "https://www.broken.third-party.site/path/to/%2F%2F%2F%2F%2F%2F%2F%2F%2F",
+                "expectURL": "https://broken.third-party.site/path/to",
+                "exceptPlatforms": [
+                    "web-extension",
+                    "safari-extension"
+                ]
             }
         ]
     },
@@ -84,49 +93,49 @@
             {
                 "name": "Simple domain - extract hostname portion from the URL",
                 "siteURL": "http://www.somesite.com",
-                "expectDomain": "www.somesite.com",
+                "expectDomain": "somesite.com",
                 "exceptPlatforms": []
             },
             {
                 "name": "Simple domain with a port",
                 "siteURL": "http://www.somesite.com:8000/",
-                "expectDomain": "www.somesite.com",
+                "expectDomain": "somesite.com",
                 "exceptPlatforms": []
             },
             {
                 "name": "Simple domain with a username",
                 "siteURL": "http://user:pass@www.somesite.com",
-                "expectDomain": "www.somesite.com",
+                "expectDomain": "somesite.com",
                 "exceptPlatforms": []
             },
             {
                 "name": "Simple domain with a fragment",
                 "siteURL": "http://www.somesite.com#fragment",
-                "expectDomain": "www.somesite.com",
+                "expectDomain": "somesite.com",
                 "exceptPlatforms": []
             },
             {
                 "name": "Simple domain with a query string",
                 "siteURL": "http://www.somesite.com?some=value",
-                "expectDomain": "www.somesite.com",
+                "expectDomain": "somesite.com",
                 "exceptPlatforms": []
             },
             {
                 "name": "Decode any %XX escapes present in the hostname",
                 "siteURL": "http://www.%73ome%73ite.com",
-                "expectDomain": "www.somesite.com",
+                "expectDomain": "somesite.com",
                 "exceptPlatforms": ["windows-browser"]
             },
             {
                 "name": "Discard any leading and/or trailing full-stops",
                 "siteURL": "http://.www.somesite.com.",
-                "expectDomain": "www.somesite.com",
+                "expectDomain": "somesite.com",
                 "exceptPlatforms": ["windows-browser"]
             },
             {
                 "name": "Replace sequences of two or more full-stops with a single full-stop.",
                 "siteURL": "http://www..example...com",
-                "expectDomain": "www.example.com",
+                "expectDomain": "example.com",
                 "exceptPlatforms": ["windows-browser"]
             },
             {
@@ -146,7 +155,13 @@
                 "siteURL": "http://192.168.001.001:8080/",
                 "expectDomain": "192.168.1.1",
                 "exceptPlatforms": []
-            }            
+            },
+            {
+                "name": "If there are more than six components in the resulting hostname, discard all but the rightmost six components after removing www prefix.",
+                "siteURL": "http://www.a.b.c.d.e.f.g.h.i.j.example.com",
+                "expectDomain": "g.h.i.j.example.com",
+                "exceptPlatforms": []
+            }
         ]
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.1.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.24.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
-        "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1746537866"
+        "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1747996876"
       },
       "devDependencies": {
         "@rollup/plugin-json": "^4.1.0",
@@ -84,36 +84,36 @@
       }
     },
     "node_modules/@duckduckgo/privacy-reference-tests": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#62791eb0363a7c4fbb4a84cbbb94995da55e0277",
+      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#47a71fcdbd1277bc2020d1239945ca6bdb22c74d",
       "license": "Apache-2.0"
     },
     "node_modules/@ghostery/adblocker": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.5.2.tgz",
-      "integrity": "sha512-/SLxUGPd1JISNGOPsxKfbso+uylDEvEp3umF5gQ3x8YgsEZzD6zYx7H4ZQxAvG1pZIr4p6N9PiAf2N88T1Wo1Q==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.6.1.tgz",
+      "integrity": "sha512-D9sLqx+StZ3JASDqKtTWUmVXRacbtZAcMUnooU0TQKcMmIeSF20TbIwde2bc+zoz1q+dV/qtYx2ngWf1Jb9KbA==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-content": "^2.5.2",
-        "@ghostery/adblocker-extended-selectors": "^2.5.2",
-        "@remusao/guess-url-type": "^2.0.0",
-        "@remusao/small": "^2.0.0",
-        "@remusao/smaz": "^2.1.0",
+        "@ghostery/adblocker-content": "^2.6.1",
+        "@ghostery/adblocker-extended-selectors": "^2.6.1",
+        "@remusao/guess-url-type": "^2.1.0",
+        "@remusao/small": "^2.1.0",
+        "@remusao/smaz": "^2.2.0",
         "tldts-experimental": "^7.0.0"
       }
     },
     "node_modules/@ghostery/adblocker-content": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.5.2.tgz",
-      "integrity": "sha512-H3e4QZsom7HqVgIBLaoHriqRh27MyXgwC43ClidOXXbCtKn6h7c3wc9TnQssQpXpcyV7HRPmWjMtADzUc+yYKg==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.6.1.tgz",
+      "integrity": "sha512-R0/X+16r1qsGSbef2UPWC35dq2+iObljLZ04lSYWz5s2fVgSu6g+qlmuPMOdB3mm/YLd+ZyQOQ/8UuSi65afGg==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-extended-selectors": "^2.5.2"
+        "@ghostery/adblocker-extended-selectors": "^2.6.1"
       }
     },
     "node_modules/@ghostery/adblocker-extended-selectors": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.5.2.tgz",
-      "integrity": "sha512-Z2MQ4BiPTPG3cI1CFF1cE0IywL1EM2KGnOVkKEx62fnkO0aRyvAeja0jhQvjENtY/hixWLrsSg3MU95Clvq23g==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.6.1.tgz",
+      "integrity": "sha512-ZNVmSan8gMaUfC6TWN/m7gErXtCMVTTWJQ7fkpd3na/GCOGMv3NbSV8fed50eK2ck2qGTNqLVPEQp+h/u/pE0w==",
       "license": "MPL-2.0"
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -181,46 +181,46 @@
       }
     },
     "node_modules/@remusao/guess-url-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@remusao/guess-url-type/-/guess-url-type-2.0.0.tgz",
-      "integrity": "sha512-L98gV/X/GESt5Tgqq/PxpZYClVqeq6/5InrRKl4elq4qXbdZjHlNTgRhXb1xIaUBkikzv410sXw3QaBUYyXt8g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@remusao/guess-url-type/-/guess-url-type-2.1.0.tgz",
+      "integrity": "sha512-zI3dlTUxpjvx2GCxp9nLOSK5yEIqDCpxlAVGwb2Y49RKkS72oeNaxxo+VWS5+XQ5+Mf8Zfp9ZXIlk+G5eoEN8A==",
       "license": "MPL-2.0"
     },
     "node_modules/@remusao/small": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@remusao/small/-/small-2.0.0.tgz",
-      "integrity": "sha512-1ksGCbl1hSeO4CV/uk0qv2vUdZ1ZRdIMzSn0HFsHTJnmWSDk2li+T5eCI9BtweYe0uVQhCvbMjk/3qwsN6fuYg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@remusao/small/-/small-2.1.0.tgz",
+      "integrity": "sha512-Y1kyjZp7JU7dXdyOdxHVNfoTr1XLZJTyQP36/esZUU/WRWq9XY0PV2HsE3CsIHuaTf4pvgWv2pvzvnZ//UHIJQ==",
       "license": "MPL-2.0"
     },
     "node_modules/@remusao/smaz": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@remusao/smaz/-/smaz-2.1.0.tgz",
-      "integrity": "sha512-hTn/ZuBY4LYaqvprTdW3U+uU4xrw5JusxqHIhUzroQlrT6l4LFQRi+aJE/SOv09iS7eO/pqg6Ec3Go+gKiWH8A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@remusao/smaz/-/smaz-2.2.0.tgz",
+      "integrity": "sha512-eSd3Qs0ELP/e7tU1SI5RWXcCn9KjDgvBY+KtWbL4i2QvvHhJOfdIt4v0AA3S5BbLWAr5dCEC7C4LUfogDm6q/Q==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@remusao/smaz-compress": "^2.1.0",
-        "@remusao/smaz-decompress": "^2.1.0"
+        "@remusao/smaz-compress": "^2.2.0",
+        "@remusao/smaz-decompress": "^2.2.0"
       }
     },
     "node_modules/@remusao/smaz-compress": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@remusao/smaz-compress/-/smaz-compress-2.1.0.tgz",
-      "integrity": "sha512-IyuzXxd5F1p5WAvA6Td9ny+wh3sj9szMmdZtQ8Fb5/yE4lIwujXCz0e702u62r3XU47qsQcR/CjSRaw65u7iGA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@remusao/smaz-compress/-/smaz-compress-2.2.0.tgz",
+      "integrity": "sha512-TXpTPgILRUYOt2rEe0+9PC12xULPvBqeMpmipzB9A7oM4fa9Ztvy9lLYzPTd7tiQEeoNa1pmxihpKfJtsxnM/w==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@remusao/trie": "^2.0.0"
+        "@remusao/trie": "^2.1.0"
       }
     },
     "node_modules/@remusao/smaz-decompress": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@remusao/smaz-decompress/-/smaz-decompress-2.1.0.tgz",
-      "integrity": "sha512-TlM/ibBOMiCRniuBjv4x4nIcVbOb1o6DdK+p5OM+zHNndEu9za2C1Bd+PSqnsVCn15Fv2HcLVWGpqh2hKs9uuw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@remusao/smaz-decompress/-/smaz-decompress-2.2.0.tgz",
+      "integrity": "sha512-ERAPwxPaA0/yg4hkNU7T2S+lnp9jj1sApcQMtOyROvOQyo+Zuh6Hn/oRcXr8mmjlYzyRaC7E6r3mT1nrdHR6pg==",
       "license": "MPL-2.0"
     },
     "node_modules/@remusao/trie": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@remusao/trie/-/trie-2.0.0.tgz",
-      "integrity": "sha512-YmVfZrd+igKXJMuAvsNdDnUAyoNw7M+9e2ij6UsaZFZGQzLd75pbxhiuFmdphEXi/s3uXe25+wtFRWjLA2Ho0Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@remusao/trie/-/trie-2.1.0.tgz",
+      "integrity": "sha512-Er3Q8q0/2OcCJPQYJOPLmCuqO0wu7cav3SPtpjlxSbjFi1x+A1pZkkLD6c9q2rGEkGW/tkrRzfrhNMt8VQjzXg==",
       "license": "MPL-2.0"
     },
     "node_modules/@rollup/plugin-json": {
@@ -283,9 +283,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.14.tgz",
-      "integrity": "sha512-BL1eyu/XWsFGTtDWOYULQEs4KR0qdtYfCxYAUYRoB7JP7h9ETYLgQTww6kH8Sj2C0pFGgrpM0XKv6/kbIzYJ1g==",
+      "version": "22.15.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.21.tgz",
+      "integrity": "sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -651,14 +651,14 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
-      "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
+      "version": "5.39.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.2.tgz",
+      "integrity": "sha512-yEPUmWve+VA78bI71BW70Dh0TuV4HHd+I5SHOAfS1+QBOmvmCiiffgjR8ryyEd3KIfvPGFqoADt8LdQ6XpXIvg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.8.2",
+        "acorn": "^8.14.0",
         "commander": "^2.20.0",
         "source-map-support": "~0.5.20"
       },
@@ -670,18 +670,18 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.6.tgz",
-      "integrity": "sha512-HZeeJrplG9y+sJx6VNcMKfbpY9UEq+JI0JRqE66Dm81QmclDgygaKOIwkeX8atmiQraJV2w4JbYI3wfCbw319w==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.7.tgz",
+      "integrity": "sha512-ECqb8imSroX1UmUuhRBNPkkmtZ8mHEenieim80UVxG0M5wXVjY2Fp2tYXCPvk+nLy1geOhFpeD5YQhM/gF63Jg==",
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.6.tgz",
-      "integrity": "sha512-aetoYSqSsxUPBBMuQGc0b3g/q1auci10DrndrzyzPscOHleL+f/Yh2SMVp90vJGc0Q+I/KBfp62xjTwiHHgzNQ==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.7.tgz",
+      "integrity": "sha512-V055ViO8G6PbTBfaiL1Utq/MLUqFZKhJ1c9+T8t+c1uPmVSAl7rR6ib8y0lleN18niKV6f1/zmMlAhpFEaPY9w==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.6"
+        "tldts-core": "^7.0.7"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.1.0",
     "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#8.24.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
-    "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1746537866"
+    "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1747996876"
   }
 }


### PR DESCRIPTION
- Automated reference tests dependency update

This PR updates the reference tests dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/0/1203766026095653/f for further information on what to do next.

- [ ] All tests must pass