### PR TITLE
remove Privacy Pro special URL test from release tests

### DIFF
--- a/.maestro/ppro/launch_privacy_pro_from_special_url.yaml
+++ b/.maestro/ppro/launch_privacy_pro_from_special_url.yaml
@@ -1,7 +1,5 @@
 appId: com.duckduckgo.mobile.android
-name: "ReleaseTest: Launch Privacy Pro from special URL is working"
-tags:
-  - releaseTest
+name: "Launch Privacy Pro from special URL is working"
 ---
 - retry:
     maxRetries: 3


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1210408722140193?focus=true

### Description
Remove the Privacy Pro special URL from release tests as we can't assert correctness of this behavior on Maestro Cloud emulators.

### Steps to test this PR

No QA needed.