### PR TITLE
Fix: E2E tests expecting the wrong hint

### DIFF
--- a/.maestro/browsing/visit_site.yaml
+++ b/.maestro/browsing/visit_site.yaml
@@ -24,4 +24,4 @@ tags:
           id: "omnibarTextInput"
       - eraseText
       - assertVisible:
-          text: "Search or type URL"
+          text: "Search"

--- a/.maestro/security_tests/5_-_AddressBarSpoof,_downloadpath.yaml
+++ b/.maestro/security_tests/5_-_AddressBarSpoof,_downloadpath.yaml
@@ -22,7 +22,7 @@ tags:
             - tapOn: "Save to Downloads"
             - copyTextFrom:
                 id: "omnibarTextInput"
-            - assertTrue: ${maestro.copiedText == "Search or type URL"} # Downloads should occur in empty origin.
+            - assertTrue: ${maestro.copiedText == "Search"} # Downloads should occur in empty origin.
             - pressKey: Back
             # Download Cancel Flow:
             - tapOn: "Start"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1210714157895784?focus=true

### Description

The PR fixes the failing tests by updating the expected search input box hint.

### Steps to test this PR

- [ ] Run the E2E tests and make sure they pass