### PR TITLE
Trigger Asana task creation only when nightly is created

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -152,6 +152,7 @@ jobs:
           pip install -r scripts/release/requirements.txt
 
       - name: Create Asana nightly release task
+        if: steps.check_for_changes.outputs.has_changes == 'true'
         env:
           ASANA_ACCESS_TOKEN: ${{ secrets.ASANA_ACCESS_TOKEN }}
         shell: bash


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1198194956794324/task/1210615704320806?focus=true

### Description
Trigger the Asana task creation only when nightlies are generated rather than always (even if develop hasn't changed)

### Steps to test this PR
NA, Code review
