### PR TITLE
Extract checks for if the WebView capabilities support importing Google passwords

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/InBrowserImportPromo.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/InBrowserImportPromo.kt
@@ -16,10 +16,8 @@
 
 package com.duckduckgo.autofill.impl.importing
 
-import com.duckduckgo.app.browser.api.WebViewCapabilityChecker
-import com.duckduckgo.app.browser.api.WebViewCapabilityChecker.WebViewCapability.DocumentStartJavaScript
-import com.duckduckgo.app.browser.api.WebViewCapabilityChecker.WebViewCapability.WebMessageListener
 import com.duckduckgo.autofill.api.AutofillFeature
+import com.duckduckgo.autofill.impl.importing.capability.ImportGooglePasswordsCapabilityChecker
 import com.duckduckgo.autofill.impl.store.InternalAutofillStore
 import com.duckduckgo.autofill.impl.store.NeverSavedSiteRepository
 import com.duckduckgo.common.utils.DispatcherProvider
@@ -42,7 +40,7 @@ class RealInBrowserImportPromo @Inject constructor(
     private val dispatchers: DispatcherProvider,
     private val neverSavedSiteRepository: NeverSavedSiteRepository,
     private val autofillFeature: AutofillFeature,
-    private val webViewCapabilityChecker: WebViewCapabilityChecker,
+    private val importPasswordCapabilityChecker: ImportGooglePasswordsCapabilityChecker,
     private val inBrowserPromoPreviousPromptsStore: InBrowserPromoPreviousPromptsStore,
 ) : InBrowserImportPromo {
 
@@ -87,18 +85,12 @@ class RealInBrowserImportPromo @Inject constructor(
                 return@withContext false
             }
 
-            if (webViewCapableOfImporting().not()) {
+            if (importPasswordCapabilityChecker.webViewCapableOfImporting().not()) {
                 return@withContext false
             }
 
             return@withContext true
         }
-    }
-
-    private suspend fun webViewCapableOfImporting(): Boolean {
-        val webViewWebMessageSupport = webViewCapabilityChecker.isSupported(WebMessageListener)
-        val webViewDocumentStartJavascript = webViewCapabilityChecker.isSupported(DocumentStartJavaScript)
-        return webViewWebMessageSupport && webViewDocumentStartJavascript
     }
 
     private fun featureEnabled(): Boolean {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/InSettingsPasswordImportPromoRules.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/InSettingsPasswordImportPromoRules.kt
@@ -16,10 +16,8 @@
 
 package com.duckduckgo.autofill.impl.importing
 
-import com.duckduckgo.app.browser.api.WebViewCapabilityChecker
-import com.duckduckgo.app.browser.api.WebViewCapabilityChecker.WebViewCapability.DocumentStartJavaScript
-import com.duckduckgo.app.browser.api.WebViewCapabilityChecker.WebViewCapability.WebMessageListener
 import com.duckduckgo.autofill.api.AutofillFeature
+import com.duckduckgo.autofill.impl.importing.capability.ImportGooglePasswordsCapabilityChecker
 import com.duckduckgo.autofill.impl.store.InternalAutofillStore
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
@@ -37,7 +35,7 @@ class RealInSettingsPasswordImportPromoRules @Inject constructor(
     private val autofillStore: InternalAutofillStore,
     private val dispatchers: DispatcherProvider,
     private val autofillFeature: AutofillFeature,
-    private val webViewCapabilityChecker: WebViewCapabilityChecker,
+    private val importPasswordCapabilityChecker: ImportGooglePasswordsCapabilityChecker,
 ) : InSettingsPasswordImportPromoRules {
 
     override suspend fun canShowPromo(): Boolean {
@@ -58,18 +56,12 @@ class RealInSettingsPasswordImportPromoRules @Inject constructor(
                 return@withContext false
             }
 
-            if (webViewCapableOfImporting().not()) {
+            if (importPasswordCapabilityChecker.webViewCapableOfImporting().not()) {
                 return@withContext false
             }
 
             return@withContext true
         }
-    }
-
-    private suspend fun webViewCapableOfImporting(): Boolean {
-        val webViewWebMessageSupport = webViewCapabilityChecker.isSupported(WebMessageListener)
-        val webViewDocumentStartJavascript = webViewCapabilityChecker.isSupported(DocumentStartJavaScript)
-        return webViewWebMessageSupport && webViewDocumentStartJavascript
     }
 
     private fun featureEnabled(): Boolean {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/capability/ImportGooglePasswordsCapabilityChecker.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/capability/ImportGooglePasswordsCapabilityChecker.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.autofill.impl.importing.capability
+
+import com.duckduckgo.app.browser.api.WebViewCapabilityChecker
+import com.duckduckgo.app.browser.api.WebViewCapabilityChecker.WebViewCapability.DocumentStartJavaScript
+import com.duckduckgo.app.browser.api.WebViewCapabilityChecker.WebViewCapability.WebMessageListener
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+interface ImportGooglePasswordsCapabilityChecker {
+    suspend fun webViewCapableOfImporting(): Boolean
+}
+
+@ContributesBinding(AppScope::class)
+class DefaultImportGooglePasswordsCapabilityChecker @Inject constructor(
+    private val webViewCapabilityChecker: WebViewCapabilityChecker,
+) : ImportGooglePasswordsCapabilityChecker {
+
+    override suspend fun webViewCapableOfImporting(): Boolean {
+        val webViewWebMessageSupport = webViewCapabilityChecker.isSupported(WebMessageListener)
+        val webViewDocumentStartJavascript = webViewCapabilityChecker.isSupported(DocumentStartJavaScript)
+        return webViewWebMessageSupport && webViewDocumentStartJavascript
+    }
+}

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/promo/ImportInPasswordsVisibility.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/promo/ImportInPasswordsVisibility.kt
@@ -16,11 +16,9 @@
 
 package com.duckduckgo.autofill.impl.importing.promo
 
-import com.duckduckgo.app.browser.api.WebViewCapabilityChecker
-import com.duckduckgo.app.browser.api.WebViewCapabilityChecker.WebViewCapability.DocumentStartJavaScript
-import com.duckduckgo.app.browser.api.WebViewCapabilityChecker.WebViewCapability.WebMessageListener
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.autofill.api.AutofillFeature
+import com.duckduckgo.autofill.impl.importing.capability.ImportGooglePasswordsCapabilityChecker
 import com.duckduckgo.autofill.impl.store.InternalAutofillStore
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
@@ -42,7 +40,7 @@ interface ImportInPasswordsVisibility {
 class RealImportInPasswordsVisibility @Inject constructor(
     private val internalAutofillStore: InternalAutofillStore,
     private val autofillFeature: AutofillFeature,
-    private val webViewCapabilityChecker: WebViewCapabilityChecker,
+    private val importGooglePasswordsCapabilityChecker: ImportGooglePasswordsCapabilityChecker,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
 ) : ImportInPasswordsVisibility {
@@ -86,9 +84,8 @@ class RealImportInPasswordsVisibility @Inject constructor(
         if (internalAutofillStore.hasEverImportedPasswords || internalAutofillStore.hasDeclinedPasswordManagementImportPromo) return false
 
         val gpmImport = autofillFeature.self().isEnabled() && autofillFeature.canImportFromGooglePasswordManager().isEnabled()
-        val webViewWebMessageSupport = webViewCapabilityChecker.isSupported(WebMessageListener)
-        val webViewDocumentStartJavascript = webViewCapabilityChecker.isSupported(DocumentStartJavaScript)
-        canShowImportPasswords = gpmImport && webViewWebMessageSupport && webViewDocumentStartJavascript
+        val webViewSupportsImportingPasswords = importGooglePasswordsCapabilityChecker.webViewCapableOfImporting()
+        canShowImportPasswords = gpmImport && webViewSupportsImportingPasswords
 
         return canShowImportPasswords
     }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillPasswordsManagementViewModel.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillPasswordsManagementViewModel.kt
@@ -20,9 +20,6 @@ import android.util.Patterns
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
-import com.duckduckgo.app.browser.api.WebViewCapabilityChecker
-import com.duckduckgo.app.browser.api.WebViewCapabilityChecker.WebViewCapability.DocumentStartJavaScript
-import com.duckduckgo.app.browser.api.WebViewCapabilityChecker.WebViewCapability.WebMessageListener
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.autofill.api.AutofillFeature
@@ -35,6 +32,7 @@ import com.duckduckgo.autofill.impl.R
 import com.duckduckgo.autofill.impl.asString
 import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator
 import com.duckduckgo.autofill.impl.deviceauth.DeviceAuthenticator.AuthConfiguration
+import com.duckduckgo.autofill.impl.importing.capability.ImportGooglePasswordsCapabilityChecker
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_DELETE_LOGIN
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_ENABLE_AUTOFILL_TOGGLE_MANUALLY_DISABLED
@@ -141,7 +139,7 @@ class AutofillPasswordsManagementViewModel @Inject constructor(
     private val autofillBreakageReportDataStore: AutofillSiteBreakageReportingDataStore,
     private val autofillBreakageReportCanShowRules: AutofillBreakageReportCanShowRules,
     private val autofillFeature: AutofillFeature,
-    private val webViewCapabilityChecker: WebViewCapabilityChecker,
+    private val importGooglePasswordsCapabilityChecker: ImportGooglePasswordsCapabilityChecker,
     private val autofillEffectDispatcher: AutofillEffectDispatcher,
 ) : ViewModel() {
 
@@ -468,9 +466,8 @@ class AutofillPasswordsManagementViewModel @Inject constructor(
 
         viewModelScope.launch(dispatchers.io()) {
             val gpmImport = autofillFeature.self().isEnabled() && autofillFeature.canImportFromGooglePasswordManager().isEnabled()
-            val webViewWebMessageSupport = webViewCapabilityChecker.isSupported(WebMessageListener)
-            val webViewDocumentStartJavascript = webViewCapabilityChecker.isSupported(DocumentStartJavaScript)
-            val canImport = gpmImport && webViewWebMessageSupport && webViewDocumentStartJavascript
+            val webViewSupportsImportingPasswords = importGooglePasswordsCapabilityChecker.webViewCapableOfImporting()
+            val canImport = gpmImport && webViewSupportsImportingPasswords
             logcat(VERBOSE) { "Can import from Google Password Manager: $canImport" }
             _viewState.value = _viewState.value.copy(
                 canImportFromGooglePasswords = canImport,

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/capability/DefaultImportGooglePasswordsCapabilityCheckerTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/capability/DefaultImportGooglePasswordsCapabilityCheckerTest.kt
@@ -1,0 +1,41 @@
+package com.duckduckgo.autofill.impl.importing.capability
+
+import com.duckduckgo.app.browser.api.WebViewCapabilityChecker
+import com.duckduckgo.app.browser.api.WebViewCapabilityChecker.WebViewCapability.DocumentStartJavaScript
+import com.duckduckgo.app.browser.api.WebViewCapabilityChecker.WebViewCapability.WebMessageListener
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
+
+class DefaultImportGooglePasswordsCapabilityCheckerTest {
+
+    private val webViewCapabilityChecker: WebViewCapabilityChecker = mock()
+
+    private val testee = DefaultImportGooglePasswordsCapabilityChecker(webViewCapabilityChecker = webViewCapabilityChecker)
+
+    @Before
+    fun setup() = runTest {
+        whenever(webViewCapabilityChecker.isSupported(WebMessageListener)).thenReturn(true)
+        whenever(webViewCapabilityChecker.isSupported(DocumentStartJavaScript)).thenReturn(true)
+    }
+
+    @Test
+    fun whenWebViewSupportsDocumentStartJavascriptApiAndWebMessageListenersThenSupportsImportingPasswords() = runTest {
+        assertTrue(testee.webViewCapableOfImporting())
+    }
+
+    @Test
+    fun whenWebViewDoesNotSupportDocumentStartJavascriptApiThenDoesNotSupportImportingPasswords() = runTest {
+        whenever(webViewCapabilityChecker.isSupported(DocumentStartJavaScript)).thenReturn(false)
+        assertFalse(testee.webViewCapableOfImporting())
+    }
+
+    @Test
+    fun whenWebViewDoesNotSupportWebMessageListenersThenDoesNotSupportImportingPasswords() = runTest {
+        whenever(webViewCapabilityChecker.isSupported(WebMessageListener)).thenReturn(false)
+        assertFalse(testee.webViewCapableOfImporting())
+    }
+}

--- a/autofill/autofill-internal/src/main/java/com/duckduckgo/autofill/internal/AutofillInternalSettingsActivity.kt
+++ b/autofill/autofill-internal/src/main/java/com/duckduckgo/autofill/internal/AutofillInternalSettingsActivity.kt
@@ -29,9 +29,6 @@ import androidx.lifecycle.Lifecycle.State.STARTED
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.duckduckgo.anvil.annotations.InjectWith
-import com.duckduckgo.app.browser.api.WebViewCapabilityChecker
-import com.duckduckgo.app.browser.api.WebViewCapabilityChecker.WebViewCapability.DocumentStartJavaScript
-import com.duckduckgo.app.browser.api.WebViewCapabilityChecker.WebViewCapability.WebMessageListener
 import com.duckduckgo.app.tabs.BrowserNav
 import com.duckduckgo.autofill.api.AutofillFeature
 import com.duckduckgo.autofill.api.AutofillScreenLaunchSource.InternalDevSettings
@@ -47,6 +44,7 @@ import com.duckduckgo.autofill.impl.importing.CredentialImporter.ImportResult.In
 import com.duckduckgo.autofill.impl.importing.CsvCredentialConverter
 import com.duckduckgo.autofill.impl.importing.CsvCredentialConverter.CsvCredentialImportResult
 import com.duckduckgo.autofill.impl.importing.InternalInBrowserPromoStore
+import com.duckduckgo.autofill.impl.importing.capability.ImportGooglePasswordsCapabilityChecker
 import com.duckduckgo.autofill.impl.importing.gpm.feature.AutofillImportPasswordConfigStore
 import com.duckduckgo.autofill.impl.importing.gpm.webflow.ImportGooglePassword.AutofillImportViaGooglePasswordManagerScreen
 import com.duckduckgo.autofill.impl.importing.gpm.webflow.ImportGooglePasswordResult
@@ -140,7 +138,7 @@ class AutofillInternalSettingsActivity : DuckDuckGoActivity() {
     lateinit var autofillImportPasswordConfigStore: AutofillImportPasswordConfigStore
 
     @Inject
-    lateinit var webViewCapabilityChecker: WebViewCapabilityChecker
+    lateinit var importGooglePasswordsCapabilityChecker: ImportGooglePasswordsCapabilityChecker
 
     @Inject
     lateinit var inBrowserImportPromoPreviousPromptsStore: InternalInBrowserPromoStore
@@ -301,9 +299,7 @@ class AutofillInternalSettingsActivity : DuckDuckGoActivity() {
         }
         binding.importPasswordsLaunchGooglePasswordCustomFlow.setClickListener {
             lifecycleScope.launch {
-                val webViewWebMessageSupport = webViewCapabilityChecker.isSupported(WebMessageListener)
-                val webViewDocumentStartJavascript = webViewCapabilityChecker.isSupported(DocumentStartJavaScript)
-                if (webViewDocumentStartJavascript && webViewWebMessageSupport) {
+                if (importGooglePasswordsCapabilityChecker.webViewCapableOfImporting()) {
                     val intent =
                         globalActivityStarter.startIntent(this@AutofillInternalSettingsActivity, AutofillImportViaGooglePasswordManagerScreen)
                     importGooglePasswordsFlowLauncher.launch(intent)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1210877903986238?focus=true 

### Description
Extracts the two checks we do against the `WebView` capabilities to ensure we can support importing Google passwords. Instead of every place which might interact with importing passwords having to know the nuances of which `WebView` APIs are needed, now they can just check against a single API.

### Steps to test this PR
- [ ] On a device with a modern `WebView` installation, make sure the password import flow is available in the usual places (e.g., password management, password settings, in-browser promo, settings promo)
- [ ] Use emulator with ancient `WebView` (or hardcode `ImportGooglePasswordsCapabilityChecker` to return `false`) and check we don't offer up the import functionality anywhere