### PR TITLE
Update content scope scripts to version 10.13.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
@@ -502,6 +502,7 @@
       "breakageReporting",
       "autofillPasswordImport",
       "favicon",
+      "webTelemetry",
       "scriptlets"
     ]
   );
@@ -522,6 +523,7 @@
     windows: [
       "cookie",
       ...baseFeatures,
+      "webTelemetry",
       "windowsPermissionUsage",
       "duckPlayer",
       "brokerProtection",

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -2001,6 +2001,7 @@
       "breakageReporting",
       "autofillPasswordImport",
       "favicon",
+      "webTelemetry",
       "scriptlets"
     ]
   );
@@ -2021,6 +2022,7 @@
     windows: [
       "cookie",
       ...baseFeatures,
+      "webTelemetry",
       "windowsPermissionUsage",
       "duckPlayer",
       "brokerProtection",

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -1330,6 +1330,7 @@
       "breakageReporting",
       "autofillPasswordImport",
       "favicon",
+      "webTelemetry",
       "scriptlets"
     ]
   );
@@ -1350,6 +1351,7 @@
     windows: [
       "cookie",
       ...baseFeatures,
+      "webTelemetry",
       "windowsPermissionUsage",
       "duckPlayer",
       "brokerProtection",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.8.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.2.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.12.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.13.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#40e84974805a910979961ded1d5003584d9d94b5",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#4935471fe659cad802f0fe3d4c51c8cf1318ae86",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.8.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.2.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.12.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.13.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1210817225484607/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [x] All tests must pass
- [x] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run