### PR TITLE
Update non-critical Autofill tests so they can run against internal builds again

### DIFF
--- a/.maestro/autofill/1_autofill_shown_in_overflow.yaml
+++ b/.maestro/autofill/1_autofill_shown_in_overflow.yaml
@@ -11,4 +11,5 @@ tags:
       - launchApp:
             clearState: true
       - runFlow: ../shared/skip_all_onboarding.yaml
+      - hideKeyboard
       - runFlow: steps/access_passwords_screen.yaml

--- a/.maestro/autofill/2_autofill_add_search_update_delete_creds.yaml
+++ b/.maestro/autofill/2_autofill_add_search_update_delete_creds.yaml
@@ -10,6 +10,7 @@ tags:
       - launchApp:
           clearState: true
       - runFlow: ../shared/skip_all_onboarding.yaml
+      - hideKeyboard
       - runFlow: steps/access_passwords_screen.yaml
 
       - assertVisible:

--- a/.maestro/autofill/3_autofill_prompted_to_save_creds_on_form.yaml
+++ b/.maestro/autofill/3_autofill_prompted_to_save_creds_on_form.yaml
@@ -10,6 +10,7 @@ tags:
         - launchApp:
               clearState: true
         - runFlow: ../shared/skip_all_onboarding.yaml
+        - hideKeyboard
 
         - tapOn:
             id: "omnibarTextInput"

--- a/.maestro/autofill/4_autofill_settings_creds.yaml
+++ b/.maestro/autofill/4_autofill_settings_creds.yaml
@@ -10,6 +10,7 @@ tags:
       - launchApp:
           clearState: true
       - runFlow: ../shared/skip_all_onboarding.yaml
+      - hideKeyboard
 
       - tapOn:
           id: "com.duckduckgo.mobile.android:id/browserMenuImageView"

--- a/.maestro/autofill/backfillingUsername/multi_step_login_username_backfilled.yaml
+++ b/.maestro/autofill/backfillingUsername/multi_step_login_username_backfilled.yaml
@@ -12,6 +12,7 @@ tags:
           clearState: true
 
       - runFlow: ../../shared/skip_all_onboarding.yaml
+      - hideKeyboard
 
       # get to autofill form
       - tapOn:

--- a/.maestro/autofill/backfillingUsername/multi_step_login_username_backfilled_for_an_update.yaml
+++ b/.maestro/autofill/backfillingUsername/multi_step_login_username_backfilled_for_an_update.yaml
@@ -12,6 +12,7 @@ tags:
           clearState: true
 
       - runFlow: ../../shared/skip_all_onboarding.yaml
+      - hideKeyboard
 
       # setup an existing credential
       - runFlow: ../steps/manually_add_existing_credential.yaml

--- a/.maestro/autofill/backfillingUsername/multi_step_login_username_not_backfilled_if_provided_explicitly.yaml
+++ b/.maestro/autofill/backfillingUsername/multi_step_login_username_not_backfilled_if_provided_explicitly.yaml
@@ -12,6 +12,7 @@ tags:
           clearState: true
 
       - runFlow: ../../shared/skip_all_onboarding.yaml
+      - hideKeyboard
 
       # get to autofill form
       - tapOn:

--- a/.maestro/autofill/backfillingUsername/multi_step_registration_username_backfilled_password_autogenerated.yaml
+++ b/.maestro/autofill/backfillingUsername/multi_step_registration_username_backfilled_password_autogenerated.yaml
@@ -12,6 +12,7 @@ tags:
           clearState: true
 
       - runFlow: ../../shared/skip_all_onboarding.yaml
+      - hideKeyboard
 
       # get to autofill form
       - tapOn:
@@ -40,6 +41,8 @@ tags:
       - tapOn:
           text: "Register"
           index: 1
+
+      - hideKeyboard
 
       # access the passwords screen and assert username and password both saved
       - runFlow: ../steps/access_passwords_screen.yaml

--- a/.maestro/autofill/backfillingUsername/multi_step_registration_username_backfilled_password_manually_entered.yaml
+++ b/.maestro/autofill/backfillingUsername/multi_step_registration_username_backfilled_password_manually_entered.yaml
@@ -12,6 +12,7 @@ tags:
           clearState: true
 
       - runFlow: ../../shared/skip_all_onboarding.yaml
