### PR TITLE
Update content scope scripts to version 10.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.3.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.1.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.10.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.11.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.5.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.5.0.tgz",
-      "integrity": "sha512-DvPtPgWWt5Ue3vs7JxZ2WQLAJOdoj5kG75rCqFQUPaXczYfwppqtc4qT9rx4HQn61dajd7XUyQF9nbXoNn6rmg==",
+      "version": "14.5.1",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.5.1.tgz",
+      "integrity": "sha512-t+9pCeZjBvvaUzCF7QP7YaM7ay7ReJWdPkm2RBVxSumL6I+xym/hFV8P/g7t4Rukk6dtI1vacjNaplJJ66fPgw==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#a5e876e1653905b6a0e6e16f8e0b8f8e52c8b6a0",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#0d45118d73af3ee9c346fffb315bd2db329684c6",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.3.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.1.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.10.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.11.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

- [ ] All tests must pass