### PR TITLE
adapt E2E tests to be compatible with the new visual design

### DIFF
--- a/.maestro/ad_click_detection_flows/10_-_m.js_bing-provided_ad_domain_provided_but_incorrect_dsl_not_needed.yaml
+++ b/.maestro/ad_click_detection_flows/10_-_m.js_bing-provided_ad_domain_provided_but_incorrect_dsl_not_needed.yaml
@@ -13,8 +13,7 @@ tags:
       - inputText: "https://www.search-company.site/#ad-id-10"
       - pressKey: Enter
 
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/fireIconMenu"
+      - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
       - tapOn:
           text: "Cancel"
       - assertVisible:
@@ -23,8 +22,7 @@ tags:
           id: "ad-id-10"
       - assertVisible:
           text: "Publisher site"
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+      - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
       - assertVisible:
           text: "View Tracker Companies"
       - tapOn:

--- a/.maestro/ad_click_detection_flows/11_-_y.js_bing-provided_ad_domain_provided_but_it's_not_a_domain_i.e.,_abcedf_u3_not_needed.yaml
+++ b/.maestro/ad_click_detection_flows/11_-_y.js_bing-provided_ad_domain_provided_but_it's_not_a_domain_i.e.,_abcedf_u3_not_needed.yaml
@@ -13,8 +13,7 @@ tags:
       - inputText: "https://www.search-company.site/#ad-id-11"
       - pressKey: Enter
 
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/fireIconMenu"
+      - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
       - tapOn:
           text: "Cancel"
       - assertVisible:
@@ -23,8 +22,7 @@ tags:
           id: "ad-id-11"
       - assertVisible:
           text: "Publisher site"
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+      - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
       - assertVisible:
           text: "View Tracker Companies"
       - tapOn:

--- a/.maestro/ad_click_detection_flows/12_-_m.js_bing-provided_ad_domain_provided_but_it's_not_a_domain_i.e.,_abcedf__dsl_not_needed.yaml
+++ b/.maestro/ad_click_detection_flows/12_-_m.js_bing-provided_ad_domain_provided_but_it's_not_a_domain_i.e.,_abcedf__dsl_not_needed.yaml
@@ -13,8 +13,7 @@ tags:
       - inputText: "https://www.search-company.site/#ad-id-12"
       - pressKey: Enter
 
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/fireIconMenu"
+      - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
       - tapOn:
           text: "Cancel"
       - assertVisible:
@@ -23,8 +22,7 @@ tags:
           id: "ad-id-12"
       - assertVisible:
           text: "Publisher site"
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+      - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
       - assertVisible:
           text: "View Tracker Companies"
       - tapOn:

--- a/.maestro/ad_click_detection_flows/13_-_y.js_bing-provided_ad_domain_provided_but_it's_a_subdomain_of_advertiser_i.e.,_foo.www.search-company-site_u3_not_needed.yaml
+++ b/.maestro/ad_click_detection_flows/13_-_y.js_bing-provided_ad_domain_provided_but_it's_a_subdomain_of_advertiser_i.e.,_foo.www.search-company-site_u3_not_needed.yaml
@@ -13,8 +13,7 @@ tags:
       - inputText: "https://www.search-company.site/#ad-id-13"
       - pressKey: Enter
 
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/fireIconMenu"
+      - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
       - tapOn:
           text: "Cancel"
       - assertVisible:
@@ -23,8 +22,7 @@ tags:
           id: "ad-id-13"
       - assertVisible:
           text: "Publisher site"
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+      - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
       - assertVisible:
           text: "View Tracker Companies"
       - tapOn:

--- a/.maestro/ad_click_detection_flows/14_-_m.js_bing-provided_ad_domain_provided_but_it's_a_subdomain_of_advertiser_i.e.,_foo.www.search-company-site__dsl_not_needed.yaml
+++ b/.maestro/ad_click_detection_flows/14_-_m.js_bing-provided_ad_domain_provided_but_it's_a_subdomain_of_advertiser_i.e.,_foo.www.search-company-site__dsl_not_needed.yaml
@@ -13,8 +13,7 @@ tags:
       - inputText: "https://www.search-company.site/#ad-id-14"
       - pressKey: Enter
 
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/fireIconMenu"
+      - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
       - tapOn:
           text: "Cancel"
       - assertVisible:
@@ -23,8 +22,7 @@ tags:
           id: "ad-id-14"
       - assertVisible:
           text: "Publisher site"
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+      - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
       - assertVisible:
           text: "View Tracker Companies"
       - tapOn:

