### PR TITLE
Update content scope scripts to version 10.1.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
@@ -996,7 +996,7 @@
      * @param {ImportMeta['injectName']} [params.injectName] - application platform
      * @param {boolean} [params.willThrow] - whether the application will simulate an error
      * @param {boolean} [params.debugState] - whether to show debugging UI
-     * @param {string} [params.locale] - for applications strings
+     * @param {keyof typeof import('./utils').translationsLocales} [params.locale] - for applications strings and numbers formatting
      * @param {number} [params.textLength] - what ratio of text should be used. Set a number higher than 1 to have longer strings for testing
      */
     constructor({
@@ -1632,12 +1632,21 @@
       "windows"
     ),
     willThrow: false,
+    /** @type {keyof typeof import('../utils').translationsLocales} */
+    locale: "en",
     /** @type {import('../environment').Environment['env']} */
     env: "production"
   });
   var THEME_QUERY = "(prefers-color-scheme: dark)";
   var REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
-  function EnvironmentProvider({ children, debugState, env = "production", willThrow = false, injectName = "windows" }) {
+  function EnvironmentProvider({
+    children,
+    debugState,
+    env = "production",
+    willThrow = false,
+    injectName = "windows",
+    locale = "en"
+  }) {
     const [theme, setTheme] = d2(window.matchMedia(THEME_QUERY).matches ? "dark" : "light");
     const [isReducedMotion, setReducedMotion] = d2(window.matchMedia(REDUCED_MOTION_QUERY).matches);
     y2(() => {
@@ -1669,7 +1678,8 @@
           isDarkMode: theme === "dark",
           injectName,
           willThrow,
-          env
+          env,
+          locale
         }
       },
       children

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.3.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#9.11.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.1.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1747996876"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#577f72869bad000f485a8d60e494380fea9f08b4",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#2e1d9f562e98d4a6caf8eaedf80e168eadf297da",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -89,14 +89,14 @@
       "license": "Apache-2.0"
     },
     "node_modules/@ghostery/adblocker": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.7.0.tgz",
-      "integrity": "sha512-OzOKr8PwT6oE5qh5dpF9qJgmNUKlK/781Pm18oEMCho+6CSseCWrTk5+m+2QNGE3Fs+QjQb7DZdMoQisZ6r3uA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.8.0.tgz",
+      "integrity": "sha512-fqPYYYoa+Lonc5RLQiOnzTfWKoi5nXkBwTQUPBaUsUifHTXHzkfgPsyIGNx8YNqcvdbDoIrReO3hIbIFf6KiWA==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-content": "^2.7.0",
-        "@ghostery/adblocker-extended-selectors": "^2.7.0",
-        "@ghostery/url-parser": "^1.2.0",
+        "@ghostery/adblocker-content": "^2.8.0",
+        "@ghostery/adblocker-extended-selectors": "^2.8.0",
+        "@ghostery/url-parser": "^1.3.0",
         "@remusao/guess-url-type": "^2.1.0",
         "@remusao/small": "^2.1.0",
         "@remusao/smaz": "^2.2.0",
@@ -104,18 +104,18 @@
       }
     },
     "node_modules/@ghostery/adblocker-content": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.7.0.tgz",
-      "integrity": "sha512-NZN4XyQ2bXBC86qFEevw8GEXoVXuzAvvj9urgHu+Ud/JfAzW5agaLUoXNz5gT/ZU6fVZScwOVvbL48AI66JUUg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.8.0.tgz",
+      "integrity": "sha512-s16EMhMmEcCkGalPcoaJB+UYhF7N91MibRSPCx0eNsFdew43zZnY3SPdatnZODk0qSCFoxa0pMCGtHJ6PypxWA==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-extended-selectors": "^2.7.0"
+        "@ghostery/adblocker-extended-selectors": "^2.8.0"
       }
     },
     "node_modules/@ghostery/adblocker-extended-selectors": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.7.0.tgz",
-      "integrity": "sha512-6lmdm3ydxpiIGwwsD8kjcFPY3IPHkveQaunZW6bHaAbN7a1eYhPZZRjNmNjhwHvu+Noa5eb2bJ4x3YnFp2TKpQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.8.0.tgz",
+      "integrity": "sha512-+iE4fd1pVxDD+3G6nfflk242CyW6XBYyZNbJmjhbImmqB+wkSZQsa+SwX55SSk7bPGI91tHsT/UPRJir2SjvTA==",
       "license": "MPL-2.0"
     },
     "node_modules/@ghostery/url-parser": {
@@ -294,9 +294,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.3.tgz",
-      "integrity": "sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==",
+      "version": "24.0.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.4.tgz",
+      "integrity": "sha512-ulyqAkrhnuNq9pB76DRBTkcS6YsmDALy6Ua63V8OhrOBgbcYt6IOdzpw5P1+dyRIyMerzLkeYWBeOXPpA9GMAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.3.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#9.11.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.1.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1747996876"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass