### PR TITLE
Visual updates: Omnibar shadows

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2684,18 +2684,26 @@ class BrowserTabFragment :
         )
     }
 
+    private fun checkIfCanScroll() {
+        val canScrollUp = newBrowserTab.newTabContainerScrollView.canScrollVertically(-1)
+        val canScrollDown = newBrowserTab.newTabContainerScrollView.canScrollVertically(1)
+
+        omnibar.setContentCanScroll(canScrollUp, canScrollDown)
+        binding.navigationBar.setCanScrollDown(canScrollDown)
+    }
+
     private fun configureNewTab() {
         newBrowserTab.newTabContainerScrollView.setOnScrollChangeListener { v, scrollX, scrollY, oldScrollX, oldScrollY ->
             if (omnibar.isEditing()) {
                 hideKeyboard()
             }
 
-            // Check if it can scroll up
-            val canScrollUp = v.canScrollVertically(-1)
-            val canScrollDown = v.canScrollVertically(1)
-            val topOfPage = scrollY == 0
+            checkIfCanScroll()
+        }
 
-            omnibar.setContentCanScroll(canScrollUp, canScrollDown, topOfPage)
+        // check if the content can scroll after a delay to allow the view to be fully laid out
+        view?.postDelayed(SCROLLABILITY_CHECK_STARTUP_DELAY) {
+            checkIfCanScroll()
         }
     }
 
@@ -3657,6 +3665,10 @@ class BrowserTabFragment :
         recreatePopupMenu()
         privacyProtectionsPopup.onConfigurationChanged()
         viewModel.onConfigurationChanged()
