### PR TITLE
always show full URL when focusing input screen

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1050,14 +1050,14 @@ class BrowserTabFragment :
         configureItemPressedListener()
         configureCustomTab()
         configureEditModeChangeDetection()
-        configureClickCatcher()
+        configureInputScreenLauncher()
     }
 
-    private fun configureClickCatcher() {
-        omnibar.omniBarClickCatcher?.setOnClickListener {
+    private fun configureInputScreenLauncher() {
+        omnibar.configureInputScreenLaunchListener { query ->
             val intent = globalActivityStarter.startIntent(
                 requireContext(),
-                InputScreenActivityParams(query = omnibar.getText()),
+                InputScreenActivityParams(query = query),
             )
             val options = ActivityOptionsCompat.makeSceneTransitionAnimation(
                 requireActivity(),

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
@@ -158,6 +158,12 @@ class Omnibar(
         fun onTrackersCountFinished()
     }
 
+    fun interface InputScreenLaunchListener {
+        fun launchInputScreen(
+            query: String,
+        )
+    }
+
     data class OmnibarTextState(
         val text: String,
         val hasFocus: Boolean,
@@ -231,13 +237,6 @@ class Omnibar(
         newOmnibar.omniBarContainer
     }
 
-    val omniBarClickCatcher: View? by lazy {
-        when (omnibarType) {
-            SINGLE -> (newOmnibar as? SingleOmnibarLayout)?.omniBarClickCatcher
-            else -> null
-        }
-    }
-
     val toolbar: Toolbar by lazy {
         newOmnibar.toolbar
     }
@@ -303,6 +302,10 @@ class Omnibar(
         } else if (omnibar is SingleOmnibarLayout) {
             omnibar.setSingleOmnibarItemPressedListener(listener)
         }
+    }
+
+    fun configureInputScreenLaunchListener(listener: InputScreenLaunchListener) {
+        newOmnibar.setInputScreenLaunchListener(listener)
     }
 
     fun addTextListener(listener: TextListener) {

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -67,6 +67,7 @@ import com.duckduckgo.app.browser.omnibar.OmnibarLayout.Decoration.NewTabScrolli
 import com.duckduckgo.app.browser.omnibar.OmnibarLayout.Decoration.PrivacyShieldChanged
 import com.duckduckgo.app.browser.omnibar.OmnibarLayout.Decoration.QueueCookiesAnimation
 import com.duckduckgo.app.browser.omnibar.OmnibarLayoutViewModel.Command
+import com.duckduckgo.app.browser.omnibar.OmnibarLayoutViewModel.Command.LaunchInputScreen
 import com.duckduckgo.app.browser.omnibar.OmnibarLayoutViewModel.Command.MoveCaretToFront
 import com.duckduckgo.app.browser.omnibar.OmnibarLayoutViewModel.Command.StartCookiesAnimation
 import com.duckduckgo.app.browser.omnibar.OmnibarLayoutViewModel.Command.StartExperimentVariant1Animation
@@ -199,6 +200,7 @@ open class OmnibarLayout @JvmOverloads constructor(
 
     private var omnibarTextListener: Omnibar.TextListener? = null
     private var omnibarItemPressedListener: Omnibar.ItemPressedListener? = null
+    private var omnibarInputScreenLaunchListener: Omnibar.InputScreenLaunchListener? = null
 
     private var decoration: Decoration? = null
     private var lastViewMode: Mode? = null
@@ -262,6 +264,7 @@ open class OmnibarLayout @JvmOverloads constructor(
             )
         }
     }
+    private val omnibarTextInputClickCatcher: View by lazy { findViewById(R.id.omnibarTextInputClickCatcher) }
 
     internal fun omnibarViews(): List<View> = listOf(
         clearTextButton,
@@ -549,6 +552,10 @@ open class OmnibarLayout @JvmOverloads constructor(
             is StartExperimentVariant2OrVariant3Animation -> {
                 startExperimentVariant2OrVariant3Animation(command.entities)
             }
+
+            is LaunchInputScreen -> {
+                omnibarInputScreenLaunchListener?.launchInputScreen(query = command.query)
+            }
         }
     }
 
@@ -668,6 +675,8 @@ open class OmnibarLayout @JvmOverloads constructor(
         }
 
         previousTransitionState = newTransitionState
+
+        enableTextInputClickCatcher(viewState.showTextInputClickCatcher)
     }
 
     private fun renderBrowserMode(viewState: ViewState) {
@@ -1027,6 +1036,23 @@ open class OmnibarLayout @JvmOverloads constructor(
 
     fun setDraftTextIfNtp(query: String) {
         viewModel.setDraftTextIfNtp(query)
+    }
+
+    private fun enableTextInputClickCatcher(enabled: Boolean) {
+        omnibarTextInputClickCatcher.isVisible = enabled
+
+        omnibarTextInput.apply {
+            isEnabled = !enabled
+            isFocusable = !enabled
+            isFocusableInTouchMode = !enabled
+        }
+    }
+
+    fun setInputScreenLaunchListener(listener: Omnibar.InputScreenLaunchListener) {
+        omnibarInputScreenLaunchListener = listener
+        omnibarTextInputClickCatcher.setOnClickListener {
+            viewModel.onTextInputClickCatcherClicked()
+        }
     }
 }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -174,7 +174,7 @@ class OmnibarLayoutViewModel @Inject constructor(
         val trackersBlocked: Int = 0,
         val previouslyTrackersBlocked: Int = 0,
         val showShadows: Boolean = false,
-        val showClickCatcher: Boolean = false,
+        val showTextInputClickCatcher: Boolean = false,
         val showFindInPage: Boolean = false,
     ) {
         fun shouldUpdateOmnibarText(isFullUrlEnabled: Boolean): Boolean {
@@ -190,6 +190,7 @@ class OmnibarLayoutViewModel @Inject constructor(
         data object StartExperimentVariant1Animation : Command()
         data class StartExperimentVariant2OrVariant3Animation(val entities: List<Entity>?) : Command()
         data object MoveCaretToFront : Command()
+        data class LaunchInputScreen(val query: String) : Command()
     }
 
     enum class LeadingIconState {
@@ -205,7 +206,7 @@ class OmnibarLayoutViewModel @Inject constructor(
         duckAiFeatureState.showInputScreen.onEach { inputScreenEnabled ->
             _viewState.update {
                 it.copy(
-                    showClickCatcher = inputScreenEnabled,
+                    showTextInputClickCatcher = inputScreenEnabled,
                 )
             }
         }.launchIn(viewModelScope)
@@ -848,6 +849,20 @@ class OmnibarLayoutViewModel @Inject constructor(
                     updateOmnibarText = true,
                 )
             }
+        }
+    }
+
+    fun onTextInputClickCatcherClicked() {
+        viewModelScope.launch {
+            val omnibarText = viewState.value.omnibarText
+            val url = viewState.value.url
+            val isDuckDuckGoQueryUrl = duckDuckGoUrlDetector.isDuckDuckGoQueryUrl(url)
+            val textToPreFill = if (omnibarText.isNotEmpty() && url.isNotEmpty() && !isDuckDuckGoQueryUrl) {
+                url
+            } else {
+                omnibarText
+            }
+            command.send(Command.LaunchInputScreen(query = textToPreFill))
         }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/FadeOmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/FadeOmnibarLayout.kt
@@ -75,7 +75,6 @@ class FadeOmnibarLayout @JvmOverloads constructor(
     private val omniBarContentContainer: View by lazy { findViewById(R.id.omniBarContentContainer) }
     private val backIcon: ImageView by lazy { findViewById(R.id.backIcon) }
     private val customTabToolbarContainerWrapper: ViewGroup by lazy { findViewById(R.id.customTabToolbarContainerWrapper) }
-    val omniBarClickCatcher: View by lazy { findViewById(R.id.omnibarClickCatcher) }
 
     override val findInPage: FindInPage by lazy {
         FindInPageImpl(IncludeFadeOmnibarFindInPageBinding.bind(findViewById(R.id.findInPage)))
@@ -224,18 +223,6 @@ class FadeOmnibarLayout @JvmOverloads constructor(
             duckPlayerIcon.gone()
         } else {
             backIcon.gone()
-        }
-
-        enableClickCatcher(viewState.showClickCatcher)
-    }
-
-    private fun enableClickCatcher(enabled: Boolean) {
-        omniBarClickCatcher.isVisible = enabled
-
-        omnibarTextInput.apply {
-            isEnabled = !enabled
-            isFocusable = !enabled
-            isFocusableInTouchMode = !enabled
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/SingleOmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/experiments/SingleOmnibarLayout.kt
@@ -65,7 +65,6 @@ class SingleOmnibarLayout @JvmOverloads constructor(
     private val omniBarContentContainer: View by lazy { findViewById(R.id.omniBarContentContainer) }
     private val backIcon: ImageView by lazy { findViewById(R.id.backIcon) }
     private val customTabToolbarContainerWrapper: ViewGroup by lazy { findViewById(R.id.customTabToolbarContainerWrapper) }
-    val omniBarClickCatcher: View by lazy { findViewById(R.id.omnibarClickCatcher) }
 
     override val findInPage: FindInPage by lazy {
         FindInPageImpl(IncludeFadeOmnibarFindInPageBinding.bind(findViewById(R.id.findInPage)))
@@ -174,8 +173,6 @@ class SingleOmnibarLayout @JvmOverloads constructor(
         } else {
             backIcon.hide()
         }
-
-        omniBarClickCatcher.isVisible = viewState.showClickCatcher
     }
 
     private fun animateOmnibarFocusedState(focused: Boolean) {

--- a/app/src/main/res/layout/view_fade_omnibar.xml
+++ b/app/src/main/res/layout/view_fade_omnibar.xml
@@ -317,7 +317,7 @@
                         </androidx.constraintlayout.widget.ConstraintLayout>
 
                         <View
-                            android:id="@+id/omnibarClickCatcher"
+                            android:id="@+id/omnibarTextInputClickCatcher"
                             android:layout_width="0dp"
                             android:layout_height="0dp"
                             android:background="@android:color/transparent"

--- a/app/src/main/res/layout/view_single_omnibar.xml
+++ b/app/src/main/res/layout/view_single_omnibar.xml
@@ -325,7 +325,7 @@
                             </androidx.constraintlayout.widget.ConstraintLayout>
 
                             <View
-                                android:id="@+id/omnibarClickCatcher"
+                                android:id="@+id/omnibarTextInputClickCatcher"
                                 android:layout_width="0dp"
                                 android:layout_height="0dp"
                                 android:background="@android:color/transparent"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1210672287029312?focus=true

### Description
Ensures that Input Screen is pre-filled with full URL even if the option to show full URL in an unfocused omnibar is disabled.

### Steps to test this PR

- [x] Disable Settings -> Appearance -> Show Full Site Address
- [x] NTP
  - [x] Go to NTP
  - [x] Open input screen
  - [x] Type anything
  - [x] Go back without submitting
  - [x] Open input screen again
  - [x] Verify your draft text is pre-filled
- [x] SERP
  - [x] Search for anything
  - [x] Open input screen
  - [x] Verify your search query is pre-filled
- [x] Website
  - [x] Go to a website, the URL should only show the domain (without protocol, path, query params, etc)
  - [x] Open input screen
  - [x] Verify that the full URL with path and query params is pre-filled
