### PR TITLE
adapt PPro E2E test for possibility of trials

### DIFF
--- a/.maestro/ppro/launch_privacy_pro_from_special_url.yaml
+++ b/.maestro/ppro/launch_privacy_pro_from_special_url.yaml
@@ -15,19 +15,12 @@ tags:
           id: "omnibarTextInput"
       - inputText: "https://duckduckgo.com/pro"
       - pressKey: Enter
-      - runFlow:
-          when:
-            visible:
-              text: "Privacy Pro"
-          commands:
-            - assertVisible:
-                text: "Subscribe to Privacy Pro"
-      - runFlow:
-          when:
-            visible:
-              id: "com.duckduckgo.mobile.android:id/omnibarIconContainer"
-          commands:
-            - copyTextFrom:
-                id: "omnibarTextInput"
-            - assertTrue: ${maestro.copiedText == "https://duckduckgo.com/pro"}
-
+      - assertVisible:
+          id: "com.duckduckgo.mobile.android:id/titleToolbar"
+          text: "Privacy Pro"
+      - assertVisible:
+          text: "VPN"
+      - assertVisible:
+          text: "Personal Information Removal"
+      - assertVisible:
+          text: "Identity Theft Restoration"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1210398081973853

### Description
Adapts the special URL PPro test to assert for more generic content which doesn't get tripped up by whether there's a trial offer or not.

### Steps to test this PR

QA optional. If you want to give it a try anyway, run the `launch_privacy_pro_from_special_url.yaml` Maestro test.
