### PR TITLE
Fix Duck.ai PoC toggle

### DIFF
--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/experiments/visual/store/VisualDesignExperimentDataStoreImpl.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/experiments/visual/store/VisualDesignExperimentDataStoreImpl.kt
@@ -68,7 +68,7 @@ class VisualDesignExperimentDataStoreImpl @Inject constructor(
     private val _experimentFeatureFlagEnabled =
         MutableStateFlow(experimentalUIThemingFeature.self().isEnabled() && experimentalUIThemingFeature.visualUpdatesFeature().isEnabled())
     private val _duckAIFeatureFlagEnabled =
-        MutableStateFlow(experimentalUIThemingFeature.self().isEnabled() && experimentalUIThemingFeature.duckAIPoCFeature().isEnabled())
+        MutableStateFlow(_experimentFeatureFlagEnabled.value && experimentalUIThemingFeature.duckAIPoCFeature().isEnabled())
 
     override val isExperimentEnabled: StateFlow<Boolean> =
         combine(
@@ -83,8 +83,8 @@ class VisualDesignExperimentDataStoreImpl @Inject constructor(
         )
 
     override val isDuckAIPoCEnabled: StateFlow<Boolean> =
-        combine(_duckAIFeatureFlagEnabled, isExperimentEnabled) { experimentEnabled, conflicts ->
-            experimentEnabled && !conflicts
+        combine(_duckAIFeatureFlagEnabled, isExperimentEnabled) { duckAIFeatureFlagEnabled, experimentEnabled ->
+            duckAIFeatureFlagEnabled && experimentEnabled
         }.stateIn(
             scope = appCoroutineScope,
             started = SharingStarted.Eagerly,
@@ -122,7 +122,7 @@ class VisualDesignExperimentDataStoreImpl @Inject constructor(
             _experimentFeatureFlagEnabled.value =
                 experimentalUIThemingFeature.self().isEnabled() && experimentalUIThemingFeature.visualUpdatesFeature().isEnabled()
             _duckAIFeatureFlagEnabled.value =
-                experimentalUIThemingFeature.self().isEnabled() && experimentalUIThemingFeature.duckAIPoCFeature().isEnabled()
+                _experimentFeatureFlagEnabled.value && experimentalUIThemingFeature.duckAIPoCFeature().isEnabled()
             _anyConflictingExperimentEnabled.value = isAnyConflictingExperimentEnabled()
         }
     }

--- a/common/common-ui/src/test/java/com/duckduckgo/common/ui/experiments/visual/store/VisualDesignExperimentDataStoreImplTest.kt
+++ b/common/common-ui/src/test/java/com/duckduckgo/common/ui/experiments/visual/store/VisualDesignExperimentDataStoreImplTest.kt
@@ -252,6 +252,42 @@ class VisualDesignExperimentDataStoreImplTest {
         Assert.assertTrue(testee.anyConflictingExperimentEnabled.value)
     }
 
+    @Test
+    fun `when Duck AI PoC FF enabled and experiment enabled, Duck AI PoC enabled`() = runTest {
+        whenever(togglesInventory.getAllActiveExperimentToggles()).thenReturn(emptyList())
+        whenever(experimentalUIThemingFeatureToggle.isEnabled()).thenReturn(true)
+        whenever(visualDesignFeatureToggle.isEnabled()).thenReturn(true)
+        whenever(duckChatPoCToggle.isEnabled()).thenReturn(true)
+
+        val testee = createTestee()
+
+        Assert.assertTrue(testee.isDuckAIPoCEnabled.value)
+    }
+
+    @Test
+    fun `when Duck AI PoC FF enabled and experiment disabled, Duck AI PoC disabled`() = runTest {
+        whenever(togglesInventory.getAllActiveExperimentToggles()).thenReturn(emptyList())
+        whenever(experimentalUIThemingFeatureToggle.isEnabled()).thenReturn(false)
+        whenever(visualDesignFeatureToggle.isEnabled()).thenReturn(false)
+        whenever(duckChatPoCToggle.isEnabled()).thenReturn(true)
+
+        val testee = createTestee()
+
+        Assert.assertFalse(testee.isDuckAIPoCEnabled.value)
+    }
+
+    @Test
+    fun `when Duck AI PoC FF disabled but experiment enabled, Duck AI PoC disabled`() = runTest {
+        whenever(togglesInventory.getAllActiveExperimentToggles()).thenReturn(emptyList())
+        whenever(experimentalUIThemingFeatureToggle.isEnabled()).thenReturn(true)
+        whenever(visualDesignFeatureToggle.isEnabled()).thenReturn(true)
+        whenever(duckChatPoCToggle.isEnabled()).thenReturn(false)
+
+        val testee = createTestee()
+
+        Assert.assertFalse(testee.isDuckAIPoCEnabled.value)
+    }
+
     private fun createTestee(): VisualDesignExperimentDataStoreImpl {
         return VisualDesignExperimentDataStoreImpl(
             appCoroutineScope = coroutineRule.testScope,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1210411891798809?focus=true

### Description
The Duck.ai experimental UI toggle always resets to false, this fixes it and adds some tests.

### Steps to test this PR

- [ ] Go to experimental UI settings
- [ ] Enable Duck.ai PoC
- [ ] Verify that Duck.ai PoC is enabled
