### PR TITLE
capture featurepage when redirecting to subscription flows

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/SubscriptionsHandler.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/SubscriptionsHandler.kt
@@ -36,6 +36,8 @@ class SubscriptionsHandler @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
 ) {
 
+    private val defaultDuckAiSubscriptionPurchase = SubscriptionPurchase(featurePage = DUCK_AI_FEATURE_PAGE)
+
     fun handleSubscriptionsFeature(
         featureName: String,
         method: String,
@@ -68,11 +70,12 @@ class SubscriptionsHandler @Inject constructor(
 
                 METHOD_OPEN_SUBSCRIPTION_PURCHASE -> {
                     val subscriptionParams = runCatching {
-                        data?.getString(MESSAGE_PARAM_ORIGIN_KEY).takeUnless { it.isNullOrBlank() }
+                        data?.getString(MESSAGE_PARAM_ORIGIN_KEY)
+                            .takeUnless { it.isNullOrBlank() }
                             ?.let { nonEmptyOrigin ->
-                                SubscriptionPurchase(nonEmptyOrigin)
-                            } ?: SubscriptionPurchase()
-                    }.getOrDefault(SubscriptionPurchase())
+                                defaultDuckAiSubscriptionPurchase.copy(origin = nonEmptyOrigin)
+                            } ?: defaultDuckAiSubscriptionPurchase
+                    }.getOrDefault(defaultDuckAiSubscriptionPurchase)
 
                     withContext(dispatcherProvider.main()) {
                         globalActivityStarter.start(context, subscriptionParams)
@@ -89,5 +92,6 @@ class SubscriptionsHandler @Inject constructor(
         private const val METHOD_OPEN_SUBSCRIPTION_ACTIVATION = "openSubscriptionActivation"
         private const val METHOD_OPEN_SUBSCRIPTION_PURCHASE = "openSubscriptionPurchase"
         private const val MESSAGE_PARAM_ORIGIN_KEY = "origin"
+        private const val DUCK_AI_FEATURE_PAGE = "duckai"
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/SubscriptionsHandlerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/SubscriptionsHandlerTest.kt
@@ -185,7 +185,7 @@ class SubscriptionsHandlerTest {
             contentScopeScripts,
         )
 
-        verify(globalActivityStarter).start(context, SubscriptionPurchase())
+        verify(globalActivityStarter).start(context, SubscriptionPurchase(featurePage = "duckai"))
     }
 
     @Test
@@ -208,7 +208,7 @@ class SubscriptionsHandlerTest {
             contentScopeScripts,
         )
 
-        verify(globalActivityStarter).start(context, SubscriptionPurchase("duckai_chat"))
+        verify(globalActivityStarter).start(context, SubscriptionPurchase(origin = "duckai_chat", featurePage = "duckai"))
     }
 
     @Test
@@ -231,7 +231,7 @@ class SubscriptionsHandlerTest {
             contentScopeScripts,
         )
 
-        verify(globalActivityStarter).start(context, SubscriptionPurchase())
+        verify(globalActivityStarter).start(context, SubscriptionPurchase(featurePage = "duckai"))
     }
 
     @Test
@@ -254,7 +254,7 @@ class SubscriptionsHandlerTest {
             contentScopeScripts,
         )
 
-        verify(globalActivityStarter).start(context, SubscriptionPurchase())
+        verify(globalActivityStarter).start(context, SubscriptionPurchase(featurePage = "duckai"))
     }
 
     @Test
@@ -302,6 +302,6 @@ class SubscriptionsHandlerTest {
         )
 
         verify(subscriptionsJSHelper).processJsCallbackMessage(featureName, method, id, data)
-        verify(globalActivityStarter).start(context, SubscriptionPurchase())
+        verify(globalActivityStarter).start(context, SubscriptionPurchase(featurePage = "duckai"))
     }
 }

