### PR TITLE
Add missing omnibarTextInputClickCatcher to "old" new_omnibars

### DIFF
--- a/app/src/main/res/layout/view_new_omnibar.xml
+++ b/app/src/main/res/layout/view_new_omnibar.xml
@@ -209,6 +209,20 @@
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintTop_toTopOf="parent" />
 
+                    <View
+                        android:id="@+id/omnibarTextInputClickCatcher"
+                        android:layout_width="0dp"
+                        android:layout_height="0dp"
+                        android:background="@android:color/transparent"
+                        android:clickable="true"
+                        android:focusable="false"
+                        android:focusableInTouchMode="false"
+                        android:visibility="gone"
+                        app:layout_constraintBottom_toBottomOf="@id/omnibarTextInput"
+                        app:layout_constraintEnd_toEndOf="@id/omnibarTextInput"
+                        app:layout_constraintStart_toStartOf="@id/omnibarTextInput"
+                        app:layout_constraintTop_toTopOf="@id/omnibarTextInput" />
+
                     <com.duckduckgo.common.ui.view.text.DaxTextView
                         android:id="@+id/trackersBlockedTextView"
                         android:layout_width="0dp"

--- a/app/src/main/res/layout/view_new_omnibar_bottom.xml
+++ b/app/src/main/res/layout/view_new_omnibar_bottom.xml
@@ -210,6 +210,20 @@
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintTop_toTopOf="parent" />
 
+                    <View
+                        android:id="@+id/omnibarTextInputClickCatcher"
+                        android:layout_width="0dp"
+                        android:layout_height="0dp"
+                        android:background="@android:color/transparent"
+                        android:clickable="true"
+                        android:focusable="false"
+                        android:focusableInTouchMode="false"
+                        android:visibility="gone"
+                        app:layout_constraintBottom_toBottomOf="@id/omnibarTextInput"
+                        app:layout_constraintEnd_toEndOf="@id/omnibarTextInput"
+                        app:layout_constraintStart_toStartOf="@id/omnibarTextInput"
+                        app:layout_constraintTop_toTopOf="@id/omnibarTextInput" />
+
                     <com.duckduckgo.common.ui.view.text.DaxTextView
                         android:id="@+id/trackersBlockedTextView"
                         android:layout_width="0dp"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1210803032371220?focus=true

### Description

Adds the missing `omnibarTextInputClickCatcher` to the old omnibars to stop the app crashing if the user is seeing these omnibar variants 

### Steps to test this PR

_Old top omnibar_
- [x] Ensure old top omnibar is visible (no hovering text input box, duck ai icon inside text input) You might need to delete `@Toggle.InternalAlwaysEnabled` from `singleOmnibarFeature` if testing on internalDebug
- [x] App does not crash
- [x] Search or enter a website
- [x] Search or website loads

_Old bottom omnibar_
- [x] Ensure old bottom omnibar is visible (no hovering text input box, duck ai icon inside text input)
- [x] App does not crash
- [x] Search or enter a website
- [x] Search or website loads

### UI changes
N/A
