### PR TITLE
Translations for promoting password import in management screen

### DIFF
--- a/autofill/autofill-impl/src/main/res/values-bg/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-bg/strings-autofill-impl.xml
@@ -281,4 +281,8 @@
     <string name="autofillSettingsImportFromDesktopSync">Синхронизиране на паролите от работния плот</string>
     <string name="autofillSettingsResetExcludedSitesTitle">Нулиране на изключените сайтове</string>
 
+    <string name="passwords_import_promo_title" instruction="The &apos;br&apos; is a forced line break for English. It does not need to be included in translations.">Пренесете паролите си от&lt;br /&gt;Google в DuckDuckGo</string>
+    <string name="passwords_import_promo_subtitle">Можете бързо и сигурно да импортирате паролите си в DuckDuckGo. Google може да поиска да въведете парола.</string>
+    <string name="passwords_import_promo_action">Импортиране от Google</string>
+
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-cs/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-cs/strings-autofill-impl.xml
@@ -293,4 +293,8 @@
     <string name="autofillSettingsImportFromDesktopSync">Synchronizovat hesla na počítači</string>
     <string name="autofillSettingsResetExcludedSitesTitle">Obnovit vyloučené stránky</string>
 
+    <string name="passwords_import_promo_title" instruction="The &apos;br&apos; is a forced line break for English. It does not need to be included in translations.">Přenes si hesla&lt;br /&gt;z Googlu do DuckDuckGo</string>
+    <string name="passwords_import_promo_subtitle">Rychle a bezpečně importuj svá hesla do DuckDuckGo. Google tě může požádat o zadání hesla.</string>
+    <string name="passwords_import_promo_action">Import z Googlu</string>
+
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-da/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-da/strings-autofill-impl.xml
@@ -281,4 +281,8 @@
     <string name="autofillSettingsImportFromDesktopSync">Synkroniser adgangskoder med pc</string>
     <string name="autofillSettingsResetExcludedSitesTitle">Nulstil ekskluderede websteder</string>
 
+    <string name="passwords_import_promo_title" instruction="The &apos;br&apos; is a forced line break for English. It does not need to be included in translations.">Flyt dine adgangskoder fra&lt;br /&gt;Google til DuckDuckGo</string>
+    <string name="passwords_import_promo_subtitle">Importer dine adgangskoder hurtigt og sikkert til DuckDuckGo. Google kan bede dig om at indtaste din adgangskode.</string>
+    <string name="passwords_import_promo_action">Importer fra Google</string>
+
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-de/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-de/strings-autofill-impl.xml
@@ -281,4 +281,8 @@
     <string name="autofillSettingsImportFromDesktopSync">Desktop-Passwörter synchronisieren</string>
     <string name="autofillSettingsResetExcludedSitesTitle">Ausgeschlossene Websites zurücksetzen</string>
 
+    <string name="passwords_import_promo_title" instruction="The &apos;br&apos; is a forced line break for English. It does not need to be included in translations.">Übertrage deine Passwörter von&lt;br /&gt;Google zu DuckDuckGo</string>
+    <string name="passwords_import_promo_subtitle">Importiere deine Passwörter schnell und sicher zu DuckDuckGo. Google fordert dich möglicherweise auf, dein Passwort einzugeben.</string>
+    <string name="passwords_import_promo_action">Von Google importieren</string>
+
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-el/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-el/strings-autofill-impl.xml
@@ -281,4 +281,8 @@
     <string name="autofillSettingsImportFromDesktopSync">Συγχρονισμός κωδικών πρόσβασης υπολογιστών</string>
     <string name="autofillSettingsResetExcludedSitesTitle">Επαναφορά αποκλεισμένων ιστότοπων</string>
 
+    <string name="passwords_import_promo_title" instruction="The &apos;br&apos; is a forced line break for English. It does not need to be included in translations.">Μεταφέρετε τους κωδικούς σας από&lt;br /&gt;το Google στο DuckDuckGo</string>
+    <string name="passwords_import_promo_subtitle">Εισαγάγετε γρήγορα και με ασφάλεια τους κωδικούς πρόσβασής σας στο DuckDuckGo. Η Google ίσως σας ζητήσει να εισαγάγετε τον κωδικό πρόσβασής σας.</string>
+    <string name="passwords_import_promo_action">Εισαγωγή από το Google</string>
+
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-es/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-es/strings-autofill-impl.xml
@@ -281,4 +281,8 @@
     <string name="autofillSettingsImportFromDesktopSync">Sincronizar contraseñas de escritorio</string>
     <string name="autofillSettingsResetExcludedSitesTitle">Restablecer sitios excluidos</string>
 
