### PR TITLE
Set default state to enabled for showing import password option in settings

### DIFF
--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillFeature.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillFeature.kt
@@ -158,6 +158,6 @@ interface AutofillFeature {
     @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.TRUE)
     fun canPromoteImportGooglePasswordsInBrowser(): Toggle
 
-    @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.INTERNAL)
+    @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.TRUE)
     fun canShowImportOptionInAppSettings(): Toggle
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1210879739526768?focus=true 

### Description
Updates default feature flag state to `enabled` instead of `internal` for showing import passwords option in app settings

### Steps to test this PR
- qa optional
