### PR TITLE
Optimize bookmarks filtering and sorting

### DIFF
--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/DevSettingsActivity.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/DevSettingsActivity.kt
@@ -39,7 +39,6 @@ import com.duckduckgo.app.dev.settings.DevSettingsViewModel.Command.CustomTabs
 import com.duckduckgo.app.dev.settings.DevSettingsViewModel.Command.Notifications
 import com.duckduckgo.app.dev.settings.DevSettingsViewModel.Command.OpenUASelector
 import com.duckduckgo.app.dev.settings.DevSettingsViewModel.Command.SendTdsIntent
-import com.duckduckgo.app.dev.settings.DevSettingsViewModel.Command.ShowSavedSitesClearedConfirmation
 import com.duckduckgo.app.dev.settings.DevSettingsViewModel.Command.Tabs
 import com.duckduckgo.app.dev.settings.customtabs.CustomTabsInternalSettingsActivity
 import com.duckduckgo.app.dev.settings.db.UAOverride
@@ -101,9 +100,6 @@ class DevSettingsActivity : DuckDuckGoActivity() {
                 Thread.sleep(10000)
             }
         }
-        binding.clearSavedSites.setOnClickListener {
-            viewModel.clearSavedSites()
-        }
         binding.overrideUserAgentSelector.setOnClickListener { viewModel.onUserAgentSelectorClicked() }
         binding.overridePrivacyRemoteConfigUrl.setOnClickListener { viewModel.onRemotePrivacyUrlClicked() }
         binding.customTabs.setOnClickListener { viewModel.customTabsClicked() }
