### PR TITLE
Tab manager update: Replace FABs with buttons

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -106,6 +106,7 @@ import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.extensions.hideKeyboard
 import com.duckduckgo.common.utils.playstore.PlayStoreUtils
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
@@ -807,6 +808,10 @@ open class BrowserActivity : DuckDuckGoActivity() {
             }
         } ?: run {
             launchNewDuckChat(url)
+        }
+
+        currentTab?.omnibar?.newOmnibar?.omnibarTextInput?.let {
+            hideKeyboard(it)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1384,6 +1384,7 @@ class BrowserTabFragment :
         val activity = activity ?: return
         val intent = TabSwitcherActivity.intent(activity, tabId)
         tabSwitcherActivityResult.launch(intent)
+        hideKeyboard()
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1384,7 +1384,6 @@ class BrowserTabFragment :
         val activity = activity ?: return
         val intent = TabSwitcherActivity.intent(activity, tabId)
         tabSwitcherActivityResult.launch(intent)
-        hideKeyboard()
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -316,9 +316,9 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
                 this as CoordinatorLayout.LayoutParams
                 this.behavior = null
                 if (settingsDataStore.omnibarPosition == OmnibarPosition.TOP) {
-                    this.topMargin = 56.toPx()
+                    this.topMargin = TABS_CONTENT_PADDING_DP.toPx()
                 } else {
-                    this.bottomMargin = 56.toPx()
+                    this.bottomMargin = TABS_CONTENT_PADDING_DP.toPx()
                 }
             }
         }
@@ -1030,5 +1030,6 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
         private const val TAB_GRID_MAX_COLUMN_COUNT = 4
         private const val KEY_FIRST_TIME_LOADING = "FIRST_TIME_LOADING"
         private const val FAB_SCROLL_THRESHOLD = 7
+        private const val TABS_CONTENT_PADDING_DP = 56
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -96,7 +96,6 @@ import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
-import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
 import java.util.ArrayList
 import javax.inject.Inject
@@ -156,9 +155,6 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
 
     @Inject
     lateinit var duckChat: DuckChat
-
-    @Inject
-    lateinit var duckAiFeatureState: DuckAiFeatureState
 
     @Inject
     lateinit var tabSwitcherAnimationFeature: TabSwitcherAnimationFeature
@@ -239,7 +235,11 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
         configureViewReferences()
         setupToolbar(toolbar)
         configureRecycler()
-        configureFabs()
+
+        if (!viewModel.isNewDesignEnabled) {
+            configureFabs()
+        }
+
         configureObservers()
         configureOnBackPressedListener()
 
@@ -256,7 +256,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
         }
 
         binding.aiChatFab.setOnClickListener {
-            viewModel.onDuckChatFabClicked()
+            viewModel.onDuckAIFabClicked()
         }
     }
 
@@ -306,7 +306,10 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
         tabsRecycler.setHasFixedSize(true)
 
         if (tabManagerFeatureFlags.multiSelection().isEnabled()) {
-            handleFabStateUpdates()
+            if (viewModel.isNewDesignEnabled) {
+                handleFabStateUpdates()
+            }
+
             handleSelectionModeCancellation()
         }
 
