### PR TITLE
Make input screen autocomplete fill viewport height

### DIFF
--- a/duckchat/duckchat-impl/src/main/res/layout/fragment_search_tab.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/fragment_search_tab.xml
@@ -33,7 +33,7 @@
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/autoCompleteSuggestionsList"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:background="?attr/daxColorBrowserOverlay"
         android:clipToPadding="false"
         android:elevation="4dp"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1210707531805579?focus=true

### Description

- Makes input screen autocomplete `match_parent`.

### Steps to test this PR

- [x] Search for something
- [x] Verify autocomplete fills viewport height
