### PR TITLE
remove top-level feature toggle reference from visual design store

### DIFF
--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/experiments/visual/store/VisualDesignExperimentDataStoreImpl.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/experiments/visual/store/VisualDesignExperimentDataStoreImpl.kt
@@ -65,10 +65,8 @@ class VisualDesignExperimentDataStoreImpl @Inject constructor(
     private val _anyConflictingExperimentEnabled = MutableStateFlow(isAnyConflictingExperimentEnabled())
     override val anyConflictingExperimentEnabled = _anyConflictingExperimentEnabled.asStateFlow()
 
-    private val _experimentFeatureFlagEnabled =
-        MutableStateFlow(experimentalUIThemingFeature.self().isEnabled() && experimentalUIThemingFeature.visualUpdatesFeature().isEnabled())
-    private val _duckAIFeatureFlagEnabled =
-        MutableStateFlow(_experimentFeatureFlagEnabled.value && experimentalUIThemingFeature.duckAIPoCFeature().isEnabled())
+    private val _experimentFeatureFlagEnabled = MutableStateFlow(experimentalUIThemingFeature.visualUpdatesFeature().isEnabled())
+    private val _duckAIFeatureFlagEnabled = MutableStateFlow(experimentalUIThemingFeature.duckAIPoCFeature().isEnabled())
 
     override val isExperimentEnabled: StateFlow<Boolean> =
         combine(
@@ -119,10 +117,8 @@ class VisualDesignExperimentDataStoreImpl @Inject constructor(
 
     private fun updateFeatureState() {
         appCoroutineScope.launch {
-            _experimentFeatureFlagEnabled.value =
-                experimentalUIThemingFeature.self().isEnabled() && experimentalUIThemingFeature.visualUpdatesFeature().isEnabled()
-            _duckAIFeatureFlagEnabled.value =
-                _experimentFeatureFlagEnabled.value && experimentalUIThemingFeature.duckAIPoCFeature().isEnabled()
+            _experimentFeatureFlagEnabled.value = experimentalUIThemingFeature.visualUpdatesFeature().isEnabled()
+            _duckAIFeatureFlagEnabled.value = experimentalUIThemingFeature.duckAIPoCFeature().isEnabled()
             _anyConflictingExperimentEnabled.value = isAnyConflictingExperimentEnabled()
         }
     }

--- a/common/common-ui/src/test/java/com/duckduckgo/common/ui/experiments/visual/store/VisualDesignExperimentDataStoreImplTest.kt
+++ b/common/common-ui/src/test/java/com/duckduckgo/common/ui/experiments/visual/store/VisualDesignExperimentDataStoreImplTest.kt
@@ -40,9 +40,6 @@ class VisualDesignExperimentDataStoreImplTest {
     private lateinit var experimentalUIThemingFeature: ExperimentalUIThemingFeature
 
     @Mock
-    private lateinit var experimentalUIThemingFeatureToggle: Toggle
-
-    @Mock
     private lateinit var visualDesignFeatureToggle: Toggle
 
     @Mock
@@ -79,7 +76,6 @@ class VisualDesignExperimentDataStoreImplTest {
     fun setUp() {
         MockitoAnnotations.openMocks(this)
 
-        whenever(experimentalUIThemingFeature.self()).thenReturn(experimentalUIThemingFeatureToggle)
         whenever(experimentalUIThemingFeature.visualUpdatesFeature()).thenReturn(visualDesignFeatureToggle)
         whenever(experimentalUIThemingFeature.duckAIPoCFeature()).thenReturn(duckChatPoCToggle)
 
@@ -110,7 +106,6 @@ class VisualDesignExperimentDataStoreImplTest {
     }
 
     private fun whenVisualExperimentEnabled(enabled: Boolean) {
-        whenever(experimentalUIThemingFeatureToggle.isEnabled()).thenReturn(enabled)
         whenever(visualDesignFeatureToggle.isEnabled()).thenReturn(enabled)
         whenever(duckChatPoCToggle.isEnabled()).thenReturn(enabled)
     }
@@ -255,7 +250,6 @@ class VisualDesignExperimentDataStoreImplTest {
     @Test
     fun `when Duck AI PoC FF enabled and experiment enabled, Duck AI PoC enabled`() = runTest {
         whenever(togglesInventory.getAllActiveExperimentToggles()).thenReturn(emptyList())
-        whenever(experimentalUIThemingFeatureToggle.isEnabled()).thenReturn(true)
         whenever(visualDesignFeatureToggle.isEnabled()).thenReturn(true)
         whenever(duckChatPoCToggle.isEnabled()).thenReturn(true)
 
@@ -267,7 +261,6 @@ class VisualDesignExperimentDataStoreImplTest {
     @Test
     fun `when Duck AI PoC FF enabled and experiment disabled, Duck AI PoC disabled`() = runTest {
         whenever(togglesInventory.getAllActiveExperimentToggles()).thenReturn(emptyList())
-        whenever(experimentalUIThemingFeatureToggle.isEnabled()).thenReturn(false)
         whenever(visualDesignFeatureToggle.isEnabled()).thenReturn(false)
         whenever(duckChatPoCToggle.isEnabled()).thenReturn(true)
 
@@ -279,7 +272,6 @@ class VisualDesignExperimentDataStoreImplTest {
     @Test
     fun `when Duck AI PoC FF disabled but experiment enabled, Duck AI PoC disabled`() = runTest {
         whenever(togglesInventory.getAllActiveExperimentToggles()).thenReturn(emptyList())
-        whenever(experimentalUIThemingFeatureToggle.isEnabled()).thenReturn(true)
         whenever(visualDesignFeatureToggle.isEnabled()).thenReturn(true)
         whenever(duckChatPoCToggle.isEnabled()).thenReturn(false)
 

--- a/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureToggles.kt
+++ b/feature-toggles/feature-toggles-api/src/main/java/com/duckduckgo/feature/toggles/api/FeatureToggles.kt
@@ -170,6 +170,10 @@ interface Toggle {
      * This is the method that SHALL be called to get whether a feature is enabled or not. DO NOT USE [getRawStoredState] for that.
      * WARNING: Calling this method with a cohort different from [ANY_COHORT] WILL ALWAYS try to enroll the user into an experiment.
      * This method enrolls users as long as they match the targets, even if the feature is disabled or the min version does not match.
+     *
+     * **Note:** Each toggle checks its state conditions independently of the parent feature toggle.
+     * Even if a parent feature toggle evaluates to a disabled state, it does not automatically disable its sub-features.
+     *
      * @return `true` if the feature should be enabled, `false` otherwise
      */
     fun isEnabled(cohort: CohortName = ANY_COHORT): Boolean


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1210397555776032?focus=true

### Description
Removes the check of the parent flag - it's unnecessary for controlling the rollout and could lead to some mistakes in the future. Just checking the `visualUpdatesFeature` child is enough.

### Steps to test this PR

- [ ] Clear the cache and launch the app.
- [ ] Verify visual design is disabled.
- [ ] Load `https://www.jsonblob.com/api/1377904106999570432` and restart the app.
- [ ] Verify visual design is enabled.