### PR TITLE
refresh subscription plan features on app fresh launch

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -213,6 +213,9 @@ interface PrivacyProFeature {
 
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun subscriptionRebranding(): Toggle
+
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun refreshSubscriptionPlanFeatures(): Toggle
 }
 
 @ContributesBinding(AppScope::class)

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionFeaturesFetcher.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionFeaturesFetcher.kt
@@ -69,7 +69,16 @@ class SubscriptionFeaturesFetcher @Inject constructor(
             ?.find { it.productId == BASIC_SUBSCRIPTION }
             ?.subscriptionOfferDetails
             ?.map { it.basePlanId }
-            ?.filter { authRepository.getFeatures(it).isEmpty() }
+            ?.distinct()
+            ?.let { basePlanIds ->
+                if (privacyProFeature.refreshSubscriptionPlanFeatures().isEnabled()) {
+                    basePlanIds
+                } else {
+                    basePlanIds.filter {
+                        authRepository.getFeatures(it).isEmpty()
+                    }
+                }
+            }
             ?.forEach { basePlanId ->
                 val features = subscriptionsService.features(basePlanId).features
                 logcat { "Subscription features for base plan $basePlanId fetched: $features" }

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/SubscriptionFeaturesFetcherTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/SubscriptionFeaturesFetcherTest.kt
@@ -12,6 +12,7 @@ import com.android.billingclient.api.ProductDetails.SubscriptionOfferDetails
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.DUCK_AI
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.ITR
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.MONTHLY_PLAN_US
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.NETP
@@ -76,15 +77,15 @@ class SubscriptionFeaturesFetcherTest {
         val productDetails = mockProductDetails()
         whenever(playBillingManager.productsFlow).thenReturn(flowOf(productDetails))
         whenever(authRepository.getFeatures(any())).thenReturn(emptySet())
-        whenever(subscriptionsService.features(any())).thenReturn(FeaturesResponse(listOf(NETP, ITR)))
+        whenever(subscriptionsService.features(any())).thenReturn(FeaturesResponse(listOf(NETP, ITR, DUCK_AI)))
 
         processLifecycleOwner.currentState = CREATED
 
         verify(playBillingManager).productsFlow
-        verify(authRepository).getFeatures(MONTHLY_PLAN_US)
-        verify(authRepository).getFeatures(YEARLY_PLAN_US)
-        verify(authRepository).setFeatures(MONTHLY_PLAN_US, setOf(NETP, ITR))
-        verify(authRepository).setFeatures(YEARLY_PLAN_US, setOf(NETP, ITR))
+        verify(subscriptionsService).features(MONTHLY_PLAN_US)
+        verify(subscriptionsService).features(YEARLY_PLAN_US)
+        verify(authRepository).setFeatures(MONTHLY_PLAN_US, setOf(NETP, ITR, DUCK_AI))
+        verify(authRepository).setFeatures(YEARLY_PLAN_US, setOf(NETP, ITR, DUCK_AI))
     }
 
     @Test
@@ -100,11 +101,13 @@ class SubscriptionFeaturesFetcherTest {
     }
 
     @Test
-    fun `when features already stored then does not fetch again`() = runTest {
+    fun `when features already stored and refresh features FF Disabled then does not fetch again`() = runTest {
+        givenRefreshSubscriptionPlanFeaturesEnabled(false)
         givenIsFeaturesApiEnabled(true)
         val productDetails = mockProductDetails()
         whenever(playBillingManager.productsFlow).thenReturn(flowOf(productDetails))
         whenever(authRepository.getFeatures(any())).thenReturn(setOf(NETP, ITR))
+        whenever(subscriptionsService.features(any())).thenReturn(FeaturesResponse(listOf(NETP, ITR)))
 
         processLifecycleOwner.currentState = CREATED
 
@@ -115,9 +118,32 @@ class SubscriptionFeaturesFetcherTest {
         verifyNoInteractions(subscriptionsService)
     }
 
+    @Test
+    fun `when features already stored and refresh features FF enabled then does fetch again`() = runTest {
+        givenRefreshSubscriptionPlanFeaturesEnabled(true)
+        givenIsFeaturesApiEnabled(true)
+        val productDetails = mockProductDetails()
+        whenever(playBillingManager.productsFlow).thenReturn(flowOf(productDetails))
+        whenever(authRepository.getFeatures(any())).thenReturn(setOf(NETP, ITR))
+        whenever(subscriptionsService.features(any())).thenReturn(FeaturesResponse(listOf(NETP, ITR, DUCK_AI)))
+
+        processLifecycleOwner.currentState = CREATED
+
+        verify(playBillingManager).productsFlow
+        verify(subscriptionsService).features(MONTHLY_PLAN_US)
+        verify(subscriptionsService).features(YEARLY_PLAN_US)
+        verify(authRepository).setFeatures(MONTHLY_PLAN_US, setOf(NETP, ITR, DUCK_AI))
+        verify(authRepository).setFeatures(YEARLY_PLAN_US, setOf(NETP, ITR, DUCK_AI))
+    }
+
     @SuppressLint("DenyListedApi")
     private fun givenIsFeaturesApiEnabled(value: Boolean) {
         privacyProFeature.featuresApi().setRawStoredState(State(value))
+    }
+
+    @SuppressLint("DenyListedApi")
+    private fun givenRefreshSubscriptionPlanFeaturesEnabled(value: Boolean) {
+        privacyProFeature.refreshSubscriptionPlanFeatures().setRawStoredState(State(value))
     }
 
     private fun mockProductDetails(): List<ProductDetails> {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1210887464493316?focus=true

### Description
Refreshes subscriptions plans included feature on fresh launch.

### Steps to test this PR

_Feature 1_
- [x] change debug package so it doesn't include `.debug` (to make subscriptions work)
- [x] install the branch
- [x] Check in the logs "Subscription features for base plan $basePlanId fetched: $features"
- [x] Kill the app and start it again
- [x] You should see in the logs again "Subscription features for base plan $basePlanId fetched: $features", which indicates we have fetched again the list of features for a planId


### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
