### PR TITLE
show only favorites without other NTP content on the Input Screen

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/state/InputScreenVisibilityState.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/state/InputScreenVisibilityState.kt
@@ -19,4 +19,5 @@ package com.duckduckgo.duckchat.impl.inputscreen.ui.state
 data class InputScreenVisibilityState(
     val voiceInputButtonVisible: Boolean,
     val forceWebSearchButtonVisible: Boolean,
+    val favoritesVisible: Boolean,
 )

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/state/InputScreenVisibilityState.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/state/InputScreenVisibilityState.kt
@@ -19,5 +19,4 @@ package com.duckduckgo.duckchat.impl.inputscreen.ui.state
 data class InputScreenVisibilityState(
     val voiceInputButtonVisible: Boolean,
     val forceWebSearchButtonVisible: Boolean,
-    val favoritesVisible: Boolean,
 )

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/tabs/SearchTabFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/tabs/SearchTabFragment.kt
@@ -103,6 +103,7 @@ class SearchTabFragment : DuckDuckGoFragment(R.layout.fragment_search_tab) {
         val favoritesGridConfig = FavoritesGridConfig(
             isExpandable = false,
             showPlaceholders = false,
+            showDaxWhenEmpty = true,
             placement = FavoritesPlacement.FOCUSED_STATE,
         )
         favoritesView = savedSitesViewsProvider.getFavoritesGridView(requireContext(), config = favoritesGridConfig)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/tabs/SearchTabFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/tabs/SearchTabFragment.kt
@@ -112,13 +112,7 @@ class SearchTabFragment : DuckDuckGoFragment(R.layout.fragment_search_tab) {
         val slideDistance = displayMetrics.heightPixels * CONTENT_SLIDE_DISTANCE
         favoritesView.translationY = -slideDistance
 
-        binding.contentContainer.addView(
-            favoritesView,
-            ViewGroup.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.MATCH_PARENT,
-            ),
-        )
+        binding.contentContainer.addView(favoritesView)
 
         favoritesView.animate()
             .alpha(1f)
@@ -197,9 +191,6 @@ class SearchTabFragment : DuckDuckGoFragment(R.layout.fragment_search_tab) {
         ) {
             it?.let { renderer.renderAutocomplete(it) }
         }
-        viewModel.visibilityState.onEach {
-            favoritesView.isVisible = it.favoritesVisible
-        }.launchIn(lifecycleScope)
     }
 
     companion object {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/tabs/SearchTabFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/tabs/SearchTabFragment.kt
@@ -19,12 +19,10 @@ package com.duckduckgo.duckchat.impl.inputscreen.ui.tabs
 import android.os.Bundle
 import android.transition.Transition
 import android.view.View
-import android.view.ViewGroup
 import android.view.animation.OvershootInterpolator
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.browser.api.ui.BrowserScreens.PrivateSearchScreenNoParams
@@ -47,8 +45,6 @@ import com.duckduckgo.savedsites.api.views.FavoritesGridConfig
 import com.duckduckgo.savedsites.api.views.FavoritesPlacement
 import com.duckduckgo.savedsites.api.views.SavedSitesViewsProvider
 import javax.inject.Inject
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 
 @InjectWith(FragmentScope::class)
 class SearchTabFragment : DuckDuckGoFragment(R.layout.fragment_search_tab) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
@@ -93,7 +93,6 @@ class InputScreenViewModel @Inject constructor(
         InputScreenVisibilityState(
             voiceInputButtonVisible = voiceServiceAvailable.value && voiceInputAllowed.value,
             forceWebSearchButtonVisible = false,
-            favoritesVisible = true,
         ),
     )
     val visibilityState: StateFlow<InputScreenVisibilityState> = _visibilityState.asStateFlow()
@@ -151,16 +150,6 @@ class InputScreenViewModel @Inject constructor(
                 )
             }
         }.launchIn(viewModelScope)
