### PR TITLE
Update content scope scripts to version 9.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.0.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.2.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#9.0.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#9.1.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1747996876"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.0.0.tgz",
-      "integrity": "sha512-bxvYvD0hp4hLWMXmgRmc0q86M9CtjzCAXn4OxQyaxcDzqK7JQ1U0Tx/puFpoRKYx7C1fScBsFj7SQT+xPM+LNQ==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.0.1.tgz",
+      "integrity": "sha512-e1Iu1fvsXx+PfpWissPWg0y9WklyobYIm0o/4KYEno2Stn1kE2lhaOBHhw1bmgj3yLgNAQuzoPgcZ5GK+jfXVA==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#1313c71152e524140e77cbca427055961180b5e8",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#707e1eb6befe94892b00a8af75cc40cad3f7293e",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -283,9 +283,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.23.tgz",
-      "integrity": "sha512-7Ec1zaFPF4RJ0eXu1YT/xgiebqwqoJz8rYPDi/O2BcZ++Wpt0Kq9cl0eg6NN6bYbPnR67ZLo7St5Q3UK0SnARw==",
+      "version": "22.15.29",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.29.tgz",
+      "integrity": "sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -670,18 +670,18 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.7.tgz",
-      "integrity": "sha512-ECqb8imSroX1UmUuhRBNPkkmtZ8mHEenieim80UVxG0M5wXVjY2Fp2tYXCPvk+nLy1geOhFpeD5YQhM/gF63Jg==",
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.8.tgz",
+      "integrity": "sha512-Ze39mm8EtocSXPbH6cv5rDeBBhehp8OLxWJKZXLEyv2dKMlblJsoAw2gmA0ZaU6iOwNlCZ4LrmaTW1reUQEmJw==",
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.7.tgz",
-      "integrity": "sha512-V055ViO8G6PbTBfaiL1Utq/MLUqFZKhJ1c9+T8t+c1uPmVSAl7rR6ib8y0lleN18niKV6f1/zmMlAhpFEaPY9w==",
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.8.tgz",
+      "integrity": "sha512-47LInzMIelfHqD1Gx5+PRYQBl6vU3Xt5KYY6AhqITIKldzu/ctwzdUpbm7AdmsRyzxnly9YH4GLHTtXPwhQhTw==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.7"
+        "tldts-core": "^7.0.8"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.0.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.2.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#9.0.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#9.1.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1747996876"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass