### PR TITLE
Fix ANR/Crash on autoconsent init handler

### DIFF
--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/handlers/ReplyHandler.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/handlers/ReplyHandler.kt
@@ -16,45 +16,12 @@
 
 package com.duckduckgo.autoconsent.impl.handlers
 
-import java.io.BufferedReader
-import java.io.StringReader
-import kotlin.sequences.forEach
-
 object ReplyHandler {
     fun constructReply(message: String): String {
         return """
             (function() {
                 window.autoconsentMessageCallback($message, window.origin);
             })();
-        """.trimIndentEfficient()
-    }
-
-    private fun String.trimIndentEfficient(): String {
-        val reader1 = BufferedReader(StringReader(this))
-        var minIndent = Int.MAX_VALUE
-        reader1.useLines { lines ->
-            lines.forEach { line ->
-                if (line.isNotBlank()) {
-                    val indent = line.takeWhile(Char::isWhitespace).length
-                    if (indent < minIndent) minIndent = indent
-                }
-            }
-        }
-        if (minIndent == Int.MAX_VALUE) minIndent = 0
-
-        val sb = StringBuilder(this.length)
-        val reader2 = BufferedReader(StringReader(this))
-        reader2.useLines { lines ->
-            lines.forEach { line ->
-                if (line.length >= minIndent) {
-                    sb.append(line, minIndent, line.length)
-                } else {
-                    sb.append(line)
-                }
-                sb.append('\n')
-            }
-        }
-
-        return sb.toString()
+        """
     }
 }

--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/handlers/ReplyHandler.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/handlers/ReplyHandler.kt
@@ -18,10 +18,6 @@ package com.duckduckgo.autoconsent.impl.handlers
 
 object ReplyHandler {
     fun constructReply(message: String): String {
-        return """
-            (function() {
-                window.autoconsentMessageCallback($message, window.origin);
-            })();
-        """
+        return "(function() {window.autoconsentMessageCallback($message, window.origin);})();"
     }
 }

--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/handlers/ReplyHandler.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/handlers/ReplyHandler.kt
@@ -16,12 +16,45 @@
 
 package com.duckduckgo.autoconsent.impl.handlers
 
+import java.io.BufferedReader
+import java.io.StringReader
+import kotlin.sequences.forEach
+
 object ReplyHandler {
     fun constructReply(message: String): String {
         return """
             (function() {
                 window.autoconsentMessageCallback($message, window.origin);
             })();
-        """.trimIndent()
+        """.trimIndentEfficient()
+    }
+
+    private fun String.trimIndentEfficient(): String {
+        val reader1 = BufferedReader(StringReader(this))
+        var minIndent = Int.MAX_VALUE
+        reader1.useLines { lines ->
+            lines.forEach { line ->
+                if (line.isNotBlank()) {
+                    val indent = line.takeWhile(Char::isWhitespace).length
+                    if (indent < minIndent) minIndent = indent
+                }
+            }
+        }
+        if (minIndent == Int.MAX_VALUE) minIndent = 0
+
+        val sb = StringBuilder(this.length)
+        val reader2 = BufferedReader(StringReader(this))
+        reader2.useLines { lines ->
+            lines.forEach { line ->
+                if (line.length >= minIndent) {
+                    sb.append(line, minIndent, line.length)
+                } else {
+                    sb.append(line)
+                }
+                sb.append('\n')
+            }
+        }
+
+        return sb.toString()
     }
 }

--- a/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/RealAutoconsentTest.kt
+++ b/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/RealAutoconsentTest.kt
@@ -117,11 +117,7 @@ class RealAutoconsentTest {
 
     @Test
     fun whenSetAutoconsentOptOutThenEvaluateJavascriptCalled() {
-        val expected = """
-        javascript:(function() {
-            window.autoconsentMessageCallback({ "type": "optOut" }, window.origin);
-        })();
-        """.trimIndent()
+        val expected = """javascript:(function() {window.autoconsentMessageCallback({ "type": "optOut" }, window.origin);})();"""
 
         autoconsent.setAutoconsentOptOut(webView)
         assertEquals(expected, shadowOf(webView).lastEvaluatedJavascript)

--- a/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/handlers/EvalMessageHandlerPluginTest.kt
+++ b/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/handlers/EvalMessageHandlerPluginTest.kt
@@ -118,8 +118,8 @@ class EvalMessageHandlerPluginTest {
 
     private fun jsonToEvalResp(json: String): EvalResp? {
         val trimmedJson = json
-            .removePrefix("javascript:(function() {\n    window.autoconsentMessageCallback(")
-            .removeSuffix(", window.origin);\n})();")
+            .removePrefix("javascript:(function() {window.autoconsentMessageCallback(")
+            .removeSuffix(", window.origin);})();")
         val moshi = Moshi.Builder().add(JSONObjectAdapter()).build()
         val jsonAdapter: JsonAdapter<EvalResp> = moshi.adapter(EvalResp::class.java)
         return jsonAdapter.fromJson(trimmedJson)

--- a/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/handlers/InitMessageHandlerPluginTest.kt
+++ b/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/handlers/InitMessageHandlerPluginTest.kt
@@ -242,8 +242,8 @@ class InitMessageHandlerPluginTest {
 
     private fun jsonToInitResp(json: String): InitResp? {
         val trimmedJson = json
-            .removePrefix("javascript:(function() {\n    window.autoconsentMessageCallback(")
-            .removeSuffix(", window.origin);\n})();")
+            .removePrefix("javascript:(function() {window.autoconsentMessageCallback(")
+            .removeSuffix(", window.origin);})();")
         val moshi = Moshi.Builder().add(JSONObjectAdapter()).build()
         val jsonAdapter: JsonAdapter<InitResp> = moshi.adapter(InitResp::class.java)
         return jsonAdapter.fromJson(trimmedJson)

--- a/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/handlers/OptOutAndAutoconsentDoneMessageHandlerPluginTest.kt
+++ b/autoconsent/autoconsent-impl/src/test/java/com/duckduckgo/autoconsent/impl/handlers/OptOutAndAutoconsentDoneMessageHandlerPluginTest.kt
@@ -92,11 +92,7 @@ class OptOutAndAutoconsentDoneMessageHandlerPluginTest {
 
     @Test
     fun whenProcessOptOutWithSelfTestThenAutoconsentCallsEvaluateJavascript() {
-        val expected = """
-        javascript:(function() {
-            window.autoconsentMessageCallback({ "type": "selfTest" }, window.origin);
-        })();
-        """.trimIndent()
+        val expected = """javascript:(function() {window.autoconsentMessageCallback({ "type": "selfTest" }, window.origin);})();"""
 
         handler.process(getOptOut(), optOutMessage(result = true, selfTest = true), webView, mockCallback)
         handler.process(getAutoconsentType(), autoconsentDoneMessage(), webView, mockCallback)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1210704553451145?focus=true 

### Description
This PR tries to fix and ANR and crash in the autoconsent init handler. It does remove the call to trimIndent() which is not very performant for long strings (and doesn't seem to be needed) and it moves all the logic to IO leaving only the webview call to evaluate JS in main.

### Steps to test this PR

- [ ] Test autoconsent

