### PR TITLE
Handle remove search suggestion from Input Screen autocomplete

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
@@ -37,6 +37,8 @@ import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.databinding.FragmentInputScreenBinding
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command.EditWithSelectedQuery
+import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command.HideKeyboard
+import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command.ShowKeyboard
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command.SubmitChat
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command.SubmitSearch
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command.SwitchToTab
@@ -155,9 +157,8 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
             }
             is SubmitSearch -> submitSearchQuery(command.query)
             is SubmitChat -> submitChatQuery(command.query)
-            else -> {
-                // TODO handle other commands
-            }
+            is ShowKeyboard -> showKeyboard(binding.inputModeWidget.inputField)
+            is HideKeyboard -> hideKeyboard(binding.inputModeWidget.inputField)
         }
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/command/SearchCommand.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/command/SearchCommand.kt
@@ -16,12 +16,8 @@
 
 package com.duckduckgo.duckchat.impl.inputscreen.ui.command
 
-sealed class Command {
-    data class SwitchToTab(val tabId: String) : Command()
-    data class UserSubmittedQuery(val query: String) : Command()
-    data class EditWithSelectedQuery(val query: String) : Command()
-    data class SubmitSearch(val query: String) : Command()
-    data class SubmitChat(val query: String) : Command()
-    data object ShowKeyboard : Command()
-    data object HideKeyboard : Command()
+import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion
+
+sealed class SearchCommand {
+    data class ShowRemoveSearchSuggestionDialog(val suggestion: AutoCompleteSuggestion) : SearchCommand()
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1210730276212926?focus=true

### Description

- Adds the ability to delete previously searched autocomplete entires (Scrolling back to last position will be handled in a follow-up PR).

### Steps to test this PR

- [x] Enable "Search Input" in “Settings” > “Duck.ai"
- [x] Search for something.
- [x] Search for the same thing and long press the history item in autocomplete.
- [x] Remove the item.
- [x] Verify that the item is removed.
