### PR TITLE
Update reference tests to version 1751029573

### DIFF
--- a/malicious-site-protection/malicious-site-protection-impl/src/test/resources/reference_tests/canonicalization/canonicalization_tests.json
+++ b/malicious-site-protection/malicious-site-protection-impl/src/test/resources/reference_tests/canonicalization/canonicalization_tests.json
@@ -81,7 +81,8 @@
                 "expectURL": "https://broken.third-party.site/path/to",
                 "exceptPlatforms": [
                     "web-extension",
-                    "safari-extension"
+                    "safari-extension",
+                    "windows-browser"
                 ]
             }
         ]
@@ -94,31 +95,31 @@
                 "name": "Simple domain - extract hostname portion from the URL",
                 "siteURL": "http://www.somesite.com",
                 "expectDomain": "somesite.com",
-                "exceptPlatforms": []
+                "exceptPlatforms": [ "windows-browser" ]
             },
             {
                 "name": "Simple domain with a port",
                 "siteURL": "http://www.somesite.com:8000/",
                 "expectDomain": "somesite.com",
-                "exceptPlatforms": []
+                "exceptPlatforms": [ "windows-browser" ]
             },
             {
                 "name": "Simple domain with a username",
                 "siteURL": "http://user:pass@www.somesite.com",
                 "expectDomain": "somesite.com",
-                "exceptPlatforms": []
+                "exceptPlatforms": [ "windows-browser" ]
             },
             {
                 "name": "Simple domain with a fragment",
                 "siteURL": "http://www.somesite.com#fragment",
                 "expectDomain": "somesite.com",
-                "exceptPlatforms": []
+                "exceptPlatforms": [ "windows-browser" ]
             },
             {
                 "name": "Simple domain with a query string",
                 "siteURL": "http://www.somesite.com?some=value",
                 "expectDomain": "somesite.com",
-                "exceptPlatforms": []
+                "exceptPlatforms": [ "windows-browser" ]
             },
             {
                 "name": "Decode any %XX escapes present in the hostname",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.0.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.1.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
-        "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1747996876"
+        "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
       },
       "devDependencies": {
         "@rollup/plugin-json": "^4.1.0",
@@ -85,7 +85,7 @@
       }
     },
     "node_modules/@duckduckgo/privacy-reference-tests": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#47a71fcdbd1277bc2020d1239945ca6bdb22c74d",
+      "resolved": "git+ssh://git@github.com/duckduckgo/privacy-reference-tests.git#58201fc6a9ffaaf53f80391c0f628d86f904193e",
       "license": "Apache-2.0"
     },
     "node_modules/@ghostery/adblocker": {
@@ -128,18 +128,14 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
-      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.9.tgz",
+      "integrity": "sha512-xpz6C/vXOegF9VEtlMBlkNNIjHrLhKaFBsO4lmQGr00x5BHp7p+oliR6i7LwIcM5cZU2VjLSwm2R+/zj5IjPWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -152,20 +148,10 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@jridgewell/source-map": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
-      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.7.tgz",
+      "integrity": "sha512-maArE+jvYbj06DXh2iFlXSSDjTWXODlPTQHdDRQdGoYw7KvT4SfYCnPHfCyww8Z3JqFsW0BBjPLj8A2fwAvv7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -174,16 +160,16 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.1.tgz",
+      "integrity": "sha512-mBLKRHc7Ffw/hObYb9+cunuGNjshQk+vZdwZBJoqiysK/mW3Jq0UXosq8aIhMnLevANhR9yoYfdUEOHg6M9y0g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "version": "0.3.26",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.26.tgz",
+      "integrity": "sha512-Z9rjt4BUVEbLFpw0qjCklVxxf421wrmcbP4w+LmBUxYCyJTYYSclgJD0YsCgGqQCtCIPiz7kjbYYJiAKhjJ3kA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -294,9 +280,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.0.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.4.tgz",
-      "integrity": "sha512-ulyqAkrhnuNq9pB76DRBTkcS6YsmDALy6Ua63V8OhrOBgbcYt6IOdzpw5P1+dyRIyMerzLkeYWBeOXPpA9GMAA==",
+      "version": "24.0.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.7.tgz",
+      "integrity": "sha512-YIEUUr4yf8q8oQoXPpSlnvKNVKDQlPMWrmOcgzoduo7kvA2UF0/BwJ/eMKFTiTtkNL17I0M6Xe2tvwFU7be6iw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.0.0",
     "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.1.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
-    "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1747996876"
+    "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
   }
 }


### PR DESCRIPTION
- Automated reference tests dependency update

This PR updates the reference tests dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/0/1203766026095653/f for further information on what to do next.

- [x] All tests must pass