### PR TITLE
Add duck.ai chat - subscriptions integration

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatWebViewActivity.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatWebViewActivity.kt
@@ -72,6 +72,7 @@ import com.duckduckgo.js.messaging.api.JsMessageCallback
 import com.duckduckgo.js.messaging.api.JsMessaging
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.navigation.api.getActivityParams
+import com.duckduckgo.subscriptions.api.SUBSCRIPTIONS_FEATURE_NAME
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import java.io.File
@@ -100,6 +101,9 @@ open class DuckChatWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
 
     @Inject
     lateinit var duckChatJSHelper: DuckChatJSHelper
+
+    @Inject
+    lateinit var subscriptionsHandler: SubscriptionsHandler
 
     @Inject
     @AppCoroutineScope
@@ -240,6 +244,19 @@ open class DuckChatWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
                                     }
                                 }
                             }
+
+                            SUBSCRIPTIONS_FEATURE_NAME -> {
+                                subscriptionsHandler.handleSubscriptionsFeature(
+                                    featureName,
+                                    method,
+                                    id,
+                                    data,
+                                    this@DuckChatWebViewActivity,
+                                    appCoroutineScope,
+                                    contentScopeScripts,
+                                )
+                            }
+
                             else -> {}
                         }
                     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatWebViewFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatWebViewFragment.kt
@@ -72,6 +72,7 @@ import com.duckduckgo.duckchat.impl.ui.filechooser.capture.launcher.UploadFromEx
 import com.duckduckgo.duckchat.impl.ui.filechooser.capture.launcher.UploadFromExternalMediaAppLauncher.MediaCaptureResult.NoMediaCaptured
 import com.duckduckgo.js.messaging.api.JsMessageCallback
 import com.duckduckgo.js.messaging.api.JsMessaging
+import com.duckduckgo.subscriptions.api.SUBSCRIPTIONS_FEATURE_NAME
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import java.io.File
@@ -95,6 +96,9 @@ open class DuckChatWebViewFragment : DuckDuckGoFragment(R.layout.activity_duck_c
 
     @Inject
     lateinit var duckChatJSHelper: DuckChatJSHelper
+
+    @Inject
+    lateinit var subscriptionsHandler: SubscriptionsHandler
 
     @Inject
     @AppCoroutineScope
@@ -234,6 +238,18 @@ open class DuckChatWebViewFragment : DuckDuckGoFragment(R.layout.activity_duck_c
                                         }
                                     }
                                 }
+                            }
+
+                            SUBSCRIPTIONS_FEATURE_NAME -> {
+                                subscriptionsHandler.handleSubscriptionsFeature(
+                                    featureName,
+                                    method,
+                                    id,
+                                    data,
+                                    requireActivity(),
+                                    appCoroutineScope,
+                                    contentScopeScripts,
+                                )
                             }
 
                             else -> {}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/SubscriptionsHandler.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/SubscriptionsHandler.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui
+
+import android.content.Context
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.js.messaging.api.JsMessaging
+import com.duckduckgo.navigation.api.GlobalActivityStarter
+import com.duckduckgo.subscriptions.api.SubscriptionScreens.RestoreSubscriptionScreenWithParams
+import com.duckduckgo.subscriptions.api.SubscriptionScreens.SubscriptionScreenNoParams
+import com.duckduckgo.subscriptions.api.SubscriptionScreens.SubscriptionsSettingsScreenWithEmptyParams
+import com.duckduckgo.subscriptions.api.SubscriptionsJSHelper
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+
+class SubscriptionsHandler @Inject constructor(
+    private val subscriptionsJSHelper: SubscriptionsJSHelper,
+    private val globalActivityStarter: GlobalActivityStarter,
+    private val dispatcherProvider: DispatcherProvider,
+) {
+
+    fun handleSubscriptionsFeature(
+        featureName: String,
+        method: String,
+        id: String?,
+        data: JSONObject?,
+        context: Context,
+        appCoroutineScope: CoroutineScope,
+        contentScopeScripts: JsMessaging,
+    ) {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            val response = subscriptionsJSHelper.processJsCallbackMessage(featureName, method, id, data)
+            withContext(dispatcherProvider.main()) {
+                response?.let {
+                    contentScopeScripts.onResponse(response)
+                }
+            }
+
+            when (method) {
+                METHOD_BACK_TO_SETTINGS -> {
+                    withContext(dispatcherProvider.main()) {
+                        globalActivityStarter.start(context, SubscriptionsSettingsScreenWithEmptyParams)
+                    }
+                }
+
+                METHOD_OPEN_SUBSCRIPTION_ACTIVATION -> {
+                    withContext(dispatcherProvider.main()) {
+                        globalActivityStarter.start(context, RestoreSubscriptionScreenWithParams(isOriginWeb = true))
+                    }
+                }
+
+                METHOD_OPEN_SUBSCRIPTION_PURCHASE -> {
+                    withContext(dispatcherProvider.main()) {
+                        globalActivityStarter.start(context, SubscriptionScreenNoParams)
+                    }
+                }
+
+                else -> {}
+            }
+        }
+    }
+
+    companion object {
+        private const val METHOD_BACK_TO_SETTINGS = "backToSettings"
+        private const val METHOD_OPEN_SUBSCRIPTION_ACTIVATION = "openSubscriptionActivation"
+        private const val METHOD_OPEN_SUBSCRIPTION_PURCHASE = "openSubscriptionPurchase"
+    }
+}

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/SubscriptionsHandlerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/SubscriptionsHandlerTest.kt
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui
+
+import android.content.Context
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.js.messaging.api.JsCallbackData
+import com.duckduckgo.js.messaging.api.JsMessaging
+import com.duckduckgo.navigation.api.GlobalActivityStarter
+import com.duckduckgo.subscriptions.api.SubscriptionScreens.RestoreSubscriptionScreenWithParams
+import com.duckduckgo.subscriptions.api.SubscriptionScreens.SubscriptionScreenNoParams
+import com.duckduckgo.subscriptions.api.SubscriptionScreens.SubscriptionsSettingsScreenWithEmptyParams
+import com.duckduckgo.subscriptions.api.SubscriptionsJSHelper
+import kotlinx.coroutines.test.runTest
+import org.json.JSONObject
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class SubscriptionsHandlerTest {
+
+    @get:Rule
+    var coroutineRule = CoroutineTestRule()
+
+    private val dispatcherProvider = coroutineRule.testDispatcherProvider
+
+    @Mock
+    private lateinit var subscriptionsJSHelper: SubscriptionsJSHelper
+
+    @Mock
+    private lateinit var globalActivityStarter: GlobalActivityStarter
+
+    @Mock
+    private lateinit var context: Context
+
+    @Mock
+    private lateinit var contentScopeScripts: JsMessaging
+
+    private lateinit var subscriptionsHandler: SubscriptionsHandler
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+
+        subscriptionsHandler = SubscriptionsHandler(
+            subscriptionsJSHelper,
+            globalActivityStarter,
+            dispatcherProvider,
+        )
+    }
+
+    @Test
+    fun `handleSubscriptionsFeature processes js callback and responds when response is not null`() = runTest {
+        val featureName = "subscriptions"
+        val method = "someMethod"
+        val id = "testId"
+        val data = JSONObject()
+        val response = JsCallbackData(JSONObject(), featureName, method, id)
+        whenever(subscriptionsJSHelper.processJsCallbackMessage(featureName, method, id, data))
+            .thenReturn(response)
+
+        subscriptionsHandler.handleSubscriptionsFeature(
+            featureName,
+            method,
+            id,
+            data,
+            context,
+            coroutineRule.testScope,
+            contentScopeScripts,
+        )
+
+        verify(subscriptionsJSHelper).processJsCallbackMessage(featureName, method, id, data)
+        verify(contentScopeScripts).onResponse(response)
+    }
+
+    @Test
+    fun `handleSubscriptionsFeature processes js callback but does not respond when response is null`() = runTest {
+        val featureName = "subscriptions"
+        val method = "someMethod"
+        val id = "testId"
+        val data = JSONObject()
+        whenever(subscriptionsJSHelper.processJsCallbackMessage(featureName, method, id, data))
+            .thenReturn(null)
+
+        subscriptionsHandler.handleSubscriptionsFeature(
+            featureName,
+            method,
+            id,
+            data,
+            context,
+            coroutineRule.testScope,
+            contentScopeScripts,
+        )
+
+        verify(subscriptionsJSHelper).processJsCallbackMessage(featureName, method, id, data)
+        verify(contentScopeScripts, never()).onResponse(any())
+    }
+
+    @Test
+    fun `handleSubscriptionsFeature launches settings screen when method is backToSettings`() = runTest {
+        val featureName = "subscriptions"
+        val method = "backToSettings"
+        val id = "testId"
+        val data = JSONObject()
+        val response = JsCallbackData(JSONObject(), featureName, method, id)
+        whenever(subscriptionsJSHelper.processJsCallbackMessage(featureName, method, id, data))
+            .thenReturn(response)
+
+        subscriptionsHandler.handleSubscriptionsFeature(
+            featureName,
+            method,
+            id,
+            data,
+            context,
+            coroutineRule.testScope,
+            contentScopeScripts,
+        )
+
+        verify(globalActivityStarter).start(context, SubscriptionsSettingsScreenWithEmptyParams)
+    }
+
+    @Test
+    fun `handleSubscriptionsFeature launches subscription activation screen when method is openSubscriptionActivation`() = runTest {
+        val featureName = "subscriptions"
+        val method = "openSubscriptionActivation"
+        val id = "testId"
+        val data = JSONObject()
+        val response = JsCallbackData(JSONObject(), featureName, method, id)
+        whenever(subscriptionsJSHelper.processJsCallbackMessage(featureName, method, id, data))
+            .thenReturn(response)
+
+        subscriptionsHandler.handleSubscriptionsFeature(
+            featureName,
+            method,
+            id,
+            data,
+            context,
+            coroutineRule.testScope,
+            contentScopeScripts,
+        )
+
+        verify(globalActivityStarter).start(context, RestoreSubscriptionScreenWithParams(isOriginWeb = true))
+    }
+
+    @Test
+    fun `handleSubscriptionsFeature launches subscription purchase screen when method is openSubscriptionPurchase`() = runTest {
+        val featureName = "subscriptions"
+        val method = "openSubscriptionPurchase"
+        val id = "testId"
+        val data = JSONObject()
+        val response = JsCallbackData(JSONObject(), featureName, method, id)
+        whenever(subscriptionsJSHelper.processJsCallbackMessage(featureName, method, id, data))
+            .thenReturn(response)
+
+        subscriptionsHandler.handleSubscriptionsFeature(
+            featureName,
+            method,
+            id,
+            data,
+            context,
+            coroutineRule.testScope,
+            contentScopeScripts,
+        )
+
+        verify(globalActivityStarter).start(context, SubscriptionScreenNoParams)
+    }
+
+    @Test
+    fun `handleSubscriptionsFeature handles null data parameter`() = runTest {
+        val featureName = "subscriptions"
+        val method = "backToSettings"
+        val id = "testId"
+        val data: JSONObject? = null
+        val response = JsCallbackData(JSONObject(), featureName, method, id)
+        whenever(subscriptionsJSHelper.processJsCallbackMessage(featureName, method, id, data))
+            .thenReturn(response)
+
+        subscriptionsHandler.handleSubscriptionsFeature(
+            featureName,
+            method,
+            id,
+            data,
+            context,
+            coroutineRule.testScope,
+            contentScopeScripts,
+        )
+
+        verify(subscriptionsJSHelper).processJsCallbackMessage(featureName, method, id, data)
+        verify(globalActivityStarter).start(context, SubscriptionsSettingsScreenWithEmptyParams)
+    }
+
+    @Test
+    fun `handleSubscriptionsFeature handles null id parameter`() = runTest {
+        val featureName = "subscriptions"
+        val method = "openSubscriptionPurchase"
+        val id: String? = null
+        val data = JSONObject()
+        val response = JsCallbackData(JSONObject(), featureName, method, "")
+        whenever(subscriptionsJSHelper.processJsCallbackMessage(featureName, method, id, data))
+            .thenReturn(response)
+
+        subscriptionsHandler.handleSubscriptionsFeature(
+            featureName,
+            method,
+            id,
+            data,
+            context,
+            coroutineRule.testScope,
+            contentScopeScripts,
+        )
+
+        verify(subscriptionsJSHelper).processJsCallbackMessage(featureName, method, id, data)
+        verify(globalActivityStarter).start(context, SubscriptionScreenNoParams)
+    }
+}

