### PR TITLE
Fix: Open bookmarks with tab swiping

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -359,7 +359,7 @@ class BrowserViewModel @Inject constructor(
             launch {
                 val existingTab = tabRepository.getTabs().firstOrNull { tab -> tab.url == url }
                 if (existingTab == null) {
-                    command.value = Command.OpenInNewTab(url)
+                    command.value = Command.OpenSavedSite(url)
                 } else {
                     command.value = Command.SwitchToTab(existingTab.tabId)
                 }

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
@@ -506,6 +506,17 @@ class BrowserViewModelTest {
         assertEquals(false, testee.viewState.value!!.isTabSwipingEnabled)
     }
 
+    @Test
+    fun whenOnBookmarksActivityResultCalledThenOpenSavedSiteCommandTriggered() = runTest {
+        swipingTabsFeature.self().setRawStoredState(State(enable = false))
+        val bookmarkUrl = "https://www.example.com"
+
+        testee.onBookmarksActivityResult(bookmarkUrl)
+
+        verify(mockCommandObserver).onChanged(commandCaptor.capture())
+        assertEquals(Command.OpenSavedSite(bookmarkUrl), commandCaptor.lastValue)
+    }
+
     private fun initTestee() {
         testee = BrowserViewModel(
             tabRepository = mockTabRepository,

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
@@ -292,7 +292,7 @@ class BrowserViewModelTest {
         testee.onBookmarksActivityResult(bookmarkUrl)
 
         verify(mockCommandObserver).onChanged(commandCaptor.capture())
-        assertEquals(Command.OpenInNewTab(bookmarkUrl), commandCaptor.lastValue)
+        assertEquals(Command.OpenSavedSite(bookmarkUrl), commandCaptor.lastValue)
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1210572537804655?focus=true

### Description

This fixes an issue when a bookmark was opened in a new tab.

### Steps to test this PR

- [ ] Enable tab swiping
- [ ] Open site A and add a bookmark
- [ ] Open some other site B
- [ ] Go to bookmarks and tap on bookmark for site A
- [ ] Notice the bookmark is opened in the existing tab