### PR TITLE
Update content scope scripts to version 10.9.1

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -4426,11 +4426,11 @@
     matchConditionalFeatureSetting(featureKeyName) {
       const conditionalChanges = this._getFeatureSettings()?.[featureKeyName] || [];
       return conditionalChanges.filter((rule) => {
-        let condition = rule.condition;
-        if (condition === void 0 && "domain" in rule) {
-          condition = this._domainToConditonBlocks(rule.domain);
+        let condition2 = rule.condition;
+        if (condition2 === void 0 && "domain" in rule) {
+          condition2 = this._domainToConditonBlocks(rule.domain);
         }
-        return this._matchConditionalBlockOrArray(condition);
+        return this._matchConditionalBlockOrArray(condition2);
       });
     }
     /**
@@ -7470,29 +7470,9 @@
 
   // src/features/broker-protection/actions/expectation.js
   init_define_import_meta_trackerLookup();
-  function expectation(action, root = document) {
-    const results = expectMany(action.expectations, root);
-    const errors = results.filter((x2, index) => {
-      if (x2.result === true) return false;
-      if (action.expectations[index].failSilently) return false;
-      return true;
-    }).map((x2) => {
-      return "error" in x2 ? x2.error : "unknown error";
-    });
-    if (errors.length > 0) {
-      return new ErrorResponse({ actionID: action.id, message: errors.join(", ") });
-    }
-    const runActions = results.every((x2) => x2.result === true);
-    if (action.actions?.length && runActions) {
-      return new SuccessResponse({
-        actionID: action.id,
-        actionType: action.actionType,
-        response: null,
-        next: action.actions
-      });
-    }
-    return new SuccessResponse({ actionID: action.id, actionType: action.actionType, response: null });
-  }
+
+  // src/features/broker-protection/utils/expectations.js
+  init_define_import_meta_trackerLookup();
   function expectMany(expectations, root) {
     return expectations.map((expectation2) => {
       switch (expectation2.type) {
@@ -7569,6 +7549,31 @@
       };
     }
     return { result: true };
+  }
+
+  // src/features/broker-protection/actions/expectation.js
+  function expectation(action, root = document) {
+    const results = expectMany(action.expectations, root);
+    const errors = results.filter((x2, index) => {
+      if (x2.result === true) return false;
+      if (action.expectations[index].failSilently) return false;
+      return true;
+    }).map((x2) => {
+      return "error" in x2 ? x2.error : "unknown error";
+    });
+    if (errors.length > 0) {
+      return new ErrorResponse({ actionID: action.id, message: errors.join(", ") });
+    }
+    const runActions = results.every((x2) => x2.result === true);
+    if (action.actions?.length && runActions) {
+      return new SuccessResponse({
+        actionID: action.id,
+        actionType: action.actionType,
+        response: null,
+        next: action.actions
+      });
+    }
+    return new SuccessResponse({ actionID: action.id, actionType: action.actionType, response: null });
   }
 
   // src/features/broker-protection/actions/navigate.js
@@ -8355,6 +8360,31 @@
     return new SuccessResponse({ actionID, actionType, response });
   }
 
+  // src/features/broker-protection/actions/condition.js
+  init_define_import_meta_trackerLookup();
+  function condition(action, root = document) {
+    const results = expectMany(action.expectations, root);
+    const errors = results.filter((x2, index) => {
+      if (x2.result === true) return false;
+      if (action.expectations[index].failSilently) return false;
+      return true;
+    }).map((x2) => {
+      return "error" in x2 ? x2.error : "unknown error";
+    });
+    if (errors.length > 0) {
+      return new ErrorResponse({ actionID: action.id, message: errors.join(", ") });
+    }
+    const returnActions = results.every((x2) => x2.result === true);
+    if (action.actions?.length && returnActions) {
+      return new SuccessResponse({
+        actionID: action.id,
+        actionType: action.actionType,
+        response: { actions: action.actions }
+      });
+    }
+    return new SuccessResponse({ actionID: action.id, actionType: action.actionType, response: { actions: [] } });
+  }
+
   // src/features/broker-protection/execute.js
   async function execute(action, inputData, root = document) {
     try {
@@ -8373,6 +8403,8 @@
           return await getCaptchaInfo2(action, root);
         case "solveCaptcha":
           return solveCaptcha2(action, data(action, inputData, "token"), root);
+        case "condition":
+          return condition(action, root);
         default: {
           return new ErrorResponse({
             actionID: action.id,
@@ -8490,7 +8522,7 @@
           maxAttempts: 30
         };
       }
-      if (!retryConfig && action.actionType === "expectation") {
+      if (!retryConfig && (action.actionType === "expectation" || action.actionType === "condition")) {
         if (action.expectations.some((x2) => x2.type === "element")) {
           return {
             interval: { ms: 1e3 },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.3.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.1.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.8.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.9.1",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#782c3fdd5c96d978e7eae5b9734be40abcfdfa50",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#04b8764f27dd1a0d8e9438cfdb633153579df12b",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -89,13 +89,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@ghostery/adblocker": {
-      "version": "2.9.5",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.9.5.tgz",
-      "integrity": "sha512-j4/5pZDKldsUlsP5kVvbU6nCHYbxb1BOj5A5BL4V6hrUp5WI7Gvjn5zwpvmTY+LRI0vREnYvuoBWbHFr505UGg==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.11.0.tgz",
+      "integrity": "sha512-7FW/Hd/lYp2OLDw6JknYLIhEoFTkcGTC3PqMu9JiOYV1CgUJ/PKhcsRsmdm1lAbhmL9Rq86z1/bhn8CZXSPZ/w==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-content": "^2.9.5",
-        "@ghostery/adblocker-extended-selectors": "^2.9.5",
+        "@ghostery/adblocker-content": "^2.11.0",
+        "@ghostery/adblocker-extended-selectors": "^2.11.0",
         "@ghostery/url-parser": "^1.3.0",
         "@remusao/guess-url-type": "^2.1.0",
         "@remusao/small": "^2.1.0",
@@ -104,18 +104,18 @@
       }
     },
     "node_modules/@ghostery/adblocker-content": {
-      "version": "2.9.5",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.9.5.tgz",
-      "integrity": "sha512-+FUf9ERyvXQDDOZIEP08OW5h0yZWuXLHsoJI0sZBp+oBRJdg8lGe3DA1QXGmnPG9V0mmP+gHwUBI2TDwiZYyoQ==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.11.0.tgz",
+      "integrity": "sha512-2TIxD5OC9lQpCq1SNC9mu4M37pZf1+1LDJCd4yM8gTGc927xMwNVkUBNDmi1aEH2r+PMtmJu4xtHN+YFhgns6A==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-extended-selectors": "^2.9.5"
+        "@ghostery/adblocker-extended-selectors": "^2.11.0"
       }
     },
     "node_modules/@ghostery/adblocker-extended-selectors": {
-      "version": "2.9.5",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.9.5.tgz",
-      "integrity": "sha512-lHAuNMG8iVRJqpZMH7MH1OnuG64jH01Z9Zegk1BWlwET4eRZJD+2W9kY5EChIhg/35EXWQkLPZyuifxVNIDn9A==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.11.0.tgz",
+      "integrity": "sha512-yl7Ygs+TFrG2ZbxynUG8Tyt3mI4WPb4Gzy4VgVXV29SYwUbok0md0Hp7vHSYeURlSzEMMa/KqgjFoZr3GY49XA==",
       "license": "MPL-2.0"
     },
     "node_modules/@ghostery/url-parser": {
@@ -280,9 +280,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.0.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.10.tgz",
-      "integrity": "sha512-ENHwaH+JIRTDIEEbDK6QSQntAYGtbvdDXnMXnZaZ6k13Du1dPMmprkEHIL7ok2Wl2aZevetwTAb5S+7yIF+enA==",
+      "version": "24.0.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.12.tgz",
+      "integrity": "sha512-LtOrbvDf5ndC9Xi+4QZjVL0woFymF/xSTKZKPgrrl7H7XoeDvnD+E2IclKVDyaK9UM756W/3BXqSU+JEHopA9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.3.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.1.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.8.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.9.1",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass