### PR TITLE
initialize VisualDesignExperimentDataStore on a worker thread

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/FadeOmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/FadeOmnibarLayout.kt
@@ -44,7 +44,6 @@ import com.duckduckgo.app.browser.omnibar.Omnibar.ViewMode
 import com.duckduckgo.app.browser.omnibar.OmnibarLayout
 import com.duckduckgo.app.browser.omnibar.OmnibarLayoutViewModel.ViewState
 import com.duckduckgo.app.browser.omnibar.model.OmnibarPosition
-import com.duckduckgo.common.ui.experiments.visual.store.VisualDesignExperimentDataStore
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.hide
 import com.duckduckgo.common.ui.view.show
@@ -63,9 +62,6 @@ class FadeOmnibarLayout @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyle: Int = 0,
 ) : OmnibarLayout(context, attrs, defStyle) {
-
-    @Inject
-    lateinit var experimentDataStore: VisualDesignExperimentDataStore
 
     @Inject
     lateinit var globalActivityStarter: GlobalActivityStarter

--- a/app/src/main/java/com/duckduckgo/app/launch/LaunchBridgeActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/launch/LaunchBridgeActivity.kt
@@ -20,26 +20,35 @@ import android.os.Bundle
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.onboarding.ui.OnboardingActivity
-import com.duckduckgo.common.ui.DuckDuckGoActivity
+import com.duckduckgo.common.ui.experiments.visual.store.VisualDesignExperimentDataStoreInitializer
 import com.duckduckgo.daxprompts.api.DaxPromptBrowserComparisonNoParams
 import com.duckduckgo.daxprompts.api.DaxPromptDuckPlayerNoParams
 import com.duckduckgo.daxprompts.impl.ui.DaxPromptBrowserComparisonActivity.Companion.DAX_PROMPT_BROWSER_COMPARISON_SET_DEFAULT_EXTRA
 import com.duckduckgo.daxprompts.impl.ui.DaxPromptDuckPlayerActivity.Companion.DAX_PROMPT_DUCK_PLAYER_ACTIVITY_URL_EXTRA
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
+import dagger.android.AndroidInjection
+import dagger.android.DaggerActivity
 import javax.inject.Inject
 import kotlinx.coroutines.launch
 import logcat.logcat
 
 @InjectWith(ActivityScope::class)
-class LaunchBridgeActivity : DuckDuckGoActivity() {
+class LaunchBridgeActivity : DaggerActivity() {
 
-    private val viewModel: LaunchViewModel by bindViewModel()
+    @Inject lateinit var visualDesignExperimentDataStoreInitializer: VisualDesignExperimentDataStoreInitializer
+
+    @Inject lateinit var viewModelFactory: ViewModelProvider.NewInstanceFactory
+
+    private val viewModel: LaunchViewModel by lazy {
+        ViewModelProvider(this, viewModelFactory)[LaunchViewModel::class.java]
+    }
 
     private val startDaxPromptDuckPlayerActivityForResult =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result: ActivityResult ->
@@ -69,6 +78,7 @@ class LaunchBridgeActivity : DuckDuckGoActivity() {
     lateinit var globalActivityStarter: GlobalActivityStarter
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        AndroidInjection.inject(this, bindingKey = DaggerActivity::class.java)
         val splashScreen = installSplashScreen()
         super.onCreate(savedInstanceState)
         splashScreen.setKeepOnScreenCondition { true }
@@ -77,7 +87,10 @@ class LaunchBridgeActivity : DuckDuckGoActivity() {
 
         configureObservers()
 
-        lifecycleScope.launch { viewModel.determineViewToShow() }
+        lifecycleScope.launch {
+            visualDesignExperimentDataStoreInitializer.initialize()
+            viewModel.determineViewToShow()
+        }
     }
 
     private fun configureObservers() {

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/experiments/visual/store/VisualDesignExperimentDataStore.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/experiments/visual/store/VisualDesignExperimentDataStore.kt
@@ -18,6 +18,15 @@ package com.duckduckgo.common.ui.experiments.visual.store
 
 import kotlinx.coroutines.flow.StateFlow
 
+interface VisualDesignExperimentDataStoreInitializer {
+    /**
+     * Initializes the [VisualDesignExperimentDataStore].
+     *
+     * This is a special, idempotent function to be called while the splash screen is visible to pre-warm the store and allow for non-blocking, synchronous access afterwards.
+     */
+    suspend fun initialize(): VisualDesignExperimentDataStore
+}
+
 interface VisualDesignExperimentDataStore {
 
     /**

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/experiments/visual/store/VisualDesignExperimentDataStoreLazyProvider.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/experiments/visual/store/VisualDesignExperimentDataStoreLazyProvider.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.ui.experiments.visual.store
+
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.common.ui.experiments.visual.ExperimentalUIThemingFeature
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.FeatureTogglesInventory
+import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+
+/**
+ * Original reason for creating this lazy provider is in https://app.asana.com/1/137249556945/task/1210355090527279/comment/1210422281011749?focus=true.
+ *
+ * Provides [VisualDesignExperimentDataStoreImpl] with an option to initialize it on a background thread
+ * to avoid blocking the main thread during app startup.
+ *
+ * The data store performs synchronous checks of feature flags and experiments during initialization
+ * to correctly set up its state flows. This is essential, as the state is used to determine the app’s main
+ * theme and must be ready before any themeable activity launches to prevent flickering or incorrect
+ * theming.
+ *
+ * Previously, the first accessor (e.g., Dagger initializer or theme manager) would block the main
+ * thread while the store initialized. Offloading this work to a worker thread eliminates that risk.
+ *
+ * This provider is used in [com.duckduckgo.app.launch.LaunchBridgeActivity] to trigger initialization
+ * while the splash screen is shown, ensuring the store is ready for synchronous access afterward.
+ *
+ * Access before the splash screen ends is not expected. A debug-only assertion guards
+ * against premature access, allowing issues to be caught during development without impacting release builds
+ * (in case there are flows we've not considered or tested yet but can happen in production).
+ */
+@ContributesBinding(
+    scope = AppScope::class,
+    boundType = VisualDesignExperimentDataStore::class,
+)
+@ContributesBinding(
+    scope = AppScope::class,
+    boundType = VisualDesignExperimentDataStoreInitializer::class,
+)
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = PrivacyConfigCallbackPlugin::class,
+)
+@SingleInstanceIn(scope = AppScope::class)
+class VisualDesignExperimentDataStoreLazyProvider @Inject constructor(
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val experimentalUIThemingFeature: ExperimentalUIThemingFeature,
+    private val featureTogglesInventory: FeatureTogglesInventory,
+    private val dispatcherProvider: DispatcherProvider,
+    private val visualDesignExperimentDataStoreImplFactory: VisualDesignExperimentDataStoreImplFactory,
+) : VisualDesignExperimentDataStoreInitializer, VisualDesignExperimentDataStore, PrivacyConfigCallbackPlugin {
+
+    private val initMutex = Mutex()
+
+    private var _store: VisualDesignExperimentDataStoreImpl? = null
+
+    private val store: VisualDesignExperimentDataStore
+        get() {
+            val ref = _store
+            assert(ref != null) { "VisualDesignExperimentDataStore is not initialized." }
+            return ref ?: runBlocking { initialize() }
+        }
+
+    override suspend fun initialize(): VisualDesignExperimentDataStore = initMutex.withLock {
+        suspend fun createStore(): VisualDesignExperimentDataStoreImpl = withContext(dispatcherProvider.io()) {
+            visualDesignExperimentDataStoreImplFactory.create(
+                appCoroutineScope = appCoroutineScope,
+                experimentalUIThemingFeature = experimentalUIThemingFeature,
+                featureTogglesInventory = featureTogglesInventory,
+            )
+        }
+
+        _store ?: createStore().also { _store = it }
+    }
+
+    override fun onPrivacyConfigDownloaded() {
+        // store fetches latest flags on initialization, so updates are only needed if the store has already been initialized before
+        _store?.onPrivacyConfigDownloaded()
+    }
+
+    override val isExperimentEnabled: StateFlow<Boolean>
+        get() = store.isExperimentEnabled
+    override val isDuckAIPoCEnabled: StateFlow<Boolean>
+        get() = store.isDuckAIPoCEnabled
+    override val anyConflictingExperimentEnabled: StateFlow<Boolean>
+        get() = store.anyConflictingExperimentEnabled
+    override fun changeExperimentFlagPreference(enabled: Boolean) = store.changeExperimentFlagPreference(enabled)
+    override fun changeDuckAIPoCFlagPreference(enabled: Boolean) = store.changeDuckAIPoCFlagPreference(enabled)
+}

--- a/common/common-ui/src/test/java/com/duckduckgo/common/ui/experiments/visual/store/VisualDesignExperimentDataStoreLazyProviderTest.kt
+++ b/common/common-ui/src/test/java/com/duckduckgo/common/ui/experiments/visual/store/VisualDesignExperimentDataStoreLazyProviderTest.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.ui.experiments.visual.store
+
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.ui.experiments.visual.ExperimentalUIThemingFeature
+import com.duckduckgo.feature.toggles.api.FeatureTogglesInventory
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class VisualDesignExperimentDataStoreLazyProviderTest {
+
+    @get:Rule
+    var coroutineRule = CoroutineTestRule()
+
+    @Mock
+    private lateinit var experimentalUIThemingFeature: ExperimentalUIThemingFeature
+
+    @Mock
+    private lateinit var togglesInventory: FeatureTogglesInventory
+
+    @Mock
+    private lateinit var visualDesignExperimentDataStoreImplFactory: VisualDesignExperimentDataStoreImplFactory
+
+    @Mock
+    private lateinit var isExperimentEnabledFlowMock: StateFlow<Boolean>
+
+    @Mock
+    private lateinit var isDuckAIPoCEnabledFlowMock: StateFlow<Boolean>
+
+    @Mock
+    private lateinit var anyConflictingExperimentEnabledFlowMock: StateFlow<Boolean>
+
+    @Mock
+    private lateinit var visualDesignExperimentDataStoreImpl: VisualDesignExperimentDataStoreImpl
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        whenever(
+            visualDesignExperimentDataStoreImplFactory.create(
+                appCoroutineScope = coroutineRule.testScope,
+                experimentalUIThemingFeature = experimentalUIThemingFeature,
+                featureTogglesInventory = togglesInventory,
+            ),
+        ).thenReturn(visualDesignExperimentDataStoreImpl)
+        whenever(visualDesignExperimentDataStoreImpl.isExperimentEnabled).thenReturn(isExperimentEnabledFlowMock)
+        whenever(visualDesignExperimentDataStoreImpl.isDuckAIPoCEnabled).thenReturn(isDuckAIPoCEnabledFlowMock)
+        whenever(visualDesignExperimentDataStoreImpl.anyConflictingExperimentEnabled).thenReturn(anyConflictingExperimentEnabledFlowMock)
+    }
+
+    @Test(expected = AssertionError::class)
+    fun `provider throws an AssertionError if store accessed before initializing`() = runTest {
+        val testee = createTestee()
+        testee.isExperimentEnabled
+    }
+
+    @Test
+    fun `initializing creates a valid store instance`() = runTest {
+        val testee = createTestee()
+        testee.initialize()
+
+        Assert.assertEquals(isExperimentEnabledFlowMock, testee.isExperimentEnabled)
+        Assert.assertEquals(isDuckAIPoCEnabledFlowMock, testee.isDuckAIPoCEnabled)
+        Assert.assertEquals(anyConflictingExperimentEnabledFlowMock, testee.anyConflictingExperimentEnabled)
+
+        testee.onPrivacyConfigDownloaded()
+        verify(visualDesignExperimentDataStoreImpl).onPrivacyConfigDownloaded()
+
+        testee.changeExperimentFlagPreference(true)
+        verify(visualDesignExperimentDataStoreImpl).changeExperimentFlagPreference(true)
+
+        testee.changeDuckAIPoCFlagPreference(true)
+        verify(visualDesignExperimentDataStoreImpl).changeDuckAIPoCFlagPreference(true)
+    }
+
+    @Test
+    fun `initializing is idempotent`() = runTest {
+        val testee = createTestee()
+
+        val jobs = listOf(
+            async { testee.initialize() },
+            async { testee.initialize() },
+            async { testee.initialize() },
+        )
+
+        val results = jobs.awaitAll()
+        results.forEach {
+            Assert.assertEquals(visualDesignExperimentDataStoreImpl, it)
+        }
+
+        verify(visualDesignExperimentDataStoreImplFactory, times(1)).create(
+            appCoroutineScope = coroutineRule.testScope,
+            experimentalUIThemingFeature = experimentalUIThemingFeature,
+            featureTogglesInventory = togglesInventory,
+        )
+    }
+
+    private fun createTestee(): VisualDesignExperimentDataStoreLazyProvider {
+        return VisualDesignExperimentDataStoreLazyProvider(
+            appCoroutineScope = coroutineRule.testScope,
+            experimentalUIThemingFeature = experimentalUIThemingFeature,
+            featureTogglesInventory = togglesInventory,
+            dispatcherProvider = coroutineRule.testDispatcherProvider,
+            visualDesignExperimentDataStoreImplFactory = visualDesignExperimentDataStoreImplFactory,
+        )
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1210355090527279

### Description
1. `LaunchBridgeActivity` now extends `DaggerActivity` directly instead of `DuckDuckGoActivity`. Since it doesn't include any styleable elements, it doesn't need to load the app theme. This allows the visual design data store - needed later to retrieve the theme instance - to be prepared asynchronously.
2. `VisualDesignExperimentDataStoreImpl` is now wrapped in `VisualDesignExperimentDataStoreLazyProvider`, which adds an initialize function. This allows `LaunchBridgeActivity` to pre-warm the data store while the splash screen is visible, before launching other activities.

Together, these changes fully move `VisualDesignExperimentDataStore` initialization to a worker thread, avoiding any feature flag reads or iterations on the main thread.

### Steps to test this PR

- [x] Launch the app and verify the production theme is loaded.
- [x] Change configuration to `https://www.jsonblob.com/api/1379819763261431808` and verify that the new visual design is loaded, without any flickers.