### PR TITLE
PIR: Create PIR modules and new entry point

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -289,6 +289,8 @@ dependencies {
     implementation project(':macos-api')
     implementation project(':macos-impl')
 
+    implementation project(":pir-api")
+    implementation project(":pir-impl")
     internalImplementation project(':pir-internal')
 
     implementation project(':privacy-dashboard-api')

--- a/pir/pir-api/build.gradle
+++ b/pir/pir-api/build.gradle
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+}
+
+apply from: "$rootProject.projectDir/gradle/android-library.gradle"
+
+android {
+    namespace "com.duckduckgo.pir.api"
+}
+
+dependencies {
+    implementation project(':navigation-api')
+
+    implementation KotlinX.coroutines.core
+}

--- a/pir/pir-api/src/main/java/com/duckduckgo/pir/api/PirFeature.kt
+++ b/pir/pir-api/src/main/java/com/duckduckgo/pir/api/PirFeature.kt
@@ -16,10 +16,12 @@
 
 package com.duckduckgo.pir.api
 
-interface PirFeatureToggle {
+interface PirFeature {
 
     /**
+     * Runs on the IO thread by default.
+     *
      * @return true if the PIR beta is enabled, false otherwise
      */
-    fun isPirBetaEnabled(): Boolean
+    suspend fun isPirBetaEnabled(): Boolean
 }

--- a/pir/pir-api/src/main/java/com/duckduckgo/pir/api/PirFeatureToggle.kt
+++ b/pir/pir-api/src/main/java/com/duckduckgo/pir/api/PirFeatureToggle.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.api
+
+interface PirFeatureToggle {
+
+    /**
+     * @return true if the PIR beta is enabled, false otherwise
+     */
+    fun isPirBetaEnabled(): Boolean
+}

--- a/pir/pir-api/src/main/java/com/duckduckgo/pir/api/dashboard/PirDashboardScreen.kt
+++ b/pir/pir-api/src/main/java/com/duckduckgo/pir/api/dashboard/PirDashboardScreen.kt
@@ -14,22 +14,11 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.pir.internal
+package com.duckduckgo.pir.api.dashboard
 
-import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
-import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.feature.toggles.api.Toggle
-import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
-import com.duckduckgo.feature.toggles.api.Toggle.DefaultValue
+import com.duckduckgo.navigation.api.GlobalActivityStarter
 
-@ContributesRemoteFeature(
-    scope = AppScope::class,
-    featureName = "pir",
-)
-interface PirRemoteFeatures {
-    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
-    fun self(): Toggle
-
-    @DefaultValue(DefaultFeatureValue.FALSE)
-    fun allowPirRun(): Toggle
-}
+/**
+ * Use this model to launch the PIR Dashboard screen.
+ */
+data object PirDashboardScreen : GlobalActivityStarter.ActivityParams

--- a/pir/pir-impl/build.gradle
+++ b/pir/pir-impl/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation project(path: ':anvil-annotations')
     implementation project(path: ':di')
     implementation project(':common-ui')
+    implementation project(':common-utils')
     implementation project(':navigation-api')
     ksp AndroidX.room.compiler
 

--- a/pir/pir-impl/build.gradle
+++ b/pir/pir-impl/build.gradle
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+    id 'com.squareup.anvil'
+    id 'com.google.devtools.ksp'
+}
+
+apply from: "$rootProject.projectDir/gradle/android-library.gradle"
+
+dependencies {
+	implementation project(":pir-api")
+
+    anvil project(path: ':anvil-compiler')
+    implementation project(path: ':anvil-annotations')
+    implementation project(path: ':di')
+    implementation project(':common-ui')
+    implementation project(':navigation-api')
+    ksp AndroidX.room.compiler
+
+    implementation AndroidX.appCompat
+    implementation KotlinX.coroutines.android
+    implementation AndroidX.core.ktx
+    implementation Google.dagger
+
+    implementation "com.squareup.logcat:logcat:_"
+
+    testImplementation Testing.junit4
+    testImplementation "org.mockito.kotlin:mockito-kotlin:_"
+    testImplementation project(path: ':common-test')
+    testImplementation CashApp.turbine
+    testImplementation Testing.robolectric
+    testImplementation(KotlinX.coroutines.test) {
+        // https://github.com/Kotlin/kotlinx.coroutines/issues/2023
+        // conflicts with mockito due to direct inclusion of byte buddy
+        exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
+    }
+
+    coreLibraryDesugaring Android.tools.desugarJdkLibs
+}
+
+android {
+    namespace "com.duckduckgo.pir.impl"
+    anvil {
+        generateDaggerFactories = true // default is false
+    }
+    lint {
+        baseline file("lint-baseline.xml")
+        abortOnError = !project.hasProperty("abortOnError") || project.property("abortOnError") != "false"
+    }
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
+    compileOptions {
+        coreLibraryDesugaringEnabled = true
+    }
+}
+

