### PR TITLE
keep input text box one line until interaction

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
@@ -145,6 +145,10 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
             }
             binding.actionSend.setImageResource(iconResource)
         }.launchIn(lifecycleScope)
+
+        viewModel.inputBoxState.onEach { inputBoxState ->
+            binding.inputModeWidget.canExpand = inputBoxState.canExpand
+        }.launchIn(lifecycleScope)
     }
 
     private fun processCommand(command: Command) {
@@ -170,8 +174,6 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
     }
 
     private fun configureOmnibar() = with(binding.inputModeWidget) {
-        setContentId(R.id.viewPager)
-
         onSearchSent = { query ->
             viewModel.onSearchSubmitted(query)
         }
@@ -201,6 +203,9 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
         }
         onChatTextChanged = { text ->
             viewModel.onChatInputTextChanged(text)
+        }
+        onInputBoxClicked = {
+            viewModel.onInputBoxTouched()
         }
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/command/InputFieldCommand.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/command/InputFieldCommand.kt
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.duckchat.impl.inputscreen.ui.state
+package com.duckduckgo.duckchat.impl.inputscreen.ui.command
 
-data class InputBoxState(
-    val canExpand: Boolean,
-)
+sealed class InputFieldCommand {
+    data object SelectAll : InputFieldCommand()
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/state/InputBoxState.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/state/InputBoxState.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.inputscreen.ui.state
+
+data class InputBoxState(
+    val canExpand: Boolean,
+)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/state/InputFieldState.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/state/InputFieldState.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.inputscreen.ui.state
+
+data class InputFieldState(
+    val canExpand: Boolean,
+)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
@@ -35,7 +35,6 @@ import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
-import androidx.annotation.IdRes
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isVisible
 import androidx.core.widget.doAfterTextChanged
@@ -74,6 +73,7 @@ class InputModeWidget @JvmOverloads constructor(
     var onVoiceInputAllowed: ((Boolean) -> Unit)? = null
     var onSearchTextChanged: ((String) -> Unit)? = null
     var onChatTextChanged: ((String) -> Unit)? = null
+    var onInputBoxClicked: (() -> Unit)? = null
 
     var text: String
         get() = inputField.text.toString()
@@ -82,8 +82,16 @@ class InputModeWidget @JvmOverloads constructor(
             inputField.setSelection(value.length)
         }
 
-    @IdRes
-    private var contentId: Int = View.NO_ID
+    var canExpand: Boolean = false
+        set(value) {
+            if (field != value) {
+                field = value
+                beginChangeBoundsTransition()
+                inputField.maxLines = if (value) MAX_LINES else 1
+                inputField.setHorizontallyScrolling(!value)
+            }
+        }
+
     private var originalText: String? = null
     private var hasTextChangedFromOriginal = false
 
@@ -118,11 +126,13 @@ class InputModeWidget @JvmOverloads constructor(
             beginChangeBoundsTransition()
         }
         inputModeWidgetBack.setOnClickListener { onBack?.invoke() }
+        inputField.setOnClickListener {
+            onInputBoxClicked?.invoke()
+        }
     }
 
     private fun configureInputBehavior() = with(inputField) {
-        maxLines = MAX_LINES
-        setHorizontallyScrolling(false)
+        setHorizontallyScrolling(true)
 
         setOnEditorActionListener { _, actionId, _ ->
             if (actionId == EditorInfo.IME_ACTION_GO) {
@@ -149,12 +159,6 @@ class InputModeWidget @JvmOverloads constructor(
 
             val isNullOrEmpty = text.isNullOrEmpty()
             fade(inputFieldClearText, !isNullOrEmpty)
-
-            if (isNullOrEmpty && inputField.minLines > 1) {
-                inputField.post {
-                    inputField.minLines = if (inputModeSwitch.selectedTabPosition == 0) SEARCH_MIN_LINES else DUCK_CHAT_MIN_LINES
-                }
-            }
         }
 
         doAfterTextChanged { text ->
@@ -201,7 +205,6 @@ class InputModeWidget @JvmOverloads constructor(
     private fun applyModeSpecificInputBehaviour(isSearchTab: Boolean) {
         inputField.apply {
             if (isSearchTab) {
-                minLines = SEARCH_MIN_LINES
                 hint = context.getString(R.string.input_screen_search_hint)
                 imeOptions = EditorInfo.IME_FLAG_NO_EXTRACT_UI or EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING or EditorInfo.IME_ACTION_GO
                 setRawInputType(
@@ -210,7 +213,6 @@ class InputModeWidget @JvmOverloads constructor(
                         InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS,
                 )
             } else {
-                minLines = DUCK_CHAT_MIN_LINES
                 hint = context.getString(R.string.input_screen_chat_hint)
                 imeOptions = EditorInfo.IME_FLAG_NO_EXTRACT_UI or EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING or EditorInfo.IME_ACTION_GO
                 setRawInputType(
@@ -225,13 +227,10 @@ class InputModeWidget @JvmOverloads constructor(
 
     private fun beginChangeBoundsTransition() {
         (parent as? ViewGroup ?: this).let { root ->
-            val pager = root.findViewById<View>(contentId).apply {
-                isTransitionGroup = true
-            }
             TransitionManager.beginDelayedTransition(
                 root,
                 ChangeBounds().apply {
-                    excludeChildren(pager, true)
+                    duration = EXPAND_COLLAPSE_TRANSITION_DURATION
                 },
             )
         }
@@ -271,10 +270,6 @@ class InputModeWidget @JvmOverloads constructor(
         view.isVisible = visible
     }
 
-    fun setContentId(@IdRes id: Int) {
-        contentId = id
-    }
-
     fun printNewLine() {
         val currentText = inputField.text.toString()
         val selectionStart = inputField.selectionStart
@@ -302,8 +297,7 @@ class InputModeWidget @JvmOverloads constructor(
 
     companion object {
         private const val FADE_DURATION = 150L
+        private const val EXPAND_COLLAPSE_TRANSITION_DURATION = 150L
         private const val MAX_LINES = 8
-        private const val SEARCH_MIN_LINES = 1
-        private const val DUCK_CHAT_MIN_LINES = 1
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
@@ -73,7 +73,7 @@ class InputModeWidget @JvmOverloads constructor(
     var onVoiceInputAllowed: ((Boolean) -> Unit)? = null
     var onSearchTextChanged: ((String) -> Unit)? = null
     var onChatTextChanged: ((String) -> Unit)? = null
-    var onInputBoxClicked: (() -> Unit)? = null
+    var onInputFieldClicked: (() -> Unit)? = null
 
     var text: String
         get() = inputField.text.toString()
@@ -115,7 +115,7 @@ class InputModeWidget @JvmOverloads constructor(
 
     fun provideInitialText(text: String) {
         originalText = text
-        inputField.setText(text)
+        this.text = text
     }
 
     private fun configureClickListeners() {
@@ -127,7 +127,7 @@ class InputModeWidget @JvmOverloads constructor(
         }
         inputModeWidgetBack.setOnClickListener { onBack?.invoke() }
         inputField.setOnClickListener {
-            onInputBoxClicked?.invoke()
+            onInputFieldClicked?.invoke()
         }
     }
 
@@ -237,7 +237,7 @@ class InputModeWidget @JvmOverloads constructor(
     }
 
     fun submitMessage(message: String? = null) {
-        val text = message?.also(inputField::setText) ?: inputField.text
+        val text = message?.also { text = it } ?: inputField.text
         val textToSubmit = text.getTextToSubmit()?.toString()
         if (textToSubmit != null) {
             if (inputModeSwitch.selectedTabPosition == 0) {
@@ -275,8 +275,12 @@ class InputModeWidget @JvmOverloads constructor(
         val selectionStart = inputField.selectionStart
         val selectionEnd = inputField.selectionEnd
         val newText = currentText.substring(0, selectionStart) + "\n" + currentText.substring(selectionEnd)
-        inputField.setText(newText)
+        text = newText
         inputField.setSelection(selectionStart + 1)
+    }
+
+    fun selectAllText() {
+        inputField.selectAll()
     }
 
     private fun CharSequence.getTextToSubmit(): CharSequence? {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
@@ -40,6 +40,7 @@ import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command.EditWithSelec
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command.SwitchToTab
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.SearchCommand
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.SearchCommand.ShowRemoveSearchSuggestionDialog
+import com.duckduckgo.duckchat.impl.inputscreen.ui.state.InputBoxState
 import com.duckduckgo.duckchat.impl.inputscreen.ui.state.InputScreenVisibilityState
 import com.duckduckgo.duckchat.impl.inputscreen.ui.state.SubmitButtonIcon
 import com.duckduckgo.duckchat.impl.inputscreen.ui.state.SubmitButtonIconState
@@ -109,16 +110,11 @@ class InputScreenViewModel @AssistedInject constructor(
     private val refreshSuggestions = MutableSharedFlow<Unit>()
 
     /**
-     * Tracks whether we should show autocomplete suggestions based on the initial input state.
-     *
      * This becomes true when either:
      * 1. The user has modified the input text from its initial state, OR
      * 2. The initial text was not a URL (e.g., search query from SERP)
-     *
-     * We suppress autocomplete when the user is on a webpage and the input still shows
-     * that page's URL unchanged, since autocomplete suggestions would then obfuscate favorites.
      */
-    private var hasMovedBeyondInitialUrl = false
+    private val hasMovedBeyondInitialUrl = MutableStateFlow(false)
 
     /**
      * Caches the feature flag and user preference state.
@@ -140,25 +136,11 @@ class InputScreenViewModel @AssistedInject constructor(
     private val shouldShowAutoComplete = combine(
         autoCompleteSuggestionsEnabled,
         searchInputTextState,
-    ) { autoCompleteEnabled, searchInput ->
-        val shouldShowBasedOnInput = if (hasMovedBeyondInitialUrl) {
-            // once user has interacted or initial text wasn't a URL, allow autocomplete (if the rest of the conditions are met as well)
-            true
-        } else {
-            // check if user modified input or initial text wasn't a webpage URL
-            val userHasModifiedInput = initialSearchInputText != searchInput
-            val initialTextWasNotWebUrl = !isWebUrl(searchInput) && searchInput.toUri().scheme != "duck"
-
-            val shouldShow = userHasModifiedInput || initialTextWasNotWebUrl
-            if (shouldShow) {
-                hasMovedBeyondInitialUrl = true
-            }
-            shouldShow
-        }
-
+        hasMovedBeyondInitialUrl,
+    ) { autoCompleteEnabled, searchInput, hasMovedBeyondInitialUrl ->
         autoCompleteEnabled &&
             searchInput.isNotEmpty() &&
-            shouldShowBasedOnInput
+            hasMovedBeyondInitialUrl
     }.stateIn(viewModelScope, SharingStarted.Eagerly, initialValue = false)
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -183,6 +165,9 @@ class InputScreenViewModel @AssistedInject constructor(
         .catch { t: Throwable? -> logcat(WARN) { "Failed to get search results: ${t?.asLog()}" } }
         .stateIn(viewModelScope, SharingStarted.Eagerly, AutoCompleteResult("", emptyList()))
 
+    private val _inputBoxState = MutableStateFlow(InputBoxState(canExpand = false))
+    val inputBoxState: StateFlow<InputBoxState> = _inputBoxState.asStateFlow()
+
     val command: SingleLiveEvent<Command> = SingleLiveEvent()
     val searchTabCommand: SingleLiveEvent<SearchCommand> = SingleLiveEvent()
 
@@ -194,6 +179,22 @@ class InputScreenViewModel @AssistedInject constructor(
                 it.copy(
                     voiceInputButtonVisible = voiceInputPossible,
                 )
+            }
+        }.launchIn(viewModelScope)
+
+        searchInputTextState.onEach { searchInput ->
+            if (!hasMovedBeyondInitialUrl.value) {
+                // check if user modified input or initial text wasn't a webpage URL
+                val userHasModifiedInput = initialSearchInputText != searchInput
+                val initialTextWasNotWebUrl = !isWebUrl(searchInput) && searchInput.toUri().scheme != "duck"
+
+                hasMovedBeyondInitialUrl.value = userHasModifiedInput || initialTextWasNotWebUrl
+            }
+        }.launchIn(viewModelScope)
+
+        hasMovedBeyondInitialUrl.onEach { hasMovedBeyondInitialUrl ->
+            _inputBoxState.update {
+                it.copy(canExpand = hasMovedBeyondInitialUrl)
             }
         }.launchIn(viewModelScope)
 
@@ -344,6 +345,12 @@ class InputScreenViewModel @AssistedInject constructor(
 
     fun hideKeyboard() {
         command.value = Command.HideKeyboard
+    }
+
+    fun onInputBoxTouched() {
+        _inputBoxState.update {
+            it.copy(canExpand = true)
+        }
     }
 
     class InputScreenViewModelProviderFactory(

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
@@ -38,9 +38,9 @@ import com.duckduckgo.common.utils.SingleLiveEvent
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command.EditWithSelectedQuery
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command.SwitchToTab
+import com.duckduckgo.duckchat.impl.inputscreen.ui.command.InputFieldCommand
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.SearchCommand
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.SearchCommand.ShowRemoveSearchSuggestionDialog
-import com.duckduckgo.duckchat.impl.inputscreen.ui.command.InputFieldCommand
 import com.duckduckgo.duckchat.impl.inputscreen.ui.state.InputFieldState
 import com.duckduckgo.duckchat.impl.inputscreen.ui.state.InputScreenVisibilityState
 import com.duckduckgo.duckchat.impl.inputscreen.ui.state.SubmitButtonIcon

--- a/duckchat/duckchat-impl/src/main/res/layout/view_input_mode_switch_widget.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_input_mode_switch_widget.xml
@@ -86,7 +86,6 @@
                 android:lineSpacingMultiplier="1.2"
                 android:minHeight="@dimen/toolbarIcon"
                 android:paddingVertical="@dimen/keyline_2"
-                android:selectAllOnFocus="true"
                 android:textColor="?attr/daxColorPrimaryText"
                 android:textColorHighlight="?attr/daxOmnibarTextColorHighlight"
                 android:textColorHint="?attr/daxColorSecondaryText"

--- a/duckchat/duckchat-impl/src/main/res/layout/view_input_mode_switch_widget.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_input_mode_switch_widget.xml
@@ -93,7 +93,7 @@
                 android:textCursorDrawable="@drawable/text_cursor"
                 android:textSize="16sp"
                 android:textStyle="normal"
-                app:type="multi_line" />
+                android:maxLines="1" />
 
             <ImageView
                 android:id="@+id/inputFieldClearText"

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
@@ -533,4 +533,77 @@ class InputScreenViewModelTest {
 
         verify(autoComplete, times(2)).autoComplete("query")
     }
+
+    @Test
+    fun `when initialized with web URL then inputBoxState canExpand should be false initially`() {
+        val viewModel = createViewModel("https://example.com")
+
+        assertFalse(viewModel.inputBoxState.value.canExpand)
+    }
+
+    @Test
+    fun `when initialized with search query then inputBoxState canExpand should be true`() {
+        val viewModel = createViewModel("search query")
+
+        assertTrue(viewModel.inputBoxState.value.canExpand)
+    }
+
+    @Test
+    fun `when user modifies initial web URL text then inputBoxState canExpand should become true`() = runTest {
+        val viewModel = createViewModel("https://example.com")
+
+        assertFalse(viewModel.inputBoxState.value.canExpand)
+        viewModel.onSearchInputTextChanged("https://example.com/modified")
+        assertTrue(viewModel.inputBoxState.value.canExpand)
+    }
+
+    @Test
+    fun `when user modifies initial search query then inputBoxState canExpand should remain true`() = runTest {
+        val viewModel = createViewModel("search query")
+
+        assertTrue(viewModel.inputBoxState.value.canExpand)
+        viewModel.onSearchInputTextChanged("modified search")
+        assertTrue(viewModel.inputBoxState.value.canExpand)
+    }
+
+    @Test
+    fun `when user restores original URL after modification then inputBoxState canExpand should remain true`() = runTest {
+        val viewModel = createViewModel("https://example.com")
+
+        // User modifies text
+        viewModel.onSearchInputTextChanged("modified")
+        assertTrue(viewModel.inputBoxState.value.canExpand)
+
+        // User restores original URL
+        viewModel.onSearchInputTextChanged("https://example.com")
+
+        // Should still allow expansion because user has moved beyond initial state
+        assertTrue(viewModel.inputBoxState.value.canExpand)
+    }
+
+    @Test
+    fun `when onInputBoxTouched called then inputBoxState canExpand should become true`() {
+        val viewModel = createViewModel("https://example.com")
+
+        assertFalse(viewModel.inputBoxState.value.canExpand)
+        viewModel.onInputBoxTouched()
+        assertTrue(viewModel.inputBoxState.value.canExpand)
+    }
+
+    @Test
+    fun `when onInputBoxTouched called then canExpand remains true even after text changes`() = runTest {
+        val viewModel = createViewModel("https://example.com")
+
+        // Touch input box to enable expansion
+        viewModel.onInputBoxTouched()
+        assertTrue(viewModel.inputBoxState.value.canExpand)
+
+        // Change text - should still allow expansion
+        viewModel.onSearchInputTextChanged("new text")
+        assertTrue(viewModel.inputBoxState.value.canExpand)
+
+        // Back to URL - should still allow expansion
+        viewModel.onSearchInputTextChanged("https://example.com")
+        assertTrue(viewModel.inputBoxState.value.canExpand)
+    }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.duckduckgo.duckchat.impl.ui.inputscreen
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.cash.turbine.test
 import com.duckduckgo.browser.api.autocomplete.AutoComplete
 import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteResult
 import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion.AutoCompleteDefaultSuggestion
@@ -11,6 +12,7 @@ import com.duckduckgo.browser.api.autocomplete.AutoCompleteSettings
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command.SubmitChat
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command.SubmitSearch
+import com.duckduckgo.duckchat.impl.inputscreen.ui.command.InputFieldCommand
 import com.duckduckgo.duckchat.impl.inputscreen.ui.state.SubmitButtonIcon
 import com.duckduckgo.duckchat.impl.inputscreen.ui.viewmodel.InputScreenViewModel
 import com.duckduckgo.history.api.NavigationHistory
@@ -535,75 +537,123 @@ class InputScreenViewModelTest {
     }
 
     @Test
-    fun `when initialized with web URL then inputBoxState canExpand should be false initially`() {
+    fun `when initialized with web URL then inputFieldState canExpand should be false initially`() {
         val viewModel = createViewModel("https://example.com")
 
-        assertFalse(viewModel.inputBoxState.value.canExpand)
+        assertFalse(viewModel.inputFieldState.value.canExpand)
     }
 
     @Test
-    fun `when initialized with search query then inputBoxState canExpand should be true`() {
+    fun `when initialized with search query then inputFieldState canExpand should be true`() {
         val viewModel = createViewModel("search query")
 
-        assertTrue(viewModel.inputBoxState.value.canExpand)
+        assertTrue(viewModel.inputFieldState.value.canExpand)
     }
 
     @Test
-    fun `when user modifies initial web URL text then inputBoxState canExpand should become true`() = runTest {
+    fun `when user modifies initial web URL text then inputFieldState canExpand should become true`() = runTest {
         val viewModel = createViewModel("https://example.com")
 
-        assertFalse(viewModel.inputBoxState.value.canExpand)
+        assertFalse(viewModel.inputFieldState.value.canExpand)
         viewModel.onSearchInputTextChanged("https://example.com/modified")
-        assertTrue(viewModel.inputBoxState.value.canExpand)
+        assertTrue(viewModel.inputFieldState.value.canExpand)
     }
 
     @Test
-    fun `when user modifies initial search query then inputBoxState canExpand should remain true`() = runTest {
+    fun `when user modifies initial search query then inputFieldState canExpand should remain true`() = runTest {
         val viewModel = createViewModel("search query")
 
-        assertTrue(viewModel.inputBoxState.value.canExpand)
+        assertTrue(viewModel.inputFieldState.value.canExpand)
         viewModel.onSearchInputTextChanged("modified search")
-        assertTrue(viewModel.inputBoxState.value.canExpand)
+        assertTrue(viewModel.inputFieldState.value.canExpand)
     }
 
     @Test
-    fun `when user restores original URL after modification then inputBoxState canExpand should remain true`() = runTest {
+    fun `when user restores original URL after modification then inputFieldState canExpand should remain true`() = runTest {
         val viewModel = createViewModel("https://example.com")
 
         // User modifies text
         viewModel.onSearchInputTextChanged("modified")
-        assertTrue(viewModel.inputBoxState.value.canExpand)
+        assertTrue(viewModel.inputFieldState.value.canExpand)
 
         // User restores original URL
         viewModel.onSearchInputTextChanged("https://example.com")
 
         // Should still allow expansion because user has moved beyond initial state
-        assertTrue(viewModel.inputBoxState.value.canExpand)
+        assertTrue(viewModel.inputFieldState.value.canExpand)
     }
 
     @Test
-    fun `when onInputBoxTouched called then inputBoxState canExpand should become true`() {
+    fun `when onInputFieldTouched called then inputFieldState canExpand should become true`() {
         val viewModel = createViewModel("https://example.com")
 
-        assertFalse(viewModel.inputBoxState.value.canExpand)
-        viewModel.onInputBoxTouched()
-        assertTrue(viewModel.inputBoxState.value.canExpand)
+        assertFalse(viewModel.inputFieldState.value.canExpand)
+        viewModel.onInputFieldTouched()
+        assertTrue(viewModel.inputFieldState.value.canExpand)
     }
 
     @Test
-    fun `when onInputBoxTouched called then canExpand remains true even after text changes`() = runTest {
+    fun `when onInputFieldTouched called then canExpand remains true even after text changes`() = runTest {
         val viewModel = createViewModel("https://example.com")
 
-        // Touch input box to enable expansion
-        viewModel.onInputBoxTouched()
-        assertTrue(viewModel.inputBoxState.value.canExpand)
+        // Touch input field to enable expansion
+        viewModel.onInputFieldTouched()
+        assertTrue(viewModel.inputFieldState.value.canExpand)
 
         // Change text - should still allow expansion
         viewModel.onSearchInputTextChanged("new text")
-        assertTrue(viewModel.inputBoxState.value.canExpand)
+        assertTrue(viewModel.inputFieldState.value.canExpand)
 
         // Back to URL - should still allow expansion
         viewModel.onSearchInputTextChanged("https://example.com")
-        assertTrue(viewModel.inputBoxState.value.canExpand)
+        assertTrue(viewModel.inputFieldState.value.canExpand)
+    }
+
+    @Test
+    fun `when initialized with web URL then SelectAll command should be sent`() = runTest {
+        val viewModel = createViewModel("https://example.com")
+
+        viewModel.inputFieldCommand.test {
+            val receivedCommand = awaitItem()
+            assertEquals(InputFieldCommand.SelectAll, receivedCommand)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when initialized with duck URL then SelectAll command should be sent`() = runTest {
+        val viewModel = createViewModel("duck://results?q=test")
+
+        viewModel.inputFieldCommand.test {
+            val receivedCommand = awaitItem()
+            assertEquals(InputFieldCommand.SelectAll, receivedCommand)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when initialized with search query then SelectAll command should NOT be sent`() = runTest {
+        val viewModel = createViewModel("search query")
+
+        viewModel.inputFieldCommand.test {
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `when user modifies URL text after initialization then no additional SelectAll commands are sent`() = runTest {
+        val viewModel = createViewModel("https://example.com")
+
+        viewModel.inputFieldCommand.test {
+            // Should receive initial SelectAll
+            val initialCommand = awaitItem()
+            assertEquals(InputFieldCommand.SelectAll, initialCommand)
+
+            // Modify text
+            viewModel.onSearchInputTextChanged("https://example.com/page")
+
+            // Should not receive any additional commands
+            expectNoEvents()
+        }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1210835160047735?focus=true

### Description
If the initial Input Screen content carried over from the omnibar is a URL, keep the Input Screen's text box a single line high unless clicked.

The idea is that the `EditText` is initialized as one line, which requires it to be scrollable horizontally. This means that operations on URL initiated by a long-click (context menus for copy/cut, and selection management) can be done within the horizontally scrolling box. This behavior exactly matches production omnibar.

However, as soon the input box is clicked, it expands to a maximum of 8 lines.

I also cleaned up unused now transition params.

### Steps to test this PR

- [x] Open input screen from a website with long-ish URL, that wouldn't normally fit in one line.
- [x] Verify input box continue to be one line.
- [x] Verify you can long click without expanding the box.
- [x] Verify clicking on the input box expands to fit all of the content (or reaches max of 8 lines).
- [x] Verify the cursor remains where you clicked.

Example:

https://github.com/user-attachments/assets/42ad7047-f26d-4db3-aa64-33c045051be0


### Known issues
Sometimes, the text doesn't immediately fill the available space after expansion, [example](https://app.asana.com/1/137249556945/task/1210835160047735/comment/1210890848594073?focus=true).