### PR TITLE
Rename GH job as it's confusing

### DIFF
--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   run-release-tests:
-    name: Create and Push git tag for version
+    name: Create release APK and run E2E Maestro tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200905986587319/task/1210498040841177?focus=true

### Description
Updated the job name in the `release_tests.yml` workflow to better reflect its purpose. Changed from "Create and Push git tag for version" to "Create release APK and run E2E Maestro tests" to accurately describe what the job actually does.

### Steps to test this PR

No QA needed.

### NO UI changes
