### PR TITLE
Extract Duck.ai feature state to DuckAiFeatureState public API

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -231,6 +231,7 @@ import com.duckduckgo.daxprompts.impl.ReactivateUsersExperiment
 import com.duckduckgo.downloads.api.DownloadStateListener
 import com.duckduckgo.downloads.api.FileDownloader
 import com.duckduckgo.downloads.api.FileDownloader.PendingFileDownload
+import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.impl.helper.DuckChatJSHelper
 import com.duckduckgo.duckchat.impl.helper.RealDuckChatJSHelper.Companion.DUCK_CHAT_FEATURE_NAME
@@ -443,6 +444,8 @@ class BrowserTabViewModelTest {
 
     private val mockDuckChat: DuckChat = mock()
 
+    private val mockDuckAiFeatureState: DuckAiFeatureState = mock()
+
     private val mockAppBuildConfig: AppBuildConfig = mock()
 
     private val mockDuckDuckGoUrlDetector: DuckDuckGoUrlDetector = mock()
@@ -643,7 +646,7 @@ class BrowserTabViewModelTest {
         whenever(mockSitePermissionsManager.hasSitePermanentPermission(any(), any())).thenReturn(false)
         whenever(mockToggleReports.shouldPrompt()).thenReturn(false)
         whenever(subscriptions.isEligible()).thenReturn(false)
-        whenever(mockDuckChat.showInBrowserMenu).thenReturn(MutableStateFlow(false))
+        whenever(mockDuckAiFeatureState.showPopupMenuShortcut).thenReturn(MutableStateFlow(false))
         whenever(mockDuckChat.showInputScreen).thenReturn(MutableStateFlow(false))
 
         remoteMessagingModel = givenRemoteMessagingModel(mockRemoteMessagingRepository, mockPixel, coroutineRule.testDispatcherProvider)
@@ -764,6 +767,7 @@ class BrowserTabViewModelTest {
             httpErrorPixels = { mockHttpErrorPixels },
             duckPlayer = mockDuckPlayer,
             duckChat = mockDuckChat,
+            duckAiFeatureState = mockDuckAiFeatureState,
             duckPlayerJSHelper = DuckPlayerJSHelper(
                 mockDuckPlayer,
                 mockAppBuildConfig,
@@ -921,7 +925,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenViewBecomesVisibleAndDuckChatDisabledThenDuckChatNotVisible() {
-        whenever(mockDuckChat.showInBrowserMenu).thenReturn(MutableStateFlow(false))
+        whenever(mockDuckAiFeatureState.showPopupMenuShortcut).thenReturn(MutableStateFlow(false))
         setBrowserShowing(true)
         testee.onViewVisible()
         assertFalse(browserViewState().showDuckChatOption)
@@ -929,7 +933,7 @@ class BrowserTabViewModelTest {
 
     @Test
     fun whenViewBecomesVisibleAndDuckChatEnabledThenDuckChatIsVisible() {
-        whenever(mockDuckChat.showInBrowserMenu).thenReturn(MutableStateFlow(true))
+        whenever(mockDuckAiFeatureState.showPopupMenuShortcut).thenReturn(MutableStateFlow(true))
         setBrowserShowing(true)
         testee.onViewVisible()
         assertTrue(browserViewState().showDuckChatOption)

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -647,7 +647,7 @@ class BrowserTabViewModelTest {
         whenever(mockToggleReports.shouldPrompt()).thenReturn(false)
         whenever(subscriptions.isEligible()).thenReturn(false)
         whenever(mockDuckAiFeatureState.showPopupMenuShortcut).thenReturn(MutableStateFlow(false))
-        whenever(mockDuckChat.showInputScreen).thenReturn(MutableStateFlow(false))
+        whenever(mockDuckAiFeatureState.showInputScreen).thenReturn(MutableStateFlow(false))
 
         remoteMessagingModel = givenRemoteMessagingModel(mockRemoteMessagingRepository, mockPixel, coroutineRule.testDispatcherProvider)
 
@@ -879,7 +879,7 @@ class BrowserTabViewModelTest {
     fun whenViewBecomesVisibleAndDuckAIPoCIsEnabledThenKeyboardNotShown() = runTest {
         whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
         whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(true)
-        whenever(mockDuckChat.showInputScreen).thenReturn(MutableStateFlow(true))
+        whenever(mockDuckAiFeatureState.showInputScreen).thenReturn(MutableStateFlow(true))
 
         testee.onViewVisible()
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -99,6 +99,7 @@ import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.playstore.PlayStoreUtils
 import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.impl.ui.DuckChatWebViewFragment
 import com.duckduckgo.duckchat.impl.ui.DuckChatWebViewFragment.Companion.KEY_DUCK_AI_URL
@@ -180,6 +181,9 @@ open class BrowserActivity : DuckDuckGoActivity() {
 
     @Inject
     lateinit var duckChat: DuckChat
+
+    @Inject
+    lateinit var duckAiFeatureState: DuckAiFeatureState
 
     @Inject
     lateinit var syncUrlIdentifier: SyncUrlIdentifier
@@ -1228,7 +1232,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
                 binding.bottomMockupToolbar.appBarLayoutMockup.gone()
                 binding.topMockupToolbar.appBarLayoutMockup.gone()
 
-                if (!duckChat.showOmnibarShortcutOnNtpAndOnFocus.value) {
+                if (!duckAiFeatureState.showOmnibarShortcutOnNtpAndOnFocus.value) {
                     experimentalToolbarMockupBinding.aiChatIconMockup.isVisible = false
                 }
             } else {
@@ -1237,7 +1241,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
                 binding.topMockupToolbar.appBarLayoutMockup.gone()
                 binding.bottomMockupToolbar.appBarLayoutMockup.gone()
 
-                if (!duckChat.showOmnibarShortcutOnNtpAndOnFocus.value) {
+                if (!duckAiFeatureState.showOmnibarShortcutOnNtpAndOnFocus.value) {
                     experimentalToolbarMockupBottomBinding.aiChatIconMockup.isVisible = false
                 }
             }
@@ -1258,7 +1262,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
                 }
             }
 
-            toolbarMockupBinding.aiChatIconMenuMockup.isVisible = duckChat.showOmnibarShortcutOnNtpAndOnFocus.value && duckChat.isEnabledInBrowser()
+            toolbarMockupBinding.aiChatIconMenuMockup.isVisible = duckAiFeatureState.showOmnibarShortcutOnNtpAndOnFocus.value && duckChat.isEnabledInBrowser()
         }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -1262,7 +1262,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
                 }
             }
 
-            toolbarMockupBinding.aiChatIconMenuMockup.isVisible = duckAiFeatureState.showOmnibarShortcutOnNtpAndOnFocus.value && duckChat.isEnabledInBrowser()
+            toolbarMockupBinding.aiChatIconMenuMockup.isVisible = duckAiFeatureState.showOmnibarShortcutInAllStates.value
         }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -1228,7 +1228,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
                 binding.bottomMockupToolbar.appBarLayoutMockup.gone()
                 binding.topMockupToolbar.appBarLayoutMockup.gone()
 
-                if (!duckChat.showInAddressBar.value) {
+                if (!duckChat.showOmnibarShortcutOnNtpAndOnFocus.value) {
                     experimentalToolbarMockupBinding.aiChatIconMockup.isVisible = false
                 }
             } else {
@@ -1237,7 +1237,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
                 binding.topMockupToolbar.appBarLayoutMockup.gone()
                 binding.bottomMockupToolbar.appBarLayoutMockup.gone()
 
-                if (!duckChat.showInAddressBar.value) {
+                if (!duckChat.showOmnibarShortcutOnNtpAndOnFocus.value) {
                     experimentalToolbarMockupBottomBinding.aiChatIconMockup.isVisible = false
                 }
             }
@@ -1258,7 +1258,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
                 }
             }
 
-            toolbarMockupBinding.aiChatIconMenuMockup.isVisible = duckChat.showInAddressBar.value && duckChat.isEnabledInBrowser()
+            toolbarMockupBinding.aiChatIconMenuMockup.isVisible = duckChat.showOmnibarShortcutOnNtpAndOnFocus.value && duckChat.isEnabledInBrowser()
         }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2876,7 +2876,7 @@ class BrowserTabViewModel @Inject constructor(
     private fun showOrHideKeyboard(cta: Cta?) {
         // we hide the keyboard when showing a DialogCta and HomeCta type in the home screen otherwise we show it
         val shouldHideKeyboard = cta is HomePanelCta || cta is DaxBubbleCta.DaxPrivacyProCta || isBuckExperimentEnabledAndDaxEndCta(cta) ||
-            duckChat.showInputScreen.value || currentBrowserViewState().lastQueryOrigin == QueryOrigin.FromBookmark
+            duckAiFeatureState.showInputScreen.value || currentBrowserViewState().lastQueryOrigin == QueryOrigin.FromBookmark
         command.value = if (shouldHideKeyboard) HideKeyboard else ShowKeyboard
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -309,6 +309,7 @@ import com.duckduckgo.downloads.api.DownloadCommand
 import com.duckduckgo.downloads.api.DownloadStateListener
 import com.duckduckgo.downloads.api.FileDownloader
 import com.duckduckgo.downloads.api.FileDownloader.PendingFileDownload
+import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.impl.helper.DuckChatJSHelper
 import com.duckduckgo.duckchat.impl.helper.RealDuckChatJSHelper.Companion.DUCK_CHAT_FEATURE_NAME
@@ -448,6 +449,7 @@ class BrowserTabViewModel @Inject constructor(
     private val httpErrorPixels: Lazy<HttpErrorPixels>,
     private val duckPlayer: DuckPlayer,
     private val duckChat: DuckChat,
+    private val duckAiFeatureState: DuckAiFeatureState,
     private val duckPlayerJSHelper: DuckPlayerJSHelper,
     private val duckChatJSHelper: DuckChatJSHelper,
     private val refreshPixelSender: RefreshPixelSender,
@@ -890,7 +892,7 @@ class BrowserTabViewModel @Inject constructor(
         }
 
         browserViewState.value = currentBrowserViewState().copy(
-            showDuckChatOption = duckChat.showInBrowserMenu.value,
+            showDuckChatOption = duckAiFeatureState.showPopupMenuShortcut.value,
         )
 
         viewModelScope.launch {
@@ -2680,7 +2682,7 @@ class BrowserTabViewModel @Inject constructor(
         withContext(dispatchers.io()) {
             val addToHomeSupported = addToHomeCapabilityDetector.isAddToHomeSupported()
             val showAutofill = autofillCapabilityChecker.canAccessCredentialManagementScreen()
-            val showDuckChat = duckChat.showInBrowserMenu.value
+            val showDuckChat = duckAiFeatureState.showPopupMenuShortcut.value
 
             withContext(dispatchers.main()) {
                 browserViewState.value = currentBrowserViewState().copy(

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -102,6 +102,7 @@ import com.duckduckgo.common.utils.FragmentViewModelFactory
 import com.duckduckgo.common.utils.extensions.replaceTextChangedListener
 import com.duckduckgo.common.utils.text.TextChangedWatcher
 import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
 import com.google.android.material.appbar.AppBarLayout
 import javax.inject.Inject
@@ -174,6 +175,9 @@ open class OmnibarLayout @JvmOverloads constructor(
 
     @Inject
     lateinit var duckChat: DuckChat
+
+    @Inject
+    lateinit var duckAiFeatureState: DuckAiFeatureState
 
     @Inject
     lateinit var dispatchers: DispatcherProvider
@@ -697,7 +701,7 @@ open class OmnibarLayout @JvmOverloads constructor(
     }
 
     private fun renderHint(viewState: ViewState) {
-        if (!viewState.isVisualDesignExperimentEnabled && viewState.viewMode is NewTab && duckChat.showOmnibarShortcutOnNtpAndOnFocus.value) {
+        if (!viewState.isVisualDesignExperimentEnabled && viewState.viewMode is NewTab && duckAiFeatureState.showOmnibarShortcutOnNtpAndOnFocus.value) {
             omnibarTextInput.hint = context.getString(R.string.search)
         } else {
             omnibarTextInput.hint = context.getString(R.string.omnibarInputHint)

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -701,7 +701,10 @@ open class OmnibarLayout @JvmOverloads constructor(
     }
 
     private fun renderHint(viewState: ViewState) {
-        if (!viewState.isVisualDesignExperimentEnabled && viewState.viewMode is NewTab && duckAiFeatureState.showOmnibarShortcutOnNtpAndOnFocus.value) {
+        if (!viewState.isVisualDesignExperimentEnabled &&
+            viewState.viewMode is NewTab &&
+            duckAiFeatureState.showOmnibarShortcutOnNtpAndOnFocus.value
+        ) {
             omnibarTextInput.hint = context.getString(R.string.search)
         } else {
             omnibarTextInput.hint = context.getString(R.string.omnibarInputHint)

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -697,7 +697,7 @@ open class OmnibarLayout @JvmOverloads constructor(
     }
 
     private fun renderHint(viewState: ViewState) {
-        if (!viewState.isVisualDesignExperimentEnabled && viewState.viewMode is NewTab && duckChat.showInAddressBar.value) {
+        if (!viewState.isVisualDesignExperimentEnabled && viewState.viewMode is NewTab && duckChat.showOmnibarShortcutOnNtpAndOnFocus.value) {
             omnibarTextInput.hint = context.getString(R.string.search)
         } else {
             omnibarTextInput.hint = context.getString(R.string.omnibarInputHint)

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -59,6 +59,7 @@ import com.duckduckgo.browser.api.UserBrowserProperties
 import com.duckduckgo.common.ui.experiments.visual.store.VisualDesignExperimentDataStore
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.duckplayer.api.DuckPlayer
@@ -95,6 +96,7 @@ class OmnibarLayoutViewModel @Inject constructor(
     private val visualDesignExperimentDataStore: VisualDesignExperimentDataStore,
     private val senseOfProtectionExperiment: SenseOfProtectionExperiment,
     private val duckChat: DuckChat,
+    private val duckAiFeatureState: DuckAiFeatureState,
     private val addressDisplayFormatter: AddressDisplayFormatter,
     private val settingsDataStore: SettingsDataStore,
 ) : ViewModel() {
@@ -183,7 +185,7 @@ class OmnibarLayoutViewModel @Inject constructor(
 
     init {
         logVoiceSearchAvailability()
-        duckChat.showInputScreen.onEach { inputScreenEnabled ->
+        duckAiFeatureState.showInputScreen.onEach { inputScreenEnabled ->
             _viewState.update {
                 it.copy(
                     showClickCatcher = inputScreenEnabled,

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -103,7 +103,7 @@ class OmnibarLayoutViewModel @Inject constructor(
 
     private val _viewState = MutableStateFlow(
         ViewState(
-            showChatMenu = duckChat.showOmnibarShortcutOnNtpAndOnFocus.value && duckChat.isEnabledInBrowser(),
+            showChatMenu = duckAiFeatureState.showOmnibarShortcutOnNtpAndOnFocus.value && duckChat.isEnabledInBrowser(),
         ),
     )
 
@@ -112,15 +112,15 @@ class OmnibarLayoutViewModel @Inject constructor(
         tabRepository.flowTabs,
         defaultBrowserPromptsExperiment.highlightPopupMenu,
         visualDesignExperimentDataStore.isExperimentEnabled,
-        duckChat.showOmnibarShortcutOnNtpAndOnFocus,
-    ) { state, tabs, highlightOverflowMenu, isVisualDesignExperimentEnabled, showInAddressBar ->
+        duckAiFeatureState.showOmnibarShortcutOnNtpAndOnFocus,
+    ) { state, tabs, highlightOverflowMenu, isVisualDesignExperimentEnabled, showOmnibarShortcutOnNtpAndOnFocus ->
         state.copy(
             shouldUpdateTabsCount = tabs.size != state.tabCount && tabs.isNotEmpty(),
             tabCount = tabs.size,
             hasUnreadTabs = tabs.firstOrNull { !it.viewed } != null,
             showBrowserMenuHighlight = highlightOverflowMenu,
             isVisualDesignExperimentEnabled = isVisualDesignExperimentEnabled,
-            showChatMenu = showInAddressBar && state.viewMode !is CustomTab &&
+            showChatMenu = showOmnibarShortcutOnNtpAndOnFocus && state.viewMode !is CustomTab &&
                 (state.viewMode is NewTab || state.hasFocus && state.omnibarText.isNotBlank() || duckChat.isEnabledInBrowser()),
         )
     }.flowOn(dispatcherProvider.io()).stateIn(viewModelScope, SharingStarted.Eagerly, _viewState.value)

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -101,7 +101,7 @@ class OmnibarLayoutViewModel @Inject constructor(
 
     private val _viewState = MutableStateFlow(
         ViewState(
-            showChatMenu = duckChat.showInAddressBar.value && duckChat.isEnabledInBrowser(),
+            showChatMenu = duckChat.showOmnibarShortcutOnNtpAndOnFocus.value && duckChat.isEnabledInBrowser(),
         ),
     )
 
@@ -110,7 +110,7 @@ class OmnibarLayoutViewModel @Inject constructor(
         tabRepository.flowTabs,
         defaultBrowserPromptsExperiment.highlightPopupMenu,
         visualDesignExperimentDataStore.isExperimentEnabled,
-        duckChat.showInAddressBar,
+        duckChat.showOmnibarShortcutOnNtpAndOnFocus,
     ) { state, tabs, highlightOverflowMenu, isVisualDesignExperimentEnabled, showInAddressBar ->
         state.copy(
             shouldUpdateTabsCount = tabs.size != state.tabCount && tabs.isNotEmpty(),

--- a/app/src/main/java/com/duckduckgo/app/global/shortcut/AppShortcutCreator.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/shortcut/AppShortcutCreator.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.appbuildconfig.api.isInternalBuild
 import com.duckduckgo.common.ui.themepreview.ui.AppComponentsActivity
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.savedsites.impl.bookmarks.BookmarksActivity
 import com.squareup.anvil.annotations.ContributesTo
@@ -79,11 +80,12 @@ class AppShortcutCreator @Inject constructor(
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val appBuildConfig: AppBuildConfig,
     private val duckChat: DuckChat,
+    private val duckAiFeatureState: DuckAiFeatureState,
     private val dispatchers: DispatcherProvider,
 ) {
 
     init {
-        duckChat.showInBrowserMenu
+        duckAiFeatureState.showPopupMenuShortcut
             .onEach { refreshAppShortcuts() }
             .flowOn(dispatchers.io())
             .launchIn(appCoroutineScope)
@@ -97,7 +99,7 @@ class AppShortcutCreator @Inject constructor(
             shortcutList.add(buildClearDataShortcut(context))
             shortcutList.add(buildBookmarksShortcut(context))
 
-            if (duckChat.showInBrowserMenu.value) {
+            if (duckAiFeatureState.showPopupMenuShortcut.value) {
                 shortcutList.add(buildDuckChatShortcut(context))
             } else if (appBuildConfig.isInternalBuild()) {
                 shortcutList.add(buildAndroidDesignSystemShortcut(context))

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -92,6 +92,7 @@ import com.duckduckgo.common.ui.view.toDp
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
 import java.util.ArrayList
 import javax.inject.Inject
@@ -151,6 +152,9 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
 
     @Inject
     lateinit var duckChat: DuckChat
+
+    @Inject
+    lateinit var duckAiFeatureState: DuckAiFeatureState
 
     @Inject
     lateinit var tabSwitcherAnimationFeature: TabSwitcherAnimationFeature
@@ -681,7 +685,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
 
     override fun onPrepareOptionsMenu(menu: Menu?): Boolean {
         val duckChatMenuItem = menu?.findItem(R.id.duckChat)
-        duckChatMenuItem?.isVisible = duckChat.showInBrowserMenu.value
+        duckChatMenuItem?.isVisible = duckAiFeatureState.showPopupMenuShortcut.value
 
         return super.onPrepareOptionsMenu(menu)
     }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -61,6 +61,7 @@ import com.duckduckgo.common.ui.tabs.SwipingTabsFeatureProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.SingleLiveEvent
 import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.savedsites.api.SavedSitesRepository
@@ -93,6 +94,7 @@ class TabSwitcherViewModel @Inject constructor(
     private val pixel: Pixel,
     private val swipingTabsFeature: SwipingTabsFeatureProvider,
     private val duckChat: DuckChat,
+    private val duckAiFeatureState: DuckAiFeatureState,
     private val tabManagerFeatureFlags: TabManagerFeatureFlags,
     private val senseOfProtectionExperiment: SenseOfProtectionExperiment,
     private val webTrackersBlockedAppRepository: WebTrackersBlockedAppRepository,
@@ -130,7 +132,7 @@ class TabSwitcherViewModel @Inject constructor(
         tabSwitcherItemsFlow,
         tabRepository.tabSwitcherData,
         visualDesignExperimentDataStore.isExperimentEnabled,
-        duckChat.showInBrowserMenu,
+        duckAiFeatureState.showPopupMenuShortcut,
     ) { viewState, tabSwitcherItems, tabSwitcherData, isVisualDesignExperimentEnabled, showInBrowserMenu ->
         viewState.copy(
             tabSwitcherItems = tabSwitcherItems,

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -138,7 +138,7 @@ class TabSwitcherViewModel @Inject constructor(
             tabSwitcherItems = tabSwitcherItems,
             layoutType = tabSwitcherData.layoutType,
             isNewVisualDesignEnabled = isVisualDesignExperimentEnabled,
-            isDuckChatEnabled = duckChat.isEnabled() && showInBrowserMenu,
+            isDuckChatEnabled = showInBrowserMenu,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), SelectionViewState())
 

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -107,7 +107,7 @@ class OmnibarLayoutViewModelTest {
         whenever(voiceSearchAvailability.shouldShowVoiceSearch(any(), any(), any(), any())).thenReturn(true)
         whenever(duckPlayer.isDuckPlayerUri(DUCK_PLAYER_URL)).thenReturn(true)
         whenever(mockVisualDesignExperimentDataStore.isExperimentEnabled).thenReturn(disabledVisualExperimentNavBarStateFlow)
-        whenever(duckChat.showInAddressBar).thenReturn(duckChatShowInAddressBarFlow)
+        whenever(duckChat.showOmnibarShortcutOnNtpAndOnFocus).thenReturn(duckChatShowInAddressBarFlow)
         whenever(settingsDataStore.isFullUrlEnabled).thenReturn(true)
         whenever(duckChat.isEnabledInBrowser()).thenReturn(true)
         whenever(duckChat.showInputScreen).thenReturn(duckChatShowInputScreenFlow)

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -74,7 +74,6 @@ class OmnibarLayoutViewModelTest {
 
     private val mockVisualDesignExperimentDataStore: VisualDesignExperimentDataStore = mock()
     private val disabledVisualExperimentNavBarStateFlow = MutableStateFlow(false)
-    private val duckAiShowInputScreenFlow = MutableStateFlow(false)
     private val enabledVisualExperimentNavBarStateFlow = MutableStateFlow(true)
 
     private val defaultBrowserPromptsExperimentHighlightOverflowMenuFlow = MutableStateFlow(false)
@@ -83,7 +82,8 @@ class OmnibarLayoutViewModelTest {
     private val mockSenseOfProtectionExperiment: SenseOfProtectionExperiment = mock()
     private val duckChat: DuckChat = mock()
     private val duckAiFeatureState: DuckAiFeatureState = mock()
-    private val duckChatShowInAddressBarFlow = MutableStateFlow(true)
+    private val duckAiShowOmnibarShortcutOnNtpAndOnFocusFlow = MutableStateFlow(true)
+    private val duckAiShowInputScreenFlow = MutableStateFlow(false)
     private val settingsDataStore: SettingsDataStore = mock()
     private val mockAddressDisplayFormatter: AddressDisplayFormatter by lazy {
         mock {
@@ -109,7 +109,7 @@ class OmnibarLayoutViewModelTest {
         whenever(voiceSearchAvailability.shouldShowVoiceSearch(any(), any(), any(), any())).thenReturn(true)
         whenever(duckPlayer.isDuckPlayerUri(DUCK_PLAYER_URL)).thenReturn(true)
         whenever(mockVisualDesignExperimentDataStore.isExperimentEnabled).thenReturn(disabledVisualExperimentNavBarStateFlow)
-        whenever(duckChat.showOmnibarShortcutOnNtpAndOnFocus).thenReturn(duckChatShowInAddressBarFlow)
+        whenever(duckAiFeatureState.showOmnibarShortcutOnNtpAndOnFocus).thenReturn(duckAiShowOmnibarShortcutOnNtpAndOnFocusFlow)
         whenever(settingsDataStore.isFullUrlEnabled).thenReturn(true)
         whenever(duckChat.isEnabledInBrowser()).thenReturn(true)
         whenever(duckAiFeatureState.showInputScreen).thenReturn(duckAiShowInputScreenFlow)
@@ -1129,7 +1129,7 @@ class OmnibarLayoutViewModelTest {
 
     @Test
     fun whenViewModeIsNewTabAndChatEntryPointDisabledThenShowChatMenuFalse() = runTest {
-        duckChatShowInAddressBarFlow.value = false
+        duckAiShowOmnibarShortcutOnNtpAndOnFocusFlow.value = false
         testee.onViewModeChanged(ViewMode.NewTab)
 
         testee.viewState.test {
@@ -1150,7 +1150,7 @@ class OmnibarLayoutViewModelTest {
 
     @Test
     fun whenNavigationBarExperimentEnabledAndChatEntryPointDisabledThenShowChatMenuFalse() = runTest {
-        duckChatShowInAddressBarFlow.value = false
+        duckAiShowOmnibarShortcutOnNtpAndOnFocusFlow.value = false
         disabledVisualExperimentNavBarStateFlow.value = true
 
         testee.viewState.test {

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.browser.api.UserBrowserProperties
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.ui.experiments.visual.store.VisualDesignExperimentDataStore
 import com.duckduckgo.common.utils.baseHost
+import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.duckplayer.api.DuckPlayer
@@ -73,7 +74,7 @@ class OmnibarLayoutViewModelTest {
 
     private val mockVisualDesignExperimentDataStore: VisualDesignExperimentDataStore = mock()
     private val disabledVisualExperimentNavBarStateFlow = MutableStateFlow(false)
-    private val duckChatShowInputScreenFlow = MutableStateFlow(false)
+    private val duckAiShowInputScreenFlow = MutableStateFlow(false)
     private val enabledVisualExperimentNavBarStateFlow = MutableStateFlow(true)
 
     private val defaultBrowserPromptsExperimentHighlightOverflowMenuFlow = MutableStateFlow(false)
@@ -81,6 +82,7 @@ class OmnibarLayoutViewModelTest {
 
     private val mockSenseOfProtectionExperiment: SenseOfProtectionExperiment = mock()
     private val duckChat: DuckChat = mock()
+    private val duckAiFeatureState: DuckAiFeatureState = mock()
     private val duckChatShowInAddressBarFlow = MutableStateFlow(true)
     private val settingsDataStore: SettingsDataStore = mock()
     private val mockAddressDisplayFormatter: AddressDisplayFormatter by lazy {
@@ -110,7 +112,7 @@ class OmnibarLayoutViewModelTest {
         whenever(duckChat.showOmnibarShortcutOnNtpAndOnFocus).thenReturn(duckChatShowInAddressBarFlow)
         whenever(settingsDataStore.isFullUrlEnabled).thenReturn(true)
         whenever(duckChat.isEnabledInBrowser()).thenReturn(true)
-        whenever(duckChat.showInputScreen).thenReturn(duckChatShowInputScreenFlow)
+        whenever(duckAiFeatureState.showInputScreen).thenReturn(duckAiShowInputScreenFlow)
 
         initializeViewModel()
     }
@@ -1290,7 +1292,7 @@ class OmnibarLayoutViewModelTest {
 
     @Test
     fun whenDuckAIPoCEnabledThenShowClickCatcherTrue() = runTest {
-        duckChatShowInputScreenFlow.value = true
+        duckAiShowInputScreenFlow.value = true
 
         testee.viewState.test {
             val viewState = expectMostRecentItem()
@@ -1301,7 +1303,7 @@ class OmnibarLayoutViewModelTest {
 
     @Test
     fun whenDuckAIPoCDisabledThenShowClickCatcherFalse() = runTest {
-        duckChatShowInputScreenFlow.value = false
+        duckAiShowInputScreenFlow.value = false
 
         testee.viewState.test {
             val viewState = expectMostRecentItem()

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -1511,7 +1511,6 @@ class TabSwitcherViewModelTest {
     @Test
     fun `when visual design enabled and show duck chat in browser menu false then AI fab not visible`() = runTest {
         defaultVisualExperimentStateFlow.value = true
-        whenever(duckChatMock.isEnabled()).thenReturn(true)
 
         initializeViewModel()
 
@@ -1524,7 +1523,6 @@ class TabSwitcherViewModelTest {
     @Test
     fun `when visual design enabled and show duck chat in browser menu true then AI fab visible`() = runTest {
         defaultVisualExperimentStateFlow.value = true
-        whenever(duckChatMock.isEnabled()).thenReturn(true)
         whenever(duckAiFeatureStateMock.showPopupMenuShortcut).thenReturn(MutableStateFlow(true))
 
         initializeViewModel()

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -65,6 +65,7 @@ import com.duckduckgo.common.ui.DuckDuckGoTheme
 import com.duckduckgo.common.ui.experiments.visual.store.VisualDesignExperimentDataStore
 import com.duckduckgo.common.ui.tabs.SwipingTabsFeature
 import com.duckduckgo.common.ui.tabs.SwipingTabsFeatureProvider
+import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.fakes.FakePixel
@@ -137,6 +138,9 @@ class TabSwitcherViewModelTest {
     private lateinit var duckChatMock: DuckChat
 
     @Mock
+    private lateinit var duckAiFeatureStateMock: DuckAiFeatureState
+
+    @Mock
     private lateinit var faviconManager: FaviconManager
 
     @Mock
@@ -198,7 +202,7 @@ class TabSwitcherViewModelTest {
         whenever(mockVisualDesignExperimentDataStore.isExperimentEnabled).thenReturn(
             defaultVisualExperimentStateFlow,
         )
-        whenever(duckChatMock.showInBrowserMenu).thenReturn(MutableStateFlow(false))
+        whenever(duckAiFeatureStateMock.showPopupMenuShortcut).thenReturn(MutableStateFlow(false))
 
         fakeSenseOfProtectionToggles = FeatureToggles.Builder(
             FakeToggleStore(),
@@ -232,6 +236,7 @@ class TabSwitcherViewModelTest {
             mockPixel,
             swipingTabsFeatureProvider,
             duckChatMock,
+            duckAiFeatureState = duckAiFeatureStateMock,
             tabManagerFeatureFlags,
             senseOfProtectionExperiment,
             mockWebTrackersBlockedAppRepository,
@@ -1520,7 +1525,7 @@ class TabSwitcherViewModelTest {
     fun `when visual design enabled and show duck chat in browser menu true then AI fab visible`() = runTest {
         defaultVisualExperimentStateFlow.value = true
         whenever(duckChatMock.isEnabled()).thenReturn(true)
-        whenever(duckChatMock.showInBrowserMenu).thenReturn(MutableStateFlow(true))
+        whenever(duckAiFeatureStateMock.showPopupMenuShortcut).thenReturn(MutableStateFlow(true))
 
         initializeViewModel()
 

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckAiFeatureState.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckAiFeatureState.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.flow.StateFlow
 
 interface DuckAiFeatureState {
     // val showSettings: StateFlow<Boolean>
-    // val showInputScreen: StateFlow<Boolean>
+    val showInputScreen: StateFlow<Boolean>
     val showPopupMenuShortcut: StateFlow<Boolean>
     // val showOmnibarShortcutOnNtpAndOnFocus: StateFlow<Boolean>
     // val showOmnibarShortcutInAllStates: StateFlow<Boolean>

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckAiFeatureState.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckAiFeatureState.kt
@@ -44,9 +44,4 @@ interface DuckAiFeatureState {
      * Indicates whether the Duck AI omnibar shortcut should be shown in all states, including when the omnibar is not focused.
      */
     val showOmnibarShortcutInAllStates: StateFlow<Boolean>
-
-    /**
-     * Indicates whether the Duck AI state should be kept when closed, so that it can be resumed later without starting a new session.
-     */
-    val keepSession: StateFlow<Boolean>
 }

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckAiFeatureState.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckAiFeatureState.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.api
+
+import kotlinx.coroutines.flow.StateFlow
+
+interface DuckAiFeatureState {
+    // val showSettings: StateFlow<Boolean>
+    // val showInputScreen: StateFlow<Boolean>
+    val showPopupMenuShortcut: StateFlow<Boolean>
+    // val showOmnibarShortcutOnNtpAndOnFocus: StateFlow<Boolean>
+    // val showOmnibarShortcutInAllStates: StateFlow<Boolean>
+    // val keepSession: StateFlow<Boolean>
+}

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckAiFeatureState.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckAiFeatureState.kt
@@ -19,7 +19,7 @@ package com.duckduckgo.duckchat.api
 import kotlinx.coroutines.flow.StateFlow
 
 interface DuckAiFeatureState {
-    // val showSettings: StateFlow<Boolean>
+    val showSettings: StateFlow<Boolean>
     val showInputScreen: StateFlow<Boolean>
     val showPopupMenuShortcut: StateFlow<Boolean>
     val showOmnibarShortcutOnNtpAndOnFocus: StateFlow<Boolean>

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckAiFeatureState.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckAiFeatureState.kt
@@ -22,7 +22,7 @@ interface DuckAiFeatureState {
     // val showSettings: StateFlow<Boolean>
     val showInputScreen: StateFlow<Boolean>
     val showPopupMenuShortcut: StateFlow<Boolean>
-    // val showOmnibarShortcutOnNtpAndOnFocus: StateFlow<Boolean>
+    val showOmnibarShortcutOnNtpAndOnFocus: StateFlow<Boolean>
     // val showOmnibarShortcutInAllStates: StateFlow<Boolean>
     // val keepSession: StateFlow<Boolean>
 }

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckAiFeatureState.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckAiFeatureState.kt
@@ -24,5 +24,5 @@ interface DuckAiFeatureState {
     val showPopupMenuShortcut: StateFlow<Boolean>
     val showOmnibarShortcutOnNtpAndOnFocus: StateFlow<Boolean>
     val showOmnibarShortcutInAllStates: StateFlow<Boolean>
-    // val keepSession: StateFlow<Boolean>
+    val keepSession: StateFlow<Boolean>
 }

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckAiFeatureState.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckAiFeatureState.kt
@@ -19,10 +19,34 @@ package com.duckduckgo.duckchat.api
 import kotlinx.coroutines.flow.StateFlow
 
 interface DuckAiFeatureState {
+
+    /**
+     * Indicates whether the Duck AI settings should be available from the main settings screen.
+     */
     val showSettings: StateFlow<Boolean>
+
+    /**
+     * Indicates whether focusing the omnibar should navigate to a new Duck.ai input screen with a Search/AI mode switcher.
+     */
     val showInputScreen: StateFlow<Boolean>
+
+    /**
+     * Indicates whether the Duck AI shortcut should be shown in the popup menus in the main browser tabs as well as on the tab switcher screen.
+     */
     val showPopupMenuShortcut: StateFlow<Boolean>
+
+    /**
+     * Indicates whether the Duck AI omnibar shortcut should be shown on the New Tab Page (NTP) and when the omnibar is focused.
+     */
     val showOmnibarShortcutOnNtpAndOnFocus: StateFlow<Boolean>
+
+    /**
+     * Indicates whether the Duck AI omnibar shortcut should be shown in all states, including when the omnibar is not focused.
+     */
     val showOmnibarShortcutInAllStates: StateFlow<Boolean>
+
+    /**
+     * Indicates whether the Duck AI state should be kept when closed, so that it can be resumed later without starting a new session.
+     */
     val keepSession: StateFlow<Boolean>
 }

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckAiFeatureState.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckAiFeatureState.kt
@@ -23,6 +23,6 @@ interface DuckAiFeatureState {
     val showInputScreen: StateFlow<Boolean>
     val showPopupMenuShortcut: StateFlow<Boolean>
     val showOmnibarShortcutOnNtpAndOnFocus: StateFlow<Boolean>
-    // val showOmnibarShortcutInAllStates: StateFlow<Boolean>
+    val showOmnibarShortcutInAllStates: StateFlow<Boolean>
     // val keepSession: StateFlow<Boolean>
 }

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
@@ -48,13 +48,6 @@ interface DuckChat {
     fun isKeepSessionEnabled(): Boolean
 
     /**
-     * Checks whether DuckChat should be shown in address bar based on user settings.
-     *
-     * @return true if DuckChat should be shown, false otherwise.
-     */
-    val showOmnibarShortcutOnNtpAndOnFocus: StateFlow<Boolean>
-
-    /**
      * Opens the DuckChat WebView with optional pre-filled [String] query.
      */
     fun openDuckChat()

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
@@ -48,13 +48,6 @@ interface DuckChat {
     fun isKeepSessionEnabled(): Boolean
 
     /**
-     * Checks whether dedicated Duck.ai input screen with the input mode switch should be used when focusing on the omnibar.
-     *
-     * @return true if the input mode switch should be used, false otherwise.
-     */
-    val showInputScreen: StateFlow<Boolean>
-
-    /**
      * Checks whether DuckChat should be shown in address bar based on user settings.
      *
      * @return true if DuckChat should be shown, false otherwise.

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.duckchat.api
 
 import android.net.Uri
-import kotlinx.coroutines.flow.StateFlow
 
 /**
  * DuckChat interface provides a set of methods for interacting and controlling DuckChat.

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
@@ -55,18 +55,11 @@ interface DuckChat {
     val showInputScreen: StateFlow<Boolean>
 
     /**
-     * Checks whether DuckChat should be shown in browser menu based on user settings.
-     *
-     * @return true if DuckChat should be shown, false otherwise.
-     */
-    val showInBrowserMenu: StateFlow<Boolean>
-
-    /**
      * Checks whether DuckChat should be shown in address bar based on user settings.
      *
      * @return true if DuckChat should be shown, false otherwise.
      */
-    val showInAddressBar: StateFlow<Boolean>
+    val showOmnibarShortcutOnNtpAndOnFocus: StateFlow<Boolean>
 
     /**
      * Opens the DuckChat WebView with optional pre-filled [String] query.

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
@@ -32,14 +32,6 @@ interface DuckChat {
     fun isEnabled(): Boolean
 
     /**
-     * Checks whether Duck.ai should keep the session alive or not
-     * Uses a cached value - does not perform disk I/O.
-     *
-     * @return true if Duck.ai keep session alive is enabled, false otherwise.
-     */
-    fun isKeepSessionEnabled(): Boolean
-
-    /**
      * Opens the DuckChat WebView with optional pre-filled [String] query.
      */
     fun openDuckChat()

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
@@ -32,14 +32,6 @@ interface DuckChat {
     fun isEnabled(): Boolean
 
     /**
-     * Checks whether Duck.ai in browser is enabled based on remote config flag.
-     * Uses a cached value - does not perform disk I/O.
-     *
-     * @return true if Duck.ai in browser is enabled, false otherwise.
-     */
-    fun isEnabledInBrowser(): Boolean
-
-    /**
      * Checks whether Duck.ai should keep the session alive or not
      * Uses a cached value - does not perform disk I/O.
      *

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -55,6 +55,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -222,6 +223,7 @@ class RealDuckChat @Inject constructor(
     private val _showInputScreen = MutableStateFlow(false)
     private val _showInBrowserMenu = MutableStateFlow(false)
     private val _showInAddressBar = MutableStateFlow(false)
+    private val _showOmnibarShortcutInAllStates = MutableStateFlow(false)
     private val _chatState = MutableStateFlow(ChatState.HIDE)
 
     private val jsonAdapter: JsonAdapter<DuckChatSettingJson> by lazy {
@@ -298,10 +300,6 @@ class RealDuckChat @Inject constructor(
         return duckAiInputScreen
     }
 
-    override fun isEnabledInBrowser(): Boolean {
-        return isDuckAiInBrowserEnabled
-    }
-
     override fun isKeepSessionEnabled(): Boolean {
         return keepSessionAliveEnabled
     }
@@ -373,6 +371,8 @@ class RealDuckChat @Inject constructor(
     override val showPopupMenuShortcut: StateFlow<Boolean> = _showInBrowserMenu.asStateFlow()
 
     override val showOmnibarShortcutOnNtpAndOnFocus: StateFlow<Boolean> = _showInAddressBar.asStateFlow()
+
+    override val showOmnibarShortcutInAllStates: StateFlow<Boolean> = _showOmnibarShortcutInAllStates.asStateFlow()
 
     override val chatState: StateFlow<ChatState> = _chatState.asStateFlow()
 
@@ -577,6 +577,9 @@ class RealDuckChat @Inject constructor(
         val showInAddressBar = duckChatFeatureRepository.shouldShowInAddressBar() &&
             isDuckChatEnabled && isDuckChatUserEnabled && isAddressBarEntryPointEnabled
         _showInAddressBar.emit(showInAddressBar)
+
+        val showOmnibarShortcutInAllStates = showInAddressBar && isDuckAiInBrowserEnabled
+        _showOmnibarShortcutInAllStates.emit(showOmnibarShortcutInAllStates)
     }
 
     companion object {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -220,6 +220,7 @@ class RealDuckChat @Inject constructor(
 ) : DuckChatInternal, DuckAiFeatureState, PrivacyConfigCallbackPlugin {
 
     private val closeChatFlow = MutableSharedFlow<Unit>(replay = 0)
+    private val _showSettings = MutableStateFlow(false)
     private val _showInputScreen = MutableStateFlow(false)
     private val _showInBrowserMenu = MutableStateFlow(false)
     private val _showInAddressBar = MutableStateFlow(false)
@@ -363,6 +364,8 @@ class RealDuckChat @Inject constructor(
     override fun updateChatState(state: ChatState) {
         _chatState.value = state
     }
+
+    override val showSettings: StateFlow<Boolean> = _showSettings.asStateFlow()
 
     override val showInputScreen: StateFlow<Boolean> = _showInputScreen.asStateFlow()
 
@@ -536,7 +539,9 @@ class RealDuckChat @Inject constructor(
 
     private fun cacheConfig() {
         appCoroutineScope.launch(dispatchers.io()) {
-            isDuckChatEnabled = duckChatFeature.self().isEnabled()
+            val featureEnabled = duckChatFeature.self().isEnabled()
+            isDuckChatEnabled = featureEnabled
+            _showSettings.value = featureEnabled
             isDuckAiInBrowserEnabled = duckChatFeature.duckAiButtonInBrowser().isEnabled()
             duckAiInputScreen = duckChatFeature.duckAiInputScreen().isEnabled()
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -292,8 +292,6 @@ class RealDuckChat @Inject constructor(
         cacheUserSettings()
     }
 
-    override val keepSession: StateFlow<Boolean> = _keepSession.asStateFlow()
-
     override fun isEnabled(): Boolean {
         return isDuckChatEnabled
     }
@@ -327,7 +325,7 @@ class RealDuckChat @Inject constructor(
     }
 
     override fun closeDuckChat() {
-        if (keepSession.value) {
+        if (_keepSession.value) {
             browserNav.closeDuckChat(context).apply {
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK
                 context.startActivity(this)
@@ -442,7 +440,7 @@ class RealDuckChat @Inject constructor(
 
             val hasSessionActive = when {
                 forceNewSession -> false
-                keepSession.value -> hasActiveSession()
+                _keepSession.value -> hasActiveSession()
                 else -> false
             }
 
@@ -450,7 +448,7 @@ class RealDuckChat @Inject constructor(
 
             withContext(dispatchers.main()) {
                 pixel.fire(DuckChatPixelName.DUCK_CHAT_OPEN, parameters = params)
-                if (keepSession.value) {
+                if (_keepSession.value) {
                     logcat { "Duck.ai: restoring Duck.ai session $url hasSessionActive $hasSessionActive" }
                     openDuckChatSession(url, hasSessionActive)
                 } else {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -55,7 +55,6 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.common.ui.experiments.visual.store.VisualDesignExperimentD
 import com.duckduckgo.common.utils.AppUrl.ParamKey.QUERY
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.api.DuckChatSettingsNoParams
 import com.duckduckgo.duckchat.impl.feature.AIChatImageUploadFeature
@@ -199,6 +200,7 @@ data class DuckChatSettingJson(
 @SingleInstanceIn(AppScope::class)
 
 @ContributesBinding(AppScope::class, boundType = DuckChat::class)
+@ContributesBinding(AppScope::class, boundType = DuckAiFeatureState::class)
 @ContributesBinding(AppScope::class, boundType = DuckChatInternal::class)
 @ContributesMultibinding(AppScope::class, boundType = PrivacyConfigCallbackPlugin::class)
 class RealDuckChat @Inject constructor(
@@ -214,7 +216,7 @@ class RealDuckChat @Inject constructor(
     private val pixel: Pixel,
     private val imageUploadFeature: AIChatImageUploadFeature,
     private val browserNav: BrowserNav,
-) : DuckChatInternal, PrivacyConfigCallbackPlugin {
+) : DuckChatInternal, DuckAiFeatureState, PrivacyConfigCallbackPlugin {
 
     private val closeChatFlow = MutableSharedFlow<Unit>(replay = 0)
     private val _showInputScreen = MutableStateFlow(false)
@@ -368,9 +370,9 @@ class RealDuckChat @Inject constructor(
 
     override val showInputScreen: StateFlow<Boolean> = _showInputScreen.asStateFlow()
 
-    override val showInBrowserMenu: StateFlow<Boolean> = _showInBrowserMenu.asStateFlow()
+    override val showPopupMenuShortcut: StateFlow<Boolean> = _showInBrowserMenu.asStateFlow()
 
-    override val showInAddressBar: StateFlow<Boolean> = _showInAddressBar.asStateFlow()
+    override val showOmnibarShortcutOnNtpAndOnFocus: StateFlow<Boolean> = _showInAddressBar.asStateFlow()
 
     override val chatState: StateFlow<ChatState> = _chatState.asStateFlow()
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -192,7 +192,7 @@ class RealDuckChatTest {
 
     @Test
     fun whenFeatureEnabledThenShowInBrowserMenuReturnsValueFromRepository() {
-        assertTrue(testee.showInBrowserMenu.value)
+        assertTrue(testee.showPopupMenuShortcut.value)
     }
 
     @Test
@@ -201,7 +201,7 @@ class RealDuckChatTest {
 
         testee.onPrivacyConfigDownloaded()
 
-        assertFalse(testee.showInBrowserMenu.value)
+        assertFalse(testee.showPopupMenuShortcut.value)
     }
 
     @Test
@@ -242,11 +242,11 @@ class RealDuckChatTest {
         whenever(mockDuckChatFeatureRepository.shouldShowInAddressBar()).thenReturn(true)
 
         testee.setShowInAddressBarUserSetting(true)
-        assertTrue(testee.showInAddressBar.value)
+        assertTrue(testee.showOmnibarShortcutOnNtpAndOnFocus.value)
 
         whenever(mockDuckChatFeatureRepository.shouldShowInAddressBar()).thenReturn(false)
         testee.setShowInAddressBarUserSetting(false)
-        assertFalse(testee.showInAddressBar.value)
+        assertFalse(testee.showOmnibarShortcutOnNtpAndOnFocus.value)
     }
 
     @Test
@@ -475,8 +475,8 @@ class RealDuckChatTest {
         testee.setEnableDuckChatUserSetting(false)
 
         verify(mockDuckChatFeatureRepository).setDuckChatUserEnabled(false)
-        assertFalse(testee.showInBrowserMenu.value)
-        assertFalse(testee.showInAddressBar.value)
+        assertFalse(testee.showPopupMenuShortcut.value)
+        assertFalse(testee.showOmnibarShortcutOnNtpAndOnFocus.value)
     }
 
     @Test
@@ -494,8 +494,8 @@ class RealDuckChatTest {
         testee.setEnableDuckChatUserSetting(true)
 
         verify(mockDuckChatFeatureRepository).setDuckChatUserEnabled(true)
-        assertTrue(testee.showInBrowserMenu.value)
-        assertTrue(testee.showInAddressBar.value)
+        assertTrue(testee.showPopupMenuShortcut.value)
+        assertTrue(testee.showOmnibarShortcutOnNtpAndOnFocus.value)
     }
 
     @Test
@@ -511,8 +511,8 @@ class RealDuckChatTest {
         )
         testee.setEnableDuckChatUserSetting(true)
 
-        assertFalse(testee.showInBrowserMenu.value)
-        assertFalse(testee.showInAddressBar.value)
+        assertFalse(testee.showPopupMenuShortcut.value)
+        assertFalse(testee.showOmnibarShortcutOnNtpAndOnFocus.value)
     }
 
     @Test
@@ -527,7 +527,7 @@ class RealDuckChatTest {
         )
         testee.onPrivacyConfigDownloaded()
 
-        assertFalse(testee.showInAddressBar.value)
+        assertFalse(testee.showOmnibarShortcutOnNtpAndOnFocus.value)
     }
 
     @Test
@@ -542,7 +542,7 @@ class RealDuckChatTest {
         )
         testee.onPrivacyConfigDownloaded()
 
-        assertTrue(testee.showInAddressBar.value)
+        assertTrue(testee.showOmnibarShortcutOnNtpAndOnFocus.value)
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -720,6 +720,24 @@ class RealDuckChatTest {
         assertTrue(testee.keepSession.value)
     }
 
+    @Test
+    fun `when global feature flag disabled then don't show settings`() = runTest {
+        duckChatFeature.self().setRawStoredState(State(false))
+
+        testee.onPrivacyConfigDownloaded()
+
+        assertFalse(testee.showSettings.value)
+    }
+
+    @Test
+    fun `when global feature flag enabled then show settings`() = runTest {
+        duckChatFeature.self().setRawStoredState(State(true))
+
+        testee.onPrivacyConfigDownloaded()
+
+        assertTrue(testee.showSettings.value)
+    }
+
     companion object {
         val SETTINGS_JSON = """
         {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -546,6 +546,54 @@ class RealDuckChatTest {
     }
 
     @Test
+    fun `when should show in address bar enabled and duckAiButtonInBrowser enabled, then show in all states enabled`() = runTest {
+        whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
+        whenever(mockDuckChatFeatureRepository.shouldShowInAddressBar()).thenReturn(true)
+        duckChatFeature.self().setRawStoredState(
+            State(
+                enable = true,
+                settings = SETTINGS_JSON_ADDRESS_BAR,
+            ),
+        )
+        duckChatFeature.duckAiButtonInBrowser().setRawStoredState(State(enable = true))
+        testee.onPrivacyConfigDownloaded()
+
+        assertTrue(testee.showOmnibarShortcutInAllStates.value)
+    }
+
+    @Test
+    fun `when should show in address bar enabled and duckAiButtonInBrowser disabled, then show in all states disabled`() = runTest {
+        whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
+        whenever(mockDuckChatFeatureRepository.shouldShowInAddressBar()).thenReturn(true)
+        duckChatFeature.self().setRawStoredState(
+            State(
+                enable = true,
+                settings = SETTINGS_JSON_ADDRESS_BAR,
+            ),
+        )
+        duckChatFeature.duckAiButtonInBrowser().setRawStoredState(State(enable = false))
+        testee.onPrivacyConfigDownloaded()
+
+        assertFalse(testee.showOmnibarShortcutInAllStates.value)
+    }
+
+    @Test
+    fun `when should show in address bar disabled and duckAiButtonInBrowser enabled, then show in all states enabled`() = runTest {
+        whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
+        whenever(mockDuckChatFeatureRepository.shouldShowInAddressBar()).thenReturn(true)
+        duckChatFeature.self().setRawStoredState(
+            State(
+                enable = false,
+                settings = SETTINGS_JSON_ADDRESS_BAR,
+            ),
+        )
+        duckChatFeature.duckAiButtonInBrowser().setRawStoredState(State(enable = true))
+        testee.onPrivacyConfigDownloaded()
+
+        assertFalse(testee.showOmnibarShortcutInAllStates.value)
+    }
+
+    @Test
     fun whenUpdateChatStateThenChatStateUpdated() = runTest {
         assertEquals(ChatState.HIDE, testee.chatState.value)
 
@@ -577,24 +625,6 @@ class RealDuckChatTest {
         testee.onPrivacyConfigDownloaded()
 
         assertFalse(testee.isImageUploadEnabled())
-    }
-
-    @Test
-    fun whenDuckAiInBrowserFeatureEnabledThenIsEnabledInBrowserReturnsTrue() = runTest {
-        duckChatFeature.duckAiButtonInBrowser().setRawStoredState(State(enable = true))
-
-        testee.onPrivacyConfigDownloaded()
-
-        assertTrue(testee.isEnabledInBrowser())
-    }
-
-    @Test
-    fun whenDuckAiInBrowserFeatureDisabledThenIsEnabledInBrowserReturnsFalse() = runTest {
-        duckChatFeature.duckAiButtonInBrowser().setRawStoredState(State(enable = false))
-
-        testee.onPrivacyConfigDownloaded()
-
-        assertFalse(testee.isEnabledInBrowser())
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -702,6 +702,24 @@ class RealDuckChatTest {
         assertTrue(testee.isInputScreenFeatureAvailable())
     }
 
+    @Test
+    fun `when keep session feature flag disabled then session is not kept alive`() = runTest {
+        duckChatFeature.keepSession().setRawStoredState(State(false))
+
+        testee.onPrivacyConfigDownloaded()
+
+        assertFalse(testee.keepSession.value)
+    }
+
+    @Test
+    fun `when keep session feature flag enabled then session is kept alive`() = runTest {
+        duckChatFeature.keepSession().setRawStoredState(State(true))
+
+        testee.onPrivacyConfigDownloaded()
+
+        assertTrue(testee.keepSession.value)
+    }
+
     companion object {
         val SETTINGS_JSON = """
         {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -703,24 +703,6 @@ class RealDuckChatTest {
     }
 
     @Test
-    fun `when keep session feature flag disabled then session is not kept alive`() = runTest {
-        duckChatFeature.keepSession().setRawStoredState(State(false))
-
-        testee.onPrivacyConfigDownloaded()
-
-        assertFalse(testee.keepSession.value)
-    }
-
-    @Test
-    fun `when keep session feature flag enabled then session is kept alive`() = runTest {
-        duckChatFeature.keepSession().setRawStoredState(State(true))
-
-        testee.onPrivacyConfigDownloaded()
-
-        assertTrue(testee.keepSession.value)
-    }
-
-    @Test
     fun `when global feature flag disabled then don't show settings`() = runTest {
         duckChatFeature.self().setRawStoredState(State(false))
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -191,12 +191,12 @@ class RealDuckChatTest {
     }
 
     @Test
-    fun whenFeatureEnabledThenShowInBrowserMenuReturnsValueFromRepository() {
+    fun whenFeatureEnabledThenShowPopupMenuShortcutReturnsValueFromRepository() {
         assertTrue(testee.showPopupMenuShortcut.value)
     }
 
     @Test
-    fun whenFeatureDisabledThenShowInBrowserMenuReturnsFalse() {
+    fun whenFeatureDisabledThenShowPopupMenuShortcutReturnsFalse() {
         duckChatFeature.self().setRawStoredState(State(false))
 
         testee.onPrivacyConfigDownloaded()
@@ -471,12 +471,14 @@ class RealDuckChatTest {
                 settings = SETTINGS_JSON_ADDRESS_BAR,
             ),
         )
+        duckChatFeature.duckAiButtonInBrowser().setRawStoredState(State(enable = true))
         testee.onPrivacyConfigDownloaded()
         testee.setEnableDuckChatUserSetting(false)
 
         verify(mockDuckChatFeatureRepository).setDuckChatUserEnabled(false)
         assertFalse(testee.showPopupMenuShortcut.value)
         assertFalse(testee.showOmnibarShortcutOnNtpAndOnFocus.value)
+        assertFalse(testee.showOmnibarShortcutInAllStates.value)
     }
 
     @Test
@@ -578,7 +580,23 @@ class RealDuckChatTest {
     }
 
     @Test
-    fun `when should show in address bar disabled and duckAiButtonInBrowser enabled, then show in all states enabled`() = runTest {
+    fun `when should show in address bar disabled and duckAiButtonInBrowser enabled, then show in all states disabled`() = runTest {
+        whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(false)
+        whenever(mockDuckChatFeatureRepository.shouldShowInAddressBar()).thenReturn(true)
+        duckChatFeature.self().setRawStoredState(
+            State(
+                enable = true,
+                settings = SETTINGS_JSON_ADDRESS_BAR,
+            ),
+        )
+        duckChatFeature.duckAiButtonInBrowser().setRawStoredState(State(enable = true))
+        testee.onPrivacyConfigDownloaded()
+
+        assertFalse(testee.showOmnibarShortcutInAllStates.value)
+    }
+
+    @Test
+    fun `when global feature flag disabled, then show in all states disabled`() = runTest {
         whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
         whenever(mockDuckChatFeatureRepository.shouldShowInAddressBar()).thenReturn(true)
         duckChatFeature.self().setRawStoredState(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1210625163271723

### Description
Extracts Duck.ai feature state from `DuckChat` to `DuckAiFeatureState` public API.

### Steps to test this PR

- [x] Verify that each setting under Settings -> Duck.ai behaves as expected.
  - [x] Turn off the whole feature and check there's no Duck.ai icons in main browser and on NTP or Tab Switcher.
  - [x] Disable browser menu and verify there's no Duck.ai in popup menus.
  - [x] Disable address bar and verify there's no Duck.ai in the omnibar when focus, unfocused, and on NTP.
  - [x] Turn all settings and verify there's in popup menus, in the omnibar on NTP and whne focused.
    - [x] To also have Duck.ai on website view when not focused, ensure you have the `duckAiButtonInBrowser` feature flag enabled.
