### PR TITLE
fix incorrectly selected current theme in the theme radio

### DIFF
--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/Theming.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/Theming.kt
@@ -42,10 +42,8 @@ enum class DuckDuckGoTheme {
     fun getOptionIndex(): Int {
         return when (this) {
             SYSTEM_DEFAULT -> 1
-            DARK -> 2
-            LIGHT -> 3
-            EXPERIMENT_DARK -> 4
-            EXPERIMENT_LIGHT -> 5
+            LIGHT, EXPERIMENT_LIGHT -> 2
+            DARK, EXPERIMENT_DARK -> 3
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1210402384079670?focus=true

### Description
Fixes the theme radio to pre-select correct theme.

### Steps to test this PR

- [x] Open Settings -> Appearance -> Theme.
  - [x] Verify that your current theme is pre-selected correctly.
  - [x] Change theme and try again.
- [x] Toggle on the Experimental UI Settings -> Enable Visual design updates.
  - [x] Verify that your current theme (light/dark) is pre-selected correctly. Previously, it would pre-select nothing.
  - [x] Change theme and try again.