### PR TITLE
Onboarding Experiment: Add button styles

### DIFF
--- a/common/common-ui/src/main/res/animator/buck_button_animator_set.xml
+++ b/common/common-ui/src/main/res/animator/buck_button_animator_set.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2025 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true">
+        <set android:ordering="together">
+            <objectAnimator
+                android:propertyName="scaleX"
+                android:duration="100"
+                android:valueTo="0.9"
+                android:valueType="floatType"/>
+            <objectAnimator
+                android:propertyName="scaleY"
+                android:duration="100"
+                android:valueTo="0.9"
+                android:valueType="floatType"/>
+        </set>
+    </item>
+    <item>
+        <set android:ordering="together">
+            <objectAnimator
+                android:propertyName="scaleX"
+                android:duration="100"
+                android:valueTo="1.0"
+                android:valueType="floatType"/>
+            <objectAnimator
+                android:propertyName="scaleY"
+                android:duration="100"
+                android:valueTo="1.0"
+                android:valueType="floatType"/>
+        </set>
+    </item>
+</selector>

--- a/common/common-ui/src/main/res/drawable/buck_button_primary_container_selector.xml
+++ b/common/common-ui/src/main/res/drawable/buck_button_primary_container_selector.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2018 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true">
+        <scale
+            android:drawable="@drawable/buck_primary_button_background"
+            android:scaleWidth="90%"
+            android:scaleHeight="90%"
+            android:scaleGravity="center"
+            />
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/buckColorButtonPrimaryContainer" />
+            <corners android:radius="30dp" />
+        </shape>
+    </item>
+</selector>

--- a/common/common-ui/src/main/res/drawable/buck_primary_button_background.xml
+++ b/common/common-ui/src/main/res/drawable/buck_primary_button_background.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2025 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/buckColorButtonPrimaryContainer" />
+    <corners android:radius="30dp" />
+</shape>

--- a/common/common-ui/src/main/res/layout/component_buttons.xml
+++ b/common/common-ui/src/main/res/layout/component_buttons.xml
@@ -17,6 +17,7 @@
 
 <androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:clipToPadding="false"
@@ -286,7 +287,8 @@
             app:icon="@drawable/ic_find_search_24"
             app:iconGravity="end"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"/>
+            android:layout_height="wrap_content"
+            tools:ignore="DeprecatedWidgetInXml" />
 
     </LinearLayout>
 

--- a/common/common-ui/src/main/res/layout/component_buttons.xml
+++ b/common/common-ui/src/main/res/layout/component_buttons.xml
@@ -263,6 +263,31 @@
             android:layout_marginTop="16dp"
             app:srcCompat="@drawable/ic_union" />
 
+        <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:primaryText="Onboarding Experiment Buttons" />
+
+        <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+            android:id="@+id/buck_button_primary"
+            style="@style/Widget.DuckDuckGo.BuckButton.TextButton.Primary"
+            android:text="Primary buck"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"/>
+
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="16dp"/>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/buck_button_secondary"
+            style="@style/Widget.DuckDuckGo.BuckButton.Secondary"
+            android:text="Secondary buck"
+            app:icon="@drawable/ic_find_search_24"
+            app:iconGravity="end"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"/>
+
     </LinearLayout>
 
 </androidx.core.widget.NestedScrollView>

--- a/common/common-ui/src/main/res/values-night/temp_colors.xml
+++ b/common/common-ui/src/main/res/values-night/temp_colors.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2025 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources>
+    <color name="buckColorButtonPrimaryContainer">#FFDF80</color>
+    <color name="buckColorButtonPrimaryContainerPressed">#CCAA00</color>
+    <color name="buckColorButtonPrimaryText">@color/black</color>
+
+    <color name="buckColorButtonSecondaryBorder">#074C89</color>
+    <color name="buckColorButtonSecondaryText">@color/white</color>
+    <color name="buckColorButtonSecondaryContainerPressed">#0267C1</color>
+</resources>

--- a/common/common-ui/src/main/res/values/temp_colors.xml
+++ b/common/common-ui/src/main/res/values/temp_colors.xml
@@ -35,6 +35,14 @@
     <color name="buckYellow">#FFE080</color>
     <color name="buckLightBlue">#4284F4</color>
 
+    <color name="buckColorButtonPrimaryContainer">#0267C1</color>
+    <color name="buckColorButtonPrimaryContainerPressed">#002E5A</color>
+    <color name="buckColorButtonPrimaryText">@color/white</color>
+
+    <color name="buckColorButtonSecondaryBorder">#0267C1</color>
+    <color name="buckColorButtonSecondaryText">#0267C1</color>
+    <color name="buckColorButtonSecondaryContainerPressed">#0267C1</color>
+
     <color name="daxOnboardingDialogBackgroundColorLight">#FEFEFE</color>
     <color name="daxOnboardingDialogBackgroundColorDark">#011D34</color>
 

