### PR TITLE
make Duck.ai container gone when it's unused

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -839,6 +839,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
 
     private fun animateDuckAiFragmentIn() {
         val duckAiContainer = binding.duckAiFragmentContainer
+        duckAiContainer.isVisible = true
         val browserContainer = if (swipingTabsFeature.isEnabled) binding.tabPager else binding.fragmentContainer
 
         duckAiContainer.slideAndFadeInFromRight()
@@ -849,7 +850,10 @@ open class BrowserActivity : DuckDuckGoActivity() {
         val duckAiContainer = binding.duckAiFragmentContainer
         val browserContainer = if (swipingTabsFeature.isEnabled) binding.tabPager else binding.fragmentContainer
 
-        duckAiContainer.slideAndFadeOutToRight(onComplete)
+        duckAiContainer.slideAndFadeOutToRight {
+            onComplete()
+            duckAiContainer.isVisible = false
+        }
         browserContainer.slideAndFadeInFromLeft()
     }
 

--- a/app/src/main/res/layout/activity_browser.xml
+++ b/app/src/main/res/layout/activity_browser.xml
@@ -50,7 +50,8 @@
     <FrameLayout
         android:id="@+id/duckAiFragmentContainer"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        android:visibility="gone" />
 
     <View
         android:id="@+id/clearingInProgressView"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1210708810784116?focus=true

### Description
Make `duckAiFragmentContainer` gone when the `DuckChatWebViewFragment` is not visible as well.

### Steps to test this PR

- [x] Open Duck.ai multiple times and ensure it's showing/hiding correctly.
