### PR TITLE
hide voice input button when duck.ai text changes

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatOmnibarLayout.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatOmnibarLayout.kt
@@ -87,6 +87,7 @@ class DuckChatOmnibarLayout @JvmOverloads constructor(
             field = value
             value?.invoke(duckChatInput.text.getTextToSubmit() != null)
         }
+    var onVoiceInputAllowed: ((Boolean) -> Unit)? = null
 
     var text: String
         get() = duckChatInput.text.toString()
@@ -98,6 +99,8 @@ class DuckChatOmnibarLayout @JvmOverloads constructor(
     @IdRes
     private var contentId: Int = View.NO_ID
     private var focusAnimator: ValueAnimator? = null
+    private var originalText: String? = null
+    private var hasTextChangedFromOriginal = false
 
     init {
         LayoutInflater.from(context).inflate(R.layout.view_duck_chat_omnibar, this, true)
@@ -112,6 +115,11 @@ class DuckChatOmnibarLayout @JvmOverloads constructor(
         configureInputBehavior()
         configureTabBehavior()
         applyModeSpecificInputBehaviour(isSearchTab = true)
+    }
+
+    fun provideInitialText(text: String) {
+        originalText = text
+        duckChatInput.setText(text)
     }
 
     private fun configureClickListeners() {
@@ -143,7 +151,13 @@ class DuckChatOmnibarLayout @JvmOverloads constructor(
         }
 
         doOnTextChanged { text, _, _, _ ->
+            if (!hasTextChangedFromOriginal) {
+                hasTextChangedFromOriginal = text != originalText
+            }
+            onVoiceInputAllowed?.invoke(!hasTextChangedFromOriginal || duckChatInput.text.isBlank())
+
             onSendMessageAvailable?.invoke(duckChatInput.text.getTextToSubmit() != null)
+
             val isNullOrEmpty = text.isNullOrEmpty()
             fade(duckChatClearText, !isNullOrEmpty)
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenVisibilityState.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenVisibilityState.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui.inputscreen
+
+data class InputScreenVisibilityState(
+    val voiceInputButtonVisible: Boolean,
+)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1210658486266625?focus=true

### Description
1. Show voice input button when input screen is initially opened (and all text is selected).
2. Show voice input button when input box is empty.
3. Hide the button in all other cases.

### Steps to test this PR
- [x] Disable voice support in Settings and verify that the voice input button is not visible when the input screen is opened.
- [x] Enable voice support in Settings
  - [x] Verify voice button is available when input screen initially opened.
  - [x] Verify button hidden when any text provided.
  - [x] Verify button visible again when text is cleared.
