### PR TITLE
default to single line input text box height

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
@@ -321,7 +321,7 @@ class InputModeWidget @JvmOverloads constructor(
         private const val DEFAULT_ANIMATION_DURATION = 300L
         private const val FADE_DURATION = 150L
         private const val MAX_LINES = 8
-        private const val SEARCH_MIN_LINES = 2
-        private const val DUCK_CHAT_MIN_LINES = 2
+        private const val SEARCH_MIN_LINES = 1
+        private const val DUCK_CHAT_MIN_LINES = 1
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1210802463306062?focus=true

### Description
Default to single line when opening the Input Screen.

### Steps to test this PR

- [ ] Verify opening the input screen from NTP (without any text) opens as a single line.
- [ ] Verify opening the input screen on web pages still pre-fills the URL in multi lines.
