### PR TITLE
Fix: Extract a single URL from an external shared text

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -691,7 +691,7 @@ class BrowserTabViewModelTest {
             coroutineRule.testScope,
         )
 
-        whenever(mockOmnibarConverter.convertQueryToUrl(any(), any(), any())).thenReturn("duckduckgo.com")
+        whenever(mockOmnibarConverter.convertQueryToUrl(any(), any(), any(), any())).thenReturn("duckduckgo.com")
         whenever(mockTabRepository.liveSelectedTab).thenReturn(selectedTabLiveData)
         whenever(mockNavigationAwareLoginDetector.loginEventLiveData).thenReturn(loginEventLiveData)
         whenever(mockTabRepository.retrieveSiteData(any())).thenReturn(MutableLiveData())

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -59,6 +59,7 @@ import com.duckduckgo.app.browser.databinding.IncludeSingleOmnibarToolbarMockupB
 import com.duckduckgo.app.browser.databinding.IncludeSingleOmnibarToolbarMockupBottomBinding
 import com.duckduckgo.app.browser.defaultbrowsing.prompts.ui.DefaultBrowserBottomSheetDialog
 import com.duckduckgo.app.browser.defaultbrowsing.prompts.ui.DefaultBrowserBottomSheetDialog.EventListener
+import com.duckduckgo.app.browser.omnibar.OmnibarEntryConverter
 import com.duckduckgo.app.browser.omnibar.model.OmnibarPosition.BOTTOM
 import com.duckduckgo.app.browser.omnibar.model.OmnibarPosition.TOP
 import com.duckduckgo.app.browser.omnibar.model.OmnibarType