-
-        autoCompleteViewState.observeForever { viewState ->
-            if (viewState != null) {
-                _visibilityState.update {
-                    it.copy(
-                        favoritesVisible = viewState.showFavorites,
-                    )
-                }
-            }
-        }
     }
 
     fun onActivityResume() {

--- a/saved-sites/saved-sites-api/src/main/java/com/duckduckgo/savedsites/api/views/SavedSitesViewsProvider.kt
+++ b/saved-sites/saved-sites-api/src/main/java/com/duckduckgo/savedsites/api/views/SavedSitesViewsProvider.kt
@@ -35,12 +35,14 @@ interface SavedSitesViewsProvider {
  *
  * @property isExpandable If true and there are two or more rows, the favorites are collapsed and can be expanded.
  * If false, the favorites are always expanded.
- * @property showPlaceholders Whether to show placeholder with onboarding if favorites list is empty.
+ * @property showPlaceholders Whether to show placeholder with onboarding if favorites list is empty. Takes precedent over [showDaxWhenEmpty].
+ * @property showDaxWhenEmpty Whether to show Dax icon if favorites list is empty.
  * @property placement The screen on which favorites are displayed.
  */
 data class FavoritesGridConfig(
     val isExpandable: Boolean,
     val showPlaceholders: Boolean,
+    val showDaxWhenEmpty: Boolean,
     val placement: FavoritesPlacement,
 )
 

--- a/saved-sites/saved-sites-api/src/main/java/com/duckduckgo/savedsites/api/views/SavedSitesViewsProvider.kt
+++ b/saved-sites/saved-sites-api/src/main/java/com/duckduckgo/savedsites/api/views/SavedSitesViewsProvider.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.savedsites.api.views
+
+import android.content.Context
+import android.view.View
+
+/**
+ * Provides views for the Saved Sites feature.
+ */
+interface SavedSitesViewsProvider {
+
+    /**
+     * Returns a view for displaying a grid of favorite sites.
+     */
+    fun getFavoritesGridView(context: Context, config: FavoritesGridConfig? = null): View
+}
+
+/**
+ * Configuration for the Favorites Grid view.
+ *
+ * @property isExpandable If true and there are two or more rows, the favorites are collapsed and can be expanded.
+ * If false, the favorites are always expanded.
+ * @property showPlaceholders Whether to show placeholder with onboarding if favorites list is empty.
+ * @property placement The screen on which favorites are displayed.
+ */
+data class FavoritesGridConfig(
+    val isExpandable: Boolean,
+    val showPlaceholders: Boolean,
+    val placement: FavoritesPlacement,
+)
+
+enum class FavoritesPlacement {
+    FOCUSED_STATE,
+    NEW_TAB_PAGE,
+    ;
+
+    companion object {
+        fun from(type: Int): FavoritesPlacement {
+            return when (type) {
+                0 -> FOCUSED_STATE
+                1 -> NEW_TAB_PAGE
+                else -> FOCUSED_STATE
+            }
+        }
+    }
+}

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionView.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionView.kt
@@ -28,6 +28,7 @@ import android.widget.LinearLayout
 import android.widget.PopupWindow
 import androidx.core.text.HtmlCompat
 import androidx.core.text.toSpannable
+import androidx.core.view.isVisible
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.findViewTreeLifecycleOwner
@@ -112,6 +113,7 @@ class FavouritesNewTabSectionView @JvmOverloads constructor(
 
     private var isExpandable = true
     private var showPlaceholders = false
+    private var showDaxWhenEmpty = false
     private var placement: FavoritesPlacement = FavoritesPlacement.NEW_TAB_PAGE
 
     private val binding: ViewNewTabFavouritesSectionBinding by viewBinding()
@@ -152,6 +154,7 @@ class FavouritesNewTabSectionView @JvmOverloads constructor(
         config?.let {
             isExpandable = it.isExpandable
             showPlaceholders = it.showPlaceholders
+            showDaxWhenEmpty = it.showDaxWhenEmpty
             placement = it.placement
         }
     }
@@ -354,6 +357,7 @@ class FavouritesNewTabSectionView @JvmOverloads constructor(
             }
             viewModel.onNewTabFavouritesShown()
         }
+        binding.ddgLogo.isVisible = showDaxWhenEmpty && viewState.favourites.isEmpty()
     }
 
     private fun processCommands(command: Command) {

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionView.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionView.kt
@@ -66,6 +66,8 @@ import com.duckduckgo.savedsites.api.models.SavedSite
 import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
 import com.duckduckgo.savedsites.api.models.SavedSite.Favorite
 import com.duckduckgo.savedsites.api.models.SavedSitesNames
+import com.duckduckgo.savedsites.api.views.FavoritesGridConfig
+import com.duckduckgo.savedsites.api.views.FavoritesPlacement
 import com.duckduckgo.savedsites.impl.dialogs.EditSavedSiteDialogFragment
 import com.duckduckgo.savedsites.impl.dialogs.EditSavedSiteDialogFragment.DeleteBookmarkListener
 import com.duckduckgo.savedsites.impl.dialogs.EditSavedSiteDialogFragment.EditSavedSiteListener
@@ -74,7 +76,6 @@ import com.duckduckgo.savedsites.impl.newtab.FavouritesNewTabSectionViewModel.Co
 import com.duckduckgo.savedsites.impl.newtab.FavouritesNewTabSectionViewModel.Command.DeleteFavoriteConfirmation
 import com.duckduckgo.savedsites.impl.newtab.FavouritesNewTabSectionViewModel.Command.DeleteSavedSiteConfirmation
 import com.duckduckgo.savedsites.impl.newtab.FavouritesNewTabSectionViewModel.Command.ShowEditSavedSiteDialog
-import com.duckduckgo.savedsites.impl.newtab.FavouritesNewTabSectionViewModel.Placement
 import com.duckduckgo.savedsites.impl.newtab.FavouritesNewTabSectionViewModel.SavedSiteChangedViewState
 import com.duckduckgo.savedsites.impl.newtab.FavouritesNewTabSectionViewModel.ViewState
 import com.duckduckgo.savedsites.impl.newtab.FavouritesNewTabSectionsAdapter.Companion.QUICK_ACCESS_GRID_MAX_COLUMNS
@@ -111,7 +112,7 @@ class FavouritesNewTabSectionView @JvmOverloads constructor(
 
     private var isExpandable = true
     private var showPlaceholders = false
-    private var placement = Placement.NEW_TAB_PAGE
+    private var placement: FavoritesPlacement = FavoritesPlacement.NEW_TAB_PAGE
 
     private val binding: ViewNewTabFavouritesSectionBinding by viewBinding()
 
@@ -142,8 +143,16 @@ class FavouritesNewTabSectionView @JvmOverloads constructor(
         ).apply {
             isExpandable = getBoolean(R.styleable.FavouritesNewTabSectionView_isExpandable, true)
             showPlaceholders = getBoolean(R.styleable.FavouritesNewTabSectionView_showPlaceholders, true)
-            placement = Placement.from(getInt(R.styleable.FavouritesNewTabSectionView_favoritesPlacement, 1))
+            placement = FavoritesPlacement.from(getInt(R.styleable.FavouritesNewTabSectionView_favoritesPlacement, 1))
             recycle()
+        }
+    }
+
+    constructor(context: Context, config: FavoritesGridConfig?) : this(context, null, 0) {
+        config?.let {
+            isExpandable = it.isExpandable
+            showPlaceholders = it.showPlaceholders
+            placement = it.placement
         }
     }
 

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionViewModel.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionViewModel.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.savedsites.api.models.BookmarkFolder
 import com.duckduckgo.savedsites.api.models.SavedSite
 import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
 import com.duckduckgo.savedsites.api.models.SavedSite.Favorite
+import com.duckduckgo.savedsites.api.views.FavoritesPlacement
 import com.duckduckgo.savedsites.impl.SavedSitesPixelName
 import com.duckduckgo.savedsites.impl.SavedSitesPixelName.*
 import com.duckduckgo.savedsites.impl.newtab.FavouritesNewTabSectionViewModel.Command.DeleteFavoriteConfirmation
@@ -70,23 +71,6 @@ class FavouritesNewTabSectionViewModel @Inject constructor(
         val savedSite: SavedSite,
         val bookmarkFolder: BookmarkFolder?,
     )
-
-    enum class Placement {
-        FOCUSED_STATE,
-        NEW_TAB_PAGE,
-        ;
-
-        companion object {
-            fun from(type: Int): Placement {
-                // same order as attrs-saved-sites.xml
-                return when (type) {
-                    0 -> Placement.FOCUSED_STATE
-                    1 -> Placement.NEW_TAB_PAGE
-                    else -> Placement.FOCUSED_STATE
-                }
-            }
-        }
-    }
 
     sealed class Command {
         class ShowEditSavedSiteDialog(val savedSiteChangedViewState: SavedSiteChangedViewState) : Command()
@@ -288,14 +272,14 @@ class FavouritesNewTabSectionViewModel @Inject constructor(
         pixel.fire(EDIT_BOOKMARK_REMOVE_FAVORITE_TOGGLED)
     }
 
-    fun onFavoriteClicked(placement: Placement) {
+    fun onFavoriteClicked(placement: FavoritesPlacement) {
         pixel.fire(formatPixelWithPlacement(FAVOURITE_CLICKED, placement))
         pixel.fire(formatPixelWithPlacement(FAVOURITE_CLICKED_DAILY, placement), type = Daily())
     }
 
     private fun formatPixelWithPlacement(
         pixelName: SavedSitesPixelName,
-        placement: Placement,
+        placement: FavoritesPlacement,
     ): String {
         return pixelName.pixelName + "_" + placement.name.lowercase()
     }

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/views/SavedSitesViewsProviderImpl.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/views/SavedSitesViewsProviderImpl.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.savedsites.impl.views
+
+import android.content.Context
+import android.view.View
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.savedsites.api.views.FavoritesGridConfig
+import com.duckduckgo.savedsites.api.views.SavedSitesViewsProvider
+import com.duckduckgo.savedsites.impl.newtab.FavouritesNewTabSectionView
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+@ContributesBinding(scope = AppScope::class)
+class SavedSitesViewsProviderImpl @Inject constructor() : SavedSitesViewsProvider {
+    override fun getFavoritesGridView(context: Context, config: FavoritesGridConfig?): View {
+        return FavouritesNewTabSectionView(context, config)
+    }
+}

--- a/saved-sites/saved-sites-impl/src/main/res/layout/view_new_tab_favourites_section.xml
+++ b/saved-sites/saved-sites-impl/src/main/res/layout/view_new_tab_favourites_section.xml
@@ -20,6 +20,18 @@
     android:layout_height="wrap_content"
     android:orientation="vertical">
 
+    <ImageView
+        android:id="@+id/ddgLogo"
+        android:layout_height="wrap_content"
+        android:layout_width="@dimen/ntpDaxLogoIconWidth"
+        android:layout_marginTop="@dimen/homeTabDdgLogoTopMargin"
+        android:adjustViewBounds="true"
+        android:maxWidth="180dp"
+        android:maxHeight="180dp"
+        app:srcCompat="@drawable/logo_full"
+        android:visibility="gone"
+        android:layout_gravity="center_horizontal" />
+
     <LinearLayout
         android:id="@+id/sectionHeaderLayout"
         android:layout_width="match_parent"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1210708810784115?focus=true

### Description
Exposes favorites grid view so that it can be independently displayed on the Input Screen without having to bundle the whole NTP.

### Steps to test this PR

- [x] Clear cache and open a new internal flavor of the app.
- [x] Enabled Duck.ai -> Input Screen.
- [x] Verify that you see the new visual design RMF banner.
- [x] Click on the omnibar, as it focuses verify that you don't see the RMF banner.
- [x] Add some favorites and verify they are visible on the "Search" page of the input screen.