--- a/pir/pir-impl/lint-baseline.xml
+++ b/pir/pir-impl/lint-baseline.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2025 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<issues format="6" by="lint 8.5.1" type="baseline" client="gradle" dependencies="false" name="AGP (8.5.1)" variant="all" version="8.5.1">
+
+</issues>

--- a/pir/pir-impl/src/main/AndroidManifest.xml
+++ b/pir/pir-impl/src/main/AndroidManifest.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2025 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET"/>
+
+    <application>
+        <activity
+            android:name=".dashboard.PirDashboardActivity"
+            android:parentActivityName="com.duckduckgo.app.settings.SettingsActivity"
+            android:label="@string/activityPirDashboard" />
+    </application>
+</manifest>

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/PirRemoteFeatures.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/PirRemoteFeatures.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultValue
+import com.duckduckgo.pir.api.PirFeatureToggle
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "pir",
+)
+interface PirRemoteFeatures {
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun self(): Toggle
+
+    @DefaultValue(DefaultFeatureValue.FALSE)
+    fun pirBeta(): Toggle
+}
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(
+    scope = AppScope::class,
+    boundType = PirFeatureToggle::class,
+)
+class PirRemoteFeatureToggleImpl @Inject constructor(
+    private val pirRemoteFeatures: PirRemoteFeatures,
+) : PirFeatureToggle {
+
+    override fun isPirBetaEnabled(): Boolean {
+        return pirRemoteFeatures.pirBeta().isEnabled()
+    }
+}

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/PirRemoteFeatures.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/PirRemoteFeatures.kt
@@ -17,14 +17,16 @@
 package com.duckduckgo.pir.impl
 
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.feature.toggles.api.Toggle.DefaultValue
-import com.duckduckgo.pir.api.PirFeatureToggle
+import com.duckduckgo.pir.api.PirFeature
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
 import javax.inject.Inject