@@ -207,6 +208,9 @@ open class BrowserActivity : DuckDuckGoActivity() {
 
     @Inject
     lateinit var onboardingExperimentFireAnimationHelper: OnboardingExperimentFireAnimationHelper
+
+    @Inject
+    lateinit var omnibarEntryConverter: OmnibarEntryConverter
 
     @Inject
     lateinit var browserFeatures: AndroidBrowserConfigFeature
@@ -618,7 +622,12 @@ open class BrowserActivity : DuckDuckGoActivity() {
                 val sourceTabId = if (selectedText) currentTab?.tabId else null
                 val skipHome = !selectedText
                 if (swipingTabsFeature.isEnabled) {
-                    launchNewTab(query = sharedText, sourceTabId = sourceTabId, skipHome = skipHome)
+                    val query = if (isExternal) {
+                        omnibarEntryConverter.convertQueryToUrl(searchQuery = sharedText, extractUrlFromQuery = true)
+                    } else {
+                        sharedText
+                    }
+                    launchNewTab(query = query, sourceTabId = sourceTabId, skipHome = skipHome)
                 } else {
                     lifecycleScope.launch { viewModel.onOpenInNewTabRequested(sourceTabId = sourceTabId, query = sharedText, skipHome = skipHome) }
                 }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarEntryConverter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarEntryConverter.kt
@@ -22,6 +22,7 @@ interface OmnibarEntryConverter {
         searchQuery: String,
         vertical: String? = null,
         queryOrigin: QueryOrigin = QueryOrigin.FromUser,
+        extractUrlFromQuery: Boolean = false,
     ): String
 }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/QueryUrlConverter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/QueryUrlConverter.kt
@@ -39,7 +39,9 @@ class QueryUrlConverter @Inject constructor(private val requestRewriter: Request
     ): String {
         val isUrl = when (queryOrigin) {
             is QueryOrigin.FromAutocomplete -> queryOrigin.isNav
-            is QueryOrigin.FromUser, QueryOrigin.FromBookmark -> UriString.isWebUrl(searchQuery, extractUrlFromQuery) || UriString.isDuckUri(searchQuery)
+            is QueryOrigin.FromUser, QueryOrigin.FromBookmark -> UriString.isWebUrl(searchQuery, extractUrlFromQuery) || UriString.isDuckUri(
+                searchQuery,
+            )
         }
 
         if (isUrl == true) {

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/QueryUrlConverter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/QueryUrlConverter.kt
@@ -35,10 +35,11 @@ class QueryUrlConverter @Inject constructor(private val requestRewriter: Request
         searchQuery: String,
         vertical: String?,
         queryOrigin: QueryOrigin,
+        extractUrlFromQuery: Boolean,
     ): String {
         val isUrl = when (queryOrigin) {
             is QueryOrigin.FromAutocomplete -> queryOrigin.isNav
-            is QueryOrigin.FromUser, QueryOrigin.FromBookmark -> UriString.isWebUrl(searchQuery) || UriString.isDuckUri(searchQuery)
+            is QueryOrigin.FromUser, QueryOrigin.FromBookmark -> UriString.isWebUrl(searchQuery, extractUrlFromQuery) || UriString.isDuckUri(searchQuery)
         }
 
         if (isUrl == true) {
@@ -63,7 +64,8 @@ class QueryUrlConverter @Inject constructor(private val requestRewriter: Request
     }
 
     private fun convertUri(input: String): String {
-        val uri = Uri.parse(input).withScheme()
+        val url = UriString.extractUrl(input) ?: input
+        val uri = Uri.parse(url).withScheme()
 
         if (requestRewriter.shouldRewriteRequest(uri)) {
             return requestRewriter.rewriteRequestWithCustomQueryParams(uri).toString()

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserViewModelTest.kt
@@ -127,7 +127,7 @@ class BrowserViewModelTest {
 
         runTest {
             whenever(mockTabRepository.add()).thenReturn(TAB_ID)
-            whenever(mockOmnibarEntryConverter.convertQueryToUrl(any(), any(), any())).then { it.arguments.first() }
+            whenever(mockOmnibarEntryConverter.convertQueryToUrl(any(), any(), any(), any())).then { it.arguments.first() }
         }
     }
 

--- a/app/src/test/java/com/duckduckgo/app/browser/QueryUrlConverterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/QueryUrlConverterTest.kt
@@ -29,7 +29,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import java.net.URLEncoder
 
 @RunWith(AndroidJUnit4::class)
 class QueryUrlConverterTest {

--- a/app/src/test/java/com/duckduckgo/app/browser/QueryUrlConverterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/QueryUrlConverterTest.kt
@@ -29,6 +29,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import java.net.URLEncoder
 
 @RunWith(AndroidJUnit4::class)
 class QueryUrlConverterTest {
@@ -153,6 +154,35 @@ class QueryUrlConverterTest {
         assertFalse(result.contains("iar=$vertical"))
     }
 
+    @Test
+    fun whenQueryContainsSingleUrlThenUrlIsExtracted() {
+        val input = "Source: Towards Data Science  https://search.app/2W427"
+        val result = testee.convertQueryToUrl(input, queryOrigin = QueryOrigin.FromUser, extractUrlFromQuery = true)
+        assertEquals("https://search.app/2W427", result)
+    }
+
+    @Test
+    fun whenQueryContainsSingleUrlWithNoSchemeThenUrlIsExtractedAndSchemeAdded() {
+        val input = "pre text duckduckgo.com post text"
+        val result = testee.convertQueryToUrl(input, queryOrigin = QueryOrigin.FromUser, extractUrlFromQuery = true)
+        assertEquals("http://duckduckgo.com", result)
+    }
+
+    @Test
+    fun whenQueryContainsMultipleUrlsThenSearchQueryBuilt() {
+        val input = "https://duckduckgo.com https://google.com"
+        val expected = "https%3A%2F%2Fduckduckgo.com%20https%3A%2F%2Fgoogle.com"
+        val result = testee.convertQueryToUrl(input, queryOrigin = QueryOrigin.FromUser, extractUrlFromQuery = true)
+        assertDuckDuckGoSearchQuery(expected, result)
+    }
+
+    @Test
+    fun whenQueryContainsUrlAndExtractUrlIsFalseThenSearchQueryBuilt() {
+        val input = "Source: Towards Data Science  https://search.app/2W427"
+        val expected = "Source%3A%20Towards%20Data%20Science%20%20https%3A%2F%2Fsearch.app%2F2W427"
+        val result = testee.convertQueryToUrl(input, queryOrigin = QueryOrigin.FromUser, extractUrlFromQuery = false)
+        assertDuckDuckGoSearchQuery(expected, result)
+    }
     private fun assertDuckDuckGoSearchQuery(
         query: String,
         url: String,

--- a/browser-api/src/main/java/com/duckduckgo/app/browser/UriString.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/browser/UriString.kt
@@ -111,8 +111,9 @@ class UriString {
             }
 
             if (extractUrlQuery) {
-                extractUrl(inputQuery)?.let {
-                    return true
+                val extractedUrl = extractUrl(inputQuery)
+                if (extractedUrl != null) {
+                    return isWebUrl(extractedUrl)
                 }
             }
 

--- a/browser-api/src/main/java/com/duckduckgo/app/browser/UriString.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/browser/UriString.kt
@@ -36,6 +36,15 @@ class UriString {
         private val domainRegex by lazy { PatternsCompat.DOMAIN_NAME.toRegex() }
         private val cache = LruCache<Int, Boolean>(250_000)
 
+        fun extractUrl(inputQuery: String): String? {
+            val urls = webUrlRegex.findAll(inputQuery).map { it.value }.toList()
+            return if (urls.size == 1) {
+                urls.first()
+            } else {
+                null
+            }
+        }
+
         fun host(uriString: String): String? {
             return Uri.parse(uriString).baseHost
         }
@@ -96,10 +105,17 @@ class UriString {
             return parentHost == childHost || (childHost.endsWith(".$parentHost") || parentHost.endsWith(".$childHost"))
         }
 
-        fun isWebUrl(inputQuery: String): Boolean {
+        fun isWebUrl(inputQuery: String, extractUrlQuery: Boolean = false): Boolean {
             if (inputQuery.contains("\"") || inputQuery.contains("'")) {
                 return false
             }
+
+            if (extractUrlQuery) {
+                extractUrl(inputQuery)?.let {
+                    return true
+                }
+            }
+
             if (inputQuery.contains(space)) return false
             val rawUri = Uri.parse(inputQuery)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1210862419441744?focus=true

### Description

This PR adds support for extracting an URL from an externally shared text if it can find one. Typing some text that contains an URL in the search box treats it like a normal query, as before.

### Steps to test this PR

_External text containing a single URL_
- [x] Share some text that contains a _single_ URL (for example using the Google Now page)
- [x] Open it in DDG
- [x] Verify the URL is correctly extracted and loaded

_Search query_
- [x] Type some text in the search box that contains a valid URL
- [x] Verify a search runs correctly and a SERP is displayed
