### PR TITLE
Update content scope scripts to version 10.8.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -7302,9 +7302,6 @@
       let id = null;
       const vParam = url.searchParams.get("v");
       const tParam = url.searchParams.get("t");
-      if (url.searchParams.has("list") && !url.searchParams.has("index")) {
-        return null;
-      }
       let time = null;
       if (vParam && _VideoParams.validVideoId.test(vParam)) {
         id = vParam;

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
@@ -3121,9 +3121,6 @@
       let id = null;
       const vParam = url.searchParams.get("v");
       const tParam = url.searchParams.get("t");
-      if (url.searchParams.has("list") && !url.searchParams.has("index")) {
-        return null;
-      }
       let time = null;
       if (vParam && _VideoParams.validVideoId.test(vParam)) {
         id = vParam;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.3.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.1.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.6.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.8.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#a382fa493c5309a5399b35ef5c49cf2895dcf367",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#782c3fdd5c96d978e7eae5b9734be40abcfdfa50",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -89,13 +89,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@ghostery/adblocker": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.9.3.tgz",
-      "integrity": "sha512-QlJ491n5bxWitonVdqk7k35GSwFbNFXypJ4mkJgjCHvxaerxZOMO99eCXu9IHeBH9T1rfdVv9bl74qITaWGOag==",
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.9.5.tgz",
+      "integrity": "sha512-j4/5pZDKldsUlsP5kVvbU6nCHYbxb1BOj5A5BL4V6hrUp5WI7Gvjn5zwpvmTY+LRI0vREnYvuoBWbHFr505UGg==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-content": "^2.9.3",
-        "@ghostery/adblocker-extended-selectors": "^2.9.3",
+        "@ghostery/adblocker-content": "^2.9.5",
+        "@ghostery/adblocker-extended-selectors": "^2.9.5",
         "@ghostery/url-parser": "^1.3.0",
         "@remusao/guess-url-type": "^2.1.0",
         "@remusao/small": "^2.1.0",
@@ -104,18 +104,18 @@
       }
     },
     "node_modules/@ghostery/adblocker-content": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.9.3.tgz",
-      "integrity": "sha512-VIRGbsSkV3OpLEnB77Ij/j5QZd+pMNnUy0L8HI17xEpeJgRcnoCIlQxdHuP60IivSdUOOaNRm/jrnsgX9ULZeA==",
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.9.5.tgz",
+      "integrity": "sha512-+FUf9ERyvXQDDOZIEP08OW5h0yZWuXLHsoJI0sZBp+oBRJdg8lGe3DA1QXGmnPG9V0mmP+gHwUBI2TDwiZYyoQ==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-extended-selectors": "^2.9.3"
+        "@ghostery/adblocker-extended-selectors": "^2.9.5"
       }
     },
     "node_modules/@ghostery/adblocker-extended-selectors": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.9.3.tgz",
-      "integrity": "sha512-1i91zh6nOLcUvjqXJYxZM8R1NZ/CncAFPpe4C7zHjHNzNJLBQ1sTvMVfJmnrSNROyCJy7ZWqVY8WAodCJXAfyQ==",
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.9.5.tgz",
+      "integrity": "sha512-lHAuNMG8iVRJqpZMH7MH1OnuG64jH01Z9Zegk1BWlwET4eRZJD+2W9kY5EChIhg/35EXWQkLPZyuifxVNIDn9A==",
       "license": "MPL-2.0"
     },
     "node_modules/@ghostery/url-parser": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.3.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.1.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.6.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.8.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass