### PR TITLE
Add extra check for Free Trials availability on Play Store

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
@@ -347,7 +347,10 @@ class RealSubscriptionsManager @Inject constructor(
         } catch (e: Exception) {
             false
         }
-        return !userHadFreeTrial && privacyProFeature.get().privacyProFreeTrial().isEnabled()
+        val freeTrialProductsAvailableInGooglePlay = getSubscriptionOffer().any {
+            it.offerId in SubscriptionsConstants.LIST_OF_FREE_TRIAL_OFFERS
+        }
+        return !userHadFreeTrial && privacyProFeature.get().privacyProFreeTrial().isEnabled() && freeTrialProductsAvailableInGooglePlay
     }
 
     override suspend fun getAccount(): Account? = authRepository.getAccount()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1210510700371845?focus=true

### Description
Added an additional check in isFreeTrialEligible to handle the edge case where the feature flag is enabled, the user hasn’t had a free trial before, but the product is not available on the Play Store.

### Steps to test this PR

_ROW & deactivated Free Trial offers_
- [x] Apply Privacy Pro patch
- [x] Make sure you have a ROW account in your device (I deactivated free trial products just for ROW)
- [x] Fresh install or make sure you don't have any expired subscriptions
- [x] Go to app Settings
- [x] Check you see Get Privacy Pro instead `Try Privacy Pro Free`
- [x] Tap on 'Get Privacy Pro'
- [x] Make sure free trial products are not offered

_US & Free Trial offered_
- [x] Make sure you have a US account in your device
- [x] Fresh install or make sure you don't have any expired subscriptions
- [x] Go to app Settings
- [x] Check you see `Try Privacy Pro Free`
- [x] Tap on 'Try Privacy Pro Free'
- [x] Make sure free trial products are offered

### No UI changes