--- a/.maestro/ad_click_detection_flows/1_-_y.js_heuristic_no_ad_domain_param_u3_param_included_1_1_1.yaml
+++ b/.maestro/ad_click_detection_flows/1_-_y.js_heuristic_no_ad_domain_param_u3_param_included_1_1_1.yaml
@@ -13,8 +13,7 @@ tags:
       - inputText: "https://www.search-company.site/#ad-id-1"
       - pressKey: Enter
 
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/fireIconMenu"
+      - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
       - tapOn:
           text: "Cancel"
       - assertVisible:
@@ -23,8 +22,7 @@ tags:
           id: "ad-id-1"
       - assertVisible:
           text: "Publisher site"
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+      - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
       - assertVisible:
           text: "View Tracker Companies"
       - tapOn:

--- a/.maestro/ad_click_detection_flows/2_-_m.js_heuristic_no_ad_domain_param_dsl_param_included_1_1.yaml
+++ b/.maestro/ad_click_detection_flows/2_-_m.js_heuristic_no_ad_domain_param_dsl_param_included_1_1.yaml
@@ -13,8 +13,7 @@ tags:
       - inputText: "https://www.search-company.site/#ad-id-2"
       - pressKey: Enter
 
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/fireIconMenu"
+      - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
       - tapOn:
           text: "Cancel"
       - assertVisible:
@@ -23,8 +22,7 @@ tags:
           id: "ad-id-2"
       - assertVisible:
           text: "Publisher site"
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+      - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
       - assertVisible:
           text: "View Tracker Companies"
       - tapOn:

--- a/.maestro/ad_click_detection_flows/3_-_y.js_heuristic_no_ad_domain_param,_but_missing_u3_param_1_1.yaml
+++ b/.maestro/ad_click_detection_flows/3_-_y.js_heuristic_no_ad_domain_param,_but_missing_u3_param_1_1.yaml
@@ -13,8 +13,7 @@ tags:
       - inputText: "https://www.search-company.site/#ad-id-3"
       - pressKey: Enter
 
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/fireIconMenu"
+      - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
       - tapOn:
           text: "Cancel"
       - assertVisible:
@@ -23,8 +22,7 @@ tags:
           id: "ad-id-3"
       - assertVisible:
           text: "Publisher site"
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+      - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
       - assertVisible:
           text: "View Tracker Companies"
       - tapOn:

--- a/.maestro/ad_click_detection_flows/4_-_m.js_heuristic_no_ad_domain_param,_but_missing_dsl_param_1_1.yaml
+++ b/.maestro/ad_click_detection_flows/4_-_m.js_heuristic_no_ad_domain_param,_but_missing_dsl_param_1_1.yaml
@@ -13,8 +13,7 @@ tags:
       - inputText: "https://www.search-company.site/#ad-id-4"
       - pressKey: Enter
 
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/fireIconMenu"
+      - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
       - tapOn:
           text: "Cancel"
       - assertVisible:
@@ -23,8 +22,7 @@ tags:
           id: "ad-id-4"
       - assertVisible:
           text: "Publisher site"
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+      - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
       - assertVisible:
           text: "View Tracker Companies"
       - tapOn:

--- a/.maestro/ad_click_detection_flows/5_-_y.js_heuristic_ad_domain_provided,_but_empty_u3_not_needed.yaml
+++ b/.maestro/ad_click_detection_flows/5_-_y.js_heuristic_ad_domain_provided,_but_empty_u3_not_needed.yaml
@@ -13,8 +13,7 @@ tags:
       - inputText: "https://www.search-company.site/#ad-id-5"
       - pressKey: Enter
 
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/fireIconMenu"
+      - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
       - tapOn:
           text: "Cancel"
       - assertVisible:
@@ -23,8 +22,7 @@ tags:
           id: "ad-id-5"
       - assertVisible:
           text: "Publisher site"
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+      - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
       - assertVisible:
           text: "View Tracker Companies"
       - tapOn:

--- a/.maestro/ad_click_detection_flows/6_-_m.js_heuristic_ad_domain_provided,_but_empty_dsl_not_needed.yaml
+++ b/.maestro/ad_click_detection_flows/6_-_m.js_heuristic_ad_domain_provided,_but_empty_dsl_not_needed.yaml
@@ -18,8 +18,7 @@ tags:
           id: "ad-id-6"
       - assertVisible:
           text: "Publisher site"
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+      - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
       - assertVisible:
           text: "View Tracker Companies"
       - tapOn:

