### PR TITLE
add NTP to Input Screen

### DIFF
--- a/duckchat/duckchat-impl/src/main/res/layout/fragment_search_tab.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/fragment_search_tab.xml
@@ -22,13 +22,17 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <FrameLayout
-        android:id="@+id/contentContainer"
+    <ScrollView
+        android:id="@+id/newTabContainerScrollView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:layout_constraintTop_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"/>
+        android:layout_height="match_parent">
+
+        <FrameLayout
+            android:id="@+id/newTabContainerLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+    </ScrollView>
 
     <FrameLayout
         android:id="@+id/bottomFadeContainer"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1210856945683405?focus=true

### Description
Adds new tab page content to the Input Screen's search mode.

### Steps to test this PR
- [x] Enable AppTP.
- [x] Verify you see the new design RMF (you might need to clear caches).
- [x] Add a favorite.
- [x] Verify all 3 of the above are visible the Input Screen is opened.
- [x] Disable AppTP dismiss RMF and remove favorites.
- [x] Verify Dax logo is visible before you start typing.
