### PR TITLE
Update content scope scripts workflow description

### DIFF
--- a/.github/workflows/update-content-scope.yml
+++ b/.github/workflows/update-content-scope.yml
@@ -70,9 +70,20 @@ jobs:
             - Automated content scope scripts dependency update
 
             This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
+
+            Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.
+
+            If only the package version has changed, there is no need to run the tests.
+
             If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.
 
+            _`content-scope-scripts` folder update_
             - [ ] All tests must pass
+            - [ ] Privacy tests must pass
+
+            _Only `content-scope-scripts` package update_
+            - [ ] All tests must pass
+            - [ ] Privacy tests do not need to run
 
       - name: Create Asana task in Android App project
         if: ${{ steps.update-check.outcome == 'failure' }}
@@ -86,7 +97,11 @@ jobs:
           asana-task-description: |
             Content scope scripts have been updated and a PR created.
 
-            If tests failed check out https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.
+            Tests will **only** run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.
+
+            If only `content-scope-scripts` package version has changed, there is no need to run the tests.
+
+            If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.
 
             See ${{ steps.create-pr.outputs.pull-request-url }}
           action: 'create-asana-task'


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1210785772751175?focus=true

### Description

This PR enhances the automated content scope scripts update workflow by:

1. Clarifying when tests need to run:
   - Tests will only run if the `node_modules/@duckduckgo/content-scope-scripts` folder content has changed
   - If only the package version changed, tests don't need to run

2. Adding clearer PR checklist with two scenarios:
   - When content-scope-scripts folder is updated: all tests and privacy tests must pass
   - When only the package version is updated: all tests must pass but privacy tests can be skipped

3. Updating the Asana task description to include the same clarification about when tests need to run

### Steps to test this PR

_Workflow Changes_
- [x] Confirm PR description includes the correct checklist based on what was updated