--- a/.maestro/ad_click_detection_flows/7_-_y.js_bing-provided_ad_domain_provided_u3_not_needed.yaml
+++ b/.maestro/ad_click_detection_flows/7_-_y.js_bing-provided_ad_domain_provided_u3_not_needed.yaml
@@ -13,8 +13,7 @@ tags:
       - inputText: "https://www.search-company.site/#ad-id-6" # scroll until the ad-id-6 instead of ad-id-7 (context: https://app.asana.com/0/0/1204397066248823/1204415854211764/f)
       - pressKey: Enter
 
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/fireIconMenu"
+      - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
       - tapOn:
           text: "Cancel"
       - assertVisible:
@@ -23,8 +22,7 @@ tags:
           id: "ad-id-7"
       - assertVisible:
           text: "Publisher site"
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+      - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
       - assertVisible:
           text: "View Tracker Companies"
       - tapOn:

--- a/.maestro/ad_click_detection_flows/8_-_m.js_bing-provided_ad_domain_provided_dsl_not_needed.yaml
+++ b/.maestro/ad_click_detection_flows/8_-_m.js_bing-provided_ad_domain_provided_dsl_not_needed.yaml
@@ -13,8 +13,7 @@ tags:
       - inputText: "https://www.search-company.site/#ad-id-8"
       - pressKey: Enter
 
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/fireIconMenu"
+      - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
       - tapOn:
           text: "Cancel"
       - assertVisible:
@@ -23,8 +22,7 @@ tags:
           id: "ad-id-8"
       - assertVisible:
           text: "Publisher site"
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+      - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
       - assertVisible:
           text: "View Tracker Companies"
       - tapOn:

--- a/.maestro/ad_click_detection_flows/9_-_y.js_bing-provided_ad_domain_provided_but_incorrect_u3_not_needed.yaml
+++ b/.maestro/ad_click_detection_flows/9_-_y.js_bing-provided_ad_domain_provided_but_incorrect_u3_not_needed.yaml
@@ -13,8 +13,7 @@ tags:
       - inputText: "https://www.search-company.site/#ad-id-9"
       - pressKey: Enter
 
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/fireIconMenu"
+      - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
       - tapOn:
           text: "Cancel"
       - assertVisible:
@@ -23,8 +22,7 @@ tags:
           id: "ad-id-9"
       - assertVisible:
           text: "Publisher site"
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+      - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
       - assertVisible:
           text: "View Tracker Companies"
       - tapOn:

--- a/.maestro/ads_preview_flows/1-_design-system-components.yaml
+++ b/.maestro/ads_preview_flows/1-_design-system-components.yaml
@@ -11,9 +11,7 @@ tags:
 
         - runFlow: ../shared/skip_all_onboarding.yaml
 
-        - hideKeyboard
-        - tapOn:
-            id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+        - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
         - tapOn:
             text: "Settings"
             index: 0

--- a/.maestro/app_tp/app_tp_onboarding.yaml
+++ b/.maestro/app_tp/app_tp_onboarding.yaml
@@ -12,8 +12,7 @@ tags:
 
         - runFlow: ../shared/skip_all_onboarding.yaml
 
-        - tapOn:
-            id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+        - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
         - tapOn:
             text: "Settings"
             index: 0

--- a/.maestro/autofill/1_autofill_shown_in_overflow.yaml
+++ b/.maestro/autofill/1_autofill_shown_in_overflow.yaml
@@ -11,5 +11,4 @@ tags:
       - launchApp:
             clearState: true
       - runFlow: ../shared/skip_all_onboarding.yaml
-      - hideKeyboard
       - runFlow: steps/access_passwords_screen.yaml

--- a/.maestro/autofill/2_autofill_add_search_update_delete_creds.yaml
+++ b/.maestro/autofill/2_autofill_add_search_update_delete_creds.yaml
@@ -10,7 +10,6 @@ tags:
       - launchApp:
           clearState: true
       - runFlow: ../shared/skip_all_onboarding.yaml
-      - hideKeyboard
       - runFlow: steps/access_passwords_screen.yaml
 
       - assertVisible:

--- a/.maestro/autofill/3_autofill_prompted_to_save_creds_on_form.yaml
+++ b/.maestro/autofill/3_autofill_prompted_to_save_creds_on_form.yaml
@@ -10,7 +10,6 @@ tags:
         - launchApp:
               clearState: true
         - runFlow: ../shared/skip_all_onboarding.yaml
-        - hideKeyboard
 
         - tapOn:
             id: "omnibarTextInput"

--- a/.maestro/autofill/4_autofill_settings_creds.yaml
+++ b/.maestro/autofill/4_autofill_settings_creds.yaml
@@ -10,10 +10,8 @@ tags:
       - launchApp:
           clearState: true
       - runFlow: ../shared/skip_all_onboarding.yaml
-      - hideKeyboard
 
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+      - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
       - assertVisible: "Settings"
       - tapOn: "Settings"
 

