### PR TITLE
Send active cohorts to broken report site

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -1192,7 +1192,12 @@ class BrowserWebViewClientTest {
         var countFinished = 0
         var countStarted = 0
 
-        override fun onPageStarted(webView: WebView, url: String?, site: Site?) {
+        override fun onPageStarted(
+            webView: WebView,
+            url: String?,
+            isDesktopMode: Boolean?,
+            activeExperiments: List<Toggle>,
+        ) {
             countStarted++
         }
 

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -73,6 +73,7 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.common.utils.device.DeviceInfo
 import com.duckduckgo.common.utils.plugins.PluginPoint
+import com.duckduckgo.contentscopescripts.api.contentscopeExperiments.ContentScopeExperiments
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckplayer.api.DuckPlayer
@@ -81,6 +82,7 @@ import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab
 import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.Off
 import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.On
 import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.Unavailable
+import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.history.api.NavigationHistory
 import com.duckduckgo.privacy.config.api.AmpLinks
 import com.duckduckgo.subscriptions.api.Subscriptions
@@ -164,6 +166,7 @@ class BrowserWebViewClientTest {
         mock(),
     )
     private val mockDuckChat: DuckChat = mock()
+    private val mockContentScopeExperiments: ContentScopeExperiments = mock()
 
     @UiThreadTest
     @Before
@@ -202,6 +205,7 @@ class BrowserWebViewClientTest {
             mockUriLoadedManager,
             mockAndroidFeaturesHeaderPlugin,
             mockDuckChat,
+            mockContentScopeExperiments,
         )
         testee.webViewClientListener = listener
         whenever(webResourceRequest.url).thenReturn(Uri.EMPTY)
@@ -221,8 +225,11 @@ class BrowserWebViewClientTest {
     @UiThreadTest
     @Test
     fun whenOnPageStartedCalledThenListenerNotified() {
+        val toggle: Toggle = mock()
+        whenever(mockContentScopeExperiments.getActiveExperiments()).thenReturn(listOf(toggle))
+
         testee.onPageStarted(webView, EXAMPLE_URL, null)
-        verify(listener).pageStarted(any())
+        verify(listener).pageStarted(any(), eq(listOf(toggle)))
     }
 
     @UiThreadTest

--- a/app/src/main/java/com/duckduckgo/app/brokensite/api/BrokenSiteSender.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/api/BrokenSiteSender.kt
@@ -149,6 +149,18 @@ class BrokenSiteSubmitter @Inject constructor(
                 }
             }
 
+            brokenSite.contentScopeExperiments
+                ?.mapNotNull { experiment ->
+                    experiment.getCohort()?.let { cohort ->
+                        "${experiment.featureName().name}:${cohort.name}"
+                    }
+                }?.sorted()
+                ?.let { activeExperiments ->
+                    if (activeExperiments.isNotEmpty()) {
+                        params[CONTENT_SCOPE_EXPERIMENTS] = activeExperiments.joinToString(",")
+                    }
+                }
+
             val lastSentDay = brokenSiteLastSentReport.getLastSentDay(domain.orEmpty())
             if (lastSentDay != null) {
                 params[LAST_SENT_DAY] = lastSentDay
@@ -228,6 +240,7 @@ class BrokenSiteSubmitter @Inject constructor(
         private const val OPENER_CONTEXT = "openerContext"
         private const val JS_PERFORMANCE = "jsPerformance"
         private const val BLOCKLIST_EXPERIMENT = "blockListExperiment"
+        private const val CONTENT_SCOPE_EXPERIMENTS = "contentScopeExperiments"
     }
 }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -380,7 +380,6 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import logcat.LogPriority.ERROR
 import logcat.LogPriority.INFO
@@ -2462,11 +2461,6 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     fun onBrokenSiteSelected() {
-        logcat("Cris") {
-            runBlocking {
-                "Report broken site: ${site?.activeContentScopeExperiments?.map { "${it.featureName().name}, ${it.getCohort()}" }}"
-            }
-        }
         command.value = BrokenSiteFeedback(BrokenSiteData.fromSite(site, reportFlow = MENU))
     }
 
@@ -3637,7 +3631,6 @@ class BrowserTabViewModel @Inject constructor(
         isActiveCustomTab: Boolean = false,
         getWebViewUrl: () -> String?,
     ) {
-        logcat("Cris") { "received CSS callback: $method" }
         when (method) {
             "webShare" -> if (id != null && data != null) {
                 webShare(featureName, method, id, data)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2465,7 +2465,7 @@ class BrowserTabViewModel @Inject constructor(
         logcat("Cris") {
             runBlocking {
                 "Report broken site: ${site?.activeContentScopeExperiments?.map { "${it.featureName().name}, ${it.getCohort()}" }}"
-            } 
+            }
         }
         command.value = BrokenSiteFeedback(BrokenSiteData.fromSite(site, reportFlow = MENU))
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -513,6 +513,8 @@ class BrowserTabViewModel @Inject constructor(
     private var ctaChangedTicker = MutableStateFlow("")
     val hiddenIds = MutableStateFlow(HiddenBookmarksIds())
 
+    private var activeExperiments: List<Toggle>? = null
+
     data class HiddenBookmarksIds(
         val favorites: List<String> = emptyList(),
         val bookmarks: List<String> = emptyList(),
@@ -800,6 +802,7 @@ class BrowserTabViewModel @Inject constructor(
         if (updateMaliciousSiteStatus) {
             site?.maliciousSiteStatus = maliciousSiteStatus
         }
+        site?.activeContentScopeExperiments = activeExperiments
         onSiteChanged()
         buildingSiteFactoryJob = viewModelScope.launch {
             site?.let {
@@ -1898,7 +1901,8 @@ class BrowserTabViewModel @Inject constructor(
         webViewNavigationState: WebViewNavigationState,
         activeExperiments: List<Toggle>,
     ) {
-        site?.activeContentScopeExperiments = activeExperiments
+        this.activeExperiments = activeExperiments
+
         browserViewState.value =
             currentBrowserViewState().copy(
                 browserShowing = true,

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -70,6 +70,7 @@ import com.duckduckgo.common.utils.AppUrl.ParamKey.QUERY
 import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.plugins.PluginPoint
+import com.duckduckgo.contentscopescripts.api.contentscopeExperiments.ContentScopeExperiments
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckplayer.api.DuckPlayer
@@ -124,6 +125,7 @@ class BrowserWebViewClient @Inject constructor(
     private val uriLoadedManager: UriLoadedManager,
     private val androidFeaturesHeaderPlugin: AndroidFeaturesHeaderPlugin,
     private val duckChat: DuckChat,
+    private val contentScopeExperiments: ContentScopeExperiments,
 ) : WebViewClient() {
 
     var webViewClientListener: WebViewClientListener? = null
@@ -437,7 +439,8 @@ class BrowserWebViewClient @Inject constructor(
             }
         }
         val navigationList = webView.safeCopyBackForwardList() ?: return
-        webViewClientListener?.pageStarted(WebViewNavigationState(navigationList))
+        val activeExperiments = contentScopeExperiments.getActiveExperiments()
+        webViewClientListener?.pageStarted(WebViewNavigationState(navigationList), activeExperiments)
         if (url != null && url == lastPageStarted) {
             webViewClientListener?.pageRefreshed(url)
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -447,7 +447,7 @@ class BrowserWebViewClient @Inject constructor(
         lastPageStarted = url
         browserAutofillConfigurator.configureAutofillForCurrentPage(webView, url)
         jsPlugins.getPlugins().forEach {
-            it.onPageStarted(webView, url, webViewClientListener?.getSite())
+            it.onPageStarted(webView, url, webViewClientListener?.getSite()?.isDesktopMode, activeExperiments)
         }
         loginDetector.onEvent(WebNavigationEvent.OnPageStarted(webView))
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.app.browser.model.BasicAuthenticationRequest
 import com.duckduckgo.app.global.model.Site
 import com.duckduckgo.app.surrogates.SurrogateResponse
 import com.duckduckgo.app.trackerdetection.model.TrackingEvent
+import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed
 import com.duckduckgo.site.permissions.api.SitePermissionsManager.SitePermissions
 
@@ -132,5 +133,8 @@ interface WebViewClientListener {
         url: String,
     )
 
-    fun pageStarted(webViewNavigationState: WebViewNavigationState)
+    fun pageStarted(
+        webViewNavigationState: WebViewNavigationState,
+        activeExperiments: List<Toggle>,
+    )
 }

--- a/app/src/main/java/com/duckduckgo/app/global/model/SiteMonitor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/model/SiteMonitor.kt
@@ -36,6 +36,7 @@ import com.duckduckgo.browser.api.brokensite.BrokenSiteContext
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.isHttps
 import com.duckduckgo.duckplayer.api.DuckPlayer
+import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.privacy.config.api.ContentBlocking
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlinx.coroutines.CoroutineScope
@@ -219,6 +220,8 @@ class SiteMonitor(
     override var maliciousSiteStatus: MaliciousSiteStatus? = null
 
     override var previousNumberOfBlockedTrackers: Int? = null
+
+    override var activeContentScopeExperiments: List<Toggle>? = null
 
     companion object {
         private val specialDomainTypes = setOf(

--- a/app/src/test/java/com/duckduckgo/app/brokensite/api/BrokenSiteSubmitterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/brokensite/api/BrokenSiteSubmitterTest.kt
@@ -29,7 +29,10 @@ import com.duckduckgo.feature.toggles.api.FakeToggleStore
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.feature.toggles.api.FeatureToggles
 import com.duckduckgo.feature.toggles.api.FeatureTogglesInventory
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.FeatureName
 import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.feature.toggles.api.Toggle.State.Cohort
 import com.duckduckgo.feature.toggles.impl.RealFeatureTogglesInventory
 import com.duckduckgo.networkprotection.api.NetworkProtectionState
 import com.duckduckgo.privacy.config.api.AmpLinkInfo
@@ -621,6 +624,28 @@ class BrokenSiteSubmitterTest {
         assertFalse(params.containsKey("protectionsState"))
     }
 
+    @Test
+    fun whenSubmitReportAndActiveContentScopeExperimentsThenIncludeParam() = runTest {
+        val brokenSite = getBrokenSite()
+        val contentScopeExperiments = listOf(
+            mock<Toggle>().apply {
+                whenever(featureName()).thenReturn(FeatureName("test", "experiment1"))
+                whenever(getCohort()).thenReturn(Cohort("control", 1, "2023-01-01T00:00:00Z"))
+            },
+            mock<Toggle>().apply {
+                whenever(featureName()).thenReturn(FeatureName("test", "experiment2"))
+                whenever(getCohort()).thenReturn(Cohort("treatment", 1, "2023-01-01T00:00:00Z"))
+            },
+        )
+
+        testee.submitBrokenSiteFeedback(brokenSite.copy(contentScopeExperiments = contentScopeExperiments), toggle = false)
+
+        val paramsCaptor = argumentCaptor<Map<String, String>>()
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), parameters = paramsCaptor.capture(), any(), eq(Count))
+        val params = paramsCaptor.lastValue
+        assertEquals("experiment1:control,experiment2:treatment", params["contentScopeExperiments"])
+    }
+
     private fun assignToExperiment() {
         val enrollmentDateET = ZonedDateTime.now(ZoneId.of("America/New_York")).toString()
         testBlockListFeature.tdsNextExperimentTest().setRawStoredState(
@@ -654,6 +679,7 @@ class BrokenSiteSubmitterTest {
             userRefreshCount = 0,
             openerContext = null,
             jsPerformance = null,
+            contentScopeExperiments = null,
         )
     }
 

--- a/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesMultipleReportReferenceTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesMultipleReportReferenceTest.kt
@@ -215,6 +215,7 @@ class BrokenSitesMultipleReportReferenceTest(private val testCase: MultipleRepor
                 userRefreshCount = 0,
                 openerContext = null,
                 jsPerformance = null,
+                contentScopeExperiments = null,
             )
 
             testee.submitBrokenSiteFeedback(brokenSite, toggle = false)

--- a/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesReferenceTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesReferenceTest.kt
@@ -202,6 +202,7 @@ class BrokenSitesReferenceTest(private val testCase: TestCase) {
             userRefreshCount = 3,
             openerContext = SERP.context,
             jsPerformance = listOf(123.45),
+            contentScopeExperiments = null,
         )
 
         testee.submitBrokenSiteFeedback(brokenSite, toggle = false)

--- a/broken-site/broken-site-api/build.gradle
+++ b/broken-site/broken-site-api/build.gradle
@@ -23,6 +23,7 @@ apply from: "$rootProject.projectDir/gradle/android-library.gradle"
 
 dependencies {
     implementation AndroidX.appCompat
+    implementation project(':feature-toggles-api')
 }
 android {
     namespace 'com.duckduckgo.brokensite.api'

--- a/broken-site/broken-site-api/src/main/java/com/duckduckgo/brokensite/api/BrokenSiteSender.kt
+++ b/broken-site/broken-site-api/src/main/java/com/duckduckgo/brokensite/api/BrokenSiteSender.kt
@@ -16,6 +16,8 @@
 
 package com.duckduckgo.brokensite.api
 
+import com.duckduckgo.feature.toggles.api.Toggle
+
 interface BrokenSiteSender {
     fun submitBrokenSiteFeedback(brokenSite: BrokenSite, toggle: Boolean)
 }
@@ -39,6 +41,7 @@ data class BrokenSite(
     val userRefreshCount: Int,
     val openerContext: String?,
     val jsPerformance: List<Double>?,
+    val contentScopeExperiments: List<Toggle>?,
 ) {
     companion object {
         const val SITE_TYPE_DESKTOP = "desktop"

--- a/browser-api/build.gradle
+++ b/browser-api/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation project(path: ':navigation-api')
     implementation project(path: ':common-ui')
     implementation project(path: ':common-utils')
+    implementation project(':feature-toggles-api')
     implementation AndroidX.core.ktx
     implementation KotlinX.coroutines.core
 

--- a/browser-api/src/main/java/com/duckduckgo/app/global/model/Site.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/global/model/Site.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.app.trackerdetection.model.TrackingEvent
 import com.duckduckgo.browser.api.brokensite.BrokenSiteContext
 import com.duckduckgo.common.utils.baseHost
 import com.duckduckgo.common.utils.domain
+import com.duckduckgo.feature.toggles.api.Toggle
 
 interface Site {
 
@@ -84,6 +85,8 @@ interface Site {
     var maliciousSiteStatus: MaliciousSiteStatus?
 
     var previousNumberOfBlockedTrackers: Int?
+
+    var activeContentScopeExperiments: List<Toggle>?
 }
 
 enum class MaliciousSiteStatus {

--- a/browser-api/src/main/java/com/duckduckgo/browser/api/JsInjectorPlugin.kt
+++ b/browser-api/src/main/java/com/duckduckgo/browser/api/JsInjectorPlugin.kt
@@ -18,13 +18,19 @@ package com.duckduckgo.browser.api
 
 import android.webkit.WebView
 import com.duckduckgo.app.global.model.Site
+import com.duckduckgo.feature.toggles.api.Toggle
 
 /** Public interface to inject JS code to a website */
 interface JsInjectorPlugin {
     /**
      * This method is called during onPageStarted and receives a [webView] instance, the [url] of the website and the [site]
      */
-    fun onPageStarted(webView: WebView, url: String?, site: Site?)
+    fun onPageStarted(
+        webView: WebView,
+        url: String?,
+        isDesktopMode: Boolean?,
+        activeExperiments: List<Toggle> = listOf(),
+    )
 
     /**
      * This method is called during onPageFinished and receives a [webView] instance, the [url] of the website and the [site]

--- a/content-scope-scripts/content-scope-scripts-api/src/main/java/com/duckduckgo/contentscopescripts/api/contentscopeExperiments/ContentScopeExperiments.kt
+++ b/content-scope-scripts/content-scope-scripts-api/src/main/java/com/duckduckgo/contentscopescripts/api/contentscopeExperiments/ContentScopeExperiments.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 DuckDuckGo
+ * Copyright (c) 2025 DuckDuckGo
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,10 @@
  * limitations under the License.
  */
 
-plugins {
-    id 'com.android.library'
-    id 'kotlin-android'
-}
+package com.duckduckgo.contentscopescripts.api.contentscopeExperiments
 
-apply from: "$rootProject.projectDir/gradle/android-library.gradle"
+import com.duckduckgo.feature.toggles.api.Toggle
 
-dependencies {
-    implementation AndroidX.core.ktx
-    implementation project(':feature-toggles-api')
-    implementation project(':js-messaging-api')
-}
-
-android {
-    namespace 'com.duckduckgo.contentscopescripts.api'
+interface ContentScopeExperiments {
+    fun getActiveExperiments(): List<Toggle>
 }

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/ContentScopeScriptsJsInjectorPlugin.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/ContentScopeScriptsJsInjectorPlugin.kt
@@ -20,6 +20,7 @@ import android.webkit.WebView
 import com.duckduckgo.app.global.model.Site
 import com.duckduckgo.browser.api.JsInjectorPlugin
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
 import com.squareup.anvil.annotations.ContributesMultibinding
 import javax.inject.Inject
 
@@ -27,9 +28,14 @@ import javax.inject.Inject
 class ContentScopeScriptsJsInjectorPlugin @Inject constructor(
     private val coreContentScopeScripts: CoreContentScopeScripts,
 ) : JsInjectorPlugin {
-    override fun onPageStarted(webView: WebView, url: String?, site: Site?) {
+    override fun onPageStarted(
+        webView: WebView,
+        url: String?,
+        isDesktopMode: Boolean?,
+        activeExperiments: List<Toggle>,
+    ) {
         if (coreContentScopeScripts.isEnabled()) {
-            webView.evaluateJavascript("javascript:${coreContentScopeScripts.getScript(site)}", null)
+            webView.evaluateJavascript("javascript:${coreContentScopeScripts.getScript(isDesktopMode, activeExperiments)}", null)
         }
     }
 

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScripts.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScripts.kt
@@ -34,7 +34,6 @@ import java.util.*
 import java.util.concurrent.CopyOnWriteArrayList
 import javax.inject.Inject
 import kotlinx.coroutines.runBlocking
-import logcat.logcat
 
 interface CoreContentScopeScripts {
     fun getScript(site: Site?): String
@@ -208,7 +207,6 @@ class RealContentScopeScripts @Inject constructor(
                         subfeature = it.featureName().name,
                     )
                 }.let {
-                    logcat("Cris") { "Injecting cohorts: $it" }
                     return@runBlocking "\"currentCohorts\":${jsonAdapter.toJson(it)}"
                 }
         }

--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/ContentScopeScriptsJsInjectorPluginTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/ContentScopeScriptsJsInjectorPluginTest.kt
@@ -1,7 +1,6 @@
 package com.duckduckgo.contentscopescripts.impl
 
 import android.webkit.WebView
-import com.duckduckgo.app.global.model.Site
 import java.util.*
 import org.junit.Assert.*
 import org.junit.Before
@@ -28,28 +27,27 @@ class ContentScopeScriptsJsInjectorPluginTest {
     @Test
     fun whenEnabledAndInjectContentScopeScriptsThenPopulateMessagingParameters() {
         whenever(mockCoreContentScopeScripts.isEnabled()).thenReturn(true)
-        whenever(mockCoreContentScopeScripts.getScript(null)).thenReturn("")
-        contentScopeScriptsJsInjectorPlugin.onPageStarted(mockWebView, null, null)
+        whenever(mockCoreContentScopeScripts.getScript(null, listOf())).thenReturn("")
+        contentScopeScriptsJsInjectorPlugin.onPageStarted(mockWebView, null, null, listOf())
 
-        verify(mockCoreContentScopeScripts).getScript(null)
+        verify(mockCoreContentScopeScripts).getScript(null, listOf())
         verify(mockWebView).evaluateJavascript(any(), anyOrNull())
     }
 
     @Test
     fun whenDisabledAndInjectContentScopeScriptsThenDoNothing() {
         whenever(mockCoreContentScopeScripts.isEnabled()).thenReturn(false)
-        contentScopeScriptsJsInjectorPlugin.onPageStarted(mockWebView, null, null)
+        contentScopeScriptsJsInjectorPlugin.onPageStarted(mockWebView, null, null, listOf())
 
         verifyNoInteractions(mockWebView)
     }
 
     @Test
-    fun whenEnabledAndInjectContentScopeScriptsThenUseSite() {
-        val site: Site = mock()
+    fun whenEnabledAndInjectContentScopeScriptsThenUseParams() {
         whenever(mockCoreContentScopeScripts.isEnabled()).thenReturn(true)
-        whenever(mockCoreContentScopeScripts.getScript(site)).thenReturn("")
-        contentScopeScriptsJsInjectorPlugin.onPageStarted(mockWebView, null, site)
+        whenever(mockCoreContentScopeScripts.getScript(true, listOf())).thenReturn("")
+        contentScopeScriptsJsInjectorPlugin.onPageStarted(mockWebView, null, true, listOf())
 
-        verify(mockCoreContentScopeScripts).getScript(site)
+        verify(mockCoreContentScopeScripts).getScript(true, listOf())
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/DuckChatWebViewClientTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/DuckChatWebViewClientTest.kt
@@ -38,6 +38,6 @@ class DuckChatWebViewClientTest {
 
         duckChatWebViewClient.onPageStarted(webView, url, null)
 
-        verify(mockPlugin).onPageStarted(webView, url, null)
+        verify(mockPlugin).onPageStarted(webView, url, null, listOf())
     }
 }

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModel.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModel.kt
@@ -447,6 +447,7 @@ class PrivacyDashboardHybridViewModel @Inject constructor(
                 userRefreshCount = site.realBrokenSiteContext.userRefreshCount,
                 openerContext = site.realBrokenSiteContext.openerContext?.context,
                 jsPerformance = site.realBrokenSiteContext.jsPerformance?.toList(),
+                contentScopeExperiments = site.activeContentScopeExperiments,
             )
 
             brokenSiteSender.submitBrokenSiteFeedback(brokenSite, toggle = false)
@@ -542,6 +543,7 @@ class PrivacyDashboardHybridViewModel @Inject constructor(
                 userRefreshCount = site.realBrokenSiteContext.userRefreshCount,
                 openerContext = site.realBrokenSiteContext.openerContext?.context,
                 jsPerformance = site.realBrokenSiteContext.jsPerformance?.toList(),
+                contentScopeExperiments = site.activeContentScopeExperiments,
             )
 
             brokenSiteSender.submitBrokenSiteFeedback(brokenSite, toggle = true)

--- a/privacy-dashboard/privacy-dashboard-impl/src/test/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModelTest.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/test/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModelTest.kt
@@ -34,6 +34,7 @@ import com.duckduckgo.browser.api.UserBrowserProperties
 import com.duckduckgo.browser.api.brokensite.BrokenSiteContext
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.plugins.PluginPoint
+import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.privacy.config.api.ContentBlocking
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.duckduckgo.privacy.dashboard.api.PrivacyProtectionTogglePlugin
@@ -232,6 +233,7 @@ class PrivacyDashboardHybridViewModelTest {
             whenever(site.upgradedHttps).thenReturn(true)
             whenever(site.consentManaged).thenReturn(true)
             whenever(site.errorCodeEvents).thenReturn(listOf("401", "401", "500"))
+            whenever(site.activeContentScopeExperiments).thenReturn(null)
 
             val brokenSiteContext: BrokenSiteContext = mock { brokenSiteContext ->
                 whenever(brokenSiteContext.userRefreshCount).thenReturn(userRefreshCount)
@@ -269,6 +271,69 @@ class PrivacyDashboardHybridViewModelTest {
             userRefreshCount = userRefreshCount,
             openerContext = null,
             jsPerformance = jsPerformance.toList(),
+            contentScopeExperiments = null,
+        )
+
+        val isToggleReport = false
+
+        verify(brokenSiteSender).submitBrokenSiteFeedback(expectedBrokenSite, isToggleReport)
+        verify(pixel).fire(REPORT_BROKEN_SITE_SENT, mapOf("opener" to "dashboard"), type = Count)
+    }
+
+    @Test
+    fun whenUserClicksOnSubmitReportWithActiveExperimentsThenSubmitsReportWithActiveExperiments() = runTest {
+        val siteUrl = "https://example.com"
+        val userRefreshCount = 2
+        val jsPerformance = doubleArrayOf(1.0, 2.0, 3.0)
+
+        val mockToggle = mock<Toggle>()
+        val site: Site = mock { site ->
+            whenever(site.uri).thenReturn(siteUrl.toUri())
+            whenever(site.url).thenReturn(siteUrl)
+            whenever(site.userAllowList).thenReturn(true)
+            whenever(site.isDesktopMode).thenReturn(false)
+            whenever(site.upgradedHttps).thenReturn(true)
+            whenever(site.consentManaged).thenReturn(true)
+            whenever(site.errorCodeEvents).thenReturn(listOf("401", "401", "500"))
+            whenever(site.activeContentScopeExperiments).thenReturn(listOf(mockToggle))
+
+            val brokenSiteContext: BrokenSiteContext = mock { brokenSiteContext ->
+                whenever(brokenSiteContext.userRefreshCount).thenReturn(userRefreshCount)
+                whenever(brokenSiteContext.jsPerformance).thenReturn(jsPerformance)
+            }
+            whenever(site.realBrokenSiteContext).thenReturn(brokenSiteContext)
+        }
+
+        testee.onSiteChanged(site)
+
+        val category = "login"
+        val description = "I can't sign in!"
+        testee.onSubmitBrokenSiteReport(
+            payload = """{"category":"$category","description":"$description"}""",
+            reportFlow = DASHBOARD,
+            opener = DashboardOpener.DASHBOARD,
+        )
+
+        val expectedBrokenSite = BrokenSite(
+            category = category,
+            description = description,
+            siteUrl = siteUrl,
+            upgradeHttps = true,
+            blockedTrackers = "",
+            surrogates = "",
+            siteType = "mobile",
+            urlParametersRemoved = false,
+            consentManaged = true,
+            consentOptOutFailed = false,
+            consentSelfTestFailed = false,
+            errorCodes = """["401","401","500"]""",
+            httpErrorCodes = "",
+            loginSite = null,
+            reportFlow = DASHBOARD,
+            userRefreshCount = userRefreshCount,
+            openerContext = null,
+            jsPerformance = jsPerformance.toList(),
+            contentScopeExperiments = listOf(mockToggle),
         )
 
         val isToggleReport = false


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205008441501016/task/1209783667491175?focus=true 

### Description
Send active cohorts for C-S-S experiments to broken site report

### Steps to test this PR

_Feature 1_
- [x] Set https://jsonblob.com/api/1381564551040000000 as RC URL
- [x] Load a site
- [x] Submit a broken site report
- [x] Check `epbf` pixel is fired and contains a parameter `contentScopeExperiments` with value `bloops:{cohort},test:{cohort}`. Note: cohorts are assigned randomly and therefore the value can't be predicted

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
