### PR TITLE
Update content scope scripts to version 10.14.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
@@ -45,6 +45,7 @@
   var globalObj = typeof window === "undefined" ? globalThis : window;
   var Error3 = globalObj.Error;
   var messageSecret;
+  var isAppleSiliconCache = null;
   var OriginalCustomEvent = typeof CustomEvent === "undefined" ? null : CustomEvent;
   var originalWindowDispatchEvent = typeof window === "undefined" ? null : window.dispatchEvent.bind(window);
   function registerMessageSecret(secret) {
@@ -152,9 +153,14 @@
     });
   }
   function isAppleSilicon() {
+    if (isAppleSiliconCache !== null) {
+      return isAppleSiliconCache;
+    }
     const canvas = document.createElement("canvas");
     const gl = canvas.getContext("webgl");
-    return gl.getSupportedExtensions().indexOf("WEBGL_compressed_texture_etc") !== -1;
+    const compressedTextureValue = gl?.getSupportedExtensions()?.indexOf("WEBGL_compressed_texture_etc");
+    isAppleSiliconCache = typeof compressedTextureValue === "number" && compressedTextureValue !== -1;
+    return isAppleSiliconCache;
   }
   function processAttrByCriteria(configSetting) {
     let bestOption;

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -1569,6 +1569,7 @@
   var globalObj = typeof window === "undefined" ? globalThis : window;
   var Error3 = globalObj.Error;
   var messageSecret;
+  var isAppleSiliconCache = null;
   var OriginalCustomEvent = typeof CustomEvent === "undefined" ? null : CustomEvent;
   var originalWindowDispatchEvent = typeof window === "undefined" ? null : window.dispatchEvent.bind(window);
   function registerMessageSecret(secret) {
@@ -1676,9 +1677,14 @@
     });
   }
   function isAppleSilicon() {
+    if (isAppleSiliconCache !== null) {
+      return isAppleSiliconCache;
+    }
     const canvas = document.createElement("canvas");
     const gl = canvas.getContext("webgl");
-    return gl.getSupportedExtensions().indexOf("WEBGL_compressed_texture_etc") !== -1;
+    const compressedTextureValue = gl?.getSupportedExtensions()?.indexOf("WEBGL_compressed_texture_etc");
+    isAppleSiliconCache = typeof compressedTextureValue === "number" && compressedTextureValue !== -1;
+    return isAppleSiliconCache;
   }
   function processAttrByCriteria(configSetting) {
     let bestOption;

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -869,6 +869,7 @@
   var globalObj = typeof window === "undefined" ? globalThis : window;
   var Error3 = globalObj.Error;
   var messageSecret;
+  var isAppleSiliconCache = null;
   var OriginalCustomEvent = typeof CustomEvent === "undefined" ? null : CustomEvent;
   var originalWindowDispatchEvent = typeof window === "undefined" ? null : window.dispatchEvent.bind(window);
   function registerMessageSecret(secret) {
@@ -1005,9 +1006,14 @@
     });
   }
   function isAppleSilicon() {
+    if (isAppleSiliconCache !== null) {
+      return isAppleSiliconCache;
+    }
     const canvas = document.createElement("canvas");
     const gl = canvas.getContext("webgl");
-    return gl.getSupportedExtensions().indexOf("WEBGL_compressed_texture_etc") !== -1;
+    const compressedTextureValue = gl?.getSupportedExtensions()?.indexOf("WEBGL_compressed_texture_etc");
+    isAppleSiliconCache = typeof compressedTextureValue === "number" && compressedTextureValue !== -1;
+    return isAppleSiliconCache;
   }
   function processAttrByCriteria(configSetting) {
     let bestOption;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.8.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.2.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.13.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.14.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.8.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.8.0.tgz",
-      "integrity": "sha512-6CJsFwBFtad9tD6ROnbwqKXETZUgV4adgMbQ/TxeVTxPEjWFi45BTKbkzUX5aJQbz0FOvYZ1T9XItSy0CgFOHg==",
+      "version": "14.9.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.9.0.tgz",
+      "integrity": "sha512-00jA5QJB6ho7m08Jy5421thNWlk1uNkXxkg1LDXrybTqJXbTyBJ7eeJnhk6CnlW/JKd/p7fvYO+cm6GuPrCmkw==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#4935471fe659cad802f0fe3d4c51c8cf1318ae86",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#0265bdf792cabae6f77af31ae5051becbe3235fe",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -89,13 +89,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@ghostery/adblocker": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.11.1.tgz",
-      "integrity": "sha512-bROAa2LayP0CfY6dJodMkV/DN7/0OgSEOrj/TnTWrOAkiSrH4rGpO3G1NlIAyF4uK9IZNOWDzcZt7/vv9qy0zA==",
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.11.3.tgz",
+      "integrity": "sha512-uNblOHFagpi7yz1nOmhPvmK1QWWzOV7K9sTNy7SDM+i1FZkfSJYCPyFBlioV15GNVm/cRfMWW7LyZKWCnQ2+sQ==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-content": "^2.11.1",
-        "@ghostery/adblocker-extended-selectors": "^2.11.1",
+        "@ghostery/adblocker-content": "^2.11.3",
+        "@ghostery/adblocker-extended-selectors": "^2.11.3",
         "@ghostery/url-parser": "^1.3.0",
         "@remusao/guess-url-type": "^2.1.0",
         "@remusao/small": "^2.1.0",
@@ -104,18 +104,18 @@
       }
     },
     "node_modules/@ghostery/adblocker-content": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.11.1.tgz",
-      "integrity": "sha512-KF1vjwp/YNzgjLKOMh+FjGcXbliZHIJnh2A9+dLgL8Fe+HCK1h49p7xa7FFa0c2pO45GDfI2LgsAiqhHSYZP6A==",
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.11.3.tgz",
+      "integrity": "sha512-Es3Mm86JStRdyl0o2/YXZot8C41dWChgY7Et3pu8Bll3+MTp+fjnXwD/a8ic1TD6UYHXPqpUU7b9f6OWa0Twnw==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-extended-selectors": "^2.11.1"
+        "@ghostery/adblocker-extended-selectors": "^2.11.3"
       }
     },
     "node_modules/@ghostery/adblocker-extended-selectors": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.11.1.tgz",
-      "integrity": "sha512-T0UpheA3cd9T/4feJkJR+i5QaDvRt5gHcFWKh7DAstdYPqbKxqDG0U2RgY1Z8PtG2dVmIzBlQ0QPUB7gCF6nyw==",
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.11.3.tgz",
+      "integrity": "sha512-+d/AZ1oIXy+WP+ogd9behZ3c136pSdt7QmwODNODeXPgEJJggersuLiKRDsBlG+nqy03gaTt5Vo7qk3rYa7cyA==",
       "license": "MPL-2.0"
     },
     "node_modules/@ghostery/url-parser": {
@@ -280,9 +280,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.0.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.14.tgz",
-      "integrity": "sha512-4zXMWD91vBLGRtHK3YbIoFMia+1nqEz72coM42C5ETjnNCa/heoj7NT1G67iAfOqMmcfhuCZ4uNpyz8EjlAejw==",
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.8.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.2.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.13.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#10.14.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1210875164740412/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run