### PR TITLE
Send debug flags to broken site report

### DIFF
--- a/.github/workflows/end-to-end-robintest.yml
+++ b/.github/workflows/end-to-end-robintest.yml
@@ -52,7 +52,14 @@ jobs:
 
       - name: Move APK to new folder
         if: always()
-        run: find . -name "*.apk"  -exec mv '{}' apk/release.apk \;
+        run: find . -name "*play-release*.apk" -exec mv '{}' apk/release.apk \;
+
+      - name: Assemble internal release APK
+        run: ./gradlew assembleInternalRelease -Pforce-default-variant -Pskip-onboarding
+
+      - name: Move APK to new folder
+        if: always()
+        run: find . -name "*internal-release*.apk" -exec mv '{}' apk/internal.apk \;
 
       - name: Onboarding flows
         uses: mobile-dev-inc/action-maestro-cloud@v1.9.8
@@ -93,6 +100,20 @@ jobs:
           android-api-level: 30
           workspace: .maestro
           include-tags: privacyTest
+
+      - name: Internal Privacy Tests
+        if: always()
+        uses: mobile-dev-inc/action-maestro-cloud@v1.9.7
+        timeout-minutes: 120
+        with:
+          api-key: ${{ secrets.ROBIN_API_KEY }}
+          project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
+          name: internalPrivacyTest_${{ github.sha }}
+          timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
+          app-file: apk/internal.apk
+          android-api-level: 30
+          workspace: .maestro
+          include-tags: privacyTestInternal
 
       - name: Security Tests
         if: always()

--- a/.github/workflows/end-to-end-robintest.yml
+++ b/.github/workflows/end-to-end-robintest.yml
@@ -111,7 +111,7 @@ jobs:
           name: internalPrivacyTest_${{ github.sha }}
           timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           app-file: apk/internal.apk
-          android-api-level: 30
+          android-api-level: 34
           workspace: .maestro
           include-tags: privacyTestInternal
 

--- a/.maestro/privacy_tests/14_-_Api_manipulation.yaml
+++ b/.maestro/privacy_tests/14_-_Api_manipulation.yaml
@@ -1,0 +1,46 @@
+appId: com.duckduckgo.mobile.android
+tags:
+  - privacyTest
+---
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
+      - runFlow: ../shared/skip_all_onboarding.yaml
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/browserMenu"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/settingsMenuItem"
+      - scrollUntilVisible:
+          element:
+            text: "Developer Settings" # or any other selector
+          direction: DOWN # DOWN|UP|LEFT|RIGHT (optional, default: DOWN)
+          timeout: 50000 # (optional, default: 20000) ms
+          speed: 40 # 0-100 (optional, default: 40) Scroll speed. Higher values scroll faster.
+          visibilityPercentage: 100 # 0-100 (optional, default: 100) Percentage of element visible in viewport
+          centerElement: false # true|false (optional, default: false)
+      - tapOn: "Developer Settings"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/overridePrivacyRemoteConfigUrl"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/trailingSwitch"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/internal_edit_text"
+      - inputText: "https://privacy-test-pages.site/content-scope-scripts/infra/config/conditional-matching-experiments.json"
+      - pressKey: Back
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/load"
+      - tapOn: "OK"
+      - pressKey: Back
+      - pressKey: Back
+      - pressKey: Back
+      - assertVisible:
+          id: "com.duckduckgo.mobile.android:id/omnibarTextInput"
+      - inputText: "https://privacy-test-pages.site/content-scope-scripts/infra/pages/conditional-matching-experiments.html?automation=1"
+      - pressKey: Enter
+      - tapOn:
+          id: "run-tests"
+      - assertVisible:
+          id: "test-status"
+          text: "pass"

--- a/.maestro/privacy_tests_internal/1_-_Api_manipulation.yaml
+++ b/.maestro/privacy_tests_internal/1_-_Api_manipulation.yaml
@@ -1,6 +1,6 @@
 appId: com.duckduckgo.mobile.android
 tags:
-  - privacyTest
+  - privacyTestInternal
 ---
 - retry:
     maxRetries: 3

--- a/.maestro/privacy_tests_internal/1_-_Api_manipulation.yaml
+++ b/.maestro/privacy_tests_internal/1_-_Api_manipulation.yaml
@@ -14,13 +14,21 @@ tags:
           id: "com.duckduckgo.mobile.android:id/settingsMenuItem"
       - scrollUntilVisible:
           element:
-            text: "Developer Settings" # or any other selector
-          direction: DOWN # DOWN|UP|LEFT|RIGHT (optional, default: DOWN)
-          timeout: 50000 # (optional, default: 20000) ms
-          speed: 40 # 0-100 (optional, default: 40) Scroll speed. Higher values scroll faster.
-          visibilityPercentage: 100 # 0-100 (optional, default: 100) Percentage of element visible in viewport
-          centerElement: false # true|false (optional, default: false)
+            text: "Developer Settings"
+          direction: DOWN
+          timeout: 50000
+          speed: 40
+          visibilityPercentage: 100
+          centerElement: false
       - tapOn: "Developer Settings"
+      - scrollUntilVisible:
+          element:
+            id: "com.duckduckgo.mobile.android:id/overridePrivacyRemoteConfigUrl"
+          direction: DOWN
+          timeout: 50000
+          speed: 40
+          visibilityPercentage: 100
+          centerElement: true
       - tapOn:
           id: "com.duckduckgo.mobile.android:id/overridePrivacyRemoteConfigUrl"
       - tapOn:
@@ -28,7 +36,7 @@ tags:
       - tapOn:
           id: "com.duckduckgo.mobile.android:id/internal_edit_text"
       - inputText: "https://privacy-test-pages.site/content-scope-scripts/infra/config/conditional-matching-experiments.json"
-      - pressKey: Back
+      - hideKeyboard
       - tapOn:
           id: "com.duckduckgo.mobile.android:id/load"
       - tapOn: "OK"

--- a/app/src/main/java/com/duckduckgo/app/brokensite/api/BrokenSiteSender.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/api/BrokenSiteSender.kt
@@ -161,6 +161,10 @@ class BrokenSiteSubmitter @Inject constructor(
                     }
                 }
 
+            brokenSite.debugFlags?.takeIf { it.isNotEmpty() }?.sorted()?.let { debugFlags ->
+                params[DEBUG_FLAGS] = debugFlags.joinToString(",")
+            }
+
             val lastSentDay = brokenSiteLastSentReport.getLastSentDay(domain.orEmpty())
             if (lastSentDay != null) {
                 params[LAST_SENT_DAY] = lastSentDay
@@ -241,6 +245,7 @@ class BrokenSiteSubmitter @Inject constructor(
         private const val JS_PERFORMANCE = "jsPerformance"
         private const val BLOCKLIST_EXPERIMENT = "blockListExperiment"
         private const val CONTENT_SCOPE_EXPERIMENTS = "contentScopeExperiments"
+        private const val DEBUG_FLAGS = "debugFlags"
     }
 }
 

--- a/app/src/main/java/com/duckduckgo/app/brokensite/api/BrokenSiteSender.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/api/BrokenSiteSender.kt
@@ -161,7 +161,7 @@ class BrokenSiteSubmitter @Inject constructor(
                     }
                 }
 
-            brokenSite.debugFlags?.takeIf { it.isNotEmpty() }?.sorted()?.let { debugFlags ->
+            brokenSite.debugFlags?.takeIf { it.isNotEmpty() }?.toSortedSet()?.let { debugFlags ->
                 params[DEBUG_FLAGS] = debugFlags.joinToString(",")
             }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -3655,7 +3655,7 @@ class BrowserTabViewModel @Inject constructor(
             }
 
             "addDebugFlag" -> {
-                site?.debugFlags = site?.debugFlags?.toMutableList()?.plus(featureName)?.toList()
+                site?.debugFlags = (site?.debugFlags ?: listOf()).toMutableList().plus(featureName)?.toList()
             }
 
             else -> {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -3654,6 +3654,10 @@ class BrowserTabViewModel @Inject constructor(
                 breakageReportResult(data)
             }
 
+            "addDebugFlag" -> {
+                site?.debugFlags = site?.debugFlags?.toMutableList()?.plus(featureName)?.toList()
+            }
+
             else -> {
                 // NOOP
             }

--- a/app/src/main/java/com/duckduckgo/app/global/model/SiteMonitor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/model/SiteMonitor.kt
@@ -223,6 +223,8 @@ class SiteMonitor(
 
     override var activeContentScopeExperiments: List<Toggle>? = null
 
+    override var debugFlags: List<String>? = null
+
     companion object {
         private val specialDomainTypes = setOf(
             TrackerStatus.AD_ALLOWED,

--- a/app/src/test/java/com/duckduckgo/app/brokensite/api/BrokenSiteSubmitterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/brokensite/api/BrokenSiteSubmitterTest.kt
@@ -646,6 +646,18 @@ class BrokenSiteSubmitterTest {
         assertEquals("experiment1:control,experiment2:treatment", params["contentScopeExperiments"])
     }
 
+    @Test
+    fun whenSubmitReportAndADebugFlagsThenIncludeParam() = runTest {
+        val brokenSite = getBrokenSite()
+
+        testee.submitBrokenSiteFeedback(brokenSite.copy(debugFlags = listOf("flag1,flag2")), toggle = false)
+
+        val paramsCaptor = argumentCaptor<Map<String, String>>()
+        verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), parameters = paramsCaptor.capture(), any(), eq(Count))
+        val params = paramsCaptor.lastValue
+        assertEquals("flag1,flag2", params["debugFlags"])
+    }
+
     private fun assignToExperiment() {
         val enrollmentDateET = ZonedDateTime.now(ZoneId.of("America/New_York")).toString()
         testBlockListFeature.tdsNextExperimentTest().setRawStoredState(
@@ -680,6 +692,7 @@ class BrokenSiteSubmitterTest {
             openerContext = null,
             jsPerformance = null,
             contentScopeExperiments = null,
+            debugFlags = null,
         )
     }
 

--- a/app/src/test/java/com/duckduckgo/app/brokensite/api/BrokenSiteSubmitterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/brokensite/api/BrokenSiteSubmitterTest.kt
@@ -647,10 +647,10 @@ class BrokenSiteSubmitterTest {
     }
 
     @Test
-    fun whenSubmitReportAndADebugFlagsThenIncludeParam() = runTest {
+    fun whenSubmitReportAndADebugFlagsThenIncludeParamSortedRemovingDuplicates() = runTest {
         val brokenSite = getBrokenSite()
 
-        testee.submitBrokenSiteFeedback(brokenSite.copy(debugFlags = listOf("flag1,flag2")), toggle = false)
+        testee.submitBrokenSiteFeedback(brokenSite.copy(debugFlags = listOf("flag2", "flag1", "flag2")), toggle = false)
 
         val paramsCaptor = argumentCaptor<Map<String, String>>()
         verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), parameters = paramsCaptor.capture(), any(), eq(Count))

--- a/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesMultipleReportReferenceTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesMultipleReportReferenceTest.kt
@@ -216,6 +216,7 @@ class BrokenSitesMultipleReportReferenceTest(private val testCase: MultipleRepor
                 openerContext = null,
                 jsPerformance = null,
                 contentScopeExperiments = null,
+                debugFlags = null,
             )
 
             testee.submitBrokenSiteFeedback(brokenSite, toggle = false)

--- a/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesReferenceTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/referencetests/brokensites/BrokenSitesReferenceTest.kt
@@ -203,6 +203,7 @@ class BrokenSitesReferenceTest(private val testCase: TestCase) {
             openerContext = SERP.context,
             jsPerformance = listOf(123.45),
             contentScopeExperiments = null,
+            debugFlags = null,
         )
 
         testee.submitBrokenSiteFeedback(brokenSite, toggle = false)

--- a/broken-site/broken-site-api/src/main/java/com/duckduckgo/brokensite/api/BrokenSiteSender.kt
+++ b/broken-site/broken-site-api/src/main/java/com/duckduckgo/brokensite/api/BrokenSiteSender.kt
@@ -42,6 +42,7 @@ data class BrokenSite(
     val openerContext: String?,
     val jsPerformance: List<Double>?,
     val contentScopeExperiments: List<Toggle>?,
+    val debugFlags: List<String>?,
 ) {
     companion object {
         const val SITE_TYPE_DESKTOP = "desktop"

--- a/browser-api/src/main/java/com/duckduckgo/app/global/model/Site.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/global/model/Site.kt
@@ -87,6 +87,8 @@ interface Site {
     var previousNumberOfBlockedTrackers: Int?
 
     var activeContentScopeExperiments: List<Toggle>?
+
+    var debugFlags: List<String>?
 }
 
 enum class MaliciousSiteStatus {

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/text/DaxTextInput.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/view/text/DaxTextInput.kt
@@ -48,6 +48,7 @@ import com.duckduckgo.common.ui.view.text.DaxTextInput.Type.INPUT_TYPE_IP_ADDRES
 import com.duckduckgo.common.ui.view.text.DaxTextInput.Type.INPUT_TYPE_MULTI_LINE
 import com.duckduckgo.common.ui.view.text.DaxTextInput.Type.INPUT_TYPE_PASSWORD
 import com.duckduckgo.common.ui.view.text.DaxTextInput.Type.INPUT_TYPE_SINGLE_LINE
+import com.duckduckgo.common.ui.view.text.DaxTextInput.Type.INPUT_TYPE_URL_MODE
 import com.duckduckgo.common.ui.view.text.TextInput.Action
 import com.duckduckgo.common.ui.view.text.TextInput.Action.PerformEndAction
 import com.duckduckgo.common.ui.viewbinding.viewBinding
@@ -368,6 +369,8 @@ class DaxTextInput @JvmOverloads constructor(
             binding.internalEditText.keyListener = DigitsKeyListener.getInstance("0123456789.")
         } else if (inputType == INPUT_TYPE_MULTI_LINE || inputType == INPUT_TYPE_FORM_MODE) {
             binding.internalEditText.inputType = EditorInfo.TYPE_CLASS_TEXT or EditorInfo.TYPE_TEXT_FLAG_MULTI_LINE
+        } else if (inputType == INPUT_TYPE_URL_MODE) {
+            binding.internalEditText.inputType = EditorInfo.TYPE_CLASS_TEXT or EditorInfo.TYPE_TEXT_VARIATION_URI
         } else {
             binding.internalEditText.inputType = EditorInfo.TYPE_CLASS_TEXT
         }
@@ -429,6 +432,7 @@ class DaxTextInput @JvmOverloads constructor(
         INPUT_TYPE_PASSWORD(2),
         INPUT_TYPE_FORM_MODE(3),
         INPUT_TYPE_IP_ADDRESS_MODE(4),
+        INPUT_TYPE_URL_MODE(5),
     }
 
     companion object {

--- a/common/common-ui/src/main/res/values/attrs-text-input.xml
+++ b/common/common-ui/src/main/res/values/attrs-text-input.xml
@@ -33,6 +33,7 @@
             <enum name="password" value="2"/>
             <enum name="form_mode" value="3"/>
             <enum name="ip_address" value="4"/>
+            <enum name="url" value="5"/>
         </attr>
 
     </declare-styleable>

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessaging.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessaging.kt
@@ -70,6 +70,16 @@ class ContentScopeScriptsJsMessaging @Inject constructor(
             }
             jsMessage?.let {
                 if (this.secret == secret && context == jsMessage.context && (allowedDomains.isEmpty() || allowedDomains.contains(domain))) {
+                    if (jsMessage.method == "addDebugFlag") {
+                        // If method is addDebugFlag, we want to handle it for all features
+                        logcat("Cris") { "Debug flag: ${jsMessage.featureName}" }
+                        jsMessageCallback.process(
+                            featureName = jsMessage.featureName,
+                            method = jsMessage.method,
+                            id = jsMessage.id,
+                            data = jsMessage.params,
+                        )
+                    }
                     handlers.getPlugins().map { it.getJsMessageHandler() }.firstOrNull {
                         it.methods.contains(jsMessage.method) && it.featureName == jsMessage.featureName &&
                             (it.allowedDomains.isEmpty() || it.allowedDomains.contains(domain))

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessaging.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessaging.kt
@@ -72,7 +72,6 @@ class ContentScopeScriptsJsMessaging @Inject constructor(
                 if (this.secret == secret && context == jsMessage.context && (allowedDomains.isEmpty() || allowedDomains.contains(domain))) {
                     if (jsMessage.method == "addDebugFlag") {
                         // If method is addDebugFlag, we want to handle it for all features
-                        logcat("Cris") { "Debug flag: ${jsMessage.featureName}" }
                         jsMessageCallback.process(
                             featureName = jsMessage.featureName,
                             method = jsMessage.method,

--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessagingTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsJsMessagingTest.kt
@@ -181,6 +181,32 @@ class ContentScopeScriptsJsMessagingTest {
         assertEquals(0, callback.counter)
     }
 
+    @Test
+    fun `when processing addDebugFlag message with valid secret and domain then process message`() = runTest {
+        givenInterfaceIsRegistered()
+
+        val message = """
+            {"context":"contentScopeScripts","featureName":"debugFeature","id":"debugId","method":"addDebugFlag","params":{}}
+        """.trimIndent()
+
+        contentScopeScriptsJsMessaging.process(message, contentScopeScriptsJsMessaging.secret)
+
+        assertEquals(1, callback.counter)
+    }
+
+    @Test
+    fun `when processing addDebugFlag message with wrong secret then do nothing`() = runTest {
+        givenInterfaceIsRegistered()
+
+        val message = """
+            {"context":"contentScopeScripts","featureName":"debugFeature","id":"debugId","method":"addDebugFlag","params":{}}
+        """.trimIndent()
+
+        contentScopeScriptsJsMessaging.process(message, "wrongSecret")
+
+        assertEquals(0, callback.counter)
+    }
+
     private val callback = object : JsMessageCallback() {
         var counter = 0
         override fun process(featureName: String, method: String, id: String?, data: JSONObject?) {

--- a/privacy-config/privacy-config-internal/src/main/res/layout/activity_privacy_config_internal_settings.xml
+++ b/privacy-config/privacy-config-internal/src/main/res/layout/activity_privacy_config_internal_settings.xml
@@ -111,6 +111,7 @@
                 android:layout_marginRight="@dimen/keyline_3"
                 android:layout_marginLeft="@dimen/keyline_3"
                 android:hint="Add your custom URL here"
+                app:type="url"
                 app:editable="true" />
 
             <com.duckduckgo.common.ui.view.text.DaxTextView

--- a/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModel.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/main/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModel.kt
@@ -448,6 +448,7 @@ class PrivacyDashboardHybridViewModel @Inject constructor(
                 openerContext = site.realBrokenSiteContext.openerContext?.context,
                 jsPerformance = site.realBrokenSiteContext.jsPerformance?.toList(),
                 contentScopeExperiments = site.activeContentScopeExperiments,
+                debugFlags = site.debugFlags,
             )
 
             brokenSiteSender.submitBrokenSiteFeedback(brokenSite, toggle = false)
@@ -544,6 +545,7 @@ class PrivacyDashboardHybridViewModel @Inject constructor(
                 openerContext = site.realBrokenSiteContext.openerContext?.context,
                 jsPerformance = site.realBrokenSiteContext.jsPerformance?.toList(),
                 contentScopeExperiments = site.activeContentScopeExperiments,
+                debugFlags = site.debugFlags,
             )
 
             brokenSiteSender.submitBrokenSiteFeedback(brokenSite, toggle = true)

--- a/privacy-dashboard/privacy-dashboard-impl/src/test/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModelTest.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/test/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModelTest.kt
@@ -234,6 +234,7 @@ class PrivacyDashboardHybridViewModelTest {
             whenever(site.consentManaged).thenReturn(true)
             whenever(site.errorCodeEvents).thenReturn(listOf("401", "401", "500"))
             whenever(site.activeContentScopeExperiments).thenReturn(null)
+            whenever(site.debugFlags).thenReturn(null)
 
             val brokenSiteContext: BrokenSiteContext = mock { brokenSiteContext ->
                 whenever(brokenSiteContext.userRefreshCount).thenReturn(userRefreshCount)
@@ -297,6 +298,7 @@ class PrivacyDashboardHybridViewModelTest {
             whenever(site.consentManaged).thenReturn(true)
             whenever(site.errorCodeEvents).thenReturn(listOf("401", "401", "500"))
             whenever(site.activeContentScopeExperiments).thenReturn(listOf(mockToggle))
+            whenever(site.debugFlags).thenReturn(null)
 
             val brokenSiteContext: BrokenSiteContext = mock { brokenSiteContext ->
                 whenever(brokenSiteContext.userRefreshCount).thenReturn(userRefreshCount)
@@ -336,6 +338,70 @@ class PrivacyDashboardHybridViewModelTest {
             jsPerformance = jsPerformance.toList(),
             contentScopeExperiments = listOf(mockToggle),
             debugFlags = null,
+        )
+
+        val isToggleReport = false
+
+        verify(brokenSiteSender).submitBrokenSiteFeedback(expectedBrokenSite, isToggleReport)
+        verify(pixel).fire(REPORT_BROKEN_SITE_SENT, mapOf("opener" to "dashboard"), type = Count)
+    }
+
+    @Test
+    fun whenUserClicksOnSubmitReportWithDebugFlagsThenSubmitsReportWithDebugFlags() = runTest {
+        val siteUrl = "https://example.com"
+        val userRefreshCount = 2
+        val jsPerformance = doubleArrayOf(1.0, 2.0, 3.0)
+
+        val debugFlags = listOf("flag1", "flag2")
+        val site: Site = mock { site ->
+            whenever(site.uri).thenReturn(siteUrl.toUri())
+            whenever(site.url).thenReturn(siteUrl)
+            whenever(site.userAllowList).thenReturn(true)
+            whenever(site.isDesktopMode).thenReturn(false)
+            whenever(site.upgradedHttps).thenReturn(true)
+            whenever(site.consentManaged).thenReturn(true)
+            whenever(site.errorCodeEvents).thenReturn(listOf("401", "401", "500"))
+            whenever(site.activeContentScopeExperiments).thenReturn(null)
+            whenever(site.debugFlags).thenReturn(debugFlags)
+
+            val brokenSiteContext: BrokenSiteContext = mock { brokenSiteContext ->
+                whenever(brokenSiteContext.userRefreshCount).thenReturn(userRefreshCount)
+                whenever(brokenSiteContext.jsPerformance).thenReturn(jsPerformance)
+            }
+            whenever(site.realBrokenSiteContext).thenReturn(brokenSiteContext)
+        }
+
+        testee.onSiteChanged(site)
+
+        val category = "login"
+        val description = "I can't sign in!"
+        testee.onSubmitBrokenSiteReport(
+            payload = """{"category":"$category","description":"$description"}""",
+            reportFlow = DASHBOARD,
+            opener = DashboardOpener.DASHBOARD,
+        )
+
+        val expectedBrokenSite = BrokenSite(
+            category = category,
+            description = description,
+            siteUrl = siteUrl,
+            upgradeHttps = true,
+            blockedTrackers = "",
+            surrogates = "",
+            siteType = "mobile",
+            urlParametersRemoved = false,
+            consentManaged = true,
+            consentOptOutFailed = false,
+            consentSelfTestFailed = false,
+            errorCodes = """["401","401","500"]""",
+            httpErrorCodes = "",
+            loginSite = null,
+            reportFlow = DASHBOARD,
+            userRefreshCount = userRefreshCount,
+            openerContext = null,
+            jsPerformance = jsPerformance.toList(),
+            contentScopeExperiments = null,
+            debugFlags = debugFlags,
         )
 
         val isToggleReport = false

--- a/privacy-dashboard/privacy-dashboard-impl/src/test/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModelTest.kt
+++ b/privacy-dashboard/privacy-dashboard-impl/src/test/java/com/duckduckgo/privacy/dashboard/impl/ui/PrivacyDashboardHybridViewModelTest.kt
@@ -272,6 +272,7 @@ class PrivacyDashboardHybridViewModelTest {
             openerContext = null,
             jsPerformance = jsPerformance.toList(),
             contentScopeExperiments = null,
+            debugFlags = null,
         )
 
         val isToggleReport = false
@@ -334,6 +335,7 @@ class PrivacyDashboardHybridViewModelTest {
             openerContext = null,
             jsPerformance = jsPerformance.toList(),
             contentScopeExperiments = listOf(mockToggle),
+            debugFlags = null,
         )
 
         val isToggleReport = false


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205008441501016/task/1210579835428579?focus=true

### Description
Send active cohorts for C-S-S experiments to broken site report

### Steps to test this PR

_Feature 1_
- [x] Set https://jsonblob.com/api/1381564551040000000 as RC URL
- [x] Load http://privacy-test-pages.site/privacy-protections/fingerprinting/
- [x] Click "start the test"
- [x] Submit a broken site report
- [x] Check `epbf` pixel is fired and contains a `debugFlags=elementHiding%2CfingerprintingScreenSize`

### UI changes
n/a
