### PR TITLE
Short URL: Omnibar address formatting

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/AddressDisplayHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/AddressDisplayHelper.kt
@@ -1,0 +1,32 @@
+package com.duckduckgo.app.browser
+
+import android.content.Context
+import androidx.core.net.toUri
+import com.duckduckgo.common.utils.baseHost
+import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.duckplayer.api.DuckPlayer
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+interface AddressDisplayFormatter {
+    fun getDisplayAddress(query: String?, url: String?, showsFullUrl: Boolean): String
+}
+
+@SingleInstanceIn(ActivityScope::class)
+@ContributesBinding(ActivityScope::class)
+class RealAddressDisplayFormatter @Inject constructor(
+    private val context: Context,
+    private val duckPlayer: DuckPlayer,
+    private val duckDuckGoUrlDetector: DuckDuckGoUrlDetector,
+) : AddressDisplayFormatter {
+    override fun getDisplayAddress(query: String?, url: String?, showsFullUrl: Boolean): String {
+        return when {
+            url == null -> ""
+            duckDuckGoUrlDetector.isDuckDuckGoQueryUrl(url) -> query ?: url
+            showsFullUrl -> url
+            duckPlayer.isDuckPlayerUri(url) -> context.getString(R.string.browserDuckPlayerShortUrl)
+            else -> url.toUri().baseHost ?: url
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2101,6 +2101,7 @@ class BrowserTabFragment :
             }
 
             is Command.StartTrackersExperimentShieldPopAnimation -> showTrackersExperimentShieldPopAnimation()
+            is Command.RefreshOmnibar -> renderer.refreshOmnibar()
             else -> {
                 // NO OP
             }
@@ -4064,6 +4065,12 @@ class BrowserTabFragment :
                 lastSeenOmnibarViewState = viewState
 
                 omnibar.renderOmnibarViewState(viewState)
+            }
+        }
+
+        fun refreshOmnibar() {
+            lastSeenOmnibarViewState?.let {
+                omnibar.renderOmnibarViewState(it, true)
             }
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -477,6 +477,7 @@ class BrowserTabViewModel @Inject constructor(
     private var buildingSiteFactoryJob: Job? = null
     private var hasUserSeenHistoryIAM = false
     private var lastAutoCompleteState: AutoCompleteViewState? = null
+    private var lastFullSiteUrlEnabled: Boolean = settingsDataStore.isFullUrlEnabled
 
     // Map<String, Map<String, JavaScriptReplyProxy>>() = Map<Origin, Map<location.href, JavaScriptReplyProxy>>()
     private val fixedReplyProxyMap = mutableMapOf<String, Map<String, JavaScriptReplyProxy>>()
@@ -855,6 +856,11 @@ class BrowserTabViewModel @Inject constructor(
     fun onViewResumed() {
         if (currentGlobalLayoutState() is Invalidated && currentBrowserViewState().browserShowing) {
             showErrorWithAction()
+        }
+
+        if (lastFullSiteUrlEnabled != settingsDataStore.isFullUrlEnabled) {
+            lastFullSiteUrlEnabled = settingsDataStore.isFullUrlEnabled
+            command.value = Command.RefreshOmnibar
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
@@ -276,4 +276,5 @@ sealed class Command {
     data class ShowAutoconsentAnimation(val isCosmetic: Boolean) : Command()
     data object LaunchBookmarksActivity : Command()
     data object StartTrackersExperimentShieldPopAnimation : Command()
+    data object RefreshOmnibar : Command()
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
@@ -326,9 +326,9 @@ class Omnibar(
         newOmnibar.reduce(StateChange.LoadingStateChange(viewState))
     }
 
-    fun renderOmnibarViewState(viewState: OmnibarViewState) {
+    fun renderOmnibarViewState(viewState: OmnibarViewState, forceRender: Boolean = false) {
         logcat { "Omnibar: renderOmnibarViewState $viewState" }
-        newOmnibar.reduce(StateChange.OmnibarStateChange(viewState))
+        newOmnibar.reduce(StateChange.OmnibarStateChange(viewState, forceRender))
     }
 
     fun setPrivacyShield(privacyShield: PrivacyShield) {

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -144,7 +144,7 @@ open class OmnibarLayout @JvmOverloads constructor(
     }
 
     sealed class StateChange {
-        data class OmnibarStateChange(val omnibarViewState: OmnibarViewState) : StateChange()
+        data class OmnibarStateChange(val omnibarViewState: OmnibarViewState, val forceRender: Boolean) : StateChange()
         data class LoadingStateChange(val loadingViewState: LoadingViewState) : StateChange()
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -21,6 +21,7 @@ import android.webkit.URLUtil
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.app.browser.AddressDisplayFormatter
 import com.duckduckgo.app.browser.DuckDuckGoUrlDetector
 import com.duckduckgo.app.browser.defaultbrowsing.prompts.DefaultBrowserPromptsExperiment
 import com.duckduckgo.app.browser.omnibar.Omnibar.ViewMode
@@ -47,6 +48,7 @@ import com.duckduckgo.app.browser.viewstate.LoadingViewState
 import com.duckduckgo.app.browser.viewstate.OmnibarViewState
 import com.duckduckgo.app.global.model.PrivacyShield
 import com.duckduckgo.app.pixels.AppPixelName
+import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.FIRE_BUTTON_STATE
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
@@ -90,6 +92,8 @@ class OmnibarLayoutViewModel @Inject constructor(
     private val visualDesignExperimentDataStore: VisualDesignExperimentDataStore,
     private val senseOfProtectionExperiment: SenseOfProtectionExperiment,
     private val duckChat: DuckChat,
+    private val addressDisplayFormatter: AddressDisplayFormatter,
+    private val settingsDataStore: SettingsDataStore,
 ) : ViewModel() {
 
     private val _viewState = MutableStateFlow(
@@ -218,6 +222,8 @@ class OmnibarLayoutViewModel @Inject constructor(
                         hasQueryChanged = false,
                         urlLoaded = _viewState.value.url,
                     ),
+                    omnibarText = addressDisplayFormatter.getDisplayAddress(query, it.url, true),
+                    updateOmnibarText = true,
                 )
             }
         } else {
@@ -225,13 +231,7 @@ class OmnibarLayoutViewModel @Inject constructor(
                 val shouldUpdateOmnibarText = it.shouldUpdateOmnibarText()
                 logcat { "Omnibar: lost focus in Browser or MaliciousSiteWarning mode $shouldUpdateOmnibarText" }
                 val omnibarText = if (shouldUpdateOmnibarText) {
-                    if (duckDuckGoUrlDetector.isDuckDuckGoQueryUrl(it.url)) {
-                        logcat { "Omnibar: is DDG url, showing query ${it.query}" }
-                        it.query
-                    } else {
-                        logcat { "Omnibar: is url, showing URL ${it.url}" }
-                        it.url
-                    }
+                    addressDisplayFormatter.getDisplayAddress(query, it.url, settingsDataStore.isFullUrlEnabled)
                 } else {
                     logcat { "Omnibar: not browser or MaliciousSiteWarning mode, not changing omnibar text" }
                     it.omnibarText
@@ -517,20 +517,25 @@ class OmnibarLayoutViewModel @Inject constructor(
 
     fun onExternalStateChange(stateChange: StateChange) {
         when (stateChange) {
-            is OmnibarStateChange -> onExternalOmnibarStateChanged(stateChange.omnibarViewState)
+            is OmnibarStateChange -> onExternalOmnibarStateChanged(stateChange.omnibarViewState, stateChange.forceRender)
             is StateChange.LoadingStateChange -> onExternalLoadingStateChanged(stateChange.loadingViewState)
         }
     }
 
-    private fun onExternalOmnibarStateChanged(omnibarViewState: OmnibarViewState) {
+    private fun onExternalOmnibarStateChanged(omnibarViewState: OmnibarViewState, forceRender: Boolean) {
         logcat { "Omnibar: onExternalOmnibarStateChanged $omnibarViewState" }
-        if (shouldUpdateOmnibarTextInput(omnibarViewState, _viewState.value.omnibarText)) {
+        if (shouldUpdateOmnibarTextInput(omnibarViewState, _viewState.value.omnibarText) || forceRender) {
+            val omnibarText = addressDisplayFormatter.getDisplayAddress(
+                omnibarViewState.omnibarText,
+                omnibarViewState.omnibarText,
+                settingsDataStore.isFullUrlEnabled || omnibarViewState.isEditing,
+            )
             if (omnibarViewState.navigationChange) {
                 _viewState.update {
                     it.copy(
                         expanded = true,
                         expandedAnimated = true,
-                        omnibarText = omnibarViewState.omnibarText,
+                        omnibarText = omnibarText,
                         updateOmnibarText = true,
                     )
                 }
@@ -539,11 +544,11 @@ class OmnibarLayoutViewModel @Inject constructor(
                     it.copy(
                         expanded = omnibarViewState.forceExpand,
                         expandedAnimated = omnibarViewState.forceExpand,
-                        omnibarText = omnibarViewState.omnibarText,
+                        omnibarText = omnibarText,
                         updateOmnibarText = true,
                         showVoiceSearch = shouldShowVoiceSearch(
                             hasFocus = omnibarViewState.isEditing,
-                            query = omnibarViewState.omnibarText,
+                            query = omnibarText,
                             hasQueryChanged = true,
                             urlLoaded = _viewState.value.url,
                         ),
@@ -592,7 +597,7 @@ class OmnibarLayoutViewModel @Inject constructor(
         )
         _viewState.update {
             it.copy(
-                omnibarText = it.url,
+                omnibarText = addressDisplayFormatter.getDisplayAddress(it.query, it.url, settingsDataStore.isFullUrlEnabled),
                 updateOmnibarText = true,
             )
         }

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -62,4 +62,7 @@
 
     <!-- Appearance Settings -->
     <string name="settingsShowFullUrlTitle">Show Full Site Address</string>
+
+    <!-- Browser tab -->
+    <string name="browserDuckPlayerShortUrl">Duck Player</string>
 </resources>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/715106103902962/task/1209579764473496?focus=true

### Description

This PR uses the short URL option to decide whether to display the short URL in the omnibar.

### Steps to test this PR

_Website_
- [ ] Visit some website with a longer link (something more than just a domain)
- [ ] Verify the full URL is displayed
- [ ] Go to Settings -> Appearance
- [ ] Disable the "Show Full Site Address" option
- [ ] Go back to the browser
- [ ] Verify the short format of the site is shown (base domain)
- [ ] Navigate somewhere else and verify the short URL is still shown
- [ ] Go to Settings -> Appearance
- [ ] Re-enable the "Show Full Site Address" option
- [ ] Go back to the browser
- [ ] Verify the full format of the site is shown

_Website_
- [ ] Open a video using Duck Player
- [ ] Verify the full Duck Player URL is displayed
- [ ] Go to Settings -> Appearance
- [ ] Disable the "Show Full Site Address" option
- [ ] Go back to the browser
- [ ] Verify that "Duck Player" is displayed instead of the URL
- [ ] Go to Settings -> Appearance
- [ ] Re-enable the "Show Full Site Address" option
- [ ] Go back to the browser
- [ ] Verify the full format of the URL is shown

_DDG Search_
- [ ] Open a NTP and enter a search query
- [ ] Verify the query is shown, not URL (no change in functionality)
- [ ] Go to Settings -> Appearance
- [ ] Disable the "Show Full Site Address" option
- [ ] Go back to the browser
- [ ] Verify the query is still shown
- [ ] Go to Settings -> Appearance
- [ ] Re-enable the "Show Full Site Address" option
- [ ] Go back to the browser
- [ ] Verify the query is still shown