--- a/.maestro/autofill/steps/access_passwords_screen.yaml
+++ b/.maestro/autofill/steps/access_passwords_screen.yaml
@@ -3,7 +3,6 @@ name: "Autofill: Autofill screen is reachable from overflow menu"
 ---
 # Pre-requisite: the user has cleared onboarding and is on the new tab page
 
-- tapOn:
-      id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+- runFlow: ../../shared/browser_screen/click_on_menu_button.yaml
 - assertVisible: "Passwords"
 - tapOn: "Passwords"

--- a/.maestro/bookmarks/ensure_bookmarks_can_be_added_and_deleted.yaml
+++ b/.maestro/bookmarks/ensure_bookmarks_can_be_added_and_deleted.yaml
@@ -16,14 +16,12 @@ tags:
           id: "omnibarTextInput"
       - inputText: "https://privacy-test-pages.site"
       - pressKey: Enter
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+      - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
       - assertVisible:
           text: "add bookmark"
       - tapOn:
           text: "add bookmark"
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+      - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
       - assertVisible:
           text: "bookmarks"
       - tapOn:

--- a/.maestro/bookmarks/open_bookmark_and_navigate_back.yaml
+++ b/.maestro/bookmarks/open_bookmark_and_navigate_back.yaml
@@ -24,14 +24,12 @@ tags:
       - pressKey: Enter
       - assertVisible:
             text: "Privacy Test Pages"
-      - tapOn:
-            id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+      - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
       - assertVisible:
             text: "add bookmark"
       - tapOn:
             text: "add bookmark"
-      - tapOn:
-            id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+      - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
       - assertVisible:
             text: "bookmarks"
       - tapOn:

--- a/.maestro/bookmarks/open_bookmark_in_folder_and_navigate_back.yaml
+++ b/.maestro/bookmarks/open_bookmark_in_folder_and_navigate_back.yaml
@@ -18,8 +18,7 @@ tags:
             - pressKey: Enter
             - assertVisible:
                   text: "Privacy Test Pages"
-            - tapOn:
-                  id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+            - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
             - assertVisible:
                   text: "add bookmark"
             - tapOn:
@@ -30,8 +29,7 @@ tags:
             - pressKey: Enter
             - assertVisible:
                 text: "Search engine"
-            - tapOn:
-                  id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+            - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
             - assertVisible:
                   text: "bookmarks"
             - tapOn:

--- a/.maestro/custom_tabs/custom_tabs_navigation.yaml
+++ b/.maestro/custom_tabs/custom_tabs_navigation.yaml
@@ -27,9 +27,7 @@ tags:
       - tapOn: "next"
       - assertVisible:
           text: ".*Try a search!.*"
-      - hideKeyboard
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+      - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
       - tapOn:
           text: "settings"
       - scrollUntilVisible:

--- a/.maestro/custom_tabs/custom_tabs_navigation_new_tab.yaml
+++ b/.maestro/custom_tabs/custom_tabs_navigation_new_tab.yaml
@@ -27,9 +27,7 @@ tags:
       - tapOn: "next"
       - assertVisible:
           text: ".*Try a search!.*"
-      - hideKeyboard
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+      - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
       - tapOn:
           text: "settings"
       - scrollUntilVisible:

--- a/.maestro/favorites/favorites_bookmarks_add.yaml
+++ b/.maestro/favorites/favorites_bookmarks_add.yaml
@@ -16,13 +16,11 @@ tags:
           id: "omnibarTextInput"
       - inputText: "https://privacy-test-pages.site"
       - pressKey: Enter
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+      - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
       - tapOn:
           text: "add bookmark"
       # Navigate to bookmarks screen
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+      - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
       - tapOn:
           text: "bookmarks"
       # Add favorite from bookmarks screen

--- a/.maestro/favorites/favorites_bookmarks_delete.yaml
+++ b/.maestro/favorites/favorites_bookmarks_delete.yaml
@@ -16,15 +16,13 @@ tags:
           id: "omnibarTextInput"
       - inputText: "https://privacy-test-pages.site"
       - pressKey: Enter
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+      - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
       - assertVisible:
           text: "add bookmark"
       - tapOn:
           text: "add bookmark"
       # Add favorite from edit saved site
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+      - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
       - assertVisible:
           text: "edit bookmark"
       - tapOn:
@@ -35,8 +33,7 @@ tags:
           text: "add to favorites"
       - tapOn:
           id: "com.duckduckgo.mobile.android:id/action_confirm_changes"
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+      - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
       - assertVisible:
           text: "bookmarks"
       - tapOn:

