### PR TITLE
Prevent multiple feedback dialogs from queueing when app is backgrounded

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/rating/di/RatingModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/rating/di/RatingModule.kt
@@ -46,8 +46,9 @@ class RatingModule {
         appEnjoymentPromptEmitter: AppEnjoymentPromptEmitter,
         promptTypeDecider: PromptTypeDecider,
         @AppCoroutineScope appCoroutineScope: CoroutineScope,
+        preventDialogQueuingFeature: PreventFeedbackDialogQueuingFeature,
     ): MainProcessLifecycleObserver {
-        return AppEnjoymentAppCreationObserver(appEnjoymentPromptEmitter, promptTypeDecider, appCoroutineScope)
+        return AppEnjoymentAppCreationObserver(appEnjoymentPromptEmitter, promptTypeDecider, appCoroutineScope, preventDialogQueuingFeature)
     }
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/global/rating/AppEnjoymentAppCreationObserver.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/rating/AppEnjoymentAppCreationObserver.kt
@@ -18,23 +18,61 @@ package com.duckduckgo.app.global.rating
 
 import androidx.annotation.UiThread
 import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.common.utils.DefaultDispatcherProvider
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import logcat.logcat
 
 class AppEnjoymentAppCreationObserver(
     private val appEnjoymentPromptEmitter: AppEnjoymentPromptEmitter,
     private val promptTypeDecider: PromptTypeDecider,
     private val appCoroutineScope: CoroutineScope,
+    private val preventDialogQueuingFeature: PreventFeedbackDialogQueuingFeature,
     private val dispatchers: DispatcherProvider = DefaultDispatcherProvider(),
 ) : MainProcessLifecycleObserver {
 
     @UiThread
     override fun onStart(owner: LifecycleOwner) {
         appCoroutineScope.launch(dispatchers.main()) {
-            appEnjoymentPromptEmitter.promptType.value = promptTypeDecider.determineInitialPromptType()
+            val shouldPreventQueueing = withContext(dispatchers.io()) {
+                preventDialogQueuingFeature.self().isEnabled()
+            }
+
+            if (shouldPreventQueueing) {
+                // Only determine prompt type if no prompt is currently being shown
+                // This prevents queueing up multiple dialogs when the app is backgrounded and foregrounded
+                val currentPromptType = appEnjoymentPromptEmitter.promptType.value
+                if (currentPromptType == null || currentPromptType == AppEnjoymentPromptOptions.ShowNothing) {
+                    appEnjoymentPromptEmitter.promptType.value = promptTypeDecider.determineInitialPromptType()
+                } else {
+                    logcat { "app enjoyment prompt type already showing, won't show another on top" }
+                }
+            } else {
+                // Original behavior: always determine prompt type on app start
+                appEnjoymentPromptEmitter.promptType.value = promptTypeDecider.determineInitialPromptType()
+            }
         }
     }
+}
+
+/**
+ * Feature flag to prevent feedback dialogs from queueing up when the app is backgrounded and foregrounded
+ * This is for fixing the bug where dialogs would accumulate if users repeatedly background the app
+ *
+ * In case of unexpected side-effects, the old behaviour can be reverted by disabling this remote feature flag
+ */
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "androidPreventFeedbackDialogQueueing",
+)
+interface PreventFeedbackDialogQueuingFeature {
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun self(): Toggle
 }

--- a/app/src/test/java/com/duckduckgo/app/global/rating/AppEnjoymentAppCreationObserverTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/global/rating/AppEnjoymentAppCreationObserverTest.kt
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global.rating
+
+import android.annotation.SuppressLint
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.MutableLiveData
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@SuppressLint("DenyListedApi")
+class AppEnjoymentAppCreationObserverTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    private val feature = FakeFeatureToggleFactory.create(PreventFeedbackDialogQueuingFeature::class.java)
+
+    private lateinit var testee: AppEnjoymentAppCreationObserver
+    private val mockAppEnjoymentPromptEmitter: AppEnjoymentPromptEmitter = mock()
+    private val mockPromptTypeDecider: PromptTypeDecider = mock()
+
+    private val testScope = TestScope()
+    private val promptTypeLiveData = MutableLiveData<AppEnjoymentPromptOptions>()
+
+    @Before
+    fun setup() = runTest {
+        whenever(mockAppEnjoymentPromptEmitter.promptType).thenReturn(promptTypeLiveData)
+        whenever(mockPromptTypeDecider.determineInitialPromptType()).thenReturn(AppEnjoymentPromptOptions.ShowEnjoymentPrompt(PromptCount.first()))
+
+        testee = AppEnjoymentAppCreationObserver(
+            appEnjoymentPromptEmitter = mockAppEnjoymentPromptEmitter,
+            promptTypeDecider = mockPromptTypeDecider,
+            appCoroutineScope = testScope,
+            preventDialogQueuingFeature = feature,
+            dispatchers = coroutineTestRule.testDispatcherProvider,
+        )
+    }
+
+    @Test
+    fun whenFeatureEnabledAndCurrentPromptTypeIsNullThenShouldDetermineInitialPromptType() = runTest {
+        feature.self().setRawStoredState(Toggle.State(enable = true))
+        promptTypeLiveData.value = null
+
+        testee.onStart(mock())
+
+        verify(mockPromptTypeDecider).determineInitialPromptType()
+    }
+
+    @Test
+    fun whenFeatureEnabledAndCurrentPromptTypeIsShowNothingThenShouldDetermineInitialPromptType() = runTest {
+        feature.self().setRawStoredState(Toggle.State(enable = true))
+        promptTypeLiveData.value = AppEnjoymentPromptOptions.ShowNothing
+
+        testee.onStart(mock())
+
+        verify(mockPromptTypeDecider).determineInitialPromptType()
+    }
+
+    @Test
+    fun whenFeatureEnabledAndCurrentPromptTypeIsShowEnjoymentPromptThenShouldNotDetermineInitialPromptType() = runTest {
+        feature.self().setRawStoredState(Toggle.State(enable = true))
+        promptTypeLiveData.value = AppEnjoymentPromptOptions.ShowEnjoymentPrompt(PromptCount.first())
+
+        testee.onStart(mock())
+
+        verify(mockPromptTypeDecider, never()).determineInitialPromptType()
+    }
+
+    @Test
+    fun whenFeatureEnabledAndCurrentPromptTypeIsShowRatingPromptThenShouldNotDetermineInitialPromptType() = runTest {
+        feature.self().setRawStoredState(Toggle.State(enable = true))
+        promptTypeLiveData.value = AppEnjoymentPromptOptions.ShowRatingPrompt(PromptCount.first())
+
+        testee.onStart(mock())
+
+        verify(mockPromptTypeDecider, never()).determineInitialPromptType()
+    }
+
+    @Test
+    fun whenFeatureEnabledAndCurrentPromptTypeIsShowFeedbackPromptThenShouldNotDetermineInitialPromptType() = runTest {
+        feature.self().setRawStoredState(Toggle.State(enable = true))
+        promptTypeLiveData.value = AppEnjoymentPromptOptions.ShowFeedbackPrompt(PromptCount.first())
+
+        testee.onStart(mock())
+
+        verify(mockPromptTypeDecider, never()).determineInitialPromptType()
+    }
+
+    @Test
+    fun whenFeatureDisabledAndCurrentPromptTypeIsNullThenShouldDetermineInitialPromptType() = runTest {
+        feature.self().setRawStoredState(Toggle.State(enable = false))
+        promptTypeLiveData.value = null
+
+        testee.onStart(mock())
+
+        verify(mockPromptTypeDecider).determineInitialPromptType()
+    }
+
+    @Test
+    fun whenFeatureDisabledAndCurrentPromptTypeIsShowNothingThenShouldDetermineInitialPromptType() = runTest {
+        feature.self().setRawStoredState(Toggle.State(enable = false))
+        promptTypeLiveData.value = AppEnjoymentPromptOptions.ShowNothing
+
+        testee.onStart(mock())
+
+        verify(mockPromptTypeDecider).determineInitialPromptType()
+    }
+
+    @Test
+    fun whenFeatureDisabledAndCurrentPromptTypeIsShowEnjoymentPromptThenShouldDetermineInitialPromptType() = runTest {
+        feature.self().setRawStoredState(Toggle.State(enable = false))
+        promptTypeLiveData.value = AppEnjoymentPromptOptions.ShowEnjoymentPrompt(PromptCount.first())
+
+        testee.onStart(mock())
+
+        verify(mockPromptTypeDecider).determineInitialPromptType()
+    }
+
+    @Test
+    fun whenFeatureDisabledAndCurrentPromptTypeIsShowRatingPromptThenShouldDetermineInitialPromptType() = runTest {
+        feature.self().setRawStoredState(Toggle.State(enable = false))
+        promptTypeLiveData.value = AppEnjoymentPromptOptions.ShowRatingPrompt(PromptCount.first())
+
+        testee.onStart(mock())
+
+        verify(mockPromptTypeDecider).determineInitialPromptType()
+    }
+
+    @Test
+    fun whenFeatureDisabledAndCurrentPromptTypeIsShowFeedbackPromptThenShouldDetermineInitialPromptType() = runTest {
+        feature.self().setRawStoredState(Toggle.State(enable = false))
+        promptTypeLiveData.value = AppEnjoymentPromptOptions.ShowFeedbackPrompt(PromptCount.first())
+
+        testee.onStart(mock())
+
+        verify(mockPromptTypeDecider).determineInitialPromptType()
+    }
+
+    @Test
+    fun whenOnStartCalledMultipleTimesThenShouldCheckFeatureToggleEachTime() = runTest {
+        feature.self().setRawStoredState(Toggle.State(enable = false))
+        promptTypeLiveData.value = AppEnjoymentPromptOptions.ShowEnjoymentPrompt(PromptCount.first())
+
+        testee.onStart(mock())
+        testee.onStart(mock())
+
+        verify(mockPromptTypeDecider, times(2)).determineInitialPromptType()
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1210133852306616?focus=true 

### Description
Fix to prevent multiple "give us feedback" dialogs from being queued up. The queuing up can happen in prod right now if:
- one of the feedback dialogs is currently showing
- you switch to another app (without dismissing the dialog)
- you return to our app
- we still show the dialog from before, but determine we should show another

This fix prevents that by only determining the prompt type if no prompt is currently being shown. Guarded by a feature flag `androidPreventFeedbackDialogQueueing` in case of issues.

### Steps to test this PR

Logcat filter: `currentPromptType|app enjoyment|InitialPromptDecider|first prompt`

### Ensuring business rules are unchanged

- [x] Fresh install; get through onboarding
- [x] Switch to another app (don't just background to the home screen, actually switch to another app)
- [x] Return to our app; verify no feedback dialogs shown
- [x] Perform 5 searches
- [x] Switch to another app and return to our app; verify no feedback dialog shown yet
- [x] Set the system date forward 1 day in the future and return to our app; verify feedback dialog not shown yet
- [x] Set the system date forward another day and return to our app; verify feedback dialog **is** shown yet
- [x] Don't interact with the dialog yet

### Testing dialogs won't queue
- [x] When feedback dialog is showing, switch to another app and return to our app; verify dialog is still showing
- [x] Choose that you like the app
- [x] On the 2nd dialog, choose `No Thanks`
- [x] Verify you do not see another pair of feedback dialogs

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/864955901782631