### PR TITLE
Show days in VPN timer

### DIFF
--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/management/TimerUtils.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/management/TimerUtils.kt
@@ -19,8 +19,16 @@ package com.duckduckgo.networkprotection.impl.management
 import java.util.concurrent.TimeUnit
 
 internal fun Long.toDisplayableTimerText(): String {
-    val hours = TimeUnit.MILLISECONDS.toHours(this) % 60
+    val days = TimeUnit.MILLISECONDS.toDays(this)
+    val hours = TimeUnit.MILLISECONDS.toHours(this) % 24
     val minutes = TimeUnit.MILLISECONDS.toMinutes(this) % 60
     val seconds = TimeUnit.MILLISECONDS.toSeconds(this) % 60
-    return String.format("%02d:%02d:%02d", hours, minutes, seconds)
+
+    val parts = mutableListOf<String>()
+    if (days > 0) parts.add("${days}d")
+    if (hours > 0) parts.add("${hours}h")
+    if (minutes > 0) parts.add("${minutes}m")
+    if (seconds > 0 || parts.isEmpty()) parts.add("${seconds}s")
+
+    return parts.joinToString(" ")
 }

--- a/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/management/NetworkProtectionManagementViewModelTest.kt
+++ b/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/management/NetworkProtectionManagementViewModelTest.kt
@@ -399,27 +399,72 @@ class NetworkProtectionManagementViewModelTest {
 
     @Test
     fun whenTimeDifferenceIs0ThenShowStartingTimeString() {
-        assertEquals("00:00:00", 0L.toDisplayableTimerText())
-    }
-
-    @Test
-    fun whenTimeDifferenceHasHoursOnlyThenSetMinsAndSecondsToDefault() {
-        assertEquals("27:00:00", 97_200_000L.toDisplayableTimerText())
+        assertEquals("0s", 0L.toDisplayableTimerText())
     }
 
     @Test
     fun whenTimeDifferenceHasMinsOnlyThenSetHoursAndSecondsToDefault() {
-        assertEquals("00:38:00", 2_280_000L.toDisplayableTimerText())
+        assertEquals("38m", 2_280_000L.toDisplayableTimerText())
     }
 
     @Test
     fun whenTimeDifferenceHasSecondsOnlyThenSetHoursAndMinutesToDefault() {
-        assertEquals("00:00:32", 32_000L.toDisplayableTimerText())
+        assertEquals("32s", 32_000L.toDisplayableTimerText())
+    }
+
+    @Test
+    fun whenTimeDifferenceHasHoursOnlyThenShowHoursOnly() {
+        assertEquals("23h", 82_800_000L.toDisplayableTimerText())
+    }
+
+    @Test
+    fun whenTimeDifferenceHasDaysOnlyThenShowDaysOnly() {
+        assertEquals("75d", 6_480_000_000.toDisplayableTimerText())
+    }
+
+    @Test
+    fun whenTimeDifferenceHasHoursOnlyThenSetMinsAndSecondsToDefault() {
+        assertEquals("1d 3h", 97_200_000L.toDisplayableTimerText())
+    }
+
+    @Test
+    fun whenTimeDifferenceHasDaysAndMinutesThenShowDaysAndMinutesOnly() {
+        assertEquals("1d 1m", 86_460_000L.toDisplayableTimerText())
+    }
+
+    @Test
+    fun whenTimeDifferenceHasDaysAndSecondsThenShowDaysAndSecondsOnly() {
+        assertEquals("1d 35s", 86_435_000L.toDisplayableTimerText())
+    }
+
+    @Test
+    fun whenTimeDifferenceHasDaysHoursAndSecondsThenShowDaysHoursAndSeconds() {
+        assertEquals("3d 15h 6s", 313_206_000L.toDisplayableTimerText())
+    }
+
+    @Test
+    fun whenTimeDifferenceHasDaysMinutesAndSecondsThenShowDaysMinutesAndSeconds() {
+        assertEquals("3d 15m 6s", 260_106_000L.toDisplayableTimerText())
+    }
+
+    @Test
+    fun whenTimeDifferenceHasDaysHoursAndMinutesThenShowDaysHoursAndMinutes() {
+        assertEquals("3d 23h 59m", 345_540_000L.toDisplayableTimerText())
+    }
+
+    @Test
+    fun whenTimeDifferenceHasHoursMinutesAndSecondsThenShowHoursMinutesAndSeconds() {
+        assertEquals("23h 59m 59s", 86_399_000L.toDisplayableTimerText())
+    }
+
+    @Test
+    fun whenTimeDifferenceThenShowAll() {
+        assertEquals("1d 3h 38m 32s", 99_512_000L.toDisplayableTimerText())
     }
 
     @Test
     fun whenTimeDifferenceThenSetHoursAndMinutesToDefault() {
-        assertEquals("27:38:32", 99_512_000L.toDisplayableTimerText())
+        assertEquals("1d 3h 38m 32s", 99_512_000L.toDisplayableTimerText())
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208589375218614/task/1210383294207835?focus=true

### Description
Improve VPN timer to show days, hours, minutes and seconds.
We also don't show 0 values except when it is the starting value which is 0s.

### Steps to test this PR

- [x] Got VPN Screen via Settings > VPN
- [x] Enable VPN
- [x] Verify 0s was shown
- [x] Verify that after a minute 1m is shown with not seconds values
- [x] Verify that 1m is shown and seconds values continues to show.

Optionally you can check hours and days values but that could take time