--- a/.maestro/fire_button/fire_during_onboarding.yaml
+++ b/.maestro/fire_button/fire_during_onboarding.yaml
@@ -22,11 +22,9 @@ tags:
           text: "got it"
       - assertVisible:
             text: ".*browsing activity with the fire button.*"
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/fireIconImageView"
+      - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
       - tapOn: "Cancel"
       - assertNotVisible: ".*browsing activity with the Fire Button.*"
-      - tapOn:
-            id: "com.duckduckgo.mobile.android:id/fireIconImageView"
+      - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
       - tapOn: "Clear All Tabs And Data"
       - assertVisible: "You've got this!.*"

--- a/.maestro/notifications_permissions_android13_plus/1_-_permissions_allowed.yaml
+++ b/.maestro/notifications_permissions_android13_plus/1_-_permissions_allowed.yaml
@@ -15,8 +15,7 @@ tags:
 
             - runFlow: ../shared/skip_all_onboarding.yaml
 
-            - tapOn:
-                id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+            - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
             - tapOn:
                 text: "Downloads"
             - assertVisible:

--- a/.maestro/notifications_permissions_android13_plus/2_-_permissions_denied.yaml
+++ b/.maestro/notifications_permissions_android13_plus/2_-_permissions_denied.yaml
@@ -15,8 +15,7 @@ tags:
 
             - runFlow: ../shared/skip_all_onboarding.yaml
 
-            - tapOn:
-                id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+            - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
             - tapOn:
                 text: "Downloads"
             - assertVisible:

--- a/.maestro/onboarding/onboarding_dismiss_all_dialogs.yaml
+++ b/.maestro/onboarding/onboarding_dismiss_all_dialogs.yaml
@@ -51,8 +51,7 @@ tags:
           id: daxDialogDismissButton
       - assertNotVisible:
           text: ".*Remember: every time you browse with me a creepy ad loses its wings..*"
-      - tapOn:
-          id: "com.duckduckgo.mobile.android:id/tabCount"
+      - runFlow: ../shared/browser_screen/click_on_tabs_button.yaml
       - tapOn: "New Tab"
       - assertVisible:
           text: ".*Try our search widget!.*"

--- a/.maestro/privacy_tests/1_-_Single-site,_single-tab,_session.yaml
+++ b/.maestro/privacy_tests/1_-_Single-site,_single-tab,_session.yaml
@@ -16,8 +16,7 @@ tags:
                 id: "ad-id-5"
             - assertVisible:
                 text: "Publisher site"
-            - tapOn:
-                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
             - assertVisible:
                 text: "View Tracker Companies"
             - tapOn:
@@ -57,8 +56,7 @@ tags:
                 id: "buy-now"
             - assertVisible:
                 text: "Checkout"
-            - tapOn:
-                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
             - assertVisible:
                 text: "View Tracker Companies"
             - tapOn:
@@ -96,8 +94,7 @@ tags:
                 id: "pay-button"
             - assertVisible:
                 text: ".*Order complete.*"
-            - tapOn:
-                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
             - assertVisible:
                 text: "View Tracker Companies"
             - tapOn:

--- a/.maestro/privacy_tests/2_-_Single-site,_new-tab,_session.yaml
+++ b/.maestro/privacy_tests/2_-_Single-site,_new-tab,_session.yaml
@@ -20,8 +20,7 @@ tags:
                 text: "Open in New Tab"
             - assertVisible:
                 text: "Publisher site"
-            - tapOn:
-                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
             - assertVisible:
                 text: "View Tracker Companies"
             - tapOn:
@@ -61,8 +60,7 @@ tags:
                 id: "buy-now"
             - assertVisible:
                 text: "Checkout"
-            - tapOn:
-                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
             - assertVisible:
                 text: "View Tracker Companies"
             - tapOn:
@@ -100,8 +98,7 @@ tags:
                 id: "pay-button"
             - assertVisible:
                 text: ".*Order complete.*"
-            - tapOn:
-                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
             - assertVisible:
                 text: "View Tracker Companies"
             - tapOn:

--- a/.maestro/privacy_tests/3_-_Single-site,_new-tab,_session_variant_two.yaml
+++ b/.maestro/privacy_tests/3_-_Single-site,_new-tab,_session_variant_two.yaml
@@ -16,8 +16,7 @@ tags:
                 id: "ad-id-5"
             - assertVisible:
                 text: "Publisher site"
-            - tapOn:
-                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
             - assertVisible:
                 text: "View Tracker Companies"
             - tapOn:
@@ -61,8 +60,7 @@ tags:
                 text: "Open in New Tab"
             - assertVisible:
                 text: "Checkout"
