### PR TITLE
PIR: Add support for multiple profile queries in PirScan and PirOptOut

### DIFF
--- a/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/common/BrokerStepsParser.kt
+++ b/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/common/BrokerStepsParser.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.pir.internal.common.BrokerStepsParser.BrokerStep.OptOutSte
 import com.duckduckgo.pir.internal.common.BrokerStepsParser.BrokerStep.ScanStep
 import com.duckduckgo.pir.internal.scripts.models.BrokerAction
 import com.duckduckgo.pir.internal.scripts.models.ExtractedProfile
+import com.duckduckgo.pir.internal.scripts.models.ProfileQuery
 import com.duckduckgo.pir.internal.store.PirRepository
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.moshi.JsonAdapter
@@ -40,12 +41,14 @@ interface BrokerStepsParser {
      *
      * @param brokerName - name of the broker to which these steps belong to
      * @param stepsJson - string in JSONObject format obtained from the broker's json representing a step (scan / opt-out).
+     * @param profileQuery - profile associated with the step (used for the opt-out step)
      * @return list of broker steps resulting from the passed params. If the step is of type OptOut, it will return a list of
      *  OptOutSteps where an OptOut step is mapped to each of the profile for the broker.
      */
     suspend fun parseStep(
         brokerName: String,
         stepsJson: String,
+        profileQuery: ProfileQuery? = null,
     ): List<BrokerStep>
 
     sealed class BrokerStep(
@@ -101,16 +104,22 @@ class RealBrokerStepsParser @Inject constructor(
     override suspend fun parseStep(
         brokerName: String,
         stepsJson: String,
+        profileQuery: ProfileQuery?,
     ): List<BrokerStep> = withContext(dispatcherProvider.io()) {
         return@withContext runCatching {
             adapter.fromJson(stepsJson)?.run {
                 if (this is OptOutStep) {
-                    repository.getExtractProfileResultForBroker(brokerName)?.extractResults?.map {
-                        this.copy(
-                            brokerName = brokerName,
-                            profileToOptOut = it,
-                        )
-                    }
+                    repository.getExtractProfileResultsForBroker(brokerName)
+                        .filter { it.profileQuery != null && it.profileQuery.id == profileQuery?.id }
+                        .map {
+                            it.extractResults.map { extractedProfile ->
+                                this.copy(
+                                    brokerName = brokerName,
+                                    profileToOptOut = extractedProfile,
+                                )
+                            }
+                        }
+                        .flatten()
                 } else {
                     listOf((this as ScanStep).copy(brokerName = brokerName))
                 }

--- a/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/common/PirActionsRunner.kt
+++ b/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/common/PirActionsRunner.kt
@@ -145,8 +145,8 @@ class RealPirActionsRunner @AssistedInject constructor(
         }
 
         withContext(dispatcherProvider.main()) {
-            logcat { "PIR-RUNNER (${this@RealPirActionsRunner}): ${Thread.currentThread().name} Brokers to execute $brokerSteps" }
-            logcat { "PIR-RUNNER (${this@RealPirActionsRunner}): ${Thread.currentThread().name} Brokers size: ${brokerSteps.size}" }
+            logcat { "PIR-RUNNER (${this@RealPirActionsRunner}): ${Thread.currentThread().name} profile=$profileQuery Brokers to execute $brokerSteps" }
+            logcat { "PIR-RUNNER (${this@RealPirActionsRunner}): ${Thread.currentThread().name} profile=$profileQuery Brokers size: ${brokerSteps.size}" }
             detachedWebView = pirDetachedWebViewProvider.createInstance(
                 context,
                 pirScriptToLoad,

--- a/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/scan/PirScan.kt
+++ b/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/scan/PirScan.kt
@@ -96,21 +96,58 @@ class RealPirScan @Inject constructor(
     callbacks: PluginPoint<PirCallbacks>,
 ) : PirScan, PirJob(callbacks) {
 
-    private var profileQuery: ProfileQuery = ProfileQuery(
-        firstName = "William",
-        lastName = "Smith",
-        city = "Chicago",
-        state = "IL",
-        addresses = listOf(
-            Address(
-                city = "Chicago",
-                state = "IL",
+    private var profileQueries: List<ProfileQuery> = listOf(
+        ProfileQuery(
+            id = -1,
+            firstName = "William",
+            lastName = "Smith",
+            city = "Chicago",
+            state = "IL",
+            addresses = listOf(
+                Address(
+                    city = "Chicago",
+                    state = "IL",
+                ),
             ),
+            birthYear = 1993,
+            fullName = "William Smith",
+            age = 32,
+            deprecated = false,
         ),
-        birthYear = 1993,
-        fullName = "William Smith",
-        age = 32,
-        deprecated = false,
+        ProfileQuery(
+            id = -2,
+            firstName = "Jane",
+            lastName = "Doe",
+            city = "New York",
+            state = "NY",
+            addresses = listOf(
+                Address(
+                    city = "New York",
+                    state = "NY",
+                ),
+            ),
+            birthYear = 1990,
+            fullName = "Jane Doe",
+            age = 35,
+            deprecated = false,
+        ),
+        ProfileQuery(
+            id = -3,
+            firstName = "Alicia",
+            lastName = "West",
+            city = "Los Angeles",
+            state = "CA",
+            addresses = listOf(
+                Address(
+                    city = "Los Angeles",
+                    state = "CA",
+                ),
+            ),
+            birthYear = 1985,
+            fullName = "Alicia West",
+            age = 40,
+            deprecated = false,
+        ),
     )
 
     private val runners: MutableList<PirActionsRunner> = mutableListOf()
@@ -149,23 +186,32 @@ class RealPirScan @Inject constructor(
             createCount++
         }
 
-        // Start each runner on a subset of the broker steps.
-        brokers.mapNotNull { broker ->
+        // Split all the broker steps into parts that can be executed in parallel
+        val brokerScanSteps = brokers.mapNotNull { broker ->
             repository.getBrokerScanSteps(broker)?.run {
                 brokerStepsParser.parseStep(broker, this)
             }
         }.filter {
             it.isNotEmpty()
-        }.flatten().splitIntoParts(maxWebViewCount)
-            .mapIndexed { index, part ->
+        }.flatten()
+            .splitIntoParts(maxWebViewCount)
+
+        // Run the scan steps for all profiles one after another
+        profileQueries.forEach { profile ->
+            logcat { "PIR-SCAN: Start scan on profile=$profile" }
+
+            brokerScanSteps.mapIndexed { index, part ->
                 // We want to run the runners in parallel but wait for everything complete before we proceed
                 async {
-                    runners[index].start(profileQuery, part)
+                    runners[index].start(profile, part)
                     runners[index].stop()
                 }
             }.awaitAll()
 
-        logcat { "PIR-SCAN: Scan completed for all runners" }
+            logcat { "PIR-SCAN: Finish scan on profile=$profile" }
+        }
+
+        logcat { "PIR-SCAN: Scan completed for all runners on all profiles" }
         emitScanCompletedPixel(
             runType,
             currentTimeProvider.currentTimeMillis() - startTimeMillis,
@@ -183,33 +229,34 @@ class RealPirScan @Inject constructor(
             runners.clear()
         }
         repository.deleteAllScanResults()
-        repository.getUserProfiles().also {
-            if (it.isNotEmpty()) {
-                // Temporarily taking the first profile only for the PoC. In the reality, more than 1 should be allowed.
-                val storedProfile = it[0]
-                profileQuery = ProfileQuery(
-                    firstName = storedProfile.userName.firstName,
-                    lastName = storedProfile.userName.lastName,
-                    city = storedProfile.addresses.city,
-                    state = storedProfile.addresses.state,
-                    addresses = listOf(
-                        Address(
-                            city = storedProfile.addresses.city,
-                            state = storedProfile.addresses.state,
+        repository.getUserProfiles().also { profiles ->
+            if (profiles.isNotEmpty()) {
+                profileQueries = profiles.map { storedProfile ->
+                    ProfileQuery(
+                        id = storedProfile.id,
+                        firstName = storedProfile.userName.firstName,
+                        lastName = storedProfile.userName.lastName,
+                        city = storedProfile.addresses.city,
+                        state = storedProfile.addresses.state,
+                        addresses = listOf(
+                            Address(
+                                city = storedProfile.addresses.city,
+                                state = storedProfile.addresses.state,
+                            ),
                         ),
-                    ),
-                    birthYear = storedProfile.birthYear,
-                    fullName = storedProfile.userName.middleName?.run {
-                        "${storedProfile.userName.firstName} $this ${storedProfile.userName.lastName}"
-                    }
-                        ?: "${storedProfile.userName.firstName} ${storedProfile.userName.lastName}",
-                    age = LocalDate.now().year - storedProfile.birthYear,
-                    deprecated = false,
-                )
+                        birthYear = storedProfile.birthYear,
+                        fullName = storedProfile.userName.middleName?.run {
+                            "${storedProfile.userName.firstName} $this ${storedProfile.userName.lastName}"
+                        }
+                            ?: "${storedProfile.userName.firstName} ${storedProfile.userName.lastName}",
+                        age = LocalDate.now().year - storedProfile.birthYear,
+                        deprecated = false,
+                    )
+                }
             }
         }
 
-        logcat { "PIR-SCAN: Running scan on profile: $profileQuery on ${Thread.currentThread().name}" }
+        logcat { "PIR-SCAN: Running scan on profiles: $profileQueries on ${Thread.currentThread().name}" }
     }
 
     override suspend fun executeAllBrokers(

--- a/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/scripts/models/PirScriptProfile.kt
+++ b/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/scripts/models/PirScriptProfile.kt
@@ -20,7 +20,7 @@ package com.duckduckgo.pir.internal.scripts.models
  * This profile represents the data we can get from the web UI / from the user
  */
 data class ProfileQuery(
-    val id: Int? = null,
+    val id: Long? = null,
     val firstName: String,
     val lastName: String,
     val middleName: String? = null,

--- a/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/store/db/ScanResultsDao.kt
+++ b/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/store/db/ScanResultsDao.kt
@@ -55,7 +55,7 @@ interface ScanResultsDao {
     fun getAllExtractProfileResult(): List<ExtractProfileResult>
 
     @Query("SELECT * FROM pir_scan_extracted_profile WHERE brokerName = :brokerName ORDER BY completionTimeInMillis")
-    fun getExtractProfileResultForProfile(brokerName: String): List<ExtractProfileResult>
+    fun getExtractProfileResultForBroker(brokerName: String): List<ExtractProfileResult>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insertExtractProfileResult(extractProfileResult: ExtractProfileResult)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1210594645151737/task/1210750227652612?focus=true

### Description
Adds support for running the initial PIR scan and PIR opt-out scan on multiple stored profiles instead of the first stored profile. See the task for more details and a full tech spec.

### Steps to test this PR

_1 profile (current behavior)_
- [ ] Enter a new profile and trigger scan - scan runs for 1 profile
- [ ] Go to opt-out scan and trigger it for any broker - scan runs for 1 profile

_Multiple profiles (new behavior)_
- [ ] Clear data and trigger scan without any input - scan runs for 3 hardcoded profiles
- [ ] Go to opt-out scan and trigger it for any broker - scan runs for all 3 profiles (assuming that the profiles were found for that broker)


### UI changes
No UI Changes
