### PR TITLE
Onboarding Experiment: Fix background for onboarding bubble dialog 

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -4068,7 +4068,7 @@ class BrowserTabViewModel @Inject constructor(
         if (onboardingDesignExperimentToggles.buckOnboarding().isEnabled()) {
             command.value = SetBrowserBackgroundColor(getBuckOnboardingExperimentBackgroundColor(lightModeEnabled))
         } else {
-            command.value = SetBrowserBackground(getBuckOnboardingExperimentBackgroundColor(lightModeEnabled))
+            command.value = SetBrowserBackground(getBackgroundResource(lightModeEnabled))
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: 

### Description

This change updates the method used to set the browser background when the onboarding experiment toggle is disabled, replacing `getBuckOnboardingExperimentBackgroundColor` with `getBackgroundResource` for determining the background resource.

### Steps to test this PR

_Onboarding bubble dialog background_

- [ ] Ensure `buckOnboarding` toggle is off (it will be unless you've turned it on to test onboarding experiment work) 
- [ ] Go through initial onboarding
- [ ] When you arrive at the browser screen onboarding with a title of "Try a search!" ensure the background is the same as initial onboarding.

### UI changes
| Before  | After |
| ------ | ----- |
<img width="1000" alt="Screenshot 2025-06-10 at 09 39 37" src="https://github.com/user-attachments/assets/d49af80c-3a77-4780-b984-dd0098000b00" />|![Screenshot_20250610_105109](https://github.com/user-attachments/assets/d7e8390a-62fe-446e-b050-79d2ca4cb9e8)|