--- a/subscriptions/subscriptions-api/src/main/java/com/duckduckgo/subscriptions/api/SubscriptionScreens.kt
+++ b/subscriptions/subscriptions-api/src/main/java/com/duckduckgo/subscriptions/api/SubscriptionScreens.kt
@@ -21,5 +21,5 @@ import com.duckduckgo.navigation.api.GlobalActivityStarter.ActivityParams
 sealed class SubscriptionScreens {
     data object SubscriptionsSettingsScreenWithEmptyParams : ActivityParams
     data class RestoreSubscriptionScreenWithParams(val isOriginWeb: Boolean = true) : ActivityParams
-    data class SubscriptionPurchase(val origin: String? = null) : ActivityParams
+    data class SubscriptionPurchase(val origin: String? = null, val featurePage: String? = null) : ActivityParams
 }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -38,6 +38,7 @@ import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.subscriptions.api.Product
 import com.duckduckgo.subscriptions.api.SubscriptionStatus
 import com.duckduckgo.subscriptions.api.Subscriptions
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.BUY_URL
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.PRIVACY_PRO_ETLD
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.PRIVACY_PRO_PATH
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.PRIVACY_SUBSCRIPTIONS_PATH
@@ -102,7 +103,7 @@ class RealSubscriptions @Inject constructor(
         val privacyPro = globalActivityStarter.startIntent(
             context,
             SubscriptionsWebViewActivityWithParams(
-                url = SubscriptionsConstants.BUY_URL,
+                url = buildSubscriptionUrl(uri),
                 origin = origin,
             ),
         ) ?: return
@@ -134,6 +135,15 @@ class RealSubscriptions @Inject constructor(
 
     override suspend fun isFreeTrialEligible(): Boolean {
         return subscriptionsManager.isFreeTrialEligible()
+    }
+
+    private fun buildSubscriptionUrl(uri: Uri?): String {
+        val queryParams = uri?.query
+        return if (!queryParams.isNullOrBlank()) {
+            "$BUY_URL?$queryParams"
+        } else {
+            BUY_URL
+        }
     }
 }
 

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsConstants.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsConstants.kt
@@ -61,6 +61,7 @@ object SubscriptionsConstants {
     const val ITR_URL = "https://duckduckgo.com/identity-theft-restoration"
     const val FAQS_URL = "https://duckduckgo.com/duckduckgo-help-pages/privacy-pro/"
     const val PRIVACY_PRO_ETLD = "duckduckgo.com"
+    const val FEATURE_PAGE_QUERY_PARAM_KEY = "featurePage"
     const val PRIVACY_PRO_PATH = "pro"
     const val PRIVACY_SUBSCRIPTIONS_PATH = "subscriptions"
 }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
@@ -76,6 +76,7 @@ import com.duckduckgo.subscriptions.impl.R.string
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.ACTIVATE_URL
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.BUY_URL
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.FEATURE_PAGE_QUERY_PARAM_KEY
 import com.duckduckgo.subscriptions.impl.databinding.ActivitySubscriptionsWebviewBinding
 import com.duckduckgo.subscriptions.impl.pir.PirActivity.Companion.PirScreenWithEmptyParams
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixelSender
@@ -107,6 +108,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import logcat.logcat
 import org.json.JSONObject
 
 data class SubscriptionsWebViewActivityWithParams(
@@ -189,7 +191,9 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        params = convertIntoSubscriptionWebViewActivityParams(intent)
+        params = convertIntoSubscriptionWebViewActivityParams(intent).also {
+            logcat { "Subscription Flow: entering with params $it" }
+        }
 
         setContentView(binding.root)
 
@@ -288,11 +292,26 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
     }
 
     private fun convertIntoSubscriptionWebViewActivityParams(intent: Intent): SubscriptionsWebViewActivityWithParams {
-        intent.getActivityParams(SubscriptionPurchase::class.java)?.let {
+        intent.getActivityParams(SubscriptionPurchase::class.java)?.let { subscriptionPurchaseActivityParams ->
             return SubscriptionsWebViewActivityWithParams(
                 url = BUY_URL,
-                origin = it.origin,
-            )
+                origin = subscriptionPurchaseActivityParams.origin,
+            ).let { webViewActivityWithParams ->
+                if (subscriptionPurchaseActivityParams.featurePage.isNullOrBlank().not()) {
+                    val urlWithParams = kotlin.runCatching {
+                        BUY_URL.toUri()
+                            .buildUpon()
+                            .appendQueryParameter(FEATURE_PAGE_QUERY_PARAM_KEY, subscriptionPurchaseActivityParams.featurePage)
+                            .build()
+                            .toString()
+                    }.getOrDefault(BUY_URL)
+                    webViewActivityWithParams.copy(
+                        url = urlWithParams,
+                    )
+                } else {
+                    webViewActivityWithParams
+                }
+            }
         }
 
         return intent.getActivityParams(SubscriptionsWebViewActivityWithParams::class.java)

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
@@ -34,6 +34,7 @@ import androidx.activity.result.contract.ActivityResultContracts.StartActivityFo
 import androidx.annotation.AnyThread
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
+import androidx.core.net.toUri
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
@@ -70,6 +71,7 @@ import com.duckduckgo.navigation.api.GlobalActivityStarter.ActivityParams
 import com.duckduckgo.navigation.api.getActivityParams
 import com.duckduckgo.subscriptions.api.SubscriptionScreens.RestoreSubscriptionScreenWithParams
 import com.duckduckgo.subscriptions.api.SubscriptionScreens.SubscriptionPurchase
+import com.duckduckgo.subscriptions.api.Subscriptions
 import com.duckduckgo.subscriptions.impl.R.string
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.ACTIVATE_URL
@@ -167,6 +169,9 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
 
     @Inject
     lateinit var duckChat: DuckChat
+
+    @Inject
+    lateinit var subscriptions: Subscriptions
 
     private val viewModel: SubscriptionWebViewViewModel by bindViewModel()
 
@@ -266,7 +271,10 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
             renderPurchaseState(it.purchaseState)
         }.launchIn(lifecycleScope)
 
-        if (savedInstanceState == null && params.url == BUY_URL) {
+        val isPrivacyProUrl by lazy {
+            runCatching { subscriptions.isPrivacyProUrl(params.url.toUri()) }.getOrDefault(false)
+        }
+        if (savedInstanceState == null && isPrivacyProUrl) {
             viewModel.paywallShown()
         }
     }

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsTest.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.subscriptions.api.Product.NetP
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.AUTO_RENEWABLE
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.UNKNOWN
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.WAITING
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.BUY_URL
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixelSender
 import com.duckduckgo.subscriptions.impl.ui.SubscriptionsWebViewActivityWithParams
 import kotlinx.coroutines.flow.flowOf
@@ -195,6 +196,64 @@ class RealSubscriptionsTest {
 
         verify(globalActivityStarter, times(2)).startIntent(eq(context), captor.capture())
         assertEquals("test", (captor.lastValue as SubscriptionsWebViewActivityWithParams).origin)
+    }
+
+    @Test
+    fun whenLaunchProUrlWithFeaturePageThenIncludeInSubscriptionURLToActivity() = runTest {
+        whenever(globalActivityStarter.startIntent(any(), any<SettingsScreenNoParams>())).thenReturn(fakeIntent())
+        whenever(globalActivityStarter.startIntent(any(), any<SubscriptionsWebViewActivityWithParams>())).thenReturn(fakeIntent())
+
+        val captor = argumentCaptor<ActivityParams>()
+        subscriptions.launchPrivacyPro(context, "https://duckduckgo.com/pro?featurePage=duckai".toUri())
+
+        verify(globalActivityStarter, times(2)).startIntent(eq(context), captor.capture())
+        assertEquals("$BUY_URL?featurePage=duckai", (captor.lastValue as SubscriptionsWebViewActivityWithParams).url)
+    }
+
+    @Test
+    fun whenLaunchProWithMultipleQueryParametersThenTheyAreIncludedInSubscriptionURLToActivity() = runTest {
+        whenever(globalActivityStarter.startIntent(any(), any<SettingsScreenNoParams>())).thenReturn(fakeIntent())
+        whenever(globalActivityStarter.startIntent(any(), any<SubscriptionsWebViewActivityWithParams>())).thenReturn(fakeIntent())
+
+        val captor = argumentCaptor<ActivityParams>()
+        subscriptions.launchPrivacyPro(context, "https://duckduckgo.com/pro?usePaidDuckAi=true&featurePage=duckai".toUri())
+
+        verify(globalActivityStarter, times(2)).startIntent(eq(context), captor.capture())
+        assertEquals("$BUY_URL?usePaidDuckAi=true&featurePage=duckai", (captor.lastValue as SubscriptionsWebViewActivityWithParams).url)
+    }
+
+    @Test
+    fun whenLaunchSubscriptionUrlWithFeaturePageThenIncludeInSubscriptionURLToActivity() = runTest {
+        whenever(globalActivityStarter.startIntent(any(), any<SettingsScreenNoParams>())).thenReturn(fakeIntent())
+        whenever(globalActivityStarter.startIntent(any(), any<SubscriptionsWebViewActivityWithParams>())).thenReturn(fakeIntent())
+
+        val captor = argumentCaptor<ActivityParams>()
+        subscriptions.launchPrivacyPro(context, "https://duckduckgo.com/subscriptions?featurePage=duckai".toUri())
+
+        verify(globalActivityStarter, times(2)).startIntent(eq(context), captor.capture())
+        assertEquals("$BUY_URL?featurePage=duckai", (captor.lastValue as SubscriptionsWebViewActivityWithParams).url)
+    }
+
+    @Test
+    fun whenLaunchSubscriptionWithMultipleQueryParametersThenTheyAreIncludedInSubscriptionURLToActivity() = runTest {
+        whenever(globalActivityStarter.startIntent(any(), any<SettingsScreenNoParams>())).thenReturn(fakeIntent())
+        whenever(globalActivityStarter.startIntent(any(), any<SubscriptionsWebViewActivityWithParams>())).thenReturn(fakeIntent())
+
+        val captor = argumentCaptor<ActivityParams>()
+        subscriptions.launchPrivacyPro(context, "https://duckduckgo.com/subscriptions?usePaidDuckAi=true&featurePage=duckai".toUri())
+
+        verify(globalActivityStarter, times(2)).startIntent(eq(context), captor.capture())
+        assertEquals("$BUY_URL?usePaidDuckAi=true&featurePage=duckai", (captor.lastValue as SubscriptionsWebViewActivityWithParams).url)
+    }
+
+    @Test
+    fun whenSubscriptionWithMultipleQueryParametersThenIsPrivacyProUrlReturnsTrue() = runTest {
+        assertTrue(subscriptions.isPrivacyProUrl("https://duckduckgo.com/subscriptions?usePaidDuckAi=true&featurePage=duckai".toUri()))
+    }
+
+    @Test
+    fun whenSubscriptionUrlButNotRootPathThenIsPrivacyProUrlReturnsFalse() = runTest {
+        assertFalse(subscriptions.isPrivacyProUrl("https://duckduckgo.com/subscriptions/welcome?usePaidDuckAi=true&featurePage=duckai".toUri()))
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1149059203486286/task/1210858657604808?focus=true

### Description
Capture feature page query param when redirecting to subscription flows

### Steps to test this PR

_Feature 1_
- [x] change debug package so it doesn't include `.debug` (to make subscriptions work)
- [x] install the branch
- [x] Visit https://duckduckgo.com/pro?something=true&featurePage=duckai
- [x] Ensure subscription flow opens loading (https://duckduckgo.com/subscriptions?something=true&featurePage=duckai)
- [x] Ensure `m_privacy-pro_offer_screen_impression` pixel is sent

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
