### PR TITLE
Tab manager update: Add a bottom toolbar position support

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -316,9 +316,9 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
                 this as CoordinatorLayout.LayoutParams
                 this.behavior = null
                 if (settingsDataStore.omnibarPosition == OmnibarPosition.TOP) {
-                    this.topMargin = 56.toPx()
+                    this.topMargin = TABS_CONTENT_PADDING_DP.toPx()
                 } else {
-                    this.bottomMargin = 56.toPx()
+                    this.bottomMargin = TABS_CONTENT_PADDING_DP.toPx()
                 }
             }
         }
@@ -1030,5 +1030,6 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
         private const val TAB_GRID_MAX_COLUMN_COUNT = 4
         private const val KEY_FIRST_TIME_LOADING = "FIRST_TIME_LOADING"
         private const val FAB_SCROLL_THRESHOLD = 7
+        private const val TABS_CONTENT_PADDING_DP = 56
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -27,6 +27,8 @@ import android.view.View
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatDelegate.FEATURE_SUPPORT_ACTION_BAR
 import androidx.appcompat.widget.Toolbar
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.view.updateLayoutParams
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -41,6 +43,7 @@ import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.ActivityTabSwitcherBinding
 import com.duckduckgo.app.browser.databinding.PopupTabsMenuBinding
 import com.duckduckgo.app.browser.favicon.FaviconManager
+import com.duckduckgo.app.browser.omnibar.model.OmnibarPosition
 import com.duckduckgo.app.browser.tabpreview.WebViewPreviewPersister
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.downloads.DownloadsActivity
@@ -89,6 +92,7 @@ import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.hide
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.view.toDp
+import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
@@ -268,6 +272,13 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
 
     private fun configureViewReferences() {
         tabsRecycler = findViewById(R.id.tabsRecycler)
+
+        if (settingsDataStore.omnibarPosition == OmnibarPosition.BOTTOM && viewModel.isNewDesignEnabled) {
+            binding.root.removeView(binding.tabSwitcherToolbarTop.root)
+        } else {
+            binding.root.removeView(binding.tabSwitcherToolbarBottom.root)
+        }
+
         toolbar = findViewById(R.id.toolbar)
     }
 
@@ -297,6 +308,19 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
         if (tabManagerFeatureFlags.multiSelection().isEnabled()) {
             handleFabStateUpdates()
             handleSelectionModeCancellation()
+        }
+
+        if (viewModel.isNewDesignEnabled) {
+            // Set the layout params for the tabs recycler view based on omnibar position
+            tabsRecycler.updateLayoutParams {
+                this as CoordinatorLayout.LayoutParams
+                this.behavior = null
+                if (settingsDataStore.omnibarPosition == OmnibarPosition.TOP) {
+                    this.topMargin = 56.toPx()
+                } else {
+                    this.bottomMargin = 56.toPx()
+                }
+            }
         }
     }
 

--- a/app/src/main/res/layout/activity_tab_switcher.xml
+++ b/app/src/main/res/layout/activity_tab_switcher.xml
@@ -22,7 +22,7 @@
     android:layout_height="match_parent">
 
     <include
-        android:id="@+id/toolbarInclude"
+        android:id="@+id/tabSwitcherToolbarTop"
         layout="@layout/include_default_toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
@@ -32,9 +32,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:clipToPadding="false"
-        android:paddingHorizontal="@dimen/keyline_2"
-        android:paddingTop="@dimen/keyline_2"
-        android:paddingBottom="@dimen/keyline_2"
+        android:padding="@dimen/keyline_2"
         app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
         app:layout_behavior="@string/appbar_scrolling_view_behavior"
         tools:itemCount="3"
@@ -71,5 +69,12 @@
         tools:text="Test"
         android:visibility="gone"
         app:icon="@drawable/ic_add_24_solid_color" />
+
+    <include
+        android:id="@+id/tabSwitcherToolbarBottom"
+        layout="@layout/include_default_toolbar"
+        android:layout_gravity="bottom"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1210728360131190?focus=true

### Description

This PR adds the bottom toolbar support, which displays the tab manager toolbar in a position set in the Appearance settings.

### Steps to test this PR

- [x] Go to Settings -> Appearance -> Address bar
- [x] Set the position to bottom
- [x] Open the tab manager screen
- [x] Verify the toolbar is position at the bottom
- [x] Change the position again to the top
- [x] Verify the toolbar in the tab manager is now at the top
