### PR TITLE
Update content scope scripts to version 9.7.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
@@ -501,11 +501,12 @@
       "performanceMetrics",
       "breakageReporting",
       "autofillPasswordImport",
-      "favicon"
+      "favicon",
+      "scriptlets"
     ]
   );
   var platformSupport = {
-    apple: ["webCompat", "duckPlayerNative", ...baseFeatures],
+    apple: ["webCompat", "duckPlayerNative", "scriptlets", ...baseFeatures],
     "apple-isolated": [
       "duckPlayer",
       "duckPlayerNative",

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -2000,11 +2000,12 @@
       "performanceMetrics",
       "breakageReporting",
       "autofillPasswordImport",
-      "favicon"
+      "favicon",
+      "scriptlets"
     ]
   );
   var platformSupport = {
-    apple: ["webCompat", "duckPlayerNative", ...baseFeatures],
+    apple: ["webCompat", "duckPlayerNative", "scriptlets", ...baseFeatures],
     "apple-isolated": [
       "duckPlayer",
       "duckPlayerNative",

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -1329,11 +1329,12 @@
       "performanceMetrics",
       "breakageReporting",
       "autofillPasswordImport",
-      "favicon"
+      "favicon",
+      "scriptlets"
     ]
   );
   var platformSupport = {
-    apple: ["webCompat", "duckPlayerNative", ...baseFeatures],
+    apple: ["webCompat", "duckPlayerNative", "scriptlets", ...baseFeatures],
     "apple-isolated": [
       "duckPlayer",
       "duckPlayerNative",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.0.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.2.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#9.5.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#9.7.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1747996876"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#23aacaa55eb0191c01b71dc30e5f521527bee8bf",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#638f9b543a0134622ac352a86bb075016b898f10",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -118,12 +118,12 @@
       "license": "MPL-2.0"
     },
     "node_modules/@ghostery/url-parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@ghostery/url-parser/-/url-parser-1.2.0.tgz",
-      "integrity": "sha512-Ca10Ym7VV/USFgGOvOhH0DeuaW3K4tsdFpDytObsuMxFx7xDae25caVUpivSqYy4UuTZ7pPCzpP5OJm+PgEveA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ghostery/url-parser/-/url-parser-1.3.0.tgz",
+      "integrity": "sha512-FEzdSeiva0Mt3bR4xePFzthhjT4IzvA5QTvS1xXkNyLpMGeq40mb3V2fSs0ZItRaP9IybZthDfHUSbQ1HLdx4Q==",
       "license": "MPL-2.0",
       "dependencies": {
-        "tldts-experimental": "^7.0.7"
+        "tldts-experimental": "^7.0.8"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -293,9 +293,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.0.tgz",
-      "integrity": "sha512-yZQa2zm87aRVcqDyH5+4Hv9KYgSdgwX1rFnGvpbzMaC7YAljmhBET93TPiTd3ObwTL+gSpIzPKg5BqVxdCvxKg==",
+      "version": "24.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.1.tgz",
+      "integrity": "sha512-MX4Zioh39chHlDJbKmEgydJDS3tspMP/lnQC67G3SWsTnb9NeYVWOjkxpOSy4oMfPs4StcWHwBrvUb4ybfnuaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.0.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#17.2.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#9.5.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#9.7.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1747996876"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass