### PR TITLE
Update subscription flow welcome page

### DIFF
--- a/subscriptions/subscriptions-impl/build.gradle
+++ b/subscriptions/subscriptions-impl/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     implementation project(':survey-api')
     implementation project(':vpn-api')
     implementation project(':content-scope-scripts-api')
+    implementation project(':duckchat-api')
 
     implementation AndroidX.appCompat
     implementation KotlinX.coroutines.core

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -168,6 +168,11 @@ interface PrivacyProFeature {
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun privacyProFreeTrial(): Toggle
 
+    /**
+     * Enables/Disables duckAi for subscribers (advanced models)
+     * This flag is used to hide the feature in the native client and FE.
+     * It will be used for the feature rollout and kill-switch if necessary.
+     */
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun duckAiPlus(): Toggle
 

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsConstants.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsConstants.kt
@@ -45,6 +45,7 @@ object SubscriptionsConstants {
     const val ITR = "Identity Theft Restoration"
     const val ROW_ITR = "Global Identity Theft Restoration"
     const val PIR = "Data Broker Protection"
+    const val DUCK_AI = "Duck.ai"
 
     // Platform
     const val PLATFORM = "android"

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionMessagingInterface.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionMessagingInterface.kt
@@ -368,8 +368,10 @@ class SubscriptionMessagingInterface @Inject constructor(
             if (privacyProFeature.enableNewSubscriptionMessages().isEnabled().not()) return
 
             val authV2Enabled = privacyProFeature.enableSubscriptionFlowsV2().isEnabled()
+            val duckAiSubscriberModelsEnabled = privacyProFeature.duckAiPlus().isEnabled()
             val resultJson = JSONObject().apply {
                 put("useSubscriptionsAuthV2", authV2Enabled)
+                put("usePaidDuckAi", duckAiSubscriberModelsEnabled)
             }
 
             val response = JsRequestResponse.Success(

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixel.kt
@@ -141,6 +141,11 @@ enum class SubscriptionPixel(
         type = Unique(),
         includedParameters = setOf(ATB, APP_VERSION),
     ),
+    ONBOARDING_DUCK_AI_CLICK(
+        baseName = "m_privacy-pro_welcome_paid-ai-chat_click",
+        type = Unique(),
+        includedParameters = setOf(ATB, APP_VERSION),
+    ),
     SUBSCRIPTION_SETTINGS_SHOWN(
         baseName = "m_privacy-pro_settings_screen_impression",
         type = Count,

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelSender.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelSender.kt
@@ -39,6 +39,7 @@ import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.OFFER_RESTORE_
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.OFFER_SCREEN_SHOWN
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.OFFER_SUBSCRIBE_CLICK
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.ONBOARDING_ADD_DEVICE_CLICK
+import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.ONBOARDING_DUCK_AI_CLICK
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.ONBOARDING_IDTR_CLICK
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.ONBOARDING_PIR_CLICK
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.ONBOARDING_VPN_CLICK
@@ -89,6 +90,7 @@ interface SubscriptionPixelSender {
     fun reportOnboardingVpnClick()
     fun reportOnboardingPirClick()
     fun reportOnboardingIdtrClick()
+    fun reportOnboardingDuckAiClick()
     fun reportSubscriptionSettingsShown()
     fun reportAppSettingsPirClick()
     fun reportAppSettingsIdtrClick()
@@ -196,6 +198,9 @@ class SubscriptionPixelSenderImpl @Inject constructor(
 
     override fun reportOnboardingIdtrClick() =
         fire(ONBOARDING_IDTR_CLICK)
+
+    override fun reportOnboardingDuckAiClick() =
+        fire(ONBOARDING_DUCK_AI_CLICK)
 
     override fun reportSubscriptionSettingsShown() =
         fire(SUBSCRIPTION_SETTINGS_SHOWN)

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.subscriptions.impl.JSONObjectAdapter
 import com.duckduckgo.subscriptions.impl.PrivacyProFeature
 import com.duckduckgo.subscriptions.impl.SubscriptionOffer
 import com.duckduckgo.subscriptions.impl.SubscriptionsChecker
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.DUCK_AI
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.ITR
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.LEGACY_FE_ITR
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.LEGACY_FE_NETP
@@ -193,6 +194,7 @@ class SubscriptionWebViewViewModel @Inject constructor(
                 NETP, LEGACY_FE_NETP -> networkProtectionAccessState.getScreenForCurrentState()?.let { GoToNetP(it) }
                 ITR, LEGACY_FE_ITR, ROW_ITR -> GoToITR
                 PIR, LEGACY_FE_PIR -> GoToPIR
+                DUCK_AI -> GoToDuckAI
                 else -> null
             }
             if (hasPurchasedSubscription()) {
@@ -200,6 +202,7 @@ class SubscriptionWebViewViewModel @Inject constructor(
                     GoToITR -> pixelSender.reportOnboardingIdtrClick()
                     is GoToNetP -> pixelSender.reportOnboardingVpnClick()
                     GoToPIR -> pixelSender.reportOnboardingPirClick()
+                    GoToDuckAI -> pixelSender.reportOnboardingDuckAiClick()
                     else -> {} // no-op
                 }
             }
@@ -428,6 +431,7 @@ class SubscriptionWebViewViewModel @Inject constructor(
         data object GoToITR : Command()
         data object GoToPIR : Command()
         data class GoToNetP(val activityParams: ActivityParams) : Command()
+        data object GoToDuckAI : Command()
         data object Reload : Command()
     }
 

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
@@ -58,6 +58,7 @@ import com.duckduckgo.downloads.api.DownloadStateListener
 import com.duckduckgo.downloads.api.DownloadsFileActions
 import com.duckduckgo.downloads.api.FileDownloader
 import com.duckduckgo.downloads.api.FileDownloader.PendingFileDownload
+import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.js.messaging.api.JsCallbackData
 import com.duckduckgo.js.messaging.api.JsMessageCallback
 import com.duckduckgo.js.messaging.api.JsMessaging
@@ -78,6 +79,7 @@ import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixelSender
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.BackToSettings
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.BackToSettingsActivateSuccess
+import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.GoToDuckAI
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.GoToITR
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.GoToNetP
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.GoToPIR
@@ -160,6 +162,9 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
 
     @Inject
     lateinit var pixelSender: SubscriptionPixelSender
+
+    @Inject
+    lateinit var duckChat: DuckChat
 
     private val viewModel: SubscriptionWebViewViewModel by bindViewModel()
 
@@ -422,6 +427,7 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
             is GoToITR -> goToITR()
             is GoToPIR -> goToPIR()
             is GoToNetP -> goToNetP(command.activityParams)
+            is GoToDuckAI -> goToDuckAI()
             Reload -> binding.webview.reload()
         }
     }
@@ -445,6 +451,10 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
 
     private fun goToNetP(params: ActivityParams) {
         globalActivityStarter.start(this, params)
+    }
+
+    private fun goToDuckAI() {
+        duckChat.openDuckChat()
     }
 
     private fun renderPurchaseState(purchaseState: PurchaseStateView) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1210461583262419?focus=true 

### Description
Updates JS messaging in subscription flows welcome pages.

Touched methods:
- ~Adds getAuthAccessToken~
- Adds getFeatureConfig
- Adds Duck.ai support in featureSelected

Feature flagging:
- ~privacyProFeature.subscriptionMessaging() -> enables getFeatureConfig~
- privacyProFeature.duckAiPlus() -> signales FE Duck.ai is enabled
- Token is not affected by FF

### Steps to test this PR

_Feature 1_
- [x] apply patch attached in the Asana task (that will target staging and specific FE sandbox)
- [x] install the branch
- [x] Ensure you don't have a subscription
- [x] Start purchase a subscription
- [x] In the landing page, scroll to the bottom.
- [x] Ensure Duck.ai appears in the comparison chart.
- [x] Purchase a subscription
- [x] After purchase, welcome page should list Duck.ai as a card
- [x] Click on the Card
- [x] Ensure pixel `m_privacy-pro_welcome_paid-ai-chat_click` emits
- [x] Ensure you navigate to Duck chat (this branch doesn't have the code to signal the token so you won't see the subscriber mode)

_Feature 2_
- [x] Go to feature flags and disable privacypro - duckAiPlus
- [x] Cancel and delete your subscription
- [x] Repeat the process again
- [x] Ensure in Landing page comparison chart, Duck.ai doesn't show.
- [x] Ensure when subscription is purchased, there's no Duck.ai card

_Feature 3_
- [x] Remove all files changed in previous patch
- [x] Apply standard patch from https://app.asana.com/1/137249556945/project/1209991789468715/task/1210448620621729?focus=true (no FE sandbox)
- [x] install the branch
- [x] Ensure you don't have a subscription
- [x] Purchase a subscription
- [x] ensure purchase succeeds
- [x] ensure no duck.ai is present


### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
