### PR TITLE
Update content scope scripts to version 10.2.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
@@ -2835,6 +2835,7 @@
       /**
        * @type {{
        *   debug?: boolean,
+       *   platform: import('./utils.js').Platform,
        *   desktopModeEnabled?: boolean,
        *   forcedZoomEnabled?: boolean,
        *   featureSettings?: Record<string, unknown>,
@@ -2906,6 +2907,7 @@
      * @typedef {object} ConditionBlock
      * @property {string[] | string} [domain]
      * @property {object} [urlPattern]
+     * @property {object} [minSupportedVersion]
      * @property {object} [experiment]
      * @property {string} [experiment.experimentName]
      * @property {string} [experiment.cohort]
@@ -2931,7 +2933,8 @@
       const conditionChecks = {
         domain: this._matchDomainConditional,
         urlPattern: this._matchUrlPatternConditional,
-        experiment: this._matchExperimentConditional
+        experiment: this._matchExperimentConditional,
+        minSupportedVersion: this._matchMinSupportedVersion
       };
       for (const key in conditionBlock) {
         if (!conditionChecks[key]) {
@@ -2994,6 +2997,15 @@
         return false;
       }
       return matchHostname(domain, conditionBlock.domain);
+    }
+    /**
+     * Takes a condition block and returns true if the platform version satisfies the `minSupportedFeature`
+     * @param {ConditionBlock} conditionBlock
+     * @returns {boolean}
+     */
+    _matchMinSupportedVersion(conditionBlock) {
+      if (!conditionBlock.minSupportedVersion) return false;
+      return isSupportedVersion(conditionBlock.minSupportedVersion, __privateGet(this, _args)?.platform?.version);
     }
     /**
      * Return the settings object for a feature

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -4378,6 +4378,7 @@
       /**
        * @type {{
        *   debug?: boolean,
+       *   platform: import('./utils.js').Platform,
        *   desktopModeEnabled?: boolean,
        *   forcedZoomEnabled?: boolean,
        *   featureSettings?: Record<string, unknown>,
@@ -4449,6 +4450,7 @@
      * @typedef {object} ConditionBlock
      * @property {string[] | string} [domain]
      * @property {object} [urlPattern]
+     * @property {object} [minSupportedVersion]
      * @property {object} [experiment]
      * @property {string} [experiment.experimentName]
      * @property {string} [experiment.cohort]
@@ -4474,7 +4476,8 @@
       const conditionChecks = {
         domain: this._matchDomainConditional,
         urlPattern: this._matchUrlPatternConditional,
-        experiment: this._matchExperimentConditional
+        experiment: this._matchExperimentConditional,
+        minSupportedVersion: this._matchMinSupportedVersion
       };
       for (const key in conditionBlock) {
         if (!conditionChecks[key]) {
@@ -4537,6 +4540,15 @@
         return false;
       }
       return matchHostname(domain, conditionBlock.domain);
+    }
+    /**
+     * Takes a condition block and returns true if the platform version satisfies the `minSupportedFeature`
+     * @param {ConditionBlock} conditionBlock
+     * @returns {boolean}
+     */
+    _matchMinSupportedVersion(conditionBlock) {
+      if (!conditionBlock.minSupportedVersion) return false;
+      return isSupportedVersion(conditionBlock.minSupportedVersion, __privateGet(this, _args)?.platform?.version);
     }
     /**
      * Return the settings object for a feature

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -4218,6 +4218,7 @@
       /**
        * @type {{
        *   debug?: boolean,
+       *   platform: import('./utils.js').Platform,
        *   desktopModeEnabled?: boolean,
        *   forcedZoomEnabled?: boolean,
        *   featureSettings?: Record<string, unknown>,
@@ -4289,6 +4290,7 @@
      * @typedef {object} ConditionBlock
      * @property {string[] | string} [domain]
      * @property {object} [urlPattern]
+     * @property {object} [minSupportedVersion]
      * @property {object} [experiment]
      * @property {string} [experiment.experimentName]
      * @property {string} [experiment.cohort]
@@ -4314,7 +4316,8 @@
       const conditionChecks = {
         domain: this._matchDomainConditional,
         urlPattern: this._matchUrlPatternConditional,
-        experiment: this._matchExperimentConditional
+        experiment: this._matchExperimentConditional,
+        minSupportedVersion: this._matchMinSupportedVersion
       };
       for (const key in conditionBlock) {
         if (!conditionChecks[key]) {
@@ -4377,6 +4380,15 @@
         return false;
       }
       return matchHostname(domain, conditionBlock.domain);
+    }
+    /**
+     * Takes a condition block and returns true if the platform version satisfies the `minSupportedFeature`
+     * @param {ConditionBlock} conditionBlock
+     * @returns {boolean}
+     */
+    _matchMinSupportedVersion(conditionBlock) {
+      if (!conditionBlock.minSupportedVersion) return false;
+      return isSupportedVersion(conditionBlock.minSupportedVersion, __privateGet(this, _args)?.platform?.version);
     }
     /**
      * Return the settings object for a feature
@@ -6149,6 +6161,9 @@
         if (change.configurable && typeof change.configurable !== "boolean") {
           return false;
         }
+        if ("define" in change && typeof change.define !== "boolean") {
+          return false;
+        }
         return typeof change.getterValue !== "undefined";
       }
       return false;
@@ -6162,6 +6177,7 @@
      * @property {import('../utils.js').ConfigSetting} [getterValue] - The value returned from a getter.
      * @property {boolean} [enumerable] - Whether the property is enumerable.
      * @property {boolean} [configurable] - Whether the property is configurable.
+     * @property {boolean} [define] - Whether to define the property if it does not exist.
      */
     /**
      * Applies a change to DOM APIs.
@@ -6211,6 +6227,15 @@
         }
         if ("configurable" in change) {
           descriptor.configurable = change.configurable;
+        }
+        if (change.define === true && !(key in api)) {
+          const defineDescriptor = {
+            ...descriptor,
+            enumerable: typeof descriptor.enumerable !== "boolean" ? true : descriptor.enumerable,
+            configurable: typeof descriptor.configurable !== "boolean" ? true : descriptor.configurable
+          };
+          this.defineProperty(api, key, defineDescriptor);
+          return;
         }
         this.wrapProperty(api, key, descriptor);
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.3.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.1.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.2.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1747996876"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#2e1d9f562e98d4a6caf8eaedf80e168eadf297da",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#30b5b64058780a65c50762dfcd12952346a1da49",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -128,18 +128,14 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
-      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.9.tgz",
+      "integrity": "sha512-xpz6C/vXOegF9VEtlMBlkNNIjHrLhKaFBsO4lmQGr00x5BHp7p+oliR6i7LwIcM5cZU2VjLSwm2R+/zj5IjPWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -152,20 +148,10 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@jridgewell/source-map": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
-      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.7.tgz",
+      "integrity": "sha512-maArE+jvYbj06DXh2iFlXSSDjTWXODlPTQHdDRQdGoYw7KvT4SfYCnPHfCyww8Z3JqFsW0BBjPLj8A2fwAvv7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -174,16 +160,16 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.1.tgz",
+      "integrity": "sha512-mBLKRHc7Ffw/hObYb9+cunuGNjshQk+vZdwZBJoqiysK/mW3Jq0UXosq8aIhMnLevANhR9yoYfdUEOHg6M9y0g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "version": "0.3.26",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.26.tgz",
+      "integrity": "sha512-Z9rjt4BUVEbLFpw0qjCklVxxf421wrmcbP4w+LmBUxYCyJTYYSclgJD0YsCgGqQCtCIPiz7kjbYYJiAKhjJ3kA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -294,9 +280,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.0.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.4.tgz",
-      "integrity": "sha512-ulyqAkrhnuNq9pB76DRBTkcS6YsmDALy6Ua63V8OhrOBgbcYt6IOdzpw5P1+dyRIyMerzLkeYWBeOXPpA9GMAA==",
+      "version": "24.0.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.7.tgz",
+      "integrity": "sha512-YIEUUr4yf8q8oQoXPpSlnvKNVKDQlPMWrmOcgzoduo7kvA2UF0/BwJ/eMKFTiTtkNL17I0M6Xe2tvwFU7be6iw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.3.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.1.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.2.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1747996876"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [x] All tests must pass