### PR TITLE
Skip onboarding process to shorten test feedback

### DIFF
--- a/.maestro/preonboarding/preonboarding_returning_user_show_tutorial.yaml
+++ b/.maestro/preonboarding/preonboarding_returning_user_show_tutorial.yaml
@@ -23,5 +23,7 @@ tags:
 - tapOn: "Show Tutorial"
 - assertVisible:
     text: "Protections activated!"
-- assertVisible:
-    text: "Choose Your Browser"
+- tapOn: "Choose Your Browser"
+- tapOn: Cancel
+- tapOn: Next
+- assertVisible: Try a search!

--- a/.maestro/shared/onboarding_scripts/setup.js
+++ b/.maestro/shared/onboarding_scripts/setup.js
@@ -1,3 +1,0 @@
-output.onboarding = {
-    runFullOnboarding: true
-}

--- a/.maestro/shared/onboarding_scripts/skipped_onboarding.js
+++ b/.maestro/shared/onboarding_scripts/skipped_onboarding.js
@@ -1,3 +1,0 @@
-output.onboarding = {
-    runFullOnboarding: false
-}

--- a/.maestro/shared/skip_all_onboarding.yaml
+++ b/.maestro/shared/skip_all_onboarding.yaml
@@ -1,23 +1,4 @@
 appId: com.duckduckgo.mobile.android
 ---
-- runScript: onboarding_scripts/setup.js
-
-- extendedWaitUntil:
-    visible: "Skip Onboarding"
-    timeout: 10000
-    optional: true
-
-- runFlow:
-    when:
-      visible: "Skip Onboarding"
-    commands:
-      - tapOn: "Skip Onboarding"
-      - runScript: onboarding_scripts/skipped_onboarding.js
-
-- runFlow:
-    when:
-      true: ${output.onboarding.runFullOnboarding}
-    commands:
-      - runFlow: pre_onboarding.yaml
-
-
+- tapOn: I've been here before
+- tapOn: Start Browsing


### PR DESCRIPTION
Task/Issue URL: 

### Description
Since there are specific test cases for the onboarding process, other tests can skip those steps to shorten running time. This reduces wasted time when writing tests and allows developers to get faster feedback.