+
+        view?.postDelayed(SCROLLABILITY_CHECK_CONFIG_CHANGE_DELAY) {
+            checkIfCanScroll()
+        }
     }
 
     fun onBackPressed(isCustomTab: Boolean = false): Boolean {
@@ -3952,6 +3964,9 @@ class BrowserTabFragment :
 
         private const val MAX_PROGRESS = 100
         private const val TRACKERS_INI_DELAY = 500L
+
+        private const val SCROLLABILITY_CHECK_STARTUP_DELAY = 1000L
+        private const val SCROLLABILITY_CHECK_CONFIG_CHANGE_DELAY = 500L
         private const val TRACKERS_SECONDARY_DELAY = 200L
 
         private const val DEFAULT_CIRCLE_TARGET_TIMES_1_5 = 96

--- a/app/src/main/java/com/duckduckgo/app/browser/navigation/bar/BrowserNavigationBarViewIntegration.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/navigation/bar/BrowserNavigationBarViewIntegration.kt
@@ -62,6 +62,7 @@ class BrowserNavigationBarViewIntegration(
             onDisabled()
         }
         navigationBarView.browserNavigationBarObserver = browserNavigationBarObserver
+        navigationBarView.setOmnibarPosition(omnibar.omnibarPosition)
     }
 
     fun configureCustomTab() {

--- a/app/src/main/java/com/duckduckgo/app/browser/navigation/bar/view/BrowserNavigationBarView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/navigation/bar/view/BrowserNavigationBarView.kt
@@ -33,7 +33,6 @@ import androidx.lifecycle.findViewTreeViewModelStoreOwner
 import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.browser.PulseAnimation
-import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.ViewBrowserNavigationBarBinding
 import com.duckduckgo.app.browser.navigation.bar.view.BrowserNavigationBarViewModel.Command
 import com.duckduckgo.app.browser.navigation.bar.view.BrowserNavigationBarViewModel.Command.NotifyAutofillButtonClicked
@@ -66,16 +65,6 @@ class BrowserNavigationBarView @JvmOverloads constructor(
     private val attrs: AttributeSet? = null,
     defStyle: Int = 0,
 ) : FrameLayout(context, attrs, defStyle), AttachedBehavior {
-
-    private var showShadows: Boolean = false
-
-    init {
-        context.theme.obtainStyledAttributes(attrs, R.styleable.BrowserNavigationBarView, defStyle, 0)
-            .apply {
-                showShadows = getBoolean(R.styleable.BrowserNavigationBarView_showShadows, true)
-                recycle()
-            }
-    }
 
     override fun setVisibility(visibility: Int) {
         val isVisibilityUpdated = this.visibility != visibility
@@ -126,6 +115,12 @@ class BrowserNavigationBarView @JvmOverloads constructor(
         }
     }
 
+    fun setOmnibarPosition(omnibarPosition: OmnibarPosition) {
+        doOnAttach {
+            viewModel.setOmnibarPosition(omnibarPosition)
+        }
+    }
+
     fun setViewMode(viewMode: ViewMode) {
         doOnAttach {
             viewModel.setViewMode(viewMode)
@@ -135,6 +130,12 @@ class BrowserNavigationBarView @JvmOverloads constructor(
     fun setFireButtonHighlight(highlighted: Boolean) {
         doOnAttach {
             viewModel.setFireButtonHighlight(highlighted)
+        }
+    }
+
+    fun setCanScrollDown(canScrollDown: Boolean) {
+        doOnAttach {
+            viewModel.onCanScrollDownChanged(canScrollDown)
         }
     }
 
@@ -196,7 +197,6 @@ class BrowserNavigationBarView @JvmOverloads constructor(
     }
 
     private fun renderView(viewState: ViewState) {
-        binding.shadowView.isVisible = showShadows
         binding.root.isVisible = viewState.isVisible
 
         binding.newTabButton.isVisible = viewState.newTabButtonVisible
@@ -208,6 +208,7 @@ class BrowserNavigationBarView @JvmOverloads constructor(
         binding.tabsButton.hasUnread = viewState.hasUnreadTabs
 
         renderFireButtonPulseAnimation(enabled = viewState.fireButtonHighlighted)
+        binding.shadowView.isVisible = viewState.showShadow
     }
 
     private fun processCommands(command: Command) {

--- a/app/src/main/java/com/duckduckgo/app/browser/navigation/bar/view/BrowserNavigationBarViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/navigation/bar/view/BrowserNavigationBarViewModel.kt
@@ -31,6 +31,7 @@ import com.duckduckgo.app.browser.navigation.bar.view.BrowserNavigationBarViewMo
 import com.duckduckgo.app.browser.navigation.bar.view.BrowserNavigationBarViewModel.Command.NotifyNewTabButtonClicked
 import com.duckduckgo.app.browser.navigation.bar.view.BrowserNavigationBarViewModel.Command.NotifyTabsButtonClicked
 import com.duckduckgo.app.browser.navigation.bar.view.BrowserNavigationBarViewModel.Command.NotifyTabsButtonLongClicked
+import com.duckduckgo.app.browser.omnibar.model.OmnibarPosition
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.FIRE_BUTTON_STATE
@@ -124,6 +125,7 @@ class BrowserNavigationBarViewModel @Inject constructor(
                         autofillButtonVisible = true,
                         fireButtonVisible = true,
                         tabsButtonVisible = true,
+                        isNewTab = true,
                     )
                 }
             }
@@ -135,6 +137,7 @@ class BrowserNavigationBarViewModel @Inject constructor(
                         autofillButtonVisible = false,
                         fireButtonVisible = true,
                         tabsButtonVisible = true,
+                        isNewTab = false,
                     )
                 }
             }
@@ -145,6 +148,22 @@ class BrowserNavigationBarViewModel @Inject constructor(
         _viewState.update {
             it.copy(
                 fireButtonHighlighted = highlighted,
+            )
+        }
+    }
+
+    fun setOmnibarPosition(omnibarPosition: OmnibarPosition) {
+        _viewState.update {
+            it.copy(
+                omnibarPosition = omnibarPosition,
+            )
+        }
+    }
+
+    fun onCanScrollDownChanged(canScrollDown: Boolean) {
+        _viewState.update {
+            it.copy(
+                canScrollDown = canScrollDown,
             )
         }
     }
@@ -172,5 +191,11 @@ class BrowserNavigationBarViewModel @Inject constructor(
         val tabsButtonVisible: Boolean = true,
         val tabsCount: Int = 0,
         val hasUnreadTabs: Boolean = false,
-    )
+        val isNewTab: Boolean = false,
+        val canScrollDown: Boolean = false,
+        val omnibarPosition: OmnibarPosition = OmnibarPosition.BOTTOM,
+    ) {
+        val showShadow: Boolean
+            get() = omnibarPosition == OmnibarPosition.TOP && (!isNewTab || canScrollDown)
+    }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
@@ -455,9 +455,8 @@ class Omnibar(
     fun setContentCanScroll(
         canScrollUp: Boolean,
         canScrollDown: Boolean,
-        topOfPage: Boolean,
     ) {
-        newOmnibar.decorate(Decoration.NewTabScrollingState(canScrollUp, canScrollDown, topOfPage))
+        newOmnibar.decorate(Decoration.NewTabScrollingState(canScrollUp, canScrollDown))
     }
 }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -139,7 +139,6 @@ open class OmnibarLayout @JvmOverloads constructor(
         data class NewTabScrollingState(
             val canScrollUp: Boolean,
             val canScrollDown: Boolean,
-            val topOfPage: Boolean,
         ) : Decoration()
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -159,7 +159,8 @@ class OmnibarLayoutViewModel @Inject constructor(
         val isVisualDesignExperimentEnabled: Boolean = false,
         val trackersBlocked: Int = 0,
         val previouslyTrackersBlocked: Int = 0,
-        val showShadows: Boolean = false,
+        val showTopShadow: Boolean = false,
+        val showBottomShadow: Boolean = false,
         val showClickCatcher: Boolean = false,
     ) {
         fun shouldUpdateOmnibarText(): Boolean {
@@ -341,7 +342,8 @@ class OmnibarLayoutViewModel @Inject constructor(
                             showBrowserMenu = true,
                             showTabsMenu = false,
                             showFireIcon = false,
-                            showShadows = true,
+                            showTopShadow = true,
+                            showBottomShadow = true,
                         )
                     }
                 }
@@ -370,7 +372,8 @@ class OmnibarLayoutViewModel @Inject constructor(
                                 hasQueryChanged = false,
                                 urlLoaded = _viewState.value.url,
                             ),
-                            showShadows = false,
+                            showTopShadow = viewMode !is NewTab,
+                            showBottomShadow = viewMode !is NewTab,
                         )
                     }
                 }
