### PR TITLE
Fix Duck.ai shortcut not showing on internal

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/shortcut/AppShortcutCreator.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/shortcut/AppShortcutCreator.kt
@@ -99,9 +99,7 @@ class AppShortcutCreator @Inject constructor(
 
             if (duckChat.showInBrowserMenu.value) {
                 shortcutList.add(buildDuckChatShortcut(context))
-            }
-
-            if (appBuildConfig.isInternalBuild()) {
+            } else if (appBuildConfig.isInternalBuild()) {
                 shortcutList.add(buildAndroidDesignSystemShortcut(context))
             }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1210512060310715?focus=true

### Description
- This is a speculative fix for https://app.asana.com/1/137249556945/project/414730916066338/task/1210509768361310

### Steps to test this PR

- [x] Long press the DuckDuckGo icon
- [x] Verify that the Duck.ai shortcut is visible
- [x] Disable Duck.ai
- [x] Long press the DuckDuckGo icon
- [x] Verify that the ADS shortcut is visible
