### PR TITLE
Update interstitial to web behavior

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -622,6 +622,7 @@ class BrowserTabViewModelTest {
         whenever(mockToggleReports.shouldPrompt()).thenReturn(false)
         whenever(subscriptions.isEligible()).thenReturn(false)
         whenever(mockDuckChat.showInBrowserMenu).thenReturn(MutableStateFlow(false))
+        whenever(mockVisualDesignExperimentDataStore.isDuckAIPoCEnabled).thenReturn(MutableStateFlow(false))
 
         remoteMessagingModel = givenRemoteMessagingModel(mockRemoteMessagingRepository, mockPixel, coroutineRule.testDispatcherProvider)
 
@@ -840,6 +841,17 @@ class BrowserTabViewModelTest {
         whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
         whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(true)
         testee.browserViewState.value = browserViewState().copy(maliciousSiteBlocked = true)
+
+        testee.onViewVisible()
+
+        assertCommandNotIssued<ShowKeyboard>()
+    }
+
+    @Test
+    fun whenViewBecomesVisibleAndDuckAIPoCIsEnabledThenKeyboardNotShown() = runTest {
+        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
+        whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(true)
+        whenever(mockVisualDesignExperimentDataStore.isDuckAIPoCEnabled).thenReturn(MutableStateFlow(true))
 
         testee.onViewVisible()
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2841,7 +2841,8 @@ class BrowserTabViewModel @Inject constructor(
 
     private fun showOrHideKeyboard(cta: Cta?) {
         // we hide the keyboard when showing a DialogCta and HomeCta type in the home screen otherwise we show it
-        val shouldHideKeyboard = cta is HomePanelCta || cta is DaxBubbleCta.DaxPrivacyProCta || isBuckExperimentEnabledAndDaxEndCta(cta)
+        val shouldHideKeyboard = cta is HomePanelCta || cta is DaxBubbleCta.DaxPrivacyProCta || isBuckExperimentEnabledAndDaxEndCta(cta) ||
+            visualDesignExperimentDataStore.isDuckAIPoCEnabled.value
         command.value = if (shouldHideKeyboard) HideKeyboard else ShowKeyboard
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatOmnibarLayout.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatOmnibarLayout.kt
@@ -91,6 +91,9 @@ class DuckChatOmnibarLayout @JvmOverloads constructor(
     var onSearchSent: ((String) -> Unit)? = null
     var onDuckChatSent: ((String) -> Unit)? = null
 
+    private var selectionStart = 0
+    private var selectionEnd = 0
+
     init {
         LayoutInflater.from(context).inflate(R.layout.view_duck_chat_omnibar, this, true)
 
@@ -162,6 +165,9 @@ class DuckChatOmnibarLayout @JvmOverloads constructor(
     }
 
     private fun applyInputBehavior(tabPosition: Int) {
+        selectionStart = duckChatInput.selectionStart
+        selectionEnd = duckChatInput.selectionEnd
+
         val isSearchTab = tabPosition == 0
 
         duckChatInput.apply {
@@ -174,6 +180,12 @@ class DuckChatOmnibarLayout @JvmOverloads constructor(
             }
         }
         (context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager).restartInput(duckChatInput)
+
+        val length = duckChatInput.text.length
+        duckChatInput.setSelection(
+            selectionStart.coerceIn(0, length),
+            selectionEnd.coerceIn(0, length),
+        )
         applyLeftInputMargin(originalStartMargin)
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/SearchInterstitialActivity.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/SearchInterstitialActivity.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.extensions.hideKeyboard
 import com.duckduckgo.common.utils.extensions.showKeyboard
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.duckchat.api.DuckChat
@@ -58,8 +59,10 @@ class SearchInterstitialActivity : DuckDuckGoActivity() {
             this,
             object : OnBackPressedCallback(true) {
                 override fun handleOnBackPressed() {
-                    binding.duckChatOmnibar.animateOmnibarFocusedState(false)
-                    supportFinishAfterTransition()
+                    val query = binding.duckChatOmnibar.duckChatInput.text.toString()
+                    val data = Intent().putExtra(QUERY, query)
+                    setResult(Activity.RESULT_CANCELED, data)
+                    exitInterstitial()
                 }
             },
         )
@@ -71,22 +74,25 @@ class SearchInterstitialActivity : DuckDuckGoActivity() {
             onSearchSent = { query ->
                 val data = Intent().putExtra(QUERY, query)
                 setResult(Activity.RESULT_OK, data)
-                supportFinishAfterTransition()
+                exitInterstitial()
             }
             onDuckChatSent = { query ->
                 duckChat.openDuckChatWithAutoPrompt(query)
                 finish()
             }
             onBack = {
-                val query = duckChatInput.text.toString()
-                val data = Intent().putExtra(QUERY, query)
-                setResult(Activity.RESULT_CANCELED, data)
                 onBackPressed()
             }
         }
         binding.duckChatOmnibar.duckChatInput.post {
             showKeyboard(binding.duckChatOmnibar.duckChatInput)
         }
+    }
+
+    private fun exitInterstitial() {
+        binding.duckChatOmnibar.animateOmnibarFocusedState(false)
+        hideKeyboard(binding.duckChatOmnibar.duckChatInput)
+        supportFinishAfterTransition()
     }
 
     companion object {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1210498773096190?focus=true

### Description
- Retains cursor position when switching between search and Duck.ai.
- Hides keyboard on browser tab when Duck.ai PoC enabled.
- Retains text when swiping back from interstitial.

### Steps to test this PR

- [x] Enable Duck.ai PoC
- [x] Verify keyboard not shown on new tab
- [x] Enter some text
- [x] Verify cursor position is respected
- [x] Swipe back from interstitial
- [x] Verify that text is retained
