### PR TITLE
Sense of Protection Experiemnt: Add new experiment names

### DIFF
--- a/app/src/internal/java/experiments/trackersblocking/TrackersBlockingExperimentViewModel.kt
+++ b/app/src/internal/java/experiments/trackersblocking/TrackersBlockingExperimentViewModel.kt
@@ -58,7 +58,7 @@ class TrackersBlockingExperimentViewModel @Inject constructor(
         viewModelScope.launch(dispatchers.io()) {
             val enrollmentDateET = ZonedDateTime.now(ZoneId.of("America/New_York")).toString()
             if (checked) {
-                senseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().setRawStoredState(
+                senseOfProtectionToggles.senseOfProtectionExistingUserExperiment27May25().setRawStoredState(
                     State(
                         remoteEnableState = true,
                         enable = true,
@@ -71,7 +71,7 @@ class TrackersBlockingExperimentViewModel @Inject constructor(
                     ),
                 )
             } else {
-                senseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().setRawStoredState(
+                senseOfProtectionToggles.senseOfProtectionExistingUserExperiment27May25().setRawStoredState(
                     State(
                         remoteEnableState = false,
                         enable = false,
@@ -93,7 +93,7 @@ class TrackersBlockingExperimentViewModel @Inject constructor(
         viewModelScope.launch(dispatchers.io()) {
             val enrollmentDateET = ZonedDateTime.now(ZoneId.of("America/New_York")).toString()
             if (checked) {
-                senseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().setRawStoredState(
+                senseOfProtectionToggles.senseOfProtectionExistingUserExperiment27May25().setRawStoredState(
                     State(
                         remoteEnableState = true,
                         enable = true,
@@ -106,7 +106,7 @@ class TrackersBlockingExperimentViewModel @Inject constructor(
                     ),
                 )
             } else {
-                senseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().setRawStoredState(
+                senseOfProtectionToggles.senseOfProtectionExistingUserExperiment27May25().setRawStoredState(
                     State(
                         remoteEnableState = false,
                         enable = false,
@@ -128,7 +128,7 @@ class TrackersBlockingExperimentViewModel @Inject constructor(
         viewModelScope.launch(dispatchers.io()) {
             val enrollmentDateET = ZonedDateTime.now(ZoneId.of("America/New_York")).toString()
             if (checked) {
-                senseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().setRawStoredState(
+                senseOfProtectionToggles.senseOfProtectionExistingUserExperiment27May25().setRawStoredState(
                     State(
                         remoteEnableState = true,
                         enable = true,
@@ -141,7 +141,7 @@ class TrackersBlockingExperimentViewModel @Inject constructor(
                     ),
                 )
             } else {
-                senseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().setRawStoredState(
+                senseOfProtectionToggles.senseOfProtectionExistingUserExperiment27May25().setRawStoredState(
                     State(
                         remoteEnableState = false,
                         enable = false,

--- a/app/src/main/java/com/duckduckgo/app/browser/senseofprotection/SenseOfProtectionExperimentImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/senseofprotection/SenseOfProtectionExperimentImpl.kt
@@ -143,11 +143,11 @@ class SenseOfProtectionExperimentImpl @Inject constructor(
     }
 
     private fun enrollInNewUserExperiment(cohortName: CohortName): Boolean {
-        return senseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().isEnabled(cohortName)
+        return senseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25().isEnabled(cohortName)
     }
 
     private fun enrollInExistingUserExperiment(cohortName: CohortName): Boolean {
-        return senseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().isEnabled(cohortName)
+        return senseOfProtectionToggles.senseOfProtectionExistingUserExperiment27May25().isEnabled(cohortName)
     }
 
     private fun isUserEnrolledInNewUserExperimentModifiedControlCohortAndExperimentEnabled(): Boolean =
@@ -183,22 +183,22 @@ class SenseOfProtectionExperimentImpl @Inject constructor(
     }
 
     private fun isNewUserExperimentEnabled(cohortName: CohortName): Boolean =
-        senseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().isEnrolledAndEnabled(cohortName)
+        senseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25().isEnrolledAndEnabled(cohortName)
 
     private fun isExistingUserExperimentEnabled(cohortName: CohortName): Boolean =
-        senseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().isEnrolledAndEnabled(cohortName)
+        senseOfProtectionToggles.senseOfProtectionExistingUserExperiment27May25().isEnrolledAndEnabled(cohortName)
 
     private fun getNewUserExperimentCohortName(): String? =
-        senseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().getCohort()?.name
+        senseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25().getCohort()?.name
 
     private fun getNewUserExperimentName(): String =
-        senseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().featureName().name
+        senseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25().featureName().name
 
     private fun getExistingUserExperimentCohortName(): String? =
-        senseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().getCohort()?.name
+        senseOfProtectionToggles.senseOfProtectionExistingUserExperiment27May25().getCohort()?.name
 
     private fun getExistingUserExperimentName(): String =
-        senseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().featureName().name
+        senseOfProtectionToggles.senseOfProtectionExistingUserExperiment27May25().featureName().name
 
     private fun MetricsPixel.fire() = getPixelDefinitions().forEach {
         pixel.fire(it.pixelName, it.params)

--- a/app/src/main/java/com/duckduckgo/app/browser/senseofprotection/SenseOfProtectionExperimentToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/senseofprotection/SenseOfProtectionExperimentToggles.kt
@@ -40,10 +40,10 @@ interface SenseOfProtectionToggles {
     fun self(): Toggle
 
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
-    fun senseOfProtectionNewUserExperimentMay25(): Toggle
+    fun senseOfProtectionNewUserExperiment27May25(): Toggle
 
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
-    fun senseOfProtectionExistingUserExperimentMay25(): Toggle
+    fun senseOfProtectionExistingUserExperiment27May25(): Toggle
 
     enum class Cohorts(override val cohortName: String) : CohortName {
         MODIFIED_CONTROL("modifiedControl"), // without grey tracker logos from original animation

--- a/app/src/main/java/com/duckduckgo/app/survey/rmf/TemporaryDefaultSurveyParameters.kt
+++ b/app/src/main/java/com/duckduckgo/app/survey/rmf/TemporaryDefaultSurveyParameters.kt
@@ -29,5 +29,5 @@ class SenseOfProtectionCohortSurveyParameterPlugin @Inject constructor(
 ) : SurveyParameterPlugin {
     override val surveyParamKey: String = "senseProtectionCohort"
 
-    override suspend fun evaluate(): String = senseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().getCohort()?.name.orEmpty()
+    override suspend fun evaluate(): String = senseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25().getCohort()?.name.orEmpty()
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/senseofprotection/SenseOfProtectionExperimentImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/senseofprotection/SenseOfProtectionExperimentImplTest.kt
@@ -85,7 +85,7 @@ class SenseOfProtectionExperimentImplTest {
     fun `when user is new and and visual design updates not enabled then user can be enrolled`() {
         whenever(mockExperimentDataStore.isExperimentEnabled).thenReturn(MutableStateFlow(false))
         fakeUserBrowserProperties.setDaysSinceInstalled(28)
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -103,7 +103,7 @@ class SenseOfProtectionExperimentImplTest {
     fun `when user is new and and visual design updates not enabled then user can't be enrolled`() {
         whenever(mockExperimentDataStore.isExperimentEnabled).thenReturn(MutableStateFlow(true))
         fakeUserBrowserProperties.setDaysSinceInstalled(28)
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -121,7 +121,7 @@ class SenseOfProtectionExperimentImplTest {
     fun `when user is new and experiment is enabled but for different cohort then isEnabled returns false`() {
         whenever(mockExperimentDataStore.isExperimentEnabled).thenReturn(MutableStateFlow(false))
         fakeUserBrowserProperties.setDaysSinceInstalled(20)
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -137,7 +137,7 @@ class SenseOfProtectionExperimentImplTest {
     fun `when user is new and experiment is disabled then isEnabled returns false`() {
         whenever(mockExperimentDataStore.isExperimentEnabled).thenReturn(MutableStateFlow(false))
         fakeUserBrowserProperties.setDaysSinceInstalled(10)
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25().setRawStoredState(
             State(
                 remoteEnableState = false,
                 enable = false,
@@ -151,7 +151,7 @@ class SenseOfProtectionExperimentImplTest {
 
     @Test
     fun `when user is enrolled in new user experiment then getTabManagerPixelParams returns new user experiment params`() {
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -163,12 +163,12 @@ class SenseOfProtectionExperimentImplTest {
         val params = testee.getTabManagerPixelParams()
 
         assertEquals(VARIANT_1.cohortName, params["cohort"])
-        assertEquals(fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().featureName().name, params["experiment"])
+        assertEquals(fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25().featureName().name, params["experiment"])
     }
 
     @Test
     fun `when user is enrolled in new user experiment but experiment is disabled then getTabManagerPixelParams returns empty map`() {
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25().setRawStoredState(
             State(
                 remoteEnableState = false,
                 enable = false,
@@ -184,7 +184,7 @@ class SenseOfProtectionExperimentImplTest {
 
     @Test
     fun `when user is enrolled in existing user experiment then getTabManagerPixelParams returns existing user experiment params`() {
-        fakeSenseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionExistingUserExperiment27May25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -196,12 +196,12 @@ class SenseOfProtectionExperimentImplTest {
         val params = testee.getTabManagerPixelParams()
 
         assertEquals(VARIANT_2.cohortName, params["cohort"])
-        assertEquals(fakeSenseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().featureName().name, params["experiment"])
+        assertEquals(fakeSenseOfProtectionToggles.senseOfProtectionExistingUserExperiment27May25().featureName().name, params["experiment"])
     }
 
     @Test
     fun `when user is enrolled in existing user experiment but experiment is disabled then getTabManagerPixelParams returns empty map`() {
-        fakeSenseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionExistingUserExperiment27May25().setRawStoredState(
             State(
                 remoteEnableState = false,
                 enable = false,
@@ -218,7 +218,7 @@ class SenseOfProtectionExperimentImplTest {
     @Test
     fun `when user is not enrolled in any experiment then getTabManagerPixelParams returns empty map`() {
         fakeUserBrowserProperties.setDaysSinceInstalled(30)
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25().setRawStoredState(
             State(
                 remoteEnableState = false,
                 enable = false,
@@ -226,7 +226,7 @@ class SenseOfProtectionExperimentImplTest {
                 cohorts = emptyList(),
             ),
         )
-        fakeSenseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionExistingUserExperiment27May25().setRawStoredState(
             State(
                 remoteEnableState = false,
                 enable = false,
@@ -242,7 +242,7 @@ class SenseOfProtectionExperimentImplTest {
 
     @Test
     fun `when user is enrolled in modified control variant then we can detect it`() {
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -260,7 +260,7 @@ class SenseOfProtectionExperimentImplTest {
 
     @Test
     fun `when user is enrolled in variant 1 then other variants are not enabled`() {
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -278,7 +278,7 @@ class SenseOfProtectionExperimentImplTest {
 
     @Test
     fun `when user is enrolled in variant 2 then other variants are not enabled`() {
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -297,7 +297,7 @@ class SenseOfProtectionExperimentImplTest {
     @Test
     fun `when user is enrolled in modified control then legacy privacy shield is shown`() {
         fakeUserBrowserProperties.setDaysSinceInstalled(20)
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -312,7 +312,7 @@ class SenseOfProtectionExperimentImplTest {
     @Test
     fun `when user is not enrolled in any variant`() {
         fakeUserBrowserProperties.setDaysSinceInstalled(20)
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -326,7 +326,7 @@ class SenseOfProtectionExperimentImplTest {
     @Test
     fun `when user is enrolled in variant 1 then new privacy shield is shown`() {
         fakeUserBrowserProperties.setDaysSinceInstalled(20)
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -341,7 +341,7 @@ class SenseOfProtectionExperimentImplTest {
     @Test
     fun `when user is enrolled in variant 2 then new privacy shield is shown`() {
         fakeUserBrowserProperties.setDaysSinceInstalled(20)
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,

--- a/app/src/test/java/com/duckduckgo/app/survey/rmf/TemporaryDefaultSurveyParametersPluginTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/survey/rmf/TemporaryDefaultSurveyParametersPluginTest.kt
@@ -22,7 +22,7 @@ class TemporaryDefaultSurveyParametersPluginTest {
             on { it.isEnabled() } doReturn true
             on { it.getCohort() } doReturn modifiedControlCohort
         }
-        whenever(mockSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25()).thenReturn(mockToggle)
+        whenever(mockSenseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25()).thenReturn(mockToggle)
 
         val plugin = SenseOfProtectionCohortSurveyParameterPlugin(mockSenseOfProtectionToggles)
 
@@ -36,7 +36,7 @@ class TemporaryDefaultSurveyParametersPluginTest {
             on { it.isEnabled() } doReturn true
             on { it.getCohort() } doReturn modifiedControlCohort
         }
-        whenever(mockSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25()).thenReturn(mockToggle)
+        whenever(mockSenseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25()).thenReturn(mockToggle)
 
         val plugin = SenseOfProtectionCohortSurveyParameterPlugin(mockSenseOfProtectionToggles)
 
@@ -50,7 +50,7 @@ class TemporaryDefaultSurveyParametersPluginTest {
             on { it.isEnabled() } doReturn true
             on { it.getCohort() } doReturn modifiedControlCohort
         }
-        whenever(mockSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25()).thenReturn(mockToggle)
+        whenever(mockSenseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25()).thenReturn(mockToggle)
 
         val plugin = SenseOfProtectionCohortSurveyParameterPlugin(mockSenseOfProtectionToggles)
 
@@ -63,7 +63,7 @@ class TemporaryDefaultSurveyParametersPluginTest {
             on { it.isEnabled() } doReturn false
             on { it.getCohort() } doReturn null
         }
-        whenever(mockSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25()).thenReturn(mockToggle)
+        whenever(mockSenseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25()).thenReturn(mockToggle)
 
         val plugin = SenseOfProtectionCohortSurveyParameterPlugin(mockSenseOfProtectionToggles)
 

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -1246,7 +1246,7 @@ class TabSwitcherViewModelTest {
 
     @Test
     fun `when animated info panel then tab switcher items include animation tile and tabs`() = runTest {
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -1275,7 +1275,7 @@ class TabSwitcherViewModelTest {
 
     @Test
     fun `when animated info panel not visible then tab switcher items contain only tabs`() = runTest {
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -1322,7 +1322,7 @@ class TabSwitcherViewModelTest {
 
     @Test
     fun `when animated info panel positive button clicked then animated info panel is still visible`() = runTest {
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -1351,7 +1351,7 @@ class TabSwitcherViewModelTest {
     fun `when animated info panel negative button clicked then animated info panel is removed`() = runTest {
         initializeViewModel(FakeTabSwitcherDataStore())
 
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -1375,7 +1375,7 @@ class TabSwitcherViewModelTest {
 
     @Test
     fun `when animated info panel visible then impressions pixel fired`() = runTest {
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -1393,7 +1393,7 @@ class TabSwitcherViewModelTest {
             pixel = AppPixelName.TAB_MANAGER_INFO_PANEL_IMPRESSIONS,
             parameters = mapOf(
                 "cohort" to VARIANT_2.cohortName,
-                "experiment" to fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().featureName().name,
+                "experiment" to fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25().featureName().name,
             ),
         )
     }
@@ -1401,7 +1401,7 @@ class TabSwitcherViewModelTest {
     @Test
     fun `when animated info panel clicked then tapped pixel fired`() = runTest {
         whenever(mockWebTrackersBlockedAppRepository.getTrackerCountForLast7Days()).thenReturn(15)
-        fakeSenseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionExistingUserExperiment27May25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -1418,14 +1418,14 @@ class TabSwitcherViewModelTest {
             pixel = AppPixelName.TAB_MANAGER_INFO_PANEL_TAPPED,
             parameters = mapOf(
                 "cohort" to VARIANT_2.cohortName,
-                "experiment" to fakeSenseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().featureName().name,
+                "experiment" to fakeSenseOfProtectionToggles.senseOfProtectionExistingUserExperiment27May25().featureName().name,
             ),
         )
     }
 
     @Test
     fun `when animated info panel negative button clicked then dismiss pixel fired`() = runTest {
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -1444,14 +1444,14 @@ class TabSwitcherViewModelTest {
             parameters = mapOf(
                 "trackerCount" to "15",
                 "cohort" to VARIANT_2.cohortName,
-                "experiment" to fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().featureName().name,
+                "experiment" to fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25().featureName().name,
             ),
         )
     }
 
     @Test
     fun `when user is in modified control of sense of protection experiment then animated tile is not shown`() = runTest {
-        fakeSenseOfProtectionToggles.senseOfProtectionExistingUserExperimentMay25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionExistingUserExperiment27May25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,
@@ -1469,7 +1469,7 @@ class TabSwitcherViewModelTest {
 
     @Test
     fun `when user is in variant 1 of sense of protection experiment then animated tile is not shown`() = runTest {
-        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperimentMay25().setRawStoredState(
+        fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25().setRawStoredState(
             State(
                 remoteEnableState = true,
                 enable = true,

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/experiments/visual/store/VisualDesignExperimentDataStoreImpl.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/experiments/visual/store/VisualDesignExperimentDataStoreImpl.kt
@@ -56,6 +56,8 @@ class VisualDesignExperimentDataStoreImpl @Inject constructor(
             "senseOfProtectionExistingUserExperimentApr25",
             "senseOfProtectionNewUserExperimentMay25",
             "senseOfProtectionExistingUserExperimentMay25",
+            "senseOfProtectionNewUserExperiment27May25",
+            "senseOfProtectionExistingUserExperiment27May25",
             "defaultBrowserAdditionalPrompts202501",
         )
     }

--- a/common/common-ui/src/test/java/com/duckduckgo/common/ui/experiments/visual/store/VisualDesignExperimentDataStoreImplTest.kt
+++ b/common/common-ui/src/test/java/com/duckduckgo/common/ui/experiments/visual/store/VisualDesignExperimentDataStoreImplTest.kt
@@ -61,6 +61,12 @@ class VisualDesignExperimentDataStoreImplTest {
     private lateinit var senseOfProtectionExistingUserExperimentMay25: Toggle
 
     @Mock
+    private lateinit var senseOfProtectionNewUserExperiment27May25: Toggle
+
+    @Mock
+    private lateinit var senseOfProtectionExistingUserExperiment27May25: Toggle
+
+    @Mock
     private lateinit var defaultBrowserAdditionalPrompts202501: Toggle
 
     @Mock
@@ -88,6 +94,12 @@ class VisualDesignExperimentDataStoreImplTest {
         )
         whenever(senseOfProtectionExistingUserExperimentMay25.featureName()).thenReturn(
             FeatureName("SenseOfProtectionToggles", "senseOfProtectionExistingUserExperimentMay25"),
+        )
+        whenever(senseOfProtectionNewUserExperiment27May25.featureName()).thenReturn(
+            FeatureName("SenseOfProtectionToggles", "senseOfProtectionNewUserExperiment27May25"),
+        )
+        whenever(senseOfProtectionExistingUserExperiment27May25.featureName()).thenReturn(
+            FeatureName("SenseOfProtectionToggles", "senseOfProtectionExistingUserExperiment27May25"),
         )
         whenever(defaultBrowserAdditionalPrompts202501.featureName()).thenReturn(
             FeatureName("DefaultBrowserPromptsFeatureToggles", "defaultBrowserAdditionalPrompts202501"),
@@ -166,6 +178,28 @@ class VisualDesignExperimentDataStoreImplTest {
     @Test
     fun `when experiment FF enabled and senseOfProtectionExistingUserExperimentMay25 active, experiment disabled`() = runTest {
         whenever(togglesInventory.getAllActiveExperimentToggles()).thenReturn(listOf(senseOfProtectionExistingUserExperimentMay25))
+        whenVisualExperimentEnabled(true)
+
+        val testee = createTestee()
+
+        Assert.assertFalse(testee.isExperimentEnabled.value)
+        Assert.assertTrue(testee.anyConflictingExperimentEnabled.value)
+    }
+
+    @Test
+    fun `when experiment FF enabled and senseOfProtectionNewUserExperiment27May25 active, experiment disabled`() = runTest {
+        whenever(togglesInventory.getAllActiveExperimentToggles()).thenReturn(listOf(senseOfProtectionNewUserExperiment27May25))
+        whenVisualExperimentEnabled(true)
+
+        val testee = createTestee()
+
+        Assert.assertFalse(testee.isExperimentEnabled.value)
+        Assert.assertTrue(testee.anyConflictingExperimentEnabled.value)
+    }
+
+    @Test
+    fun `when experiment FF enabled and senseOfProtectionExistingUserExperiment27May25 active, experiment disabled`() = runTest {
+        whenever(togglesInventory.getAllActiveExperimentToggles()).thenReturn(listOf(senseOfProtectionExistingUserExperiment27May25))
         whenVisualExperimentEnabled(true)
 
         val testee = createTestee()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207908166761516/task/1210385405168427 

### Description
Updated the Sense of Protection experiment toggle names from `senseOfProtectionNewUserExperimentMay25` and `senseOfProtectionExistingUserExperimentMay25` to `senseOfProtectionNewUserExperiment27May25` and `senseOfProtectionExistingUserExperiment27May25` respectively. Also added these new toggle names to the list of visual design experiment toggles.

### Steps to test this PR

_Sense of Protection Experiment_
- [ ] Verify that the experiment toggles work correctly for new users
- [ ] Verify that the experiment toggles work correctly for existing users
- [ ] Check that the experiment cohorts are properly assigned
- [ ] Ensure that the tab manager pixel parameters are correctly populated

### UI changes
N/A