### PR TITLE
Update chat send and search URL icon to right arrow

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
@@ -44,7 +44,6 @@ import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command.SubmitChat
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command.SubmitSearch
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command.SwitchToTab
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command.UserSubmittedQuery
-import com.duckduckgo.duckchat.impl.inputscreen.ui.state.SubmitButtonIcon.GLOBE
 import com.duckduckgo.duckchat.impl.inputscreen.ui.state.SubmitButtonIcon.SEARCH
 import com.duckduckgo.duckchat.impl.inputscreen.ui.state.SubmitButtonIcon.SEND
 import com.duckduckgo.duckchat.impl.inputscreen.ui.tabs.InputScreenPagerAdapter
@@ -139,9 +138,8 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
 
         viewModel.submitButtonIconState.onEach { iconState ->
             val iconResource = when (iconState.icon) {
-                GLOBE -> com.duckduckgo.mobile.android.R.drawable.ic_globe_24
                 SEARCH -> com.duckduckgo.mobile.android.R.drawable.ic_find_search_24
-                SEND -> R.drawable.ic_arrow_up_24
+                SEND -> com.duckduckgo.mobile.android.R.drawable.ic_arrow_right_24
             }
             binding.actionSend.setImageResource(iconResource)
         }.launchIn(lifecycleScope)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/state/SubmitButtonIconState.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/state/SubmitButtonIconState.kt
@@ -21,5 +21,5 @@ data class SubmitButtonIconState(
 )
 
 enum class SubmitButtonIcon {
-    SEARCH, GLOBE, SEND
+    SEARCH, SEND
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
@@ -280,14 +280,11 @@ class InputScreenViewModel @AssistedInject constructor(
     fun onSearchInputTextChanged(query: String) {
         searchInputTextState.value = query.trim()
         _submitButtonIconState.update {
-            it.copy(icon = if (isWebUrl(query)) SubmitButtonIcon.GLOBE else SubmitButtonIcon.SEARCH)
+            it.copy(icon = if (isWebUrl(query)) SubmitButtonIcon.SEND else SubmitButtonIcon.SEARCH)
         }
     }
 
     fun onChatInputTextChanged(query: String) {
-        _submitButtonIconState.update {
-            it.copy(icon = if (isWebUrl(query)) SubmitButtonIcon.GLOBE else SubmitButtonIcon.SEND)
-        }
         _visibilityState.update {
             it.copy(showChatLogo = (query == initialSearchInputText && !it.autoCompleteSuggestionsVisible) || query.isEmpty())
         }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
@@ -398,24 +398,26 @@ class InputScreenViewModelTest {
     }
 
     @Test
-    fun `when chat text is web url then submitButtonIcon is GLOBE`() {
+    fun `when chat text is web url then submitButtonIcon is SEND`() {
         val viewModel = createViewModel()
+        viewModel.onChatSelected()
         viewModel.onChatInputTextChanged("https://example.com")
-        assertEquals(SubmitButtonIcon.GLOBE, viewModel.submitButtonIconState.value.icon)
+        assertEquals(SubmitButtonIcon.SEND, viewModel.submitButtonIconState.value.icon)
     }
 
     @Test
     fun `when chat text is not web url then submitButtonIcon is SEND`() {
         val viewModel = createViewModel()
+        viewModel.onChatSelected()
         viewModel.onChatInputTextChanged("example")
         assertEquals(SubmitButtonIcon.SEND, viewModel.submitButtonIconState.value.icon)
     }
 
     @Test
-    fun `when search text is web url then submitButtonIcon is GLOBE`() {
+    fun `when search text is web url then submitButtonIcon is SEND`() {
         val viewModel = createViewModel()
         viewModel.onSearchInputTextChanged("https://example.com")
-        assertEquals(SubmitButtonIcon.GLOBE, viewModel.submitButtonIconState.value.icon)
+        assertEquals(SubmitButtonIcon.SEND, viewModel.submitButtonIconState.value.icon)
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1210902983583192?focus=true

### Description

- Removes the globe icon when searching for a URL and replaces it with a right arrow.
- Also replaces the Duck.ai send button with a right arrow.

### Steps to test this PR

- [x] Enable "Search Input" in “Settings” > “Duck.ai"
- [x] Type a query in “Search”
- [x] Verify that a magnifying glass icon is shown
- [x] Type a URL in “Search”
- [ ] Verify that a right arrow is shown
- [x] Change the tab to “Duck.ai"
- [ ] Verify that the icon is a right arrow (for queries and URLs)