+      - hideKeyboard
 
       # get to autofill form
       - tapOn:

--- a/.maestro/autofill/backfillingUsername/password_reset_flow_autogenerated_password.yaml
+++ b/.maestro/autofill/backfillingUsername/password_reset_flow_autogenerated_password.yaml
@@ -12,6 +12,7 @@ tags:
           clearState: true
 
       - runFlow: ../../shared/skip_all_onboarding.yaml
+      - hideKeyboard
 
       # get to autofill login form
       - tapOn:
@@ -42,6 +43,8 @@ tags:
       - tapOn:
           text: "Change Password"
           index: 1
+
+      - hideKeyboard
 
       # access the passwords screen and assert username and password both saved
       - runFlow: ../steps/access_passwords_screen.yaml

--- a/.maestro/autofill/backfillingUsername/password_reset_flow_for_existing_credential_generated_password.yaml
+++ b/.maestro/autofill/backfillingUsername/password_reset_flow_for_existing_credential_generated_password.yaml
@@ -12,6 +12,7 @@ tags:
           clearState: true
 
       - runFlow: ../../shared/skip_all_onboarding.yaml
+      - hideKeyboard
 
       # get to autofill login form
       - tapOn:

--- a/.maestro/autofill/backfillingUsername/password_reset_flow_for_existing_credential_manual_password.yaml
+++ b/.maestro/autofill/backfillingUsername/password_reset_flow_for_existing_credential_manual_password.yaml
@@ -12,6 +12,7 @@ tags:
           clearState: true
 
       - runFlow: ../../shared/skip_all_onboarding.yaml
+      - hideKeyboard
 
       # manually add a credential
       - runFlow: ../steps/manually_add_existing_credential.yaml

--- a/.maestro/autofill/passwordGeneration/autosaves_credential_when_password_generated_with_username.yaml
+++ b/.maestro/autofill/passwordGeneration/autosaves_credential_when_password_generated_with_username.yaml
@@ -12,6 +12,7 @@ tags:
           clearState: true
 
       - runFlow: ../../shared/skip_all_onboarding.yaml
+      - hideKeyboard
 
       # get to autofill form
       - tapOn:

--- a/.maestro/autofill/passwordGeneration/autosaves_credential_when_password_generated_without_username.yaml
+++ b/.maestro/autofill/passwordGeneration/autosaves_credential_when_password_generated_without_username.yaml
@@ -12,6 +12,7 @@ tags:
           clearState: true
 
       - runFlow: ../../shared/skip_all_onboarding.yaml
+      - hideKeyboard
 
       # get to autofill form
       - tapOn:

--- a/autofill/autofill-impl/build.gradle
+++ b/autofill/autofill-impl/build.gradle
@@ -128,10 +128,10 @@ android {
 }
 
 tasks.register('installForAutofillTesting', Exec) {
-    commandLine "$rootDir/gradlew", ':app:installInternalRelease', "-P$autofillDisableAuthRequirementBuildFlag"
+    commandLine "$rootDir/gradlew", ':app:installInternalRelease', "-Pforce-default-variant", "-P$autofillDisableAuthRequirementBuildFlag"
 }
 
 tasks.register('autofillTestLocal', Exec) {
-    commandLine 'maestro', 'test', '--include-tags', 'autofillNoAuthTests', "$rootDir/.maestro"
+    commandLine 'maestro', 'test', '--include-tags', 'autofillNoAuthTests,autofillPasswordGeneration,autofillBackfillingUsername', "$rootDir/.maestro"
     dependsOn 'installForAutofillTesting'
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1210387502072421?focus=true 

### Description
Updates the remaining Autofill tests to run against `internal` build types. The critical tests were updated already.

### Steps to test this PR

This is **QA optional**. If you want to test:
- [ ] you can test `./gradlew autofillTestLocal` correctly installs a build which forces default variant and has auth requirement disabled, and that it runs the following test types: `autofillNoAuthTests,autofillPasswordGeneration,autofillBackfillingUsername`. (note, typically tested against API 30/33, other APIs might not succeed due to minor unaccounted for differences)