-            - tapOn:
-                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
             - assertVisible:
                 text: "View Tracker Companies"
             - tapOn:
@@ -100,8 +98,7 @@ tags:
                 id: "pay-button"
             - assertVisible:
                 text: ".*Order complete.*"
-            - tapOn:
-                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
             - assertVisible:
                 text: "View Tracker Companies"
             - tapOn:

--- a/.maestro/privacy_tests/4_-_Single-site,_multi-tab_session.yaml
+++ b/.maestro/privacy_tests/4_-_Single-site,_multi-tab_session.yaml
@@ -16,8 +16,7 @@ tags:
                 id: "ad-id-5"
             - assertVisible:
                 text: "Publisher site"
-            - tapOn:
-                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
             - assertVisible:
                 text: "View Tracker Companies"
             - tapOn:
@@ -73,8 +72,7 @@ tags:
                 id: "pay-button"
             - assertVisible:
                 text: ".*Order complete.*"
-            - tapOn:
-                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
             - assertVisible:
                 text: "View Tracker Companies"
             - tapOn:

--- a/.maestro/privacy_tests/5_-_Multi-site,_single-tab,_session.yaml
+++ b/.maestro/privacy_tests/5_-_Multi-site,_single-tab,_session.yaml
@@ -16,8 +16,7 @@ tags:
                 id: "ad-id-5"
             - assertVisible:
                 text: "Publisher site"
-            - tapOn:
-                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
             - assertVisible:
                 text: "View Tracker Companies"
             - tapOn:
@@ -73,8 +72,7 @@ tags:
                 id: "payment-company"
             - assertVisible:
                 text: "Pay First Party"
-            - tapOn:
-                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
             - assertVisible:
                 text: "View Tracker Companies"
             - tapOn:
@@ -108,8 +106,7 @@ tags:
                 id: "pay-button"
             - assertVisible:
                 text: "Order complete.*"
-            - tapOn:
-                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
             - assertVisible:
                 text: "View Tracker Companies"
             - tapOn:

--- a/.maestro/privacy_tests/6_-_Multi-tab.yaml
+++ b/.maestro/privacy_tests/6_-_Multi-tab.yaml
@@ -16,8 +16,7 @@ tags:
                 id: "ad-id-5"
             - assertVisible:
                 text: "Publisher site"
-            - tapOn:
-                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
             - assertVisible:
                 text: "View Tracker Companies"
             - tapOn:
@@ -81,8 +80,7 @@ tags:
                 id: "pay-button"
             - assertVisible:
                 text: ".*Order complete.*"
-            - tapOn:
-                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
             - assertVisible:
                 text: "View Tracker Companies"
             - tapOn:

--- a/.maestro/privacy_tests/7_-_Browser_restart_mid-session.yaml
+++ b/.maestro/privacy_tests/7_-_Browser_restart_mid-session.yaml
@@ -16,8 +16,7 @@ tags:
                 id: "ad-id-5"
             - assertVisible:
                 text: "Publisher site"
-            - tapOn:
-                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
             - assertVisible:
                 text: "View Tracker Companies"
             - tapOn:
@@ -59,8 +58,7 @@ tags:
                 id: "buy-now"
             - assertVisible:
                 text: "Pay"
-            - tapOn:
-                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
             - assertVisible:
                 text: "View Tracker Companies"
             - tapOn:
@@ -103,8 +101,7 @@ tags:
                 id: "pay-button"
             - assertVisible:
                 text: ".*Order complete.*"
-            - tapOn:
-                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
             - assertVisible:
                 text: "View Tracker Companies"
             - tapOn:

--- a/.maestro/privacy_tests/8_-_Navigation_with_back_forward.yaml
+++ b/.maestro/privacy_tests/8_-_Navigation_with_back_forward.yaml
@@ -16,8 +16,7 @@ tags:
                 id: "ad-id-5"
             - assertVisible:
                 text: "Publisher site"
-            - tapOn:
-                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
             - assertVisible:
                 text: "View Tracker Companies"
             - tapOn:
@@ -73,8 +72,7 @@ tags:
                 id: "payment-company"
             - assertVisible:
                 text: "Pay First Party"
-            - tapOn:
-                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
             - assertVisible:
                 text: "View Tracker Companies"
             - tapOn:
@@ -138,8 +136,7 @@ tags:
                 id: "pay-button"
             - tapOn:
                 id: "pay-button"
-            - tapOn:
-                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
             - assertVisible:
                 text: "View Tracker Companies"
             - tapOn:

