### PR TITLE
GHA: Allow for triggering of workflow as long as PR it's labeled

### DIFF
--- a/.github/workflows/action-pr-sync.yaml
+++ b/.github/workflows/action-pr-sync.yaml
@@ -20,7 +20,8 @@ jobs:
     name: Sync Asana PR task
     runs-on: ubuntu-latest
     if: |
-      github.event.label.name == 'PR-task' && github.actor != 'dependabot[bot]'
+      contains(github.event.pull_request.labels.*.name, 'PR-task') &&
+      github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1174433894299346/task/1210579770193532?focus=true

### Description
Allow for triggering of workflow as long as PR it's labeled