+    <string name="passwords_import_promo_title" instruction="The &apos;br&apos; is a forced line break for English. It does not need to be included in translations.">Trae tus contraseñas de&lt;br /&gt;Google a DuckDuckGo</string>
+    <string name="passwords_import_promo_subtitle">Importa tus contraseñas a DuckDuckGo de forma rápida y segura. Google puede pedirte que introduzcas tu contraseña.</string>
+    <string name="passwords_import_promo_action">Importar desde Google</string>
+
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-et/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-et/strings-autofill-impl.xml
@@ -281,4 +281,8 @@
     <string name="autofillSettingsImportFromDesktopSync">Töölaua paroolide sünkroonimine</string>
     <string name="autofillSettingsResetExcludedSitesTitle">Lähtesta välistatud saidid</string>
 
+    <string name="passwords_import_promo_title" instruction="The &apos;br&apos; is a forced line break for English. It does not need to be included in translations.">Too oma paroolid Google\'ist DuckDuckGo\'sse</string>
+    <string name="passwords_import_promo_subtitle">Impordi oma paroolid kiiresti ja turvaliselt DuckDuckGosse. Google võib paluda sul oma parooli sisestada.</string>
+    <string name="passwords_import_promo_action">Impordi Google\'ist</string>
+
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-fi/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-fi/strings-autofill-impl.xml
@@ -281,4 +281,8 @@
     <string name="autofillSettingsImportFromDesktopSync">Synkronoi työpöytäsalasanat</string>
     <string name="autofillSettingsResetExcludedSitesTitle">Nollaa poissuljetut sivustot</string>
 
+    <string name="passwords_import_promo_title" instruction="The &apos;br&apos; is a forced line break for English. It does not need to be included in translations.">Tuo salasanasi Googlesta DuckDuckGohon</string>
+    <string name="passwords_import_promo_subtitle">Tuo salasanasi nopeasti ja turvallisesti DuckDuckGohon. Google saattaa pyytää sinua antamaan salasanasi.</string>
+    <string name="passwords_import_promo_action">Tuo Googlesta</string>
+
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-fr/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-fr/strings-autofill-impl.xml
@@ -281,4 +281,8 @@
     <string name="autofillSettingsImportFromDesktopSync">Synchroniser les mots de passe de bureau</string>
     <string name="autofillSettingsResetExcludedSitesTitle">Réinitialiser les sites exclus</string>
 
+    <string name="passwords_import_promo_title" instruction="The &apos;br&apos; is a forced line break for English. It does not need to be included in translations.">Transférez vos mots de passe de Google vers DuckDuckGo</string>
+    <string name="passwords_import_promo_subtitle">Importez rapidement et en toute sécurité vos mots de passe dans DuckDuckGo. Google peut vous demander de saisir votre mot de passe.</string>
+    <string name="passwords_import_promo_action">Importer depuis Google</string>
+
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-hr/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-hr/strings-autofill-impl.xml
@@ -293,4 +293,8 @@
     <string name="autofillSettingsImportFromDesktopSync">Sinkroniziraj lozinke za radnu površinu</string>
     <string name="autofillSettingsResetExcludedSitesTitle">Resetiraj isključene web lokacije</string>
 
+    <string name="passwords_import_promo_title" instruction="The &apos;br&apos; is a forced line break for English. It does not need to be included in translations.">Prenesi svoje lozinke s&lt;br /&gt;Googlea na DuckDuckGo</string>
+    <string name="passwords_import_promo_subtitle">Brzo i sigurno uvezi svoje lozinke u DuckDuckGo. Google će te možda zamoliti da uneseš svoju lozinku.</string>
+    <string name="passwords_import_promo_action">Uvezi s Googlea</string>
+
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-hu/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-hu/strings-autofill-impl.xml
@@ -281,4 +281,8 @@
     <string name="autofillSettingsImportFromDesktopSync">Asztali jelszavak szinkronizálása</string>
     <string name="autofillSettingsResetExcludedSitesTitle">Kizárt webhelyek visszaállítása</string>
 