--- a/common/common-ui/src/main/res/values/widgets.xml
+++ b/common/common-ui/src/main/res/values/widgets.xml
@@ -643,4 +643,53 @@
         <item name="android:minHeight">@dimen/checkListItemHeight</item>
     </style>
 
+    <style name="Typography.DuckDuckGo.BuckButton">
+        <item name="fontFamily">@font/pangea_bold</item>
+        <item name="android:textSize">16sp</item>
+        <item name="lineHeight">11sp</item>
+    </style>
+
+    <style name="Widget.DuckDuckGo.BuckButton.TextButton" parent="Widget.MaterialComponents.Button.TextButton">
+        <item name="cornerRadius">30dp</item>
+        <item name="android:textAppearance">@style/Typography.DuckDuckGo.BuckButton</item>
+        <item name="android:includeFontPadding">false</item>
+        <item name="android:paddingLeft">0dp</item>
+        <item name="android:paddingTop">0dp</item>
+        <item name="android:paddingBottom">0dp</item>
+        <item name="android:paddingRight">0dp</item>
+        <item name="android:insetTop">0dp</item>
+        <item name="android:insetBottom">0dp</item>
+        <item name="iconPadding">@dimen/keyline_2</item>
+        <item name="rippleColor">@color/buckColorButtonPrimaryContainerPressed</item>
+        <item name="android:stateListAnimator">@animator/buck_button_animator_set</item>
+    </style>
+
+    <style name="Widget.DuckDuckGo.BuckButton.TextButton.Primary">
+        <item name="android:textColor">@color/buckColorButtonPrimaryText</item>
+        <item name="backgroundTint">@color/buckColorButtonPrimaryContainer</item>
+        <item name="iconTint">@color/buckColorButtonPrimaryText</item>
+    </style>
+
+    <style name="Widget.DuckDuckGo.BuckButton.Secondary" parent="Widget.MaterialComponents.Button.OutlinedButton">
+        <item name="cornerRadius">30dp</item>
+        <item name="android:textAppearance">@style/Typography.DuckDuckGo.BuckButton</item>
+        <item name="android:textColor">@color/buckColorButtonSecondaryText</item>
+        <item name="android:includeFontPadding">false</item>
+        <item name="android:paddingLeft">24dp</item>
+        <item name="android:paddingTop">0dp</item>
+        <item name="android:paddingBottom">0dp</item>
+        <item name="android:paddingRight">20dp</item>
+        <item name="iconGravity">end</item>
+        <item name="iconSize">24dp</item>
+        <item name="android:textSize">13sp</item>
+        <item name="android:insetTop">0dp</item>
+        <item name="android:insetBottom">0dp</item>
+        <item name="rippleColor">@color/buckColorButtonSecondaryContainerPressed</item>
+        <item name="android:gravity">start|center_vertical</item>
+        <item name="android:stateListAnimator">@animator/buck_button_animator_set</item>
+        <item name="strokeColor">@color/buckColorButtonSecondaryBorder</item>
+        <item name="iconTint">@color/buckColorButtonSecondaryText</item>
+        <item name="iconPadding">@dimen/keyline_2</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207908166761516/task/1210435540768301 

### Description
Added new button styles for the onboarding experiment. Created primary and secondary "buck" button variants with custom animations, colors, and styling for both light and dark themes.

### Steps to test this PR

Note: As we're using temp colors and not making this part of the theme, enabling "Dark Theme" on the ADS screen will not work. 

This is of no consequence for the experiment as we'll be targeting people new to the app and we'll be using system theme settings (not app theme settings) to determine the button theme.

_Button Styles_
- [x] Navigate to the component buttons screen and scroll to the bottom
- [x] Verify the new "Onboarding Experiment Buttons" section displays both primary and secondary buck buttons
- [x] Test the press animation on both buttons
- [x] Verify the secondary button displays the search icon at the end
- [x] Enable system dark theme
- [x] Enable "Dark theme on ADS screen" so the buttons are more visible 
- [x] Check button colors match

### UI changes
| Light  | Dark |
| ------ | ----- |
|![Screenshot_20250602_112101](https://github.com/user-attachments/assets/72b9aaca-41b4-4c91-8966-a3f6aed8328f)|![Screenshot_20250602_112126](https://github.com/user-attachments/assets/cb1fd974-12ad-4fd2-a12a-bca0a4a7e1fd)|