### PR TITLE
restore last selected Duck.ai input screen mode

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatOmnibarLayout.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatOmnibarLayout.kt
@@ -106,8 +106,6 @@ class DuckChatOmnibarLayout @JvmOverloads constructor(
         configureInputBehavior()
         configureTabBehavior()
         applyModeSpecificInputBehaviour(isSearchTab = true)
-
-        onSearchSelected?.invoke()
     }
 
     private fun configureClickListeners() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/SearchInterstitialFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/SearchInterstitialFragment.kt
@@ -36,6 +36,8 @@ import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.databinding.FragmentSearchInterstitialBinding
 import com.duckduckgo.duckchat.impl.ui.inputscreen.Command
+import com.duckduckgo.duckchat.impl.ui.inputscreen.Command.SwitchModeToChat
+import com.duckduckgo.duckchat.impl.ui.inputscreen.Command.SwitchModeToSearch
 import com.duckduckgo.duckchat.impl.ui.inputscreen.Command.UserSubmittedQuery
 import com.duckduckgo.duckchat.impl.ui.inputscreen.InputScreenViewModel
 import com.duckduckgo.navigation.api.getActivityParams
@@ -121,8 +123,19 @@ class SearchInterstitialFragment : DuckDuckGoFragment(R.layout.fragment_search_i
     }
 
     private fun processCommand(command: Command) {
-        if (command is UserSubmittedQuery) {
-            binding.duckChatOmnibar.submitMessage(command.query)
+        when (command) {
+            is UserSubmittedQuery -> binding.duckChatOmnibar.submitMessage(command.query)
+            SwitchModeToSearch -> {
+                binding.viewPager.setCurrentItem(0, false)
+            }
+
+            SwitchModeToChat -> {
+                binding.viewPager.setCurrentItem(1, false)
+            }
+
+            else -> {
+                // TODO handle other commands
+            }
         }
     }
 
@@ -134,7 +147,6 @@ class SearchInterstitialFragment : DuckDuckGoFragment(R.layout.fragment_search_i
 
     private fun configureOmnibar() = with(binding.duckChatOmnibar) {
         setContentId(R.id.viewPager)
-        selectTab(0)
 
         onSearchSent = { query ->
             val data = Intent().putExtra(SearchInterstitialActivity.QUERY, query)
@@ -153,10 +165,12 @@ class SearchInterstitialFragment : DuckDuckGoFragment(R.layout.fragment_search_i
         onSearchSelected = {
             binding.actionSend.icon = AppCompatResources.getDrawable(context, com.duckduckgo.mobile.android.R.drawable.ic_find_search_24)
             binding.viewPager.setCurrentItem(0, true)
+            viewModel.onSearchSelected()
         }
         onDuckChatSelected = {
             binding.actionSend.icon = AppCompatResources.getDrawable(context, R.drawable.ic_arrow_up_24)
             binding.viewPager.setCurrentItem(1, true)
+            viewModel.onChatSelected()
         }
         onSendMessageAvailable = { isAvailable ->
             binding.actionSend.isVisible = isAvailable

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/inputscreen/Command.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/inputscreen/Command.kt
@@ -24,4 +24,6 @@ sealed class Command {
     data class SwitchToTab(val tabId: String) : Command()
     data class UserSubmittedQuery(val query: String) : Command()
     data class EditWithSelectedQuery(val query: String) : Command()
+    data object SwitchModeToSearch : Command()
+    data object SwitchModeToChat : Command()
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/inputscreen/DuckAiInputScreenDataStore.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/inputscreen/DuckAiInputScreenDataStore.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui.inputscreen
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.duckchat.impl.di.DuckChat
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
+
+interface DuckAiInputScreenDataStore {
+    suspend fun getLastUsedMode(): DuckAiInputScreenMode?
+    suspend fun setLastUsedMode(mode: DuckAiInputScreenMode)
+}
+
+enum class DuckAiInputScreenMode {
+    CHAT,
+    SEARCH,
+    ;
+}
+
+@ContributesBinding(FragmentScope::class)
+class DuckAiInputScreenDataStoreImpl @Inject constructor(
+    @DuckChat private val dataStore: DataStore<Preferences>,
+) : DuckAiInputScreenDataStore {
+
+    private val lastUsedModeKey = stringPreferencesKey("duck.ai_input-screen_last-used-mode")
+
+    override suspend fun getLastUsedMode(): DuckAiInputScreenMode? {
+        return dataStore.data.map { preferences ->
+            preferences[lastUsedModeKey]?.let { modeString ->
+                try {
+                    DuckAiInputScreenMode.valueOf(modeString)
+                } catch (e: IllegalArgumentException) {
+                    null
+                }
+            }
+        }.firstOrNull()
+    }
+
+    override suspend fun setLastUsedMode(mode: DuckAiInputScreenMode) {
+        dataStore.edit { preferences ->
+            preferences[lastUsedModeKey] = mode.name
+        }
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenDataStore.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenDataStore.kt
@@ -27,29 +27,29 @@ import javax.inject.Inject
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 
-interface DuckAiInputScreenDataStore {
-    suspend fun getLastUsedMode(): DuckAiInputScreenMode?
-    suspend fun setLastUsedMode(mode: DuckAiInputScreenMode)
+interface InputScreenDataStore {
+    suspend fun getLastUsedMode(): InputScreenMode?
+    suspend fun setLastUsedMode(mode: InputScreenMode)
 }
 
-enum class DuckAiInputScreenMode {
+enum class InputScreenMode {
     CHAT,
     SEARCH,
     ;
 }
 
 @ContributesBinding(FragmentScope::class)
-class DuckAiInputScreenDataStoreImpl @Inject constructor(
+class InputScreenDataStoreImpl @Inject constructor(
     @DuckChat private val dataStore: DataStore<Preferences>,
-) : DuckAiInputScreenDataStore {
+) : InputScreenDataStore {
 
     private val lastUsedModeKey = stringPreferencesKey("duck.ai_input-screen_last-used-mode")
 
-    override suspend fun getLastUsedMode(): DuckAiInputScreenMode? {
+    override suspend fun getLastUsedMode(): InputScreenMode? {
         return dataStore.data.map { preferences ->
             preferences[lastUsedModeKey]?.let { modeString ->
                 try {
-                    DuckAiInputScreenMode.valueOf(modeString)
+                    InputScreenMode.valueOf(modeString)
                 } catch (e: IllegalArgumentException) {
                     null
                 }
@@ -57,7 +57,7 @@ class DuckAiInputScreenDataStoreImpl @Inject constructor(
         }.firstOrNull()
     }
 
-    override suspend fun setLastUsedMode(mode: DuckAiInputScreenMode) {
+    override suspend fun setLastUsedMode(mode: InputScreenMode) {
         dataStore.edit { preferences ->
             preferences[lastUsedModeKey] = mode.name
         }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModel.kt
@@ -70,6 +70,7 @@ class InputScreenViewModel @Inject constructor(
     private val history: NavigationHistory,
     savedSitesRepository: SavedSitesRepository,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val duckAiInputScreenDataStore: DuckAiInputScreenDataStore,
 ) : ViewModel() {
 
     private var hasUserSeenHistoryIAM = false
@@ -105,6 +106,17 @@ class InputScreenViewModel @Inject constructor(
                 }
             }
             .launchIn(viewModelScope)
+
+        viewModelScope.launch {
+            duckAiInputScreenDataStore.getLastUsedMode().let { mode ->
+                command.value = when (mode) {
+                    null,
+                    DuckAiInputScreenMode.SEARCH,
+                    -> Command.SwitchModeToSearch
+                    DuckAiInputScreenMode.CHAT -> Command.SwitchModeToChat
+                }
+            }
+        }
     }
 
     @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
@@ -273,6 +285,18 @@ class InputScreenViewModel @Inject constructor(
             hasUserSeenHistoryIAM = false
             lastAutoCompleteState = null
             autoCompleteJob.cancel()
+        }
+    }
+
+    fun onSearchSelected() {
+        viewModelScope.launch {
+            duckAiInputScreenDataStore.setLastUsedMode(DuckAiInputScreenMode.SEARCH)
+        }
+    }
+
+    fun onChatSelected() {
+        viewModelScope.launch {
+            duckAiInputScreenDataStore.setLastUsedMode(DuckAiInputScreenMode.CHAT)
         }
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModel.kt
@@ -70,7 +70,7 @@ class InputScreenViewModel @Inject constructor(
     private val history: NavigationHistory,
     savedSitesRepository: SavedSitesRepository,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
-    private val duckAiInputScreenDataStore: DuckAiInputScreenDataStore,
+    private val inputScreenDataStore: InputScreenDataStore,
 ) : ViewModel() {
 
     private var hasUserSeenHistoryIAM = false
@@ -108,12 +108,12 @@ class InputScreenViewModel @Inject constructor(
             .launchIn(viewModelScope)
 
         viewModelScope.launch {
-            duckAiInputScreenDataStore.getLastUsedMode().let { mode ->
+            inputScreenDataStore.getLastUsedMode().let { mode ->
                 command.value = when (mode) {
                     null,
-                    DuckAiInputScreenMode.SEARCH,
+                    InputScreenMode.SEARCH,
                     -> Command.SwitchModeToSearch
-                    DuckAiInputScreenMode.CHAT -> Command.SwitchModeToChat
+                    InputScreenMode.CHAT -> Command.SwitchModeToChat
                 }
             }
         }
@@ -290,13 +290,13 @@ class InputScreenViewModel @Inject constructor(
 
     fun onSearchSelected() {
         viewModelScope.launch {
-            duckAiInputScreenDataStore.setLastUsedMode(DuckAiInputScreenMode.SEARCH)
+            inputScreenDataStore.setLastUsedMode(InputScreenMode.SEARCH)
         }
     }
 
     fun onChatSelected() {
         viewModelScope.launch {
-            duckAiInputScreenDataStore.setLastUsedMode(DuckAiInputScreenMode.CHAT)
+            inputScreenDataStore.setLastUsedMode(InputScreenMode.CHAT)
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1210658958592463

### Description
Persist the last used Input Screen mode and restore it when user opens the screen again.

### Steps to test this PR
- [x] Open Input Screen, select Duck.ai
- [x] Go back
- [x] Reopen the screen and verify Duck.ai is selected
