### PR TITLE
Fix: Web Search not working reliably

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -298,6 +298,7 @@
         <activity
             android:name="com.duckduckgo.app.SelectedTextSearchActivity"
             android:exported="true"
+            android:launchMode="singleTask"
             android:label="@string/systemTextSearchMessage">
             <intent-filter>
                 <action android:name="android.intent.action.PROCESS_TEXT" />

--- a/app/src/main/java/com/duckduckgo/app/dispatchers/IntentDispatcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/dispatchers/IntentDispatcherActivity.kt
@@ -30,8 +30,8 @@ import com.duckduckgo.common.ui.view.getColorFromAttr
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import javax.inject.Inject
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 import logcat.logcat
 
 @InjectWith(ActivityScope::class)
@@ -47,9 +47,11 @@ class IntentDispatcherActivity : DuckDuckGoActivity() {
 
         logcat { "onCreate called with intent $intent" }
 
-        viewModel.viewState.flowWithLifecycle(lifecycle, Lifecycle.State.CREATED).onEach {
-            dispatch(it)
-        }.launchIn(lifecycleScope)
+        lifecycleScope.launch {
+            viewModel.viewState.flowWithLifecycle(lifecycle, Lifecycle.State.CREATED).collectLatest {
+                dispatch(it)
+            }
+        }
 
         val surfaceColor = getColorFromAttr(com.duckduckgo.mobile.android.R.attr.daxColorToolbar)
         viewModel.onIntentReceived(intent, surfaceColor, isExternal = true)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1210860582231062?focus=true

### Description

This PR fixes an issue when using the "Web Search" context menu did not work sometimes.

### Steps to test this PR

- [x] Use a physical device
- [x] Bring the app in the foreground and kill it to make sure it runs fresh for the web search
- [x] Open a different app, like Gmail
- [x] Long press on some text and select "Web Search"
- [x] Notice that DDG app loads the query
- [x] Switch back to Gmail without dismissing the DDG app
- [x] Long press on a different text and select "Web Search"
- [x] Verify that DDG app loads the new query correctly

Regression testing #1
- [x] Ensure DDG is default browser.
- [x] Ensure DDG is NOT running. Press the recent apps button and note that you do NOT see DDG there.
- [x] Open an app that is known to open links in Custom Tabs. I.e Gmail.
- [x] Open a link from that app and ensure it is open in a DDG Custom Tab.
- [x] Press the recent apps button and ensure the Custom Tab looks as expected (the logo is Gmail's logo). No other instance of DDG is shown.

Regression testing #2
- [x] Ensure DDG is default browser.
- [x] Ensure DDG IS running. Press the recent apps button and note that you see DDG there.
- [x] Open an app that is known to open links in Custom Tabs. I.e Gmail.
- [x] Open a link from that app (Gmail) and ensure it is open in a DDG Custom Tab.
- [x] Press the recent apps button and ensure the Custom Tab looks as expected (the logo is Gmail's logo). The other instance of DDG is shown.