+    <string name="passwords_import_promo_title" instruction="The &apos;br&apos; is a forced line break for English. It does not need to be included in translations.">Hozd át a jelszavaidat a&lt;br /&gt;Google-ból a DuckDuckGóba</string>
+    <string name="passwords_import_promo_subtitle">Gyorsan és biztonságosan importáld jelszavaidat a DuckDuckGóba. A Google megkérhet, hogy add meg a jelszavad.</string>
+    <string name="passwords_import_promo_action">Importálás a Google-ból</string>
+
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-it/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-it/strings-autofill-impl.xml
@@ -281,4 +281,8 @@
     <string name="autofillSettingsImportFromDesktopSync">Sincronizza le password del desktop</string>
     <string name="autofillSettingsResetExcludedSitesTitle">Ripristina siti esclusi</string>
 
+    <string name="passwords_import_promo_title" instruction="The &apos;br&apos; is a forced line break for English. It does not need to be included in translations.">Porta le password da&lt;br /&gt;Google a DuckDuckGo</string>
+    <string name="passwords_import_promo_subtitle">Importa rapidamente e in modo sicuro le password su DuckDuckGo. Google potrebbe chiederti di inserire la tua password.</string>
+    <string name="passwords_import_promo_action">Importa da Google</string>
+
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-lt/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-lt/strings-autofill-impl.xml
@@ -293,4 +293,8 @@
     <string name="autofillSettingsImportFromDesktopSync">Sinchronizuoti darbalaukio slaptažodžius</string>
     <string name="autofillSettingsResetExcludedSitesTitle">Iš naujo nustatyti neįtrauktas svetaines</string>
 
+    <string name="passwords_import_promo_title" instruction="The &apos;br&apos; is a forced line break for English. It does not need to be included in translations.">Perkelk savo slaptažodžius iš&lt;br /&gt;Google“ į „DuckDuckGo“</string>
+    <string name="passwords_import_promo_subtitle">Greitai ir saugiai importuok savo slaptažodžius į „DuckDuckGo“. „Google“ gali paprašyti tavęs įvesti slaptažodį.</string>
+    <string name="passwords_import_promo_action">Importuok iš „Google“</string>
+
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-lv/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-lv/strings-autofill-impl.xml
@@ -287,4 +287,8 @@
     <string name="autofillSettingsImportFromDesktopSync">Sinhronizēt darbvirsmas paroles</string>
     <string name="autofillSettingsResetExcludedSitesTitle">Atiestatīt izslēgtās vietnes</string>
 
+    <string name="passwords_import_promo_title" instruction="The &apos;br&apos; is a forced line break for English. It does not need to be included in translations.">Pārnes savas paroles no&lt;br /&gt;Google uz DuckDuckGo</string>
+    <string name="passwords_import_promo_subtitle">Ātri un droši importē savas paroles DuckDuckGo. Google var lūgt tevi ievadīt savu paroli.</string>
+    <string name="passwords_import_promo_action">Importēt no Google</string>
+
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-nb/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-nb/strings-autofill-impl.xml
@@ -281,4 +281,8 @@
     <string name="autofillSettingsImportFromDesktopSync">Synkroniser passord på datamaskinen</string>
     <string name="autofillSettingsResetExcludedSitesTitle">Tilbakestill ekskluderte nettsteder</string>
 
+    <string name="passwords_import_promo_title" instruction="The &apos;br&apos; is a forced line break for English. It does not need to be included in translations.">Ta med passordene dine fra&lt;br /&gt;Google til DuckDuckGo</string>
+    <string name="passwords_import_promo_subtitle">Importer passordene dine raskt og sikkert til DuckDuckGo. Det kan hende Google ber deg om å skrive inn passordet ditt.</string>
+    <string name="passwords_import_promo_action">Importer fra Google</string>
+
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-nl/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-nl/strings-autofill-impl.xml
@@ -281,4 +281,8 @@
     <string name="autofillSettingsImportFromDesktopSync">Wachtwoorden bureaublad synchroniseren</string>
     <string name="autofillSettingsResetExcludedSitesTitle">Uitgesloten sites opnieuw instellen</string>
 
