### PR TITLE
Fix UninitializedPropertyAccessException in geoswitching

### DIFF
--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/settings/geoswitching/NetpGeoswitchingActivity.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/settings/geoswitching/NetpGeoswitchingActivity.kt
@@ -44,7 +44,7 @@ import kotlinx.coroutines.flow.onEach
 class NetpGeoswitchingActivity : DuckDuckGoActivity() {
     private val binding: ActivityNetpGeoswitchingBinding by viewBinding()
     private val viewModel: NetpGeoSwitchingViewModel by bindViewModel()
-    private lateinit var lastSelectedButton: CompoundButton
+    private var lastSelectedButton: CompoundButton? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -110,7 +110,7 @@ class NetpGeoswitchingActivity : DuckDuckGoActivity() {
 
             this.radioButton.setOnCheckedChangeListener { view, isChecked ->
                 if (isChecked && view != lastSelectedButton) {
-                    lastSelectedButton.isChecked = false
+                    lastSelectedButton?.isChecked = false
                     lastSelectedButton = view
                     viewModel.onNearestAvailableCountrySelected()
                 }
@@ -154,7 +154,7 @@ class NetpGeoswitchingActivity : DuckDuckGoActivity() {
 
         itemBinding.root.radioButton.setOnCheckedChangeListener { view, isChecked ->
             if (isChecked && view != lastSelectedButton) {
-                lastSelectedButton.isChecked = false
+                lastSelectedButton?.isChecked = false
                 lastSelectedButton = view
                 viewModel.onCountrySelected(this.countryCode)
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1210704215272651?focus=true

### Description
Remove lateinit for lastSelectedButton and just make it nullable

### Steps to test this PR

_VPN_
- [ ] Obtain PrivacyPro subscription
- [ ] Open VPN screen
- [ ] Enable VPN and quickly open geoswitching screen by pressing selected location
- [ ] Verify no crash happens

