### PR TITLE
Attempt to fix widget test failures on Nightlies

### DIFF
--- a/app/src/test/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/ui/experiment/OnboardingHomeScreenWidgetExperimentImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/ui/experiment/OnboardingHomeScreenWidgetExperimentImplTest.kt
@@ -137,6 +137,7 @@ class OnboardingHomeScreenWidgetExperimentTest {
     fun `when fireWidgetSearchXCount and count reaches 3 then 3x pixel is fired`() = runTest {
         val pixelDefinition = createPixelDefinitionWithValidWindow()
         whenever(mockOnboardingHomeScreenWidgetPixelsPlugin.getWidgetSearch3xMetric()).thenReturn(mockMetricsPixel)
+        whenever(mockOnboardingHomeScreenWidgetPixelsPlugin.getWidgetSearch5xMetric()).thenReturn(null)
         whenever(mockMetricsPixel.getPixelDefinitions()).thenReturn(listOf(pixelDefinition))
         whenever(mockWidgetSearchCountDataStore.getMetricForPixelDefinition(any())).thenReturn(2)
         whenever(mockWidgetSearchCountDataStore.increaseMetricForPixelDefinition(any())).thenReturn(3)
@@ -150,6 +151,7 @@ class OnboardingHomeScreenWidgetExperimentTest {
     fun `when fireWidgetSearchXCount and count is already 3 then 3x pixel is not fired again`() = runTest {
         val pixelDefinition = createPixelDefinitionWithValidWindow()
         whenever(mockOnboardingHomeScreenWidgetPixelsPlugin.getWidgetSearch3xMetric()).thenReturn(mockMetricsPixel)
+        whenever(mockOnboardingHomeScreenWidgetPixelsPlugin.getWidgetSearch5xMetric()).thenReturn(null)
         whenever(mockMetricsPixel.getPixelDefinitions()).thenReturn(listOf(pixelDefinition))
         whenever(mockWidgetSearchCountDataStore.getMetricForPixelDefinition(any())).thenReturn(3)
 
@@ -162,6 +164,7 @@ class OnboardingHomeScreenWidgetExperimentTest {
     @Test
     fun `when fireWidgetSearchXCount and count reaches 5 then 5x pixel is fired`() = runTest {
         val pixelDefinition = createPixelDefinitionWithValidWindow()
+        whenever(mockOnboardingHomeScreenWidgetPixelsPlugin.getWidgetSearch3xMetric()).thenReturn(null)
         whenever(mockOnboardingHomeScreenWidgetPixelsPlugin.getWidgetSearch5xMetric()).thenReturn(mockMetricsPixel)
         whenever(mockMetricsPixel.getPixelDefinitions()).thenReturn(listOf(pixelDefinition))
         whenever(mockWidgetSearchCountDataStore.getMetricForPixelDefinition(any())).thenReturn(4)
@@ -176,6 +179,7 @@ class OnboardingHomeScreenWidgetExperimentTest {
     fun `when fireWidgetSearchXCount and pixel is outside conversion window then metrics are not updated`() = runTest {
         val pixelDefinition = createPixelDefinitionWithInvalidWindow()
         whenever(mockOnboardingHomeScreenWidgetPixelsPlugin.getWidgetSearch3xMetric()).thenReturn(mockMetricsPixel)
+        whenever(mockOnboardingHomeScreenWidgetPixelsPlugin.getWidgetSearch5xMetric()).thenReturn(null)
         whenever(mockMetricsPixel.getPixelDefinitions()).thenReturn(listOf(pixelDefinition))
 
         testee.fireWidgetSearchXCount()
@@ -189,6 +193,7 @@ class OnboardingHomeScreenWidgetExperimentTest {
     fun `when fireWidgetSearchXCount and count is less than threshold then pixel is not fired`() = runTest {
         val pixelDefinition = createPixelDefinitionWithValidWindow()
         whenever(mockOnboardingHomeScreenWidgetPixelsPlugin.getWidgetSearch3xMetric()).thenReturn(mockMetricsPixel)
+        whenever(mockOnboardingHomeScreenWidgetPixelsPlugin.getWidgetSearch5xMetric()).thenReturn(null)
         whenever(mockMetricsPixel.getPixelDefinitions()).thenReturn(listOf(pixelDefinition))
         whenever(mockWidgetSearchCountDataStore.getMetricForPixelDefinition(any())).thenReturn(1)
         whenever(mockWidgetSearchCountDataStore.increaseMetricForPixelDefinition(any())).thenReturn(2)

--- a/app/src/test/java/com/duckduckgo/widget/experiment/PostCtaExperienceExperimentTest.kt
+++ b/app/src/test/java/com/duckduckgo/widget/experiment/PostCtaExperienceExperimentTest.kt
@@ -108,6 +108,7 @@ class PostCtaExperienceExperimentTest {
     fun `when fireWidgetSearchXCount and count reaches 3 then 3x pixel is fired`() = runTest {
         val pixelDefinitions = listOf(createPixelDefinitionWithValidWindow())
         whenever(mockPostCtaExperiencePixelsPlugin.getWidgetSearch3xMetric()).thenReturn(metricsPixel)
+        whenever(mockPostCtaExperiencePixelsPlugin.getWidgetSearch5xMetric()).thenReturn(null)
         whenever(metricsPixel.getPixelDefinitions()).thenReturn(pixelDefinitions)
         whenever(mockWidgetSearchCountDataStore.getMetricForPixelDefinition(any())).thenReturn(2)
         whenever(mockWidgetSearchCountDataStore.increaseMetricForPixelDefinition(any())).thenReturn(3)
@@ -121,6 +122,7 @@ class PostCtaExperienceExperimentTest {
     fun `when fireWidgetSearchXCount and count is already 3 then 3x pixel is not fired again`() = runTest {
         val pixelDefinitions = listOf(createPixelDefinitionWithValidWindow())
         whenever(mockPostCtaExperiencePixelsPlugin.getWidgetSearch3xMetric()).thenReturn(metricsPixel)
+        whenever(mockPostCtaExperiencePixelsPlugin.getWidgetSearch5xMetric()).thenReturn(null)
         whenever(metricsPixel.getPixelDefinitions()).thenReturn(pixelDefinitions)
         whenever(mockWidgetSearchCountDataStore.getMetricForPixelDefinition(any())).thenReturn(3)
 
@@ -132,6 +134,7 @@ class PostCtaExperienceExperimentTest {
     @Test
     fun `when fireWidgetSearchXCount and count reaches 5 then 5x pixel is fired`() = runTest {
         val pixelDefinitions = listOf(createPixelDefinitionWithValidWindow())
+        whenever(mockPostCtaExperiencePixelsPlugin.getWidgetSearch3xMetric()).thenReturn(null)
         whenever(mockPostCtaExperiencePixelsPlugin.getWidgetSearch5xMetric()).thenReturn(metricsPixel)
         whenever(metricsPixel.getPixelDefinitions()).thenReturn(pixelDefinitions)
         whenever(mockWidgetSearchCountDataStore.getMetricForPixelDefinition(any())).thenReturn(4)
@@ -145,6 +148,7 @@ class PostCtaExperienceExperimentTest {
     @Test
     fun `when fireWidgetSearchXCount and count is already 5 then 5x pixel is not fired again`() = runTest {
         val pixelDefinitions = listOf(createPixelDefinitionWithValidWindow())
+        whenever(mockPostCtaExperiencePixelsPlugin.getWidgetSearch3xMetric()).thenReturn(null)
         whenever(mockPostCtaExperiencePixelsPlugin.getWidgetSearch5xMetric()).thenReturn(metricsPixel)
         whenever(metricsPixel.getPixelDefinitions()).thenReturn(pixelDefinitions)
         whenever(mockWidgetSearchCountDataStore.getMetricForPixelDefinition(any())).thenReturn(5)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1210683053177448?focus=true

### Description

The tests for `fireWidgetSearchXCount` in `OnboardingHomeScreenWidgetExperimentImplTest` and `PostCtaExperienceExperimentTest` have been updated.

The changes ensure that when testing the 3x search pixel, the 5x search pixel is explicitly mocked to return null, and vice-versa

### Steps to test this PR

- [x] Run `testPlayDebugUnitTest` 
- [x] Tests should pass

### UI changes
N/A