+    <string name="passwords_import_promo_title" instruction="The &apos;br&apos; is a forced line break for English. It does not need to be included in translations.">Breng je wachtwoorden van&lt;br /&gt;Google over naar DuckDuckGo</string>
+    <string name="passwords_import_promo_subtitle">Importeer snel en veilig je wachtwoorden naar DuckDuckGo. Google kan je vragen om je wachtwoord in te voeren.</string>
+    <string name="passwords_import_promo_action">Importeren van Google</string>
+
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-pl/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-pl/strings-autofill-impl.xml
@@ -293,4 +293,8 @@
     <string name="autofillSettingsImportFromDesktopSync">Synchronizuj hasła na komputerze</string>
     <string name="autofillSettingsResetExcludedSitesTitle">Resetowanie wykluczonych witryn</string>
 
+    <string name="passwords_import_promo_title" instruction="The &apos;br&apos; is a forced line break for English. It does not need to be included in translations.">Przenieś swoje hasła z&lt;br /&gt;Google do DuckDuckGo</string>
+    <string name="passwords_import_promo_subtitle">Szybko i bezpiecznie importuj hasła do DuckDuckGo. Google może poprosić o wpisanie hasła.</string>
+    <string name="passwords_import_promo_action">Importuj z Google</string>
+
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-pt/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-pt/strings-autofill-impl.xml
@@ -281,4 +281,8 @@
     <string name="autofillSettingsImportFromDesktopSync">Sincronizar palavras-passe com o computador</string>
     <string name="autofillSettingsResetExcludedSitesTitle">Repor sites excluídos</string>
 
+    <string name="passwords_import_promo_title" instruction="The &apos;br&apos; is a forced line break for English. It does not need to be included in translations.">Traz as tuas palavras-passe do&lt;br /&gt;Google para o DuckDuckGo</string>
+    <string name="passwords_import_promo_subtitle">Importa a tuas palavras-passe para o DuckDuckGo de forma rápida e segura. O Google pode pedir-te para introduzires a tua palavra-passe.</string>
+    <string name="passwords_import_promo_action">Importar do Google</string>
+
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-ro/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-ro/strings-autofill-impl.xml
@@ -287,4 +287,8 @@
     <string name="autofillSettingsImportFromDesktopSync">Sincronizează parolele de pe desktop</string>
     <string name="autofillSettingsResetExcludedSitesTitle">Resetează site-urile excluse</string>
 
+    <string name="passwords_import_promo_title" instruction="The &apos;br&apos; is a forced line break for English. It does not need to be included in translations.">Importă parolele tale din&lt;br /&gt;Google în DuckDuckGo</string>
+    <string name="passwords_import_promo_subtitle">Importă-ți parolele rapid și în siguranță în DuckDuckGo. Google îți poate cere să completezi parola.</string>
+    <string name="passwords_import_promo_action">Importă din Google</string>
+
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-ru/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-ru/strings-autofill-impl.xml
@@ -293,4 +293,8 @@
     <string name="autofillSettingsImportFromDesktopSync">Взять пароли из настольного приложения</string>
     <string name="autofillSettingsResetExcludedSitesTitle">Сбросить список исключений</string>
 
+    <string name="passwords_import_promo_title" instruction="The &apos;br&apos; is a forced line break for English. It does not need to be included in translations.">Пароли из Google — в DuckDuckGo</string>
+    <string name="passwords_import_promo_subtitle">Импортировать пароли в DuckDuckGo легко и безопасно. В ходе операции Google может попросить вас ввести свой пароль.</string>
+    <string name="passwords_import_promo_action">Импортировать из Google</string>
+
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-sk/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-sk/strings-autofill-impl.xml
@@ -293,4 +293,8 @@
     <string name="autofillSettingsImportFromDesktopSync">Synchronizuj heslá pracovnej plochy</string>
     <string name="autofillSettingsResetExcludedSitesTitle">Obnovenie vylúčených lokalít</string>
 
