### PR TITLE
Add source to import flow pixels

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/AutofillImportLaunchSource.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/AutofillImportLaunchSource.kt
@@ -16,8 +16,14 @@
 
 package com.duckduckgo.autofill.impl.importing
 
-enum class AutofillImportLaunchSource(val value: String) {
-    PasswordManagementPromo("passwords_management_promo"),
-    AutofillSettings("autofill_settings"),
-    PasswordManagementEmpty("passwords_management_empty"),
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+enum class AutofillImportLaunchSource(val value: String) : Parcelable {
+    PasswordManagementPromo("password_management_promo"),
+    PasswordManagementEmptyState("password_management_empty_state"),
+    PasswordManagementOverflow("password_management_overflow"),
+    AutofillSettings("autofill_settings_button"),
+    Unknown("unknown"),
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/promo/ImportInPasswordsPromotionViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/promo/ImportInPasswordsPromotionViewModel.kt
@@ -20,7 +20,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.autofill.impl.importing.AutofillImportLaunchSource
+import com.duckduckgo.autofill.impl.importing.AutofillImportLaunchSource.PasswordManagementPromo
 import com.duckduckgo.autofill.impl.importing.promo.ImportInPasswordsPromotionViewModel.Command.DismissImport
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_GOOGLE_PASSWORDS_EMPTY_STATE_CTA_BUTTON_TAPPED
@@ -56,7 +56,7 @@ class ImportInPasswordsPromotionViewModel @Inject constructor(
     fun onPromoShown() {
         if (!promoDisplayedPixelSent) {
             promoDisplayedPixelSent = true
-            val params = mapOf("source" to AutofillImportLaunchSource.PasswordManagementPromo.value)
+            val params = mapOf("source" to PasswordManagementPromo.value)
             pixel.fire(AutofillPixelNames.AUTOFILL_IMPORT_GOOGLE_PASSWORDS_EMPTY_STATE_CTA_BUTTON_SHOWN, params)
         }
     }
@@ -65,10 +65,10 @@ class ImportInPasswordsPromotionViewModel @Inject constructor(
         viewModelScope.launch(dispatchers.io()) {
             promoEventDispatcher.emit(
                 AutofillEffect.LaunchImportPasswords(
-                    source = AutofillImportLaunchSource.PasswordManagementPromo,
+                    source = PasswordManagementPromo,
                 ),
             )
-            val params = mapOf("source" to AutofillImportLaunchSource.PasswordManagementPromo.value)
+            val params = mapOf("source" to PasswordManagementPromo.value)
             pixel.fire(AUTOFILL_IMPORT_GOOGLE_PASSWORDS_EMPTY_STATE_CTA_BUTTON_TAPPED, params)
         }
     }
@@ -77,6 +77,11 @@ class ImportInPasswordsPromotionViewModel @Inject constructor(
         viewModelScope.launch(dispatchers.io()) {
             importInPasswordsVisibility.onPromoDismissed()
             command.send(DismissImport)
+            pixel.fire(
+                pixel = AutofillPixelNames.AUTOFILL_IMPORT_GOOGLE_PASSWORDS_EMPTY_STATE_CTA_BUTTON_DISMISSED,
+                parameters = mapOf("source" to PasswordManagementPromo.value),
+                encodedParameters = emptyMap(),
+            )
         }
     }
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
@@ -161,6 +161,7 @@ enum class AutofillPixelNames(override val pixelName: String) : Pixel.PixelName 
 
     AUTOFILL_IMPORT_GOOGLE_PASSWORDS_EMPTY_STATE_CTA_BUTTON_TAPPED("autofill_import_google_passwords_import_button_tapped"),
     AUTOFILL_IMPORT_GOOGLE_PASSWORDS_EMPTY_STATE_CTA_BUTTON_SHOWN("autofill_import_google_passwords_import_button_shown"),
+    AUTOFILL_IMPORT_GOOGLE_PASSWORDS_EMPTY_STATE_CTA_BUTTON_DISMISSED("autofill_import_google_passwords_import_button_dismissed"),
     AUTOFILL_IMPORT_GOOGLE_PASSWORDS_OVERFLOW_MENU("autofill_import_google_passwords_overflow_menu_tapped"),
     AUTOFILL_IMPORT_GOOGLE_PASSWORDS_PREIMPORT_PROMPT_DISPLAYED("autofill_import_google_passwords_preimport_prompt_displayed"),
     AUTOFILL_IMPORT_GOOGLE_PASSWORDS_PREIMPORT_PROMPT_CONFIRMED("autofill_import_google_passwords_preimport_prompt_confirmed"),

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillPasswordsManagementViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillPasswordsManagementViewModel.kt
@@ -34,6 +34,7 @@ import com.duckduckgo.autofill.impl.asString
 import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator
 import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator.AuthConfiguration
 import com.duckduckgo.autofill.impl.importing.AutofillImportLaunchSource
+import com.duckduckgo.autofill.impl.importing.AutofillImportLaunchSource.PasswordManagementPromo
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_DELETE_LOGIN
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENABLE_AUTOFILL_TOGGLE_MANUALLY_DISABLED
@@ -454,7 +455,7 @@ class AutofillPasswordsManagementViewModel @Inject constructor(
         viewModelScope.launch(dispatchers.io()) {
             autofillEffectDispatcher.effects.collect { effect ->
                 when {
-                    effect is LaunchImportPasswords -> addCommand(LaunchImportGooglePasswords(showImportInstructions = false))
+                    effect is LaunchImportPasswords -> addCommand(LaunchImportGooglePasswords(PasswordManagementPromo))
                 }
             }
         }
@@ -738,9 +739,9 @@ class AutofillPasswordsManagementViewModel @Inject constructor(
         }
     }
 
-    fun onImportPasswordsFromGooglePasswordManager() {
+    fun onImportPasswordsFromGooglePasswordManager(importSource: AutofillImportLaunchSource) {
         viewModelScope.launch(dispatchers.io()) {
-            addCommand(LaunchImportGooglePasswords(showImportInstructions = true))
+            addCommand(LaunchImportGooglePasswords(importSource))
         }
     }
 
@@ -814,7 +815,7 @@ class AutofillPasswordsManagementViewModel @Inject constructor(
     fun recordImportGooglePasswordButtonShown() {
         if (!importGooglePasswordButtonShownPixelSent) {
             importGooglePasswordButtonShownPixelSent = true
-            val params = mapOf("source" to AutofillImportLaunchSource.PasswordManagementEmpty.value)
+            val params = mapOf("source" to AutofillImportLaunchSource.PasswordManagementEmptyState.value)
             pixel.fire(AUTOFILL_IMPORT_GOOGLE_PASSWORDS_EMPTY_STATE_CTA_BUTTON_SHOWN, params)
         }
     }
@@ -904,7 +905,7 @@ class AutofillPasswordsManagementViewModel @Inject constructor(
         data object LaunchResetNeverSaveListConfirmation : ListModeCommand()
         data class LaunchDeleteAllPasswordsConfirmation(val numberToDelete: Int) : ListModeCommand()
         data class PromptUserToAuthenticateMassDeletion(val authConfiguration: AuthConfiguration) : ListModeCommand()
-        data class LaunchImportGooglePasswords(val showImportInstructions: Boolean) : ListModeCommand()
+        data class LaunchImportGooglePasswords(val importSource: AutofillImportLaunchSource) : ListModeCommand()
         data class LaunchReportAutofillBreakageConfirmation(val eTldPlusOne: String) : ListModeCommand()
         data object ShowUserReportSentMessage : ListModeCommand()
         data object ReevalutePromotions : ListModeCommand()

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/importpassword/ImportPasswordsPixelSender.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/importpassword/ImportPasswordsPixelSender.kt
@@ -35,12 +35,12 @@ import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 
 interface ImportPasswordsPixelSender {
-    fun onImportPasswordsDialogDisplayed()
-    fun onImportPasswordsDialogImportButtonClicked()
-    fun onUserCancelledImportPasswordsDialog()
-    fun onUserCancelledImportWebFlow(stage: String)
-    fun onImportSuccessful(savedCredentials: Int, numberSkipped: Int)
-    fun onImportFailed(reason: UserCannotImportReason)
+    fun onImportPasswordsDialogDisplayed(source: AutofillImportLaunchSource)
+    fun onImportPasswordsDialogImportButtonClicked(source: AutofillImportLaunchSource)
+    fun onUserCancelledImportPasswordsDialog(source: AutofillImportLaunchSource)
+    fun onUserCancelledImportWebFlow(stage: String, source: AutofillImportLaunchSource)
+    fun onImportSuccessful(savedCredentials: Int, numberSkipped: Int, source: AutofillImportLaunchSource)
+    fun onImportFailed(reason: UserCannotImportReason, source: AutofillImportLaunchSource)
     fun onImportPasswordsButtonTapped(launchSource: AutofillImportLaunchSource)
     fun onImportPasswordsOverflowMenuTapped()
     fun onImportPasswordsViaDesktopSyncButtonTapped()
@@ -53,39 +53,49 @@ class ImportPasswordsPixelSenderImpl @Inject constructor(
     private val engagementBucketing: AutofillEngagementBucketing,
 ) : ImportPasswordsPixelSender {
 
-    override fun onImportPasswordsDialogDisplayed() {
-        pixel.fire(AUTOFILL_IMPORT_GOOGLE_PASSWORDS_PREIMPORT_PROMPT_DISPLAYED)
+    override fun onImportPasswordsDialogDisplayed(source: AutofillImportLaunchSource) {
+        val params = mapOf(SOURCE_KEY to source.value)
+        pixel.fire(AUTOFILL_IMPORT_GOOGLE_PASSWORDS_PREIMPORT_PROMPT_DISPLAYED, params)
     }
 
-    override fun onImportPasswordsDialogImportButtonClicked() {
-        pixel.fire(AUTOFILL_IMPORT_GOOGLE_PASSWORDS_PREIMPORT_PROMPT_CONFIRMED)
+    override fun onImportPasswordsDialogImportButtonClicked(source: AutofillImportLaunchSource) {
+        val params = mapOf(SOURCE_KEY to source.value)
+        pixel.fire(AUTOFILL_IMPORT_GOOGLE_PASSWORDS_PREIMPORT_PROMPT_CONFIRMED, params)
     }
 
-    override fun onUserCancelledImportPasswordsDialog() {
-        val params = mapOf(CANCELLATION_STAGE_KEY to PRE_IMPORT_DIALOG_STAGE)
+    override fun onUserCancelledImportPasswordsDialog(source: AutofillImportLaunchSource) {
+        val params = mapOf(
+            CANCELLATION_STAGE_KEY to PRE_IMPORT_DIALOG_STAGE,
+            SOURCE_KEY to source.value,
+        )
         pixel.fire(AUTOFILL_IMPORT_GOOGLE_PASSWORDS_RESULT_FAILURE_USER_CANCELLED, params)
     }
 
-    override fun onUserCancelledImportWebFlow(stage: String) {
-        val params = mapOf(CANCELLATION_STAGE_KEY to stage)
+    override fun onUserCancelledImportWebFlow(stage: String, source: AutofillImportLaunchSource) {
+        val params = mapOf(
+            CANCELLATION_STAGE_KEY to stage,
+            SOURCE_KEY to source.value,
+        )
         pixel.fire(AUTOFILL_IMPORT_GOOGLE_PASSWORDS_RESULT_FAILURE_USER_CANCELLED, params)
     }
 
-    override fun onImportSuccessful(savedCredentials: Int, numberSkipped: Int) {
+    override fun onImportSuccessful(savedCredentials: Int, numberSkipped: Int, source: AutofillImportLaunchSource) {
         val savedCredentialsBucketed = engagementBucketing.bucketNumberOfCredentials(savedCredentials)
         val skippedCredentialsBucketed = engagementBucketing.bucketNumberOfCredentials(numberSkipped)
         val params = mapOf(
             "saved_credentials" to savedCredentialsBucketed,
             "skipped_credentials" to skippedCredentialsBucketed,
+            SOURCE_KEY to source.value,
         )
         pixel.fire(AUTOFILL_IMPORT_GOOGLE_PASSWORDS_RESULT_SUCCESS, params)
     }
 
-    override fun onImportFailed(reason: UserCannotImportReason) {
+    override fun onImportFailed(reason: UserCannotImportReason, source: AutofillImportLaunchSource) {
         val pixelName = when (reason) {
             ErrorParsingCsv -> AUTOFILL_IMPORT_GOOGLE_PASSWORDS_RESULT_FAILURE_ERROR_PARSING
         }
-        pixel.fire(pixelName)
+        val params = mapOf(SOURCE_KEY to source.value)
+        pixel.fire(pixelName, params)
     }
 
     override fun onImportPasswordsButtonTapped(launchSource: AutofillImportLaunchSource) {
@@ -94,7 +104,8 @@ class ImportPasswordsPixelSenderImpl @Inject constructor(
     }
 
     override fun onImportPasswordsOverflowMenuTapped() {
-        pixel.fire(AUTOFILL_IMPORT_GOOGLE_PASSWORDS_OVERFLOW_MENU)
+        val params = mapOf(SOURCE_KEY to AutofillImportLaunchSource.PasswordManagementOverflow.value)
+        pixel.fire(AUTOFILL_IMPORT_GOOGLE_PASSWORDS_OVERFLOW_MENU, params)
     }
 
     override fun onImportPasswordsViaDesktopSyncButtonTapped() {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementListMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementListMode.kt
@@ -37,7 +37,9 @@ import com.duckduckgo.autofill.impl.databinding.FragmentAutofillManagementListMo
 import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator
 import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator.AuthConfiguration
 import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator.AuthResult.Success
-import com.duckduckgo.autofill.impl.importing.AutofillImportLaunchSource.PasswordManagementEmpty
+import com.duckduckgo.autofill.impl.importing.AutofillImportLaunchSource
+import com.duckduckgo.autofill.impl.importing.AutofillImportLaunchSource.PasswordManagementEmptyState
+import com.duckduckgo.autofill.impl.importing.AutofillImportLaunchSource.PasswordManagementOverflow
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillManagementActivity
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillManagementRecyclerAdapter
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillManagementRecyclerAdapter.AutofillToggleState
@@ -233,7 +235,7 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
                         }
 
                         R.id.importGooglePasswords -> {
-                            viewModel.onImportPasswordsFromGooglePasswordManager()
+                            viewModel.onImportPasswordsFromGooglePasswordManager(importSource = PasswordManagementOverflow)
                             importPasswordsPixelSender.onImportPasswordsOverflowMenuTapped()
                             true
                         }
@@ -339,7 +341,7 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
             LaunchResetNeverSaveListConfirmation -> launchResetNeverSavedSitesConfirmation()
             is LaunchDeleteAllPasswordsConfirmation -> launchDeleteAllLoginsConfirmationDialog(command.numberToDelete)
             is PromptUserToAuthenticateMassDeletion -> promptUserToAuthenticateMassDeletion(command.authConfiguration)
-            is LaunchImportGooglePasswords -> launchImportPasswordsScreen(showInitialInstructionalPrompt = command.showImportInstructions)
+            is LaunchImportGooglePasswords -> launchImportPasswordsScreen(importSource = command.importSource)
             is LaunchReportAutofillBreakageConfirmation -> launchReportBreakageConfirmation(command.eTldPlusOne)
             is ShowUserReportSentMessage -> showUserReportSentMessage()
             is ReevalutePromotions -> evaluatePromotions()
@@ -357,9 +359,9 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
         Snackbar.make(binding.root, R.string.autofillManagementReportBreakageSuccessMessage, Snackbar.LENGTH_LONG).show()
     }
 
-    private fun launchImportPasswordsScreen(showInitialInstructionalPrompt: Boolean) {
+    private fun launchImportPasswordsScreen(importSource: AutofillImportLaunchSource) {
         context?.let {
-            val dialog = ImportFromGooglePasswordsDialog.instance(showInitialInstructionalPrompt = showInitialInstructionalPrompt)
+            val dialog = ImportFromGooglePasswordsDialog.instance(importSource = importSource)
             dialog.show(parentFragmentManager, IMPORT_FROM_GPM_DIALOG_TAG)
         }
     }
@@ -523,7 +525,7 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
             onReportBreakageClicked = { viewModel.onReportBreakageClicked() },
             launchHelpPageClicked = this::launchHelpPage,
             onAutofillToggleClicked = this::onAutofillToggledChanged,
-            onImportFromGoogleClicked = this::onImportFromGoogleClicked,
+            onImportFromGoogleClicked = this::onImportFromGoogleClickedFromEmptyList,
             onImportViaDesktopSyncClicked = this::onImportViaDesktopSyncClicked,
         ).also { binding.logins.adapter = it }
     }
@@ -536,9 +538,9 @@ class AutofillManagementListMode : DuckDuckGoFragment(R.layout.fragment_autofill
         }
     }
 
-    private fun onImportFromGoogleClicked() {
-        viewModel.onImportPasswordsFromGooglePasswordManager()
-        importPasswordsPixelSender.onImportPasswordsButtonTapped(PasswordManagementEmpty)
+    private fun onImportFromGoogleClickedFromEmptyList() {
+        viewModel.onImportPasswordsFromGooglePasswordManager(PasswordManagementEmptyState)
+        importPasswordsPixelSender.onImportPasswordsButtonTapped(PasswordManagementEmptyState)
     }
 
     private fun onImportViaDesktopSyncClicked() {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementListModeLegacy.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementListModeLegacy.kt
@@ -46,7 +46,9 @@ import com.duckduckgo.autofill.impl.databinding.FragmentAutofillManagementListMo
 import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator
 import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator.AuthConfiguration
 import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator.AuthResult.Success
-import com.duckduckgo.autofill.impl.importing.AutofillImportLaunchSource.PasswordManagementEmpty
+import com.duckduckgo.autofill.impl.importing.AutofillImportLaunchSource
+import com.duckduckgo.autofill.impl.importing.AutofillImportLaunchSource.PasswordManagementEmptyState
+import com.duckduckgo.autofill.impl.importing.AutofillImportLaunchSource.PasswordManagementOverflow
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillManagementActivity
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillManagementRecyclerAdapterLegacy
 import com.duckduckgo.autofill.impl.ui.credential.management.AutofillManagementRecyclerAdapterLegacy.ContextMenuAction.CopyPassword
@@ -244,8 +246,8 @@ class AutofillManagementListModeLegacy : DuckDuckGoFragment(R.layout.fragment_au
 
     private fun configureImportPasswordsButton() {
         binding.emptyStateLayout.importPasswordsFromGoogleButton.setOnClickListener {
-            viewModel.onImportPasswordsFromGooglePasswordManager()
-            importPasswordsPixelSender.onImportPasswordsButtonTapped(PasswordManagementEmpty)
+            viewModel.onImportPasswordsFromGooglePasswordManager(PasswordManagementEmptyState)
+            importPasswordsPixelSender.onImportPasswordsButtonTapped(launchSource = PasswordManagementEmptyState)
         }
 
         binding.emptyStateLayout.importPasswordsViaDesktopSyncButton.setOnClickListener {
@@ -298,7 +300,7 @@ class AutofillManagementListModeLegacy : DuckDuckGoFragment(R.layout.fragment_au
                         }
 
                         R.id.importGooglePasswords -> {
-                            viewModel.onImportPasswordsFromGooglePasswordManager()
+                            viewModel.onImportPasswordsFromGooglePasswordManager(PasswordManagementOverflow)
                             importPasswordsPixelSender.onImportPasswordsOverflowMenuTapped()
                             true
                         }
@@ -421,7 +423,7 @@ class AutofillManagementListModeLegacy : DuckDuckGoFragment(R.layout.fragment_au
             LaunchResetNeverSaveListConfirmation -> launchResetNeverSavedSitesConfirmation()
             is LaunchDeleteAllPasswordsConfirmation -> launchDeleteAllLoginsConfirmationDialog(command.numberToDelete)
             is PromptUserToAuthenticateMassDeletion -> promptUserToAuthenticateMassDeletion(command.authConfiguration)
-            is LaunchImportGooglePasswords -> launchImportPasswordsScreen(command.showImportInstructions)
+            is LaunchImportGooglePasswords -> launchImportPasswordsScreen(command.importSource)
             is LaunchReportAutofillBreakageConfirmation -> launchReportBreakageConfirmation(command.eTldPlusOne)
             is ShowUserReportSentMessage -> showUserReportSentMessage()
             is ReevalutePromotions -> configurePromotionsContainer()
@@ -433,9 +435,9 @@ class AutofillManagementListModeLegacy : DuckDuckGoFragment(R.layout.fragment_au
         Snackbar.make(binding.root, R.string.autofillManagementReportBreakageSuccessMessage, Snackbar.LENGTH_LONG).show()
     }
 
-    private fun launchImportPasswordsScreen(showImportInstructions: Boolean) {
+    private fun launchImportPasswordsScreen(importSource: AutofillImportLaunchSource) {
         context?.let {
-            val dialog = ImportFromGooglePasswordsDialog.instance(showInitialInstructionalPrompt = showImportInstructions)
+            val dialog = ImportFromGooglePasswordsDialog.instance(importSource)
             dialog.show(parentFragmentManager, IMPORT_FROM_GPM_DIALOG_TAG)
         }
     }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/settings/AutofillSettingsActivity.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/settings/AutofillSettingsActivity.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.autofill.api.AutofillScreens.AutofillPasswordsManagementSc
 import com.duckduckgo.autofill.api.AutofillScreens.AutofillSettingsScreen
 import com.duckduckgo.autofill.impl.R
 import com.duckduckgo.autofill.impl.databinding.ActivityAutofillSettingsBinding
+import com.duckduckgo.autofill.impl.importing.AutofillImportLaunchSource
 import com.duckduckgo.autofill.impl.ui.credential.management.importpassword.ImportPasswordActivityParams
 import com.duckduckgo.autofill.impl.ui.credential.management.importpassword.google.ImportFromGooglePasswordsDialog
 import com.duckduckgo.autofill.impl.ui.credential.management.viewing.AutofillManagementDeviceUnsupportedMode
@@ -174,7 +175,7 @@ class AutofillSettingsActivity : DuckDuckGoActivity() {
             viewModel.onPasswordListClicked()
         }
         binding.autofillAvailable.importPasswordsOption.setOnClickListener {
-            viewModel.onImportPasswordsClicked(getAutofillSettingsLaunchSource())
+            viewModel.onImportPasswordsClicked(AutofillImportLaunchSource.AutofillSettings)
         }
         binding.autofillAvailable.syncDesktopPasswordsOption.setOnClickListener {
             viewModel.onImportFromDesktopWithSyncClicked(getAutofillSettingsLaunchSource())
@@ -223,7 +224,7 @@ class AutofillSettingsActivity : DuckDuckGoActivity() {
     }
 
     private fun launchImportPasswordsScreen() {
-        val dialog = ImportFromGooglePasswordsDialog.instance(showInitialInstructionalPrompt = true)
+        val dialog = ImportFromGooglePasswordsDialog.instance(AutofillImportLaunchSource.AutofillSettings)
         dialog.show(supportFragmentManager, IMPORT_FROM_GPM_DIALOG_TAG)
     }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/settings/AutofillSettingsViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/settings/AutofillSettingsViewModel.kt
@@ -190,13 +190,13 @@ class AutofillSettingsViewModel @Inject constructor(
         }
     }
 
-    fun onImportPasswordsClicked(autofillScreenLaunchSource: AutofillScreenLaunchSource?) {
+    fun onImportPasswordsClicked(launchSource: AutofillImportLaunchSource) {
         viewModelScope.launch {
             _commands.send(ImportPasswordsFromGoogle)
             // we use AUTOFILL_IMPORT_GOOGLE_PASSWORDS_EMPTY_STATE_CTA_BUTTON_TAPPED for consistency with iOS
             pixel.fire(
                 AUTOFILL_IMPORT_GOOGLE_PASSWORDS_EMPTY_STATE_CTA_BUTTON_TAPPED,
-                mapOf("source" to AutofillImportLaunchSource.AutofillSettings.value),
+                mapOf("source" to launchSource.value),
             )
         }
     }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsActivityScreenViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillSettingsActivityScreenViewModelTest.kt
@@ -38,6 +38,7 @@ import com.duckduckgo.autofill.api.domain.app.LoginCredentials
 import com.duckduckgo.autofill.api.email.EmailManager
 import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator
 import com.duckduckgo.autofill.impl.encoding.UrlUnicodeNormalizerImpl
+import com.duckduckgo.autofill.impl.importing.AutofillImportLaunchSource.PasswordManagementEmptyState
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_COPY_PASSWORD
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_COPY_USERNAME
@@ -1065,11 +1066,11 @@ class AutofillSettingsActivityScreenViewModelTest {
 
     @Test
     fun whenOnImportPasswordsFromGooglePasswordManagerCalledThenCorrectCommandIsAdded() = runTest {
-        testee.onImportPasswordsFromGooglePasswordManager()
+        testee.onImportPasswordsFromGooglePasswordManager(PasswordManagementEmptyState)
 
         testee.commandsListView.test {
             val commands = awaitItem()
-            assertTrue(commands.contains(LaunchImportGooglePasswords(true)))
+            assertTrue(commands.contains(LaunchImportGooglePasswords(PasswordManagementEmptyState)))
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/importpassword/google/ImportFromGooglePasswordsDialogViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/credential/management/importpassword/google/ImportFromGooglePasswordsDialogViewModelTest.kt
@@ -2,6 +2,7 @@ package com.duckduckgo.autofill.impl.ui.credential.management.importpassword.goo
 
 import app.cash.turbine.TurbineTestContext
 import app.cash.turbine.test
+import com.duckduckgo.autofill.impl.importing.AutofillImportLaunchSource
 import com.duckduckgo.autofill.impl.importing.CredentialImporter
 import com.duckduckgo.autofill.impl.importing.CredentialImporter.ImportResult.Finished
 import com.duckduckgo.autofill.impl.importing.CredentialImporter.ImportResult.InProgress
@@ -46,7 +47,7 @@ class ImportFromGooglePasswordsDialogViewModelTest {
 
     @Test
     fun whenParsingErrorOnImportThenViewModeUpdatedToError() = runTest {
-        testee.onImportFlowFinishedWithError(ErrorParsingCsv)
+        testee.onImportFlowFinishedWithError(reason = ErrorParsingCsv, importSource = TEST_SOURCE)
         testee.viewState.test {
             assertTrue(awaitItem().viewMode is ViewMode.ImportError)
         }
@@ -55,8 +56,8 @@ class ImportFromGooglePasswordsDialogViewModelTest {
     @Test
     fun whenSuccessfulImportThenViewModeUpdatedToInProgress() = runTest {
         configureImportInProgress()
-        testee.shouldShowInitialInstructionalPrompt()
-        testee.onImportFlowFinishedSuccessfully()
+        testee.shouldShowInitialInstructionalPrompt(importSource = TEST_SOURCE)
+        testee.onImportFlowFinishedSuccessfully(importSource = TEST_SOURCE)
         testee.viewState.test {
             awaitImportInProgress()
         }
@@ -65,8 +66,8 @@ class ImportFromGooglePasswordsDialogViewModelTest {
     @Test
     fun whenSuccessfulImportFlowThenImportFinishesNothingImportedThenViewModeUpdatedToResults() = runTest {
         configureImportFinished(savedCredentials = 0, numberSkipped = 0)
-        testee.shouldShowInitialInstructionalPrompt()
-        testee.onImportFlowFinishedSuccessfully()
+        testee.shouldShowInitialInstructionalPrompt(importSource = TEST_SOURCE)
+        testee.onImportFlowFinishedSuccessfully(importSource = TEST_SOURCE)
         testee.viewState.test {
             awaitImportSuccess()
         }
@@ -75,8 +76,8 @@ class ImportFromGooglePasswordsDialogViewModelTest {
     @Test
     fun whenSuccessfulImportFlowThenImportFinishesCredentialsImportedNoDuplicatesThenViewModeUpdatedToResults() = runTest {
         configureImportFinished(savedCredentials = 10, numberSkipped = 0)
-        testee.shouldShowInitialInstructionalPrompt()
-        testee.onImportFlowFinishedSuccessfully()
+        testee.shouldShowInitialInstructionalPrompt(importSource = TEST_SOURCE)
+        testee.onImportFlowFinishedSuccessfully(importSource = TEST_SOURCE)
         testee.viewState.test {
             val result = awaitImportSuccess()
             assertEquals(10, result.importResult.savedCredentials)
@@ -87,8 +88,8 @@ class ImportFromGooglePasswordsDialogViewModelTest {
     @Test
     fun whenSuccessfulImportFlowThenImportFinishesOnlyDuplicatesThenViewModeUpdatedToResults() = runTest {
         configureImportFinished(savedCredentials = 0, numberSkipped = 2)
-        testee.shouldShowInitialInstructionalPrompt()
-        testee.onImportFlowFinishedSuccessfully()
+        testee.shouldShowInitialInstructionalPrompt(importSource = TEST_SOURCE)
+        testee.onImportFlowFinishedSuccessfully(importSource = TEST_SOURCE)
         testee.viewState.test {
             val result = awaitImportSuccess()
             assertEquals(0, result.importResult.savedCredentials)
@@ -98,8 +99,8 @@ class ImportFromGooglePasswordsDialogViewModelTest {
 
     @Test
     fun whenSuccessfulImportNoUpdatesThenThenViewModeFirstInitialisedToPreImport() = runTest {
-        testee.shouldShowInitialInstructionalPrompt()
-        testee.onImportFlowFinishedSuccessfully()
+        testee.shouldShowInitialInstructionalPrompt(importSource = TEST_SOURCE)
+        testee.onImportFlowFinishedSuccessfully(importSource = TEST_SOURCE)
         testee.viewState.test {
             awaitItem().assertIsPreImport()
         }
@@ -114,7 +115,7 @@ class ImportFromGooglePasswordsDialogViewModelTest {
 
     @Test
     fun whenFirstCreatedPreImportRequiredThenViewModeFirstInitialisedToPreImportView() = runTest {
-        testee.shouldShowInitialInstructionalPrompt()
+        testee.shouldShowInitialInstructionalPrompt(importSource = TEST_SOURCE)
         testee.viewState.test {
             awaitItem().assertIsPreImport()
         }
@@ -157,5 +158,9 @@ class ImportFromGooglePasswordsDialogViewModelTest {
 
     private fun ViewState.assertIsDeterminingFirstViewToShow() {
         assertTrue(viewMode is DeterminingFirstView)
+    }
+
+    companion object {
+        private val TEST_SOURCE = AutofillImportLaunchSource.PasswordManagementEmptyState
     }
 }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/settings/AutofillSettingsViewModelTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/ui/settings/AutofillSettingsViewModelTest.kt
@@ -9,7 +9,9 @@ import com.duckduckgo.app.browser.api.WebViewCapabilityChecker.WebViewCapability
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.autofill.api.AutofillFeature
 import com.duckduckgo.autofill.api.AutofillScreenLaunchSource
+import com.duckduckgo.autofill.api.AutofillScreenLaunchSource.SettingsActivity
 import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator
+import com.duckduckgo.autofill.impl.importing.AutofillImportLaunchSource.AutofillSettings
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENABLE_AUTOFILL_TOGGLE_MANUALLY_DISABLED
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENABLE_AUTOFILL_TOGGLE_MANUALLY_ENABLED
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_IMPORT_GOOGLE_PASSWORDS_EMPTY_STATE_CTA_BUTTON_SHOWN
@@ -84,7 +86,7 @@ class AutofillSettingsViewModelTest {
     fun whenScreenRendersIfImportButtonAvailableThenPixelIsSent() = runTest {
         testee.viewState(launchSource).test {
             awaitItem()
-            val expectedParams = mapOf("source" to "autofill_settings")
+            val expectedParams = mapOf("source" to AutofillSettings.value)
             verify(pixel).fire(
                 pixel = eq(AUTOFILL_IMPORT_GOOGLE_PASSWORDS_EMPTY_STATE_CTA_BUTTON_SHOWN),
                 parameters = eq(expectedParams),
@@ -273,10 +275,10 @@ class AutofillSettingsViewModelTest {
 
     @Test
     fun whenUserClickOnImportGooglePasswordsThenCommandIsSent() = runTest {
-        testee.onImportPasswordsClicked(AutofillScreenLaunchSource.SettingsActivity)
+        testee.onImportPasswordsClicked(AutofillSettings)
         testee.commands.test {
             assertEquals(AutofillSettingsViewModel.Command.ImportPasswordsFromGoogle, awaitItem())
-            val expectedParams = mapOf("source" to "autofill_settings")
+            val expectedParams = mapOf("source" to AutofillSettings.value)
             verify(pixel).fire(
                 pixel = eq(AUTOFILL_IMPORT_GOOGLE_PASSWORDS_EMPTY_STATE_CTA_BUTTON_TAPPED),
                 parameters = eq(expectedParams),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1210421589932466 

### Description
Updates the pixels around password import prompts/buttons/dialogs, namely to include a `source` parameter indicating where the import was launched from.

Possible values: 
- `password_management_promo`
- `password_management_empty_state`
- `password_management_overflow`
- `autofill_settings_button`
- `unknown` (should never happen in reality)

### Steps to test this PR

Suggested logcat filter: `message~:"Pixel sent.*source="`

#### Password management view
- [x] Fresh install, and visit Passwords from the browser overflow menu
- [x] Verify: `autofill_import_google_passwords_import_button_shown with params: {source=password_management_empty_state}`
- [x] Verify: `autofill_import_google_passwords_preimport_prompt_displayed with params: {source=password_management_empty_state}`
- [x] Verify: `autofill_import_google_passwords_import_button_tapped with params: {source=password_management_empty_state}`
- [x] Dismiss the dialog. Verify: `autofill_import_google_passwords_result_user_cancelled with params: {stage=pre-import-dialog, source=password_management_empty_state}`
- [x] Manually add a password and return to the list
- [x] Verify you see the password import promo, and `autofill_import_google_passwords_import_button_shown with params: {source=password_management_promo}`
- [x] Tap the promo CTA; verify: `autofill_import_google_passwords_import_button_tapped with params: {source=password_management_promo}`
- [x] Complete or cancel the import flow to return to the password list. Tap on overflow and choose `Import Passwords From Google`. 
- [x] Verify: `autofill_import_google_passwords_overflow_menu_tapped with params: {source=password_management_overflow}`
- [x] Verify: `autofill_import_google_passwords_preimport_prompt_displayed with params: {source=password_management_overflow}`

#### Password settings screen
- [x] Leave management screen, and visit app settings, then `Passwords & Autofill`
- [x] Verify: `autofill_import_google_passwords_import_button_shown with params: {source=autofill_settings_button}`