### PR TITLE
extract Input Screen's public API

### DIFF
--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/inputscreen/InputScreenActivityParams.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/inputscreen/InputScreenActivityParams.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.api.inputscreen
+
+import android.app.Activity
+import androidx.activity.result.ActivityResult
+import com.duckduckgo.navigation.api.GlobalActivityStarter
+
+/**
+ * Parameters for launching the Input Screen activity.
+ *
+ * @param query The initial query text to pre-populate in the input field
+ */
+data class InputScreenActivityParams(
+    val query: String,
+) : GlobalActivityStarter.ActivityParams
+
+/**
+ * Result codes returned by the Input Screen activity's [ActivityResult].
+ */
+data object InputScreenActivityResultCodes {
+    /** User requested to perform a new search */
+    const val NEW_SEARCH_REQUESTED = 1
+
+    /** User requested to switch to an existing tab */
+    const val SWITCH_TO_TAB_REQUESTED = 2
+}
+
+/**
+ * Parameter names for data returned by the Input Screen activity's [ActivityResult.getData].
+ */
+data object InputScreenActivityResultParams {
+    /** Key for the search query string when result is [InputScreenActivityResultCodes.NEW_SEARCH_REQUESTED] */
+    const val SEARCH_QUERY_PARAM = "query"
+
+    /** Key for the target tab ID when result is [InputScreenActivityResultCodes.SWITCH_TO_TAB_REQUESTED] */
+    const val TAB_ID_PARAM = "tab_id"
+
+    /** Key for any canceled draft content when result is [Activity.RESULT_CANCELED] */
+    const val CANCELED_DRAFT_PARAM = "draft"
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenActivity.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenActivity.kt
@@ -23,13 +23,9 @@ import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.duckchat.api.inputscreen.BrowserAndInputScreenTransitionProvider
+import com.duckduckgo.duckchat.api.inputscreen.InputScreenActivityParams
 import com.duckduckgo.duckchat.impl.R
-import com.duckduckgo.navigation.api.GlobalActivityStarter
 import javax.inject.Inject
-
-data class InputScreenActivityParams(
-    val query: String,
-) : GlobalActivityStarter.ActivityParams
 
 @InjectWith(ActivityScope::class)
 @ContributeToActivityStarter(InputScreenActivityParams::class)
@@ -64,11 +60,5 @@ class InputScreenActivity : DuckDuckGoActivity() {
                 exitTransition,
             )
         }
-    }
-
-    companion object {
-        // TODO: This is in an :impl module and accessed directly from :app module, it should be moved to an API
-        const val QUERY = "query"
-        const val TAB_ID = "tab_id"
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
@@ -33,6 +33,9 @@ import com.duckduckgo.common.utils.extensions.hideKeyboard
 import com.duckduckgo.common.utils.extensions.showKeyboard
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.api.inputscreen.InputScreenActivityParams
+import com.duckduckgo.duckchat.api.inputscreen.InputScreenActivityResultCodes
+import com.duckduckgo.duckchat.api.inputscreen.InputScreenActivityResultParams
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.databinding.FragmentInputScreenBinding
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command
@@ -109,9 +112,9 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
             object : OnBackPressedCallback(true) {
                 override fun handleOnBackPressed() {
                     val query = binding.inputModeWidget.text
-                    val data = Intent().putExtra(InputScreenActivity.QUERY, query)
+                    val data = Intent().putExtra(InputScreenActivityResultParams.CANCELED_DRAFT_PARAM, query)
                     requireActivity().setResult(Activity.RESULT_CANCELED, data)
-                    exitInterstitial()
+                    exitInputScreen()
                 }
             },
         )
@@ -149,9 +152,9 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
             is UserSubmittedQuery -> binding.inputModeWidget.submitMessage(command.query)
             is EditWithSelectedQuery -> binding.inputModeWidget.text = command.query
             is SwitchToTab -> {
-                val data = Intent().putExtra(InputScreenActivity.TAB_ID, command.tabId)
-                requireActivity().setResult(Activity.RESULT_OK, data)
-                exitInterstitial()
+                val data = Intent().putExtra(InputScreenActivityResultParams.TAB_ID_PARAM, command.tabId)
+                requireActivity().setResult(InputScreenActivityResultCodes.SWITCH_TO_TAB_REQUESTED, data)
+                exitInputScreen()
             }
             is SubmitSearch -> submitSearchQuery(command.query)
             is SubmitChat -> submitChatQuery(command.query)
@@ -203,16 +206,16 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
     }
 
     private fun submitChatQuery(query: String) {
-        val data = Intent().putExtra(InputScreenActivity.QUERY, query)
+        val data = Intent().putExtra(InputScreenActivityResultParams.CANCELED_DRAFT_PARAM, query)
         requireActivity().setResult(Activity.RESULT_CANCELED, data)
         requireActivity().finish()
         duckChat.openDuckChatWithAutoPrompt(query)
     }
 
     private fun submitSearchQuery(query: String) {
-        val data = Intent().putExtra(InputScreenActivity.QUERY, query)
-        requireActivity().setResult(Activity.RESULT_OK, data)
-        exitInterstitial()
+        val data = Intent().putExtra(InputScreenActivityResultParams.SEARCH_QUERY_PARAM, query)
+        requireActivity().setResult(InputScreenActivityResultCodes.NEW_SEARCH_REQUESTED, data)
+        exitInputScreen()
     }
 
     private fun configureVoice() {
@@ -235,7 +238,7 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
         }.launchIn(lifecycleScope)
     }
 
-    private fun exitInterstitial() {
+    private fun exitInputScreen() {
         hideKeyboard(binding.inputModeWidget.inputField)
         requireActivity().supportFinishAfterTransition()
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1210846340363977?focus=true

### Description
Cleans up the Input Screen's internal module references made outside of the implementation.

### Steps to test this PR

- [x] Verify searches can be made from the Input Screen.
- [x] Open NTP, draft some text, back out.
  - [x] Verify the draft text is moved to the unfocused omnibar.
- [x] Search for open tab and verify that you can switch to it.
