### PR TITLE
Add app file for Release - Run E2E Maestro Tests

### DIFF
--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -81,6 +81,7 @@ jobs:
           api-key: ${{ secrets.ROBIN_API_KEY }}
           project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
           timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
+          app-file: apk/release.apk
           android-api-level: 30
           workspace: .maestro
           include-tags: ${{ github.event.inputs.test-tag }}


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/1/137249556945/project/488551667048375/task/1210449163160266?focus=true

### Description
Add missing app `app-file` for  m`obile-dev-inc/action-maestro-cloud` in release_tests.yml
### Steps to test this PR
This should pass https://github.com/duckduckgo/Android/actions/runs/15412985893/job/43369119483
