### PR TITLE
Attempt 2 to fix widget experiment nightly test failures

### DIFF
--- a/app/src/test/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/ui/experiment/OnboardingHomeScreenWidgetExperimentImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/defaultbrowsing/prompts/ui/experiment/OnboardingHomeScreenWidgetExperimentImplTest.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.feature.toggles.api.MetricsPixel
 import com.duckduckgo.feature.toggles.api.PixelDefinition
 import com.duckduckgo.feature.toggles.api.Toggle
 import java.time.LocalDate
+import java.time.ZoneId
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
@@ -205,7 +206,7 @@ class OnboardingHomeScreenWidgetExperimentTest {
     }
 
     private fun createPixelDefinitionWithValidWindow(): PixelDefinition {
-        val today = LocalDate.now().minusDays(5)
+        val today = LocalDate.now(ZoneId.of("America/New_York")).minusDays(5)
         return PixelDefinition(
             "pixel_name",
             mapOf(
@@ -216,7 +217,7 @@ class OnboardingHomeScreenWidgetExperimentTest {
     }
 
     private fun createPixelDefinitionWithInvalidWindow(): PixelDefinition {
-        val pastDate = LocalDate.now().minusDays(20)
+        val pastDate = LocalDate.now(ZoneId.of("America/New_York")).minusDays(20)
         return PixelDefinition(
             "pixel_name",
             mapOf(

--- a/app/src/test/java/com/duckduckgo/widget/experiment/PostCtaExperienceExperimentTest.kt
+++ b/app/src/test/java/com/duckduckgo/widget/experiment/PostCtaExperienceExperimentTest.kt
@@ -26,6 +26,8 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.MetricsPixel
 import com.duckduckgo.feature.toggles.api.PixelDefinition
 import com.duckduckgo.feature.toggles.api.Toggle
+import java.time.LocalDate
+import java.time.ZoneId
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
@@ -159,11 +161,11 @@ class PostCtaExperienceExperimentTest {
     }
 
     private fun createPixelDefinitionWithValidWindow(): PixelDefinition {
-        val today = java.time.LocalDate.now().minusDays(5)
+        val pastDate = LocalDate.now(ZoneId.of("America/New_York")).minusDays(5)
         return PixelDefinition(
             "pixel_name",
             mapOf(
-                "enrollmentDate" to today.toString(),
+                "enrollmentDate" to pastDate.toString(),
                 "conversionWindowDays" to "5-7",
             ),
         )


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1210689268710086

### Description

Fixed timezone-related issues in widget experiment tests by explicitly specifying the timezone as "America/New_York" when creating test dates. This ensures consistent test behavior regardless of the environment's default timezone.

### Steps to test this PR

_Widget Experiment Tests_
- [ ] Run the OnboardingHomeScreenWidgetExperimentImplTest and verify all tests pass
- [ ] Run the PostCtaExperienceExperimentTest and verify all tests pass
- [x] Verify nightly tests pass on CI: https://github.com/duckduckgo/Android/actions/runs/16021812080