--- a/.maestro/privacy_tests/9_-_Navigation_with_refresh.yaml
+++ b/.maestro/privacy_tests/9_-_Navigation_with_refresh.yaml
@@ -16,8 +16,7 @@ tags:
                 id: "ad-id-5"
             - assertVisible:
                 text: "Publisher site"
-            - tapOn:
-                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
             - assertVisible:
                 text: "View Tracker Companies"
             - tapOn:
@@ -73,8 +72,7 @@ tags:
                 id: "payment-company"
             - assertVisible:
                 text: "Pay First Party"
-            - tapOn:
-                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
             - assertVisible:
                 text: "View Tracker Companies"
             - tapOn:
@@ -114,8 +112,7 @@ tags:
                 id: "pay-button"
             - tapOn:
                 id: "pay-button"
-            - tapOn:
-                id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+            - runFlow: ../shared/browser_screen/click_on_privacy_shield.yaml
             - assertVisible:
                 text: "View Tracker Companies"
             - tapOn:

--- a/.maestro/shared/browser_screen/click_on_fire_button.yaml
+++ b/.maestro/shared/browser_screen/click_on_fire_button.yaml
@@ -1,0 +1,13 @@
+appId: com.duckduckgo.mobile.android
+---
+- runFlow:
+    when:
+        notVisible:
+            id: 'com.duckduckgo.mobile.android:id/fireIconImageView'
+    commands:
+        - hideKeyboard
+        - assertVisible:
+            id: 'com.duckduckgo.mobile.android:id/fireIconImageView'
+
+- tapOn:
+    id: 'com.duckduckgo.mobile.android:id/fireIconImageView'

--- a/.maestro/shared/browser_screen/click_on_menu_button.yaml
+++ b/.maestro/shared/browser_screen/click_on_menu_button.yaml
@@ -1,0 +1,13 @@
+appId: com.duckduckgo.mobile.android
+---
+- runFlow:
+    when:
+        notVisible:
+            id: 'com.duckduckgo.mobile.android:id/browserMenuImageView'
+    commands:
+        - hideKeyboard
+        - assertVisible:
+            id: 'com.duckduckgo.mobile.android:id/browserMenuImageView'
+
+- tapOn:
+    id: 'com.duckduckgo.mobile.android:id/browserMenuImageView'

--- a/.maestro/shared/browser_screen/click_on_privacy_shield.yaml
+++ b/.maestro/shared/browser_screen/click_on_privacy_shield.yaml
@@ -1,0 +1,36 @@
+appId: com.duckduckgo.mobile.android
+---
+
+# This flow opens the Privacy Dashboard from the Omnibar.
+#
+# Unfortunately, we can't click the privacy shield directly because the shield is a Lottie animation view which extends beyond the bounds of the text input field.
+# Trying to click it directly will result in a tap on the text input field instead.
+#
+# I tried using the "point" and "leftOf" selector features to click the shield directly, the former is a known issue (https://github.com/mobile-dev-inc/Maestro/issues/1421)
+# and trying to click to the left of the input text field didn't work for me either.
+#
+# To work around this, when view_new_omnibar is used, we tap on the Omnibar icon container
+# which aligns with the shield and has a non-zero size because of an invisible pulse animation placeholder that's within it.
+# That shield animation placeholder is in a different place for the view_fade_omnibar, so we're using a conditional flow to handle both cases.
+
+# flow for view_new_omnibar
+- runFlow:
+      when:
+          notVisible:
+              id: "com.duckduckgo.mobile.android:id/shieldIconPulseAnimationContainer"
+      commands:
+          - assertVisible:
+              id: "com.duckduckgo.mobile.android:id/shieldIcon"
+          - tapOn:
+              id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
+
+# flow for view_fade_omnibar
+- runFlow:
+      when:
+          visible:
+              id: "com.duckduckgo.mobile.android:id/shieldIconPulseAnimationContainer"
+      commands:
+          - assertVisible:
+                id: "com.duckduckgo.mobile.android:id/shieldIconExperiment"
+          - tapOn:
+                id: "com.duckduckgo.mobile.android:id/shieldIconPulseAnimationContainer"

--- a/.maestro/shared/browser_screen/click_on_tabs_button.yaml
+++ b/.maestro/shared/browser_screen/click_on_tabs_button.yaml
@@ -1,0 +1,13 @@
+appId: com.duckduckgo.mobile.android
+---
+- runFlow:
+    when:
+        notVisible:
+            id: 'com.duckduckgo.mobile.android:id/tabCount'
+    commands:
+        - hideKeyboard
+        - assertVisible:
+            id: 'com.duckduckgo.mobile.android:id/tabCount'
+
+- tapOn:
+    id: 'com.duckduckgo.mobile.android:id/tabCount'

