### PR TITLE
Don't show dax when favorites empty (Input Screen)

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/tabs/SearchTabFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/tabs/SearchTabFragment.kt
@@ -91,7 +91,6 @@ class SearchTabFragment : DuckDuckGoFragment(R.layout.fragment_search_tab) {
         val favoritesGridConfig = FavoritesGridConfig(
             isExpandable = false,
             showPlaceholders = false,
-            showDaxWhenEmpty = true,
             placement = FavoritesPlacement.FOCUSED_STATE,
         )
         favoritesView = savedSitesViewsProvider.getFavoritesGridView(requireContext(), config = favoritesGridConfig)

--- a/saved-sites/saved-sites-api/src/main/java/com/duckduckgo/savedsites/api/views/SavedSitesViewsProvider.kt
+++ b/saved-sites/saved-sites-api/src/main/java/com/duckduckgo/savedsites/api/views/SavedSitesViewsProvider.kt
@@ -35,14 +35,12 @@ interface SavedSitesViewsProvider {
  *
  * @property isExpandable If true and there are two or more rows, the favorites are collapsed and can be expanded.
  * If false, the favorites are always expanded.
- * @property showPlaceholders Whether to show placeholder with onboarding if favorites list is empty. Takes precedent over [showDaxWhenEmpty].
- * @property showDaxWhenEmpty Whether to show Dax icon if favorites list is empty.
+ * @property showPlaceholders Whether to show placeholder with onboarding if favorites list is empty.
  * @property placement The screen on which favorites are displayed.
  */
 data class FavoritesGridConfig(
     val isExpandable: Boolean,
     val showPlaceholders: Boolean,
-    val showDaxWhenEmpty: Boolean,
     val placement: FavoritesPlacement,
 )
 

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionView.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionView.kt
@@ -28,7 +28,6 @@ import android.widget.LinearLayout
 import android.widget.PopupWindow
 import androidx.core.text.HtmlCompat
 import androidx.core.text.toSpannable
-import androidx.core.view.isVisible
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.findViewTreeLifecycleOwner
@@ -113,7 +112,6 @@ class FavouritesNewTabSectionView @JvmOverloads constructor(
 
     private var isExpandable = true
     private var showPlaceholders = false
-    private var showDaxWhenEmpty = false
     private var placement: FavoritesPlacement = FavoritesPlacement.NEW_TAB_PAGE
 
     private val binding: ViewNewTabFavouritesSectionBinding by viewBinding()
@@ -154,7 +152,6 @@ class FavouritesNewTabSectionView @JvmOverloads constructor(
         config?.let {
             isExpandable = it.isExpandable
             showPlaceholders = it.showPlaceholders
-            showDaxWhenEmpty = it.showDaxWhenEmpty
             placement = it.placement
         }
     }
@@ -357,7 +354,6 @@ class FavouritesNewTabSectionView @JvmOverloads constructor(
             }
             viewModel.onNewTabFavouritesShown()
         }
-        binding.ddgLogo.isVisible = showDaxWhenEmpty && viewState.favourites.isEmpty()
     }
 
     private fun processCommands(command: Command) {

--- a/saved-sites/saved-sites-impl/src/main/res/layout/view_new_tab_favourites_section.xml
+++ b/saved-sites/saved-sites-impl/src/main/res/layout/view_new_tab_favourites_section.xml
@@ -20,18 +20,6 @@
     android:layout_height="wrap_content"
     android:orientation="vertical">
 
-    <ImageView
-        android:id="@+id/ddgLogo"
-        android:layout_height="wrap_content"
-        android:layout_width="@dimen/ntpDaxLogoIconWidth"
-        android:layout_marginTop="@dimen/homeTabDdgLogoTopMargin"
-        android:adjustViewBounds="true"
-        android:maxWidth="180dp"
-        android:maxHeight="180dp"
-        app:srcCompat="@drawable/logo_full"
-        android:visibility="gone"
-        android:layout_gravity="center_horizontal" />
-
     <LinearLayout
         android:id="@+id/sectionHeaderLayout"
         android:layout_width="match_parent"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1210771657899806?focus=true

### Description
This reverts commit cba06921f59efe724d1cb551c64e79c29bb604e6.

### Steps to test this PR

- [x] Enable Input Screen.
- [x] Focus omnibar (ensure you have no favorites).
- [x] Verify Dax logo is not visible.
