### PR TITLE
Fix: Swiping animation stuck between tabs

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -984,6 +984,8 @@ open class BrowserActivity : DuckDuckGoActivity() {
 
         private const val MAX_ACTIVE_TABS = 40
         private const val KEY_TAB_PAGER_STATE = "tabPagerState"
+
+        private const val DISABLE_SWIPING_DELAY = 1000L
     }
 
     inner class BrowserStateRenderer {
@@ -1002,7 +1004,15 @@ open class BrowserActivity : DuckDuckGoActivity() {
                 }
 
                 if (swipingTabsFeature.isEnabled) {
-                    tabPager.isUserInputEnabled = viewState.isTabSwipingEnabled
+                    if (!viewState.isTabSwipingEnabled) {
+                        lifecycleScope.launch {
+                            // delay disabling of the swiping to allow the swipe animation to finish
+                            delay(DISABLE_SWIPING_DELAY)
+                            tabPager.isUserInputEnabled = false
+                        }
+                    } else {
+                        tabPager.isUserInputEnabled = true
+                    }
                 }
             }
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1210859467773737?focus=true

### Description

This PR adds a delay before disabling the swiping to allow the swiping animation to finish and avoid getting stuck in between tabs.

### Steps to test this PR

- [x] Create at least 20 tabs
- [x] Starting at the end, keep swiping to the beginning (so that the tabs get loaded in memory)
- [x] When you're on the first tab, long-tap on the Tab switcher button to create a NTP
- [x] Verify the current tab is animated to the new tab and it looks correct
- [x] After 1s, try swiping on the focused toolbar
- [x] Verify the swiping is disabled

