### PR TITLE
Update content scope scripts to version 10.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.3.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.1.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.4.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.6.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.3.0.tgz",
-      "integrity": "sha512-TJakO7am9x2bBkJG8I0ke/OAGOOQEHmjyK1YXEqNo3cz5s3ctAi/ag6LV7yctgHj+VVBdemginubTYSStVBWtA==",
+      "version": "14.5.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.5.0.tgz",
+      "integrity": "sha512-DvPtPgWWt5Ue3vs7JxZ2WQLAJOdoj5kG75rCqFQUPaXczYfwppqtc4qT9rx4HQn61dajd7XUyQF9nbXoNn6rmg==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#144965a993714b67dc6429b6c344e4b7db9c722c",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#a382fa493c5309a5399b35ef5c49cf2895dcf367",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -89,13 +89,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@ghostery/adblocker": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.8.0.tgz",
-      "integrity": "sha512-fqPYYYoa+Lonc5RLQiOnzTfWKoi5nXkBwTQUPBaUsUifHTXHzkfgPsyIGNx8YNqcvdbDoIrReO3hIbIFf6KiWA==",
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.9.3.tgz",
+      "integrity": "sha512-QlJ491n5bxWitonVdqk7k35GSwFbNFXypJ4mkJgjCHvxaerxZOMO99eCXu9IHeBH9T1rfdVv9bl74qITaWGOag==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-content": "^2.8.0",
-        "@ghostery/adblocker-extended-selectors": "^2.8.0",
+        "@ghostery/adblocker-content": "^2.9.3",
+        "@ghostery/adblocker-extended-selectors": "^2.9.3",
         "@ghostery/url-parser": "^1.3.0",
         "@remusao/guess-url-type": "^2.1.0",
         "@remusao/small": "^2.1.0",
@@ -104,18 +104,18 @@
       }
     },
     "node_modules/@ghostery/adblocker-content": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.8.0.tgz",
-      "integrity": "sha512-s16EMhMmEcCkGalPcoaJB+UYhF7N91MibRSPCx0eNsFdew43zZnY3SPdatnZODk0qSCFoxa0pMCGtHJ6PypxWA==",
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.9.3.tgz",
+      "integrity": "sha512-VIRGbsSkV3OpLEnB77Ij/j5QZd+pMNnUy0L8HI17xEpeJgRcnoCIlQxdHuP60IivSdUOOaNRm/jrnsgX9ULZeA==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-extended-selectors": "^2.8.0"
+        "@ghostery/adblocker-extended-selectors": "^2.9.3"
       }
     },
     "node_modules/@ghostery/adblocker-extended-selectors": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.8.0.tgz",
-      "integrity": "sha512-+iE4fd1pVxDD+3G6nfflk242CyW6XBYyZNbJmjhbImmqB+wkSZQsa+SwX55SSk7bPGI91tHsT/UPRJir2SjvTA==",
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.9.3.tgz",
+      "integrity": "sha512-1i91zh6nOLcUvjqXJYxZM8R1NZ/CncAFPpe4C7zHjHNzNJLBQ1sTvMVfJmnrSNROyCJy7ZWqVY8WAodCJXAfyQ==",
       "license": "MPL-2.0"
     },
     "node_modules/@ghostery/url-parser": {
@@ -667,18 +667,18 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.9.tgz",
-      "integrity": "sha512-/FGY1+CryHsxF9SFiPZlMOcwQsfABkAvOJO5VEKE8TNifVEqgMF7+UVXHGhm1z4gPUfvVS/EYcwhiRU3vUa1ag==",
+      "version": "7.0.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.10.tgz",
+      "integrity": "sha512-z7PilFbUHwd+IlQ72D0aHDpqykUUpe9yvwa5k/rFvFLmpvNmWqHEIHoSYwE5sA5LZU4bTTIjhDZEjURHc8f2ag==",
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.9.tgz",
-      "integrity": "sha512-rKxpX0gaR5SD17gclTl52x+uOF05xlQC1cAAKTnoiTXZeXA3qd93R73mSS4valR+Ca1H4dUmpCbWpYXRu6QTtQ==",
+      "version": "7.0.10",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.10.tgz",
+      "integrity": "sha512-5qrQCSbJwrSlO4Rg/KFLnyMhkv5ngTeFh0pRYxEr5q+8eh0gguXqCO+RvzOEMEKqasR9XPYkSPTaoPUx0UBv8w==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.9"
+        "tldts-core": "^7.0.10"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.3.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.1.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.4.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.6.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass