### PR TITLE
Adds support for getFeatureConfig and getAuthAccessToken in subscriptions flows

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -167,6 +167,23 @@ interface PrivacyProFeature {
 
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun privacyProFreeTrial(): Toggle
+
+    /**
+     * Android supports v2 token, but still relies on old v1 subscription messaging.
+     * We are introducing new JS messaging. Use this flag as kill-switch if necessary.
+     * It doesn't control which version of messaging FE uses.
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun enableNewSubscriptionMessages(): Toggle
+
+    /**
+     * When enabled, we signal FE if v2 is available, enabling v2 messaging
+     * When disabled, FE works with old messaging (v1)
+     * This flag will be used to select FE subscription messaging mode.
+     * The value is added into GetFeatureConfig to allow FE to select the mode.
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun enableSubscriptionFlowsV2(): Toggle
 }
 
 @ContributesBinding(AppScope::class)

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionMessagingInterfaceTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionMessagingInterfaceTest.kt
@@ -9,6 +9,7 @@ import com.duckduckgo.js.messaging.api.JsRequestResponse
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.AUTO_RENEWABLE
 import com.duckduckgo.subscriptions.impl.AccessTokenResult
 import com.duckduckgo.subscriptions.impl.AuthTokenResult
+import com.duckduckgo.subscriptions.impl.PrivacyProFeature
 import com.duckduckgo.subscriptions.impl.SubscriptionsChecker
 import com.duckduckgo.subscriptions.impl.SubscriptionsManager
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixelSender
@@ -40,6 +41,7 @@ class SubscriptionMessagingInterfaceTest {
     private val subscriptionsManager: SubscriptionsManager = mock()
     private val pixelSender: SubscriptionPixelSender = mock()
     private val subscriptionsChecker: SubscriptionsChecker = mock()
+    private val privacyProFeature: PrivacyProFeature = mock()
     private val messagingInterface = SubscriptionMessagingInterface(
         subscriptionsManager,
         jsMessageHelper,
@@ -47,6 +49,7 @@ class SubscriptionMessagingInterfaceTest {
         coroutineRule.testScope,
         pixelSender,
         subscriptionsChecker,
+        privacyProFeature,
     )
 
     private val callback = object : JsMessageCallback() {
@@ -714,6 +717,158 @@ class SubscriptionMessagingInterfaceTest {
         verify(subscriptionsManager, never()).refreshAccessToken()
     }
 
+    @Test
+    fun `when process and get auth access token then return response`() = runTest {
+        givenInterfaceIsRegistered()
+        givenAccessTokenIsSuccess()
+
+        val expected = JsRequestResponse.Success(
+            context = "subscriptionPages",
+            featureName = "useSubscription",
+            method = "getAuthAccessToken",
+            id = "myId",
+            result = JSONObject("""{"accessToken":"accessToken"}"""),
+        )
+
+        val message = """
+            {"context":"subscriptionPages","featureName":"useSubscription","method":"getAuthAccessToken","id":"myId","params":{}}
+        """.trimIndent()
+
+        messagingInterface.process(message, "duckduckgo-android-messaging-secret")
+
+        val captor = argumentCaptor<JsRequestResponse>()
+        verify(jsMessageHelper).sendJsResponse(captor.capture(), eq(CALLBACK_NAME), eq(SECRET), eq(webView))
+        val jsMessage = captor.firstValue
+
+        assertTrue(jsMessage is JsRequestResponse.Success)
+        checkEquals(expected, jsMessage)
+    }
+
+    @Test
+    fun `when process and get auth access token message error then return response`() = runTest {
+        givenInterfaceIsRegistered()
+        givenAccessTokenIsFailure()
+
+        val expected = JsRequestResponse.Success(
+            context = "subscriptionPages",
+            featureName = "useSubscription",
+            method = "getAuthAccessToken",
+            id = "myId",
+            result = JSONObject("""{}"""),
+        )
+
+        val message = """
+            {"context":"subscriptionPages","featureName":"useSubscription","method":"getAuthAccessToken","id":"myId","params":{}}
+        """.trimIndent()
+
+        messagingInterface.process(message, "duckduckgo-android-messaging-secret")
+
+        val captor = argumentCaptor<JsRequestResponse>()
+        verify(jsMessageHelper).sendJsResponse(captor.capture(), eq(CALLBACK_NAME), eq(SECRET), eq(webView))
+        val jsMessage = captor.firstValue
+
+        assertTrue(jsMessage is JsRequestResponse.Success)
+        checkEquals(expected, jsMessage)
+    }
+
+    @Test
+    fun `when process and get auth access token if no id do nothing`() = runTest {
+        givenInterfaceIsRegistered()
+        givenAccessTokenIsSuccess()
+
+        val message = """
+            {"context":"subscriptionPages","featureName":"useSubscription","method":"getAuthAccessToken","params":{}}
+        """.trimIndent()
+
+        messagingInterface.process(message, "duckduckgo-android-messaging-secret")
+
+        verifyNoInteractions(jsMessageHelper)
+    }
+
+    @Test
+    fun `when process and get feature config and messaging enabled then return response with feature flags`() = runTest {
+        givenInterfaceIsRegistered()
+        givenSubscriptionMessaging(enabled = true)
+        givenAuthV2(enabled = true)
+
+        val expected = JsRequestResponse.Success(
+            context = "subscriptionPages",
+            featureName = "useSubscription",
+            method = "getFeatureConfig",
+            id = "myId",
+            result = JSONObject("""{"useSubscriptionsAuthV2":true}"""),
+        )
+
+        val message = """
+            {"context":"subscriptionPages","featureName":"useSubscription","method":"getFeatureConfig","id":"myId","params":{}}
+        """.trimIndent()
+
+        messagingInterface.process(message, "duckduckgo-android-messaging-secret")
+
+        val captor = argumentCaptor<JsRequestResponse>()
+        verify(jsMessageHelper).sendJsResponse(captor.capture(), eq(CALLBACK_NAME), eq(SECRET), eq(webView))
+        val jsMessage = captor.firstValue
+
+        assertTrue(jsMessage is JsRequestResponse.Success)
+        checkEquals(expected, jsMessage)
+    }
+
+    @Test
+    fun `when process and get feature config and messaging enabled but auth v2 disabled then return response with auth v2 false`() = runTest {
+        givenInterfaceIsRegistered()
+        givenSubscriptionMessaging(enabled = true)
+        givenAuthV2(enabled = false)
+
+        val expected = JsRequestResponse.Success(
+            context = "subscriptionPages",
+            featureName = "useSubscription",
+            method = "getFeatureConfig",
+            id = "myId",
+            result = JSONObject("""{"useSubscriptionsAuthV2":false}"""),
+        )
+
+        val message = """
+            {"context":"subscriptionPages","featureName":"useSubscription","method":"getFeatureConfig","id":"myId","params":{}}
+        """.trimIndent()
+
+        messagingInterface.process(message, "duckduckgo-android-messaging-secret")
+
+        val captor = argumentCaptor<JsRequestResponse>()
+        verify(jsMessageHelper).sendJsResponse(captor.capture(), eq(CALLBACK_NAME), eq(SECRET), eq(webView))
+        val jsMessage = captor.firstValue
+
+        assertTrue(jsMessage is JsRequestResponse.Success)
+        checkEquals(expected, jsMessage)
+    }
+
+    @Test
+    fun `when process and get feature config and messaging disabled then do nothing`() = runTest {
+        givenInterfaceIsRegistered()
+        givenSubscriptionMessaging(enabled = false)
+
+        val message = """
+            {"context":"subscriptionPages","featureName":"useSubscription","method":"getFeatureConfig","id":"myId","params":{}}
+        """.trimIndent()
+
+        messagingInterface.process(message, "duckduckgo-android-messaging-secret")
+
+        verifyNoInteractions(jsMessageHelper)
+    }
+
+    @Test
+    fun `when process and get feature config if no id do nothing`() = runTest {
+        givenInterfaceIsRegistered()
+        givenSubscriptionMessaging(enabled = true)
+
+        val message = """
+            {"context":"subscriptionPages","featureName":"useSubscription","method":"getFeatureConfig","params":{}}
+        """.trimIndent()
+
+        messagingInterface.process(message, "duckduckgo-android-messaging-secret")
+
+        verifyNoInteractions(jsMessageHelper)
+    }
+
     private fun givenInterfaceIsRegistered() {
         messagingInterface.register(webView, callback)
         whenever(webView.url).thenReturn("https://duckduckgo.com/test")
@@ -751,6 +906,18 @@ class SubscriptionMessagingInterfaceTest {
 
     private suspend fun givenAccessTokenIsFailure() {
         whenever(subscriptionsManager.getAccessToken()).thenReturn(AccessTokenResult.Failure(message = "something happened"))
+    }
+
+    private fun givenSubscriptionMessaging(enabled: Boolean) {
+        val subscriptionMessagingToggle = mock<com.duckduckgo.feature.toggles.api.Toggle>()
+        whenever(subscriptionMessagingToggle.isEnabled()).thenReturn(enabled)
+        whenever(privacyProFeature.enableNewSubscriptionMessages()).thenReturn(subscriptionMessagingToggle)
+    }
+
+    private fun givenAuthV2(enabled: Boolean) {
+        val v2SubscriptionFlow = mock<com.duckduckgo.feature.toggles.api.Toggle>()
+        whenever(v2SubscriptionFlow.isEnabled()).thenReturn(enabled)
+        whenever(privacyProFeature.enableSubscriptionFlowsV2()).thenReturn(v2SubscriptionFlow)
     }
 
     private fun checkEquals(expected: JsRequestResponse, actual: JsRequestResponse) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1210705948833249?focus=true 

### Description

- Adds support for getFeatureConfig and getAuthAccessToken
- Preparation work to fully migrate subscriptions flows to v2 ([Migrate Subscriptions flows to v2](https://app.asana.com/1/137249556945/task/1210705424261806?focus=true))
- Include FF for rollout and kill switch if necessary
- New messaging FF will be enabled
- V2 flows FF will be disabled until fully migrated

### Steps to test this PR
_Feature 1_
- [x] checkout + apply staging patch
- [x] install changes
- [x] Try to purchase a subscription
- [x] ensure no issues
- [x] Try to activate a subscription
- [x] ensure no issues

(add any smoke testing to ensure subscription flow is not impacted)

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