@@ -135,7 +131,6 @@ class DevSettingsActivity : DuckDuckGoActivity() {
         when (it) {
             is SendTdsIntent -> sendTdsIntent()
             is OpenUASelector -> showUASelector()
-            is ShowSavedSitesClearedConfirmation -> showSavedSitesClearedConfirmation()
             is ChangePrivacyConfigUrl -> showChangePrivacyUrl()
             is CustomTabs -> showCustomTabs()
             Notifications -> showNotifications()
@@ -165,10 +160,6 @@ class DevSettingsActivity : DuckDuckGoActivity() {
             onMenuItemClicked(view.findViewById(R.id.webView)) { viewModel.onUserAgentSelected(UAOverride.WEBVIEW) }
         }
         popup.show(binding.root, binding.overrideUserAgentSelector)
-    }
-
-    private fun showSavedSitesClearedConfirmation() {
-        Toast.makeText(this, getString(R.string.devSettingsClearSavedSitesConfirmation), Toast.LENGTH_SHORT).show()
     }
 
     private fun showChangePrivacyUrl() {

--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/DevSettingsViewModel.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/DevSettingsViewModel.kt
@@ -25,7 +25,6 @@ import com.duckduckgo.app.survey.api.SurveyEndpointDataStore
 import com.duckduckgo.app.tabs.store.TabSwitcherPrefsDataStore
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
-import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.traces.api.StartupTraces
 import com.duckduckgo.user.agent.api.UserAgentProvider
 import javax.inject.Inject

--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/DevSettingsViewModel.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/DevSettingsViewModel.kt
@@ -44,7 +44,6 @@ class DevSettingsViewModel @Inject constructor(
     private val devSettingsDataStore: DevSettingsDataStore,
     private val startupTraces: StartupTraces,
     private val userAgentProvider: UserAgentProvider,
-    private val savedSitesRepository: SavedSitesRepository,
     private val dispatcherProvider: DispatcherProvider,
     private val surveyEndpointDataStore: SurveyEndpointDataStore,
     private val tabSwitcherPrefsDataStore: TabSwitcherPrefsDataStore,
@@ -60,7 +59,6 @@ class DevSettingsViewModel @Inject constructor(
     sealed class Command {
         object SendTdsIntent : Command()
         object OpenUASelector : Command()
-        object ShowSavedSitesClearedConfirmation : Command()
         object ChangePrivacyConfigUrl : Command()
         object CustomTabs : Command()
         data object Notifications : Command()
@@ -134,13 +132,6 @@ class DevSettingsViewModel @Inject constructor(
         devSettingsDataStore.selectedUA = userAgent
         viewModelScope.launch {
             viewState.emit(currentViewState().copy(userAgent = userAgentProvider.userAgent("", false)))
-        }
-    }
-
-    fun clearSavedSites() {
-        viewModelScope.launch(dispatcherProvider.io()) {
-            savedSitesRepository.deleteAll()
-            command.send(Command.ShowSavedSitesClearedConfirmation)
         }
     }
 

--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/tabs/DevTabsActivity.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/tabs/DevTabsActivity.kt
@@ -59,7 +59,7 @@ class DevTabsActivity : DuckDuckGoActivity() {
         }
 
         binding.addBookmarksButton.setOnClickListener {
-            viewModel.addBookmarks(binding.tabCount.text.toInt())
+            viewModel.addBookmarks(binding.bookmarksCount.text.toInt())
         }
 
         binding.clearBookmarksButton.setOnClickListener {

--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/tabs/DevTabsActivity.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/tabs/DevTabsActivity.kt
@@ -51,11 +51,19 @@ class DevTabsActivity : DuckDuckGoActivity() {
         setupToolbar(binding.includeToolbar.toolbar)
 
         binding.addTabsButton.setOnClickListener {
-            viewModel.addTabs(binding.tabCount.text.toString().toInt())
+            viewModel.addTabs(binding.tabCount.text.toInt())
         }
 
         binding.clearTabsButton.setOnClickListener {
             viewModel.clearTabs()
+        }
+
+        binding.addBookmarksButton.setOnClickListener {
+            viewModel.addBookmarks(binding.tabCount.text.toInt())
+        }
+
+        binding.clearBookmarksButton.setOnClickListener {
+            viewModel.clearBookmarks()
         }
 
         observeViewState()
@@ -68,6 +76,7 @@ class DevTabsActivity : DuckDuckGoActivity() {
 
     private fun render(viewState: ViewState) {
         binding.tabCountHeader.text = getString(R.string.devSettingsTabsScreenHeader, viewState.tabCount)
+        binding.bookmarksCountHeader.text = getString(R.string.devSettingsTabsBookmarksScreenHeader, viewState.bookmarkCount)
     }
 
     companion object {

--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/tabs/DevTabsViewModel.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/tabs/DevTabsViewModel.kt
@@ -109,7 +109,7 @@ class DevTabsViewModel @Inject constructor(
                 val randomIndex = randomUrls.indices.random()
                 savedSitesRepository.insertBookmark(
                     title = "",
-                    url = randomUrls[randomIndex]
+                    url = randomUrls[randomIndex],
                 )
             }
         }

--- a/app/src/internal/res/layout/activity_dev_settings.xml
+++ b/app/src/internal/res/layout/activity_dev_settings.xml
@@ -74,13 +74,6 @@
                 app:secondaryText="@string/devSettingsTriggerAnrSubtitle" />
 
             <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
-                android:id="@+id/clearSavedSites"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:primaryText="@string/devSettingsClearSavedSites"
-                app:secondaryText="@string/devSettingsClearSavedSitesSubtitle" />
-
-            <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
                 android:id="@+id/customTabs"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/app/src/internal/res/layout/activity_dev_tabs.xml
+++ b/app/src/internal/res/layout/activity_dev_tabs.xml
@@ -100,5 +100,78 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="8dp" />
+
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+            android:id="@+id/bookmarksCountHeader"
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:gravity="center"
+            android:text="@string/devSettingsTabsBookmarksScreenHeader"
+            app:typography="caption_allCaps" />
+
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="8dp" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <com.duckduckgo.common.ui.view.listitem.OneLineListItem
+                android:id="@+id/generateBookmarksItem"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                app:layout_constraintEnd_toStartOf="@id/bookmarksCount"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:primaryText="@string/devSettingsTabsScreenBookmarksToAdd" />
+
+            <com.duckduckgo.common.ui.view.text.DaxTextInput
+                android:id="@+id/bookmarksCount"
+                style="@style/Widget.DuckDuckGo.TextInput"
+                android:layout_width="72dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/keyline_4"
+                android:gravity="center"
+                android:inputType="number"
+                android:text="25"
+                app:layout_constraintBottom_toBottomOf="@id/generateBookmarksItem"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/generateBookmarksItem"
+                app:layout_constraintTop_toTopOf="@id/generateBookmarksItem"
+                app:type="single_line"
+                tools:ignore="HardcodedText" />
+
+            <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+                android:id="@+id/addBookmarksButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/keyline_4"
+                android:text="@string/devSettingsTabsScreenAddBookmarksButtonText"
+                app:daxButtonSize="large" />
+
+            <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+                android:id="@+id/clearBookmarksButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/keyline_4"
+                android:text="@string/devSettingsTabsScreenClearBookmarksButtonText"
+                app:daxButtonSize="large" />
+
+            <androidx.constraintlayout.helper.widget.Flow
+                android:id="@+id/bookmarksFlowView"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_marginTop="@dimen/keyline_4"
+                app:constraint_referenced_ids="addBookmarksButton,clearBookmarksButton"
+                app:flow_horizontalStyle="spread"
+                app:flow_wrapMode="chain"
+                app:layout_constraintTop_toBottomOf="@id/generateBookmarksItem" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
     </LinearLayout>
 </LinearLayout>

--- a/app/src/internal/res/values/donottranslate.xml
+++ b/app/src/internal/res/values/donottranslate.xml
@@ -49,13 +49,17 @@
     <string name="devSettingsShowTabSwitcherAnimatedTile">Reset TabSwitcher Animated Tile</string>
     <string name="devSettingsShowTabSwitcherAnimatedSubtitle">Click here to reset the animated tile if you have previously dismissed it</string>
 
-    <!-- Tabs -->
-    <string name="devSettingsScreenTabs">Tabs</string>
-    <string name="devSettingsScreenTabsSubtitle">Create tabs for testing</string>
+    <!-- Tabs and Saved Sites -->
+    <string name="devSettingsScreenTabs">Tabs and Saved Sites</string>
+    <string name="devSettingsScreenTabsSubtitle">Create tabs or bookmarks for testing</string>
     <string name="devSettingsTabsScreenHeader" instruction="Not translated">Current tab count: %1$d</string>
     <string name="devSettingsTabsScreenTabsToAdd">Tabs to add</string>
     <string name="devSettingsTabsScreenAddTabsButtonText">Add Tabs</string>
     <string name="devSettingsTabsScreenClearTabsButtonText">Clear Tabs</string>
+    <string name="devSettingsTabsBookmarksScreenHeader" instruction="Not translated">Current bookmarks count: %1$d</string>
+    <string name="devSettingsTabsScreenBookmarksToAdd">Bookmarks to add</string>
+    <string name="devSettingsTabsScreenAddBookmarksButtonText">Add Bookmarks</string>
+    <string name="devSettingsTabsScreenClearBookmarksButtonText">Clear Bookmarks</string>
 
     <!-- Privacy Audit settings -->
     <string name="auditSettingsTitle">Audit Settings</string>

--- a/app/src/internal/res/values/donottranslate.xml
+++ b/app/src/internal/res/values/donottranslate.xml
@@ -27,9 +27,6 @@
     <string name="devStartupTracingByline">Enable/disable start-up tracing</string>
     <string name="devSettingsTriggerAnr">Trigger ANR</string>
     <string name="devSettingsTriggerAnrSubtitle">Click here to trigger an ANR in the app</string>
-    <string name="devSettingsClearSavedSites">Clear saved sites</string>
-    <string name="devSettingsClearSavedSitesSubtitle">Click here to clear all bookmarks, folders and favorites</string>
-    <string name="devSettingsClearSavedSitesConfirmation">Saved sites cleared</string>
     <string name="devSettingsUseSandBoxSurvey">Use Sandbox Survey</string>
     <string name="devEnableWebContentDebuggingTitle">Web Content Debugging</string>
     <string name="devEnableWebContentDebuggingByline">Enable WebView debugging in Chrome DevTools</string>

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksActivity.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksActivity.kt
@@ -92,13 +92,13 @@ import com.duckduckgo.savedsites.impl.store.SortingMode.NAME
 import com.duckduckgo.sync.api.SyncActivityWithEmptyParams
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import java.util.TimeZone
 import javax.inject.Inject
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 
 @InjectWith(ActivityScope::class)

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksActivity.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksActivity.kt
@@ -397,7 +397,7 @@ class BookmarksActivity : DuckDuckGoActivity(), BookmarksScreenPromotionPlugin.C
     }
 
     private fun observeItemsToDisplay() {
-        viewModel.sortedItems.onEach { items ->
+        viewModel.itemsToDisplay.onEach { items ->
             bookmarksAdapter.setItems(
                 items,
                 showEmptyHint = items.isEmpty() && getParentFolderId() == SavedSitesNames.BOOKMARKS_ROOT,

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksActivity.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksActivity.kt
@@ -366,8 +366,9 @@ class BookmarksActivity : DuckDuckGoActivity(), BookmarksScreenPromotionPlugin.C
 
                 bookmarksAdapter.setItems(
                     items,
-                    items.isEmpty() && getParentFolderId() == SavedSitesNames.BOOKMARKS_ROOT,
-                    false,
+                    showEmptyHint = items.isEmpty() && getParentFolderId() == SavedSitesNames.BOOKMARKS_ROOT,
+                    showEmptySearchHint = false,
+                    detectMoves = true,
                 )
                 binding.searchMenu.isVisible =
                     viewModel.viewState.value?.enableSearch == true || getParentFolderId() != SavedSitesNames.BOOKMARKS_ROOT

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksActivity.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksActivity.kt
@@ -323,7 +323,8 @@ class BookmarksActivity : DuckDuckGoActivity(), BookmarksScreenPromotionPlugin.C
     private fun setupBookmarksRecycler() {
         bookmarksAdapter = BookmarksAdapter(
             viewModel,
-            this,
+            lifecycleOwner = this,
+            dispatcherProvider = dispatchers,
             faviconManager,
             onBookmarkClick = { bookmark ->
                 viewModel.onSelected(bookmark)
@@ -491,7 +492,7 @@ class BookmarksActivity : DuckDuckGoActivity(), BookmarksScreenPromotionPlugin.C
     }
 
     private fun initializeSearchBar() {
-        searchListener = BookmarksQueryListener(viewModel, bookmarksAdapter)
+        searchListener = BookmarksQueryListener(viewModel, bookmarksAdapter, dispatchers)
         if (bookmarksSortingFeature.self().isEnabled()) {
             binding.searchMenu.setOnClickListener {
                 showSearchBar()

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksAdapter.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksAdapter.kt
@@ -66,15 +66,16 @@ class BookmarksAdapter(
     data class BookmarkFolderItem(val bookmarkFolder: BookmarkFolder) : BookmarksItemTypes
 
     fun setItems(
-        bookmarkItems: List<BookmarksItemTypes>,
+        newBookmarkItems: List<BookmarksItemTypes>,
         showEmptyHint: Boolean,
         showEmptySearchHint: Boolean,
+        detectMoves: Boolean,
     ) {
-        val generatedList = generateNewList(bookmarkItems, showEmptyHint, showEmptySearchHint)
-        val diffCallback = DiffCallback(old = this.bookmarkItems, new = generatedList)
-        val diffResult = DiffUtil.calculateDiff(diffCallback)
-        this.bookmarkItems.clear().also { this.bookmarkItems.addAll(generatedList) }
-        diffResult.dispatchUpdatesTo(this)
+        val generatedList = generateNewList(newBookmarkItems, showEmptyHint, showEmptySearchHint)
+        val diffCallback = DiffCallback(old = bookmarkItems, new = generatedList)
+        val diffResult = DiffUtil.calculateDiff(diffCallback, detectMoves)
+        bookmarkItems.clear().also { bookmarkItems.addAll(generatedList) }
+        diffResult.dispatchUpdatesTo(this@BookmarksAdapter)
     }
 
     private fun generateNewList(

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksAdapter.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksAdapter.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.savedsites.impl.bookmarks
 
+import android.annotation.SuppressLint
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -73,6 +74,7 @@ class BookmarksAdapter(
     data class BookmarkItem(val bookmark: SavedSite.Bookmark) : BookmarksItemTypes
     data class BookmarkFolderItem(val bookmarkFolder: BookmarkFolder) : BookmarksItemTypes
 
+    @SuppressLint("AvoidComputationUsage")
     fun setItems(
         newBookmarkItems: List<BookmarksItemTypes>,
         showEmptyHint: Boolean,

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksAdapter.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksAdapter.kt
@@ -37,9 +37,9 @@ import com.duckduckgo.savedsites.impl.bookmarks.BookmarkScreenViewHolders.Bookma
 import com.duckduckgo.savedsites.impl.bookmarks.BookmarkScreenViewHolders.BookmarksViewHolder
 import com.duckduckgo.savedsites.impl.bookmarks.BookmarkScreenViewHolders.EmptyHint
 import com.duckduckgo.savedsites.impl.bookmarks.BookmarkScreenViewHolders.EmptySearchHint
+import java.util.Collections
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.util.Collections
 
 class BookmarksAdapter(
     private val viewModel: BookmarksViewModel,

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksQueryListener.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksQueryListener.kt
@@ -46,6 +46,8 @@ class BookmarksQueryListener(
                     filteredBookmarks,
                     showEmptyHint = false,
                     showEmptySearchHint = true,
+                    // when filtering, we don't need to account for moves because the relative order of items doesn't change,
+                    // this allows to optimization calculations
                     detectMoves = false,
                 )
             }

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksQueryListener.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksQueryListener.kt
@@ -26,7 +26,6 @@ import com.duckduckgo.savedsites.impl.bookmarks.BookmarksAdapter.BookmarksItemTy
 import java.util.*
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import logcat.logcat
 
 class BookmarksQueryListener(
     private val viewModel: BookmarksViewModel,
@@ -41,7 +40,7 @@ class BookmarksQueryListener(
             delay(DEBOUNCE_PERIOD)
             viewModel.onSearchQueryUpdated(newText)
             val favorites = viewModel.viewState.value?.favorites
-            viewModel.sortedItems.value.let { bookmarks ->
+            viewModel.itemsToDisplay.value.let { bookmarks ->
                 val filteredBookmarks = filterBookmarks(newText, bookmarks, favorites)
                 bookmarksAdapter.setItems(
                     filteredBookmarks,

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksQueryListener.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksQueryListener.kt
@@ -40,7 +40,12 @@ class BookmarksQueryListener(
             val favorites = viewModel.viewState.value?.favorites
             viewModel.viewState.value?.sortedItems?.let { bookmarks ->
                 val filteredBookmarks = filterBookmarks(newText, bookmarks, favorites)
-                bookmarksAdapter.setItems(filteredBookmarks, false, true)
+                bookmarksAdapter.setItems(
+                    filteredBookmarks,
+                    showEmptyHint = false,
+                    showEmptySearchHint = true,
+                    detectMoves = false,
+                )
             }
         }
     }

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksQueryListener.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksQueryListener.kt
@@ -41,7 +41,7 @@ class BookmarksQueryListener(
             delay(DEBOUNCE_PERIOD)
             viewModel.onSearchQueryUpdated(newText)
             val favorites = viewModel.viewState.value?.favorites
-            viewModel.viewState.value?.sortedItems?.let { bookmarks ->
+            viewModel.sortedItems.value.let { bookmarks ->
                 val filteredBookmarks = filterBookmarks(newText, bookmarks, favorites)
                 bookmarksAdapter.setItems(
                     filteredBookmarks,

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksQueryListener.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksQueryListener.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.savedsites.impl.bookmarks
 
+import android.annotation.SuppressLint
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.DispatcherProvider
@@ -35,6 +36,7 @@ class BookmarksQueryListener(
 
     private var searchJob = ConflatedJob()
 
+    @SuppressLint("AvoidComputationUsage")
     fun onQueryTextChange(newText: String) {
         searchJob += viewModel.viewModelScope.launch(dispatcherProvider.computation()) {
             delay(DEBOUNCE_PERIOD)
@@ -47,7 +49,7 @@ class BookmarksQueryListener(
                     showEmptyHint = false,
                     showEmptySearchHint = true,
                     // when filtering, we don't need to account for moves because the relative order of items doesn't change,
-                    // this allows to optimization calculations
+                    // this allows to optimize recycler diff calculations
                     detectMoves = false,
                 )
             }

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksQueryListener.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksQueryListener.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.savedsites.impl.bookmarks
 
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.common.utils.ConflatedJob
+import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.savedsites.api.models.SavedSite.Favorite
 import com.duckduckgo.savedsites.impl.bookmarks.BookmarksAdapter.BookmarkFolderItem
 import com.duckduckgo.savedsites.impl.bookmarks.BookmarksAdapter.BookmarkItem
@@ -25,16 +26,18 @@ import com.duckduckgo.savedsites.impl.bookmarks.BookmarksAdapter.BookmarksItemTy
 import java.util.*
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import logcat.logcat
 
 class BookmarksQueryListener(
     private val viewModel: BookmarksViewModel,
     private val bookmarksAdapter: BookmarksAdapter,
+    private val dispatcherProvider: DispatcherProvider,
 ) {
 
     private var searchJob = ConflatedJob()
 
     fun onQueryTextChange(newText: String) {
-        searchJob += viewModel.viewModelScope.launch {
+        searchJob += viewModel.viewModelScope.launch(dispatcherProvider.computation()) {
             delay(DEBOUNCE_PERIOD)
             viewModel.onSearchQueryUpdated(newText)
             val favorites = viewModel.viewState.value?.favorites

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksViewModel.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksViewModel.kt
@@ -128,8 +128,8 @@ class BookmarksViewModel @Inject constructor(
 
     data class HiddenBookmarksIds(val items: List<String> = emptyList())
 
-    private val _sortedItems = MutableStateFlow<List<BookmarksItemTypes>>(emptyList())
-    val sortedItems = _sortedItems.asStateFlow()
+    private val _itemsToDisplay = MutableStateFlow<List<BookmarksItemTypes>>(emptyList())
+    val itemsToDisplay = _itemsToDisplay.asStateFlow()
 
     init {
         viewState.value = ViewState()
@@ -366,7 +366,7 @@ class BookmarksViewModel @Inject constructor(
         }
 
         val sortingMode = bookmarksDataStore.getSortingMode()
-        _sortedItems.value = sortElements(bookmarkItems, sortingMode)
+        _itemsToDisplay.value = sortElements(bookmarkItems, sortingMode)
         withContext(dispatcherProvider.main()) {
             viewState.value = viewState.value?.copy(
                 favorites = favorites,
@@ -501,7 +501,7 @@ class BookmarksViewModel @Inject constructor(
             bookmarksDataStore.setSortingMode(mode)
             val bookmarkItems = viewState.value?.bookmarkItems
             val sortedBookmarks = sortElements(bookmarkItems ?: emptyList(), mode)
-            _sortedItems.value = sortedBookmarks
+            _itemsToDisplay.value = sortedBookmarks
             withContext(dispatcherProvider.main()) {
                 viewState.value = viewState.value?.copy(
                     sortingMode = bookmarksDataStore.getSortingMode(),

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksViewModel.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksViewModel.kt
@@ -379,7 +379,7 @@ class BookmarksViewModel @Inject constructor(
         showSyncPromotionIfEligible()
     }
 
-    fun sortElements(
+    private fun sortElements(
         bookmarkItems: List<BookmarksItemTypes>,
         sortingMode: SortingMode,
     ): List<BookmarksItemTypes> {

--- a/saved-sites/saved-sites-impl/src/test/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksViewModelTest.kt
+++ b/saved-sites/saved-sites-impl/src/test/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksViewModelTest.kt
@@ -34,7 +34,6 @@ import com.duckduckgo.savedsites.api.models.SavedSitesNames.BOOKMARKS_ROOT
 import com.duckduckgo.savedsites.api.service.SavedSitesManager
 import com.duckduckgo.savedsites.impl.SavedSitesPixelName
 import com.duckduckgo.savedsites.impl.bookmarks.BookmarksAdapter.BookmarkItem
-import com.duckduckgo.savedsites.impl.bookmarks.BookmarksAdapter.BookmarksItemTypes
 import com.duckduckgo.savedsites.impl.store.BookmarksDataStore
 import com.duckduckgo.savedsites.impl.store.SortingMode.MANUAL
 import com.duckduckgo.savedsites.impl.store.SortingMode.NAME

--- a/saved-sites/saved-sites-impl/src/test/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksViewModelTest.kt
+++ b/saved-sites/saved-sites-impl/src/test/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksViewModelTest.kt
@@ -40,6 +40,7 @@ import com.duckduckgo.savedsites.impl.store.SortingMode.MANUAL
 import com.duckduckgo.savedsites.impl.store.SortingMode.NAME
 import com.duckduckgo.sync.api.engine.SyncEngine
 import com.duckduckgo.sync.api.favicons.FaviconsFetchingPrompt
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -91,6 +92,14 @@ class BookmarksViewModelTest {
     private val bookmarkFolder = BookmarkFolder(id = "folder1", name = "folder", parentId = SavedSitesNames.BOOKMARKS_ROOT, 0, 0, "timestamp")
     private val bookmarkFolderItem = BookmarkFolderItem(0, bookmarkFolder, true)
 
+    private val favoritesFlow = MutableStateFlow(listOf(favorite))
+    private val savedSitesFlow = MutableStateFlow(
+        SavedSites(
+            listOf(favorite),
+            listOf(bookmark, bookmarkFolder, bookmarkFolder, bookmarkFolder),
+        ),
+    )
+
     private val testee: BookmarksViewModel by lazy {
         val model = BookmarksViewModel(
             savedSitesRepository,
@@ -110,16 +119,9 @@ class BookmarksViewModelTest {
 
     @Before
     fun before() = runTest {
-        whenever(savedSitesRepository.getFavorites()).thenReturn(flowOf(listOf(favorite)))
+        whenever(savedSitesRepository.getFavorites()).thenReturn(favoritesFlow)
 
-        whenever(savedSitesRepository.getSavedSites(anyString())).thenReturn(
-            flowOf(
-                SavedSites(
-                    listOf(favorite),
-                    listOf(bookmark, bookmarkFolder, bookmarkFolder, bookmarkFolder),
-                ),
-            ),
-        )
+        whenever(savedSitesRepository.getSavedSites(anyString())).thenReturn(savedSitesFlow)
 
         whenever(bookmarksDataStore.getSortingMode()).thenReturn(NAME)
         testee.fetchBookmarksAndFolders(SavedSitesNames.BOOKMARKS_ROOT)
@@ -476,8 +478,7 @@ class BookmarksViewModelTest {
     }
 
     @Test
-    fun whenSortingByNameSelectedThenListIsSorted() {
-        val items = mutableListOf<BookmarksItemTypes>()
+    fun whenSortingByNameSelectedThenListIsSorted() = runTest {
         val folderNews = BookmarkFolder(id = "folderA", name = "News", parentId = SavedSitesNames.BOOKMARKS_ROOT, 0, 0, "timestamp")
         val folderSports = BookmarkFolder(id = "folderB", name = "Sports", parentId = SavedSitesNames.BOOKMARKS_ROOT, 0, 0, "timestamp")
         val bookmarkAs = Bookmark(id = "bookmarkA", title = "As", url = "www.example.com", parentId = SavedSitesNames.BOOKMARKS_ROOT, "timestamp")
@@ -497,20 +498,59 @@ class BookmarksViewModelTest {
             "timestamp",
         )
 
-        items.add(BookmarkItem(bookmarkAs))
-        items.add(BookmarkItem(bookmarkReddit))
-        items.add(BookmarkItem(bookmarkCnn))
-        items.add(BookmarkItem(bookmarkTheGuardian))
-        items.add(BookmarksAdapter.BookmarkFolderItem(folderSports))
-        items.add(BookmarksAdapter.BookmarkFolderItem(folderNews))
+        savedSitesFlow.value = SavedSites(
+            emptyList(),
+            listOf(bookmarkAs, bookmarkReddit, bookmarkCnn, bookmarkTheGuardian, folderSports, folderNews),
+        )
+        testee.fetchBookmarksAndFolders(BOOKMARKS_ROOT)
 
-        val sortedElements = testee.sortElements(items, NAME)
+        testee.onSortingModeSelected(NAME)
+
+        val sortedElements = testee.itemsToDisplay.value
         assertEquals((sortedElements[0] as BookmarkItem).bookmark, bookmarkAs)
         assertEquals((sortedElements[1] as BookmarkItem).bookmark, bookmarkCnn)
         assertEquals((sortedElements[2] as BookmarksAdapter.BookmarkFolderItem).bookmarkFolder, folderNews)
         assertEquals((sortedElements[3] as BookmarkItem).bookmark, bookmarkReddit)
         assertEquals((sortedElements[4] as BookmarksAdapter.BookmarkFolderItem).bookmarkFolder, folderSports)
         assertEquals((sortedElements[5] as BookmarkItem).bookmark, bookmarkTheGuardian)
+    }
+
+    @Test
+    fun whenSortingManualSelectedThenListIsSorted() = runTest {
+        val folderNews = BookmarkFolder(id = "folderA", name = "News", parentId = SavedSitesNames.BOOKMARKS_ROOT, 0, 0, "timestamp")
+        val folderSports = BookmarkFolder(id = "folderB", name = "Sports", parentId = SavedSitesNames.BOOKMARKS_ROOT, 0, 0, "timestamp")
+        val bookmarkAs = Bookmark(id = "bookmarkA", title = "As", url = "www.example.com", parentId = SavedSitesNames.BOOKMARKS_ROOT, "timestamp")
+        val bookmarkCnn = Bookmark(id = "bookmarCnn", title = "Cnn", url = "www.example.com", parentId = SavedSitesNames.BOOKMARKS_ROOT, "timestamp")
+        val bookmarkReddit = Bookmark(
+            id = "bookmarReddit",
+            title = "Reddit",
+            url = "www.example.com",
+            parentId = SavedSitesNames.BOOKMARKS_ROOT,
+            "timestamp",
+        )
+        val bookmarkTheGuardian = Bookmark(
+            id = "bookmarT",
+            title = "The Guardian",
+            url = "www.example.com",
+            parentId = SavedSitesNames.BOOKMARKS_ROOT,
+            "timestamp",
+        )
+
+        savedSitesFlow.value = SavedSites(
+            emptyList(),
+            listOf(bookmarkAs, bookmarkReddit, bookmarkCnn, bookmarkTheGuardian, folderSports, folderNews),
+        )
+        testee.fetchBookmarksAndFolders(BOOKMARKS_ROOT)
+
+        testee.onSortingModeSelected(MANUAL)
+
+        val sortedElements = testee.itemsToDisplay.value
+        assertEquals((sortedElements[0] as BookmarkItem).bookmark, bookmarkAs)
+        assertEquals((sortedElements[1] as BookmarkItem).bookmark, bookmarkReddit)
+        assertEquals((sortedElements[2] as BookmarkItem).bookmark, bookmarkCnn)
+        assertEquals((sortedElements[3] as BookmarkItem).bookmark, bookmarkTheGuardian)
+        assertEquals((sortedElements[4] as BookmarksAdapter.BookmarkFolderItem).bookmarkFolder, folderSports)
+        assertEquals((sortedElements[5] as BookmarksAdapter.BookmarkFolderItem).bookmarkFolder, folderNews)
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1210718637089838?focus=true

### Description
1. Adds a new dev setting to populate saved sites repo with random bookmarks.
2. Optimizes bookmark search by skipping relative position recalculations. When filtering, item order remains unchanged, allowing us to bypass an extra round of equality checks.
3. Moves bookmark update diff computation to a worker thread to avoid UI thread contention and ANRs.
4. Decouples bookmark items to display from the rest of the state to avoid unnecessary computations and UI updates. Previously, updating the search query triggered a view state change (due to the persisted `ViewState#searchQuery`), which caused the `RecyclerView` to recalculate before the actual filtering occurred. As a result, the `RecyclerView` was recalculated and updated twice per query, which was also contributing to resource contention.

### Steps to test this PR

- [x] With bookmarks populated, open "Menu -> Bookmarks".
- [x] Verify that both "manual" and "by name" options work correctly.
- [x] Verify that searching for tabs works correctly. 
- [x] Try with an extreme number of tabs (500+) and verify that there are no ANRs or main thread hangs when sorting/filtering. 
  - [x] (optional) Try the new dev setting under "Developer Settings -> Tabs and Saved Sites"