### PR TITLE
Include FeaturePage when navigating from Duckai to subscription flow

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/SubscriptionsHandler.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/SubscriptionsHandler.kt
@@ -36,6 +36,8 @@ class SubscriptionsHandler @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
 ) {
 
+    private val defaultDuckAiSubscriptionPurchase = SubscriptionPurchase(featurePage = DUCK_AI_FEATURE_PAGE)
+
     fun handleSubscriptionsFeature(
         featureName: String,
         method: String,
@@ -68,11 +70,12 @@ class SubscriptionsHandler @Inject constructor(
 
                 METHOD_OPEN_SUBSCRIPTION_PURCHASE -> {
                     val subscriptionParams = runCatching {
-                        data?.getString(MESSAGE_PARAM_ORIGIN_KEY).takeUnless { it.isNullOrBlank() }
+                        data?.getString(MESSAGE_PARAM_ORIGIN_KEY)
+                            .takeUnless { it.isNullOrBlank() }
                             ?.let { nonEmptyOrigin ->
-                                SubscriptionPurchase(nonEmptyOrigin)
-                            } ?: SubscriptionPurchase()
-                    }.getOrDefault(SubscriptionPurchase())
+                                defaultDuckAiSubscriptionPurchase.copy(origin = nonEmptyOrigin)
+                            } ?: defaultDuckAiSubscriptionPurchase
+                    }.getOrDefault(defaultDuckAiSubscriptionPurchase)
 
                     withContext(dispatcherProvider.main()) {
                         globalActivityStarter.start(context, subscriptionParams)
@@ -89,5 +92,6 @@ class SubscriptionsHandler @Inject constructor(
         private const val METHOD_OPEN_SUBSCRIPTION_ACTIVATION = "openSubscriptionActivation"
         private const val METHOD_OPEN_SUBSCRIPTION_PURCHASE = "openSubscriptionPurchase"
         private const val MESSAGE_PARAM_ORIGIN_KEY = "origin"
+        private const val DUCK_AI_FEATURE_PAGE = "duckai"
     }
 }

--- a/subscriptions/subscriptions-api/src/main/java/com/duckduckgo/subscriptions/api/SubscriptionScreens.kt
+++ b/subscriptions/subscriptions-api/src/main/java/com/duckduckgo/subscriptions/api/SubscriptionScreens.kt
@@ -21,5 +21,5 @@ import com.duckduckgo.navigation.api.GlobalActivityStarter.ActivityParams
 sealed class SubscriptionScreens {
     data object SubscriptionsSettingsScreenWithEmptyParams : ActivityParams
     data class RestoreSubscriptionScreenWithParams(val isOriginWeb: Boolean = true) : ActivityParams
-    data class SubscriptionPurchase(val origin: String? = null) : ActivityParams
+    data class SubscriptionPurchase(val origin: String? = null, val featurePage: String? = null) : ActivityParams
 }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsConstants.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsConstants.kt
@@ -61,6 +61,7 @@ object SubscriptionsConstants {
     const val ITR_URL = "https://duckduckgo.com/identity-theft-restoration"
     const val FAQS_URL = "https://duckduckgo.com/duckduckgo-help-pages/privacy-pro/"
     const val PRIVACY_PRO_ETLD = "duckduckgo.com"
+    const val FEATURE_PAGE_QUERY_PARAM_KEY = "featurePage"
     const val PRIVACY_PRO_PATH = "pro"
     const val PRIVACY_SUBSCRIPTIONS_PATH = "subscriptions"
 }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
@@ -76,6 +76,7 @@ import com.duckduckgo.subscriptions.impl.R.string
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.ACTIVATE_URL
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.BUY_URL
+import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.FEATURE_PAGE_QUERY_PARAM_KEY
 import com.duckduckgo.subscriptions.impl.databinding.ActivitySubscriptionsWebviewBinding
 import com.duckduckgo.subscriptions.impl.pir.PirActivity.Companion.PirScreenWithEmptyParams
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixelSender
@@ -107,6 +108,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import logcat.logcat
 import org.json.JSONObject
 
 data class SubscriptionsWebViewActivityWithParams(
@@ -189,7 +191,9 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        params = convertIntoSubscriptionWebViewActivityParams(intent)
+        params = convertIntoSubscriptionWebViewActivityParams(intent).also {
+            logcat { "Subscription Flow: entering with params $it" }
+        }
 
         setContentView(binding.root)
 
@@ -288,11 +292,26 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
     }
 
     private fun convertIntoSubscriptionWebViewActivityParams(intent: Intent): SubscriptionsWebViewActivityWithParams {
-        intent.getActivityParams(SubscriptionPurchase::class.java)?.let {
+        intent.getActivityParams(SubscriptionPurchase::class.java)?.let { subscriptionPurchaseActivityParams ->
             return SubscriptionsWebViewActivityWithParams(
                 url = BUY_URL,
-                origin = it.origin,
-            )
+                origin = subscriptionPurchaseActivityParams.origin,
+            ).let { webViewActivityWithParams ->
+                if (subscriptionPurchaseActivityParams.featurePage.isNullOrBlank().not()) {
+                    val urlWithParams = kotlin.runCatching {
+                        BUY_URL.toUri()
+                            .buildUpon()
+                            .appendQueryParameter(FEATURE_PAGE_QUERY_PARAM_KEY, subscriptionPurchaseActivityParams.featurePage)
+                            .build()
+                            .toString()
+                    }.getOrDefault(BUY_URL)
+                    webViewActivityWithParams.copy(
+                        url = urlWithParams,
+                    )
+                } else {
+                    webViewActivityWithParams
+                }
+            }
         }
 
         return intent.getActivityParams(SubscriptionsWebViewActivityWithParams::class.java)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1149059203486286/task/1210891403305047?focus=true

### Description
Includes featurePage in url when capturing subscription navigation from duckai chat. 

### Steps to test this PR

Use filter in logcat `message~:"Subscription Flow:"`

_Feature 1_
- [x] change debug package so it doesn't include `.debug` (to make subscriptions work)
- [x] install the branch
- [x] Without a subscription, visit Duck.ai
- [x] Open model selector to visualize upsells
- [x] Click on the upsell
- [x] Ensure it navigates to subscription flows
- [x] Check in the logs you see `url=https://duckduckgo.com/subscriptions?featurePage=duckai`

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
