### PR TITLE
Pixels: Measure omnibar clicks from NTP

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -5539,7 +5539,7 @@ class BrowserTabViewModelTest {
         )
         testee.ctaViewState.value = ctaViewState().copy(cta = cta)
 
-        testee.userLaunchingTabSwitcher()
+        testee.userLaunchingTabSwitcher(false)
 
         verify(mockDismissedCtaDao).insert(DismissedCta(cta.ctaId))
     }
@@ -5717,7 +5717,7 @@ class BrowserTabViewModelTest {
             PixelParameter.TAB_INACTIVE_3W to inactive3w,
         )
 
-        testee.userLaunchingTabSwitcher()
+        testee.userLaunchingTabSwitcher(false)
 
         assertCommandIssued<Command.LaunchTabSwitcher>()
         verify(mockPixel).fire(AppPixelName.TAB_MANAGER_CLICKED)
@@ -6070,30 +6070,40 @@ class BrowserTabViewModelTest {
         val domain = "https://www.example.com"
         givenCurrentSite(domain)
 
-        testee.userLaunchingTabSwitcher()
+        testee.userLaunchingTabSwitcher(false)
 
         verify(mockPixel).fire(AppPixelName.TAB_MANAGER_OPENED_FROM_SITE)
     }
 
     @Test
-    fun whenTabSwitcherPressedAndUserOnSerpThenPixelIsSent() = runTest {
+    fun whenTabSwitcherPressedAndUserOnNtpThenPixelIsSent() = runTest {
         givenTabManagerData()
         setBrowserShowing(false)
 
-        testee.userLaunchingTabSwitcher()
+        testee.userLaunchingTabSwitcher(false)
 
-        verify(mockPixel).fire(AppPixelName.TAB_MANAGER_OPENED_FROM_NEW_TAB)
+        verify(mockPixel).fire(AppPixelName.TAB_MANAGER_OPENED_FROM_NEW_TAB, mapOf(PixelParameter.FROM_FOCUSED_NTP to "false"))
     }
 
     @Test
-    fun whenTabSwitcherPressedAndUserOnNewTabThenPixelIsSent() = runTest {
+    fun whenTabSwitcherPressedInFocusModeAndUserOnNtpThenPixelIsSent() = runTest {
+        givenTabManagerData()
+        setBrowserShowing(false)
+
+        testee.userLaunchingTabSwitcher(true)
+
+        verify(mockPixel).fire(AppPixelName.TAB_MANAGER_OPENED_FROM_NEW_TAB, mapOf(PixelParameter.FROM_FOCUSED_NTP to "true"))
+    }
+
+    @Test
+    fun whenTabSwitcherPressedAndUserOnSerpThenPixelIsSent() = runTest {
         givenTabManagerData()
         setBrowserShowing(true)
         whenever(mockDuckDuckGoUrlDetector.isDuckDuckGoUrl(any())).thenReturn(true)
         val domain = "https://duckduckgo.com/?q=test&atb=v395-1-wb&ia=web"
         givenCurrentSite(domain)
 
-        testee.userLaunchingTabSwitcher()
+        testee.userLaunchingTabSwitcher(false)
 
         verify(mockPixel).fire(AppPixelName.TAB_MANAGER_OPENED_FROM_SERP)
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -90,6 +90,7 @@ import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.settings.clear.OnboardingExperimentFireAnimationHelper
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter
 import com.duckduckgo.app.tabs.TabManagerFeatureFlags
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.ui.DefaultSnackbar
@@ -744,8 +745,10 @@ open class BrowserActivity : DuckDuckGoActivity() {
         recreate()
     }
 
-    fun launchFire() {
-        pixel.fire(AppPixelName.FORGET_ALL_PRESSED_BROWSING)
+    fun launchFire(launchedFromFocusedNtp: Boolean = false) {
+        val params = mapOf(PixelParameter.FROM_FOCUSED_NTP to launchedFromFocusedNtp.toString())
+        pixel.fire(AppPixelName.FORGET_ALL_PRESSED_BROWSING, params)
+
         val dialog = FireDialog(
             context = this,
             clearPersonalDataAction = clearPersonalDataAction,

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -3068,13 +3068,14 @@ class BrowserTabViewModel @Inject constructor(
         command.value = ShowWebContent
     }
 
-    fun userLaunchingTabSwitcher() {
+    fun userLaunchingTabSwitcher(launchedFromFocusedNtp: Boolean) {
         command.value = LaunchTabSwitcher
         pixel.fire(AppPixelName.TAB_MANAGER_CLICKED)
         fireDailyLaunchPixel()
 
         if (!currentBrowserViewState().browserShowing) {
-            pixel.fire(AppPixelName.TAB_MANAGER_OPENED_FROM_NEW_TAB)
+            val params = mapOf(PixelParameter.FROM_FOCUSED_NTP to launchedFromFocusedNtp.toString())
+            pixel.fire(AppPixelName.TAB_MANAGER_OPENED_FROM_NEW_TAB, parameters = params)
         } else {
             val url = site?.url
             if (url != null) {

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
@@ -262,27 +262,31 @@ class Omnibar(
             newOmnibar.isScrollingEnabled = value
         }
 
-    fun setViewMode(viewMode: ViewMode) {
-        logcat { "Omnibar: setViewMode $viewMode" }
-        when (viewMode) {
+    var viewMode: ViewMode = ViewMode.Browser(null)
+        private set
+
+    fun setViewMode(newViewMode: ViewMode) {
+        logcat { "Omnibar: setViewMode $newViewMode" }
+        viewMode = newViewMode
+        when (newViewMode) {
             Error -> {
-                newOmnibar.decorate(Mode(viewMode))
+                newOmnibar.decorate(Mode(newViewMode))
             }
 
             NewTab -> {
-                newOmnibar.decorate(Mode(viewMode))
+                newOmnibar.decorate(Mode(newViewMode))
             }
 
             SSLWarning -> {
-                newOmnibar.decorate(Mode(viewMode))
+                newOmnibar.decorate(Mode(newViewMode))
             }
 
             MaliciousSiteWarning -> {
-                newOmnibar.decorate(Mode(viewMode))
+                newOmnibar.decorate(Mode(newViewMode))
             }
 
             else -> {
-                newOmnibar.decorate(Mode(viewMode))
+                newOmnibar.decorate(Mode(newViewMode))
             }
         }
     }

--- a/statistics/statistics-api/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
+++ b/statistics/statistics-api/src/main/java/com/duckduckgo/app/statistics/pixels/Pixel.kt
@@ -67,6 +67,7 @@ interface Pixel {
         const val TAB_INACTIVE_2W = "tab_inactive_2w"
         const val TAB_INACTIVE_3W = "tab_inactive_3w"
         const val IS_ENABLED = "is_enabled"
+        const val FROM_FOCUSED_NTP = "from_focused_ntp"
     }
 
     object PixelValues {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1210832415028455?focus=true

### Description

This PR adds a `from_focused_ntp` parameter that indicates, whether a pixel was triggered when an omnibar was focused on a NTP. The parameter is added to the following pixels:

- MENU_ACTION_POPUP_OPENED("m_nav_pm_o")
- FORGET_ALL_PRESSED_BROWSING("mf_bp")
- TAB_MANAGER_OPENED_FROM_NEW_TAB("m_tab_manager_open_from_newtabpage")

### Steps to test this PR

_Fire button_
- [x] Open a NTP
- [x] Select the address bar (make sure it's empty)
- [x] Tap on the fire button
- [x] Verify pixel is sent with the corrent parameter: `Pixel sent: mf_bp with params: {from_focused_ntp=true}`

_Tab switcher button_
- [x] Open a NTP
- [x] Select the address bar (make sure it's empty)
- [x] Tap on the tab button
- [x] Verify pixel is sent with the corrent parameter: `Pixel sent: m_tab_manager_open_from_newtabpage with params: {from_focused_ntp=true}`

_Menu button_
- [x] Open a NTP
- [x] Select the address bar (make sure it's empty)
- [x] Tap on the overflow menu button
- [x] Verify pixel is sent with the corrent parameter: `Pixel sent: m_nav_pm_o with params: {from_focused_ntp=true}`

_Unfocused_
- [x] Open a NTP
- [x] Remove the focus from the omnibar
- [x] Tap on each button and verify `from_focused_ntp=false` is sent

_Not in NTP_
- [x] Open a SERP or a website
- [x] Tap on each button and verify `from_focused_ntp=true` is never sent (tab switcher uses a completely different pixel for non-NTP)
