### PR TITLE
move duck.ai input screen return button, improve input string management

### DIFF
--- a/duckchat/duckchat-impl/src/main/res/layout/fragment_search_interstitial.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/fragment_search_interstitial.xml
@@ -63,27 +63,6 @@
         app:layout_constraintEnd_toEndOf="parent"/>
 
     <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
-        android:id="@+id/actionVoice"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
-        android:minWidth="0dp"
-        android:minHeight="0dp"
-        android:backgroundTint="?attr/daxColorSurface"
-        android:layout_marginBottom="@dimen/keyline_3"
-        android:layout_marginEnd="@dimen/keyline_3"
-        android:importantForAccessibility="no"
-        android:text="&#8203;"
-        android:textColor="@android:color/transparent"
-        android:visibility="gone"
-        app:icon="@drawable/ic_microphone_24"
-        app:iconTint="?attr/daxColorPrimaryIcon"
-        app:iconPadding="0dp"
-        app:iconGravity="textStart"
-        app:rippleColor="?attr/daxColorRipple"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/actionSend"/>
-
-    <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
         android:id="@+id/actionNewLine"
         android:layout_width="40dp"
         android:layout_height="40dp"
@@ -102,6 +81,27 @@
         app:iconGravity="textStart"
         app:rippleColor="?attr/daxColorRipple"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/actionVoice"/>
+        app:layout_constraintEnd_toStartOf="@id/actionSend"/>
+
+    <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
+        android:id="@+id/actionVoice"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:minWidth="0dp"
+        android:minHeight="0dp"
+        android:backgroundTint="?attr/daxColorWindow"
+        android:layout_marginBottom="@dimen/keyline_3"
+        android:layout_marginEnd="@dimen/keyline_3"
+        android:importantForAccessibility="no"
+        android:text="&#8203;"
+        android:textColor="@android:color/transparent"
+        android:visibility="gone"
+        app:icon="@drawable/ic_microphone_24"
+        app:iconTint="?attr/daxColorPrimaryIcon"
+        app:iconPadding="0dp"
+        app:iconGravity="textStart"
+        app:rippleColor="?attr/daxColorRipple"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/actionNewLine"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1210659642047207?focus=true

### Description
- Moves the return button in the Duck.ai input screen to the side of the submit button.
- Fixes an issue where the submit button was visible when only new lines were in the input field.
- Fixes an issue where return key didn't replace selected text.
- Fixes voice input button's background color.

### Steps to test this PR
- [x] Verify that even if voice input is enabled, return key is next to submit button.
- [x] Open the input screen, clear text, add new lines. Verify the submit button is not visible.
- [x] Input some text, select all or portion of it, click the return key and verify that the whole selection is replaced.

