### PR TITLE
Fix animation for VPN toggle

### DIFF
--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/management/NetworkProtectionManagementActivity.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/management/NetworkProtectionManagementActivity.kt
@@ -244,6 +244,7 @@ class NetworkProtectionManagementActivity : DuckDuckGoActivity() {
         netpStatusDescription.setText(R.string.netpManagementDescriptionOn)
         netpToggle.indicator.setImageDrawable(AppCompatResources.getDrawable(applicationContext, R.drawable.indicator_vpn_connected))
         netpToggle.quietlySetChecked(true)
+        netpToggle.jumpDrawablesToCurrentState()
         netpToggle.isEnabled = true
 
         locationDetails.locationHeader.setText(R.string.netpManagementLocationHeaderVpnOn)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1209485948709260?focus=true

### Description
Remove the transition from OFF to ON for the VPN toggle when visiting the VPN screen.

### Steps to test this PR

- [ ] Go to VPN screen
- [ ] Enable the VPN
- [ ] Verify that animation from OFF to ON is shown
- [ ] Leave the VPN screen and re-enter again
- [ ] Verify that button does NOT animate from off to ON.
- [ ] Disable the VPN
- [ ] Verify that animation from ON to OFF is shown
- [ ] Leave the VPN screen and re-enter again
- [ ] Verify toggle doesn't animate
- [ ] Smoke test toggle enables (via quick action, another VPN) and verify animation is as expected