@@ -742,12 +745,13 @@ class OmnibarLayoutViewModel @Inject constructor(
 
     fun onNewTabScrollingStateChanged(scrollingState: Decoration.NewTabScrollingState) {
         val viewMode = viewState.value.viewMode
-        // if (viewMode is NewTab) {
-        //     _viewState.update {
-        //         it.copy(
-        //             showShadows = (scrollingState.canScrollUp || scrollingState.canScrollDown) && !scrollingState.topOfPage,
-        //         )
-        //     }
-        // }
+        if (viewMode is NewTab) {
+            _viewState.update {
+                it.copy(
+                    showTopShadow = scrollingState.canScrollDown,
+                    showBottomShadow = scrollingState.canScrollUp,
+                )
+            }
+        }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/FadeOmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/FadeOmnibarLayout.kt
@@ -130,8 +130,11 @@ class FadeOmnibarLayout @JvmOverloads constructor(
 
         val rootContainer = root.findViewById<LinearLayout>(R.id.rootContainer)
         val navBar = rootContainer.findViewById<BrowserNavigationBarView>(R.id.omnibarNavigationBar)
+        val shadowTop = rootContainer.findViewById<View>(R.id.shadowViewTop)
         if (omnibarPosition == OmnibarPosition.TOP) {
             rootContainer.removeView(navBar)
+
+            shadowTop.gone()
         } else {
             navigationBar = navBar
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/FadeOmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/FadeOmnibarLayout.kt
@@ -48,7 +48,6 @@ import com.duckduckgo.common.ui.experiments.visual.store.VisualDesignExperimentD
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.hide
 import com.duckduckgo.common.ui.view.show
-import com.duckduckgo.common.ui.view.toDp
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.duckchat.impl.ui.SearchInterstitialActivityParams
 import com.duckduckgo.mobile.android.R as CommonR
@@ -133,8 +132,6 @@ class FadeOmnibarLayout @JvmOverloads constructor(
         val navBar = rootContainer.findViewById<BrowserNavigationBarView>(R.id.omnibarNavigationBar)
         if (omnibarPosition == OmnibarPosition.TOP) {
             rootContainer.removeView(navBar)
-
-            omnibarCard.elevation = 1f.toDp(context)
         } else {
             navigationBar = navBar
 
@@ -148,8 +145,6 @@ class FadeOmnibarLayout @JvmOverloads constructor(
             navBar.findViewById<LinearLayout>(R.id.barView).updatePadding(
                 top = 0,
             )
-
-            omnibarCard.elevation = 0.5f.toDp(context)
         }
         omniBarClickCatcher.setOnClickListener {
             globalActivityStarter.start(context, SearchInterstitialActivityParams)
@@ -191,8 +186,6 @@ class FadeOmnibarLayout @JvmOverloads constructor(
 
     override fun render(viewState: ViewState) {
         super.render(viewState)
-
-        renderShadows(viewState.showShadows)
 
         if (viewState.hasFocus || isFindInPageVisible) {
             animateOmnibarFocusedState(focused = true)
@@ -361,14 +354,6 @@ class FadeOmnibarLayout @JvmOverloads constructor(
             viewModel.onBackButtonPressed()
             fadeOmnibarItemPressedListener?.onBackButtonPressed()
         }
-    }
-
-    private fun renderShadows(showShadows: Boolean) {
-        // outlineProvider = if (showShadows) {
-        //     ViewOutlineProvider.BACKGROUND
-        // } else {
-        //     null
-        // }
     }
 
     companion object {

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/FadeOmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/FadeOmnibarLayout.kt
@@ -75,8 +75,10 @@ class FadeOmnibarLayout @JvmOverloads constructor(
     private val backIcon: ImageView by lazy { findViewById(R.id.backIcon) }
     private val customTabToolbarContainerWrapper: ViewGroup by lazy { findViewById(R.id.customTabToolbarContainerWrapper) }
     private val omniBarClickCatcher: View by lazy { findViewById(R.id.omnibarClickCatcher) }
-    private val shadowTop: View by lazy { findViewById<View>(R.id.shadowViewTop) }
-    private val shadowBottom: View by lazy { findViewById<View>(R.id.shadowViewBottom) }
+    private val shadowTop: View by lazy { findViewById(R.id.shadowViewTop) }
+    private val shadowLineBottom: View by lazy { findViewById(R.id.shadowLineViewBottom) }
+
+    private val shadowGradientBottom: View by lazy { findViewById(R.id.shadowViewBottom) }
 
     override val findInPage: FindInPage by lazy {
         FindInPageImpl(IncludeFadeOmnibarFindInPageBinding.bind(findViewById(R.id.findInPage)))
@@ -363,8 +365,15 @@ class FadeOmnibarLayout @JvmOverloads constructor(
     }
 
     private fun renderShadows(showTopShadow: Boolean, showBottomShadow: Boolean) {
+        val isBottomShadowVisible = showBottomShadow && omnibarPosition == OmnibarPosition.TOP
+        if (viewModel.viewState.value.viewMode == ViewMode.NewTab) {
+            shadowLineBottom.gone()
+            shadowGradientBottom.isVisible = isBottomShadowVisible
+        } else {
+            shadowLineBottom.isVisible = isBottomShadowVisible
+            shadowGradientBottom.gone()
+        }
         shadowTop.isVisible = showTopShadow && omnibarPosition == OmnibarPosition.BOTTOM
-        shadowBottom.isVisible = showBottomShadow && omnibarPosition == OmnibarPosition.TOP
     }
 
     companion object {

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/FadeOmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/FadeOmnibarLayout.kt
@@ -75,6 +75,8 @@ class FadeOmnibarLayout @JvmOverloads constructor(
     private val backIcon: ImageView by lazy { findViewById(R.id.backIcon) }
     private val customTabToolbarContainerWrapper: ViewGroup by lazy { findViewById(R.id.customTabToolbarContainerWrapper) }
     private val omniBarClickCatcher: View by lazy { findViewById(R.id.omnibarClickCatcher) }
+    private val shadowTop: View by lazy { findViewById<View>(R.id.shadowViewTop) }
+    private val shadowBottom: View by lazy { findViewById<View>(R.id.shadowViewBottom) }
 
     override val findInPage: FindInPage by lazy {
         FindInPageImpl(IncludeFadeOmnibarFindInPageBinding.bind(findViewById(R.id.findInPage)))
@@ -128,13 +130,12 @@ class FadeOmnibarLayout @JvmOverloads constructor(
 
         AndroidSupportInjection.inject(this)
 
+        outlineProvider = null
+
         val rootContainer = root.findViewById<LinearLayout>(R.id.rootContainer)
         val navBar = rootContainer.findViewById<BrowserNavigationBarView>(R.id.omnibarNavigationBar)
-        val shadowTop = rootContainer.findViewById<View>(R.id.shadowViewTop)
         if (omnibarPosition == OmnibarPosition.TOP) {
             rootContainer.removeView(navBar)
-
-            shadowTop.gone()
         } else {
             navigationBar = navBar
 
@@ -189,6 +190,8 @@ class FadeOmnibarLayout @JvmOverloads constructor(
 
     override fun render(viewState: ViewState) {
         super.render(viewState)
+
+        renderShadows(viewState.showTopShadow, viewState.showBottomShadow)
 
         if (viewState.hasFocus || isFindInPageVisible) {
             animateOmnibarFocusedState(focused = true)
@@ -357,6 +360,11 @@ class FadeOmnibarLayout @JvmOverloads constructor(
             viewModel.onBackButtonPressed()
             fadeOmnibarItemPressedListener?.onBackButtonPressed()
         }
+    }
+
+    private fun renderShadows(showTopShadow: Boolean, showBottomShadow: Boolean) {
+        shadowTop.isVisible = showTopShadow && omnibarPosition == OmnibarPosition.BOTTOM
+        shadowBottom.isVisible = showBottomShadow && omnibarPosition == OmnibarPosition.TOP
     }
 
     companion object {

--- a/app/src/main/res/drawable/background_webview_bottom_shadow.xml
+++ b/app/src/main/res/drawable/background_webview_bottom_shadow.xml
@@ -17,7 +17,7 @@
     android:shape="rectangle">
     <gradient
         android:angle="270"
-        android:endColor="#00000000"
-        android:startColor="#1A000000"
+        android:endColor="?attr/daxColorToolbar"
+        android:startColor="?attr/daxColorShadow"
         android:type="linear" />
 </shape>

--- a/app/src/main/res/drawable/background_webview_bottom_shadow.xml
+++ b/app/src/main/res/drawable/background_webview_bottom_shadow.xml
@@ -16,7 +16,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <gradient
-        android:angle="270"
+        android:angle="90"
         android:endColor="?attr/daxColorToolbar"
         android:startColor="?attr/daxColorShadow"
         android:type="linear" />

--- a/app/src/main/res/drawable/background_webview_top_shadow.xml
+++ b/app/src/main/res/drawable/background_webview_top_shadow.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2025 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <gradient
+        android:angle="90"
+        android:endColor="?attr/daxColorToolbar"
+        android:startColor="?attr/daxColorShadow"
+        android:type="linear" />
+</shape>

--- a/app/src/main/res/drawable/background_webview_top_shadow.xml
+++ b/app/src/main/res/drawable/background_webview_top_shadow.xml
@@ -16,7 +16,7 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <gradient
-        android:angle="90"
+        android:angle="270"
         android:endColor="?attr/daxColorToolbar"
         android:startColor="?attr/daxColorShadow"
         android:type="linear" />

--- a/app/src/main/res/layout-w600dp/view_browser_navigation_bar.xml
+++ b/app/src/main/res/layout-w600dp/view_browser_navigation_bar.xml
@@ -176,8 +176,8 @@
     <View
         android:id="@+id/shadowView"
         android:layout_width="match_parent"
-        android:layout_height="2dp"
-        android:background="@drawable/background_navigation_bar_shadow"
+        android:layout_height="3dp"
+        android:background="@drawable/background_webview_bottom_shadow"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout-w600dp/view_browser_navigation_bar.xml
+++ b/app/src/main/res/layout-w600dp/view_browser_navigation_bar.xml
@@ -177,7 +177,7 @@
         android:id="@+id/shadowView"
         android:layout_width="match_parent"
         android:layout_height="3dp"
-        android:background="@drawable/background_webview_bottom_shadow"
+        android:background="@drawable/background_webview_top_shadow"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/fragment_browser_tab.xml
+++ b/app/src/main/res/layout/fragment_browser_tab.xml
@@ -157,7 +157,6 @@
         android:id="@+id/navigationBar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:showShadows="true"
         android:layout_gravity="bottom" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/view_browser_navigation_bar.xml
+++ b/app/src/main/res/layout/view_browser_navigation_bar.xml
@@ -155,7 +155,7 @@
         android:id="@+id/shadowView"
         android:layout_width="match_parent"
         android:layout_height="3dp"
-        android:background="@drawable/background_webview_bottom_shadow"
+        android:background="@drawable/background_webview_top_shadow"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/view_browser_navigation_bar.xml
+++ b/app/src/main/res/layout/view_browser_navigation_bar.xml
@@ -154,8 +154,8 @@
     <View
         android:id="@+id/shadowView"
         android:layout_width="match_parent"
-        android:layout_height="2dp"
-        android:background="@drawable/background_navigation_bar_shadow"
+        android:layout_height="3dp"
+        android:background="@drawable/background_webview_bottom_shadow"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/view_fade_omnibar.xml
+++ b/app/src/main/res/layout/view_fade_omnibar.xml
@@ -31,6 +31,12 @@
         android:orientation="vertical"
         app:layout_scrollFlags="scroll|enterAlways|snap">
 
+        <View
+            android:id="@+id/shadowViewTop"
+            android:layout_width="match_parent"
+            android:layout_height="3dp"
+            android:background="@drawable/background_webview_bottom_shadow" />
+
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/toolbarContainer"
             android:layout_width="match_parent"
@@ -55,7 +61,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:layout_marginHorizontal="@dimen/experimentalOmnibarCardMarginHorizontal"
-                    app:cardElevation="1dp"
+                    app:cardElevation="2dp"
                     android:layout_marginTop="@dimen/experimentalOmnibarCardMarginTop"
                     android:layout_marginBottom="@dimen/experimentalOmnibarCardMarginBottom"
                     app:strokeColor="?daxColorAccentBlue"

--- a/app/src/main/res/layout/view_fade_omnibar.xml
+++ b/app/src/main/res/layout/view_fade_omnibar.xml
@@ -458,11 +458,16 @@
             </FrameLayout>
         </androidx.constraintlayout.widget.ConstraintLayout>
 
+        <View
+            android:id="@+id/shadowViewBottom"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="?attr/daxColorLineShadow" />
+
         <com.duckduckgo.app.browser.navigation.bar.view.BrowserNavigationBarView
             android:id="@+id/omnibarNavigationBar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:showShadows="false"
             android:layout_gravity="bottom" />
 
     </LinearLayout>

--- a/app/src/main/res/layout/view_fade_omnibar.xml
+++ b/app/src/main/res/layout/view_fade_omnibar.xml
@@ -35,7 +35,7 @@
             android:id="@+id/shadowViewTop"
             android:layout_width="match_parent"
             android:layout_height="3dp"
-            android:background="@drawable/background_webview_bottom_shadow" />
+            android:background="@drawable/background_webview_top_shadow" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/toolbarContainer"
@@ -459,10 +459,16 @@
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <View
-            android:id="@+id/shadowViewBottom"
+            android:id="@+id/shadowLineViewBottom"
             android:layout_width="match_parent"
             android:layout_height="1dp"
             android:background="?attr/daxColorLineShadow" />
+
+        <View
+            android:id="@+id/shadowViewBottom"
+            android:layout_width="match_parent"
+            android:layout_height="3dp"
+            android:background="@drawable/background_webview_bottom_shadow" />
 
         <com.duckduckgo.app.browser.navigation.bar.view.BrowserNavigationBarView
             android:id="@+id/omnibarNavigationBar"

--- a/app/src/main/res/values/attrs-omnibar-view.xml
+++ b/app/src/main/res/values/attrs-omnibar-view.xml
@@ -37,8 +37,4 @@
         <attr name="omnibarPosition"/>
     </declare-styleable>
 
-    <declare-styleable name="BrowserNavigationBarView">
-        <attr name="showShadows" format="boolean"/>
-    </declare-styleable>
-
 </resources>

--- a/common/common-ui/src/main/res/values/design-experiments-colors.xml
+++ b/common/common-ui/src/main/res/values/design-experiments-colors.xml
@@ -40,6 +40,7 @@
 
     <!-- Lines-->
     <color name="lines_dark">#1FF9F9F9</color>
+    <color name="line_shadow_dark">#08F9F9F9</color>
 
     <!-- Controls -->
     <color name="controls_fill_primary_dark">#1FF9F9F9</color>
@@ -67,6 +68,7 @@
 
     <!-- Lines-->
     <color name="lines_light">#171F1F1F</color>
+    <color name="line_shadow_light">#00000000</color>
 
     <!-- Controls -->
     <color name="controls_fill_primary_light">#171F1F1F</color>

--- a/common/common-ui/src/main/res/values/design-experiments-colors.xml
+++ b/common/common-ui/src/main/res/values/design-experiments-colors.xml
@@ -26,6 +26,7 @@
     <color name="background_surface_dark">#333538</color>
     <color name="background_window_dark">#404145</color>
     <color name="background_container_dark">#404145</color>
+    <color name="background_shadow_dark">#202021</color>
 
     <!-- Text -->
     <color name="text_primary_dark">#E6FFFFFF</color>
@@ -52,6 +53,7 @@
     <color name="background_surface_light">#F9F9F9</color>
     <color name="background_window_light">#FFFFFF</color>
     <color name="background_container_light">#FFFFFF</color>
+    <color name="background_shadow_light">#DEDEE0</color>
 
     <!-- Text -->
     <color name="text_primary_light">#1F1F1F</color>

--- a/common/common-ui/src/main/res/values/design-experiments-theming.xml
+++ b/common/common-ui/src/main/res/values/design-experiments-theming.xml
@@ -36,6 +36,7 @@
 
         <!-- Lines-->
         <item name="daxColorLines">@color/lines_dark</item>
+        <item name="daxColorLineShadow">@color/lines_dark</item>
 
         <!-- Controls -->
         <item name="daxColorControlFillPrimary">@color/controls_fill_primary_dark</item>
@@ -77,6 +78,7 @@
 
         <!-- Lines-->
         <item name="daxColorLines">@color/lines_light</item>
+        <item name="daxColorLineShadow">@color/line_shadow_light</item>
 
         <!-- Controls -->
         <item name="daxColorControlFillPrimary">@color/controls_fill_primary_light</item>

--- a/common/common-ui/src/main/res/values/design-experiments-theming.xml
+++ b/common/common-ui/src/main/res/values/design-experiments-theming.xml
@@ -23,6 +23,7 @@
         <item name="daxColorBackground">@color/background_background_dark</item>
         <item name="daxColorSurface">@color/background_surface_dark</item>
         <item name="daxColorWindow">@color/background_window_dark</item>
+        <item name="daxColorShadow">@color/background_shadow_dark</item>
 
         <!-- Text -->
         <item name="daxColorPrimaryText">@color/text_primary_dark</item>
@@ -63,6 +64,7 @@
         <item name="daxColorBackground">@color/background_background_light</item>
         <item name="daxColorSurface">@color/background_surface_light</item>
         <item name="daxColorWindow">@color/background_window_light</item>
+        <item name="daxColorShadow">@color/background_shadow_light</item>
 
         <!-- Text -->
         <item name="daxColorPrimaryText">@color/text_primary_light</item>

--- a/common/common-ui/src/main/res/values/design-system-colors.xml
+++ b/common/common-ui/src/main/res/values/design-system-colors.xml
@@ -48,6 +48,7 @@
     <attr name="daxColorSurface" format="color"/>
     <attr name="daxColorContainer" format="color"/>
     <attr name="daxColorWindow" format="color"/>
+    <attr name="daxColorShadow" format="color"/>
     <attr name="daxColorPrimaryText" format="color"/>
     <attr name="daxColorPrimaryInvertedText" format="color"/>
     <attr name="daxColorSecondaryText" format="color"/>

--- a/common/common-ui/src/main/res/values/design-system-colors.xml
+++ b/common/common-ui/src/main/res/values/design-system-colors.xml
@@ -59,6 +59,7 @@
     <attr name="daxColorIconDisabled" format="color"/>
     <attr name="daxColorDestructive" format="color"/>
     <attr name="daxColorLines" format="color"/>
+    <attr name="daxColorLineShadow" format="color"/>
     <attr name="daxColorAccentBlue" format="color"/>
     <attr name="daxColorAccentYellow" format="color"/>
     <attr name="daxColorContainerDisabled" format="color"/>

--- a/common/common-ui/src/main/res/values/design-system-theming.xml
+++ b/common/common-ui/src/main/res/values/design-system-theming.xml
@@ -127,6 +127,7 @@
         <item name="preferredNavigationBarColor">?attr/daxColorSurface</item>
         <item name="daxColorToolbar">?attr/daxColorSurface</item>
         <item name="daxColorBrowserOverlay">?attr/daxColorSurface</item>
+        <item name="daxColorLineShadow">#00000000</item>
 
         <!--disables the overlay so that elevated surfaces are always daxColorSurface-->
         <item name="elevationOverlayEnabled">false</item>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1210209951324419?focus=true

### Description

This PR updates the shadows of omnibar both in light and dark mode. It hides the shadows on the NTP and only displays the side where it's possible to scroll favorites.

### Steps to test this PR

- [ ] Enable the experimental UI
- [ ] Verify the shadows in light mode match the design in [Figma](https://www.figma.com/design/triNDLtPcx4by8Hsw9CzYt/%F0%9F%96%8D%EF%B8%8F-2025-Visual-Design-Update---1-Tap-AI-ChatOS---Android?node-id=7839-40464&t=Vp1V1KckXpc8cDrs-1) in the browser
- [ ] Verify the shadows in light mode match the design in [Figma](https://www.figma.com/design/triNDLtPcx4by8Hsw9CzYt/%F0%9F%96%8D%EF%B8%8F-2025-Visual-Design-Update---1-Tap-AI-ChatOS---Android?node-id=7839-40464&t=Vp1V1KckXpc8cDrs-1) on NTP
- [ ] Verify the shadows in dark mode match the design in [Figma](https://www.figma.com/design/triNDLtPcx4by8Hsw9CzYt/%F0%9F%96%8D%EF%B8%8F-2025-Visual-Design-Update---1-Tap-AI-ChatOS---Android?node-id=7839-40464&t=Vp1V1KckXpc8cDrs-1) in the browser
- [ ] Verify the shadows in dark mode match the design in [Figma](https://www.figma.com/design/triNDLtPcx4by8Hsw9CzYt/%F0%9F%96%8D%EF%B8%8F-2025-Visual-Design-Update---1-Tap-AI-ChatOS---Android?node-id=7839-40464&t=Vp1V1KckXpc8cDrs-1) on NTP
- [ ] Verify the old UI works as expected

### Screenshots

![Screenshot_20250603_084153](https://github.com/user-attachments/assets/8ae81805-a2db-4b6d-9136-6745b9313294)

![Screenshot_20250603_084220](https://github.com/user-attachments/assets/e8dbe858-5034-4215-9057-8339d7b95cd6)

![Screenshot_20250603_084239](https://github.com/user-attachments/assets/7530f5c5-e2e0-448a-8ba6-6297de7bd6cc)

![Screenshot_20250603_084259](https://github.com/user-attachments/assets/3471ed18-52a1-481b-b3e0-63ccbeb3081f)

![Screenshot_20250603_084316](https://github.com/user-attachments/assets/5878e4f0-6c8d-4388-8bee-3d096c4a996c)

![Screenshot_20250603_085449](https://github.com/user-attachments/assets/f1efe349-cf86-470a-bc27-0e8c59c38c77)

![Screenshot_20250603_085605](https://github.com/user-attachments/assets/764bbf26-9ac2-4255-beee-c146a6cc2c99)

![Screenshot_20250603_085623](https://github.com/user-attachments/assets/7935fd15-1ed2-4246-a4cf-d2cccfce837c)

![Screenshot_20250603_085645](https://github.com/user-attachments/assets/55ae4d9e-e620-4ce5-884e-3e34757b177f)
