### PR TITLE
Fix Translation of Subscription Settings Strings

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionSettingsActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionSettingsActivity.kt
@@ -183,9 +183,9 @@ class SubscriptionSettingsActivity : DuckDuckGoActivity() {
 
                 val subscriptionRenewalDetailsRes = when {
                     viewState.status == AUTO_RENEWABLE && viewState.duration == Monthly ->
-                        getString(string.freeTrialActiveSubscriptionsData, viewState.date, getString(string.monthly))
+                        getString(string.freeTrialMonthlyActiveSubscriptionsData, viewState.date)
                     viewState.status == AUTO_RENEWABLE && viewState.duration == Yearly ->
-                        getString(string.freeTrialActiveSubscriptionsData, viewState.date, getString(string.yearly))
+                        getString(string.freeTrialYearlyActiveSubscriptionsData, viewState.date)
                     else -> getString(string.freeTrialCancelledSubscriptionsData, viewState.date)
                 }
                 binding.changePlan.setSecondaryText(subscriptionRenewalDetailsRes)

--- a/subscriptions/subscriptions-impl/src/main/res/values-bg/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-bg/strings-subscriptions.xml
@@ -62,9 +62,8 @@
     <string name="subscriptionStatusSubscribed">Активен абонамент</string>
     <string name="privacyPolicyAndTermsOfService">Политика за поверителност и Условия на услугата</string>
     <string name="subscriptionStatusFreeTrial">Безплатна пробна версия е активна</string>
-    <string name="monthly">месечен</string>
-    <string name="yearly">годишен</string>
-    <string name="freeTrialActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy, second is if trial is monthly or yearly">Безплатният ви пробен период приключва на %1$s и автоматично се преобразува в %2$s платен абонамент на този ден.</string>
+    <string name="freeTrialMonthlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Безплатният ви пробен период приключва на %1$s и автоматично се преобразува в месечен платен абонамент на този ден.</string>
+    <string name="freeTrialYearlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Безплатният ти пробен период приключва на %1$s и автоматично се преобразува в годишен платен абонамент на този ден.</string>
     <string name="freeTrialCancelledSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Безплатният ви пробен период приключва на %1$s и няма да се преобразува в платен абонамент.</string>
 
     <!--Settings Subscriptions-->

--- a/subscriptions/subscriptions-impl/src/main/res/values-cs/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-cs/strings-subscriptions.xml
@@ -62,9 +62,8 @@
     <string name="subscriptionStatusSubscribed">Přihlášeno</string>
     <string name="privacyPolicyAndTermsOfService">Zásady ochrany osobních údajů a podmínky služby</string>
     <string name="subscriptionStatusFreeTrial">Bezplatná zkušební verze je aktivní</string>
-    <string name="monthly">měsíční</string>
-    <string name="yearly">roční</string>
-    <string name="freeTrialActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy, second is if trial is monthly or yearly">Tvoje bezplatná zkušební verze končí %1$s a ten samý den se automaticky prodlouží jako %2$s placené předplatné.</string>
+    <string name="freeTrialMonthlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Bezplatné zkušební období ti končí %1$s a ten samý den se automaticky prodlouží jako měsíční placené předplatné.</string>
+    <string name="freeTrialYearlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Bezplatné zkušební období ti končí %1$s a ten samý den se automaticky prodlouží jako roční placené předplatné.</string>
     <string name="freeTrialCancelledSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Tvoje bezplatná zkušební verze končí %1$s a neprodlouží se jako placené předplatné.</string>
 
     <!--Settings Subscriptions-->

--- a/subscriptions/subscriptions-impl/src/main/res/values-da/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-da/strings-subscriptions.xml
@@ -62,9 +62,8 @@
     <string name="subscriptionStatusSubscribed">Abonneret</string>
     <string name="privacyPolicyAndTermsOfService">Fortrolighedspolitik og servicevilkår</string>
     <string name="subscriptionStatusFreeTrial">Gratis prøveperiode er aktiv</string>
-    <string name="monthly">månedlige</string>
-    <string name="yearly">årligt</string>
-    <string name="freeTrialActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy, second is if trial is monthly or yearly">Din gratis prøveperiode slutter den %1$s og konverteres automatisk til et %2$s betalt abonnement fra denne dag.</string>
+    <string name="freeTrialMonthlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Din gratis prøveperiode slutter den %1$s og konverteres automatisk til et månedligt betalt abonnement den dag.</string>
+    <string name="freeTrialYearlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Din gratis prøveperiode slutter den %1$s og konverteres automatisk til et årligt betalt abonnement fra denne dag.</string>
     <string name="freeTrialCancelledSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Din gratis prøveperiode slutter den %1$s og konverteres ikke til et betalt abonnement.</string>
 
     <!--Settings Subscriptions-->

--- a/subscriptions/subscriptions-impl/src/main/res/values-de/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-de/strings-subscriptions.xml
@@ -62,9 +62,8 @@
     <string name="subscriptionStatusSubscribed">Abonniert</string>
     <string name="privacyPolicyAndTermsOfService">Datenschutzerklärung und Nutzungsbedingungen</string>
     <string name="subscriptionStatusFreeTrial">Kostenlose Testphase aktiv</string>
-    <string name="monthly">monatlich</string>
-    <string name="yearly">Jährlich</string>
-    <string name="freeTrialActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy, second is if trial is monthly or yearly">Deine kostenlose Testphase endet am %1$s und wird an diesem Tag automatisch in ein kostenpflichtiges %2$s-Abo umgewandelt.</string>
+    <string name="freeTrialMonthlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Deine kostenlose Testphase endet am %1$s und wird an diesem Tag automatisch in ein kostenpflichtiges Monatsabo umgewandelt.</string>
+    <string name="freeTrialYearlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Deine kostenlose Testphase endet am %1$s und wird an diesem Tag automatisch in ein kostenpflichtiges Jahresabo umgewandelt.</string>
     <string name="freeTrialCancelledSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Deine kostenlose Testphase endet am %1$s und wird nicht in ein kostenpflichtiges Abonnement umgewandelt.</string>
 
     <!--Settings Subscriptions-->

--- a/subscriptions/subscriptions-impl/src/main/res/values-el/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-el/strings-subscriptions.xml
@@ -62,9 +62,8 @@
     <string name="subscriptionStatusSubscribed">Έχει γίνει εγγραφή</string>
     <string name="privacyPolicyAndTermsOfService">Πολιτική απορρήτου και Όροι χρήσης υπηρεσιών</string>
     <string name="subscriptionStatusFreeTrial">Η δωρεάν δοκιμή είναι ενεργή</string>
-    <string name="monthly">μηνιαία</string>
-    <string name="yearly">ετήσια</string>
-    <string name="freeTrialActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy, second is if trial is monthly or yearly">Η δωρεάν δοκιμή σας λήγει στις %1$s και μετατρέπεται αυτόματα σε %2$s συνδρομή επί πληρωμή την ίδια ημέρα.</string>
+    <string name="freeTrialMonthlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Η δωρεάν δοκιμή σας λήγει στις %1$s και μετατρέπεται αυτόματα σε μηνιαία συνδρομή επί πληρωμή την ίδια ημέρα.</string>
+    <string name="freeTrialYearlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Η δωρεάν δοκιμή σας λήγει στις %1$s και μετατρέπεται αυτόματα σε ετήσια συνδρομή επί πληρωμή την ίδια ημέρα.</string>
     <string name="freeTrialCancelledSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Η δωρεάν δοκιμή σας λήγει %1$s και δεν θα μετατραπεί σε συνδρομή επί πληρωμή.</string>
 
     <!--Settings Subscriptions-->

--- a/subscriptions/subscriptions-impl/src/main/res/values-es/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-es/strings-subscriptions.xml
@@ -62,9 +62,8 @@
     <string name="subscriptionStatusSubscribed">Suscrito</string>
     <string name="privacyPolicyAndTermsOfService">Política de privacidad y condiciones del servicio</string>
     <string name="subscriptionStatusFreeTrial">Prueba gratuita activa</string>
-    <string name="monthly">mensual</string>
-    <string name="yearly">Anual</string>
-    <string name="freeTrialActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy, second is if trial is monthly or yearly">Tu prueba gratuita finaliza el %1$s y ese día pasará automáticamente a una suscripción %2$s de pago.</string>
+    <string name="freeTrialMonthlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Tu prueba gratuita finaliza el %1$s y ese día pasará automáticamente a una suscripción mensual de pago.</string>
+    <string name="freeTrialYearlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Tu prueba gratuita finaliza el %1$s y ese día pasará automáticamente a una suscripción anual de pago.</string>
     <string name="freeTrialCancelledSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Tu prueba gratuita finaliza el %1$s y no se convertirá en una suscripción de pago.</string>
 
     <!--Settings Subscriptions-->

--- a/subscriptions/subscriptions-impl/src/main/res/values-et/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-et/strings-subscriptions.xml
@@ -62,9 +62,8 @@
     <string name="subscriptionStatusSubscribed">Tellitud</string>
     <string name="privacyPolicyAndTermsOfService">Privaatsuspoliitika ja teenusetingimused</string>
     <string name="subscriptionStatusFreeTrial">Tasuta prooviperiood aktiveeritud</string>
-    <string name="monthly">igakuine</string>
-    <string name="yearly">aastane</string>
-    <string name="freeTrialActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy, second is if trial is monthly or yearly">Teie tasuta prooviperiood lõpeb %1$s ja muutub sel päeval automaatselt %2$s tasuliseks tellimuseks.</string>
+    <string name="freeTrialMonthlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Teie tasuta prooviperiood lõpeb %1$s ja muutub sel päeval automaatselt tasuliseks kuutellimuseks.</string>
+    <string name="freeTrialYearlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Teie tasuta prooviperiood lõpeb %1$s ja muutub sel päeval automaatselt tasuliseks aastatellimuseks.</string>
     <string name="freeTrialCancelledSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Teie tasuta prooviperiood lõpeb %1$s ega muutu tasuliseks tellimuseks.</string>
 
     <!--Settings Subscriptions-->

--- a/subscriptions/subscriptions-impl/src/main/res/values-fi/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-fi/strings-subscriptions.xml
@@ -62,9 +62,8 @@
     <string name="subscriptionStatusSubscribed">Tilattu</string>
     <string name="privacyPolicyAndTermsOfService">Tietosuojakäytäntö ja palveluehdot</string>
     <string name="subscriptionStatusFreeTrial">Ilmainen kokeilujakso on aktiivinen</string>
-    <string name="monthly">kuukausittain</string>
-    <string name="yearly">vuosittain</string>
-    <string name="freeTrialActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy, second is if trial is monthly or yearly">Ilmainen kokeilujaksosi päättyy %1$s. Kokeilujaksosi muunnetaan automaattisesti maksulliseksi tilaukseksi (%2$s) kyseisenä päivänä.</string>
+    <string name="freeTrialMonthlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Ilmainen kokeilujaksosi päättyy %1$s. Se muuttuu automaattisesti maksulliseksi kuukausitilaukseksi kyseisenä päivänä.</string>
+    <string name="freeTrialYearlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Ilmainen kokeilujaksosi päättyy %1$s. Se muuttuu automaattisesti maksulliseksi vuositilaukseksi kyseisenä päivänä.</string>
     <string name="freeTrialCancelledSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Ilmainen kokeilujaksosi päättyy %1$s. Sitä ei muunneta maksulliseksi tilaukseksi.</string>
 
     <!--Settings Subscriptions-->

--- a/subscriptions/subscriptions-impl/src/main/res/values-fr/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-fr/strings-subscriptions.xml
@@ -62,9 +62,8 @@
     <string name="subscriptionStatusSubscribed">Abonné(e)</string>
     <string name="privacyPolicyAndTermsOfService">Politique de confidentialité et conditions d\'utilisation</string>
     <string name="subscriptionStatusFreeTrial">Essai gratuit actif</string>
-    <string name="monthly">mensuel</string>
-    <string name="yearly">Annuel</string>
-    <string name="freeTrialActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy, second is if trial is monthly or yearly">Votre essai gratuit se termine le %1$s ; il sera automatiquement converti en abonnement %2$s payant ce jour-là.</string>
+    <string name="freeTrialMonthlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Votre essai gratuit se termine le %1$s ; il sera automatiquement converti en abonnement mensuel payant ce jour-là.</string>
+    <string name="freeTrialYearlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Votre essai gratuit se termine le %1$s ; il sera automatiquement converti en abonnement annuel payant ce jour-là.</string>
     <string name="freeTrialCancelledSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Votre essai gratuit se termine le %1$s ; il ne sera pas converti en abonnement payant.</string>
 
     <!--Settings Subscriptions-->

--- a/subscriptions/subscriptions-impl/src/main/res/values-hr/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-hr/strings-subscriptions.xml
@@ -62,9 +62,8 @@
     <string name="subscriptionStatusSubscribed">Pretplaćen</string>
     <string name="privacyPolicyAndTermsOfService">Pravila privatnosti i Uvjeti pružanja usluge</string>
     <string name="subscriptionStatusFreeTrial">Besplatno probno razdoblje je aktivno</string>
-    <string name="monthly">mjesečna</string>
-    <string name="yearly">godišnju</string>
-    <string name="freeTrialActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy, second is if trial is monthly or yearly">Tvoja besplatna probna verzija završava %1$s i tog se dana automatski pretvara u %2$s plaćenu pretplatu.</string>
+    <string name="freeTrialMonthlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Tvoja besplatna probna verzija završava %1$s i tog se dana automatski pretvara u mjesečnu plaćenu pretplatu.</string>
+    <string name="freeTrialYearlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Tvoja besplatna probna verzija završava %1$s i tog se dana automatski pretvara u godišnju plaćenu pretplatu.</string>
     <string name="freeTrialCancelledSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Tvoja besplatna probna verzija završava %1$s i neće se pretvoriti u plaćenu pretplatu.</string>
 
     <!--Settings Subscriptions-->

--- a/subscriptions/subscriptions-impl/src/main/res/values-hu/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-hu/strings-subscriptions.xml
@@ -62,9 +62,8 @@
     <string name="subscriptionStatusSubscribed">Előfizetve</string>
     <string name="privacyPolicyAndTermsOfService">Adatvédelmi szabályzat és szolgáltatási feltételek</string>
     <string name="subscriptionStatusFreeTrial">Az ingyenes próbaidőszak aktív</string>
-    <string name="monthly">havi</string>
-    <string name="yearly">éves</string>
-    <string name="freeTrialActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy, second is if trial is monthly or yearly">Az ingyenes próbaidőszakod %1$s dátummal véget ér, és aznap automatikusan %2$s előfizetéssé alakul.</string>
+    <string name="freeTrialMonthlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Az ingyenes próbaidőszakod %1$s dátummal véget ér, és aznap automatikusan fizetős havi előfizetéssé alakul.</string>
+    <string name="freeTrialYearlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Az ingyenes próbaidőszakod %1$s dátummal véget ér, és aznap automatikusan fizetős éves előfizetéssé alakul.</string>
     <string name="freeTrialCancelledSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Az ingyenes próbaidőszakod %1$s dátummal véget ér, és nem alakul automatikusan előfizetéssé.</string>
 
     <!--Settings Subscriptions-->

--- a/subscriptions/subscriptions-impl/src/main/res/values-it/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-it/strings-subscriptions.xml
@@ -62,9 +62,8 @@
     <string name="subscriptionStatusSubscribed">Iscritto</string>
     <string name="privacyPolicyAndTermsOfService">Privacy policy e Termini del servizio</string>
     <string name="subscriptionStatusFreeTrial">Prova gratuita attiva</string>
-    <string name="monthly">mensile</string>
-    <string name="yearly">Annuale</string>
-    <string name="freeTrialActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy, second is if trial is monthly or yearly">La prova gratuita termina il %1$s e lo stesso giorno si converte automaticamente in un abbonamento %2$s a pagamento.</string>
+    <string name="freeTrialMonthlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">La prova gratuita termina il %1$s e lo stesso giorno si converte automaticamente in un abbonamento mensile a pagamento.</string>
+    <string name="freeTrialYearlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">La prova gratuita termina il %1$s e lo stesso giorno si converte automaticamente in un abbonamento annuale a pagamento.</string>
     <string name="freeTrialCancelledSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">La prova gratuita termina il %1$s e non si convertirà in un abbonamento a pagamento.</string>
 
     <!--Settings Subscriptions-->

--- a/subscriptions/subscriptions-impl/src/main/res/values-lt/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-lt/strings-subscriptions.xml
@@ -62,9 +62,8 @@
     <string name="subscriptionStatusSubscribed">Prenumeruota</string>
     <string name="privacyPolicyAndTermsOfService">Privatumo politika ir paslaugų teikimo sąlygos</string>
     <string name="subscriptionStatusFreeTrial">Nemokama bandomoji versija aktyvi</string>
-    <string name="monthly">mėnesinis</string>
-    <string name="yearly">metinė</string>
-    <string name="freeTrialActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy, second is if trial is monthly or yearly">Jūsų nemokama bandomoji versija baigiasi %1$s ir tą dieną automatiškai taps %2$s mokama prenumerata.</string>
+    <string name="freeTrialMonthlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Nemokama bandomoji versija baigiasi %1$s ir tą dieną automatiškai taps mėnesine mokama prenumerata.</string>
+    <string name="freeTrialYearlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Nemokama bandomoji versija baigiasi %1$s ir tą dieną automatiškai taps metine mokama prenumerata.</string>
     <string name="freeTrialCancelledSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Jūsų nemokama bandomoji versija baigiasi %1$s ir nebus pakeista į mokamą prenumeratą.</string>
 
     <!--Settings Subscriptions-->

--- a/subscriptions/subscriptions-impl/src/main/res/values-lv/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-lv/strings-subscriptions.xml
@@ -62,9 +62,8 @@
     <string name="subscriptionStatusSubscribed">Abonēts</string>
     <string name="privacyPolicyAndTermsOfService">Privātuma politika un Pakalpojumu sniegšanas noteikumi</string>
     <string name="subscriptionStatusFreeTrial">Bezmaksas izmēģinājuma periods ir aktīvs</string>
-    <string name="monthly">ikmēneša</string>
-    <string name="yearly">ikgadējs</string>
-    <string name="freeTrialActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy, second is if trial is monthly or yearly">Tava bezmaksas izmēģinājuma versija beidzas %1$s un tajā pašā dienā automātiski tiek pārvērsta par %2$s maksas abonementu.</string>
+    <string name="freeTrialMonthlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Tavs bezmaksas izmēģinājuma periods beidzas %1$s un tajā dienā automātiski pārvēršas par ikmēneša maksas abonementu.</string>
+    <string name="freeTrialYearlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Tavs bezmaksas izmēģinājuma periods beidzas %1$s un tajā pašā dienā automātiski pārvēršas par par gada maksas abonementu.</string>
     <string name="freeTrialCancelledSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Tava bezmaksas izmēģinājuma versija beidzas %1$s un tā netiks pārvērsta par maksas abonementu.</string>
 
     <!--Settings Subscriptions-->

--- a/subscriptions/subscriptions-impl/src/main/res/values-nb/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-nb/strings-subscriptions.xml
@@ -62,9 +62,8 @@
     <string name="subscriptionStatusSubscribed">Abonnerer</string>
     <string name="privacyPolicyAndTermsOfService">Personvernerklæring og vilkår for bruk</string>
     <string name="subscriptionStatusFreeTrial">Gratis prøveperiode er aktiv</string>
-    <string name="monthly">månedlige</string>
-    <string name="yearly">årlig</string>
-    <string name="freeTrialActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy, second is if trial is monthly or yearly">Din gratis prøveperiode avsluttes %1$s og blir automatisk omgjort til et %2$s betalt abonnement den dagen.</string>
+    <string name="freeTrialMonthlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Den gratis prøveperioden utløper %1$s, og på den dagen gjøres det automatisk om til et abonnement som betales månedlig.</string>
+    <string name="freeTrialYearlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Den gratis prøveperioden utløper %1$s, og på den dagen gjøres det automatisk om til et abonnement som betales årlig.</string>
     <string name="freeTrialCancelledSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Din gratis prøveperioden avsluttes %1$s og blir ikke omgjort til et betalt abonnement.</string>
 
     <!--Settings Subscriptions-->

--- a/subscriptions/subscriptions-impl/src/main/res/values-nl/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-nl/strings-subscriptions.xml
@@ -62,9 +62,8 @@
     <string name="subscriptionStatusSubscribed">Geabonneerd</string>
     <string name="privacyPolicyAndTermsOfService">Privacybeleid en servicevoorwaarden</string>
     <string name="subscriptionStatusFreeTrial">Gratis proefversie actief</string>
-    <string name="monthly">per maand</string>
-    <string name="yearly">Jaarlijks</string>
-    <string name="freeTrialActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy, second is if trial is monthly or yearly">Je gratis proefperiode eindigt op %1$s en wordt op die dag automatisch omgezet in een %2$s betaald abonnement.</string>
+    <string name="freeTrialMonthlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Je gratis proefperiode eindigt op %1$s en wordt op die dag automatisch omgezet in een maandelijks betaald abonnement.</string>
+    <string name="freeTrialYearlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Je gratis proefperiode eindigt op %1$s en wordt op die dag automatisch omgezet in een jaarlijks betaald abonnement.</string>
     <string name="freeTrialCancelledSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Je gratis proefperiode eindigt op %1$s en wordt niet omgezet naar een betaald abonnement.</string>
 
     <!--Settings Subscriptions-->

--- a/subscriptions/subscriptions-impl/src/main/res/values-pl/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-pl/strings-subscriptions.xml
@@ -62,9 +62,8 @@
     <string name="subscriptionStatusSubscribed">Subskrypcja</string>
     <string name="privacyPolicyAndTermsOfService">Polityka prywatności i warunki użytkowania</string>
     <string name="subscriptionStatusFreeTrial">Aktywny bezpłatny okres próbny</string>
-    <string name="monthly">miesięczne</string>
-    <string name="yearly">Rocznie</string>
-    <string name="freeTrialActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy, second is if trial is monthly or yearly">Bezpłatny okres próbny kończy się %1$s i tego samego dnia automatycznie przekształca się w %2$s płatną subskrypcję.</string>
+    <string name="freeTrialMonthlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Bezpłatny okres próbny kończy się %1$s i tego samego dnia automatycznie przekształca się w miesięczną płatną subskrypcję.</string>
+    <string name="freeTrialYearlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Bezpłatny okres próbny kończy się %1$s i tego samego dnia automatycznie przekształca się w roczną płatną subskrypcję.</string>
     <string name="freeTrialCancelledSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Bezpłatny okres próbny kończy się %1$s i nie zostanie przekształcony w płatną subskrypcję.</string>
 
     <!--Settings Subscriptions-->

--- a/subscriptions/subscriptions-impl/src/main/res/values-pt/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-pt/strings-subscriptions.xml
@@ -62,9 +62,8 @@
     <string name="subscriptionStatusSubscribed">Subscrito</string>
     <string name="privacyPolicyAndTermsOfService">Política de Privacidade e Termos de Serviço</string>
     <string name="subscriptionStatusFreeTrial">Período de teste gratuito ativo</string>
-    <string name="monthly">mensal</string>
-    <string name="yearly">Anualmente</string>
-    <string name="freeTrialActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy, second is if trial is monthly or yearly">O teu período de teste gratuito termina a %1$s e será automaticamente convertido numa subscrição %2$s paga nesse dia.</string>
+    <string name="freeTrialMonthlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">O teu período de teste gratuito termina em %1$s e converte-se automaticamente numa subscrição mensal paga nesse dia.</string>
+    <string name="freeTrialYearlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">O teu período de teste gratuito termina em %1$s e converte-se automaticamente numa subscrição anual paga nesse dia.</string>
     <string name="freeTrialCancelledSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">O teu período de teste gratuito termina a %1$s e não será convertido numa subscrição paga.</string>
 
     <!--Settings Subscriptions-->

--- a/subscriptions/subscriptions-impl/src/main/res/values-ro/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-ro/strings-subscriptions.xml
@@ -62,9 +62,8 @@
     <string name="subscriptionStatusSubscribed">Abonat</string>
     <string name="privacyPolicyAndTermsOfService">Politica de confidențialitate și Condițiile de prestare a serviciului</string>
     <string name="subscriptionStatusFreeTrial">Perioada de încercare gratuită este activă</string>
-    <string name="monthly">lunar</string>
-    <string name="yearly">anual</string>
-    <string name="freeTrialActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy, second is if trial is monthly or yearly">Perioada de încercare gratuită se încheie pe %1$s și se transformă automat într-un abonament %2$s cu plată, începând din ziua respectivă.</string>
+    <string name="freeTrialMonthlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Perioada de încercare gratuită se încheie pe %1$s și se transformă automat într-un abonament lunar cu plată, începând din ziua respectivă.</string>
+    <string name="freeTrialYearlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Perioada de încercare gratuită se încheie pe %1$s și se transformă automat într-un abonament anual cu plată, începând din ziua respectivă.</string>
     <string name="freeTrialCancelledSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Perioada de încercare gratuită se încheie pe %1$s și nu se va transforma într-un abonament cu plată.</string>
 
     <!--Settings Subscriptions-->

--- a/subscriptions/subscriptions-impl/src/main/res/values-ru/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-ru/strings-subscriptions.xml
@@ -62,9 +62,8 @@
     <string name="subscriptionStatusSubscribed">Подписка оформлена</string>
     <string name="privacyPolicyAndTermsOfService">Политика конфиденциальности и условия обслуживания</string>
     <string name="subscriptionStatusFreeTrial">Бесплатный пробный доступ активирован</string>
-    <string name="monthly">ежемесячная</string>
-    <string name="yearly">Годовая</string>
-    <string name="freeTrialActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy, second is if trial is monthly or yearly">Ваш бесплатный пробный период завершится %1$s. В тот же день для вас автоматически будет оформлена %2$s платная подписка.</string>
+    <string name="freeTrialMonthlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Ваш бесплатный пробный период завершится %1$s. В тот же день вы автоматически перейдете на платную ежемесячную подписку.</string>
+    <string name="freeTrialYearlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Ваш бесплатный пробный период завершится %1$s. В тот же день вы автоматически перейдете на платную годовую подписку.</string>
     <string name="freeTrialCancelledSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Ваш бесплатный пробный период завершится %1$s без перехода на платную подписку.</string>
 
     <!--Settings Subscriptions-->

--- a/subscriptions/subscriptions-impl/src/main/res/values-sk/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-sk/strings-subscriptions.xml
@@ -62,9 +62,8 @@
     <string name="subscriptionStatusSubscribed">Prihlásený/-á</string>
     <string name="privacyPolicyAndTermsOfService">Zásady ochrany osobných údajov a podmienky služby</string>
     <string name="subscriptionStatusFreeTrial">Bezplatná skúšobná verzia je aktívna</string>
-    <string name="monthly">mesačné</string>
-    <string name="yearly">ročne</string>
-    <string name="freeTrialActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy, second is if trial is monthly or yearly">Tvoja bezplatná skúšobná verzia končí dňa %1$s a v ten deň sa automaticky zmení na %2$s platené predplatné.</string>
+    <string name="freeTrialMonthlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Tvoja bezplatná skúšobná verzia končí dňa %1$s a v ten deň sa automaticky zmení na mesačné platené predplatné.</string>
+    <string name="freeTrialYearlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Tvoja bezplatná skúšobná verzia končí dňa %1$s a v ten deň sa automaticky zmení na ročné platené predplatné.</string>
     <string name="freeTrialCancelledSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Tvoja bezplatná skúšobná verzia končí %1$s a nebude sa automaticky meniť na platené predplatné.</string>
 
     <!--Settings Subscriptions-->

--- a/subscriptions/subscriptions-impl/src/main/res/values-sl/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-sl/strings-subscriptions.xml
@@ -62,9 +62,8 @@
     <string name="subscriptionStatusSubscribed">Naročeni</string>
     <string name="privacyPolicyAndTermsOfService">Pravilnik o zasebnosti in pogoji storitve</string>
     <string name="subscriptionStatusFreeTrial">Brezplačni preizkus je aktiven</string>
-    <string name="monthly">mesečno</string>
-    <string name="yearly">letno</string>
-    <string name="freeTrialActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy, second is if trial is monthly or yearly">Vaša brezplačna preizkusna različica se konča dne %1$s in se na ta dan samodejno spremeni v %2$s plačljivo naročnino.</string>
+    <string name="freeTrialMonthlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Vaša brezplačna preizkusna različica se konča dne %1$s in se na ta dan samodejno spremeni v mesečno plačljivo naročnino.</string>
+    <string name="freeTrialYearlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Vaša brezplačna preizkusna različica se konča dne %1$s in se na ta dan samodejno spremeni v letno plačljivo naročnino.</string>
     <string name="freeTrialCancelledSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Vaša brezplačna preizkusna različica se konča dne %1$s in se ne bo spremenila v plačljivo naročnino.</string>
 
     <!--Settings Subscriptions-->

--- a/subscriptions/subscriptions-impl/src/main/res/values-sv/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-sv/strings-subscriptions.xml
@@ -62,9 +62,8 @@
     <string name="subscriptionStatusSubscribed">Prenumererad</string>
     <string name="privacyPolicyAndTermsOfService">Integritetspolicy och användarvillkor</string>
     <string name="subscriptionStatusFreeTrial">Gratis provperiod aktiv</string>
-    <string name="monthly">månatlig</string>
-    <string name="yearly">årligen</string>
-    <string name="freeTrialActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy, second is if trial is monthly or yearly">Din kostnadsfria provperiod upphör den %1$s och övergår automatiskt till ett betalt %2$s-abonnemang på den dagen.</string>
+    <string name="freeTrialMonthlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Din kostnadsfria provperiod upphör den %1$s och övergår automatiskt till ett betalt månadsabonnemang på den dagen.</string>
+    <string name="freeTrialYearlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Din kostnadsfria provperiod upphör den %1$s och övergår automatiskt till ett betalt årsabonnemang på den dagen.</string>
     <string name="freeTrialCancelledSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Din kostnadsfria provperiod upphör den %1$s och kommer inte att övergå till ett betalt abonnemang.</string>
 
     <!--Settings Subscriptions-->

--- a/subscriptions/subscriptions-impl/src/main/res/values-tr/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values-tr/strings-subscriptions.xml
@@ -62,9 +62,8 @@
     <string name="subscriptionStatusSubscribed">Abone olundu</string>
     <string name="privacyPolicyAndTermsOfService">Gizlilik Politikası ve Hizmet Koşulları</string>
     <string name="subscriptionStatusFreeTrial">Ücretsiz Deneme Süresi Aktif</string>
-    <string name="monthly">aylık</string>
-    <string name="yearly">yıllık</string>
-    <string name="freeTrialActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy, second is if trial is monthly or yearly">Ücretsiz deneme sürümünüz %1$s tarihinde sona erecek ve aynı gün otomatik olarak %2$s ücretli aboneliğe dönüşecektir.</string>
+    <string name="freeTrialMonthlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Ücretsiz denemeniz %1$s tarihinde sona erecek ve aynı gün otomatik olarak aylık ücretli aboneliğe dönüşecektir.</string>
+    <string name="freeTrialYearlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Ücretsiz denemeniz %1$s tarihinde sona erecek ve aynı gün otomatik olarak yıllık ücretli aboneliğe dönüşecektir.</string>
     <string name="freeTrialCancelledSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Ücretsiz deneme sürümünüz %1$s tarihinde sona erecek ve ücretli aboneliğe dönüşmeyecektir.</string>
 
     <!--Settings Subscriptions-->

--- a/subscriptions/subscriptions-impl/src/main/res/values/strings-subscriptions.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values/strings-subscriptions.xml
@@ -61,9 +61,8 @@
     <string name="subscriptionStatusSubscribed">Subscribed</string>
     <string name="privacyPolicyAndTermsOfService">Privacy Policy and Terms of Service</string>
     <string name="subscriptionStatusFreeTrial">Free Trial Active</string>
-    <string name="monthly">monthly</string>
-    <string name="yearly">yearly</string>
-    <string name="freeTrialActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy, second is if trial is monthly or yearly">Your free trial ends on %1$s &amp; automatically converts to a %2$s paid subscription on that day.</string>
+    <string name="freeTrialMonthlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Your free trial ends on %1$s &amp; automatically converts to a monthly paid subscription on that day.</string>
+    <string name="freeTrialYearlyActiveSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Your free trial ends on %1$s &amp; automatically converts to a yearly paid subscription on that day.</string>
     <string name="freeTrialCancelledSubscriptionsData" instruction="Placeholder is a date in format MMMM dd, yyyy">Your free trial ends on %1$s &amp; will not convert to a paid subscription.</string>
 
     <!--Settings Subscriptions-->


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1210449725813015?focus=true

### Description
Split the subscription renewal information string into separate monthly and yearly resources

### Steps to test this PR

- [x]  Set a Privacy Pro eligible account
- [x] Set device to Polish
- [x] Fresh install
- [x] Go to Settings, and check 'Try Privacy Pro Free' is displayed in the Settings menu
- [x] Tap on Privacy Pro which will display the paywall screen
- [x] Check you see the free trial products on paywall
- [x] Purchase any product
- [x] Check Subscription Settings screen is showing status/renewal text correctly for Free Trial
- [x] Cancel subscription (when still on Free Trial)
- [x] Check Subscription Settings screen is showing status/expire text correctly for Free Trial

### No UI changes
