### PR TITLE
Visual update: Apply new design to the exisiting omnibar

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -699,7 +699,7 @@ class BrowserTabViewModelTest {
         whenever(mockDefaultBrowserPromptsExperiment.showSetAsDefaultPopupMenuItem).thenReturn(
             defaultBrowserPromptsExperimentShowPopupMenuItemFlow,
         )
-        whenever(mockVisualDesignExperimentDataStore.isExperimentEnabled).thenReturn(
+        whenever(mockVisualDesignExperimentDataStore.isNewDesignEnabled).thenReturn(
             defaultVisualExperimentStateFlow,
         )
 

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/omnibar/animations/LottiePrivacyShieldAnimationHelperTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/omnibar/animations/LottiePrivacyShieldAnimationHelperTest.kt
@@ -42,7 +42,7 @@ class LottiePrivacyShieldAnimationHelperTest {
 
     @Before
     fun setup() {
-        whenever(visualDesignExperimentDataStore.isExperimentEnabled).thenReturn(
+        whenever(visualDesignExperimentDataStore.isNewDesignEnabled).thenReturn(
             disabledVisualExperimentStateFlow,
         )
     }
@@ -220,7 +220,7 @@ class LottiePrivacyShieldAnimationHelperTest {
     @Test
     fun whenLightModeAndProtectedAndSelfEnabledAndShouldShowNewVisualDesignShieldThenUseExperimentAssets() = runTest {
         whenever(senseOfProtectionExperiment.shouldShowNewPrivacyShield()).thenReturn(false)
-        whenever(visualDesignExperimentDataStore.isExperimentEnabled).thenReturn(
+        whenever(visualDesignExperimentDataStore.isNewDesignEnabled).thenReturn(
             enabledVisualExperimentStateFlow,
         )
 
@@ -239,7 +239,7 @@ class LottiePrivacyShieldAnimationHelperTest {
     @Test
     fun whenLightModeAndUnprotectedAndSelfEnabledAndShouldShowNewVisualDesignShieldThenUseExperimentAssets() = runTest {
         whenever(senseOfProtectionExperiment.shouldShowNewPrivacyShield()).thenReturn(false)
-        whenever(visualDesignExperimentDataStore.isExperimentEnabled).thenReturn(
+        whenever(visualDesignExperimentDataStore.isNewDesignEnabled).thenReturn(
             enabledVisualExperimentStateFlow,
         )
 
@@ -258,7 +258,7 @@ class LottiePrivacyShieldAnimationHelperTest {
     @Test
     fun whenDarkModeAndProtectedAndSelfEnabledAndShouldShowNewVisualDesignShieldThenUseExperimentAssets() = runTest {
         whenever(senseOfProtectionExperiment.shouldShowNewPrivacyShield()).thenReturn(false)
-        whenever(visualDesignExperimentDataStore.isExperimentEnabled).thenReturn(
+        whenever(visualDesignExperimentDataStore.isNewDesignEnabled).thenReturn(
             enabledVisualExperimentStateFlow,
         )
 
@@ -277,7 +277,7 @@ class LottiePrivacyShieldAnimationHelperTest {
     @Test
     fun whenDarkModeAndUnprotectedAndSelfEnabledAndShouldShowNewVisualDesignShieldThenUseExperimentAssets() = runTest {
         whenever(senseOfProtectionExperiment.shouldShowNewPrivacyShield()).thenReturn(false)
-        whenever(visualDesignExperimentDataStore.isExperimentEnabled).thenReturn(
+        whenever(visualDesignExperimentDataStore.isNewDesignEnabled).thenReturn(
             enabledVisualExperimentStateFlow,
         )
 
@@ -297,7 +297,7 @@ class LottiePrivacyShieldAnimationHelperTest {
     fun whenLightModeAndProtectedAndSelfEnabledAndShouldShowNotNewVisualDesignShieldThenUseNonExperimentAssets() = runTest {
         whenever(senseOfProtectionExperiment.shouldShowNewPrivacyShield()).thenReturn(false)
         whenever(senseOfProtectionExperiment.isUserEnrolledInAVariantAndExperimentEnabled()).thenReturn(false)
-        whenever(visualDesignExperimentDataStore.isExperimentEnabled).thenReturn(
+        whenever(visualDesignExperimentDataStore.isNewDesignEnabled).thenReturn(
             disabledVisualExperimentStateFlow,
         )
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -49,6 +49,7 @@ import com.duckduckgo.app.browser.databinding.ActivityBrowserBinding
 import com.duckduckgo.app.browser.databinding.IncludeExperimentalOmnibarToolbarMockupBinding
 import com.duckduckgo.app.browser.databinding.IncludeExperimentalOmnibarToolbarMockupBottomBinding
 import com.duckduckgo.app.browser.databinding.IncludeOmnibarToolbarMockupBinding
+import com.duckduckgo.app.browser.databinding.IncludeSingleOmnibarToolbarMockupBinding
 import com.duckduckgo.app.browser.defaultbrowsing.prompts.ui.DefaultBrowserBottomSheetDialog
 import com.duckduckgo.app.browser.defaultbrowsing.prompts.ui.DefaultBrowserBottomSheetDialog.EventListener
 import com.duckduckgo.app.browser.omnibar.model.OmnibarPosition.BOTTOM
@@ -233,6 +234,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
     private lateinit var toolbarMockupBinding: IncludeOmnibarToolbarMockupBinding
     private lateinit var experimentalToolbarMockupBinding: IncludeExperimentalOmnibarToolbarMockupBinding
     private lateinit var experimentalToolbarMockupBottomBinding: IncludeExperimentalOmnibarToolbarMockupBottomBinding
+    private lateinit var singleToolBarMockupBinding: IncludeSingleOmnibarToolbarMockupBinding
 
     private var openMessageInNewTabJob: Job? = null
 
@@ -790,6 +792,9 @@ open class BrowserActivity : DuckDuckGoActivity() {
                 if (this::experimentalToolbarMockupBottomBinding.isInitialized) {
                     experimentalToolbarMockupBottomBinding.appBarLayoutMockup.visibility = View.GONE
                 }
+                if (this::singleToolBarMockupBinding.isInitialized) {
+                    singleToolBarMockupBinding.appBarLayoutMockup.visibility = View.GONE
+                }
             },
             300,
         )
@@ -1136,44 +1141,65 @@ open class BrowserActivity : DuckDuckGoActivity() {
     }
 
     private fun bindMockupToolbars() {
-        if (visualDesignExperimentDataStore.isNewDesignEnabled.value) {
-            if (settingsDataStore.omnibarPosition == TOP) {
-                experimentalToolbarMockupBinding = binding.topMockupExperimentalToolbar
+        when {
+            visualDesignExperimentDataStore.isNewDesignEnabled.value -> {
+                when (settingsDataStore.omnibarPosition) {
+                    TOP -> {
+                        experimentalToolbarMockupBinding = binding.topMockupExperimentalToolbar
+                        binding.bottomMockupExperimentalToolbar.appBarLayoutMockup.gone()
+
+                        experimentalToolbarMockupBinding.aiChatIconMockup.isVisible = duckChat.showInAddressBar.value && duckChat.isEnabledInBrowser()
+                    }
+                    BOTTOM -> {
+                        experimentalToolbarMockupBottomBinding = binding.bottomMockupExperimentalToolbar
+                        binding.topMockupExperimentalToolbar.appBarLayoutMockup.gone()
+
+                        experimentalToolbarMockupBottomBinding.aiChatIconMockup.isVisible = duckChat.showInAddressBar.value &&
+                            duckChat.isEnabledInBrowser()
+                    }
+                }
+                binding.bottomMockupToolbar.appBarLayoutMockup.gone()
+                binding.bottomMockupSingleToolbar.appBarLayoutMockup.gone()
+                binding.topMockupToolbar.appBarLayoutMockup.gone()
+                binding.topMockupSingleToolbar.appBarLayoutMockup.gone()
+            }
+            visualDesignExperimentDataStore.isNewDesignWithoutBottomBarEnabled.value -> {
+                singleToolBarMockupBinding = when (settingsDataStore.omnibarPosition) {
+                    TOP -> {
+                        binding.bottomMockupSingleToolbar.appBarLayoutMockup.gone()
+                        binding.topMockupSingleToolbar
+                    }
+                    BOTTOM -> {
+                        binding.topMockupSingleToolbar.appBarLayoutMockup.gone()
+                        binding.bottomMockupSingleToolbar
+                    }
+                }
                 binding.bottomMockupExperimentalToolbar.appBarLayoutMockup.gone()
                 binding.bottomMockupToolbar.appBarLayoutMockup.gone()
-                binding.topMockupToolbar.appBarLayoutMockup.gone()
-
-                if (!duckChat.showInAddressBar.value) {
-                    experimentalToolbarMockupBinding.aiChatIconMockup.isVisible = false
-                }
-            } else {
-                experimentalToolbarMockupBottomBinding = binding.bottomMockupExperimentalToolbar
                 binding.topMockupExperimentalToolbar.appBarLayoutMockup.gone()
                 binding.topMockupToolbar.appBarLayoutMockup.gone()
-                binding.bottomMockupToolbar.appBarLayoutMockup.gone()
 
-                if (!duckChat.showInAddressBar.value) {
-                    experimentalToolbarMockupBottomBinding.aiChatIconMockup.isVisible = false
-                }
+                singleToolBarMockupBinding.aiChatIconMockup.isVisible = duckChat.showInAddressBar.value && duckChat.isEnabledInBrowser()
             }
-        } else {
-            toolbarMockupBinding = when (settingsDataStore.omnibarPosition) {
-                TOP -> {
-                    binding.bottomMockupToolbar.appBarLayoutMockup.gone()
-                    binding.topMockupExperimentalToolbar.appBarLayoutMockup.gone()
-                    binding.bottomMockupExperimentalToolbar.appBarLayoutMockup.gone()
-                    binding.topMockupToolbar
+            else -> {
+                toolbarMockupBinding = when (settingsDataStore.omnibarPosition) {
+                    TOP -> {
+                        binding.bottomMockupToolbar.appBarLayoutMockup.gone()
+                        binding.topMockupToolbar
+                    }
+                    BOTTOM -> {
+                        binding.topMockupToolbar.appBarLayoutMockup.gone()
+                        binding.bottomMockupToolbar
+                    }
                 }
 
-                BOTTOM -> {
-                    binding.topMockupToolbar.appBarLayoutMockup.gone()
-                    binding.topMockupExperimentalToolbar.appBarLayoutMockup.gone()
-                    binding.bottomMockupExperimentalToolbar.appBarLayoutMockup.gone()
-                    binding.bottomMockupToolbar
-                }
+                binding.topMockupSingleToolbar.appBarLayoutMockup.gone()
+                binding.topMockupExperimentalToolbar.appBarLayoutMockup.gone()
+                binding.bottomMockupExperimentalToolbar.appBarLayoutMockup.gone()
+                binding.bottomMockupSingleToolbar.appBarLayoutMockup.gone()
+
+                toolbarMockupBinding.aiChatIconMenuMockup.isVisible = duckChat.showInAddressBar.value && duckChat.isEnabledInBrowser()
             }
-
-            toolbarMockupBinding.aiChatIconMenuMockup.isVisible = duckChat.showInAddressBar.value && duckChat.isEnabledInBrowser()
         }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -1136,7 +1136,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
     }
 
     private fun bindMockupToolbars() {
-        if (visualDesignExperimentDataStore.isExperimentEnabled.value) {
+        if (visualDesignExperimentDataStore.isNewDesignEnabled.value) {
             if (settingsDataStore.omnibarPosition == TOP) {
                 experimentalToolbarMockupBinding = binding.topMockupExperimentalToolbar
                 binding.bottomMockupExperimentalToolbar.appBarLayoutMockup.gone()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2718,7 +2718,8 @@ class BrowserTabFragment :
         binding.autoCompleteSuggestionsList.addItemDecoration(
             SuggestionItemDecoration(
                 divider = ContextCompat.getDrawable(context, R.drawable.suggestions_divider)!!,
-                addExtraDividerPadding = visualDesignExperimentDataStore.isNewDesignEnabled.value,
+                addExtraDividerPadding = visualDesignExperimentDataStore.isNewDesignEnabled.value ||
+                    visualDesignExperimentDataStore.isNewDesignWithoutBottomBarEnabled.value,
             ),
         )
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -148,10 +148,10 @@ import com.duckduckgo.app.browser.newtab.NewTabPageProvider
 import com.duckduckgo.app.browser.omnibar.Omnibar
 import com.duckduckgo.app.browser.omnibar.Omnibar.OmnibarTextState
 import com.duckduckgo.app.browser.omnibar.Omnibar.ViewMode
-import com.duckduckgo.app.browser.omnibar.experiments.FadeOmnibarItemPressedListener
-import com.duckduckgo.app.browser.omnibar.getOmnibarType
+import com.duckduckgo.app.browser.omnibar.OmnibarItemPressedListener
 import com.duckduckgo.app.browser.omnibar.model.OmnibarPosition.BOTTOM
 import com.duckduckgo.app.browser.omnibar.model.OmnibarPosition.TOP
+import com.duckduckgo.app.browser.omnibar.model.OmnibarTypeResolver
 import com.duckduckgo.app.browser.print.PrintDocumentAdapterFactory
 import com.duckduckgo.app.browser.print.PrintInjector
 import com.duckduckgo.app.browser.remotemessage.SharePromoLinkRMFBroadCastReceiver
@@ -565,6 +565,9 @@ class BrowserTabFragment :
     @Inject
     lateinit var onboardingDesignExperimentToggles: OnboardingDesignExperimentToggles
 
+    @Inject
+    lateinit var omnibarTypeResolver: OmnibarTypeResolver
+
     /**
      * We use this to monitor whether the user was seeing the in-context Email Protection signup prompt
      * This is needed because the activity stack will be cleared if an external link is opened in our browser
@@ -948,7 +951,7 @@ class BrowserTabFragment :
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
-        omnibar = Omnibar(settingsDataStore.omnibarPosition, visualDesignExperimentDataStore.getOmnibarType(), binding)
+        omnibar = Omnibar(settingsDataStore.omnibarPosition, omnibarTypeResolver.getOmnibarType(), binding)
 
         webViewContainer = binding.webViewContainer
         configureObservers()
@@ -1369,7 +1372,7 @@ class BrowserTabFragment :
         }
 
         val hasOmnibarPositionChanged = viewModel.hasOmnibarPositionChanged(omnibar.omnibarPosition)
-        val hasOmnibarTypeChanged = omnibar.omnibarType != visualDesignExperimentDataStore.getOmnibarType()
+        val hasOmnibarTypeChanged = omnibar.omnibarType != omnibarTypeResolver.getOmnibarType()
         if (hasOmnibarPositionChanged || hasOmnibarTypeChanged) {
             viewModel.resetTrackersCount()
             if (swipingTabsFeature.isEnabled && requireActivity() is BrowserActivity) {
@@ -2806,8 +2809,8 @@ class BrowserTabFragment :
                 }
             },
         )
-        omnibar.configureFadeOmnibarItemPressedListeners(
-            object : FadeOmnibarItemPressedListener {
+        omnibar.configureOmnibarItemPressedListeners(
+            object : OmnibarItemPressedListener {
                 override fun onBackButtonPressed() {
                     hideKeyboard()
                 }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1094,7 +1094,7 @@ class BrowserTabFragment :
         browserNavigationBarIntegration = BrowserNavigationBarViewIntegration(
             lifecycleScope = lifecycleScope,
             browserTabFragmentBinding = binding,
-            isExperimentEnabled = visualDesignExperimentDataStore.isExperimentEnabled.value,
+            isExperimentEnabled = visualDesignExperimentDataStore.isNewDesignEnabled.value,
             omnibar = omnibar,
             browserNavigationBarObserver = observer,
         )
@@ -1183,7 +1183,7 @@ class BrowserTabFragment :
     }
 
     private fun createPopupMenu() {
-        val popupMenuResourceType = if (!isActiveCustomTab() && visualDesignExperimentDataStore.isExperimentEnabled.value) {
+        val popupMenuResourceType = if (!isActiveCustomTab() && visualDesignExperimentDataStore.isNewDesignEnabled.value) {
             // when not custom tab and bottom navigation bar is enabled, we always inflate the popup menu from the bottom
             BrowserPopupMenu.ResourceType.BOTTOM
         } else {
@@ -2718,7 +2718,7 @@ class BrowserTabFragment :
         binding.autoCompleteSuggestionsList.addItemDecoration(
             SuggestionItemDecoration(
                 divider = ContextCompat.getDrawable(context, R.drawable.suggestions_divider)!!,
-                addExtraDividerPadding = visualDesignExperimentDataStore.isExperimentEnabled.value,
+                addExtraDividerPadding = visualDesignExperimentDataStore.isNewDesignEnabled.value,
             ),
         )
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2792,7 +2792,7 @@ class BrowserTabViewModel @Inject constructor(
                 showMenuButton = HighlightableButton.Visible(highlighted = false),
             )
         }
-        command.value = LaunchPopupMenu(anchorToNavigationBar = !isCustomTab && visualDesignExperimentDataStore.isExperimentEnabled.value)
+        command.value = LaunchPopupMenu(anchorToNavigationBar = !isCustomTab && visualDesignExperimentDataStore.isNewDesignEnabled.value)
     }
 
     fun onPopupMenuLaunched() {

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
@@ -104,7 +104,7 @@ class Omnibar(
                         binding.rootView.removeView(binding.singleOmnibarBottom)
                     }
 
-                    SINGLE ->  {
+                    SINGLE -> {
                         // remove bottom variant
                         binding.rootView.removeView(binding.singleOmnibarBottom)
 
@@ -349,8 +349,7 @@ class Omnibar(
         val omnibar = newOmnibar
         if (omnibar is FadeOmnibarLayout) {
             omnibar.setFadeOmnibarItemPressedListener(listener)
-        }
-        else if (omnibar is SingleOmnibarLayout) {
+        } else if (omnibar is SingleOmnibarLayout) {
             omnibar.setSingleOmnibarItemPressedListener(listener)
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
@@ -39,12 +39,13 @@ import com.duckduckgo.app.browser.omnibar.OmnibarLayout.Decoration.DisableVoiceS
 import com.duckduckgo.app.browser.omnibar.OmnibarLayout.Decoration.HighlightOmnibarItem
 import com.duckduckgo.app.browser.omnibar.OmnibarLayout.Decoration.Mode
 import com.duckduckgo.app.browser.omnibar.OmnibarLayout.StateChange
-import com.duckduckgo.app.browser.omnibar.experiments.FadeOmnibarItemPressedListener
 import com.duckduckgo.app.browser.omnibar.experiments.FadeOmnibarLayout
+import com.duckduckgo.app.browser.omnibar.experiments.SingleOmnibarLayout
 import com.duckduckgo.app.browser.omnibar.model.OmnibarPosition
 import com.duckduckgo.app.browser.omnibar.model.OmnibarType
 import com.duckduckgo.app.browser.omnibar.model.OmnibarType.FADE
 import com.duckduckgo.app.browser.omnibar.model.OmnibarType.SCROLLING
+import com.duckduckgo.app.browser.omnibar.model.OmnibarType.SINGLE
 import com.duckduckgo.app.browser.viewstate.BrowserViewState
 import com.duckduckgo.app.browser.viewstate.FindInPageViewState
 import com.duckduckgo.app.browser.viewstate.LoadingViewState
@@ -52,7 +53,6 @@ import com.duckduckgo.app.browser.viewstate.OmnibarViewState
 import com.duckduckgo.app.browser.webview.BottomOmnibarBrowserContainerLayoutBehavior
 import com.duckduckgo.app.global.model.PrivacyShield
 import com.duckduckgo.app.trackerdetection.model.Entity
-import com.duckduckgo.common.ui.experiments.visual.store.VisualDesignExperimentDataStore
 import com.duckduckgo.common.ui.view.KeyboardAwareEditText
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.hide
@@ -85,6 +85,10 @@ class Omnibar(
                         // remove all fade omnibars
                         binding.rootView.removeView(binding.fadeOmnibar)
                         binding.rootView.removeView(binding.fadeOmnibarBottom)
+
+                        // remove all single omnibars
+                        binding.rootView.removeView(binding.singleOmnibar)
+                        binding.rootView.removeView(binding.singleOmnibarBottom)
                     }
 
                     FADE -> {
@@ -94,6 +98,23 @@ class Omnibar(
                         // remove all scrolling omnibars
                         binding.rootView.removeView(binding.newOmnibar)
                         binding.rootView.removeView(binding.newOmnibarBottom)
+
+                        // remove all single omnibars
+                        binding.rootView.removeView(binding.singleOmnibar)
+                        binding.rootView.removeView(binding.singleOmnibarBottom)
+                    }
+
+                    SINGLE ->  {
+                        // remove bottom variant
+                        binding.rootView.removeView(binding.singleOmnibarBottom)
+
+                        // remove all scrolling omnibars
+                        binding.rootView.removeView(binding.newOmnibar)
+                        binding.rootView.removeView(binding.newOmnibarBottom)
+
+                        // remove all fade omnibars
+                        binding.rootView.removeView(binding.fadeOmnibar)
+                        binding.rootView.removeView(binding.fadeOmnibarBottom)
                     }
                 }
             }
@@ -107,6 +128,10 @@ class Omnibar(
                         // remove all fade omnibars
                         binding.rootView.removeView(binding.fadeOmnibar)
                         binding.rootView.removeView(binding.fadeOmnibarBottom)
+
+                        // remove all single omnibars
+                        binding.rootView.removeView(binding.singleOmnibar)
+                        binding.rootView.removeView(binding.singleOmnibarBottom)
                     }
 
                     FADE -> {
@@ -116,6 +141,23 @@ class Omnibar(
                         // remove all scrolling omnibars
                         binding.rootView.removeView(binding.newOmnibar)
                         binding.rootView.removeView(binding.newOmnibarBottom)
+
+                        // remove all single omnibars
+                        binding.rootView.removeView(binding.singleOmnibar)
+                        binding.rootView.removeView(binding.singleOmnibarBottom)
+                    }
+
+                    SINGLE -> {
+                        // remove top variant
+                        binding.rootView.removeView(binding.singleOmnibar)
+
+                        // remove all scrolling omnibars
+                        binding.rootView.removeView(binding.newOmnibar)
+                        binding.rootView.removeView(binding.newOmnibarBottom)
+
+                        // remove all fade omnibars
+                        binding.rootView.removeView(binding.fadeOmnibar)
+                        binding.rootView.removeView(binding.fadeOmnibarBottom)
                     }
                 }
 
@@ -187,6 +229,7 @@ class Omnibar(
                 when (omnibarType) {
                     SCROLLING -> binding.newOmnibar
                     FADE -> binding.fadeOmnibar
+                    SINGLE -> binding.singleOmnibar
                 }
             }
 
@@ -194,6 +237,7 @@ class Omnibar(
                 when (omnibarType) {
                     SCROLLING -> binding.newOmnibarBottom
                     FADE -> binding.fadeOmnibarBottom
+                    SINGLE -> binding.singleOmnibarBottom
                 }
             }
         }
@@ -236,7 +280,11 @@ class Omnibar(
     }
 
     val omniBarClickCatcher: View? by lazy {
-        (newOmnibar as? FadeOmnibarLayout)?.omniBarClickCatcher
+        when (omnibarType) {
+            FADE -> (newOmnibar as? FadeOmnibarLayout)?.omniBarClickCatcher
+            SINGLE -> (newOmnibar as? SingleOmnibarLayout)?.omniBarClickCatcher
+            else -> null
+        }
     }
 
     val toolbar: Toolbar by lazy {
@@ -297,10 +345,13 @@ class Omnibar(
         newOmnibar.setOmnibarItemPressedListener(listener)
     }
 
-    fun configureFadeOmnibarItemPressedListeners(listener: FadeOmnibarItemPressedListener) {
+    fun configureOmnibarItemPressedListeners(listener: OmnibarItemPressedListener) {
         val omnibar = newOmnibar
         if (omnibar is FadeOmnibarLayout) {
             omnibar.setFadeOmnibarItemPressedListener(listener)
+        }
+        else if (omnibar is SingleOmnibarLayout) {
+            omnibar.setSingleOmnibarItemPressedListener(listener)
         }
     }
 
@@ -462,13 +513,5 @@ class Omnibar(
         topOfPage: Boolean,
     ) {
         newOmnibar.decorate(Decoration.NewTabScrollingState(canScrollUp, canScrollDown, topOfPage))
-    }
-}
-
-fun VisualDesignExperimentDataStore.getOmnibarType(): OmnibarType {
-    return if (isExperimentEnabled.value) {
-        FADE
-    } else {
-        SCROLLING
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -624,12 +624,12 @@ open class OmnibarLayout @JvmOverloads constructor(
         val newTransitionState = TransitionState(
             showClearButton = viewState.showClearButton,
             showVoiceSearch = viewState.showVoiceSearch,
-            showTabsMenu = viewState.showTabsMenu,
-            showFireIcon = viewState.showFireIcon,
-            showBrowserMenu = viewState.showBrowserMenu,
+            showTabsMenu = viewState.showTabsMenu && !viewState.showFindInPage,
+            showFireIcon = viewState.showFireIcon && !viewState.showFindInPage,
+            showBrowserMenu = viewState.showBrowserMenu && !viewState.showFindInPage,
             showBrowserMenuHighlight = viewState.showBrowserMenuHighlight,
             showChatMenu = viewState.showChatMenu,
-            showSpacer = viewState.showClearButton || viewState.showVoiceSearch,
+            showSpacer = viewState.showClearButton || viewState.showVoiceSearch || viewState.showFindInPage,
         )
 
         if (omnibarAnimationManager.isFeatureEnabled() &&

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -1031,3 +1031,7 @@ open class OmnibarLayout @JvmOverloads constructor(
         omnibarTextListener?.onTrackersCountFinished()
     }
 }
+
+interface OmnibarItemPressedListener {
+    fun onBackButtonPressed()
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -629,7 +629,7 @@ open class OmnibarLayout @JvmOverloads constructor(
             showBrowserMenu = viewState.showBrowserMenu && !viewState.showFindInPage,
             showBrowserMenuHighlight = viewState.showBrowserMenuHighlight,
             showChatMenu = viewState.showChatMenu,
-            showSpacer = viewState.showClearButton || viewState.showVoiceSearch || viewState.showFindInPage,
+            showSpacer = viewState.showClearButton || viewState.showVoiceSearch,
         )
 
         if (omnibarAnimationManager.isFeatureEnabled() &&

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -107,7 +107,7 @@ class OmnibarLayoutViewModel @Inject constructor(
     // We need to do this since the max overloads for combine is 5
     private val visualDesignExperimentFlags =
         combine(
-            visualDesignExperimentDataStore.isExperimentEnabled,
+            visualDesignExperimentDataStore.isNewDesignEnabled,
             visualDesignExperimentDataStore.isDuckAIPoCEnabled,
         ) { isExperimentEnabled, isDuckAIPoCEnabled ->
             isExperimentEnabled to isDuckAIPoCEnabled

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -167,6 +167,7 @@ class OmnibarLayoutViewModel @Inject constructor(
         val previouslyTrackersBlocked: Int = 0,
         val showShadows: Boolean = false,
         val showClickCatcher: Boolean = false,
+        val showFindInPage: Boolean = false,
     ) {
         fun shouldUpdateOmnibarText(isFullUrlEnabled: Boolean): Boolean {
             return this.viewMode is Browser || this.viewMode is MaliciousSiteWarning || (!isFullUrlEnabled && omnibarText.isNotEmpty())
@@ -193,6 +194,18 @@ class OmnibarLayoutViewModel @Inject constructor(
 
     init {
         logVoiceSearchAvailability()
+    }
+
+    fun onFindInPageRequested() {
+        _viewState.update {
+            it.copy(showFindInPage = true)
+        }
+    }
+
+    fun onFindInPageDismissed() {
+        _viewState.update {
+            it.copy(showFindInPage = false)
+        }
     }
 
     fun onOmnibarFocusChanged(

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -48,7 +48,6 @@ import com.duckduckgo.app.browser.viewstate.LoadingViewState
 import com.duckduckgo.app.browser.viewstate.OmnibarViewState
 import com.duckduckgo.app.global.model.PrivacyShield
 import com.duckduckgo.app.pixels.AppPixelName
-import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter.FIRE_BUTTON_STATE
@@ -93,7 +92,6 @@ class OmnibarLayoutViewModel @Inject constructor(
     private val visualDesignExperimentDataStore: VisualDesignExperimentDataStore,
     private val senseOfProtectionExperiment: SenseOfProtectionExperiment,
     private val duckChat: DuckChat,
-    private val browserFeatures: AndroidBrowserConfigFeature,
     private val addressDisplayFormatter: AddressDisplayFormatter,
     private val settingsDataStore: SettingsDataStore,
 ) : ViewModel() {

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/LottiePrivacyShieldAnimationHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/LottiePrivacyShieldAnimationHelper.kt
@@ -54,7 +54,8 @@ class LottiePrivacyShieldAnimationHelper @Inject constructor(
             protectedShieldDark = R.raw.protected_shield_experiment
             unprotectedShield = R.raw.unprotected_shield_experiment
             unprotectedShieldDark = R.raw.unprotected_shield_experiment_dark
-        } else if (visualDesignExperimentDataStore.isNewDesignEnabled.value) {
+        } else if (visualDesignExperimentDataStore.isNewDesignEnabled.value ||
+            visualDesignExperimentDataStore.isNewDesignWithoutBottomBarEnabled.value) {
             protectedShield = R.raw.protected_shield_visual_updates
             protectedShieldDark = R.raw.dark_protected_shield_visual_updates
             unprotectedShield = R.raw.unprotected_shield_visual_updates

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/LottiePrivacyShieldAnimationHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/LottiePrivacyShieldAnimationHelper.kt
@@ -55,7 +55,8 @@ class LottiePrivacyShieldAnimationHelper @Inject constructor(
             unprotectedShield = R.raw.unprotected_shield_experiment
             unprotectedShieldDark = R.raw.unprotected_shield_experiment_dark
         } else if (visualDesignExperimentDataStore.isNewDesignEnabled.value ||
-            visualDesignExperimentDataStore.isNewDesignWithoutBottomBarEnabled.value) {
+            visualDesignExperimentDataStore.isNewDesignWithoutBottomBarEnabled.value
+        ) {
             protectedShield = R.raw.protected_shield_visual_updates
             protectedShieldDark = R.raw.dark_protected_shield_visual_updates
             unprotectedShield = R.raw.unprotected_shield_visual_updates

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/LottiePrivacyShieldAnimationHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/LottiePrivacyShieldAnimationHelper.kt
@@ -54,7 +54,7 @@ class LottiePrivacyShieldAnimationHelper @Inject constructor(
             protectedShieldDark = R.raw.protected_shield_experiment
             unprotectedShield = R.raw.unprotected_shield_experiment
             unprotectedShieldDark = R.raw.unprotected_shield_experiment_dark
-        } else if (visualDesignExperimentDataStore.isExperimentEnabled.value) {
+        } else if (visualDesignExperimentDataStore.isNewDesignEnabled.value) {
             protectedShield = R.raw.protected_shield_visual_updates
             protectedShieldDark = R.raw.dark_protected_shield_visual_updates
             unprotectedShield = R.raw.unprotected_shield_visual_updates

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/FadeOmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/FadeOmnibarLayout.kt
@@ -41,6 +41,7 @@ import com.duckduckgo.app.browser.navigation.bar.view.BrowserNavigationBarView
 import com.duckduckgo.app.browser.omnibar.FindInPage
 import com.duckduckgo.app.browser.omnibar.FindInPageImpl
 import com.duckduckgo.app.browser.omnibar.Omnibar.ViewMode
+import com.duckduckgo.app.browser.omnibar.OmnibarItemPressedListener
 import com.duckduckgo.app.browser.omnibar.OmnibarLayout
 import com.duckduckgo.app.browser.omnibar.OmnibarLayoutViewModel.ViewState
 import com.duckduckgo.app.browser.omnibar.model.OmnibarPosition
@@ -119,7 +120,7 @@ class FadeOmnibarLayout @JvmOverloads constructor(
 
     private var focusAnimator: ValueAnimator? = null
 
-    private var fadeOmnibarItemPressedListener: FadeOmnibarItemPressedListener? = null
+    private var fadeOmnibarItemPressedListener: OmnibarItemPressedListener? = null
 
     init {
         val attr = context.theme.obtainStyledAttributes(attrs, R.styleable.FadeOmnibarLayout, defStyle, 0)
@@ -355,7 +356,7 @@ class FadeOmnibarLayout @JvmOverloads constructor(
         }
     }
 
-    fun setFadeOmnibarItemPressedListener(itemPressedListener: FadeOmnibarItemPressedListener) {
+    fun setFadeOmnibarItemPressedListener(itemPressedListener: OmnibarItemPressedListener) {
         fadeOmnibarItemPressedListener = itemPressedListener
         backIcon.setOnClickListener {
             viewModel.onBackButtonPressed()
@@ -374,8 +375,4 @@ class FadeOmnibarLayout @JvmOverloads constructor(
     companion object {
         private const val DEFAULT_ANIMATION_DURATION = 300L
     }
-}
-
-interface FadeOmnibarItemPressedListener {
-    fun onBackButtonPressed()
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/SingleOmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/SingleOmnibarLayout.kt
@@ -83,9 +83,6 @@ class SingleOmnibarLayout @JvmOverloads constructor(
     private val toolbarContainerPaddingTopWhenAtBottom by lazy {
         resources.getDimensionPixelSize(CommonR.dimen.experimentalToolbarContainerPaddingTopWhenAtBottom)
     }
-    private val toolbarContainerPaddingHorizontalWhenAtBottom by lazy {
-        resources.getDimensionPixelSize(CommonR.dimen.experimentalToolbarContainerPaddingHorizontalWhenAtBottom)
-    }
     private val omnibarOutlineWidth by lazy { resources.getDimensionPixelSize(CommonR.dimen.experimentalOmnibarOutlineWidth) }
     private val omnibarOutlineFocusedWidth by lazy { resources.getDimensionPixelSize(CommonR.dimen.experimentalOmnibarOutlineFocusedWidth) }
 
@@ -107,8 +104,6 @@ class SingleOmnibarLayout @JvmOverloads constructor(
             // When omnibar is at the bottom, we're adding an additional space at the top
             toolbarContainer.updatePadding(
                 top = toolbarContainerPaddingTopWhenAtBottom,
-                right = toolbarContainerPaddingHorizontalWhenAtBottom,
-                left = toolbarContainerPaddingHorizontalWhenAtBottom,
             )
 
             omnibarCard.elevation = 0.5f.toDp(context)

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/SingleOmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/SingleOmnibarLayout.kt
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2024 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.omnibar.experiments
+
+import android.animation.ValueAnimator
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import android.view.ViewGroup
+import android.view.ViewTreeObserver.OnGlobalLayoutListener
+import android.view.animation.DecelerateInterpolator
+import android.widget.ImageView
+import androidx.core.view.isVisible
+import androidx.core.view.marginEnd
+import androidx.core.view.updatePadding
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.databinding.IncludeFadeOmnibarFindInPageBinding
+import com.duckduckgo.app.browser.omnibar.FindInPage
+import com.duckduckgo.app.browser.omnibar.FindInPageImpl
+import com.duckduckgo.app.browser.omnibar.Omnibar.ViewMode
+import com.duckduckgo.app.browser.omnibar.OmnibarItemPressedListener
+import com.duckduckgo.app.browser.omnibar.OmnibarLayout
+import com.duckduckgo.app.browser.omnibar.OmnibarLayoutViewModel.ViewState
+import com.duckduckgo.app.browser.omnibar.model.OmnibarPosition
+import com.duckduckgo.common.ui.view.gone
+import com.duckduckgo.common.ui.view.hide
+import com.duckduckgo.common.ui.view.show
+import com.duckduckgo.common.ui.view.toDp
+import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.navigation.api.GlobalActivityStarter
+import com.google.android.material.card.MaterialCardView
+import dagger.android.support.AndroidSupportInjection
+import javax.inject.Inject
+import com.duckduckgo.mobile.android.R as CommonR
+
+@InjectWith(FragmentScope::class)
+class SingleOmnibarLayout @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyle: Int = 0,
+) : OmnibarLayout(context, attrs, defStyle) {
+    @Inject
+    lateinit var globalActivityStarter: GlobalActivityStarter
+
+    private val aiChatDivider: View by lazy { findViewById(R.id.verticalDivider) }
+    private val omnibarCard: MaterialCardView by lazy { findViewById(R.id.omniBarContainer) }
+    private val omniBarContentContainer: View by lazy { findViewById(R.id.omniBarContentContainer) }
+    private val backIcon: ImageView by lazy { findViewById(R.id.backIcon) }
+    private val customTabToolbarContainerWrapper: ViewGroup by lazy { findViewById(R.id.customTabToolbarContainerWrapper) }
+    val omniBarClickCatcher: View by lazy { findViewById(R.id.omnibarClickCatcher) }
+
+    override val findInPage: FindInPage by lazy {
+        FindInPageImpl(IncludeFadeOmnibarFindInPageBinding.bind(findViewById(R.id.findInPage)))
+    }
+    private var isFindInPageVisible = false
+    private val findInPageLayoutVisibilityChangeListener = OnGlobalLayoutListener {
+        val isVisible = findInPage.findInPageContainer.isVisible
+        if (isFindInPageVisible != isVisible) {
+            isFindInPageVisible = isVisible
+            if (isVisible) {
+                onFindInPageShown()
+            } else {
+                onFindInPageHidden()
+            }
+        }
+    }
+
+    private val toolbarContainerPaddingTopWhenAtBottom by lazy {
+        resources.getDimensionPixelSize(CommonR.dimen.experimentalToolbarContainerPaddingTopWhenAtBottom)
+    }
+    private val toolbarContainerPaddingHorizontalWhenAtBottom by lazy {
+        resources.getDimensionPixelSize(CommonR.dimen.experimentalToolbarContainerPaddingHorizontalWhenAtBottom)
+    }
+    private val omnibarOutlineWidth by lazy { resources.getDimensionPixelSize(CommonR.dimen.experimentalOmnibarOutlineWidth) }
+    private val omnibarOutlineFocusedWidth by lazy { resources.getDimensionPixelSize(CommonR.dimen.experimentalOmnibarOutlineFocusedWidth) }
+
+    private var focusAnimator: ValueAnimator? = null
+
+    private var singleOmnibarItemPressedListener: OmnibarItemPressedListener? = null
+
+    init {
+        val attr = context.theme.obtainStyledAttributes(attrs, R.styleable.SingleOmnibarLayout, defStyle, 0)
+        omnibarPosition = OmnibarPosition.entries[attr.getInt(R.styleable.SingleOmnibarLayout_omnibarPosition, 0)]
+
+        inflate(context, R.layout.view_single_omnibar, this)
+
+        AndroidSupportInjection.inject(this)
+
+        if (omnibarPosition == OmnibarPosition.TOP) {
+            omnibarCard.elevation = 1f.toDp(context)
+        } else {
+            // When omnibar is at the bottom, we're adding an additional space at the top
+            toolbarContainer.updatePadding(
+                top = toolbarContainerPaddingTopWhenAtBottom,
+                right = toolbarContainerPaddingHorizontalWhenAtBottom,
+                left = toolbarContainerPaddingHorizontalWhenAtBottom,
+            )
+
+            omnibarCard.elevation = 0.5f.toDp(context)
+        }
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        findInPage.findInPageContainer.viewTreeObserver.addOnGlobalLayoutListener(findInPageLayoutVisibilityChangeListener)
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        focusAnimator?.cancel()
+        findInPage.findInPageContainer.viewTreeObserver.removeOnGlobalLayoutListener(findInPageLayoutVisibilityChangeListener)
+    }
+
+    override fun render(viewState: ViewState) {
+        super.render(viewState)
+
+        renderShadows(viewState.showShadows)
+
+        if (viewState.hasFocus || isFindInPageVisible) {
+            animateOmnibarFocusedState(focused = true)
+        } else {
+            animateOmnibarFocusedState(focused = false)
+        }
+    }
+
+    override fun renderButtons(viewState: ViewState) {
+        super.renderButtons(viewState)
+
+        clearTextButton.isVisible = viewState.showClearButton
+        voiceSearchButton.isVisible = viewState.showVoiceSearch
+        spacer.isVisible = false
+
+        aiChatMenu?.isVisible = viewState.showChatMenu
+        aiChatDivider.isVisible = (viewState.showVoiceSearch || viewState.showClearButton) && viewState.showChatMenu
+
+        val showBackArrow = viewState.hasFocus
+        if (showBackArrow) {
+            backIcon.show()
+            searchIcon.gone()
+            shieldIcon.gone()
+            daxIcon.gone()
+            globeIcon.gone()
+            duckPlayerIcon.gone()
+        } else {
+            backIcon.gone()
+        }
+
+        omniBarClickCatcher.isVisible = viewState.showClickCatcher
+    }
+
+    private fun animateOmnibarFocusedState(focused: Boolean) {
+        focusAnimator?.cancel()
+
+        val startCardStrokeWidth = omnibarCard.strokeWidth
+        val endCardStrokeWidth: Int = if (focused) {
+            omnibarOutlineFocusedWidth
+        } else {
+            omnibarOutlineWidth
+        }
+
+        val animator = ValueAnimator.ofFloat(0f, 1f)
+        animator.duration = DEFAULT_ANIMATION_DURATION
+        animator.interpolator = DecelerateInterpolator()
+        animator.addUpdateListener { valueAnimator ->
+            val fraction = valueAnimator.animatedValue as Float
+
+            val animatedCardStrokeWidth = (startCardStrokeWidth + (endCardStrokeWidth - startCardStrokeWidth) * fraction).toInt()
+
+            val params = omnibarCard.layoutParams as MarginLayoutParams
+            omnibarCard.setLayoutParams(params)
+
+            omnibarCard.strokeWidth = animatedCardStrokeWidth
+        }
+
+        animator.start()
+        focusAnimator = animator
+    }
+
+
+    private fun onFindInPageShown() {
+        omniBarContentContainer.hide()
+        customTabToolbarContainerWrapper.hide()
+        if (viewModel.viewState.value.viewMode is ViewMode.CustomTab) {
+            omniBarContainer.show()
+            browserMenu.gone()
+        }
+        animateOmnibarFocusedState(focused = true)
+    }
+
+    private fun onFindInPageHidden() {
+        omniBarContentContainer.show()
+        customTabToolbarContainerWrapper.show()
+        if (viewModel.viewState.value.viewMode is ViewMode.CustomTab) {
+            omniBarContainer.hide()
+            browserMenu.isVisible = viewModel.viewState.value.showBrowserMenu
+        }
+        if (!viewModel.viewState.value.hasFocus) {
+            animateOmnibarFocusedState(focused = false)
+        }
+    }
+
+    fun setSingleOmnibarItemPressedListener(itemPressedListener: OmnibarItemPressedListener) {
+        singleOmnibarItemPressedListener = itemPressedListener
+        backIcon.setOnClickListener {
+            viewModel.onBackButtonPressed()
+            singleOmnibarItemPressedListener?.onBackButtonPressed()
+        }
+    }
+
+    private fun renderShadows(showShadows: Boolean) {
+        // outlineProvider = if (showShadows) {
+        //     ViewOutlineProvider.BACKGROUND
+        // } else {
+        //     null
+        // }
+    }
+
+    companion object {
+        private const val DEFAULT_ANIMATION_DURATION = 300L
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/SingleOmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/SingleOmnibarLayout.kt
@@ -175,9 +175,6 @@ class SingleOmnibarLayout @JvmOverloads constructor(
 
             val animatedCardStrokeWidth = (startCardStrokeWidth + (endCardStrokeWidth - startCardStrokeWidth) * fraction).toInt()
 
-            val params = omnibarCard.layoutParams as MarginLayoutParams
-            omnibarCard.setLayoutParams(params)
-
             omnibarCard.strokeWidth = animatedCardStrokeWidth
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/SingleOmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/SingleOmnibarLayout.kt
@@ -200,6 +200,7 @@ class SingleOmnibarLayout @JvmOverloads constructor(
             browserMenu.gone()
         }
         animateOmnibarFocusedState(focused = true)
+        viewModel.onFindInPageRequested()
     }
 
     private fun onFindInPageHidden() {
@@ -212,6 +213,7 @@ class SingleOmnibarLayout @JvmOverloads constructor(
         if (!viewModel.viewState.value.hasFocus) {
             animateOmnibarFocusedState(focused = false)
         }
+        viewModel.onFindInPageDismissed()
     }
 
     fun setSingleOmnibarItemPressedListener(itemPressedListener: OmnibarItemPressedListener) {

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/SingleOmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/SingleOmnibarLayout.kt
@@ -25,7 +25,6 @@ import android.view.ViewTreeObserver.OnGlobalLayoutListener
 import android.view.animation.DecelerateInterpolator
 import android.widget.ImageView
 import androidx.core.view.isVisible
-import androidx.core.view.marginEnd
 import androidx.core.view.updatePadding
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.browser.R

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/SingleOmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/SingleOmnibarLayout.kt
@@ -39,14 +39,12 @@ import com.duckduckgo.app.browser.omnibar.model.OmnibarPosition
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.hide
 import com.duckduckgo.common.ui.view.show
-import com.duckduckgo.common.ui.view.toDp
-import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.mobile.android.R as CommonR
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.google.android.material.card.MaterialCardView
 import dagger.android.support.AndroidSupportInjection
 import javax.inject.Inject
-import com.duckduckgo.mobile.android.R as CommonR
 
 @InjectWith(FragmentScope::class)
 class SingleOmnibarLayout @JvmOverloads constructor(
@@ -178,7 +176,6 @@ class SingleOmnibarLayout @JvmOverloads constructor(
         animator.start()
         focusAnimator = animator
     }
-
 
     private fun onFindInPageShown() {
         omniBarContentContainer.hide()

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/SingleOmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/SingleOmnibarLayout.kt
@@ -40,6 +40,7 @@ import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.hide
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.view.toDp
+import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.google.android.material.card.MaterialCardView
@@ -97,15 +98,11 @@ class SingleOmnibarLayout @JvmOverloads constructor(
 
         AndroidSupportInjection.inject(this)
 
-        if (omnibarPosition == OmnibarPosition.TOP) {
-            omnibarCard.elevation = 1f.toDp(context)
-        } else {
+        if (omnibarPosition == OmnibarPosition.BOTTOM) {
             // When omnibar is at the bottom, we're adding an additional space at the top
             toolbarContainer.updatePadding(
                 top = toolbarContainerPaddingTopWhenAtBottom,
             )
-
-            omnibarCard.elevation = 0.5f.toDp(context)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/model/OmnibarType.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/model/OmnibarType.kt
@@ -19,4 +19,5 @@ package com.duckduckgo.app.browser.omnibar.model
 enum class OmnibarType {
     SCROLLING,
     FADE,
+    SINGLE,
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/model/OmnibarTypeResolver.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/model/OmnibarTypeResolver.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.omnibar.model
+
+import com.duckduckgo.app.browser.omnibar.model.OmnibarType.FADE
+import com.duckduckgo.app.browser.omnibar.model.OmnibarType.SCROLLING
+import com.duckduckgo.app.browser.omnibar.model.OmnibarType.SINGLE
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.common.ui.experiments.visual.store.VisualDesignExperimentDataStore
+import javax.inject.Inject
+
+class OmnibarTypeResolver @Inject constructor(
+    private val experimentsDataStore: VisualDesignExperimentDataStore,
+    private val browserFeatures: AndroidBrowserConfigFeature
+) {
+    fun getOmnibarType(): OmnibarType {
+        return if (experimentsDataStore.isExperimentEnabled.value) {
+            FADE
+        } else if (browserFeatures.newUIWithoutNavBar().isEnabled()) {
+            SINGLE
+        } else {
+            SCROLLING
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/model/OmnibarTypeResolver.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/model/OmnibarTypeResolver.kt
@@ -19,18 +19,16 @@ package com.duckduckgo.app.browser.omnibar.model
 import com.duckduckgo.app.browser.omnibar.model.OmnibarType.FADE
 import com.duckduckgo.app.browser.omnibar.model.OmnibarType.SCROLLING
 import com.duckduckgo.app.browser.omnibar.model.OmnibarType.SINGLE
-import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.common.ui.experiments.visual.store.VisualDesignExperimentDataStore
 import javax.inject.Inject
 
 class OmnibarTypeResolver @Inject constructor(
     private val experimentsDataStore: VisualDesignExperimentDataStore,
-    private val browserFeatures: AndroidBrowserConfigFeature
 ) {
     fun getOmnibarType(): OmnibarType {
-        return if (experimentsDataStore.isExperimentEnabled.value) {
+        return if (experimentsDataStore.isNewDesignEnabled.value) {
             FADE
-        } else if (browserFeatures.newUIWithoutNavBar().isEnabled()) {
+        } else if (experimentsDataStore.isNewDesignWithoutBottomBarEnabled.value) {
             SINGLE
         } else {
             SCROLLING

--- a/app/src/main/java/com/duckduckgo/app/browser/senseofprotection/SenseOfProtectionExperimentImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/senseofprotection/SenseOfProtectionExperimentImpl.kt
@@ -209,7 +209,8 @@ class SenseOfProtectionExperimentImpl @Inject constructor(
     }
 
     private fun seesNewVisualDesign(): Boolean {
-        val seesNewVisualDesing = visualDesignExperimentDataStore.isNewDesignEnabled.value
+        val seesNewVisualDesing = visualDesignExperimentDataStore.isNewDesignEnabled.value ||
+            visualDesignExperimentDataStore.isNewDesignWithoutBottomBarEnabled.value
         logcat { "VisualDesign: seesNewVisualDesign $seesNewVisualDesing" }
         return seesNewVisualDesing
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/senseofprotection/SenseOfProtectionExperimentImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/senseofprotection/SenseOfProtectionExperimentImpl.kt
@@ -209,7 +209,7 @@ class SenseOfProtectionExperimentImpl @Inject constructor(
     }
 
     private fun seesNewVisualDesign(): Boolean {
-        val seesNewVisualDesing = visualDesignExperimentDataStore.isExperimentEnabled.value
+        val seesNewVisualDesing = visualDesignExperimentDataStore.isNewDesignEnabled.value
         logcat { "VisualDesign: seesNewVisualDesign $seesNewVisualDesing" }
         return seesNewVisualDesing
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/tabswitcher/NewTabSwitcherButton.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabswitcher/NewTabSwitcherButton.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.app.browser.tabswitcher
 
 import android.content.Context
 import android.util.AttributeSet
-import com.duckduckgo.app.browser.databinding.ViewExperimentalTabSwitcherButtonBinding
 import com.duckduckgo.app.browser.databinding.ViewNewToolbarTabSwitcherButtonBinding
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.show

--- a/app/src/main/java/com/duckduckgo/app/browser/tabswitcher/NewTabSwitcherButton.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabswitcher/NewTabSwitcherButton.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.tabswitcher
+
+import android.content.Context
+import android.util.AttributeSet
+import com.duckduckgo.app.browser.databinding.ViewExperimentalTabSwitcherButtonBinding
+import com.duckduckgo.app.browser.databinding.ViewNewToolbarTabSwitcherButtonBinding
+import com.duckduckgo.common.ui.view.gone
+import com.duckduckgo.common.ui.view.show
+import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.mobile.android.R as CommonR
+
+class NewTabSwitcherButton @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+) : TabSwitcherButton(context, attrs, defStyleAttr) {
+
+    private val binding: ViewNewToolbarTabSwitcherButtonBinding by viewBinding()
+
+    override var hasUnread: Boolean = false
+        set(value) {
+            if (field != value) {
+                if (value) {
+                    binding.tabsImageView.setImageResource(CommonR.drawable.ic_tab_24_highlighted)
+                } else {
+                    binding.tabsImageView.setImageResource(CommonR.drawable.ic_tab_24)
+                }
+            }
+            field = value
+        }
+
+    override var count = 0
+        set(value) {
+            if (field != value) {
+                if (value < 100) {
+                    binding.tabCount.text = "$value"
+                    binding.tabCount.show()
+                    binding.tabCountInfinite.gone()
+                } else {
+                    binding.tabCount.gone()
+                    binding.tabCountInfinite.show()
+                }
+            }
+            field = value
+        }
+}

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabItemDecorator.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabItemDecorator.kt
@@ -32,13 +32,14 @@ import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.mobile.android.R as CommonR
 
 class TabItemDecorator(context: Context, experimentStore: VisualDesignExperimentDataStore) : RecyclerView.ItemDecoration() {
-    private val borderPadding = if (experimentStore.isNewDesignEnabled.value) BORDER_PADDING_NEW else BORDER_PADDING
-    private val activeTabBorderColor = if (experimentStore.isNewDesignEnabled.value) {
+    private val isNewDesignEnabled = experimentStore.isNewDesignEnabled.value || experimentStore.isNewDesignWithoutBottomBarEnabled.value
+    private val borderPadding = if (isNewDesignEnabled) BORDER_PADDING_NEW else BORDER_PADDING
+    private val activeTabBorderColor = if (isNewDesignEnabled) {
         CommonR.attr.daxColorTabHighlight
     } else {
         CommonR.attr.daxColorBackgroundInverted
     }
-    private val selectionBorderWidth = if (experimentStore.isNewDesignEnabled.value) {
+    private val selectionBorderWidth = if (isNewDesignEnabled) {
         ACTIVE_TAB_BORDER_WIDTH
     } else {
         SELECTION_BORDER_WIDTH

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabItemDecorator.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabItemDecorator.kt
@@ -32,13 +32,13 @@ import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.mobile.android.R as CommonR
 
 class TabItemDecorator(context: Context, experimentStore: VisualDesignExperimentDataStore) : RecyclerView.ItemDecoration() {
-    private val borderPadding = if (experimentStore.isExperimentEnabled.value) BORDER_PADDING_NEW else BORDER_PADDING
-    private val activeTabBorderColor = if (experimentStore.isExperimentEnabled.value) {
+    private val borderPadding = if (experimentStore.isNewDesignEnabled.value) BORDER_PADDING_NEW else BORDER_PADDING
+    private val activeTabBorderColor = if (experimentStore.isNewDesignEnabled.value) {
         CommonR.attr.daxColorTabHighlight
     } else {
         CommonR.attr.daxColorBackgroundInverted
     }
-    private val selectionBorderWidth = if (experimentStore.isExperimentEnabled.value) {
+    private val selectionBorderWidth = if (experimentStore.isNewDesignEnabled.value) {
         ACTIVE_TAB_BORDER_WIDTH
     } else {
         SELECTION_BORDER_WIDTH

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -174,7 +174,8 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
 
     private val tabsAdapter: TabSwitcherAdapter by lazy {
         TabSwitcherAdapter(
-            isVisualExperimentEnabled = visualDesignExperimentDataStore.isNewDesignEnabled.value,
+            isVisualExperimentEnabled = visualDesignExperimentDataStore.isNewDesignEnabled.value ||
+                visualDesignExperimentDataStore.isNewDesignWithoutBottomBarEnabled.value,
             itemClickListener = this,
             webViewPreviewPersister = webViewPreviewPersister,
             lifecycleOwner = this,

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -174,7 +174,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
 
     private val tabsAdapter: TabSwitcherAdapter by lazy {
         TabSwitcherAdapter(
-            isVisualExperimentEnabled = visualDesignExperimentDataStore.isExperimentEnabled.value,
+            isVisualExperimentEnabled = visualDesignExperimentDataStore.isNewDesignEnabled.value,
             itemClickListener = this,
             webViewPreviewPersister = webViewPreviewPersister,
             lifecycleOwner = this,

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -129,7 +129,7 @@ class TabSwitcherViewModel @Inject constructor(
         _selectionViewState,
         tabSwitcherItemsFlow,
         tabRepository.tabSwitcherData,
-        visualDesignExperimentDataStore.isExperimentEnabled,
+        visualDesignExperimentDataStore.isNewDesignEnabled,
         duckChat.showInBrowserMenu,
     ) { viewState, tabSwitcherItems, tabSwitcherData, isVisualDesignExperimentEnabled, showInBrowserMenu ->
         viewState.copy(

--- a/app/src/main/res/layout/activity_browser.xml
+++ b/app/src/main/res/layout/activity_browser.xml
@@ -36,6 +36,13 @@
         android:layout_alignParentTop="true"
         layout="@layout/include_experimental_omnibar_toolbar_mockup" />
 
+    <include
+        android:id="@+id/topMockupSingleToolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/experimentalToolbarSize"
+        android:layout_alignParentTop="true"
+        layout="@layout/include_single_omnibar_toolbar_mockup" />
+
     <FrameLayout
         android:id="@+id/fragmentContainer"
         android:layout_width="match_parent"
@@ -67,5 +74,12 @@
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
         layout="@layout/include_experimental_omnibar_toolbar_mockup_bottom" />
+
+    <include
+        android:id="@+id/bottomMockupSingleToolbar"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/experimentalToolbarSize"
+        android:layout_alignParentBottom="true"
+        layout="@layout/include_single_omnibar_toolbar_mockup" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_browser_tab.xml
+++ b/app/src/main/res/layout/fragment_browser_tab.xml
@@ -32,6 +32,12 @@
         android:layout_height="wrap_content"
         app:omnibarPosition="top" />
 
+    <com.duckduckgo.app.browser.omnibar.experiments.SingleOmnibarLayout
+        android:id="@+id/singleOmnibar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:omnibarPosition="top" />
+
     <FrameLayout
         android:id="@+id/webViewFullScreenContainer"
         android:layout_width="match_parent"
@@ -148,6 +154,13 @@
 
     <com.duckduckgo.app.browser.omnibar.experiments.FadeOmnibarLayout
         android:id="@+id/fadeOmnibarBottom"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        app:omnibarPosition="bottom" />
+
+    <com.duckduckgo.app.browser.omnibar.experiments.SingleOmnibarLayout
+        android:id="@+id/singleOmnibarBottom"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"

--- a/app/src/main/res/layout/include_single_omnibar_toolbar_mockup.xml
+++ b/app/src/main/res/layout/include_single_omnibar_toolbar_mockup.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright (c) 2018 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/appBarLayoutMockup"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/experimentalToolbarSize"
+    android:background="?daxColorToolbar"
+    android:theme="@style/Widget.DuckDuckGo.ToolbarTheme">
+
+    <LinearLayout
+        android:id="@+id/omniBarContainerMockup"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_marginEnd="@dimen/experimentalOmnibarCardMarginEnd"
+        android:layout_marginStart="@dimen/keyline_4"
+        android:layout_marginTop="@dimen/experimentalOmnibarCardMarginTop"
+        android:layout_marginBottom="12dp"
+        android:background="@drawable/fade_omnibar_field_background"
+        android:orientation="horizontal"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/iconsContainer"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageView
+            android:id="@+id/searchIconMockup"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:gravity="center"
+            android:importantForAccessibility="no"
+            android:paddingVertical="6dp"
+            android:paddingStart="10dp"
+            android:paddingEnd="8dp"
+            android:src="@drawable/ic_find_search_small_24" />
+
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+            android:id="@+id/omnibarTextInputMockup"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:gravity="start|center"
+            android:maxLines="1"
+            android:paddingEnd="8dp"
+            android:text="@string/omnibarInputHint"
+            android:textColor="?attr/daxColorSecondaryText" />
+
+        <ImageView
+            android:id="@+id/aiChatIconMockup"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:gravity="center"
+            android:importantForAccessibility="no"
+            android:paddingVertical="6dp"
+            android:paddingHorizontal="10dp"
+            android:src="@drawable/ic_ai_chat_24" />
+
+    </LinearLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/iconsContainer"
+        android:layout_width="wrap_content"
+        android:layout_height="@dimen/toolbarIcon"
+        android:layout_marginTop="@dimen/experimentalOmnibarCardMarginTop"
+        android:layout_marginBottom="@dimen/experimentalOmnibarCardMarginBottom"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/omniBarContainerMockup"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.duckduckgo.app.browser.tabswitcher.NewTabSwitcherButton
+            android:id="@+id/tabsMenu"
+            android:layout_width="@dimen/toolbarIcon"
+            android:layout_height="@dimen/toolbarIcon"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/browserMenu"
+            app:layout_constraintStart_toEndOf="@id/fireIconMenu"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <FrameLayout
+            android:id="@+id/browserMenu"
+            android:layout_width="@dimen/toolbarIcon"
+            android:layout_height="@dimen/toolbarIcon"
+            android:background="@drawable/selectable_item_experimental_background"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/tabsMenu"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageView
+                android:id="@+id/browserMenuImageView"
+                android:layout_width="@dimen/bottomNavIcon"
+                android:layout_height="@dimen/bottomNavIcon"
+                android:layout_gravity="center"
+                android:contentDescription="@string/browserPopupMenu"
+                android:scaleType="center"
+                android:src="@drawable/ic_menu_vertical_24" />
+
+
+            <View
+                android:id="@+id/browserMenuHighlight"
+                android:layout_width="7dp"
+                android:layout_height="7dp"
+                android:layout_gravity="end"
+                android:layout_margin="@dimen/keyline_2"
+                android:background="@drawable/ic_circle_7_accent_blue"
+                android:visibility="gone" />
+
+        </FrameLayout>
+
+        <FrameLayout
+            android:id="@+id/fireIconMenu"
+            android:layout_width="@dimen/toolbarIcon"
+            android:layout_height="@dimen/toolbarIcon"
+            android:background="@drawable/selectable_item_experimental_background"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/tabsMenu"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageView
+                android:id="@+id/fireIconImageView"
+                android:layout_width="@dimen/bottomNavIcon"
+                android:layout_height="@dimen/bottomNavIcon"
+                android:layout_gravity="center"
+                android:contentDescription="@string/fireMenu"
+                android:scaleType="center"
+                android:src="@drawable/ic_fire_24" />
+        </FrameLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/view_new_toolbar_tab_switcher_button.xml
+++ b/app/src/main/res/layout/view_new_toolbar_tab_switcher_button.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2018 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/tabsButton"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/selectable_item_experimental_background"
+    tools:layout_height="@dimen/toolbarIcon"
+    tools:layout_width="@dimen/toolbarIcon">
+
+    <ImageView
+        android:id="@+id/tabsImageView"
+        android:layout_width="@dimen/bottomNavIcon"
+        android:layout_height="@dimen/bottomNavIcon"
+        android:layout_gravity="center"
+        android:contentDescription="@string/tabsMenuItem"
+        android:scaleType="center"
+        android:src="@drawable/ic_tab_24" />
+
+    <!--
+         Below TextViews aren't a DaxTextView, special case for the Tabs icon.
+         They also uses DP instead of SP, because the background icon can't resize to accommodate
+         different font sizes.
+         The "∞" character is separated into its own view because the horizontal center-line
+         of that character is at a different height than numbers' horizontal center-line.
+    -->
+
+    <TextView
+        android:id="@+id/tabCount"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_marginStart="9.75dp"
+        android:layout_marginTop="5.5dp"
+        android:fontFamily="sans-serif-condensed"
+        android:gravity="center"
+        android:textColor="?attr/daxColorPrimaryIcon"
+        android:textSize="9dp"
+        android:textStyle="bold"
+        tools:ignore="DeprecatedWidgetInXml,SpUsage"
+        tools:text="99" />
+
+    <TextView
+        android:id="@+id/tabCountInfinite"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_marginStart="10dp"
+        android:layout_marginTop="4dp"
+        android:fontFamily="sans-serif-condensed"
+        android:gravity="center"
+        android:text="∞"
+        android:textColor="?attr/daxColorPrimaryIcon"
+        android:textSize="11dp"
+        android:textStyle="bold"
+        android:visibility="gone"
+        tools:ignore="DeprecatedWidgetInXml,HardcodedText,SpUsage" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/view_single_omnibar.xml
+++ b/app/src/main/res/layout/view_single_omnibar.xml
@@ -344,16 +344,6 @@
 
             </androidx.appcompat.widget.Toolbar>
 
-            <Space
-                android:id="@+id/spacer1X"
-                android:layout_width="10dp"
-                android:layout_height="match_parent"
-                android:visibility="gone"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/toolbar"
-                app:layout_constraintTop_toTopOf="parent" />
-
             <FrameLayout
                 android:id="@+id/shieldIconPulseAnimationContainer"
                 android:layout_width="74dp"
@@ -469,6 +459,13 @@
                         android:scaleType="center"
                         android:src="@drawable/ic_fire_24" />
                 </FrameLayout>
+
+                <Space
+                    android:layout_width="10dp"
+                    android:layout_height="match_parent"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/view_single_omnibar.xml
+++ b/app/src/main/res/layout/view_single_omnibar.xml
@@ -1,0 +1,478 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright (c) 2018 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/appBarLayout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:theme="@style/Widget.DuckDuckGo.ToolbarTheme"
+    tools:parentTag="androidx.coordinatorlayout.widget.CoordinatorLayout">
+
+    <LinearLayout
+        android:id="@+id/rootContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_scrollFlags="scroll|enterAlways|snap">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/toolbarContainer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?attr/daxColorToolbar">
+
+            <androidx.appcompat.widget.Toolbar
+                android:id="@+id/toolbar"
+                android:layout_width="0dp"
+                android:layout_height="@dimen/experimentalToolbarSize"
+                app:contentInsetEnd="0dp"
+                app:contentInsetStart="0dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/iconsContainer"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:popupTheme="@style/Widget.DuckDuckGo.PopUpOverflowMenu">
+
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/omniBarContainer"
+                    style="@style/Widget.DuckDuckGo.OmnibarCardView"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:layout_marginStart="@dimen/experimentalOmnibarCardMarginHorizontal"
+                    android:layout_marginEnd="@dimen/experimentalOmnibarCardMarginEnd"
+                    android:layout_marginTop="@dimen/experimentalOmnibarCardMarginTop"
+                    android:layout_marginBottom="@dimen/experimentalOmnibarCardMarginBottom"
+                    android:transitionName="omnibar_transition"
+                    app:cardElevation="1dp"
+                    app:strokeColor="?daxColorAccentBlue"
+                    app:strokeWidth="@dimen/experimentalOmnibarOutlineWidth">
+
+                    <androidx.constraintlayout.widget.ConstraintLayout
+                        android:id="@+id/omniBarContentContainer"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:layout_gravity="center">
+
+                        <ProgressBar
+                            android:id="@+id/pageLoadingIndicator"
+                            style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+                            android:layout_width="match_parent"
+                            android:layout_height="2dp"
+                            android:progressDrawable="@drawable/loading_progress"
+                            android:visibility="invisible"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintStart_toStartOf="parent"
+                            tools:progress="50"
+                            tools:visibility="visible" />
+
+                        <com.airbnb.lottie.LottieAnimationView
+                            android:id="@+id/trackersAnimation"
+                            android:layout_width="wrap_content"
+                            android:layout_height="0dp"
+                            android:layout_marginStart="4dp"
+                            android:layout_marginEnd="@dimen/keyline_1"
+                            android:importantForAccessibility="no"
+                            android:paddingStart="@dimen/keyline_4"
+                            android:saveEnabled="false"
+                            android:scaleType="centerCrop"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintStart_toStartOf="@id/omniBarContentContainer"
+                            app:layout_constraintTop_toTopOf="parent"
+                            app:lottie_autoPlay="false" />
+
+                        <com.airbnb.lottie.LottieAnimationView
+                            android:id="@+id/shieldIcon"
+                            android:layout_width="wrap_content"
+                            android:layout_height="match_parent"
+                            android:importantForAccessibility="no"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintStart_toStartOf="@id/omniBarContentContainer"
+                            app:layout_constraintTop_toTopOf="parent" />
+
+                        <com.airbnb.lottie.LottieAnimationView
+                            android:id="@+id/shieldIconExperiment"
+                            android:layout_width="wrap_content"
+                            android:layout_height="match_parent"
+                            android:importantForAccessibility="no"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintStart_toStartOf="@id/omniBarContentContainer"
+                            app:layout_constraintTop_toTopOf="parent" />
+
+                        <FrameLayout
+                            android:id="@+id/omnibarIconContainer"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="@dimen/keyline_0"
+                            android:layout_marginEnd="@dimen/keyline_0"
+                            android:minWidth="@dimen/toolbarIcon"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="parent">
+
+                            <ImageView
+                                android:id="@+id/daxIcon"
+                                android:layout_width="@dimen/toolbarIcon"
+                                android:layout_height="@dimen/toolbarIcon"
+                                android:layout_gravity="center"
+                                android:importantForAccessibility="no"
+                                android:padding="@dimen/keyline_1"
+                                android:scaleType="center"
+                                android:visibility="gone"
+                                app:srcCompat="@drawable/ic_ddg_logo" />
+
+                            <ImageView
+                                android:id="@+id/duckPlayerIcon"
+                                android:layout_width="@dimen/toolbarIcon"
+                                android:layout_height="@dimen/toolbarIcon"
+                                android:layout_gravity="center"
+                                android:importantForAccessibility="no"
+                                android:padding="@dimen/keyline_1"
+                                android:scaleType="center"
+                                android:visibility="gone"
+                                app:srcCompat="@drawable/ic_video_player_color_24" />
+
+                            <ImageView
+                                android:id="@+id/searchIcon"
+                                android:layout_width="@dimen/toolbarIcon"
+                                android:layout_height="@dimen/toolbarIcon"
+                                android:layout_gravity="center"
+                                android:gravity="center"
+                                android:importantForAccessibility="no"
+                                android:padding="@dimen/keyline_2"
+                                android:scaleType="center"
+                                android:src="@drawable/ic_find_search_small_24" />
+
+                            <ImageView
+                                android:id="@+id/backIcon"
+                                android:layout_width="@dimen/toolbarIcon"
+                                android:layout_height="@dimen/toolbarIcon"
+                                android:layout_gravity="center"
+                                android:background="@drawable/selectable_item_experimental_background"
+                                android:contentDescription="@string/back"
+                                android:gravity="center"
+                                android:padding="@dimen/keyline_2"
+                                android:scaleType="center"
+                                android:src="@drawable/ic_arrow_left_small_24"
+                                android:visibility="gone" />
+
+                            <ImageView
+                                android:id="@+id/globeIcon"
+                                android:layout_width="@dimen/toolbarIcon"
+                                android:layout_height="@dimen/toolbarIcon"
+                                android:layout_gravity="center"
+                                android:importantForAccessibility="no"
+                                android:padding="@dimen/keyline_2"
+                                android:scaleType="center"
+                                android:visibility="gone"
+                                app:srcCompat="@drawable/ic_globe_24" />
+
+                            <FrameLayout
+                                android:id="@+id/sceneRoot"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_gravity="start|center_vertical"
+                                android:layout_marginStart="16dp"
+                                android:visibility="gone">
+
+                                <include layout="@layout/cookie_scene_1" />
+                            </FrameLayout>
+
+                        </FrameLayout>
+
+                        <View
+                            android:id="@+id/cookieDummyView"
+                            android:layout_width="@dimen/omnibarCookieAnimationBannerHeight"
+                            android:layout_height="?attr/cookiesAnimationHeight"
+                            android:layout_gravity="start|center_vertical"
+                            android:layout_marginStart="@dimen/keyline_1"
+                            android:alpha="0"
+                            android:background="@drawable/cookies_dummy_background"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintStart_toStartOf="@id/omniBarContentContainer"
+                            app:layout_constraintTop_toTopOf="parent" />
+
+                        <com.airbnb.lottie.LottieAnimationView
+                            android:id="@+id/cookieAnimation"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="start|center_vertical"
+                            android:layout_marginStart="2dp"
+                            android:saveEnabled="false"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintStart_toStartOf="@id/omniBarContentContainer"
+                            app:layout_constraintTop_toTopOf="parent"
+                            app:lottie_loop="false" />
+
+                        <com.duckduckgo.common.ui.view.KeyboardAwareEditText
+                            android:id="@+id/omnibarTextInput"
+                            style="@style/Base.V7.Widget.AppCompat.EditText"
+                            android:layout_width="0dp"
+                            android:layout_height="0dp"
+                            android:background="@null"
+                            android:fontFamily="sans-serif"
+                            android:hint="@string/omnibarInputHint"
+                            android:imeOptions="flagNoExtractUi|actionGo|flagNoPersonalizedLearning"
+                            android:inputType="textUri|textNoSuggestions"
+                            android:maxLines="1"
+                            android:selectAllOnFocus="true"
+                            android:textColor="?attr/daxColorPrimaryText"
+                            android:textColorHighlight="?attr/daxOmnibarTextColorHighlight"
+                            android:textColorHint="?attr/daxColorSecondaryText"
+                            android:textCursorDrawable="@drawable/text_cursor"
+                            android:textSize="16sp"
+                            android:textStyle="normal"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toStartOf="@id/endIconsContainer"
+                            app:layout_constraintStart_toEndOf="@id/omnibarIconContainer"
+                            app:layout_constraintTop_toTopOf="parent" />
+
+                        <androidx.constraintlayout.widget.ConstraintLayout
+                            android:id="@+id/endIconsContainer"
+                            android:layout_width="wrap_content"
+                            android:layout_height="match_parent"
+                            android:layout_marginEnd="@dimen/keyline_0"
+                            android:minWidth="8dp"
+                            app:layout_constraintEnd_toEndOf="parent">
+
+                            <ImageView
+                                android:id="@+id/clearTextButton"
+                                android:layout_width="@dimen/toolbarIcon"
+                                android:layout_height="@dimen/toolbarIcon"
+                                android:background="@drawable/selectable_item_experimental_background"
+                                android:contentDescription="@string/clearButtonContentDescription"
+                                android:scaleType="center"
+                                android:src="@drawable/ic_close_circle_small_secondary_24"
+                                android:visibility="gone"
+                                app:layout_constraintBottom_toBottomOf="parent"
+                                app:layout_constraintEnd_toStartOf="@id/voiceSearchButton"
+                                app:layout_constraintTop_toTopOf="parent"
+                                tools:visibility="visible" />
+
+                            <ImageView
+                                android:id="@+id/voiceSearchButton"
+                                android:layout_width="@dimen/toolbarIcon"
+                                android:layout_height="@dimen/toolbarIcon"
+                                android:background="@drawable/selectable_item_experimental_background"
+                                android:contentDescription="@string/voiceSearchIconContentDescription"
+                                android:scaleType="center"
+                                android:visibility="gone"
+                                app:layout_constraintBottom_toBottomOf="parent"
+                                app:layout_constraintEnd_toStartOf="@+id/verticalDivider"
+                                app:layout_constraintTop_toTopOf="parent"
+                                app:srcCompat="@drawable/ic_microphone_24"
+                                tools:visibility="visible" />
+
+                            <View
+                                android:id="@+id/spacer"
+                                android:layout_width="5dp"
+                                android:layout_height="0dp"
+                                android:importantForAccessibility="no"
+                                app:layout_constraintBottom_toBottomOf="parent"
+                                app:layout_constraintEnd_toStartOf="@id/verticalDivider"
+                                app:layout_constraintTop_toTopOf="parent" />
+
+                            <View
+                                android:id="@+id/verticalDivider"
+                                android:layout_width="1dp"
+                                android:layout_height="20dp"
+                                android:layout_marginHorizontal="2dp"
+                                android:background="?daxColorLines"
+                                android:importantForAccessibility="no"
+                                app:layout_constraintBottom_toBottomOf="parent"
+                                app:layout_constraintEnd_toStartOf="@id/aiChatIconMenu"
+                                app:layout_constraintTop_toTopOf="parent"
+                                tools:ignore="MissingVerticalDivider" />
+
+                            <ImageView
+                                android:id="@+id/aiChatIconMenu"
+                                android:layout_width="@dimen/toolbarIcon"
+                                android:layout_height="@dimen/toolbarIcon"
+                                android:layout_gravity="center"
+                                android:background="@drawable/selectable_item_experimental_background"
+                                android:contentDescription="@string/browserPopupMenu"
+                                android:scaleType="center"
+                                android:src="@drawable/ic_ai_chat_24"
+                                android:visibility="gone"
+                                app:layout_constraintBottom_toBottomOf="parent"
+                                app:layout_constraintEnd_toEndOf="parent"
+                                app:layout_constraintTop_toTopOf="parent"
+                                tools:visibility="visible" />
+
+                        </androidx.constraintlayout.widget.ConstraintLayout>
+
+                        <View
+                            android:id="@+id/omnibarClickCatcher"
+                            android:layout_width="0dp"
+                            android:layout_height="0dp"
+                            android:background="@android:color/transparent"
+                            android:clickable="true"
+                            android:focusable="false"
+                            android:focusableInTouchMode="false"
+                            android:visibility="gone"
+                            app:layout_constraintBottom_toBottomOf="@id/omnibarTextInput"
+                            app:layout_constraintEnd_toEndOf="@id/omnibarTextInput"
+                            app:layout_constraintStart_toStartOf="@id/omnibarTextInput"
+                            app:layout_constraintTop_toTopOf="@id/omnibarTextInput" />
+
+                    </androidx.constraintlayout.widget.ConstraintLayout>
+
+                    <include
+                        android:id="@+id/findInPage"
+                        layout="@layout/include_fade_omnibar_find_in_page"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:visibility="gone" />
+
+                </com.google.android.material.card.MaterialCardView>
+
+            </androidx.appcompat.widget.Toolbar>
+
+            <Space
+                android:id="@+id/spacer1X"
+                android:layout_width="10dp"
+                android:layout_height="match_parent"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/toolbar"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <FrameLayout
+                android:id="@+id/shieldIconPulseAnimationContainer"
+                android:layout_width="74dp"
+                android:layout_height="match_parent"
+                android:paddingTop="@dimen/experimentalOmnibarCardMarginTop"
+                android:paddingBottom="@dimen/experimentalOmnibarCardMarginBottom"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:documentation="The values of layout width and paddings is tweaked manually to position the pulsing circle
+                precisely on top of the lottie-animated shield, keeping in mind that the added animated ImageView will use Gravity.CENTER.">
+
+                <View
+                    android:id="@+id/placeholder"
+                    android:layout_width="28dp"
+                    android:layout_height="28dp"
+                    android:layout_gravity="center"
+                    android:visibility="invisible"
+                    tools:documentation="This view is a reference for the PulseAnimation.kt.
+                    PulseAnimation class will add a new ImageView to the parent layout, with a Gravity.CENTER, and size equal to the size of this view.
+                    However, the animator will scale the resulting ImageView from 0.95x to 2.0x size of this view.
+                    Keep this in mind when considering clipping - the PulseAnimation will try to disable clipping for all parents in the hierarchy,
+                    but you might start running against views that always have clipping enabled (like material cards), or system UI." />
+
+            </FrameLayout>
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/customTabToolbarContainerWrapper"
+                android:layout_width="0dp"
+                android:layout_height="@dimen/experimentalToolbarSize"
+                android:layout_marginHorizontal="@dimen/keyline_2"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/iconsContainer"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <include
+                    android:id="@+id/customTabToolbarContainer"
+                    layout="@layout/include_custom_tab_toolbar"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:visibility="gone" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/iconsContainer"
+                android:layout_width="wrap_content"
+                android:layout_height="@dimen/toolbarIcon"
+                android:layout_marginTop="@dimen/experimentalOmnibarCardMarginTop"
+                android:layout_marginBottom="@dimen/experimentalOmnibarCardMarginBottom"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/toolbar"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <com.duckduckgo.app.browser.tabswitcher.NewTabSwitcherButton
+                    android:id="@+id/tabsMenu"
+                    android:layout_width="@dimen/toolbarIcon"
+                    android:layout_height="@dimen/toolbarIcon"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toStartOf="@id/browserMenu"
+                    app:layout_constraintStart_toEndOf="@id/fireIconMenu"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <FrameLayout
+                    android:id="@+id/browserMenu"
+                    android:layout_width="@dimen/toolbarIcon"
+                    android:layout_height="@dimen/toolbarIcon"
+                    android:background="@drawable/selectable_item_experimental_background"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/tabsMenu"
+                    app:layout_constraintTop_toTopOf="parent">
+
+                    <ImageView
+                        android:id="@+id/browserMenuImageView"
+                        android:layout_width="@dimen/bottomNavIcon"
+                        android:layout_height="@dimen/bottomNavIcon"
+                        android:layout_gravity="center"
+                        android:contentDescription="@string/browserPopupMenu"
+                        android:scaleType="center"
+                        android:src="@drawable/ic_menu_vertical_24" />
+
+
+                    <View
+                        android:id="@+id/browserMenuHighlight"
+                        android:layout_width="7dp"
+                        android:layout_height="7dp"
+                        android:layout_gravity="end"
+                        android:layout_margin="@dimen/keyline_2"
+                        android:background="@drawable/ic_circle_7_accent_blue"
+                        android:visibility="gone" />
+
+                </FrameLayout>
+
+                <FrameLayout
+                    android:id="@+id/fireIconMenu"
+                    android:layout_width="@dimen/toolbarIcon"
+                    android:layout_height="@dimen/toolbarIcon"
+                    android:background="@drawable/selectable_item_experimental_background"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toStartOf="@id/tabsMenu"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent">
+
+                    <ImageView
+                        android:id="@+id/fireIconImageView"
+                        android:layout_width="@dimen/bottomNavIcon"
+                        android:layout_height="@dimen/bottomNavIcon"
+                        android:layout_gravity="center"
+                        android:contentDescription="@string/fireMenu"
+                        android:scaleType="center"
+                        android:src="@drawable/ic_fire_24" />
+                </FrameLayout>
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </LinearLayout>
+</merge>

--- a/app/src/main/res/layout/view_single_omnibar.xml
+++ b/app/src/main/res/layout/view_single_omnibar.xml
@@ -59,7 +59,7 @@
                     android:layout_marginTop="@dimen/experimentalOmnibarCardMarginTop"
                     android:layout_marginBottom="@dimen/experimentalOmnibarCardMarginBottom"
                     android:transitionName="omnibar_transition"
-                    app:cardElevation="1dp"
+                    app:cardElevation="2dp"
                     app:strokeColor="?daxColorAccentBlue"
                     app:strokeWidth="@dimen/experimentalOmnibarOutlineWidth">
 

--- a/app/src/main/res/values/attrs-omnibar-view.xml
+++ b/app/src/main/res/values/attrs-omnibar-view.xml
@@ -37,6 +37,11 @@
         <attr name="omnibarPosition"/>
     </declare-styleable>
 
+    <!-- SingleOmnibarView-->
+    <declare-styleable name="SingleOmnibarLayout">
+        <attr name="omnibarPosition"/>
+    </declare-styleable>
+
     <declare-styleable name="BrowserNavigationBarView">
         <attr name="showShadows" format="boolean"/>
     </declare-styleable>

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -1459,6 +1459,31 @@ class OmnibarLayoutViewModelTest {
         }
     }
 
+    @Test
+    fun whenFindInPageDismissedThenShowFindInPageIsFalse() = runTest {
+        // First set showFindInPage to true
+        testee.onFindInPageRequested()
+
+        // Then dismiss it
+        testee.onFindInPageDismissed()
+
+        testee.viewState.test {
+            val viewState = awaitItem()
+            assertFalse(viewState.showFindInPage)
+        }
+    }
+
+    @Test
+    fun whenFindInPageRequestedThenShowFindInPageIsTrue() = runTest {
+        // First set showFindInPage to true
+        testee.onFindInPageRequested()
+
+        testee.viewState.test {
+            val viewState = awaitItem()
+            assertTrue(viewState.showFindInPage)
+        }
+    }
+
     private fun givenSiteLoaded(loadedUrl: String) {
         testee.onViewModeChanged(ViewMode.Browser(loadedUrl))
         testee.onExternalStateChange(

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -153,7 +153,6 @@ class OmnibarLayoutViewModelTest {
             visualDesignExperimentDataStore = mockVisualDesignExperimentDataStore,
             senseOfProtectionExperiment = mockSenseOfProtectionExperiment,
             duckChat = duckChat,
-            browserFeatures = browserFeatures,
             addressDisplayFormatter = mockAddressDisplayFormatter,
             settingsDataStore = settingsDataStore,
         )

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -109,7 +109,7 @@ class OmnibarLayoutViewModelTest {
         whenever(tabRepository.flowTabs).thenReturn(flowOf(emptyList()))
         whenever(voiceSearchAvailability.shouldShowVoiceSearch(any(), any(), any(), any())).thenReturn(true)
         whenever(duckPlayer.isDuckPlayerUri(DUCK_PLAYER_URL)).thenReturn(true)
-        whenever(mockVisualDesignExperimentDataStore.isExperimentEnabled).thenReturn(disabledVisualExperimentNavBarStateFlow)
+        whenever(mockVisualDesignExperimentDataStore.isNewDesignEnabled).thenReturn(disabledVisualExperimentNavBarStateFlow)
         whenever(mockVisualDesignExperimentDataStore.isDuckAIPoCEnabled).thenReturn(duckAIPoCStateFlow)
         whenever(duckChat.showInAddressBar).thenReturn(duckChatShowInAddressBarFlow)
         whenever(settingsDataStore.isFullUrlEnabled).thenReturn(true)
@@ -1210,7 +1210,7 @@ class OmnibarLayoutViewModelTest {
 
     @Test
     fun whenDuckChatButtonPressedAndExperimentEnabledThenPixelSent() = runTest {
-        whenever(mockVisualDesignExperimentDataStore.isExperimentEnabled).thenReturn(enabledVisualExperimentNavBarStateFlow)
+        whenever(mockVisualDesignExperimentDataStore.isNewDesignEnabled).thenReturn(enabledVisualExperimentNavBarStateFlow)
         initializeViewModel()
 
         testee.viewState.test {

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/model/OmnibarTypeResolverTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/model/OmnibarTypeResolverTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.omnibar.model
+
+import com.duckduckgo.app.browser.omnibar.model.OmnibarType.FADE
+import com.duckduckgo.app.browser.omnibar.model.OmnibarType.SCROLLING
+import com.duckduckgo.app.browser.omnibar.model.OmnibarType.SINGLE
+import com.duckduckgo.common.ui.experiments.visual.store.VisualDesignExperimentDataStore
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class OmnibarTypeResolverTest {
+
+    private lateinit var testee: OmnibarTypeResolver
+    private val mockExperimentDataStore: VisualDesignExperimentDataStore = mock()
+    private val mockIsNewDesignEnabled = mock<MutableStateFlow<Boolean>>()
+    private val mockIsNewDesignWithoutBottomBarEnabled = mock<MutableStateFlow<Boolean>>()
+
+    @Before
+    fun setup() {
+        whenever(mockExperimentDataStore.isNewDesignEnabled).thenReturn(mockIsNewDesignEnabled)
+        whenever(mockExperimentDataStore.isNewDesignWithoutBottomBarEnabled).thenReturn(mockIsNewDesignWithoutBottomBarEnabled)
+        testee = OmnibarTypeResolver(mockExperimentDataStore)
+    }
+
+    @Test
+    fun whenNewDesignIsEnabledThenOmnibarTypeIsFade() {
+        whenever(mockIsNewDesignEnabled.value).thenReturn(true)
+        whenever(mockIsNewDesignWithoutBottomBarEnabled.value).thenReturn(false)
+
+        val omnibarType = testee.getOmnibarType()
+
+        assertEquals(FADE, omnibarType)
+    }
+
+    @Test
+    fun whenNewDesignWithoutBottomBarIsEnabledThenOmnibarTypeIsSingle() {
+        whenever(mockIsNewDesignEnabled.value).thenReturn(false)
+        whenever(mockIsNewDesignWithoutBottomBarEnabled.value).thenReturn(true)
+
+        val omnibarType = testee.getOmnibarType()
+
+        assertEquals(SINGLE, omnibarType)
+    }
+
+    @Test
+    fun whenBothNewDesignFlagsAreEnabledThenOmnibarWithNabBarTakesPrecedent() {
+        whenever(mockIsNewDesignEnabled.value).thenReturn(true)
+        whenever(mockIsNewDesignWithoutBottomBarEnabled.value).thenReturn(true)
+
+        val omnibarType = testee.getOmnibarType()
+
+        assertEquals(FADE, omnibarType)
+    }
+
+    @Test
+    fun whenNoExperimentIsEnabledThenOmnibarTypeIsScrolling() {
+        whenever(mockIsNewDesignEnabled.value).thenReturn(false)
+        whenever(mockIsNewDesignWithoutBottomBarEnabled.value).thenReturn(false)
+
+        val omnibarType = testee.getOmnibarType()
+
+        assertEquals(SCROLLING, omnibarType)
+    }
+}
+

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/model/OmnibarTypeResolverTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/model/OmnibarTypeResolverTest.kt
@@ -81,4 +81,3 @@ class OmnibarTypeResolverTest {
         assertEquals(SCROLLING, omnibarType)
     }
 }
-

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/model/OmnibarTypeResolverTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/model/OmnibarTypeResolverTest.kt
@@ -62,7 +62,7 @@ class OmnibarTypeResolverTest {
     }
 
     @Test
-    fun whenBothNewDesignFlagsAreEnabledThenOmnibarWithNabBarTakesPrecedent() {
+    fun whenBothNewDesignFlagsAreEnabledThenOmnibarWithNabBarTakesPrecedence() {
         whenever(mockIsNewDesignEnabled.value).thenReturn(true)
         whenever(mockIsNewDesignWithoutBottomBarEnabled.value).thenReturn(true)
 

--- a/app/src/test/java/com/duckduckgo/app/browser/senseofprotection/SenseOfProtectionExperimentImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/senseofprotection/SenseOfProtectionExperimentImplTest.kt
@@ -84,7 +84,7 @@ class SenseOfProtectionExperimentImplTest {
 
     @Test
     fun `when user is new and and visual design updates not enabled then user can be enrolled`() = runTest {
-        whenever(mockExperimentDataStore.isExperimentEnabled).thenReturn(MutableStateFlow(false))
+        whenever(mockExperimentDataStore.isNewDesignEnabled).thenReturn(MutableStateFlow(false))
         fakeUserBrowserProperties.setDaysSinceInstalled(28)
         fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25().setRawStoredState(
             State(
@@ -102,7 +102,7 @@ class SenseOfProtectionExperimentImplTest {
 
     @Test
     fun `when user is new and and visual design updates not enabled then user can't be enrolled`() = runTest {
-        whenever(mockExperimentDataStore.isExperimentEnabled).thenReturn(MutableStateFlow(true))
+        whenever(mockExperimentDataStore.isNewDesignEnabled).thenReturn(MutableStateFlow(true))
         fakeUserBrowserProperties.setDaysSinceInstalled(28)
         fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25().setRawStoredState(
             State(
@@ -120,7 +120,7 @@ class SenseOfProtectionExperimentImplTest {
 
     @Test
     fun `when user is new and experiment is enabled but for different cohort then isEnabled returns false`() = runTest {
-        whenever(mockExperimentDataStore.isExperimentEnabled).thenReturn(MutableStateFlow(false))
+        whenever(mockExperimentDataStore.isNewDesignEnabled).thenReturn(MutableStateFlow(false))
         fakeUserBrowserProperties.setDaysSinceInstalled(20)
         fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25().setRawStoredState(
             State(
@@ -136,7 +136,7 @@ class SenseOfProtectionExperimentImplTest {
 
     @Test
     fun `when user is new and experiment is disabled then isEnabled returns false`() = runTest {
-        whenever(mockExperimentDataStore.isExperimentEnabled).thenReturn(MutableStateFlow(false))
+        whenever(mockExperimentDataStore.isNewDesignEnabled).thenReturn(MutableStateFlow(false))
         fakeUserBrowserProperties.setDaysSinceInstalled(10)
         fakeSenseOfProtectionToggles.senseOfProtectionNewUserExperiment27May25().setRawStoredState(
             State(

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -195,7 +195,7 @@ class TabSwitcherViewModelTest {
         }
         whenever(mockTabRepository.tabSwitcherData).thenReturn(flowOf(tabSwitcherData))
 
-        whenever(mockVisualDesignExperimentDataStore.isExperimentEnabled).thenReturn(
+        whenever(mockVisualDesignExperimentDataStore.isNewDesignEnabled).thenReturn(
             defaultVisualExperimentStateFlow,
         )
         whenever(duckChatMock.showInBrowserMenu).thenReturn(MutableStateFlow(false))

--- a/common/common-ui-internal/src/main/java/com/duckduckgo/common/ui/internal/experiments/visual/VisualDesignExperimentViewModel.kt
+++ b/common/common-ui-internal/src/main/java/com/duckduckgo/common/ui/internal/experiments/visual/VisualDesignExperimentViewModel.kt
@@ -60,7 +60,7 @@ class VisualDesignExperimentViewModel @Inject constructor(
 
     init {
         combine(
-            visualDesignExperimentDataStore.isExperimentEnabled,
+            visualDesignExperimentDataStore.isNewDesignEnabled,
             visualDesignExperimentDataStore.isDuckAIPoCEnabled,
             visualUpdatesDesignExperimentConflictChecker.anyConflictingExperimentEnabled,
         ) { isExperimentEnabled, isDuckAIPoC, anyConflictingExperimentEnabled ->

--- a/common/common-ui-internal/src/main/res/values/donottranslate.xml
+++ b/common/common-ui-internal/src/main/res/values/donottranslate.xml
@@ -18,7 +18,7 @@
 
     <!-- Appearance -->
     <string name="experimentalUISettings">Visual design updates from O-A</string>
-    <string name="experimentalUITitle">Enable Visual design updates</string>
+    <string name="experimentalUITitle">Enable new UI design with the navigation bar</string>
     <string name="experimentalUIMessage">This feature is in active development, intended for feedback purposes.</string>
     <string name="experimentalUIWarmColorsTitle">Use Warm colors palette</string>
     <string name="experimentalUIWarmColorsMessage">When disabled, it uses Cool colors instead.</string>

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/experiments/visual/ExperimentalUIThemingFeature.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/experiments/visual/ExperimentalUIThemingFeature.kt
@@ -34,4 +34,7 @@ interface ExperimentalUIThemingFeature {
 
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun visualUpdatesFeature(): Toggle
+
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun visualUpdatesWithoutBottomBarFeature(): Toggle
 }

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/experiments/visual/store/VisualDesignExperimentDataStore.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/experiments/visual/store/VisualDesignExperimentDataStore.kt
@@ -23,7 +23,13 @@ interface VisualDesignExperimentDataStore {
     /**
      * State flow which returns `true` if the feature flag for the experiment is enabled and there are no conflicting experiments detected.
      */
-    val isExperimentEnabled: StateFlow<Boolean>
+    val isNewDesignEnabled: StateFlow<Boolean>
+
+    /**
+     * State flow which returns `true` if the feature flag for the new design without the bottom navigation bar is enabled
+     * and there are no conflicting experiments detected (the full new design with the bottom bar).
+     */
+    val isNewDesignWithoutBottomBarEnabled: StateFlow<Boolean>
 
     /**
      * State flow which returns `true` if the feature flag for the Duck AI PoC is enabled and there are no conflicting experiments detected.

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/experiments/visual/store/VisualDesignExperimentDataStoreImpl.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/experiments/visual/store/VisualDesignExperimentDataStoreImpl.kt
@@ -59,7 +59,7 @@ class VisualDesignExperimentDataStoreImpl @Inject constructor(
     )
 
     override val isNewDesignWithoutBottomBarEnabled: StateFlow<Boolean> = combine(isNewDesignEnabled, _newDesignWithoutBottomBarFeatureFlagEnabled) {
-        withBottomBar, withoutBottomBar ->
+            withBottomBar, withoutBottomBar ->
         !withBottomBar && withoutBottomBar
     }.stateIn(
         scope = appCoroutineScope,

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/store/ThemingSharedPreferences.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/store/ThemingSharedPreferences.kt
@@ -45,7 +45,8 @@ class ThemingSharedPreferences @Inject constructor(
             savedValue,
             DuckDuckGoTheme.SYSTEM_DEFAULT,
             context.isInNightMode(),
-            visualDesignExperimentDataStore.isExperimentEnabled.value,
+            visualDesignExperimentDataStore.isNewDesignEnabled.value ||
+                visualDesignExperimentDataStore.isNewDesignWithoutBottomBarEnabled.value,
         )
     }
 
@@ -70,23 +71,23 @@ class ThemingSharedPreferences @Inject constructor(
             value: String?,
             defValue: DuckDuckGoTheme,
             isInNightMode: Boolean,
-            isExperimentEnabled: Boolean,
+            isNewDesignEnabled: Boolean,
         ) =
             when (value) {
-                THEME_LIGHT -> if (isExperimentEnabled) {
+                THEME_LIGHT -> if (isNewDesignEnabled) {
                     DuckDuckGoTheme.EXPERIMENT_LIGHT
                 } else {
                     DuckDuckGoTheme.LIGHT
                 }
 
-                THEME_DARK -> if (isExperimentEnabled) {
+                THEME_DARK -> if (isNewDesignEnabled) {
                     DuckDuckGoTheme.EXPERIMENT_DARK
                 } else {
                     DuckDuckGoTheme.DARK
                 }
 
                 else ->
-                    if (isExperimentEnabled) {
+                    if (isNewDesignEnabled) {
                         if (isInNightMode) {
                             DuckDuckGoTheme.EXPERIMENT_DARK
                         } else {

--- a/common/common-ui/src/main/res/values/design-experiments-dimens.xml
+++ b/common/common-ui/src/main/res/values/design-experiments-dimens.xml
@@ -25,6 +25,8 @@
     <dimen name="experimentalToolbarContainerPaddingTopWhenAtBottom">8dp</dimen>
     <dimen name="experimentalToolbarContainerPaddingHorizontalWhenAtBottom">2dp</dimen>
     <dimen name="experimentalOmnibarCardMarginHorizontal">16dp</dimen>
+    <dimen name="experimentalOmnibarCardMarginEnd">6dp</dimen>
+    <dimen name="experimentalOmnibarCardFocusedMarginEnd">16dp</dimen>
     <dimen name="experimentalOmnibarCardMarginTop">4dp</dimen>
     <dimen name="experimentalOmnibarCardMarginBottom">12dp</dimen>
     <dimen name="experimentalOmnibarCardFocusedMarginHorizontal">14dp</dimen>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1210552742244184?focus=true

### Description

This PR uses the new UI design theme and applies it to the existing omnibar layout.

### Steps to test this PR

_Input box animation_
- [ ] Go to dev settings and enable the `visualUpdatesWithoutBottomBarFeature` feature flag
- [ ] Make sure the "Enable new UI with the navigation bar" in the Experimental UI settings is disabled, as that takes precedence
- [ ] Go to the browser
- [ ] Verify the new UI design theme is shown with the original omnibar layout (no bottom bar, toobar buttons next to the input box)
- [ ] Tap on the input box to add focus
- [ ] Notice the input box expands, hiding the toolbar button
- [ ] Tap on the back arrow
- [ ] Notice the input box contracts
- [ ] Go to the menu and select Find in Page
- [ ] Notice the input box expands and it becomes a search box
- [ ] Tap on the X to close it
- [ ] Notice the input box returns to the contracted state

_Bottom potision smoke test_
- [ ] Switch the omnibar to the bottom position in the Appearance settings
- [ ] Verify the omnibar looks and behaves as expected

_Browser smoke testing_
- [ ] Smoke test searching and website navigation