--- a/.maestro/shared/open_bookmarks.yaml
+++ b/.maestro/shared/open_bookmarks.yaml
@@ -1,8 +1,7 @@
 appId: com.duckduckgo.mobile.android
 ---
 - hideKeyboard
-- tapOn:
-      id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+- runFlow: ../shared/browser_screen/click_on_menu_button.yaml
 - tapOn: "Bookmarks"
 - runFlow:
     when:

--- a/.maestro/shared/open_sync_dev_settings_screen.yaml
+++ b/.maestro/shared/open_sync_dev_settings_screen.yaml
@@ -1,8 +1,6 @@
 appId: com.duckduckgo.mobile.android
 ---
-- hideKeyboard
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+- runFlow: ../shared/browser_screen/click_on_menu_button.yaml
 - tapOn: "Settings"
 - scrollUntilVisible:
    element: "Sync Dev Settings"

--- a/.maestro/shared/open_sync_screen.yaml
+++ b/.maestro/shared/open_sync_screen.yaml
@@ -1,7 +1,5 @@
 appId: com.duckduckgo.mobile.android
 ---
-- hideKeyboard
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+- runFlow: ../shared/browser_screen/click_on_menu_button.yaml
 - tapOn: "Settings"
 - tapOn: "Sync & Backup"

--- a/.maestro/sync_flows/steps/action_add_bookmarks_and_folders.yaml
+++ b/.maestro/sync_flows/steps/action_add_bookmarks_and_folders.yaml
@@ -23,16 +23,14 @@ appId: com.duckduckgo.mobile.android
     commands:
       - tapOn:
           id: "com.duckduckgo.mobile.android:id/primaryCta"
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+- runFlow: ../../shared/browser_screen/click_on_menu_button.yaml
 - tapOn: "Add Bookmark"
 - tapOn:
     id: "omnibarTextInput"
 # Now, we add a favourite
 - inputText: "${output.bookmarks.domains[1]}"
 - pressKey: Enter
-- tapOn:
-    id: "com.duckduckgo.mobile.android:id/browserMenuImageView"
+- runFlow: ../../shared/browser_screen/click_on_menu_button.yaml
 - tapOn: "Add Bookmark"
 - tapOn:
     id: "com.duckduckgo.mobile.android:id/bookmarksBottomSheetSwitch"

--- a/.maestro/tabs/open_multiple_tabs.yaml
+++ b/.maestro/tabs/open_multiple_tabs.yaml
@@ -16,8 +16,7 @@ tags:
                 id: "omnibarTextInput"
             - inputText: "https://privacy-test-pages.site"
             - pressKey: Enter
-            - tapOn:
-                id: "com.duckduckgo.mobile.android:id/tabCount"
+            - runFlow: ../shared/browser_screen/click_on_tabs_button.yaml
             - assertVisible:
                 text: "Privacy Test Pages - Home"
             - tapOn: "New Tab"
@@ -27,8 +26,7 @@ tags:
             - pressKey: Enter
             - assertVisible:
                 text: "Search engine"
-            - tapOn:
-                id: "com.duckduckgo.mobile.android:id/tabCount"
+            - runFlow: ../shared/browser_screen/click_on_tabs_button.yaml
             - assertVisible:
                 text: "Ad Click Flow"
             - assertVisible:
@@ -39,8 +37,7 @@ tags:
                 text: "Ad Click Flow"
             - assertVisible:
                 text: "Privacy Test Pages - Home"
-            - tapOn:
-                id: "com.duckduckgo.mobile.android:id/tabCount"
+            - runFlow: ../shared/browser_screen/click_on_tabs_button.yaml
             - assertVisible:
                 text: "Ad Click Flow"
             - tapOn:

--- a/app/src/main/res/layout/view_fade_omnibar.xml
+++ b/app/src/main/res/layout/view_fade_omnibar.xml
@@ -343,6 +343,7 @@
             </androidx.appcompat.widget.Toolbar>
 
             <FrameLayout
+                android:id="@+id/shieldIconPulseAnimationContainer"
                 android:layout_width="74dp"
                 android:layout_height="match_parent"
                 android:paddingTop="@dimen/experimentalOmnibarCardMarginTop"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1210387720528713?focus=true

### Description
Adapts the Maestro tests to successfully run with or without the new visual design.

### Steps to test this PR
QA optional - visual design currently isn't enabled for any build version or flavor.

If you do want to give it a try, you can hardcode `https://www.jsonblob.com/api/1376886835833397248` locally and try any of the Maestro tests, especially the ones that interact with the bottom menu/tabs buttons or privacy shield.

Separately, I'll look into adding dedicated tests for the new visual design.