### PR TITLE
Add referer header for Duck Player

### DIFF
--- a/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerFeature.kt
+++ b/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/DuckPlayerFeature.kt
@@ -57,4 +57,11 @@ interface DuckPlayerFeature {
      */
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun customError(): Toggle
+
+    /**
+     * @return `true` when the remote config has the "addCustomEmbedReferer" feature flag enabled
+     * If the remote feature is not present defaults to `false`
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun addCustomEmbedReferer(): Toggle
 }

--- a/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/RealDuckPlayer.kt
+++ b/duckplayer/duckplayer-impl/src/main/java/com/duckduckgo/duckplayer/impl/RealDuckPlayer.kt
@@ -66,7 +66,6 @@ import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
-import java.io.IOException
 import java.io.InputStream
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
@@ -326,10 +325,8 @@ class RealDuckPlayer @Inject constructor(
             } else if (isSimulatedYoutubeNoCookie(url)) {
                 return processSimulatedYouTubeNoCookieUri(url, webView)
             } else if (duckPlayerFeature.addCustomEmbedReferer().isEnabled() && isYouTubeNoCookieEmbedUri(url, webViewUrl)) {
-                return try {
-                    WebResourceResponse("text/html", "UTF-8", getEmbedWithReferer(request))
-                } catch (e: IOException) {
-                    null
+                return getEmbedWithReferer(request)?.let { inputStream ->
+                    WebResourceResponse("text/html", "UTF-8", inputStream)
                 }
             }
         }

--- a/duckplayer/duckplayer-impl/src/test/kotlin/com/duckduckgo/duckplayer/impl/RealDuckPlayerTest.kt
+++ b/duckplayer/duckplayer-impl/src/test/kotlin/com/duckduckgo/duckplayer/impl/RealDuckPlayerTest.kt
@@ -53,6 +53,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -80,6 +81,7 @@ class RealDuckPlayerTest {
     private val mockDuckPlayerLocalFilesPath: DuckPlayerLocalFilesPath = mock()
     private val mimeType: MimeTypeMap = mock()
     private val dispatcherProvider = coroutineRule.testDispatcherProvider
+    private val mockOkHttpClient: OkHttpClient = mock()
 
     private val testee = RealDuckPlayer(
         mockDuckPlayerFeatureRepository,
@@ -90,6 +92,7 @@ class RealDuckPlayerTest {
         dispatcherProvider,
         true,
         coroutineRule.testScope,
+        mockOkHttpClient,
     )
 
     @Before

--- a/duckplayer/duckplayer-impl/src/test/kotlin/com/duckduckgo/duckplayer/impl/RealDuckPlayerTest.kt
+++ b/duckplayer/duckplayer-impl/src/test/kotlin/com/duckduckgo/duckplayer/impl/RealDuckPlayerTest.kt
@@ -783,6 +783,27 @@ class RealDuckPlayerTest {
     }
 
     @Test
+    fun whenIsYouTubeNoCookieEmbedUriForCurrentDuckPlayerVideoAndAddCustomEmbedRefererAndRequestEmbedReturnsNull_thenReturnNull() = runTest {
+        val mockRequest: WebResourceRequest = mock()
+        whenever(mockRequest.isForMainFrame).thenReturn(true)
+        val headers = mapOf("header" to "value", "referer" to "value")
+        val expectedHeaders = headers.plus("referer" to "http://android.mobile.duckduckgo.com")
+        whenever(mockRequest.requestHeaders).thenReturn(headers)
+        val url: Uri = Uri.parse("https://www.youtube-nocookie.com/embed/12345")
+        whenever(mockRequest.url).thenReturn(url)
+        duckPlayerFeature.addCustomEmbedReferer().setRawStoredState(State(true))
+        val webView: WebView = mock()
+        whenever(webView.url).thenReturn("https://www.youtube-nocookie.com?videoID=12345")
+        whenever(mockDuckPlayerFeatureRepository.getUserPreferences()).thenReturn(UserPreferences(true, AlwaysAsk))
+        whenever(mockDuckPlayerFeatureRepository.requestEmbed(url.toString(), expectedHeaders)).thenReturn(null)
+
+        val result = testee.intercept(mockRequest, url, webView)
+
+        verify(mockDuckPlayerFeatureRepository).requestEmbed(url.toString(), expectedHeaders)
+        assertNull(result)
+    }
+
+    @Test
     fun whenIsYouTubeNoCookieEmbedUriForCurrentDuckPlayerVideoAndAddCustomEmbedRefererDisabled_thenReturnNull() = runTest {
         val mockRequest: WebResourceRequest = mock()
         whenever(mockRequest.isForMainFrame).thenReturn(true)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1210811808963690?focus=true 

### Description
Set referer header to local assets directory in compliance with new TOS

### Steps to test this PR

_Feature 1_
- [ ] Set up Charles Proxy
    - [ ] Disable macOS proxy under Charles toolbar > Proxy
    - [ ] Enable SSL proxying and include location `*:*` under Charles toolbar > Proxy > SSL Proxying settings
    - [ ] Check IP address under Charles toolbar > Help > Local IP addresses. Check port under Charles toolbar > Proxy settings
- [ ] Set up proxy for WiFi connection on your phone by setting IP address and port from previous step
- [ ] Open the app and load http://charlesproxy.com/getssl
- [ ] Download the certificate and install as CA certificate
- [ ] Load a video on Duck Player
- [ ] Using Charles proxy, check that requests to `https://www.youtube-nocookie.com/embed/...` have `referer` header set to `http://android.mobile.duckduckgo.com`

### UI changes
n/a
