### PR TITLE
add missing discovery param to autofill_settings_opened pixel

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/settings/AutofillSettingsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/settings/AutofillSettingsViewModel.kt
@@ -43,12 +43,14 @@ import com.duckduckgo.autofill.impl.ui.settings.AutofillSettingsViewModel.Comman
 import com.duckduckgo.autofill.impl.ui.settings.AutofillSettingsViewModel.Command.NavigatePasswordList
 import com.duckduckgo.autofill.impl.ui.settings.AutofillSettingsViewModel.Command.NavigateToHowToSyncWithDesktop
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.extensions.toBinaryString
 import com.duckduckgo.di.scopes.ActivityScope
 import javax.inject.Inject
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -106,10 +108,16 @@ class AutofillSettingsViewModel @Inject constructor(
     }
 
     fun sendLaunchPixel(autofillScreenLaunchSource: AutofillScreenLaunchSource) {
-        pixel.fire(
-            AUTOFILL_SETTINGS_OPENED,
-            parameters = mapOf("source" to autofillScreenLaunchSource.asString()),
-        )
+        viewModelScope.launch {
+            val hasCredentialsSaved = (autofillStore.getCredentialCount().firstOrNull() ?: 0) > 0
+            pixel.fire(
+                AUTOFILL_SETTINGS_OPENED,
+                parameters = mapOf(
+                    "source" to autofillScreenLaunchSource.asString(),
+                    "has_credentials_saved" to hasCredentialsSaved.toBinaryString(),
+                ),
+            )
+        }
     }
 
     private fun onViewStateFlowStart() {

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/settings/AutofillSettingsViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/settings/AutofillSettingsViewModelTest.kt
@@ -122,9 +122,18 @@ class AutofillSettingsViewModelTest {
     }
 
     @Test
-    fun whenSendLaunchPixelThenPixelIsSent() = runTest {
+    fun `when send launch pixel and no credentials saved then pixel is sent`() = runTest {
+        whenever(mockStore.getCredentialCount()).thenReturn(flowOf(0))
         testee.sendLaunchPixel(AutofillScreenLaunchSource.SettingsActivity)
-        val expectedParams = mapOf("source" to "settings")
+        val expectedParams = mapOf("source" to "settings", "has_credentials_saved" to "0")
+        verify(pixel).fire(pixel = eq(AUTOFILL_SETTINGS_OPENED), parameters = eq(expectedParams), any(), any())
+    }
+
+    @Test
+    fun `when send launch pixel and has credentials saved then pixel is sent`() = runTest {
+        whenever(mockStore.getCredentialCount()).thenReturn(flowOf(5))
+        testee.sendLaunchPixel(AutofillScreenLaunchSource.BrowserOverflow)
+        val expectedParams = mapOf("source" to "overflow_menu", "has_credentials_saved" to "1")
         verify(pixel).fire(pixel = eq(AUTOFILL_SETTINGS_OPENED), parameters = eq(expectedParams), any(), any())
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1210398081973867?focus=true

### Description
Adds missing pixel parameter.

### Steps to test this PR

- [ ] Launch a clean app.
- [ ] Open "Passwords & Autofill" from settings.
- [ ] Verify that `autofill_settings_opened` pixel is sent with `source=settings` and `has_credentials_saved=0` parameters.
- [ ] Add a password.
- [ ] Close and reopen "Passwords & Autofill" from settings.
- [ ] Verify that `autofill_settings_opened` pixel is sent with `source=settings` and `has_credentials_saved=1` parameters.