### PR TITLE
Update destination screen for clear data notification

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/firebutton/FireButtonActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/firebutton/FireButtonActivity.kt
@@ -17,6 +17,8 @@
 package com.duckduckgo.app.firebutton
 
 import android.app.ActivityOptions
+import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import androidx.annotation.StringRes
 import androidx.lifecycle.Lifecycle
@@ -70,6 +72,10 @@ class FireButtonActivity : DuckDuckGoActivity() {
 
         configureUiEventHandlers()
         observeViewModel()
+
+        intent?.getStringExtra(LAUNCH_FROM_NOTIFICATION_PIXEL_NAME)?.let {
+            viewModel.onLaunchedFromNotification(it)
+        }
     }
 
     private fun configureUiEventHandlers() {
@@ -237,5 +243,13 @@ class FireButtonActivity : DuckDuckGoActivity() {
                 },
             )
             .show()
+    }
+
+    companion object {
+        const val LAUNCH_FROM_NOTIFICATION_PIXEL_NAME = "LAUNCH_FROM_NOTIFICATION_PIXEL_NAME"
+
+        fun intent(context: Context): Intent {
+            return Intent(context, FireButtonActivity::class.java)
+        }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/firebutton/FireButtonViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/firebutton/FireButtonViewModel.kt
@@ -172,6 +172,10 @@ class FireButtonViewModel @Inject constructor(
         pixel.fire(AppPixelName.FIRE_ANIMATION_NEW_SELECTED, mapOf(Pixel.PixelParameter.FIRE_ANIMATION to selectedFireAnimation.getPixelValue()))
     }
 
+    fun onLaunchedFromNotification(pixelName: String) {
+        pixel.fire(pixelName)
+    }
+
     private fun ClearWhatOption.pixelEvent(): Pixel.PixelName {
         return when (this) {
             ClearWhatOption.CLEAR_NONE -> AppPixelName.AUTOMATIC_CLEAR_DATA_WHAT_OPTION_NONE

--- a/app/src/main/java/com/duckduckgo/app/notification/model/ClearDataNotification.kt
+++ b/app/src/main/java/com/duckduckgo/app/notification/model/ClearDataNotification.kt
@@ -21,11 +21,11 @@ import android.content.Context
 import android.os.Bundle
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.firebutton.FireButtonActivity
 import com.duckduckgo.app.notification.NotificationRegistrar
 import com.duckduckgo.app.notification.TaskStackBuilderFactory
 import com.duckduckgo.app.notification.db.NotificationDao
 import com.duckduckgo.app.pixels.AppPixelName
-import com.duckduckgo.app.settings.SettingsActivity
 import com.duckduckgo.app.settings.clear.ClearWhatOption
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -114,8 +114,8 @@ class ClearDataNotificationPlugin @Inject constructor(
     }
 
     override fun getLaunchIntent(): PendingIntent? {
-        val intent = SettingsActivity.intent(context).apply {
-            putExtra(SettingsActivity.LAUNCH_FROM_NOTIFICATION_PIXEL_NAME, pixelName(AppPixelName.NOTIFICATION_LAUNCHED.pixelName))
+        val intent = FireButtonActivity.intent(context).apply {
+            putExtra(FireButtonActivity.LAUNCH_FROM_NOTIFICATION_PIXEL_NAME, pixelName(AppPixelName.NOTIFICATION_LAUNCHED.pixelName))
         }
         val pendingIntent: PendingIntent? = taskStackBuilderFactory.createTaskBuilder().run {
             addNextIntentWithParentStack(intent)

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsActivity.kt
@@ -182,10 +182,6 @@ class SettingsActivity : DuckDuckGoActivity() {
         configureSettings()
         lifecycle.addObserver(viewModel)
         observeViewModel()
-
-        intent?.getStringExtra(BrowserActivity.LAUNCH_FROM_NOTIFICATION_PIXEL_NAME)?.let {
-            viewModel.onLaunchedFromNotification(it)
-        }
     }
 
     override fun onResume() {
@@ -435,8 +431,6 @@ class SettingsActivity : DuckDuckGoActivity() {
     }
 
     companion object {
-        const val LAUNCH_FROM_NOTIFICATION_PIXEL_NAME = "LAUNCH_FROM_NOTIFICATION_PIXEL_NAME"
-
         fun intent(context: Context): Intent {
             return Intent(context, SettingsActivity::class.java)
         }

--- a/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/SettingsViewModel.kt
@@ -398,10 +398,6 @@ class SettingsViewModel @Inject constructor(
         pixel.fire(SETTINGS_ABOUT_DDG_SHARE_FEEDBACK_PRESSED)
     }
 
-    fun onLaunchedFromNotification(pixelName: String) {
-        pixel.fire(pixelName)
-    }
-
     fun onDdgOnOtherPlatformsClicked() {
         viewModelScope.launch { command.send(LaunchOtherPlatforms) }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1210122720065734

### Description
Updated the navigation from "Data clearing notification" to open the "Data Clearing" screen and not the "Settings" screen.

### Steps to test this PR

_Notification navigation_
- [ ] Start with fresh install if you've previously already seen this notification
- [ ] Change "Automatically Clear Data" option to "None"
- [ ] Leave the app
- [ ] Wait for the notification to display and click on it

### UI changes
| Before  | After |
| ------ | ----- |
| <video src="https://github.com/user-attachments/assets/81d5f3a8-21da-4b95-a578-b77dc80b2f4e" /> | <video src="https://github.com/user-attachments/assets/e8c6c294-55d5-440d-a6bf-cf186adae63e" />|







