### PR TITLE
Fix: Prevent the first tab from always loading

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -219,10 +219,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
     }
 
     private val tabPagerAdapter by lazy {
-        TabPagerAdapter(
-            activity = this,
-            tabManager = tabManager,
-        )
+        TabPagerAdapter(activity = this)
     }
 
     private lateinit var toolbarMockupBinding: IncludeOmnibarToolbarMockupBinding
@@ -1000,6 +997,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
 
     private fun onMoveToTabRequested(index: Int) {
         tabPager.post {
+            tabPagerAdapter.currentTabIndex = index
             tabPager.setCurrentItem(index, false)
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -221,7 +221,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
     private val tabPagerAdapter by lazy {
         TabPagerAdapter(
             activity = this,
-            swipingTabsFeature = swipingTabsFeature,
+            tabManager = tabManager,
         )
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -205,6 +205,7 @@ import com.duckduckgo.app.browser.omnibar.model.OmnibarPosition.TOP
 import com.duckduckgo.app.browser.refreshpixels.RefreshPixelSender
 import com.duckduckgo.app.browser.senseofprotection.SenseOfProtectionExperiment
 import com.duckduckgo.app.browser.session.WebViewSessionStorage
+import com.duckduckgo.app.browser.tabs.TabManager
 import com.duckduckgo.app.browser.urlextraction.UrlExtractionListener
 import com.duckduckgo.app.browser.viewstate.AccessibilityViewState
 import com.duckduckgo.app.browser.viewstate.AutoCompleteViewState
@@ -465,6 +466,7 @@ class BrowserTabViewModel @Inject constructor(
     private val senseOfProtectionExperiment: SenseOfProtectionExperiment,
     private val subscriptionsJSHelper: SubscriptionsJSHelper,
     private val onboardingDesignExperimentToggles: OnboardingDesignExperimentToggles,
+    private val tabManager: TabManager,
 ) : WebViewClientListener,
     EditSavedSiteListener,
     DeleteBookmarkListener,
@@ -1241,6 +1243,14 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     override fun isDesktopSiteEnabled(): Boolean = currentBrowserViewState().isDesktopBrowsingMode
+
+    override fun isTabInForeground(): Boolean {
+        return if (swipingTabsFeature.isEnabled) {
+            tabId == tabManager.getSelectedTabId()
+        } else {
+            true
+        }
+    }
 
     override fun closeCurrentTab() {
         viewModelScope.launch {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -479,7 +479,13 @@ class BrowserWebViewClient @Inject constructor(
                 if (url != ABOUT_BLANK) {
                     start?.let { safeStart ->
                         // TODO (cbarreiro - 22/05/2024): Extract to plugins
-                        pageLoadedHandler.onPageLoaded(it, navigationList.currentItem?.title, safeStart, currentTimeProvider.elapsedRealtime())
+                        pageLoadedHandler.onPageLoaded(
+                            url = it,
+                            title = navigationList.currentItem?.title,
+                            start = safeStart,
+                            end = currentTimeProvider.elapsedRealtime(),
+                            isTabInForeground = webViewClientListener?.isTabInForeground() ?: true,
+                        )
                         shouldSendPagePaintedPixel(webView = webView, url = it)
                         appCoroutineScope.launch(dispatcherProvider.io()) {
                             if (duckPlayer.getDuckPlayerState() == ENABLED && duckPlayer.isSimulatedYoutubeNoCookie(uri)) {

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
@@ -82,6 +82,8 @@ interface WebViewClientListener {
     fun surrogateDetected(surrogate: SurrogateResponse)
     fun isDesktopSiteEnabled(): Boolean
 
+    fun isTabInForeground(): Boolean
+
     fun loginDetected()
     fun dosAttackDetected()
     fun iconReceived(

--- a/app/src/main/java/com/duckduckgo/app/browser/pageloadpixel/PageLoadedHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pageloadpixel/PageLoadedHandler.kt
@@ -29,9 +29,10 @@ import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import logcat.logcat
 
 interface PageLoadedHandler {
-    fun onPageLoaded(url: String, title: String?, start: Long, end: Long)
+    fun onPageLoaded(url: String, title: String?, start: Long, end: Long, isTabInForeground: Boolean)
 }
 
 @ContributesBinding(AppScope::class)
@@ -45,7 +46,7 @@ class RealPageLoadedHandler @Inject constructor(
     private val optimizeTrackerEvaluationRCWrapper: OptimizeTrackerEvaluationRCWrapper,
 ) : PageLoadedHandler {
 
-    override fun onPageLoaded(url: String, title: String?, start: Long, end: Long) {
+    override fun onPageLoaded(url: String, title: String?, start: Long, end: Long, isTabInForeground: Boolean) {
         appCoroutineScope.launch(dispatcherProvider.io()) {
             if (sites.any { UriString.sameOrSubdomain(url, it) }) {
                 pageLoadedPixelDao.add(
@@ -58,6 +59,7 @@ class RealPageLoadedHandler @Inject constructor(
                     ),
                 )
             }
+            logcat { "$$$: Page load time: ${end - start}, foreground: $isTabInForeground" }
         }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/DefaultTabManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/DefaultTabManager.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
 import javax.inject.Inject
 import kotlinx.coroutines.withContext
 import logcat.LogPriority.INFO
@@ -50,6 +51,7 @@ interface TabManager {
     )
 }
 
+@SingleInstanceIn(ActivityScope::class)
 @ContributesBinding(ActivityScope::class)
 class DefaultTabManager @Inject constructor(
     private val tabRepository: TabRepository,

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/FragmentStateAdapter.java
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/FragmentStateAdapter.java
@@ -102,9 +102,6 @@ public abstract class FragmentStateAdapter extends RecyclerView.Adapter<Fragment
     @SuppressWarnings("WeakerAccess") // to avoid creation of a synthetic accessor
     final FragmentManager mFragmentManager;
 
-    @SuppressWarnings("WeakerAccess") // to avoid creation of a synthetic accessor
-    final SwipingTabsFeatureProvider mSwipingTabsFeature;
-
     // Fragment bookkeeping
     @SuppressWarnings("WeakerAccess") // to avoid creation of a synthetic accessor
     final LongSparseArray<Fragment> mFragments = new LongSparseArray<>();
@@ -131,28 +128,22 @@ public abstract class FragmentStateAdapter extends RecyclerView.Adapter<Fragment
     /**
      * @param fragmentActivity if the {@link ViewPager2} lives directly in a {@link
      *     FragmentActivity} subclass.
-     * @param swipingTabsFeature Feature flag to enable swiping tabs fixes
      */
     public FragmentStateAdapter(
-            @NonNull FragmentActivity fragmentActivity,
-            SwipingTabsFeatureProvider swipingTabsFeature) {
+            @NonNull FragmentActivity fragmentActivity) {
         this(fragmentActivity.getSupportFragmentManager(),
-                fragmentActivity.getLifecycle(),
-                swipingTabsFeature);
+                fragmentActivity.getLifecycle());
     }
 
     /**
      * @param fragmentManager of {@link ViewPager2}'s host
      * @param lifecycle of {@link ViewPager2}'s host
-     * @param swipingTabsFeature Feature flag to enable swiping tabs fixes
      */
     public FragmentStateAdapter(
             @NonNull FragmentManager fragmentManager,
-            @NonNull Lifecycle lifecycle,
-            SwipingTabsFeatureProvider swipingTabsFeature) {
+            @NonNull Lifecycle lifecycle) {
         mFragmentManager = fragmentManager;
         mLifecycle = lifecycle;
-        mSwipingTabsFeature = swipingTabsFeature;
         super.setHasStableIds(true);
     }
 
@@ -185,6 +176,8 @@ public abstract class FragmentStateAdapter extends RecyclerView.Adapter<Fragment
      * @see ViewPager2#setOffscreenPageLimit
      */
     public abstract @NonNull Fragment createFragment(int position);
+
+    public abstract @NonNull Boolean isAdapterInitialized();
 
     @NonNull
     @Override
@@ -292,8 +285,10 @@ public abstract class FragmentStateAdapter extends RecyclerView.Adapter<Fragment
 
     @Override
     public final void onViewAttachedToWindow(@NonNull final FragmentViewHolder holder) {
-        placeFragmentInViewHolder(holder);
-        gcFragments();
+        if (isAdapterInitialized()) {
+            placeFragmentInViewHolder(holder);
+            gcFragments();
+        }
     }
 
     /**

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/FragmentStateAdapter.java
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/FragmentStateAdapter.java
@@ -49,7 +49,6 @@ import androidx.viewpager2.adapter.StatefulAdapter;
 import androidx.viewpager2.widget.ViewPager2;
 
 import com.duckduckgo.app.browser.tabs.TabManager;
-import com.duckduckgo.common.ui.tabs.SwipingTabsFeatureProvider;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -177,7 +176,7 @@ public abstract class FragmentStateAdapter extends RecyclerView.Adapter<Fragment
      */
     public abstract @NonNull Fragment createFragment(int position);
 
-    public abstract @NonNull Boolean isAdapterInitialized();
+    public abstract @NonNull Boolean shouldPlaceFragmentInViewHolder(int position);
 
     @NonNull
     @Override
@@ -285,7 +284,7 @@ public abstract class FragmentStateAdapter extends RecyclerView.Adapter<Fragment
 
     @Override
     public final void onViewAttachedToWindow(@NonNull final FragmentViewHolder holder) {
-        if (isAdapterInitialized()) {
+        if (shouldPlaceFragmentInViewHolder(holder.getBindingAdapterPosition())) {
             placeFragmentInViewHolder(holder);
             gcFragments();
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabPagerAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabPagerAdapter.kt
@@ -24,13 +24,13 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.BrowserTabFragment
+import com.duckduckgo.app.browser.tabs.TabManager
 import com.duckduckgo.app.browser.tabs.TabManager.TabModel
-import com.duckduckgo.common.ui.tabs.SwipingTabsFeatureProvider
 
 class TabPagerAdapter(
     private val activity: BrowserActivity,
-    swipingTabsFeature: SwipingTabsFeatureProvider,
-) : FragmentStateAdapter(activity, swipingTabsFeature) {
+    private val tabManager: TabManager,
+) : FragmentStateAdapter(activity) {
     private val tabs = mutableListOf<TabModel>()
     private var messageForNewFragment: Message? = null
 
@@ -59,6 +59,10 @@ class TabPagerAdapter(
         } else {
             BrowserTabFragment.newInstance(tab.tabId, tab.url, tab.skipHome, isExternal)
         }
+    }
+
+    override fun isAdapterInitialized(): Boolean {
+        return tabManager.getSelectedTabId() != null
     }
 
     fun restore(state: Bundle) {

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabPagerAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabPagerAdapter.kt
@@ -24,15 +24,24 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.BrowserTabFragment
-import com.duckduckgo.app.browser.tabs.TabManager
 import com.duckduckgo.app.browser.tabs.TabManager.TabModel
 
 class TabPagerAdapter(
     private val activity: BrowserActivity,
-    private val tabManager: TabManager,
 ) : FragmentStateAdapter(activity) {
     private val tabs = mutableListOf<TabModel>()
     private var messageForNewFragment: Message? = null
+
+    var currentTabIndex = -1
+        @SuppressLint("NotifyDataSetChanged")
+        set(value) {
+            // if the current tab index is -1 and the set value 0, it means the first tab is really selected
+            // and we need to notify the adapter to create the first fragment
+            if (field == -1 && value == 0) {
+                notifyDataSetChanged()
+            }
+            field = value
+        }
 
     override fun getItemCount() = tabs.size
 
@@ -61,8 +70,9 @@ class TabPagerAdapter(
         }
     }
 
-    override fun isAdapterInitialized(): Boolean {
-        return tabManager.getSelectedTabId() != null
+    // This method prevents the creation of a tab fragment for the first tab when we don't know the current tab index yet
+    override fun shouldPlaceFragmentInViewHolder(position: Int): Boolean {
+        return currentTabIndex != -1 || position != 0
     }
 
     fun restore(state: Bundle) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1210452628649549?focus=true

### Description

This PR prevents the 1st tab to load by default if it's not the selected tab.

I also added code that can determine whether the load request is for a tab in the foreground (currently only used for logging).

### Steps to test this PR

_Non-first tab_
- [ ] Make sure you have a couple of tabs already
- [ ] Make sure the `swipingTabs` flag is enabled
- [ ] Select a tab other than the first tab
- [ ] Kill the app
- [ ] In logcat, add a filter for `$$$: Page load time`
- [ ] Start the app
- [ ] Verify the tab is loaded
- [ ] Verify the "Page load time" is logged only once

_First tab_
- [ ] Make sure you have a couple of tabs already
- [ ] Select the first tab
- [ ] Kill the app and restart it
- [ ] Verify the tab is loaded
- [ ] In logcat, add a filter for `$$$: Page load time`
- [ ] Verify the "Page load time" is logged only once