@@ -651,7 +654,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
             )
         } else {
             menuInflater.inflate(R.menu.menu_tab_switcher_activity, menu)
-            layoutTypeMenuItem = menu.findItem(R.id.layoutTypeMenuItem)
+            layoutTypeMenuItem = menu.findItem(R.id.layoutTypeToolbarButton)
 
             when (viewModel.layoutType.value) {
                 LayoutType.GRID -> showListLayoutButton()
@@ -665,7 +668,6 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
 
     private fun initMenuClickListeners() {
         popupMenu.onMenuItemClicked(popupMenu.contentView.findViewById(R.id.newTabMenuItem)) { onNewTabRequested(fromOverflowMenu = true) }
-        popupMenu.onMenuItemClicked(popupMenu.contentView.findViewById(R.id.duckChatMenuItem)) { viewModel.onDuckChatMenuClicked() }
         popupMenu.onMenuItemClicked(popupMenu.contentView.findViewById(R.id.selectAllMenuItem)) { viewModel.onSelectAllTabs() }
         popupMenu.onMenuItemClicked(popupMenu.contentView.findViewById(R.id.deselectAllMenuItem)) { viewModel.onDeselectAllTabs() }
         popupMenu.onMenuItemClicked(popupMenu.contentView.findViewById(R.id.shareSelectedLinksMenuItem)) { viewModel.onShareSelectedTabs() }
@@ -682,17 +684,11 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
-            R.id.layoutTypeMenuItem -> onLayoutTypeToggled()
-            R.id.fireMenuItem -> onFire()
-            R.id.popupMenuItem -> showPopupMenu(item.itemId)
-            R.id.newTab -> onNewTabRequested(fromOverflowMenu = false)
-            R.id.newTabOverflow -> onNewTabRequested(fromOverflowMenu = true)
-            R.id.duckChat -> {
-                viewModel.onDuckChatMenuClicked()
-            }
-            R.id.closeAllTabs -> closeAllTabs()
-            R.id.downloads -> showDownloads()
-            R.id.settings -> showSettings()
+            R.id.layoutTypeToolbarButton -> onLayoutTypeToggled()
+            R.id.fireToolbarButton -> onFireButtonClicked()
+            R.id.popupMenuToolbarButton -> showPopupMenu(item.itemId)
+            R.id.newTabToolbarButton -> onNewTabRequested(fromOverflowMenu = false)
+            R.id.duckAIToolbarButton -> viewModel.onDuckAIButtonClicked()
             android.R.id.home -> {
                 viewModel.onUpButtonPressed()
                 return true
@@ -707,13 +703,6 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
         viewModel.onMenuOpened()
     }
 
-    override fun onPrepareOptionsMenu(menu: Menu?): Boolean {
-        val duckChatMenuItem = menu?.findItem(R.id.duckChat)
-        duckChatMenuItem?.isVisible = duckAiFeatureState.showPopupMenuShortcut.value
-
-        return super.onPrepareOptionsMenu(menu)
-    }
-
     override fun onMenuOpened(featureId: Int, menu: Menu): Boolean {
         if (featureId == FEATURE_SUPPORT_ACTION_BAR) {
             viewModel.onMenuOpened()
@@ -721,7 +710,7 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
         return super.onMenuOpened(featureId, menu)
     }
 
-    private fun onFire() {
+    private fun onFireButtonClicked() {
         pixel.fire(AppPixelName.FORGET_ALL_PRESSED_TABSWITCHING)
         val dialog = FireDialog(
             context = this,

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -27,6 +27,8 @@ import android.view.View
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatDelegate.FEATURE_SUPPORT_ACTION_BAR
 import androidx.appcompat.widget.Toolbar
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.view.updateLayoutParams
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -41,6 +43,7 @@ import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.ActivityTabSwitcherBinding
 import com.duckduckgo.app.browser.databinding.PopupTabsMenuBinding
 import com.duckduckgo.app.browser.favicon.FaviconManager
+import com.duckduckgo.app.browser.omnibar.model.OmnibarPosition
 import com.duckduckgo.app.browser.tabpreview.WebViewPreviewPersister
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.downloads.DownloadsActivity
@@ -89,6 +92,7 @@ import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.hide
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.view.toDp
+import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
@@ -268,6 +272,13 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
 
     private fun configureViewReferences() {
         tabsRecycler = findViewById(R.id.tabsRecycler)
+
+        if (settingsDataStore.omnibarPosition == OmnibarPosition.BOTTOM && viewModel.isNewDesignEnabled) {
+            binding.root.removeView(binding.tabSwitcherToolbarTop.root)
+        } else {
+            binding.root.removeView(binding.tabSwitcherToolbarBottom.root)
+        }
+
         toolbar = findViewById(R.id.toolbar)
     }
 
@@ -297,6 +308,19 @@ class TabSwitcherActivity : DuckDuckGoActivity(), TabSwitcherListener, Coroutine
         if (tabManagerFeatureFlags.multiSelection().isEnabled()) {
             handleFabStateUpdates()
             handleSelectionModeCancellation()
+        }
+
+        if (viewModel.isNewDesignEnabled) {
+            // Set the layout params for the tabs recycler view based on omnibar position
+            tabsRecycler.updateLayoutParams {
+                this as CoordinatorLayout.LayoutParams
+                this.behavior = null
+                if (settingsDataStore.omnibarPosition == OmnibarPosition.TOP) {
+                    this.topMargin = 56.toPx()
+                } else {
+                    this.bottomMargin = 56.toPx()
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherMenuExt.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherMenuExt.kt
@@ -27,9 +27,9 @@ import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.BackBu
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.BackButtonType.CLOSE
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.DynamicInterface
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.FabType
-import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.LayoutButtonType.GRID
-import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.LayoutButtonType.HIDDEN
-import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.LayoutButtonType.LIST
+import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.LayoutMode.GRID
+import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.LayoutMode.HIDDEN
+import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.LayoutMode.LIST
 import com.duckduckgo.mobile.android.R as commonR
 import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
 import com.google.android.material.floatingactionbutton.FloatingActionButton
@@ -43,8 +43,7 @@ fun Menu.createDynamicInterface(
     toolbar: Toolbar,
     dynamicMenu: DynamicInterface,
 ) {
-    popupMenu.newTabMenuItem.isVisible = dynamicMenu.isNewTabVisible
-    popupMenu.duckChatMenuItem.isVisible = dynamicMenu.isDuckChatVisible
+    popupMenu.newTabMenuItem.isVisible = dynamicMenu.isNewTabMenuVisible
     popupMenu.selectAllMenuItem.isVisible = dynamicMenu.isSelectAllVisible
     popupMenu.deselectAllMenuItem.isVisible = dynamicMenu.isDeselectAllVisible
     popupMenu.selectionActionsDivider.isVisible = dynamicMenu.isSelectionActionsDividerVisible
@@ -98,8 +97,8 @@ fun Menu.createDynamicInterface(
         CLOSE -> AppCompatResources.getDrawable(toolbar.context, commonR.drawable.ic_close_24)
     }
 
-    findItem(R.id.layoutTypeMenuItem).apply {
-        when (dynamicMenu.layoutButtonType) {
+    findItem(R.id.layoutTypeToolbarButton).apply {
+        when (dynamicMenu.layoutButtonMode) {
             GRID -> {
                 setIcon(com.duckduckgo.mobile.android.R.drawable.ic_view_grid_24)
                 title = toolbar.resources.getString(R.string.tabSwitcherGridViewMenu)
@@ -114,8 +113,10 @@ fun Menu.createDynamicInterface(
         }
     }
 
-    findItem(R.id.popupMenuItem).isEnabled = dynamicMenu.isMoreMenuItemEnabled
-    findItem(R.id.fireMenuItem).isVisible = dynamicMenu.isFireButtonVisible
+    findItem(R.id.popupMenuToolbarButton).isEnabled = dynamicMenu.isMenuButtonEnabled
+    findItem(R.id.fireToolbarButton).isVisible = dynamicMenu.isFireButtonVisible
+    findItem(R.id.duckAIToolbarButton).isVisible = dynamicMenu.isDuckAIButtonVisible
+    findItem(R.id.newTabToolbarButton).isVisible = dynamicMenu.isNewTabButtonVisible
 
     val bottomPadding = if (dynamicMenu.isAIFabVisible) {
         tabsRecycler.context.resources.getDimension(R.dimen.recyclerViewTwoFabsBottomPadding)

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -49,8 +49,6 @@ import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.ShareLink
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.ShareLinks
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.ShowAnimatedTileDismissalDialog
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command.ShowUndoBookmarkMessage
-import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.BackButtonType.ARROW
-import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.BackButtonType.CLOSE
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.FabType
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.Mode
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.Mode.Normal
@@ -67,6 +65,7 @@ import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.savedsites.api.models.SavedSite.Bookmark
 import javax.inject.Inject
+import kotlin.Boolean
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
@@ -126,21 +125,23 @@ class TabSwitcherViewModel @Inject constructor(
 
     val tabSwitcherItemsLiveData: LiveData<List<TabSwitcherItem>> = tabSwitcherItemsFlow.asLiveData()
 
-    private val _selectionViewState = MutableStateFlow(SelectionViewState())
+    val isNewDesignEnabled: Boolean by lazy {
+        tabManagerFeatureFlags.newToolbarFeature().isEnabled() && experimentalThemingDataStore.isSingleOmnibarEnabled.value
+    }
+
+    private val _selectionViewState = MutableStateFlow(SelectionViewState(isNewToolbarEnabled = isNewDesignEnabled))
     val selectionViewState = combine(
         _selectionViewState,
         tabSwitcherItemsFlow,
         tabRepository.tabSwitcherData,
-        experimentalThemingDataStore.isSingleOmnibarEnabled,
         duckAiFeatureState.showPopupMenuShortcut,
-    ) { viewState, tabSwitcherItems, tabSwitcherData, isSingleOmnibarEnabled, showInBrowserMenu ->
+    ) { viewState, tabSwitcherItems, tabSwitcherData, showInBrowserMenu ->
         viewState.copy(
             tabSwitcherItems = tabSwitcherItems,
             layoutType = tabSwitcherData.layoutType,
-            isNewVisualDesignEnabled = isSingleOmnibarEnabled,
-            isDuckChatEnabled = showInBrowserMenu,
+            isDuckAIButtonVisible = showInBrowserMenu,
         )
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), SelectionViewState())
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), SelectionViewState(isNewToolbarEnabled = isNewDesignEnabled))
 
     val layoutType = tabRepository.tabSwitcherData
         .map { it.layoutType }
@@ -166,18 +167,22 @@ class TabSwitcherViewModel @Inject constructor(
     private val selectionMode: Selection
         get() = requireNotNull(selectionViewState.value.mode as Selection)
 
-    val isNewDesignEnabled: Boolean by lazy {
-        tabManagerFeatureFlags.newToolbarFeature().isEnabled()
-    }
-
     sealed class Command {
         data object Close : Command()
         data class CloseAndShowUndoMessage(val deletedTabIds: List<String>) : Command()
-        data class CloseTabsRequest(val tabIds: List<String>, val isClosingOtherTabs: Boolean = false) : Command()
+        data class CloseTabsRequest(
+            val tabIds: List<String>,
+            val isClosingOtherTabs: Boolean = false,
+        ) : Command()
+
         data class CloseAllTabsRequest(val numTabs: Int) : Command()
         data object ShowAnimatedTileDismissalDialog : Command()
         data object DismissAnimatedTileDismissalDialog : Command()
-        data class ShareLink(val link: String, val title: String) : Command()
+        data class ShareLink(
+            val link: String,
+            val title: String,
+        ) : Command()
+
         data class ShareLinks(val links: List<String>) : Command()
         data class BookmarkTabsRequest(val tabIds: List<String>) : Command()
         data class ShowUndoBookmarkMessage(val numBookmarks: Int) : Command()
@@ -393,7 +398,10 @@ class TabSwitcherViewModel @Inject constructor(
         onCloseTabsConfirmed(tabs.map { it.id })
     }
 
-    fun onTabCloseInNormalModeRequested(tab: Tab, swipeGestureUsed: Boolean = false) {
+    fun onTabCloseInNormalModeRequested(
+        tab: Tab,
+        swipeGestureUsed: Boolean = false,
+    ) {
         viewModelScope.launch {
             if (tabs.size == 1) {
                 if (tabManagerFeatureFlags.multiSelection().isEnabled()) {
@@ -416,7 +424,10 @@ class TabSwitcherViewModel @Inject constructor(
         }
     }
 
-    private suspend fun markTabAsDeletable(tab: Tab, swipeGestureUsed: Boolean) {
+    private suspend fun markTabAsDeletable(
+        tab: Tab,
+        swipeGestureUsed: Boolean,
+    ) {
         tabRepository.markDeletable(tab.tabEntity)
         if (swipeGestureUsed) {
             pixel.fire(AppPixelName.TAB_MANAGER_CLOSE_TAB_SWIPED)
@@ -502,7 +513,10 @@ class TabSwitcherViewModel @Inject constructor(
         pixel.fire(AppPixelName.TAB_MANAGER_MENU_SETTINGS_PRESSED)
     }
 
-    fun onTabMoved(fromIndex: Int, toIndex: Int) {
+    fun onTabMoved(
+        fromIndex: Int,
+        toIndex: Int,
+    ) {
         viewModelScope.launch(dispatcherProvider.io()) {
             tabRepository.updateTabPosition(fromIndex, toIndex)
         }
@@ -522,10 +536,12 @@ class TabSwitcherViewModel @Inject constructor(
                     pixel.fire(TAB_MANAGER_LIST_VIEW_BUTTON_CLICKED)
                     tabRepository.setTabLayoutType(LIST)
                 }
+
                 LIST -> {
                     pixel.fire(TAB_MANAGER_GRID_VIEW_BUTTON_CLICKED)
                     tabRepository.setTabLayoutType(GRID)
                 }
+
                 else -> Unit
             }
         }
@@ -553,7 +569,7 @@ class TabSwitcherViewModel @Inject constructor(
         return@withContext null
     }
 
-    fun onDuckChatFabClicked() {
+    fun onDuckAIFabClicked() {
         viewModelScope.launch {
             val params = duckChat.createWasUsedBeforePixelParams()
             pixel.fire(DuckChatPixelName.DUCK_CHAT_OPEN_TAB_SWITCHER_FAB, parameters = params)
@@ -562,7 +578,7 @@ class TabSwitcherViewModel @Inject constructor(
         }
     }
 
-    fun onDuckChatMenuClicked() {
+    fun onDuckAIButtonClicked() {
         viewModelScope.launch {
             val params = duckChat.createWasUsedBeforePixelParams()
             pixel.fire(DuckChatPixelName.DUCK_CHAT_OPEN_NEW_TAB_MENU, parameters = params)
@@ -641,8 +657,8 @@ class TabSwitcherViewModel @Inject constructor(
         val tabSwitcherItems: List<TabSwitcherItem> = emptyList(),
         val mode: Mode = Normal,
         val layoutType: LayoutType? = null,
-        val isNewVisualDesignEnabled: Boolean = false,
-        val isDuckChatEnabled: Boolean = false,
+        val isDuckAIButtonVisible: Boolean = false,
+        val isNewToolbarEnabled: Boolean = false,
     ) {
         val tabs: List<Tab> = tabSwitcherItems.filterIsInstance<Tab>()
         val numSelectedTabs: Int = (mode as? Selection)?.selectedTabs?.size ?: 0
@@ -652,8 +668,9 @@ class TabSwitcherViewModel @Inject constructor(
                 val isThereOnlyNewTabPage = tabs.size == 1 && tabs.first().isNewTabPage
                 DynamicInterface(
                     isFireButtonVisible = true,
-                    isNewTabVisible = true,
-                    isDuckChatVisible = !isNewVisualDesignEnabled && isDuckChatEnabled,
+                    isNewTabButtonVisible = isNewToolbarEnabled,
+                    isNewTabMenuVisible = !isNewToolbarEnabled,
+                    isDuckAIButtonVisible = isDuckAIButtonVisible && isNewToolbarEnabled,
                     isSelectAllVisible = false,
                     isDeselectAllVisible = false,
                     isSelectionActionsDividerVisible = false,
@@ -665,15 +682,20 @@ class TabSwitcherViewModel @Inject constructor(
                     isCloseOtherTabsVisible = false,
                     isCloseAllTabsDividerVisible = true,
                     isCloseAllTabsVisible = true,
-                    isMoreMenuItemEnabled = !isThereOnlyNewTabPage,
-                    isMainFabVisible = true,
-                    isAIFabVisible = isNewVisualDesignEnabled && isDuckChatEnabled,
+                    isMenuButtonEnabled = !isThereOnlyNewTabPage,
+                    isMainFabVisible = !isNewToolbarEnabled,
+                    isAIFabVisible = isDuckAIButtonVisible && !isNewToolbarEnabled,
                     mainFabType = FabType.NEW_TAB,
-                    backButtonType = ARROW,
-                    layoutButtonType = when (layoutType) {
-                        GRID -> LayoutButtonType.LIST
-                        LIST -> LayoutButtonType.GRID
-                        else -> LayoutButtonType.HIDDEN
+                    backButtonType = BackButtonType.ARROW,
+                    layoutButtonMode = when {
+                        layoutType == GRID && !isNewToolbarEnabled -> LayoutMode.LIST
+                        layoutType == LIST && !isNewToolbarEnabled -> LayoutMode.GRID
+                        else -> LayoutMode.HIDDEN
+                    },
+                    layoutMenuMode = when {
+                        layoutType == GRID && isNewToolbarEnabled -> LayoutMode.LIST
+                        layoutType == LIST && isNewToolbarEnabled -> LayoutMode.GRID
+                        else -> LayoutMode.HIDDEN
                     },
                 )
             }
@@ -686,8 +708,9 @@ class TabSwitcherViewModel @Inject constructor(
                 val isSelectionActionable = isSomethingSelected && !isNtpTheOnlySelectedTab
                 DynamicInterface(
                     isFireButtonVisible = false,
-                    isNewTabVisible = false,
-                    isDuckChatVisible = false,
+                    isNewTabButtonVisible = false,
+                    isNewTabMenuVisible = false,
+                    isDuckAIButtonVisible = false,
                     isSelectAllVisible = !areAllTabsSelected,
                     isDeselectAllVisible = areAllTabsSelected,
                     isSelectionActionsDividerVisible = isSelectionActionable,
@@ -699,20 +722,22 @@ class TabSwitcherViewModel @Inject constructor(
                     isCloseOtherTabsVisible = isSomethingSelected && !areAllTabsSelected,
                     isCloseAllTabsDividerVisible = isSomethingSelected,
                     isCloseAllTabsVisible = false,
-                    isMoreMenuItemEnabled = true,
-                    isMainFabVisible = isSomethingSelected,
+                    isMenuButtonEnabled = true,
+                    isMainFabVisible = isSomethingSelected && !isNewToolbarEnabled,
                     isAIFabVisible = false,
                     mainFabType = FabType.CLOSE_TABS,
-                    backButtonType = CLOSE,
-                    layoutButtonType = LayoutButtonType.HIDDEN,
+                    backButtonType = BackButtonType.CLOSE,
+                    layoutButtonMode = LayoutMode.HIDDEN,
+                    layoutMenuMode = LayoutMode.HIDDEN,
                 )
             }
         }
 
         data class DynamicInterface(
             val isFireButtonVisible: Boolean,
-            val isNewTabVisible: Boolean,
-            val isDuckChatVisible: Boolean,
+            val isNewTabButtonVisible: Boolean,
+            val isNewTabMenuVisible: Boolean,
+            val isDuckAIButtonVisible: Boolean,
             val isSelectAllVisible: Boolean,
             val isDeselectAllVisible: Boolean,
             val isSelectionActionsDividerVisible: Boolean,
@@ -724,12 +749,13 @@ class TabSwitcherViewModel @Inject constructor(
             val isCloseOtherTabsVisible: Boolean,
             val isCloseAllTabsDividerVisible: Boolean,
             val isCloseAllTabsVisible: Boolean,
-            val isMoreMenuItemEnabled: Boolean,
+            val isMenuButtonEnabled: Boolean,
             val isMainFabVisible: Boolean,
             val isAIFabVisible: Boolean,
             val mainFabType: FabType,
             val backButtonType: BackButtonType,
-            val layoutButtonType: LayoutButtonType,
+            val layoutButtonMode: LayoutMode,
+            val layoutMenuMode: LayoutMode,
         )
 
         enum class FabType {
@@ -742,7 +768,7 @@ class TabSwitcherViewModel @Inject constructor(
             CLOSE,
         }
 
-        enum class LayoutButtonType {
+        enum class LayoutMode {
             GRID,
             LIST,
             HIDDEN,

--- a/app/src/main/res/layout/activity_tab_switcher.xml
+++ b/app/src/main/res/layout/activity_tab_switcher.xml
@@ -22,7 +22,7 @@
     android:layout_height="match_parent">
 
     <include
-        android:id="@+id/toolbarInclude"
+        android:id="@+id/tabSwitcherToolbarTop"
         layout="@layout/include_default_toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
@@ -32,9 +32,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:clipToPadding="false"
-        android:paddingHorizontal="@dimen/keyline_2"
-        android:paddingTop="@dimen/keyline_2"
-        android:paddingBottom="@dimen/keyline_2"
+        android:padding="@dimen/keyline_2"
         app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
         app:layout_behavior="@string/appbar_scrolling_view_behavior"
         tools:itemCount="3"
@@ -71,5 +69,12 @@
         tools:text="Test"
         android:visibility="gone"
         app:icon="@drawable/ic_add_24_solid_color" />
+
+    <include
+        android:id="@+id/tabSwitcherToolbarBottom"
+        layout="@layout/include_default_toolbar"
+        android:layout_gravity="bottom"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/popup_tabs_menu.xml
+++ b/app/src/main/res/layout/popup_tabs_menu.xml
@@ -28,12 +28,6 @@
         app:primaryText="@string/newTabMenuItem" />
 
     <com.duckduckgo.common.ui.view.PopupMenuItemView
-        android:id="@+id/duckChatMenuItem"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:primaryText="@string/duckChatMenuItem" />
-
-    <com.duckduckgo.common.ui.view.PopupMenuItemView
         android:id="@+id/selectAllMenuItem"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -74,7 +68,7 @@
         app:primaryText="@string/selectTabsMenuItem" />
 
     <com.duckduckgo.common.ui.view.divider.HorizontalDivider
-        android:id="@+id/close_all_tabs_divider"
+        android:id="@+id/closeAllTabsDivider"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:defaultPadding="false" />

--- a/app/src/main/res/menu/menu_tab_switcher_activity.xml
+++ b/app/src/main/res/menu/menu_tab_switcher_activity.xml
@@ -20,47 +20,21 @@
     tools:ignore="AlwaysShowAction">
 
     <item
-        android:id="@+id/layoutTypeMenuItem"
+        android:id="@+id/layoutTypeToolbarButton"
         android:icon="@drawable/ic_view_list_24"
         android:title="@string/tabSwitcherListViewMenu"
-        android:visible="false"
         app:showAsAction="always" />
 
     <item
-        android:id="@+id/fireMenuItem"
+        android:id="@+id/fireToolbarButton"
         android:icon="@drawable/ic_fire_24"
         android:title="@string/fireMenu"
         app:showAsAction="always" />
 
     <item
-        android:id="@+id/newTab"
+        android:id="@+id/newTabToolbarButton"
         android:icon="@drawable/ic_add_24"
         android:title="@string/newTabMenuItem"
         app:showAsAction="always" />
-
-    <item
-        android:id="@+id/newTabOverflow"
-        android:title="@string/newTabMenuItem"
-        app:showAsAction="never" />
-
-    <item
-        android:id="@+id/duckChat"
-        android:title="@string/duckChatMenuItem"
-        app:showAsAction="never" />
-
-    <item
-        android:id="@+id/closeAllTabs"
-        android:title="@string/closeAllTabsMenuItem"
-        app:showAsAction="never" />
-
-    <item
-        android:id="@+id/downloads"
-        android:title="@string/downloadsMenuItemTitle"
-        app:showAsAction="never" />
-
-    <item
-        android:id="@+id/settings"
-        android:title="@string/settingsMenuItemTitle"
-        app:showAsAction="never" />
 
 </menu>

--- a/app/src/main/res/menu/menu_tab_switcher_activity_with_selection.xml
+++ b/app/src/main/res/menu/menu_tab_switcher_activity_with_selection.xml
@@ -20,20 +20,31 @@
     tools:ignore="AlwaysShowAction">
 
     <item
-        android:id="@+id/fireMenuItem"
+        android:id="@+id/duckAIToolbarButton"
+        android:icon="@drawable/ic_ai_chat_24"
+        android:title="@string/tabSwitcherListViewMenu"
+        app:showAsAction="always" />
+
+    <item
+        android:id="@+id/fireToolbarButton"
         android:icon="@drawable/ic_fire_24"
         android:title="@string/fireMenu"
         app:showAsAction="always" />
 
     <item
-        android:id="@+id/layoutTypeMenuItem"
-        android:icon="@drawable/ic_view_list_24"
-        android:title="@string/tabSwitcherListViewMenu"
-        android:visible="false"
+        android:id="@+id/newTabToolbarButton"
+        android:icon="@drawable/ic_add_24"
+        android:title="@string/newTabMenuItem"
         app:showAsAction="always" />
 
     <item
-        android:id="@+id/popupMenuItem"
+        android:id="@+id/layoutTypeToolbarButton"
+        android:icon="@drawable/ic_view_list_24"
+        android:title="@string/tabSwitcherListViewMenu"
+        app:showAsAction="always" />
+
+    <item
+        android:id="@+id/popupMenuToolbarButton"
         android:icon="@drawable/ic_menu_vertical_24"
         android:title="@string/browserPopupMenu"
         app:showAsAction="always" />

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -54,7 +54,7 @@ import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.BackButtonType
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.DynamicInterface
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.FabType
-import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.LayoutButtonType
+import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.LayoutMode
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.Mode.Normal
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.SelectionViewState.Mode.Selection
 import com.duckduckgo.app.trackerdetection.api.WebTrackersBlockedAppRepository
@@ -189,6 +189,7 @@ class TabSwitcherViewModelTest {
 
         swipingTabsFeature.self().setRawStoredState(State(enable = false))
         tabManagerFeatureFlags.multiSelection().setRawStoredState(State(enable = false))
+        tabManagerFeatureFlags.newToolbarFeature().setRawStoredState(State(enable = false))
         swipingTabsFeature.enabledForUsers().setRawStoredState(State(enable = true))
 
         whenever(mockTabSwitcherPrefsDataStore.isAnimationTileDismissed()).thenReturn(flowOf(false))
@@ -842,7 +843,7 @@ class TabSwitcherViewModelTest {
     fun `when Duck Chat menu item clicked and it wasn't used before then open Duck Chat and send a pixel`() = runTest {
         whenever(duckChatMock.wasOpenedBefore()).thenReturn(false)
 
-        testee.onDuckChatMenuClicked()
+        testee.onDuckAIButtonClicked()
 
         verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_OPEN_NEW_TAB_MENU, mapOf("was_used_before" to "0"))
         verify(duckChatMock).openDuckChat()
@@ -852,7 +853,7 @@ class TabSwitcherViewModelTest {
     fun `when Duck Chat menu item clicked and it was used before then open Duck Chat and send a pixel`() = runTest {
         whenever(duckChatMock.wasOpenedBefore()).thenReturn(true)
 
-        testee.onDuckChatMenuClicked()
+        testee.onDuckAIButtonClicked()
 
         verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_OPEN_NEW_TAB_MENU, mapOf("was_used_before" to "1"))
         verify(duckChatMock).openDuckChat()
@@ -862,7 +863,7 @@ class TabSwitcherViewModelTest {
     fun `when Duck Chat fab clicked and it wasn't used before then open Duck Chat and send a pixel`() = runTest {
         whenever(duckChatMock.wasOpenedBefore()).thenReturn(false)
 
-        testee.onDuckChatFabClicked()
+        testee.onDuckAIFabClicked()
 
         verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_OPEN_TAB_SWITCHER_FAB, mapOf("was_used_before" to "0"))
         verify(duckChatMock).openDuckChat()
@@ -872,7 +873,7 @@ class TabSwitcherViewModelTest {
     fun `when Duck Chat fab clicked and it was used before then open Duck Chat and send a pixel`() = runTest {
         whenever(duckChatMock.wasOpenedBefore()).thenReturn(true)
 
-        testee.onDuckChatFabClicked()
+        testee.onDuckAIFabClicked()
 
         verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_OPEN_TAB_SWITCHER_FAB, mapOf("was_used_before" to "1"))
         verify(duckChatMock).openDuckChat()
@@ -880,11 +881,12 @@ class TabSwitcherViewModelTest {
 
     @Test
     fun whenNormalModeAndNoTabsThenVerifyDynamicInterface() {
-        val viewState = SelectionViewState(tabSwitcherItems = emptyList(), mode = Normal, layoutType = null, isDuckChatEnabled = true)
+        val viewState = SelectionViewState(tabSwitcherItems = emptyList(), mode = Normal, layoutType = null, isDuckAIButtonVisible = true)
         val expected = DynamicInterface(
             isFireButtonVisible = true,
-            isNewTabVisible = true,
-            isDuckChatVisible = true,
+            isNewTabMenuVisible = true,
+            isNewTabButtonVisible = false,
+            isDuckAIButtonVisible = false,
             isSelectAllVisible = false,
             isDeselectAllVisible = false,
             isSelectionActionsDividerVisible = false,
@@ -896,12 +898,13 @@ class TabSwitcherViewModelTest {
             isCloseOtherTabsVisible = false,
             isCloseAllTabsDividerVisible = true,
             isCloseAllTabsVisible = true,
-            isMoreMenuItemEnabled = true,
+            isMenuButtonEnabled = true,
             isMainFabVisible = true,
-            isAIFabVisible = false,
+            isAIFabVisible = true,
             mainFabType = FabType.NEW_TAB,
             backButtonType = BackButtonType.ARROW,
-            layoutButtonType = LayoutButtonType.HIDDEN,
+            layoutButtonMode = LayoutMode.HIDDEN,
+            layoutMenuMode = LayoutMode.HIDDEN,
         )
         assertEquals(expected, viewState.dynamicInterface)
     }
@@ -909,11 +912,12 @@ class TabSwitcherViewModelTest {
     @Test
     fun whenNormalModeAndOneNewTabPageThenVerifyDynamicInterface() {
         val tabItems = listOf(NormalTab(TabEntity("1"), true))
-        val viewState = SelectionViewState(tabSwitcherItems = tabItems, mode = Normal, layoutType = null, isDuckChatEnabled = true)
+        val viewState = SelectionViewState(tabSwitcherItems = tabItems, mode = Normal, layoutType = null, isDuckAIButtonVisible = true)
         val expected = DynamicInterface(
             isFireButtonVisible = true,
-            isNewTabVisible = true,
-            isDuckChatVisible = true,
+            isNewTabMenuVisible = true,
+            isNewTabButtonVisible = false,
+            isDuckAIButtonVisible = false,
             isSelectAllVisible = false,
             isDeselectAllVisible = false,
             isSelectionActionsDividerVisible = false,
@@ -925,12 +929,13 @@ class TabSwitcherViewModelTest {
             isCloseOtherTabsVisible = false,
             isCloseAllTabsDividerVisible = true,
             isCloseAllTabsVisible = true,
-            isMoreMenuItemEnabled = false,
+            isMenuButtonEnabled = false,
             isMainFabVisible = true,
-            isAIFabVisible = false,
+            isAIFabVisible = true,
             mainFabType = FabType.NEW_TAB,
             backButtonType = BackButtonType.ARROW,
-            layoutButtonType = LayoutButtonType.HIDDEN,
+            layoutButtonMode = LayoutMode.HIDDEN,
+            layoutMenuMode = LayoutMode.HIDDEN,
         )
         assertEquals(expected, viewState.dynamicInterface)
     }
@@ -942,13 +947,13 @@ class TabSwitcherViewModelTest {
             tabSwitcherItems = tabItems,
             mode = Normal,
             layoutType = null,
-            isNewVisualDesignEnabled = true,
-            isDuckChatEnabled = true,
+            isDuckAIButtonVisible = true,
         )
         val expected = DynamicInterface(
             isFireButtonVisible = true,
-            isNewTabVisible = true,
-            isDuckChatVisible = false,
+            isNewTabMenuVisible = true,
+            isNewTabButtonVisible = false,
+            isDuckAIButtonVisible = false,
             isSelectAllVisible = false,
             isDeselectAllVisible = false,
             isSelectionActionsDividerVisible = false,
@@ -960,12 +965,13 @@ class TabSwitcherViewModelTest {
             isCloseOtherTabsVisible = false,
             isCloseAllTabsDividerVisible = true,
             isCloseAllTabsVisible = true,
-            isMoreMenuItemEnabled = true,
+            isMenuButtonEnabled = true,
             isMainFabVisible = true,
             isAIFabVisible = true,
             mainFabType = FabType.NEW_TAB,
             backButtonType = BackButtonType.ARROW,
-            layoutButtonType = LayoutButtonType.HIDDEN,
+            layoutButtonMode = LayoutMode.HIDDEN,
+            layoutMenuMode = LayoutMode.HIDDEN,
         )
         assertEquals(expected, viewState.dynamicInterface)
     }
@@ -977,13 +983,13 @@ class TabSwitcherViewModelTest {
             tabSwitcherItems = tabItems,
             mode = Normal,
             layoutType = null,
-            isNewVisualDesignEnabled = true,
-            isDuckChatEnabled = false,
+            isDuckAIButtonVisible = false,
         )
         val expected = DynamicInterface(
             isFireButtonVisible = true,
-            isNewTabVisible = true,
-            isDuckChatVisible = false,
+            isNewTabMenuVisible = true,
+            isNewTabButtonVisible = false,
+            isDuckAIButtonVisible = false,
             isSelectAllVisible = false,
             isDeselectAllVisible = false,
             isSelectionActionsDividerVisible = false,
@@ -995,12 +1001,13 @@ class TabSwitcherViewModelTest {
             isCloseOtherTabsVisible = false,
             isCloseAllTabsDividerVisible = true,
             isCloseAllTabsVisible = true,
-            isMoreMenuItemEnabled = true,
+            isMenuButtonEnabled = true,
             isMainFabVisible = true,
             isAIFabVisible = false,
             mainFabType = FabType.NEW_TAB,
             backButtonType = BackButtonType.ARROW,
-            layoutButtonType = LayoutButtonType.HIDDEN,
+            layoutButtonMode = LayoutMode.HIDDEN,
+            layoutMenuMode = LayoutMode.HIDDEN,
         )
         assertEquals(expected, viewState.dynamicInterface)
     }
@@ -1012,13 +1019,13 @@ class TabSwitcherViewModelTest {
             tabSwitcherItems = tabItems,
             mode = Normal,
             layoutType = null,
-            isNewVisualDesignEnabled = false,
-            isDuckChatEnabled = false,
+            isDuckAIButtonVisible = false,
         )
         val expected = DynamicInterface(
             isFireButtonVisible = true,
-            isNewTabVisible = true,
-            isDuckChatVisible = false,
+            isNewTabMenuVisible = true,
+            isNewTabButtonVisible = false,
+            isDuckAIButtonVisible = false,
             isSelectAllVisible = false,
             isDeselectAllVisible = false,
             isSelectionActionsDividerVisible = false,
@@ -1030,12 +1037,13 @@ class TabSwitcherViewModelTest {
             isCloseOtherTabsVisible = false,
             isCloseAllTabsDividerVisible = true,
             isCloseAllTabsVisible = true,
-            isMoreMenuItemEnabled = true,
+            isMenuButtonEnabled = true,
             isMainFabVisible = true,
             isAIFabVisible = false,
             mainFabType = FabType.NEW_TAB,
             backButtonType = BackButtonType.ARROW,
-            layoutButtonType = LayoutButtonType.HIDDEN,
+            layoutButtonMode = LayoutMode.HIDDEN,
+            layoutMenuMode = LayoutMode.HIDDEN,
         )
         assertEquals(expected, viewState.dynamicInterface)
     }
@@ -1043,11 +1051,12 @@ class TabSwitcherViewModelTest {
     @Test
     fun whenNormalModeAndMultipleTabsAndLayoutIsGridThenVerifyDynamicInterface() {
         val tabItems = listOf(NormalTab(TabEntity("1"), true), NormalTab(TabEntity("2"), false))
-        val viewState = SelectionViewState(tabSwitcherItems = tabItems, mode = Normal, layoutType = GRID, isDuckChatEnabled = true)
+        val viewState = SelectionViewState(tabSwitcherItems = tabItems, mode = Normal, layoutType = GRID, isDuckAIButtonVisible = true)
         val expected = DynamicInterface(
             isFireButtonVisible = true,
-            isNewTabVisible = true,
-            isDuckChatVisible = true,
+            isNewTabMenuVisible = true,
+            isNewTabButtonVisible = false,
+            isDuckAIButtonVisible = false,
             isSelectAllVisible = false,
             isDeselectAllVisible = false,
             isSelectionActionsDividerVisible = false,
@@ -1059,12 +1068,13 @@ class TabSwitcherViewModelTest {
             isCloseOtherTabsVisible = false,
             isCloseAllTabsDividerVisible = true,
             isCloseAllTabsVisible = true,
-            isMoreMenuItemEnabled = true,
+            isMenuButtonEnabled = true,
             isMainFabVisible = true,
-            isAIFabVisible = false,
+            isAIFabVisible = true,
             mainFabType = FabType.NEW_TAB,
             backButtonType = BackButtonType.ARROW,
-            layoutButtonType = LayoutButtonType.LIST,
+            layoutButtonMode = LayoutMode.LIST,
+            layoutMenuMode = LayoutMode.HIDDEN,
         )
         assertEquals(expected, viewState.dynamicInterface)
     }
@@ -1076,13 +1086,13 @@ class TabSwitcherViewModelTest {
             tabSwitcherItems = tabItems,
             mode = Normal,
             layoutType = LIST,
-            isNewVisualDesignEnabled = true,
-            isDuckChatEnabled = true,
+            isDuckAIButtonVisible = true,
         )
         val expected = DynamicInterface(
             isFireButtonVisible = true,
-            isNewTabVisible = true,
-            isDuckChatVisible = false,
+            isNewTabMenuVisible = true,
+            isNewTabButtonVisible = false,
+            isDuckAIButtonVisible = false,
             isSelectAllVisible = false,
             isDeselectAllVisible = false,
             isSelectionActionsDividerVisible = false,
@@ -1094,12 +1104,13 @@ class TabSwitcherViewModelTest {
             isCloseOtherTabsVisible = false,
             isCloseAllTabsDividerVisible = true,
             isCloseAllTabsVisible = true,
-            isMoreMenuItemEnabled = true,
+            isMenuButtonEnabled = true,
             isMainFabVisible = true,
             isAIFabVisible = true,
             mainFabType = FabType.NEW_TAB,
             backButtonType = BackButtonType.ARROW,
-            layoutButtonType = LayoutButtonType.GRID,
+            layoutButtonMode = LayoutMode.GRID,
+            layoutMenuMode = LayoutMode.HIDDEN,
         )
         assertEquals(expected, viewState.dynamicInterface)
     }
@@ -1113,8 +1124,9 @@ class TabSwitcherViewModelTest {
         val viewState = SelectionViewState(tabSwitcherItems = tabItems, mode = Selection(emptyList()), layoutType = null)
         val expected = DynamicInterface(
             isFireButtonVisible = false,
-            isNewTabVisible = false,
-            isDuckChatVisible = false,
+            isNewTabMenuVisible = false,
+            isNewTabButtonVisible = false,
+            isDuckAIButtonVisible = false,
             isSelectAllVisible = true,
             isDeselectAllVisible = false,
             isSelectionActionsDividerVisible = false,
@@ -1126,12 +1138,13 @@ class TabSwitcherViewModelTest {
             isCloseOtherTabsVisible = false,
             isCloseAllTabsDividerVisible = false,
             isCloseAllTabsVisible = false,
-            isMoreMenuItemEnabled = true,
+            isMenuButtonEnabled = true,
             isMainFabVisible = false,
             isAIFabVisible = false,
             mainFabType = FabType.CLOSE_TABS,
             backButtonType = BackButtonType.CLOSE,
-            layoutButtonType = LayoutButtonType.HIDDEN,
+            layoutButtonMode = LayoutMode.HIDDEN,
+            layoutMenuMode = LayoutMode.HIDDEN,
         )
         assertEquals(expected, viewState.dynamicInterface)
     }
@@ -1145,8 +1158,9 @@ class TabSwitcherViewModelTest {
         val viewState = SelectionViewState(tabSwitcherItems = tabItems, mode = Selection(listOf("1")), layoutType = null)
         val expected = DynamicInterface(
             isFireButtonVisible = false,
-            isNewTabVisible = false,
-            isDuckChatVisible = false,
+            isNewTabMenuVisible = false,
+            isNewTabButtonVisible = false,
+            isDuckAIButtonVisible = false,
             isSelectAllVisible = true,
             isDeselectAllVisible = false,
             isSelectionActionsDividerVisible = true,
@@ -1158,12 +1172,13 @@ class TabSwitcherViewModelTest {
             isCloseOtherTabsVisible = true,
             isCloseAllTabsDividerVisible = true,
             isCloseAllTabsVisible = false,
-            isMoreMenuItemEnabled = true,
+            isMenuButtonEnabled = true,
             isMainFabVisible = true,
             isAIFabVisible = false,
             mainFabType = FabType.CLOSE_TABS,
             backButtonType = BackButtonType.CLOSE,
-            layoutButtonType = LayoutButtonType.HIDDEN,
+            layoutButtonMode = LayoutMode.HIDDEN,
+            layoutMenuMode = LayoutMode.HIDDEN,
         )
         assertEquals(expected, viewState.dynamicInterface)
     }
@@ -1177,8 +1192,9 @@ class TabSwitcherViewModelTest {
         val viewState = SelectionViewState(tabSwitcherItems = tabItems, mode = Selection(listOf("1")), layoutType = null)
         val expected = DynamicInterface(
             isFireButtonVisible = false,
-            isNewTabVisible = false,
-            isDuckChatVisible = false,
+            isNewTabMenuVisible = false,
+            isNewTabButtonVisible = false,
+            isDuckAIButtonVisible = false,
             isSelectAllVisible = true,
             isDeselectAllVisible = false,
             isSelectionActionsDividerVisible = false,
@@ -1190,12 +1206,13 @@ class TabSwitcherViewModelTest {
             isCloseOtherTabsVisible = true,
             isCloseAllTabsDividerVisible = true,
             isCloseAllTabsVisible = false,
-            isMoreMenuItemEnabled = true,
+            isMenuButtonEnabled = true,
             isMainFabVisible = true,
             isAIFabVisible = false,
             mainFabType = FabType.CLOSE_TABS,
             backButtonType = BackButtonType.CLOSE,
-            layoutButtonType = LayoutButtonType.HIDDEN,
+            layoutButtonMode = LayoutMode.HIDDEN,
+            layoutMenuMode = LayoutMode.HIDDEN,
         )
         assertEquals(expected, viewState.dynamicInterface)
     }
@@ -1210,8 +1227,9 @@ class TabSwitcherViewModelTest {
         val viewState = SelectionViewState(tabSwitcherItems = tabItems, mode = Selection(listOf("1", "2")), layoutType = null)
         val expected = DynamicInterface(
             isFireButtonVisible = false,
-            isNewTabVisible = false,
-            isDuckChatVisible = false,
+            isNewTabMenuVisible = false,
+            isNewTabButtonVisible = false,
+            isDuckAIButtonVisible = false,
             isSelectAllVisible = true,
             isDeselectAllVisible = false,
             isSelectionActionsDividerVisible = true,
@@ -1223,12 +1241,13 @@ class TabSwitcherViewModelTest {
             isCloseOtherTabsVisible = true,
             isCloseAllTabsDividerVisible = true,
             isCloseAllTabsVisible = false,
-            isMoreMenuItemEnabled = true,
+            isMenuButtonEnabled = true,
             isMainFabVisible = true,
             isAIFabVisible = false,
             mainFabType = FabType.CLOSE_TABS,
             backButtonType = BackButtonType.CLOSE,
-            layoutButtonType = LayoutButtonType.HIDDEN,
+            layoutButtonMode = LayoutMode.HIDDEN,
+            layoutMenuMode = LayoutMode.HIDDEN,
         )
         assertEquals(expected, viewState.dynamicInterface)
     }
@@ -1242,8 +1261,9 @@ class TabSwitcherViewModelTest {
         val viewState = SelectionViewState(tabSwitcherItems = tabItems, mode = Selection(listOf("1", "2")), layoutType = null)
         val expected = DynamicInterface(
             isFireButtonVisible = false,
-            isNewTabVisible = false,
-            isDuckChatVisible = false,
+            isNewTabMenuVisible = false,
+            isNewTabButtonVisible = false,
+            isDuckAIButtonVisible = false,
             isSelectAllVisible = false,
             isDeselectAllVisible = true,
             isSelectionActionsDividerVisible = true,
@@ -1255,12 +1275,468 @@ class TabSwitcherViewModelTest {
             isCloseOtherTabsVisible = false,
             isCloseAllTabsDividerVisible = true,
             isCloseAllTabsVisible = false,
-            isMoreMenuItemEnabled = true,
+            isMenuButtonEnabled = true,
             isMainFabVisible = true,
             isAIFabVisible = false,
             mainFabType = FabType.CLOSE_TABS,
             backButtonType = BackButtonType.CLOSE,
-            layoutButtonType = LayoutButtonType.HIDDEN,
+            layoutButtonMode = LayoutMode.HIDDEN,
+            layoutMenuMode = LayoutMode.HIDDEN,
+        )
+        assertEquals(expected, viewState.dynamicInterface)
+    }
+
+    // -----
+
+    @Test
+    fun whenNormalModeAndNoTabsAndNewToolbarEnabledThenVerifyDynamicInterface() {
+        val viewState = SelectionViewState(
+            tabSwitcherItems = emptyList(),
+            mode = Normal,
+            layoutType = null,
+            isDuckAIButtonVisible = true,
+            isNewToolbarEnabled = true,
+        )
+        val expected = DynamicInterface(
+            isFireButtonVisible = true,
+            isNewTabMenuVisible = false,
+            isNewTabButtonVisible = true,
+            isDuckAIButtonVisible = true,
+            isSelectAllVisible = false,
+            isDeselectAllVisible = false,
+            isSelectionActionsDividerVisible = false,
+            isShareSelectedLinksVisible = false,
+            isBookmarkSelectedTabsVisible = false,
+            isSelectTabsDividerVisible = true,
+            isSelectTabsVisible = true,
+            isCloseSelectedTabsVisible = false,
+            isCloseOtherTabsVisible = false,
+            isCloseAllTabsDividerVisible = true,
+            isCloseAllTabsVisible = true,
+            isMenuButtonEnabled = true,
+            isMainFabVisible = false,
+            isAIFabVisible = false,
+            mainFabType = FabType.NEW_TAB,
+            backButtonType = BackButtonType.ARROW,
+            layoutButtonMode = LayoutMode.HIDDEN,
+            layoutMenuMode = LayoutMode.HIDDEN,
+        )
+        assertEquals(expected, viewState.dynamicInterface)
+    }
+
+    @Test
+    fun whenNormalModeAndOneNewTabPageAndNewToolbarEnabledThenVerifyDynamicInterface() {
+        val tabItems = listOf(NormalTab(TabEntity("1"), true))
+        val viewState = SelectionViewState(
+            tabSwitcherItems = tabItems,
+            mode = Normal,
+            layoutType = null,
+            isDuckAIButtonVisible = true,
+            isNewToolbarEnabled = true,
+        )
+        val expected = DynamicInterface(
+            isFireButtonVisible = true,
+            isNewTabMenuVisible = false,
+            isNewTabButtonVisible = true,
+            isDuckAIButtonVisible = true,
+            isSelectAllVisible = false,
+            isDeselectAllVisible = false,
+            isSelectionActionsDividerVisible = false,
+            isShareSelectedLinksVisible = false,
+            isBookmarkSelectedTabsVisible = false,
+            isSelectTabsDividerVisible = true,
+            isSelectTabsVisible = true,
+            isCloseSelectedTabsVisible = false,
+            isCloseOtherTabsVisible = false,
+            isCloseAllTabsDividerVisible = true,
+            isCloseAllTabsVisible = true,
+            isMenuButtonEnabled = false,
+            isMainFabVisible = false,
+            isAIFabVisible = false,
+            mainFabType = FabType.NEW_TAB,
+            backButtonType = BackButtonType.ARROW,
+            layoutButtonMode = LayoutMode.HIDDEN,
+            layoutMenuMode = LayoutMode.HIDDEN,
+        )
+        assertEquals(expected, viewState.dynamicInterface)
+    }
+
+    @Test
+    fun whenNormalModeAndMultipleTabsAndNewToolbarEnabledThenVerifyDynamicInterface() {
+        val tabItems = listOf(NormalTab(TabEntity("1"), true), NormalTab(TabEntity("2"), false))
+        val viewState = SelectionViewState(
+            tabSwitcherItems = tabItems,
+            mode = Normal,
+            layoutType = null,
+            isDuckAIButtonVisible = true,
+            isNewToolbarEnabled = true,
+        )
+        val expected = DynamicInterface(
+            isFireButtonVisible = true,
+            isNewTabMenuVisible = false,
+            isNewTabButtonVisible = true,
+            isDuckAIButtonVisible = true,
+            isSelectAllVisible = false,
+            isDeselectAllVisible = false,
+            isSelectionActionsDividerVisible = false,
+            isShareSelectedLinksVisible = false,
+            isBookmarkSelectedTabsVisible = false,
+            isSelectTabsDividerVisible = true,
+            isSelectTabsVisible = true,
+            isCloseSelectedTabsVisible = false,
+            isCloseOtherTabsVisible = false,
+            isCloseAllTabsDividerVisible = true,
+            isCloseAllTabsVisible = true,
+            isMenuButtonEnabled = true,
+            isMainFabVisible = false,
+            isAIFabVisible = false,
+            mainFabType = FabType.NEW_TAB,
+            backButtonType = BackButtonType.ARROW,
+            layoutButtonMode = LayoutMode.HIDDEN,
+            layoutMenuMode = LayoutMode.HIDDEN,
+        )
+        assertEquals(expected, viewState.dynamicInterface)
+    }
+
+    @Test
+    fun whenNormalModeAndNewVisualDesignEnabledAndDuckChatDisabledAndNewToolbarEnabledThenVerifyDynamicInterface() {
+        val tabItems = listOf(NormalTab(TabEntity("1"), true), NormalTab(TabEntity("2"), false))
+        val viewState = SelectionViewState(
+            tabSwitcherItems = tabItems,
+            mode = Normal,
+            layoutType = null,
+            isDuckAIButtonVisible = false,
+            isNewToolbarEnabled = true,
+        )
+        val expected = DynamicInterface(
+            isFireButtonVisible = true,
+            isNewTabMenuVisible = false,
+            isNewTabButtonVisible = true,
+            isDuckAIButtonVisible = false,
+            isSelectAllVisible = false,
+            isDeselectAllVisible = false,
+            isSelectionActionsDividerVisible = false,
+            isShareSelectedLinksVisible = false,
+            isBookmarkSelectedTabsVisible = false,
+            isSelectTabsDividerVisible = true,
+            isSelectTabsVisible = true,
+            isCloseSelectedTabsVisible = false,
+            isCloseOtherTabsVisible = false,
+            isCloseAllTabsDividerVisible = true,
+            isCloseAllTabsVisible = true,
+            isMenuButtonEnabled = true,
+            isMainFabVisible = false,
+            isAIFabVisible = false,
+            mainFabType = FabType.NEW_TAB,
+            backButtonType = BackButtonType.ARROW,
+            layoutButtonMode = LayoutMode.HIDDEN,
+            layoutMenuMode = LayoutMode.HIDDEN,
+        )
+        assertEquals(expected, viewState.dynamicInterface)
+    }
+
+    @Test
+    fun whenNormalModeAndNewVisualDesignDisabledAndDuckChatDisabledAndNewToolbarEnabledThenVerifyDynamicInterface() {
+        val tabItems = listOf(NormalTab(TabEntity("1"), true), NormalTab(TabEntity("2"), false))
+        val viewState = SelectionViewState(
+            tabSwitcherItems = tabItems,
+            mode = Normal,
+            layoutType = null,
+            isDuckAIButtonVisible = false,
+            isNewToolbarEnabled = true,
+        )
+        val expected = DynamicInterface(
+            isFireButtonVisible = true,
+            isNewTabMenuVisible = false,
+            isNewTabButtonVisible = true,
+            isDuckAIButtonVisible = false,
+            isSelectAllVisible = false,
+            isDeselectAllVisible = false,
+            isSelectionActionsDividerVisible = false,
+            isShareSelectedLinksVisible = false,
+            isBookmarkSelectedTabsVisible = false,
+            isSelectTabsDividerVisible = true,
+            isSelectTabsVisible = true,
+            isCloseSelectedTabsVisible = false,
+            isCloseOtherTabsVisible = false,
+            isCloseAllTabsDividerVisible = true,
+            isCloseAllTabsVisible = true,
+            isMenuButtonEnabled = true,
+            isMainFabVisible = false,
+            isAIFabVisible = false,
+            mainFabType = FabType.NEW_TAB,
+            backButtonType = BackButtonType.ARROW,
+            layoutButtonMode = LayoutMode.HIDDEN,
+            layoutMenuMode = LayoutMode.HIDDEN,
+        )
+        assertEquals(expected, viewState.dynamicInterface)
+    }
+
+    @Test
+    fun whenNormalModeAndMultipleTabsAndLayoutIsGridAndNewToolbarEnabledThenVerifyDynamicInterface() {
+        val tabItems = listOf(NormalTab(TabEntity("1"), true), NormalTab(TabEntity("2"), false))
+        val viewState = SelectionViewState(
+            tabSwitcherItems = tabItems,
+            mode = Normal,
+            layoutType = GRID,
+            isDuckAIButtonVisible = true,
+            isNewToolbarEnabled = true,
+        )
+        val expected = DynamicInterface(
+            isFireButtonVisible = true,
+            isNewTabMenuVisible = false,
+            isNewTabButtonVisible = true,
+            isDuckAIButtonVisible = true,
+            isSelectAllVisible = false,
+            isDeselectAllVisible = false,
+            isSelectionActionsDividerVisible = false,
+            isShareSelectedLinksVisible = false,
+            isBookmarkSelectedTabsVisible = false,
+            isSelectTabsDividerVisible = true,
+            isSelectTabsVisible = true,
+            isCloseSelectedTabsVisible = false,
+            isCloseOtherTabsVisible = false,
+            isCloseAllTabsDividerVisible = true,
+            isCloseAllTabsVisible = true,
+            isMenuButtonEnabled = true,
+            isMainFabVisible = false,
+            isAIFabVisible = false,
+            mainFabType = FabType.NEW_TAB,
+            backButtonType = BackButtonType.ARROW,
+            layoutButtonMode = LayoutMode.HIDDEN,
+            layoutMenuMode = LayoutMode.LIST,
+        )
+        assertEquals(expected, viewState.dynamicInterface)
+    }
+
+    @Test
+    fun whenNormalModeAndMultipleTabsAndLayoutIsListAndNewToolbarEnabledThenVerifyDynamicInterface() {
+        val tabItems = listOf(NormalTab(TabEntity("1", "http://cnn.com"), true), NormalTab(TabEntity("2"), false))
+        val viewState = SelectionViewState(
+            tabSwitcherItems = tabItems,
+            mode = Normal,
+            layoutType = LIST,
+            isDuckAIButtonVisible = true,
+            isNewToolbarEnabled = true,
+        )
+        val expected = DynamicInterface(
+            isFireButtonVisible = true,
+            isNewTabMenuVisible = false,
+            isNewTabButtonVisible = true,
+            isDuckAIButtonVisible = true,
+            isSelectAllVisible = false,
+            isDeselectAllVisible = false,
+            isSelectionActionsDividerVisible = false,
+            isShareSelectedLinksVisible = false,
+            isBookmarkSelectedTabsVisible = false,
+            isSelectTabsDividerVisible = true,
+            isSelectTabsVisible = true,
+            isCloseSelectedTabsVisible = false,
+            isCloseOtherTabsVisible = false,
+            isCloseAllTabsDividerVisible = true,
+            isCloseAllTabsVisible = true,
+            isMenuButtonEnabled = true,
+            isMainFabVisible = false,
+            isAIFabVisible = false,
+            mainFabType = FabType.NEW_TAB,
+            backButtonType = BackButtonType.ARROW,
+            layoutButtonMode = LayoutMode.HIDDEN,
+            layoutMenuMode = LayoutMode.GRID,
+        )
+        assertEquals(expected, viewState.dynamicInterface)
+    }
+
+    @Test
+    fun whenSelectionModeAndNoTabsSelectedAndNewToolbarEnabledThenVerifyDynamicInterface() {
+        val tabItems = listOf(
+            SelectableTab(TabEntity("1", "http://cnn.com"), false),
+            SelectableTab(TabEntity("2"), false),
+        )
+        val viewState = SelectionViewState(
+            tabSwitcherItems = tabItems,
+            mode = Selection(emptyList()),
+            layoutType = null,
+            isNewToolbarEnabled = true,
+        )
+        val expected = DynamicInterface(
+            isFireButtonVisible = false,
+            isNewTabMenuVisible = false,
+            isNewTabButtonVisible = false,
+            isDuckAIButtonVisible = false,
+            isSelectAllVisible = true,
+            isDeselectAllVisible = false,
+            isSelectionActionsDividerVisible = false,
+            isShareSelectedLinksVisible = false,
+            isBookmarkSelectedTabsVisible = false,
+            isSelectTabsDividerVisible = false,
+            isSelectTabsVisible = false,
+            isCloseSelectedTabsVisible = false,
+            isCloseOtherTabsVisible = false,
+            isCloseAllTabsDividerVisible = false,
+            isCloseAllTabsVisible = false,
+            isMenuButtonEnabled = true,
+            isMainFabVisible = false,
+            isAIFabVisible = false,
+            mainFabType = FabType.CLOSE_TABS,
+            backButtonType = BackButtonType.CLOSE,
+            layoutButtonMode = LayoutMode.HIDDEN,
+            layoutMenuMode = LayoutMode.HIDDEN,
+        )
+        assertEquals(expected, viewState.dynamicInterface)
+    }
+
+    @Test
+    fun whenSelectionModeAndOneTabSelectedAndNewToolbarEnabledThenVerifyDynamicInterface() {
+        val tabItems = listOf(
+            SelectableTab(TabEntity("1", "http://cnn.com"), true),
+            SelectableTab(TabEntity("2"), false),
+        )
+        val viewState = SelectionViewState(
+            tabSwitcherItems = tabItems,
+            mode = Selection(listOf("1")),
+            layoutType = null,
+            isNewToolbarEnabled = true,
+        )
+        val expected = DynamicInterface(
+            isFireButtonVisible = false,
+            isNewTabMenuVisible = false,
+            isNewTabButtonVisible = false,
+            isDuckAIButtonVisible = false,
+            isSelectAllVisible = true,
+            isDeselectAllVisible = false,
+            isSelectionActionsDividerVisible = true,
+            isShareSelectedLinksVisible = true,
+            isBookmarkSelectedTabsVisible = true,
+            isSelectTabsDividerVisible = false,
+            isSelectTabsVisible = false,
+            isCloseSelectedTabsVisible = true,
+            isCloseOtherTabsVisible = true,
+            isCloseAllTabsDividerVisible = true,
+            isCloseAllTabsVisible = false,
+            isMenuButtonEnabled = true,
+            isMainFabVisible = false,
+            isAIFabVisible = false,
+            mainFabType = FabType.CLOSE_TABS,
+            backButtonType = BackButtonType.CLOSE,
+            layoutButtonMode = LayoutMode.HIDDEN,
+            layoutMenuMode = LayoutMode.HIDDEN,
+        )
+        assertEquals(expected, viewState.dynamicInterface)
+    }
+
+    @Test
+    fun whenSelectionModeAndOneNewTabPageSelectedAndNewToolbarEnabledThenVerifyDynamicInterface() {
+        val tabItems = listOf(
+            SelectableTab(TabEntity("1"), true),
+            SelectableTab(TabEntity("2", url = "cnn.com"), false),
+        )
+        val viewState = SelectionViewState(
+            tabSwitcherItems = tabItems,
+            mode = Selection(listOf("1")),
+            layoutType = null,
+            isNewToolbarEnabled = true,
+        )
+        val expected = DynamicInterface(
+            isFireButtonVisible = false,
+            isNewTabMenuVisible = false,
+            isNewTabButtonVisible = false,
+            isDuckAIButtonVisible = false,
+            isSelectAllVisible = true,
+            isDeselectAllVisible = false,
+            isSelectionActionsDividerVisible = false,
+            isShareSelectedLinksVisible = false,
+            isBookmarkSelectedTabsVisible = false,
+            isSelectTabsDividerVisible = false,
+            isSelectTabsVisible = false,
+            isCloseSelectedTabsVisible = true,
+            isCloseOtherTabsVisible = true,
+            isCloseAllTabsDividerVisible = true,
+            isCloseAllTabsVisible = false,
+            isMenuButtonEnabled = true,
+            isMainFabVisible = false,
+            isAIFabVisible = false,
+            mainFabType = FabType.CLOSE_TABS,
+            backButtonType = BackButtonType.CLOSE,
+            layoutButtonMode = LayoutMode.HIDDEN,
+            layoutMenuMode = LayoutMode.HIDDEN,
+        )
+        assertEquals(expected, viewState.dynamicInterface)
+    }
+
+    @Test
+    fun whenSelectionModeAndMultipleTabsSelectedAndNewToolbarEnabledThenVerifyDynamicInterface() {
+        val tabItems = listOf(
+            SelectableTab(TabEntity("1", "http://cnn.com"), true),
+            SelectableTab(TabEntity("2"), true),
+        )
+        val viewState = SelectionViewState(
+            tabSwitcherItems = tabItems,
+            mode = Selection(listOf("1", "2")),
+            layoutType = null,
+            isNewToolbarEnabled = true,
+        )
+        val expected = DynamicInterface(
+            isFireButtonVisible = false,
+            isNewTabMenuVisible = false,
+            isNewTabButtonVisible = false,
+            isDuckAIButtonVisible = false,
+            isSelectAllVisible = false,
+            isDeselectAllVisible = true,
+            isSelectionActionsDividerVisible = true,
+            isShareSelectedLinksVisible = true,
+            isBookmarkSelectedTabsVisible = true,
+            isSelectTabsDividerVisible = false,
+            isSelectTabsVisible = false,
+            isCloseSelectedTabsVisible = true,
+            isCloseOtherTabsVisible = false,
+            isCloseAllTabsDividerVisible = true,
+            isCloseAllTabsVisible = false,
+            isMenuButtonEnabled = true,
+            isMainFabVisible = false,
+            isAIFabVisible = false,
+            mainFabType = FabType.CLOSE_TABS,
+            backButtonType = BackButtonType.CLOSE,
+            layoutButtonMode = LayoutMode.HIDDEN,
+            layoutMenuMode = LayoutMode.HIDDEN,
+        )
+        assertEquals(expected, viewState.dynamicInterface)
+    }
+
+    @Test
+    fun whenSelectionModeAndAllTabsSelectedAndNewToolbarEnabledThenVerifyDynamicInterface() {
+        val tabItems = listOf(
+            SelectableTab(TabEntity("1", "http://cnn.com"), true),
+            SelectableTab(TabEntity("2"), true),
+        )
+        val viewState = SelectionViewState(
+            tabSwitcherItems = tabItems,
+            mode = Selection(listOf("1", "2")),
+            layoutType = null,
+            isNewToolbarEnabled = true,
+        )
+        val expected = DynamicInterface(
+            isFireButtonVisible = false,
+            isNewTabMenuVisible = false,
+            isNewTabButtonVisible = false,
+            isDuckAIButtonVisible = false,
+            isSelectAllVisible = false,
+            isDeselectAllVisible = true,
+            isSelectionActionsDividerVisible = true,
+            isShareSelectedLinksVisible = true,
+            isBookmarkSelectedTabsVisible = true,
+            isSelectTabsDividerVisible = false,
+            isSelectTabsVisible = false,
+            isCloseSelectedTabsVisible = true,
+            isCloseOtherTabsVisible = false,
+            isCloseAllTabsDividerVisible = true,
+            isCloseAllTabsVisible = false,
+            isMenuButtonEnabled = true,
+            isMainFabVisible = false,
+            isAIFabVisible = false,
+            mainFabType = FabType.CLOSE_TABS,
+            backButtonType = BackButtonType.CLOSE,
+            layoutButtonMode = LayoutMode.HIDDEN,
+            layoutMenuMode = LayoutMode.HIDDEN,
         )
         assertEquals(expected, viewState.dynamicInterface)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1210543205190057?focus=true

### Description

This PR hides the FABs and replaces them with toolbar buttons (NTP, Duck.ai).

### Steps to test this PR

_Normal mode_
- [x] Go to the tab manager
- [x] Verify the FABs are gone
- [x] Verify the layout button is gone (will be added to the menu later)
- [x] Verify the Duck.ai and NTP buttons are visible
- [x] Tap on the menu button
- [x] Verify thew Net tab and Duck.ai menu items are gone
- [x] Check that the new toolbar buttons are functional

_Selection Mode_
- [x] Go to tab manager -> Tap on the Menu button -> Tap Select Tabs
- [x] Verify all toolbar buttons are hidden
- [x] Tap one the Menu button
- [x] Verify Select All option is visible
- [x] Tap on the Select All menu item
- [x] Verify the toolbar buttons are still hidden
- [x] Exit the selection mode
- [x] Verify the Duck.ai and NTP buttons are visible now
