### PR TITLE
Support launching Privacy Pro paywall for subscriptions path

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -40,6 +40,7 @@ import com.duckduckgo.subscriptions.api.SubscriptionStatus
 import com.duckduckgo.subscriptions.api.Subscriptions
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.PRIVACY_PRO_ETLD
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.PRIVACY_PRO_PATH
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.PRIVACY_SUBSCRIPTIONS_PATH
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixelSender
 import com.duckduckgo.subscriptions.impl.repository.isActiveOrWaiting
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionsWebViewActivityWithParams
@@ -124,7 +125,7 @@ class RealSubscriptions @Inject constructor(
         val eTld = uri.host?.toTldPlusOne() ?: return false
         val size = uri.pathSegments.size
         val path = uri.pathSegments.firstOrNull()
-        return eTld == PRIVACY_PRO_ETLD && size == 1 && path == PRIVACY_PRO_PATH
+        return eTld == PRIVACY_PRO_ETLD && size == 1 && (path == PRIVACY_PRO_PATH || path == PRIVACY_SUBSCRIPTIONS_PATH)
     }
 
     override suspend fun isFreeTrialEligible(): Boolean {

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsConstants.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsConstants.kt
@@ -61,4 +61,5 @@ object SubscriptionsConstants {
     const val FAQS_URL = "https://duckduckgo.com/duckduckgo-help-pages/privacy-pro/"
     const val PRIVACY_PRO_ETLD = "duckduckgo.com"
     const val PRIVACY_PRO_PATH = "pro"
+    const val PRIVACY_SUBSCRIPTIONS_PATH = "subscriptions"
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201807753394693/task/1210694952143862?focus=true

### Description
Launch Privacy Pro activity when users navigate to  duckduckgo.com/subscriptions URL

### Steps to test this PR

- [x] Apply patch from https://app.asana.com/app/asana/-/get_asset?asset_id=1210591812666423
- [x] Install from branch
- [x] Go to duckduckgo.com/subscriptions
- [x] Check Privacy Pro native paywall is loaded
- [x] Check products are loaded
- [x] Check purchase flow works as expected

### No UI changes