+    <string name="passwords_import_promo_title" instruction="The &apos;br&apos; is a forced line break for English. It does not need to be included in translations.">Prenes si heslá z&lt;br /&gt;Google do DuckDuckGo</string>
+    <string name="passwords_import_promo_subtitle">Rýchlo a bezpečne importuj svoje heslá do DuckDuckGo. Google ťa môže požiadať o zadanie hesla.</string>
+    <string name="passwords_import_promo_action">Importovať z Google</string>
+
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-sl/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-sl/strings-autofill-impl.xml
@@ -293,4 +293,8 @@
     <string name="autofillSettingsImportFromDesktopSync">Sinhroniziraj gesla za namizje</string>
     <string name="autofillSettingsResetExcludedSitesTitle">Ponastavi izključena spletna mesta</string>
 
+    <string name="passwords_import_promo_title" instruction="The &apos;br&apos; is a forced line break for English. It does not need to be included in translations.">Prenesite gesla iz&lt;br /&gt;Googla v DuckDuckGo</string>
+    <string name="passwords_import_promo_subtitle">Hitro in varno uvozite svoja gesla v DuckDuckGo. Google vas bo morda prosil, da vnesete geslo.</string>
+    <string name="passwords_import_promo_action">Uvozi iz Googla</string>
+
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-sv/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-sv/strings-autofill-impl.xml
@@ -281,4 +281,8 @@
     <string name="autofillSettingsImportFromDesktopSync">Synkronisera lösenord för dator</string>
     <string name="autofillSettingsResetExcludedSitesTitle">Återställ exkluderade webbplatser</string>
 
+    <string name="passwords_import_promo_title" instruction="The &apos;br&apos; is a forced line break for English. It does not need to be included in translations.">Ta med dina lösenord från&lt;br /&gt;Google till DuckDuckGo</string>
+    <string name="passwords_import_promo_subtitle">Importera snabbt och säkert dina lösenord till DuckDuckGo. Google kan be dig att ange ditt lösenord.</string>
+    <string name="passwords_import_promo_action">Importera från Google</string>
+
 </resources>

--- a/autofill/autofill-impl/src/main/res/values-tr/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values-tr/strings-autofill-impl.xml
@@ -281,4 +281,8 @@
     <string name="autofillSettingsImportFromDesktopSync">Masaüstü Şifrelerini Senkronize Et</string>
     <string name="autofillSettingsResetExcludedSitesTitle">Hariç Tutulan Siteleri Sıfırla</string>
 
+    <string name="passwords_import_promo_title" instruction="The &apos;br&apos; is a forced line break for English. It does not need to be included in translations.">Şifrelerinizi Google\'dan&lt;br /&gt;DuckDuckGo\'ya getirin</string>
+    <string name="passwords_import_promo_subtitle">Şifrelerinizi hızlı ve güvenli bir şekilde DuckDuckGo\'ya aktarın. Google sizden şifrenizi girmenizi isteyebilir.</string>
+    <string name="passwords_import_promo_action">Google\'dan İçe Aktar</string>
+
 </resources>

--- a/autofill/autofill-impl/src/main/res/values/donottranslate.xml
+++ b/autofill/autofill-impl/src/main/res/values/donottranslate.xml
@@ -15,7 +15,5 @@
   -->
 
 <resources>
-    <string name="passwords_import_promo_title">Bring your passwords from&lt;br /&gt;Google to DuckDuckGo</string>
-    <string name="passwords_import_promo_subtitle">Quickly and securely import your passwords to DuckDuckGo. Google may ask you to enter your password.</string>
-    <string name="passwords_import_promo_action">Import From Google</string>
+
 </resources>

--- a/autofill/autofill-impl/src/main/res/values/strings-autofill-impl.xml
+++ b/autofill/autofill-impl/src/main/res/values/strings-autofill-impl.xml
@@ -277,4 +277,8 @@
     <string name="autofillSettingsImportFromDesktopSync">Sync Desktop Passwords</string>
     <string name="autofillSettingsResetExcludedSitesTitle">Reset Excluded Sites</string>
 
+    <string name="passwords_import_promo_title" instruction="The 'br' is a forced line break for English. It does not need to be included in translations.">Bring your passwords from&lt;br /&gt;Google to DuckDuckGo</string>
+    <string name="passwords_import_promo_subtitle">Quickly and securely import your passwords to DuckDuckGo. Google may ask you to enter your password.</string>
+    <string name="passwords_import_promo_action">Import From Google</string>
+
 </resources>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/608920331025315/task/1210709764115871?focus=true 

### Description
Translations for the password import promo in password management screen.

### Steps to test this PR
- qa optional (lint check passing)