+import kotlinx.coroutines.withContext
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
@@ -41,13 +43,14 @@ interface PirRemoteFeatures {
 @SingleInstanceIn(AppScope::class)
 @ContributesBinding(
     scope = AppScope::class,
-    boundType = PirFeatureToggle::class,
+    boundType = PirFeature::class,
 )
-class PirRemoteFeatureToggleImpl @Inject constructor(
+class PirRemoteFeatureImpl @Inject constructor(
     private val pirRemoteFeatures: PirRemoteFeatures,
-) : PirFeatureToggle {
+    private val dispatcherProvider: DispatcherProvider,
+) : PirFeature {
 
-    override fun isPirBetaEnabled(): Boolean {
-        return pirRemoteFeatures.pirBeta().isEnabled()
+    override suspend fun isPirBetaEnabled(): Boolean = withContext(dispatcherProvider.io()) {
+        pirRemoteFeatures.pirBeta().isEnabled()
     }
 }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/PirDashboardActivity.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/PirDashboardActivity.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.dashboard
+
+import android.os.Bundle
+import android.webkit.WebViewClient
+import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.common.ui.DuckDuckGoActivity
+import com.duckduckgo.common.ui.store.AppTheme
+import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.pir.api.dashboard.PirDashboardScreen
+import com.duckduckgo.pir.impl.databinding.ActivityPirDashboardBinding
+import javax.inject.Inject
+
+@InjectWith(ActivityScope::class)
+@ContributeToActivityStarter(PirDashboardScreen::class)
+class PirDashboardActivity : DuckDuckGoActivity() {
+
+    @Inject
+    lateinit var appTheme: AppTheme
+
+    private val binding: ActivityPirDashboardBinding by viewBinding()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(binding.root)
+
+        setupWebView()
+    }
+
+    private fun setupWebView() {
+        // TODO: temporarily load DuckDuckGo Pro page until the actual PIR dashboard is ready
+        binding.pirWebView.webViewClient = WebViewClient()
+        binding.pirWebView.loadUrl("https://duckduckgo.com/")
+    }
+}

--- a/pir/pir-impl/src/main/res/layout/activity_pir_dashboard.xml
+++ b/pir/pir-impl/src/main/res/layout/activity_pir_dashboard.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2025 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <WebView
+        android:id="@+id/pirWebView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+
+</LinearLayout>

--- a/pir/pir-impl/src/main/res/values/donottranslate.xml
+++ b/pir/pir-impl/src/main/res/values/donottranslate.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2025 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources>
+    <string name="activityPirDashboard" translatable="false">PIR</string>
+</resources>

--- a/pir/pir-internal/build.gradle
+++ b/pir/pir-internal/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation project(':internal-features-api')
     implementation project(':js-messaging-api')
     implementation project(':navigation-api')
+    implementation project(':pir-impl')
     implementation project(':subscriptions-api')
     implementation project(':statistics-api')
     implementation "com.squareup.logcat:logcat:_"

--- a/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/brokers/PirDataUpdateObserver.kt
+++ b/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/brokers/PirDataUpdateObserver.kt
@@ -21,7 +21,7 @@ import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.pir.internal.PirRemoteFeatures
+import com.duckduckgo.pir.impl.PirRemoteFeatures
 import com.duckduckgo.pir.internal.store.PitTestingStore
 import com.duckduckgo.subscriptions.api.Subscriptions
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -45,7 +45,7 @@ class PirDataUpdateObserver @Inject constructor(
 ) : MainProcessLifecycleObserver {
     override fun onCreate(owner: LifecycleOwner) {
         coroutineScope.launch(dispatcherProvider.io()) {
-            if (pirRemoteFeatures.allowPirRun().isEnabled() && subscriptions.getAccessToken() != null) {
+            if (pirRemoteFeatures.pirBeta().isEnabled() && subscriptions.getAccessToken() != null) {
                 if (testingStore.testerId == null) {
                     testingStore.testerId = UUID.randomUUID().toString()
                 }

--- a/pir/readme.md
+++ b/pir/readme.md
@@ -1,0 +1,9 @@
+# PIR
+Contains the PIR feature
+
+## Who can help you better understand this feature?
+- Karl Dimla
+- Domen Lanisnik
+
+## More information
+- [Asana: feature documentation](https://app.asana.com/1/137249556945/project/1204586965688315/task/1210414383205722?focus=true)

--- a/subscriptions/subscriptions-impl/build.gradle
+++ b/subscriptions/subscriptions-impl/build.gradle
@@ -61,6 +61,7 @@ dependencies {
     implementation project(':vpn-api')
     implementation project(':content-scope-scripts-api')
     implementation project(':duckchat-api')
+    implementation project(':pir-api')
 
     implementation AndroidX.appCompat
     implementation KotlinX.coroutines.core

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/settings/views/PirSettingView.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/settings/views/PirSettingView.kt
@@ -32,18 +32,19 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.ViewViewModelFactory
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
+import com.duckduckgo.pir.api.dashboard.PirDashboardScreen
 import com.duckduckgo.subscriptions.impl.R
 import com.duckduckgo.subscriptions.impl.databinding.ViewPirSettingsBinding
 import com.duckduckgo.subscriptions.impl.pir.PirActivity.Companion.PirScreenWithEmptyParams
 import com.duckduckgo.subscriptions.impl.settings.views.PirSettingViewModel.Command
-import com.duckduckgo.subscriptions.impl.settings.views.PirSettingViewModel.Command.OpenPir
+import com.duckduckgo.subscriptions.impl.settings.views.PirSettingViewModel.Command.OpenPirDashboard
+import com.duckduckgo.subscriptions.impl.settings.views.PirSettingViewModel.Command.OpenPirDesktop
 import com.duckduckgo.subscriptions.impl.settings.views.PirSettingViewModel.ViewState
 import com.duckduckgo.subscriptions.impl.settings.views.PirSettingViewModel.ViewState.PirState.Disabled
 import com.duckduckgo.subscriptions.impl.settings.views.PirSettingViewModel.ViewState.PirState.Enabled
 import com.duckduckgo.subscriptions.impl.settings.views.PirSettingViewModel.ViewState.PirState.Hidden
 import dagger.android.support.AndroidSupportInjection
 import javax.inject.Inject
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
@@ -102,8 +103,9 @@ class PirSettingView @JvmOverloads constructor(
                     setStatus(isOn = true)
                     setLeadingIconResource(R.drawable.ic_identity_blocked_pir_color_24)
                     isClickable = true
-                    binding.pirSettings.setClickListener { viewModel.onPir() }
+                    binding.pirSettings.setClickListener { viewModel.onPir(viewState.pirState.type) }
                 }
+
                 is Disabled -> {
                     isVisible = true
                     isClickable = false
@@ -111,6 +113,7 @@ class PirSettingView @JvmOverloads constructor(
                     binding.pirSettings.setClickListener(null)
                     setLeadingIconResource(R.drawable.ic_identity_blocked_pir_grayscale_color_24)
                 }
+
                 Hidden -> isGone = true
             }
         }
@@ -118,8 +121,12 @@ class PirSettingView @JvmOverloads constructor(
 
     private fun processCommands(command: Command) {
         when (command) {
-            is OpenPir -> {
+            is OpenPirDesktop -> {
                 globalActivityStarter.start(context, PirScreenWithEmptyParams)
+            }
+
+            OpenPirDashboard -> {
+                globalActivityStarter.start(context, PirDashboardScreen)
             }
         }
     }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/settings/views/PirSettingViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/settings/views/PirSettingViewModel.kt
@@ -23,7 +23,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.di.scopes.ViewScope
-import com.duckduckgo.pir.api.PirFeatureToggle
+import com.duckduckgo.pir.api.PirFeature
 import com.duckduckgo.subscriptions.api.Product.PIR
 import com.duckduckgo.subscriptions.api.SubscriptionStatus
 import com.duckduckgo.subscriptions.api.Subscriptions
@@ -51,7 +51,7 @@ import kotlinx.coroutines.launch
 class PirSettingViewModel @Inject constructor(
     private val pixelSender: SubscriptionPixelSender,
     private val subscriptions: Subscriptions,
-    private val pirFeatureToggle: PirFeatureToggle,
+    private val pirFeature: PirFeature,
 ) : ViewModel(), DefaultLifecycleObserver {
 
     sealed class Command {
@@ -128,7 +128,7 @@ class PirSettingViewModel @Inject constructor(
             SubscriptionStatus.GRACE_PERIOD,
             -> {
                 if (hasValidEntitlement) {
-                    val type = if (pirFeatureToggle.isPirBetaEnabled()) {
+                    val type = if (pirFeature.isPirBetaEnabled()) {
                         DASHBOARD
                     } else {
                         DESKTOP

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/settings/views/PirSettingViewModelTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/settings/views/PirSettingViewModelTest.kt
@@ -18,7 +18,7 @@ package com.duckduckgo.subscriptions.impl.settings.views
 
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
-import com.duckduckgo.pir.api.PirFeatureToggle
+import com.duckduckgo.pir.api.PirFeature
 import com.duckduckgo.subscriptions.api.Product
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.AUTO_RENEWABLE
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.EXPIRED
@@ -50,7 +50,7 @@ class PirSettingViewModelTest {
 
     private val subscriptionPixelSender: SubscriptionPixelSender = mock()
     private val subscriptions: Subscriptions = mock()
-    private val pirFeatureToggle: PirFeatureToggle = mock()
+    private val pirFeature: PirFeature = mock()
     private lateinit var pirSettingsViewModel: PirSettingViewModel
 
     @Before
@@ -58,7 +58,7 @@ class PirSettingViewModelTest {
         pirSettingsViewModel = PirSettingViewModel(
             subscriptionPixelSender,
             subscriptions,
-            pirFeatureToggle,
+            pirFeature,
         )
     }
 
@@ -183,7 +183,7 @@ class PirSettingViewModelTest {
     fun `when subscription state is auto renewable and entitled then PirState is enabled and beta FF is false`() = runTest {
         whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(Product.PIR)))
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(AUTO_RENEWABLE)
-        whenever(pirFeatureToggle.isPirBetaEnabled()).thenReturn(false)
+        whenever(pirFeature.isPirBetaEnabled()).thenReturn(false)
 
         pirSettingsViewModel.onCreate(mock())
 
@@ -199,7 +199,7 @@ class PirSettingViewModelTest {
     fun `when subscription state is auto renewable and entitled then PirState is enabled and beta FF is true`() = runTest {
         whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(Product.PIR)))
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(AUTO_RENEWABLE)
-        whenever(pirFeatureToggle.isPirBetaEnabled()).thenReturn(true)
+        whenever(pirFeature.isPirBetaEnabled()).thenReturn(true)
 
         pirSettingsViewModel.onCreate(mock())
 
@@ -230,7 +230,7 @@ class PirSettingViewModelTest {
     fun `when subscription state is not auto renewable and entitled then PirState is enabled and beta FF is false`() = runTest {
         whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(Product.PIR)))
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(NOT_AUTO_RENEWABLE)
-        whenever(pirFeatureToggle.isPirBetaEnabled()).thenReturn(false)
+        whenever(pirFeature.isPirBetaEnabled()).thenReturn(false)
 
         pirSettingsViewModel.onCreate(mock())
 
@@ -246,7 +246,7 @@ class PirSettingViewModelTest {
     fun `when subscription state is not auto renewable and entitled then PirState is enabled and beta FF is true`() = runTest {
         whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(Product.PIR)))
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(NOT_AUTO_RENEWABLE)
-        whenever(pirFeatureToggle.isPirBetaEnabled()).thenReturn(true)
+        whenever(pirFeature.isPirBetaEnabled()).thenReturn(true)
 
         pirSettingsViewModel.onCreate(mock())
 
@@ -277,7 +277,7 @@ class PirSettingViewModelTest {
     fun `when subscription state is grace period and entitled then PirState is enabled and beta FF is false`() = runTest {
         whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(Product.PIR)))
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(GRACE_PERIOD)
-        whenever(pirFeatureToggle.isPirBetaEnabled()).thenReturn(false)
+        whenever(pirFeature.isPirBetaEnabled()).thenReturn(false)
 
         pirSettingsViewModel.onCreate(mock())
 
@@ -293,7 +293,7 @@ class PirSettingViewModelTest {
     fun `when subscription state is grace period and entitled then PirState is enabled and beta FF is true`() = runTest {
         whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(Product.PIR)))
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(GRACE_PERIOD)
-        whenever(pirFeatureToggle.isPirBetaEnabled()).thenReturn(true)
+        whenever(pirFeature.isPirBetaEnabled()).thenReturn(true)
 
         pirSettingsViewModel.onCreate(mock())
 

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/settings/views/PirSettingViewModelTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/settings/views/PirSettingViewModelTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.subscriptions.impl.settings.views
 
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.pir.api.PirFeatureToggle
 import com.duckduckgo.subscriptions.api.Product
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.AUTO_RENEWABLE
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.EXPIRED
@@ -30,10 +31,11 @@ import com.duckduckgo.subscriptions.api.Subscriptions
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixelSender
 import com.duckduckgo.subscriptions.impl.settings.views.PirSettingViewModel.ViewState.PirState.Disabled
 import com.duckduckgo.subscriptions.impl.settings.views.PirSettingViewModel.ViewState.PirState.Enabled
+import com.duckduckgo.subscriptions.impl.settings.views.PirSettingViewModel.ViewState.PirState.Enabled.Type
 import com.duckduckgo.subscriptions.impl.settings.views.PirSettingViewModel.ViewState.PirState.Hidden
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -48,6 +50,7 @@ class PirSettingViewModelTest {
 
     private val subscriptionPixelSender: SubscriptionPixelSender = mock()
     private val subscriptions: Subscriptions = mock()
+    private val pirFeatureToggle: PirFeatureToggle = mock()
     private lateinit var pirSettingsViewModel: PirSettingViewModel
 
     @Before
@@ -55,12 +58,13 @@ class PirSettingViewModelTest {
         pirSettingsViewModel = PirSettingViewModel(
             subscriptionPixelSender,
             subscriptions,
+            pirFeatureToggle,
         )
     }
 
     @Test
     fun `when onPir then report app settings pixel sent`() = runTest {
-        pirSettingsViewModel.onPir()
+        pirSettingsViewModel.onPir(Type.DESKTOP)
         verify(subscriptionPixelSender).reportAppSettingsPirClick()
     }
 
@@ -176,15 +180,32 @@ class PirSettingViewModelTest {
     }
 
     @Test
-    fun `when subscription state is auto renewable and entitled then PirState is enabled`() = runTest {
+    fun `when subscription state is auto renewable and entitled then PirState is enabled and beta FF is false`() = runTest {
         whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(Product.PIR)))
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(AUTO_RENEWABLE)
+        whenever(pirFeatureToggle.isPirBetaEnabled()).thenReturn(false)
 
         pirSettingsViewModel.onCreate(mock())
 
         pirSettingsViewModel.viewState.test {
             assertEquals(
-                Enabled,
+                Enabled(Type.DESKTOP),
+                expectMostRecentItem().pirState,
+            )
+        }
+    }
+
+    @Test
+    fun `when subscription state is auto renewable and entitled then PirState is enabled and beta FF is true`() = runTest {
+        whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(Product.PIR)))
+        whenever(subscriptions.getSubscriptionStatus()).thenReturn(AUTO_RENEWABLE)
+        whenever(pirFeatureToggle.isPirBetaEnabled()).thenReturn(true)
+
+        pirSettingsViewModel.onCreate(mock())
+
+        pirSettingsViewModel.viewState.test {
+            assertEquals(
+                Enabled(Type.DASHBOARD),
                 expectMostRecentItem().pirState,
             )
         }
@@ -206,15 +227,32 @@ class PirSettingViewModelTest {
     }
 
     @Test
-    fun `when subscription state is not auto renewable and entitled then PirState is enabled`() = runTest {
+    fun `when subscription state is not auto renewable and entitled then PirState is enabled and beta FF is false`() = runTest {
         whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(Product.PIR)))
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(NOT_AUTO_RENEWABLE)
+        whenever(pirFeatureToggle.isPirBetaEnabled()).thenReturn(false)
 
         pirSettingsViewModel.onCreate(mock())
 
         pirSettingsViewModel.viewState.test {
             assertEquals(
-                Enabled,
+                Enabled(Type.DESKTOP),
+                expectMostRecentItem().pirState,
+            )
+        }
+    }
+
+    @Test
+    fun `when subscription state is not auto renewable and entitled then PirState is enabled and beta FF is true`() = runTest {
+        whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(Product.PIR)))
+        whenever(subscriptions.getSubscriptionStatus()).thenReturn(NOT_AUTO_RENEWABLE)
+        whenever(pirFeatureToggle.isPirBetaEnabled()).thenReturn(true)
+
+        pirSettingsViewModel.onCreate(mock())
+
+        pirSettingsViewModel.viewState.test {
+            assertEquals(
+                Enabled(Type.DASHBOARD),
                 expectMostRecentItem().pirState,
             )
         }
@@ -236,15 +274,32 @@ class PirSettingViewModelTest {
     }
 
     @Test
-    fun `when subscription state is grace period and entitled then PirState is enabled`() = runTest {
+    fun `when subscription state is grace period and entitled then PirState is enabled and beta FF is false`() = runTest {
         whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(Product.PIR)))
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(GRACE_PERIOD)
+        whenever(pirFeatureToggle.isPirBetaEnabled()).thenReturn(false)
 
         pirSettingsViewModel.onCreate(mock())
 
         pirSettingsViewModel.viewState.test {
             assertEquals(
-                Enabled,
+                Enabled(Type.DESKTOP),
+                expectMostRecentItem().pirState,
+            )
+        }
+    }
+
+    @Test
+    fun `when subscription state is grace period and entitled then PirState is enabled and beta FF is true`() = runTest {
+        whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(Product.PIR)))
+        whenever(subscriptions.getSubscriptionStatus()).thenReturn(GRACE_PERIOD)
+        whenever(pirFeatureToggle.isPirBetaEnabled()).thenReturn(true)
+
+        pirSettingsViewModel.onCreate(mock())
+
+        pirSettingsViewModel.viewState.test {
+            assertEquals(
+                Enabled(Type.DASHBOARD),
                 expectMostRecentItem().pirState,
             )
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1210856899271207?focus=true

### Description
Creates new `pir-impl` and `pir-api` modules and adds a new empty PIR dashboard activity that is opened from the existing PIR entry point when FF enabled.

Removing testing IDs, moving `PirDataUpdateObserver` and canceling already scheduled jobs will be done in later PRs to keep it easier to review.

### Steps to test this PR
https://app.asana.com/1/137249556945/task/1210885772041360?focus=true
