### PR TITLE
Handle URI_INTENT_SCHEME scheme and open market place when no fallback

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2479,6 +2479,21 @@ class BrowserTabFragment :
             val activities = pm.queryIntentActivities(intent, 0)
 
             if (activities.isEmpty()) {
+                if (fallbackIntent == null && fallbackUrl == null) {
+                    intent.`package`?.let { pkg ->
+                        val playIntent = Intent(
+                            Intent.ACTION_VIEW,
+                            "market://details?id=$pkg".toUri(),
+                        ).apply { addCategory(Intent.CATEGORY_BROWSABLE) }
+
+                        if (pm.resolveActivity(playIntent, 0) != null) {
+                            kotlin.runCatching {
+                                launchDialogForIntent(it, pm, playIntent, activities, useFirstActivityFound, viewModel.linkOpenedInNewTab())
+                                return
+                            }
+                        }
+                    }
+                }
                 when {
                     fallbackIntent != null -> {
                         val fallbackActivities = pm.queryIntentActivities(fallbackIntent, 0)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2488,7 +2488,7 @@ class BrowserTabFragment :
                         intent.`package`?.let { pkg ->
                             val playIntent = Intent(
                                 Intent.ACTION_VIEW,
-                                "market://details?id=$pkg".toUri(),
+                                "$STORE_PREFIX$pkg".toUri(),
                             ).apply { addCategory(Intent.CATEGORY_BROWSABLE) }
 
                             if (pm.resolveActivity(playIntent, 0) != null) {
@@ -4110,6 +4110,8 @@ class BrowserTabFragment :
         private const val AUTOCOMPLETE_PADDING_DP = 6
 
         private const val SITE_SECURITY_WARNING = "Warning: Security Risk"
+
+        private const val STORE_PREFIX = "market://details?id="
 
         fun newInstance(
             tabId: String,

--- a/app/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
@@ -24,6 +24,7 @@ import android.content.IntentFilter
 import android.content.pm.PackageManager
 import android.content.pm.ResolveInfo
 import android.net.Uri
+import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
 import com.duckduckgo.app.browser.SpecialUrlDetector.UrlType
 import com.duckduckgo.app.browser.applinks.ExternalAppIntentFlagsFeature
@@ -177,7 +178,8 @@ class SpecialUrlDetectorImpl(
     private fun isBrowserFilter(filter: IntentFilter) =
         filter.countDataAuthorities() == 0 && filter.countDataPaths() == 0
 
-    private fun checkForIntent(
+    @VisibleForTesting
+    internal fun checkForIntent(
         scheme: String,
         uriString: String,
         intentFlags: Int,

--- a/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
@@ -182,6 +182,7 @@ class BrowserModule {
         duckPlayer: DuckPlayer,
         duckChat: DuckChat,
         aiChatQueryDetectionFeature: AIChatQueryDetectionFeature,
+        androidBrowserConfigFeature: AndroidBrowserConfigFeature,
     ): SpecialUrlDetector = SpecialUrlDetectorImpl(
         packageManager,
         ampLinks,
@@ -191,6 +192,7 @@ class BrowserModule {
         duckPlayer,
         duckChat,
         aiChatQueryDetectionFeature,
+        androidBrowserConfigFeature,
     )
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -149,4 +149,13 @@ interface AndroidBrowserConfigFeature {
 
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun newThreatProtectionSettings(): Toggle
+
+    /**
+     * Kill switch for INTENT_SCHEME handling in SpecialUrlDetector
+     * @return `true` when the remote config has the global "handleIntentScheme" androidBrowserConfig
+     * sub-feature flag enabled
+     * If the remote feature is not present defaults to `true`
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun handleIntentScheme(): Toggle
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/SpecialUrlDetectorImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/SpecialUrlDetectorImplTest.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.app.browser.SpecialUrlDetectorImpl.Companion.PHONE_MAX_LEN
 import com.duckduckgo.app.browser.SpecialUrlDetectorImpl.Companion.SMS_MAX_LENGTH
 import com.duckduckgo.app.browser.applinks.ExternalAppIntentFlagsFeature
 import com.duckduckgo.app.browser.duckchat.AIChatQueryDetectionFeature
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckplayer.api.DuckPlayer
 import com.duckduckgo.feature.toggles.api.Toggle
@@ -73,6 +74,8 @@ class SpecialUrlDetectorImplTest {
 
     val mockAIChatQueryDetectionFeatureToggle: Toggle = mock()
 
+    val androidBrowserConfigFeature: AndroidBrowserConfigFeature = mock()
+
     @Before
     fun setup() = runTest {
         testee = SpecialUrlDetectorImpl(
@@ -84,11 +87,14 @@ class SpecialUrlDetectorImplTest {
             duckPlayer = mockDuckPlayer,
             duckChat = mockDuckChat,
             aiChatQueryDetectionFeature = mockAIChatQueryDetectionFeature,
+            androidBrowserConfigFeature = androidBrowserConfigFeature,
         )
         whenever(mockPackageManager.queryIntentActivities(any(), anyInt())).thenReturn(emptyList())
         whenever(mockDuckPlayer.willNavigateToDuckPlayer(any())).thenReturn(false)
         whenever(mockAIChatQueryDetectionFeatureToggle.isEnabled()).thenReturn(false)
         whenever(mockAIChatQueryDetectionFeature.self()).thenReturn(mockAIChatQueryDetectionFeatureToggle)
+        whenever(androidBrowserConfigFeature.handleIntentScheme()).thenReturn(mockToggle)
+        whenever(mockToggle.isEnabled()).thenReturn(true)
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1210763884565991?focus=true

### Description

- Handles URI_INTENT_SCHEME and opens the market place using the package name if a link not present in the fallback. 

### Steps to test this PR

- [x] Go to https://www.xbox.com/en-US/XboxSetupAndroid
- [x] Tap “Tap to continue setup in Xbox app"
- [x] Tap “Open” in the diaog
- [x] Verify that Xbox store listing is opened in Google Play
- [x] Install the Xbox app
- [x] Go back to the browser
- [x] Tap “Tap to continue setup in Xbox app” again
- [x] Verify that the Xbox app is opened

_Feature flag disabled_
- [x] Uninstall Xbox app
- [x] Go to feature flag inventory
- [x] Disable “handleIntentScheme”
- [x] Go back to the browser
- [x] Tap “Tap to continue setup in Xbox app”
- [x] Verify that the “Unable to open this type of link” toast is shown 