### PR TITLE
Change requirement for marking a previous password import as having happened

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/CredentialImporter.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/CredentialImporter.kt
@@ -86,10 +86,8 @@ class CredentialImporterImpl @Inject constructor(
 
         skippedCredentials += (importList.size - insertedIds.size)
 
-        // Set the flag when at least one credential was successfully imported
-        if (insertedIds.isNotEmpty()) {
-            autofillStore.hasEverImportedPasswords = true
-        }
+        // mark that the user has imported passwords at least once, regardless of the number of credentials imported
+        autofillStore.hasEverImportedPasswords = true
 
         _importStatus.emit(Finished(savedCredentials = insertedIds.size, numberSkipped = skippedCredentials))
     }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/CredentialImporterImplTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/CredentialImporterImplTest.kt
@@ -13,7 +13,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -119,17 +118,17 @@ class CredentialImporterImplTest {
     }
 
     @Test
-    fun whenImportingNoCredentialsThenHasEverImportedPasswordsIsNotSet() = runTest {
+    fun whenImportingNoCredentialsThenHasEverImportedPasswordsIsStillSet() = runTest {
         listOf<LoginCredentials>().import()
-        verify(autofillStore, never()).hasEverImportedPasswords = true
+        verify(autofillStore).hasEverImportedPasswords = true
     }
 
     @Test
-    fun whenImportingOnlyDuplicatesThenHasEverImportedPasswordsIsNotSet() = runTest {
+    fun whenImportingOnlyDuplicatesThenHasEverImportedPasswordsIsStillSet() = runTest {
         val duplicatedLogin = creds(username = "username")
         duplicatedLogin.treatAsDuplicate()
         listOf(duplicatedLogin).import()
-        verify(autofillStore, never()).hasEverImportedPasswords = true
+        verify(autofillStore).hasEverImportedPasswords = true
     }
 
     private suspend fun List<LoginCredentials>.import(originalListSize: Int = this.size) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1210619659166977?focus=true 

### Description
Changes the requirements around how many passwords must be imported to mark a previous import as having happened. 
- **Before:** we required 1 or more passwords were imported
- **Now:** we require that the user has finished the import flow, regardless of the number of credentials imported.

### Steps to test this PR

- QA optional