### PR TITLE
add new line button to Duck.ai input screen

### DIFF
--- a/common/common-ui/src/main/res/drawable/ic_return_24.xml
+++ b/common/common-ui/src/main/res/drawable/ic_return_24.xml
@@ -1,0 +1,36 @@
+<!--
+  ~ Copyright (c) 2025 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M6.5,19L3.207,15.707C2.816,15.317 2.816,14.683 3.207,14.293L6.5,11"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="?attr/daxColorPrimaryIcon"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M4,15H17.25C19.459,15 21.25,13.209 21.25,11V9.75C21.25,7.541 19.459,5.75 17.25,5.75H11.75"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="?attr/daxColorPrimaryIcon"
+      android:strokeLineCap="round"/>
+</vector>

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatOmnibarLayout.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatOmnibarLayout.kt
@@ -309,6 +309,14 @@ class DuckChatOmnibarLayout @JvmOverloads constructor(
         }
     }
 
+    fun printNewLine() {
+        val currentText = duckChatInput.text.toString()
+        val currentSelection = duckChatInput.selectionStart
+        val newText = currentText.substring(0, currentSelection) + "\n" + currentText.substring(currentSelection)
+        duckChatInput.setText(newText)
+        duckChatInput.setSelection(currentSelection + 1)
+    }
+
     companion object {
         private const val DEFAULT_ANIMATION_DURATION = 300L
         private const val FADE_DURATION = 150L

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/SearchInterstitialFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/SearchInterstitialFragment.kt
@@ -94,6 +94,9 @@ class SearchInterstitialFragment : DuckDuckGoFragment(R.layout.fragment_search_i
         binding.duckChatOmnibar.duckChatInput.post {
             showKeyboard(binding.duckChatOmnibar.duckChatInput)
         }
+        binding.actionNewLine.setOnClickListener {
+            binding.duckChatOmnibar.printNewLine()
+        }
     }
 
     private fun configureViewPager() {

--- a/duckchat/duckchat-impl/src/main/res/layout/fragment_search_interstitial.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/fragment_search_interstitial.xml
@@ -82,4 +82,25 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/actionSend"/>
 
+    <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
+        android:id="@+id/actionNewLine"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:minWidth="0dp"
+        android:minHeight="0dp"
+        android:backgroundTint="?attr/daxColorWindow"
+        android:layout_marginBottom="@dimen/keyline_3"
+        android:layout_marginEnd="@dimen/keyline_3"
+        android:importantForAccessibility="no"
+        android:text="&#8203;"
+        android:textColor="@android:color/transparent"
+        android:visibility="visible"
+        app:icon="@drawable/ic_return_24"
+        app:iconTint="?attr/daxColorPrimaryIcon"
+        app:iconPadding="0dp"
+        app:iconGravity="textStart"
+        app:rippleColor="?attr/daxColorRipple"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/actionVoice"/>
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1210649707519320?focus=true

### Description

Adds a "return" button to the toolbar above the keyboard on the Duck.ai Input Screen.

### Steps to test this PR

- [ ] Enable Settings -> Duck.ai -> Search Input
- [ ] Focus on the omnibar and try adding new line at the end, or in the middle of text.

### UI changes
<img src="https://github.com/user-attachments/assets/449c6429-87d6-43a5-986f-bf63324d8b8e" width="30%" />


