### PR TITLE
Fix clipped mic icon

### DIFF
--- a/voice-search/voice-search-impl/src/main/res/layout/view_voice_recognizing_indicator.xml
+++ b/voice-search/voice-search-impl/src/main/res/layout/view_voice_recognizing_indicator.xml
@@ -40,7 +40,6 @@
         android:background="@drawable/background_voice_search_indicator"
         android:clickable="false"
         android:focusable="false"
-        android:padding="16dp"
         tools:ignore="ContentDescription">
 
             <ImageView


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1210621076566331?focus=true

### Description

- Fixes the clipped mic icon when using private voice search.

### Steps to test this PR

- [ ] Tap on voice search
- [ ] Verify icon is not clipped

### UI changes
| Before  | After |
| ------ | ----- |
![Screenshot_20250623_211350](https://github.com/user-attachments/assets/c0a26ddb-cfe0-49ad-873a-e8a4f39a7f74)|![Screenshot_20250623_211311](https://github.com/user-attachments/assets/a21bcfa7-2428-4583-bc38-d14c8eaaab90)
