### PR TITLE
Bug: Snackbars shown at the top

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1507,16 +1507,16 @@ class BrowserTabFragment :
 
     @SuppressLint("WrongConstant")
     private fun downloadStarted(command: DownloadCommand.ShowDownloadStartedMessage) {
-        binding.browserLayout.makeSnackbarWithNoBottomInset(getString(command.messageId, command.fileName), DOWNLOAD_SNACKBAR_LENGTH)?.show()
+        view?.makeSnackbarWithNoBottomInset(getString(command.messageId, command.fileName), DOWNLOAD_SNACKBAR_LENGTH)?.show()
     }
 
     private fun downloadFailed(command: DownloadCommand.ShowDownloadFailedMessage) {
-        val downloadFailedSnackbar = binding.browserLayout.makeSnackbarWithNoBottomInset(getString(command.messageId), Snackbar.LENGTH_LONG)
-        view?.postDelayed({ downloadFailedSnackbar.show() }, DOWNLOAD_SNACKBAR_DELAY)
+        val downloadFailedSnackbar = view?.makeSnackbarWithNoBottomInset(getString(command.messageId), Snackbar.LENGTH_LONG)
+        view?.postDelayed({ downloadFailedSnackbar?.show() }, DOWNLOAD_SNACKBAR_DELAY)
     }
 
     private fun downloadSucceeded(command: DownloadCommand.ShowDownloadSuccessMessage) {
-        val downloadSucceededSnackbar = binding.browserLayout.makeSnackbarWithNoBottomInset(
+        val downloadSucceededSnackbar = view?.makeSnackbarWithNoBottomInset(
             getString(command.messageId, command.fileName),
             Snackbar.LENGTH_LONG,
         )

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1507,16 +1507,19 @@ class BrowserTabFragment :
 
     @SuppressLint("WrongConstant")
     private fun downloadStarted(command: DownloadCommand.ShowDownloadStartedMessage) {
-        view?.makeSnackbarWithNoBottomInset(getString(command.messageId, command.fileName), DOWNLOAD_SNACKBAR_LENGTH)?.show()
+        binding.browserLayout.makeSnackbarWithNoBottomInset(getString(command.messageId, command.fileName), DOWNLOAD_SNACKBAR_LENGTH)?.show()
     }
 
     private fun downloadFailed(command: DownloadCommand.ShowDownloadFailedMessage) {
-        val downloadFailedSnackbar = view?.makeSnackbarWithNoBottomInset(getString(command.messageId), Snackbar.LENGTH_LONG)
-        view?.postDelayed({ downloadFailedSnackbar?.show() }, DOWNLOAD_SNACKBAR_DELAY)
+        val downloadFailedSnackbar = binding.browserLayout.makeSnackbarWithNoBottomInset(getString(command.messageId), Snackbar.LENGTH_LONG)
+        view?.postDelayed({ downloadFailedSnackbar.show() }, DOWNLOAD_SNACKBAR_DELAY)
     }
 
     private fun downloadSucceeded(command: DownloadCommand.ShowDownloadSuccessMessage) {
-        val downloadSucceededSnackbar = view?.makeSnackbarWithNoBottomInset(getString(command.messageId, command.fileName), Snackbar.LENGTH_LONG)
+        val downloadSucceededSnackbar = binding.browserLayout.makeSnackbarWithNoBottomInset(
+            getString(command.messageId, command.fileName),
+            Snackbar.LENGTH_LONG,
+        )
             ?.apply {
                 this.setAction(R.string.downloadsDownloadFinishedActionName) {
                     val result = downloadsFileActions.openFile(requireActivity(), File(command.filePath))

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/BottomAppBarBehavior.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/BottomAppBarBehavior.kt
@@ -58,7 +58,11 @@ class BottomAppBarBehavior<V : View>(
     )
 
     @SuppressLint("RestrictedApi")
-    override fun layoutDependsOn(parent: CoordinatorLayout, child: V, dependency: View): Boolean {
+    override fun layoutDependsOn(
+        parent: CoordinatorLayout,
+        child: V,
+        dependency: View,
+    ): Boolean {
         if (dependency is Snackbar.SnackbarLayout) {
             updateSnackbar(child, dependency)
         }
@@ -118,7 +122,12 @@ class BottomAppBarBehavior<V : View>(
         }
     }
 
-    override fun onStopNestedScroll(coordinatorLayout: CoordinatorLayout, child: V, target: View, type: Int) {
+    override fun onStopNestedScroll(
+        coordinatorLayout: CoordinatorLayout,
+        child: V,
+        target: View,
+        type: Int,
+    ) {
         if (lastStartedType == ViewCompat.TYPE_TOUCH || type == ViewCompat.TYPE_NON_TOUCH) {
             val dY = child.translationY
             val threshold = child.height * 0.5f
@@ -132,7 +141,10 @@ class BottomAppBarBehavior<V : View>(
         }
     }
 
-    fun setExpanded(expanded: Boolean, animate: Boolean = true) {
+    fun setExpanded(
+        expanded: Boolean,
+        animate: Boolean = true,
+    ) {
         if (animate) {
             animateToolbarVisibility(expanded)
         } else {
@@ -162,7 +174,10 @@ class BottomAppBarBehavior<V : View>(
     }
 
     @SuppressLint("RestrictedApi")
-    private fun updateSnackbar(child: View, snackbarLayout: Snackbar.SnackbarLayout) {
+    private fun updateSnackbar(
+        child: View,
+        snackbarLayout: Snackbar.SnackbarLayout,
+    ) {
         if (snackbarLayout.layoutParams is CoordinatorLayout.LayoutParams) {
             val params = snackbarLayout.layoutParams as CoordinatorLayout.LayoutParams
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarBehaviour.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarBehaviour.kt
@@ -27,4 +27,6 @@ interface OmnibarBehaviour {
     fun setTranslation(y: Float)
 
     fun isOmnibarScrollingEnabled(): Boolean
+
+    fun isBottomNavEnabled(): Boolean
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -999,6 +999,10 @@ open class OmnibarLayout @JvmOverloads constructor(
         return isScrollingEnabled
     }
 
+    override fun isBottomNavEnabled(): Boolean {
+        return false
+    }
+
     override fun getBehavior(): CoordinatorLayout.Behavior<AppBarLayout> {
         return when (omnibarPosition) {
             OmnibarPosition.TOP -> TopAppBarBehavior(context, this)

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/TopAppBarBehavior.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/TopAppBarBehavior.kt
@@ -45,9 +45,15 @@ class TopAppBarBehavior(
     }
 
     @SuppressLint("RestrictedApi")
-    override fun layoutDependsOn(parent: CoordinatorLayout, child: AppBarLayout, dependency: View): Boolean {
+    override fun layoutDependsOn(
+        parent: CoordinatorLayout,
+        child: AppBarLayout,
+        dependency: View,
+    ): Boolean {
         if (dependency is Snackbar.SnackbarLayout) {
-            updateSnackbar(child, dependency)
+            if (omnibar.isBottomNavEnabled()) {
+                updateSnackbar(child, dependency)
+            }
         } else if (!viewsExemptedFromOffset.contains(dependency.id)) {
             offsetBottomByToolbar(dependency)
         }
@@ -72,7 +78,10 @@ class TopAppBarBehavior(
     }
 
     @SuppressLint("RestrictedApi")
-    private fun updateSnackbar(child: View, snackbarLayout: Snackbar.SnackbarLayout) {
+    private fun updateSnackbar(
+        child: View,
+        snackbarLayout: Snackbar.SnackbarLayout,
+    ) {
         if (snackbarLayout.layoutParams is CoordinatorLayout.LayoutParams) {
             val params = snackbarLayout.layoutParams as CoordinatorLayout.LayoutParams
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/FadeOmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/FadeOmnibarLayout.kt
@@ -185,6 +185,10 @@ class FadeOmnibarLayout @JvmOverloads constructor(
         }
     }
 
+    override fun isBottomNavEnabled(): Boolean {
+        return true
+    }
+
     override fun render(viewState: ViewState) {
         super.render(viewState)
 

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DefaultFileDownloadNotificationManager.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DefaultFileDownloadNotificationManager.kt
@@ -79,7 +79,7 @@ class DefaultFileDownloadNotificationManager @Inject constructor(
             .setContentTitle(applicationContext.getString(R.string.downloadInProgress))
             .setContentText("$filename ($progress%).")
             .setShowWhen(false)
-            .setSmallIcon(com.duckduckgo.mobile.android.R.drawable.ic_downloads_white_16)
+            .setSmallIcon(com.duckduckgo.mobile.android.R.drawable.notification_logo)
             .setProgress(100, progress, progress == 0)
             .setOngoing(true)
             .setGroup(DOWNLOAD_IN_PROGRESS_GROUP)
@@ -93,7 +93,7 @@ class DefaultFileDownloadNotificationManager @Inject constructor(
         val summary = NotificationCompat.Builder(applicationContext, FileDownloadNotificationChannelType.FILE_DOWNLOADING.id)
             .setPriority(FileDownloadNotificationChannelType.FILE_DOWNLOADING.priority)
             .setShowWhen(false)
-            .setSmallIcon(com.duckduckgo.mobile.android.R.drawable.ic_downloads_white_16)
+            .setSmallIcon(com.duckduckgo.mobile.android.R.drawable.notification_logo)
             .setGroup(DOWNLOAD_IN_PROGRESS_GROUP)
             .setGroupSummary(true)
             .build()
@@ -126,7 +126,7 @@ class DefaultFileDownloadNotificationManager @Inject constructor(
             .setContentText(applicationContext.getString(R.string.notificationDownloadComplete))
             .setContentIntent(PendingIntent.getActivity(applicationContext, downloadId.toInt(), intent, pendingIntentFlags))
             .setAutoCancel(true)
-            .setSmallIcon(com.duckduckgo.mobile.android.R.drawable.ic_downloads_white_16)
+            .setSmallIcon(com.duckduckgo.mobile.android.R.drawable.notification_logo)
             .build()
 
         cancelDownloadFileNotification(downloadId)
@@ -142,7 +142,7 @@ class DefaultFileDownloadNotificationManager @Inject constructor(
             .setPriority(FileDownloadNotificationChannelType.FILE_DOWNLOADING.priority)
             .setShowWhen(false)
             .setContentTitle(applicationContext.getString(R.string.notificationDownloadFailed))
-            .setSmallIcon(com.duckduckgo.mobile.android.R.drawable.ic_downloads_white_16)
+            .setSmallIcon(com.duckduckgo.mobile.android.R.drawable.notification_logo)
             .apply {
                 url?.let { fileUrl ->
                     val pendingIntent = PendingIntent.getBroadcast(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1157893581871903/task/1210530805272776?focus=true

### Description
This PR fixes the wrong position of the Snackbar when the omnbiar at the top

### Steps to test this PR

_Visual Designs Disabled_
- [x] Open the app and ensure omnibar is in Top position
- [x] Start a download (image, test file, etc…)
- [x] Verify Snackbar is at the bottom
- [x] Go to Settings / Appearance and move Omnibar to the bottom
- [x] Start a download (image, test file, etc…)
- [x] Verify Snackbar is at the bottom

_Visual Designs Enabled_
- [x] Open the app and ensure omnibar is in Top position
- [x] Enable Visual Design Experiments
- [x] Start a download (image, test file, etc…)
- [x] Verify Snackbar is at the bottom, over the Bottom Nav
- [x] Go to Settings / Appearance and move Omnibar to the bottom
- [x] Start a download (image, test file, etc…)
- [x] Verify Snackbar is at the bottom, over the Bottom Nav