--- a/subscriptions/subscriptions-api/src/main/java/com/duckduckgo/subscriptions/api/SubscriptionScreens.kt
+++ b/subscriptions/subscriptions-api/src/main/java/com/duckduckgo/subscriptions/api/SubscriptionScreens.kt
@@ -19,5 +19,7 @@ package com.duckduckgo.subscriptions.api
 import com.duckduckgo.navigation.api.GlobalActivityStarter.ActivityParams
 
 sealed class SubscriptionScreens {
+    data object SubscriptionsSettingsScreenWithEmptyParams : ActivityParams
     data object SubscriptionScreenNoParams : ActivityParams
+    data class RestoreSubscriptionScreenWithParams(val isOriginWeb: Boolean = true) : ActivityParams
 }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -187,6 +187,14 @@ interface PrivacyProFeature {
      */
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun enableSubscriptionFlowsV2(): Toggle
+
+    /**
+     * As part of Duck.ai we are adding new supported JS messages.
+     * This is enabled by default, but can be disabled if necessary.
+     * FF only controls native messaging (enabled/disabled).
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun duckAISubscriptionMessaging(): Toggle
 }
 
 @ContributesBinding(AppScope::class)

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionsContentScopeJsMessageHandler.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionsContentScopeJsMessageHandler.kt
@@ -41,6 +41,8 @@ class SubscriptionsContentScopeJsMessageHandler @Inject constructor() : ContentS
         override val methods: List<String> = listOf(
             "handshake",
             "subscriptionDetails",
+            "getAuthAccessToken",
+            "getFeatureConfig",
         )
     }
 }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionsContentScopeJsMessageHandler.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionsContentScopeJsMessageHandler.kt
@@ -43,6 +43,9 @@ class SubscriptionsContentScopeJsMessageHandler @Inject constructor() : ContentS
             "subscriptionDetails",
             "getAuthAccessToken",
             "getFeatureConfig",
+            "backToSettings",
+            "openSubscriptionActivation",
+            "openSubscriptionPurchase",
         )
     }
 }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionsJSHelper.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionsJSHelper.kt
@@ -38,7 +38,11 @@ class RealSubscriptionsJSHelper @Inject constructor(
     ): JsCallbackData? = when (method) {
         METHOD_HANDSHAKE -> id?.let {
             val jsonPayload = JSONObject().apply {
-                put(AVAILABLE_MESSAGES, JSONArray().put(SUBSCRIPTION_DETAILS))
+                put(AVAILABLE_MESSAGES, JSONArray().apply {
+                    put(SUBSCRIPTION_DETAILS)
+                    put(GET_AUTH_ACCESS_TOKEN)
+                    put(GET_FEATURE_CONFIG)
+                })
                 put(PLATFORM, ANDROID)
             }
             return JsCallbackData(jsonPayload, featureName, method, id)
@@ -71,8 +75,12 @@ class RealSubscriptionsJSHelper @Inject constructor(
     companion object {
         private const val METHOD_HANDSHAKE = "handshake"
         private const val METHOD_SUBSCRIPTION_DETAILS = "subscriptionDetails"
+        private const val METHOD_GET_AUTH_ACCESS_TOKEN = "getAuthAccessToken"
+        private const val METHOD_GET_FEATURE_CONFIG = "getFeatureConfig"
         private const val AVAILABLE_MESSAGES = "availableMessages"
         private const val SUBSCRIPTION_DETAILS = "subscriptionDetails"
+        private const val GET_AUTH_ACCESS_TOKEN = "getAuthAccessToken"
+        private const val GET_FEATURE_CONFIG = "getFeatureConfig"
         private const val PLATFORM = "platform"
         private const val ANDROID = "android"
         private const val IS_SUBSCRIBED = "isSubscribed"

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionsJSHelper.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionsJSHelper.kt
@@ -20,6 +20,7 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.js.messaging.api.JsCallbackData
 import com.duckduckgo.subscriptions.api.SubscriptionsJSHelper
 import com.duckduckgo.subscriptions.impl.AccessTokenResult
+import com.duckduckgo.subscriptions.impl.PrivacyProFeature
 import com.duckduckgo.subscriptions.impl.SubscriptionsManager
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
@@ -29,6 +30,7 @@ import org.json.JSONObject
 @ContributesBinding(AppScope::class)
 class RealSubscriptionsJSHelper @Inject constructor(
     private val subscriptionsManager: SubscriptionsManager,
+    private val privacyProFeature: PrivacyProFeature,
 ) : SubscriptionsJSHelper {
 
     override suspend fun processJsCallbackMessage(
@@ -55,6 +57,10 @@ class RealSubscriptionsJSHelper @Inject constructor(
 
         METHOD_GET_AUTH_ACCESS_TOKEN -> id?.let {
             getAuthAccessTokenData(featureName, method, it)
+        }
+
+        METHOD_GET_FEATURE_CONFIG -> id?.let {
+            getFeatureConfigData(featureName, method, it)
         }
 
         else -> null
@@ -88,6 +94,14 @@ class RealSubscriptionsJSHelper @Inject constructor(
         return JsCallbackData(jsonPayload, featureName, method, id)
     }
 
+    private suspend fun getFeatureConfigData(featureName: String, method: String, id: String): JsCallbackData {
+        val jsonPayload = JSONObject().apply {
+            put(USE_PAID_DUCK_AI, privacyProFeature.duckAiPlus().isEnabled())
+        }
+
+        return JsCallbackData(jsonPayload, featureName, method, id)
+    }
+
     companion object {
         private const val METHOD_HANDSHAKE = "handshake"
         private const val METHOD_SUBSCRIPTION_DETAILS = "subscriptionDetails"
@@ -106,5 +120,6 @@ class RealSubscriptionsJSHelper @Inject constructor(
         private const val PAYMENT_PLATFORM = "paymentPlatform"
         private const val STATUS = "status"
         private const val ACCESS_TOKEN = "accessToken"
+        private const val USE_PAID_DUCK_AI = "usePaidDuckAi"
     }
 }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/settings/views/ProSettingView.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/settings/views/ProSettingView.kt
@@ -34,6 +34,8 @@ import com.duckduckgo.common.utils.ViewViewModelFactory
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.mobile.android.R as CommonR
 import com.duckduckgo.navigation.api.GlobalActivityStarter
+import com.duckduckgo.subscriptions.api.SubscriptionScreens.RestoreSubscriptionScreenWithParams
+import com.duckduckgo.subscriptions.api.SubscriptionScreens.SubscriptionsSettingsScreenWithEmptyParams
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.AUTO_RENEWABLE
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.EXPIRED
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.GRACE_PERIOD
@@ -50,8 +52,6 @@ import com.duckduckgo.subscriptions.impl.settings.views.ProSettingViewModel.Comm
 import com.duckduckgo.subscriptions.impl.settings.views.ProSettingViewModel.ViewState
 import com.duckduckgo.subscriptions.impl.settings.views.ProSettingViewModel.ViewState.SubscriptionRegion.ROW
 import com.duckduckgo.subscriptions.impl.settings.views.ProSettingViewModel.ViewState.SubscriptionRegion.US
-import com.duckduckgo.subscriptions.impl.ui.RestoreSubscriptionActivity.Companion.RestoreSubscriptionScreenWithParams
-import com.duckduckgo.subscriptions.impl.ui.SubscriptionSettingsActivity.Companion.SubscriptionsSettingsScreenWithEmptyParams
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionsWebViewActivityWithParams
 import dagger.android.support.AndroidSupportInjection
 import javax.inject.Inject

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/RestoreSubscriptionActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/RestoreSubscriptionActivity.kt
@@ -30,12 +30,13 @@ import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.navigation.api.getActivityParams
+import com.duckduckgo.subscriptions.api.SubscriptionScreens.RestoreSubscriptionScreenWithParams
+import com.duckduckgo.subscriptions.api.SubscriptionScreens.SubscriptionsSettingsScreenWithEmptyParams
 import com.duckduckgo.subscriptions.impl.R.string
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.ACTIVATE_URL
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.BUY_URL
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.WELCOME_URL
 import com.duckduckgo.subscriptions.impl.databinding.ActivityRestoreSubscriptionBinding
-import com.duckduckgo.subscriptions.impl.ui.RestoreSubscriptionActivity.Companion.RestoreSubscriptionScreenWithParams
 import com.duckduckgo.subscriptions.impl.ui.RestoreSubscriptionViewModel.Command
 import com.duckduckgo.subscriptions.impl.ui.RestoreSubscriptionViewModel.Command.Error
 import com.duckduckgo.subscriptions.impl.ui.RestoreSubscriptionViewModel.Command.FinishAndGoToOnboarding
@@ -43,7 +44,6 @@ import com.duckduckgo.subscriptions.impl.ui.RestoreSubscriptionViewModel.Command
 import com.duckduckgo.subscriptions.impl.ui.RestoreSubscriptionViewModel.Command.RestoreFromEmail
 import com.duckduckgo.subscriptions.impl.ui.RestoreSubscriptionViewModel.Command.SubscriptionNotFound
 import com.duckduckgo.subscriptions.impl.ui.RestoreSubscriptionViewModel.Command.Success
-import com.duckduckgo.subscriptions.impl.ui.SubscriptionSettingsActivity.Companion.SubscriptionsSettingsScreenWithEmptyParams
 import javax.inject.Inject
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -192,8 +192,5 @@ class RestoreSubscriptionActivity : DuckDuckGoActivity() {
             is FinishAndGoToOnboarding -> finishAndGoToOnboarding()
             is FinishAndGoToSubscriptionSettings -> finishAndGoToSubscriptionSettings()
         }
-    }
-    companion object {
-        data class RestoreSubscriptionScreenWithParams(val isOriginWeb: Boolean = true) : GlobalActivityStarter.ActivityParams
     }
 }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionSettingsActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionSettingsActivity.kt
@@ -39,6 +39,7 @@ import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.subscriptions.api.ActiveOfferType
 import com.duckduckgo.subscriptions.api.PrivacyProFeedbackScreens.PrivacyProFeedbackScreenWithParams
 import com.duckduckgo.subscriptions.api.PrivacyProUnifiedFeedback.PrivacyProFeedbackSource.SUBSCRIPTION_SETTINGS
+import com.duckduckgo.subscriptions.api.SubscriptionScreens.SubscriptionsSettingsScreenWithEmptyParams
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.AUTO_RENEWABLE
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.EXPIRED
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.INACTIVE
@@ -50,7 +51,6 @@ import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.FAQS_URL
 import com.duckduckgo.subscriptions.impl.databinding.ActivitySubscriptionSettingsBinding
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixelSender
 import com.duckduckgo.subscriptions.impl.ui.ChangePlanActivity.Companion.ChangePlanScreenWithEmptyParams
-import com.duckduckgo.subscriptions.impl.ui.SubscriptionSettingsActivity.Companion.SubscriptionsSettingsScreenWithEmptyParams
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionSettingsViewModel.Command
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionSettingsViewModel.Command.FinishSignOut
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionSettingsViewModel.Command.GoToActivationScreen
@@ -334,7 +334,5 @@ class SubscriptionSettingsActivity : DuckDuckGoActivity() {
         const val MANAGE_URL = "https://duckduckgo.com/subscriptions/manage"
         const val LEARN_MORE_URL = "https://duckduckgo.com/duckduckgo-help-pages/privacy-pro/adding-email"
         const val PRIVACY_POLICY_URL = "https://duckduckgo.com/pro/privacy-terms"
-
-        data object SubscriptionsSettingsScreenWithEmptyParams : GlobalActivityStarter.ActivityParams
     }
 }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
@@ -66,6 +66,7 @@ import com.duckduckgo.mobile.android.R
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.navigation.api.GlobalActivityStarter.ActivityParams
 import com.duckduckgo.navigation.api.getActivityParams
+import com.duckduckgo.subscriptions.api.SubscriptionScreens.RestoreSubscriptionScreenWithParams
 import com.duckduckgo.subscriptions.api.SubscriptionScreens.SubscriptionScreenNoParams
 import com.duckduckgo.subscriptions.impl.R.string
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants
@@ -74,7 +75,6 @@ import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.BUY_URL
 import com.duckduckgo.subscriptions.impl.databinding.ActivitySubscriptionsWebviewBinding
 import com.duckduckgo.subscriptions.impl.pir.PirActivity.Companion.PirScreenWithEmptyParams
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixelSender
-import com.duckduckgo.subscriptions.impl.ui.RestoreSubscriptionActivity.Companion.RestoreSubscriptionScreenWithParams
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.BackToSettings
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionWebViewViewModel.Command.BackToSettingsActivateSuccess

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/messaging/RealSubscriptionsJSHelperTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/messaging/RealSubscriptionsJSHelperTest.kt
@@ -60,7 +60,11 @@ class RealSubscriptionsJSHelperTest {
         val result = testee.processJsCallbackMessage(featureName, method, id, null)
 
         val jsonPayload = JSONObject().apply {
-            put("availableMessages", JSONArray().put("subscriptionDetails"))
+            put("availableMessages", JSONArray().apply {
+                put("subscriptionDetails")
+                put("getAuthAccessToken")
+                put("getFeatureConfig")
+            })
             put("platform", "android")
         }
 

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/messaging/RealSubscriptionsJSHelperTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/messaging/RealSubscriptionsJSHelperTest.kt
@@ -1,18 +1,19 @@
 package com.duckduckgo.subscriptions.impl.messaging
 
+import android.annotation.SuppressLint
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.js.messaging.api.JsCallbackData
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.AUTO_RENEWABLE
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.EXPIRED
 import com.duckduckgo.subscriptions.impl.AccessTokenResult
+import com.duckduckgo.subscriptions.impl.PrivacyProFeature
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.MONTHLY
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.YEARLY
 import com.duckduckgo.subscriptions.impl.SubscriptionsManager
 import com.duckduckgo.subscriptions.impl.repository.Subscription
-import com.duckduckgo.subscriptions.impl.PrivacyProFeature
-import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import kotlinx.coroutines.test.runTest
 import org.json.JSONArray
 import org.json.JSONObject
@@ -24,9 +25,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import org.robolectric.RobolectricTestRunner
 
 @RunWith(AndroidJUnit4::class)
+@SuppressLint("DenyListedApi")
 class RealSubscriptionsJSHelperTest {
 
     @get:Rule
@@ -35,7 +36,7 @@ class RealSubscriptionsJSHelperTest {
     private val mockSubscriptionsManager: SubscriptionsManager = mock()
     private val privacyProFeature = FakeFeatureToggleFactory.create(PrivacyProFeature::class.java)
 
-    private val testee = RealSubscriptionsJSHelper(mockSubscriptionsManager, privacyProFeature)
+    private val testee = RealSubscriptionsJSHelper(mockSubscriptionsManager, privacyProFeature, coroutineRule.testDispatcherProvider)
 
     private val featureName = "subscriptions"
 
@@ -71,11 +72,14 @@ class RealSubscriptionsJSHelperTest {
         val result = testee.processJsCallbackMessage(featureName, method, id, null)
 
         val jsonPayload = JSONObject().apply {
-            put("availableMessages", JSONArray().apply {
-                put("subscriptionDetails")
-                put("getAuthAccessToken")
-                put("getFeatureConfig")
-            })
+            put(
+                "availableMessages",
+                JSONArray().apply {
+                    put("subscriptionDetails")
+                    put("getAuthAccessToken")
+                    put("getFeatureConfig")
+                },
+            )
             put("platform", "android")
         }
 

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionsContentScopeJsMessageHandlerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionsContentScopeJsMessageHandlerTest.kt
@@ -40,11 +40,14 @@ class SubscriptionsContentScopeJsMessageHandlerTest {
     @Test
     fun `only contains valid methods`() = runTest {
         val methods = handler.methods
-        assertTrue(methods.size == 4)
+        assertTrue(methods.size == 7)
         assertTrue(methods.contains("handshake"))
         assertTrue(methods.contains("subscriptionDetails"))
         assertTrue(methods.contains("getAuthAccessToken"))
         assertTrue(methods.contains("getFeatureConfig"))
+        assertTrue(methods.contains("backToSettings"))
+        assertTrue(methods.contains("openSubscriptionActivation"))
+        assertTrue(methods.contains("openSubscriptionPurchase"))
     }
 
     private val callback = object : JsMessageCallback() {

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionsContentScopeJsMessageHandlerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/messaging/SubscriptionsContentScopeJsMessageHandlerTest.kt
@@ -40,9 +40,11 @@ class SubscriptionsContentScopeJsMessageHandlerTest {
     @Test
     fun `only contains valid methods`() = runTest {
         val methods = handler.methods
-        assertTrue(methods.size == 2)
-        assertTrue(methods.first() == "handshake")
-        assertTrue(methods.last() == "subscriptionDetails")
+        assertTrue(methods.size == 4)
+        assertTrue(methods.contains("handshake"))
+        assertTrue(methods.contains("subscriptionDetails"))
+        assertTrue(methods.contains("getAuthAccessToken"))
+        assertTrue(methods.contains("getFeatureConfig"))
     }
 
     private val callback = object : JsMessageCallback() {

--- a/subscriptions/subscriptions-internal/build.gradle
+++ b/subscriptions/subscriptions-internal/build.gradle
@@ -32,6 +32,7 @@ android {
 dependencies {
     anvil project(':anvil-compiler')
     implementation project(':anvil-annotations')
+    implementation project(':subscriptions-api')
     implementation project(':subscriptions-impl')
     implementation project(':di')
     implementation project(':common-utils')

--- a/subscriptions/subscriptions-internal/src/main/java/com/duckduckgo/subscriptions/internal/settings/RecoverSubscriptionView.kt
+++ b/subscriptions/subscriptions-internal/src/main/java/com/duckduckgo/subscriptions/internal/settings/RecoverSubscriptionView.kt
@@ -25,7 +25,7 @@ import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
-import com.duckduckgo.subscriptions.impl.ui.RestoreSubscriptionActivity.Companion.RestoreSubscriptionScreenWithParams
+import com.duckduckgo.subscriptions.api.SubscriptionScreens.RestoreSubscriptionScreenWithParams
 import com.duckduckgo.subscriptions.internal.SubsSettingPlugin
 import com.duckduckgo.subscriptions.internal.databinding.SubsSimpleViewBinding
 import com.squareup.anvil.annotations.ContributesMultibinding


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1210461583262416?focus=true 

### Description
Adds integration between duck.ai and subscriptions.
Includes:
- messaging for Feature Flags in FE
- share token
- navigational events

### Steps to test this PR

_Feature 1_
- [x] Apply patch from https://app.asana.com/1/137249556945/project/1149059203486286/task/1210461583262416?focus=true
- [x] Fresh install
- [x] Install branch
- [x] Open Duck.ai, if onboarding shows, skip it
- [x] After onboarding, Duck.ai should be displayed as Free (Background logo just says "Duck.ai Free", models selector only display free models and no upsells)
- [ ] ~Go to models selector, you should see the advance models~
- [ ] ~If you select one, the upsell appears "Unlock with a DuckDuckGo...."~
- [ ] ~Clicking on the upsell takes you to subscription flow~
- [ ] ~Ensure it does, and go back to chat~
- [ ] ~Click on Duck.ai settings (top right)~
- [ ] ~The options "Subscribe to DuckDuckGo" and "I have a subscription" appear~
- [ ] ~Click on "I have a Subscription"~
- [ ] ~Ensure it navigate to activation flow~
- [ ] ~Go back to Duck.ai~
- [x] go to settings, and purchase a subscription (or go there using any upsell link)
(after subscription restart the app, this is to avoid Duck.ai chat being restored, something we need to fix in https://app.asana.com/1/137249556945/project/1149059203486286/task/1210671370392466?focus=true)
- [x] Open Duck.ai again (from any entry point)
- [x] An Duck.ai paid onboarding appears (depending if this is your first visit as subscriber)
- [x] Duck.ai is in subscriber mode (background logo has changed "Subscriber" and model selector includes advanced models)
- [x] Inside Duck.ai settings now it shows "manage", and if you click there you can navigate to subscription settings


### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
