### PR TITLE
Fix: Duck.ai button visibility

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -1173,8 +1173,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
                 }
             }
 
-            toolbarMockupBinding.aiChatIconMenuMockup.isVisible = duckChat.showInAddressBar.value &&
-                browserFeatures.duckAiButtonInBrowser().isEnabled()
+            toolbarMockupBinding.aiChatIconMenuMockup.isVisible = duckChat.showInAddressBar.value && duckChat.isDuckAiInBrowserEnabled()
         }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -1173,7 +1173,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
                 }
             }
 
-            toolbarMockupBinding.aiChatIconMenuMockup.isVisible = duckChat.showInAddressBar.value && duckChat.isDuckAiInBrowserEnabled()
+            toolbarMockupBinding.aiChatIconMenuMockup.isVisible = duckChat.showInAddressBar.value && duckChat.isEnabledInBrowser()
         }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -100,7 +100,7 @@ class OmnibarLayoutViewModel @Inject constructor(
 
     private val _viewState = MutableStateFlow(
         ViewState(
-            showChatMenu = duckChat.showInAddressBar.value,
+            showChatMenu = duckChat.showInAddressBar.value && browserFeatures.duckAiButtonInBrowser().isEnabled(),
         ),
     )
 
@@ -127,7 +127,8 @@ class OmnibarLayoutViewModel @Inject constructor(
             hasUnreadTabs = tabs.firstOrNull { !it.viewed } != null,
             showBrowserMenuHighlight = highlightOverflowMenu,
             isVisualDesignExperimentEnabled = isVisualDesignExperimentEnabled,
-            showChatMenu = showInAddressBar && state.viewMode !is CustomTab && browserFeatures.duckAiButtonInBrowser().isEnabled(),
+            showChatMenu = showInAddressBar && state.viewMode !is CustomTab &&
+                (state.viewMode is NewTab || state.hasFocus && state.omnibarText.isNotBlank() || browserFeatures.duckAiButtonInBrowser().isEnabled()),
             showClickCatcher = isDuckAIPoCEnabled,
         )
     }.flowOn(dispatcherProvider.io()).stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000L), _viewState.value)

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -100,7 +100,7 @@ class OmnibarLayoutViewModel @Inject constructor(
 
     private val _viewState = MutableStateFlow(
         ViewState(
-            showChatMenu = duckChat.showInAddressBar.value && browserFeatures.duckAiButtonInBrowser().isEnabled(),
+            showChatMenu = duckChat.showInAddressBar.value && duckChat.isDuckAiInBrowserEnabled(),
         ),
     )
 
@@ -128,7 +128,7 @@ class OmnibarLayoutViewModel @Inject constructor(
             showBrowserMenuHighlight = highlightOverflowMenu,
             isVisualDesignExperimentEnabled = isVisualDesignExperimentEnabled,
             showChatMenu = showInAddressBar && state.viewMode !is CustomTab &&
-                (state.viewMode is NewTab || state.hasFocus && state.omnibarText.isNotBlank() || browserFeatures.duckAiButtonInBrowser().isEnabled()),
+                (state.viewMode is NewTab || state.hasFocus && state.omnibarText.isNotBlank() || duckChat.isDuckAiInBrowserEnabled()),
             showClickCatcher = isDuckAIPoCEnabled,
         )
     }.flowOn(dispatcherProvider.io()).stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000L), _viewState.value)

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -100,7 +100,7 @@ class OmnibarLayoutViewModel @Inject constructor(
 
     private val _viewState = MutableStateFlow(
         ViewState(
-            showChatMenu = duckChat.showInAddressBar.value && duckChat.isDuckAiInBrowserEnabled(),
+            showChatMenu = duckChat.showInAddressBar.value && duckChat.isEnabledInBrowser(),
         ),
     )
 
@@ -128,7 +128,7 @@ class OmnibarLayoutViewModel @Inject constructor(
             showBrowserMenuHighlight = highlightOverflowMenu,
             isVisualDesignExperimentEnabled = isVisualDesignExperimentEnabled,
             showChatMenu = showInAddressBar && state.viewMode !is CustomTab &&
-                (state.viewMode is NewTab || state.hasFocus && state.omnibarText.isNotBlank() || duckChat.isDuckAiInBrowserEnabled()),
+                (state.viewMode is NewTab || state.hasFocus && state.omnibarText.isNotBlank() || duckChat.isEnabledInBrowser()),
             showClickCatcher = isDuckAIPoCEnabled,
         )
     }.flowOn(dispatcherProvider.io()).stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000L), _viewState.value)

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -149,7 +149,4 @@ interface AndroidBrowserConfigFeature {
 
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun newThreatProtectionSettings(): Toggle
-
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
-    fun duckAiButtonInBrowser(): Toggle
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -121,7 +121,7 @@ class OmnibarLayoutViewModelTest {
         whenever(mockVisualDesignExperimentDataStore.isDuckAIPoCEnabled).thenReturn(duckAIPoCStateFlow)
         whenever(duckChat.showInAddressBar).thenReturn(duckChatShowInAddressBarFlow)
         whenever(settingsDataStore.isFullUrlEnabled).thenReturn(true)
-        whenever(duckChat.isDuckAiInBrowserEnabled()).thenReturn(true)
+        whenever(duckChat.isEnabledInBrowser()).thenReturn(true)
 
         initializeViewModel()
     }
@@ -1248,7 +1248,7 @@ class OmnibarLayoutViewModelTest {
 
     @Test
     fun whenDuckAiButtonInBrowserFeatureFlagIsDisabledTheButtonIsNotVisible() = runTest {
-        whenever(duckChat.isDuckAiInBrowserEnabled()).thenReturn(false)
+        whenever(duckChat.isEnabledInBrowser()).thenReturn(false)
         testee.viewState.test {
             val viewState = awaitItem()
             assertFalse(viewState.showChatMenu)
@@ -1333,7 +1333,7 @@ class OmnibarLayoutViewModelTest {
 
     @Test
     fun whenDuckAiButtonInBrowserFeatureFlagIsDisabledAndOtherConditionsAreNotMetThenButtonIsNotVisible() = runTest {
-        whenever(duckChat.isDuckAiInBrowserEnabled()).thenReturn(false)
+        whenever(duckChat.isEnabledInBrowser()).thenReturn(false)
         initializeViewModel()
         testee.viewState.test {
             val viewState = awaitItem()
@@ -1343,7 +1343,7 @@ class OmnibarLayoutViewModelTest {
 
     @Test
     fun whenDuckAiButtonInBrowserFeatureFlagIsDisabledButInNewTabThenShowChatMenuIsTrue() = runTest {
-        whenever(duckChat.isDuckAiInBrowserEnabled()).thenReturn(false)
+        whenever(duckChat.isEnabledInBrowser()).thenReturn(false)
         initializeViewModel()
 
         testee.onViewModeChanged(ViewMode.NewTab)
@@ -1357,7 +1357,7 @@ class OmnibarLayoutViewModelTest {
 
     @Test
     fun whenDuckAiButtonInBrowserFeatureFlagIsDisabledButHasFocusAndTextThenShowChatMenuIsTrue() = runTest {
-        whenever(duckChat.isDuckAiInBrowserEnabled()).thenReturn(false)
+        whenever(duckChat.isEnabledInBrowser()).thenReturn(false)
         initializeViewModel()
 
         testee.onInputStateChanged(QUERY, hasFocus = true, clearQuery = false, deleteLastCharacter = false)

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
@@ -37,7 +37,7 @@ interface DuckChat {
      *
      * @return true if Duck.ai in browser is enabled, false otherwise.
      */
-    fun isDuckAiInBrowserEnabled(): Boolean
+    fun isEnabledInBrowser(): Boolean
 
     /**
      * Checks whether DuckChat should be shown in browser menu based on user settings.

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
@@ -32,6 +32,14 @@ interface DuckChat {
     fun isEnabled(): Boolean
 
     /**
+     * Checks whether Duck.ai in browser is enabled based on remote config flag.
+     * Uses a cached value - does not perform disk I/O.
+     *
+     * @return true if Duck.ai in browser is enabled, false otherwise.
+     */
+    fun isDuckAiInBrowserEnabled(): Boolean
+
+    /**
      * Checks whether DuckChat should be shown in browser menu based on user settings.
      *
      * @return true if DuckChat should be shown, false otherwise.

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -178,6 +178,7 @@ class RealDuckChat @Inject constructor(
     }
 
     private var isDuckChatEnabled = false
+    private var isDuckAiInBrowserEnabled = false
     private var isDuckChatUserEnabled = false
     private var duckChatLink = DUCK_CHAT_WEB_LINK
     private var bangRegex: Regex? = null
@@ -226,6 +227,10 @@ class RealDuckChat @Inject constructor(
 
     override fun isEnabled(): Boolean {
         return isDuckChatEnabled
+    }
+
+    override fun isDuckAiInBrowserEnabled(): Boolean {
+        return isDuckAiInBrowserEnabled
     }
 
     override fun observeEnableDuckChatUserSetting(): Flow<Boolean> {
@@ -375,6 +380,7 @@ class RealDuckChat @Inject constructor(
     private fun cacheConfig() {
         appCoroutineScope.launch(dispatchers.io()) {
             isDuckChatEnabled = duckChatFeature.self().isEnabled()
+            isDuckAiInBrowserEnabled = duckChatFeature.duckAiButtonInBrowser().isEnabled()
 
             val settingsString = duckChatFeature.self().getSettings()
             val settingsJson = settingsString?.let {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -229,7 +229,7 @@ class RealDuckChat @Inject constructor(
         return isDuckChatEnabled
     }
 
-    override fun isDuckAiInBrowserEnabled(): Boolean {
+    override fun isEnabledInBrowser(): Boolean {
         return isDuckAiInBrowserEnabled
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -35,4 +35,12 @@ interface DuckChatFeature {
      */
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
+
+    /**
+     * @return `true` when the remote config has the "duckAiButtonInBrowser" Duck.ai button in browser
+     * sub-feature flag enabled
+     * If the remote feature is not present defaults to `false`
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun duckAiButtonInBrowser(): Toggle
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -564,6 +564,24 @@ class RealDuckChatTest {
         assertFalse(testee.isImageUploadEnabled())
     }
 
+    @Test
+    fun whenDuckAiInBrowserFeatureEnabledThenIsDuckAiInBrowserEnabledReturnsTrue() = runTest {
+        duckChatFeature.duckAiButtonInBrowser().setRawStoredState(State(enable = true))
+
+        testee.onPrivacyConfigDownloaded()
+
+        assertTrue(testee.isDuckAiInBrowserEnabled())
+    }
+
+    @Test
+    fun whenDuckAiInBrowserFeatureDisabledThenIsDuckAiInBrowserEnabledReturnsFalse() = runTest {
+        duckChatFeature.duckAiButtonInBrowser().setRawStoredState(State(enable = false))
+
+        testee.onPrivacyConfigDownloaded()
+
+        assertFalse(testee.isDuckAiInBrowserEnabled())
+    }
+
     companion object {
         val SETTINGS_JSON = """
         {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -565,21 +565,21 @@ class RealDuckChatTest {
     }
 
     @Test
-    fun whenDuckAiInBrowserFeatureEnabledThenIsDuckAiInBrowserEnabledReturnsTrue() = runTest {
+    fun whenDuckAiInBrowserFeatureEnabledThenIsEnabledInBrowserReturnsTrue() = runTest {
         duckChatFeature.duckAiButtonInBrowser().setRawStoredState(State(enable = true))
 
         testee.onPrivacyConfigDownloaded()
 
-        assertTrue(testee.isDuckAiInBrowserEnabled())
+        assertTrue(testee.isEnabledInBrowser())
     }
 
     @Test
-    fun whenDuckAiInBrowserFeatureDisabledThenIsDuckAiInBrowserEnabledReturnsFalse() = runTest {
+    fun whenDuckAiInBrowserFeatureDisabledThenIsEnabledInBrowserReturnsFalse() = runTest {
         duckChatFeature.duckAiButtonInBrowser().setRawStoredState(State(enable = false))
 
         testee.onPrivacyConfigDownloaded()
 
-        assertFalse(testee.isDuckAiInBrowserEnabled())
+        assertFalse(testee.isEnabledInBrowser())
     }
 
     companion object {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1210579127221598?focus=true

### Description

This PR fixes the Duck.ai button display logic so that the original behavior is independent of the "Duck.ai in browser" feature flag.

### Steps to test this PR

- [x] Both the main Duck chat feature flag and Duck.ai button flag should be enabled by default
- [x] Open the app and verify the Duck.ai button is visible both in the browser mode, when focused and on NTP
- [x] Go to the dev settings and disable the `aiChat -> duckAiButtonInBrowser` flag
- [x] Verify the Duck.ai button is not visible in the browser mode anymore, only on the NTP or when focused
- [x] Re-enable the Duck.ai button flag
- [x] Go to Settings -> Duck.ai and disable the Address bar toggle
- [x] Verify the Duck.ai button is not displayed at all

