### PR TITLE
Fix: WebView not destroyed when tab closed

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/FragmentStateAdapter.java
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/FragmentStateAdapter.java
@@ -229,6 +229,9 @@ public abstract class FragmentStateAdapter extends RecyclerView.Adapter<Fragment
 
             for (int ix = 0; ix < mFragments.size(); ix++) {
                 long itemId = mFragments.keyAt(ix);
+                // Exclude items in itemIdQueue from garbage collection. itemIdQueue is a FIFO queue
+                // that tracks fragments which are hidden but not yet eligible for removal. This ensures
+                // that fragments are only removed when the maximum active tab limit is reached.
                 if (!isFragmentViewBound(itemId) && !itemIdQueue.contains(itemId)) {
                     toRemove.add(itemId);
                 }

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/FragmentStateAdapter.java
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/FragmentStateAdapter.java
@@ -459,6 +459,11 @@ public abstract class FragmentStateAdapter extends RecyclerView.Adapter<Fragment
         }
     }
 
+    public void cleanupRemovedItems() {
+        mHasStaleFragments = true;
+        gcFragments();
+    }
+
     @Override
     public final boolean onFailedToRecycleView(@NonNull FragmentViewHolder holder) {
         /*

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/FragmentStateAdapter.java
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/FragmentStateAdapter.java
@@ -223,13 +223,13 @@ public abstract class FragmentStateAdapter extends RecyclerView.Adapter<Fragment
             }
         }
 
-        // Remove Fragments that are not bound anywhere -- pending a grace period
+        // Remove Fragments that are not bound anywhere and are not hidden -- pending a grace period
         if (!mIsInGracePeriod) {
             mHasStaleFragments = false; // we've executed all GC checks
 
             for (int ix = 0; ix < mFragments.size(); ix++) {
                 long itemId = mFragments.keyAt(ix);
-                if (!isFragmentViewBound(itemId)) {
+                if (!isFragmentViewBound(itemId) && !itemIdQueue.contains(itemId)) {
                     toRemove.add(itemId);
                 }
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabPagerAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/adapter/TabPagerAdapter.kt
@@ -95,39 +95,35 @@ class TabPagerAdapter(
 
             tabs.clear()
             tabs.addAll(newTabs)
-            diff.dispatchUpdatesTo(this)
 
-            cleanupIfTabsRemoved(diff)
+            var wereTabsRemoved = false
+            val updateCallback = object : ListUpdateCallback {
+                override fun onInserted(position: Int, count: Int) {
+                    this@TabPagerAdapter.notifyItemRangeInserted(position, count)
+                }
+
+                override fun onRemoved(position: Int, count: Int) {
+                    this@TabPagerAdapter.notifyItemRangeRemoved(position, count)
+                    wereTabsRemoved = true
+                }
+
+                override fun onMoved(fromPosition: Int, toPosition: Int) {
+                    this@TabPagerAdapter.notifyItemMoved(fromPosition, toPosition)
+                }
+
+                override fun onChanged(position: Int, count: Int, payload: Any?) {
+                    this@TabPagerAdapter.notifyItemRangeChanged(position, count, payload)
+                }
+            }
+            diff.dispatchUpdatesTo(updateCallback)
+
+            if (wereTabsRemoved) {
+                cleanupRemovedItems()
+            }
         } else {
             // the state of tabs is managed separately, so we don't need to notify the adapter, but we need URL and skipHome to create new fragments
             tabs.clear()
             tabs.addAll(newTabs)
-        }
-    }
-
-    private fun cleanupIfTabsRemoved(diff: DiffUtil.DiffResult) {
-        var wereTabsRemoved = false
-        val updateCallback = object : ListUpdateCallback {
-            override fun onInserted(position: Int, count: Int) {
-                // Not needed for tracking removals
-            }
-
-            override fun onRemoved(position: Int, count: Int) {
-                wereTabsRemoved = true
-            }
-
-            override fun onMoved(fromPosition: Int, toPosition: Int) {
-                // Not needed for tracking removals
-            }
-
-            override fun onChanged(position: Int, count: Int, payload: Any?) {
-                // Not needed for tracking removals
-            }
-        }
-        diff.dispatchUpdatesTo(updateCallback)
-
-        if (wereTabsRemoved) {
-            cleanupRemovedItems()
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1210856603267238?focus=true

### Description

This PR implements a cleanup mechanism that checks if some tabs were removed and if they were, it cleans up fragments.

### Steps to test this PR

- [x] Open the Chrome device inspection tool: `chrome://inspect/#devices`
- [x] Open some tabs in the app
- [x] Verify the open tabs are visible in the inspection tool
- [x] Go to tab manager
- [x] Choose some tab and close it
- [x] Go back to the browser
- [x] Verify the closed tab disappears from the inspection tool