### PR TITLE
Scroll to last position when deleting autocomplete entry (Input Screen)

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/state/AutoCompleteScrollState.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/state/AutoCompleteScrollState.kt
@@ -14,11 +14,9 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.duckchat.impl.inputscreen.ui.command
+package com.duckduckgo.duckchat.impl.inputscreen.ui.state
 
-import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion
-
-sealed class SearchCommand {
-    data class ShowRemoveSearchSuggestionDialog(val suggestion: AutoCompleteSuggestion) : SearchCommand()
-    data class RestoreAutoCompleteScrollPosition(val firstVisibleItemPosition: Int, val itemOffsetTop: Int) : SearchCommand()
-}
+data class AutoCompleteScrollState(
+    val firstVisibleItemPosition: Int = 0,
+    val itemOffsetTop: Int = 0,
+)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/tabs/SearchTabFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/tabs/SearchTabFragment.kt
@@ -155,7 +155,7 @@ class SearchTabFragment : DuckDuckGoFragment(R.layout.fragment_search_tab) {
     private fun processCommand(command: SearchCommand) {
         when (command) {
             is ShowRemoveSearchSuggestionDialog -> showRemoveSearchSuggestionDialog(command.suggestion)
-            is RestoreAutoCompleteScrollPosition -> showKeyboardAndRestorePosition(
+            is RestoreAutoCompleteScrollPosition -> restoreAutoCompleteScrollPosition(
                 command.firstVisibleItemPosition,
                 command.itemOffsetTop,
             )
@@ -195,7 +195,7 @@ class SearchTabFragment : DuckDuckGoFragment(R.layout.fragment_search_tab) {
         viewModel.storeAutoCompleteScrollPosition(firstVisibleItemPosition, itemOffsetTop)
     }
 
-    private fun showKeyboardAndRestorePosition(position: Int, offset: Int) {
+    private fun restoreAutoCompleteScrollPosition(position: Int, offset: Int) {
         val layoutListener = object : ViewTreeObserver.OnGlobalLayoutListener {
             override fun onGlobalLayout() {
                 binding.autoCompleteSuggestionsList.viewTreeObserver.removeOnGlobalLayoutListener(this)
@@ -203,7 +203,6 @@ class SearchTabFragment : DuckDuckGoFragment(R.layout.fragment_search_tab) {
             }
         }
         binding.autoCompleteSuggestionsList.viewTreeObserver.addOnGlobalLayoutListener(layoutListener)
-        viewModel.showKeyboard()
     }
 
     private fun scrollToPositionWithOffset(position: Int, offset: Int) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/tabs/SearchTabFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/tabs/SearchTabFragment.kt
@@ -39,6 +39,7 @@ import com.duckduckgo.duckchat.impl.databinding.FragmentSearchTabBinding
 import com.duckduckgo.duckchat.impl.inputscreen.autocomplete.BrowserAutoCompleteSuggestionsAdapter
 import com.duckduckgo.duckchat.impl.inputscreen.autocomplete.OmnibarPosition.TOP
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.SearchCommand
+import com.duckduckgo.duckchat.impl.inputscreen.ui.command.SearchCommand.RestoreAutoCompleteScrollPosition
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.SearchCommand.ShowRemoveSearchSuggestionDialog
 import com.duckduckgo.duckchat.impl.inputscreen.ui.view.BottomBlurView
 import com.duckduckgo.duckchat.impl.inputscreen.ui.viewmodel.InputScreenViewModel
@@ -154,10 +155,16 @@ class SearchTabFragment : DuckDuckGoFragment(R.layout.fragment_search_tab) {
     private fun processCommand(command: SearchCommand) {
         when (command) {
             is ShowRemoveSearchSuggestionDialog -> showRemoveSearchSuggestionDialog(command.suggestion)
+            is RestoreAutoCompleteScrollPosition -> showKeyboardAndRestorePosition(
+                command.firstVisibleItemPosition,
+                command.itemOffsetTop,
+            )
         }
     }
 
     private fun showRemoveSearchSuggestionDialog(suggestion: AutoCompleteSuggestion) {
+        storeAutocompletePosition()
+
         TextAlertDialogBuilder(requireContext())
             .setTitle(R.string.autocompleteRemoveItemTitle)
             .setCancellable(true)
@@ -167,16 +174,40 @@ class SearchTabFragment : DuckDuckGoFragment(R.layout.fragment_search_tab) {
                 object : TextAlertDialogBuilder.EventListener() {
                     override fun onPositiveButtonClicked() {
                         viewModel.onRemoveSearchSuggestionConfirmed(suggestion)
+                        viewModel.restoreAutoCompleteScrollPosition()
                     }
 
                     override fun onNegativeButtonClicked() {
-                        viewModel.showKeyboard()
+                        viewModel.restoreAutoCompleteScrollPosition()
                     }
 
                     override fun onDialogCancelled() {
-                        viewModel.showKeyboard()
+                        viewModel.restoreAutoCompleteScrollPosition()
                     }
                 },
             ).show()
+    }
+
+    private fun storeAutocompletePosition() {
+        val layoutManager = binding.autoCompleteSuggestionsList.layoutManager as LinearLayoutManager
+        val firstVisibleItemPosition = layoutManager.findFirstVisibleItemPosition()
+        val itemOffsetTop = layoutManager.findViewByPosition(firstVisibleItemPosition)?.top ?: 0
+        viewModel.storeAutoCompleteScrollPosition(firstVisibleItemPosition, itemOffsetTop)
+    }
+
+    private fun showKeyboardAndRestorePosition(position: Int, offset: Int) {
+        val layoutListener = object : ViewTreeObserver.OnGlobalLayoutListener {
+            override fun onGlobalLayout() {
+                binding.autoCompleteSuggestionsList.viewTreeObserver.removeOnGlobalLayoutListener(this)
+                scrollToPositionWithOffset(position, offset)
+            }
+        }
+        binding.autoCompleteSuggestionsList.viewTreeObserver.addOnGlobalLayoutListener(layoutListener)
+        viewModel.showKeyboard()
+    }
+
+    private fun scrollToPositionWithOffset(position: Int, offset: Int) {
+        val layoutManager = binding.autoCompleteSuggestionsList.layoutManager as LinearLayoutManager
+        layoutManager.scrollToPositionWithOffset(position, offset)
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
@@ -279,7 +279,6 @@ class InputScreenViewModel @AssistedInject constructor(
             }
             withContext(dispatchers.main()) {
                 refreshSuggestions.emit(Unit)
-                showKeyboard()
             }
         }
     }
@@ -375,6 +374,7 @@ class InputScreenViewModel @AssistedInject constructor(
             firstVisibleItemPosition = autoCompleteScrollState.firstVisibleItemPosition,
             itemOffsetTop = autoCompleteScrollState.itemOffsetTop,
         )
+        showKeyboard()
     }
 
     private fun checkMovedBeyondInitialUrl(searchInput: String): Boolean {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
@@ -41,6 +41,7 @@ import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command.SwitchToTab
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.InputFieldCommand
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.SearchCommand
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.SearchCommand.ShowRemoveSearchSuggestionDialog
+import com.duckduckgo.duckchat.impl.inputscreen.ui.state.AutoCompleteScrollState
 import com.duckduckgo.duckchat.impl.inputscreen.ui.state.InputFieldState
 import com.duckduckgo.duckchat.impl.inputscreen.ui.state.InputScreenVisibilityState
 import com.duckduckgo.duckchat.impl.inputscreen.ui.state.SubmitButtonIcon
@@ -170,6 +171,8 @@ class InputScreenViewModel @AssistedInject constructor(
 
     private val _inputFieldState = MutableStateFlow(InputFieldState(canExpand = false))
     val inputFieldState: StateFlow<InputFieldState> = _inputFieldState.asStateFlow()
+
+    private var autoCompleteScrollState = AutoCompleteScrollState()
 
     val command: SingleLiveEvent<Command> = SingleLiveEvent()
     val searchTabCommand: SingleLiveEvent<SearchCommand> = SingleLiveEvent()
@@ -358,6 +361,20 @@ class InputScreenViewModel @AssistedInject constructor(
         _inputFieldState.update {
             it.copy(canExpand = true)
         }
+    }
+
+    fun storeAutoCompleteScrollPosition(firstVisibleItemPosition: Int, itemOffsetTop: Int) {
+        autoCompleteScrollState = autoCompleteScrollState.copy(
+            firstVisibleItemPosition = firstVisibleItemPosition,
+            itemOffsetTop = itemOffsetTop,
+        )
+    }
+
+    fun restoreAutoCompleteScrollPosition() {
+        searchTabCommand.value = SearchCommand.RestoreAutoCompleteScrollPosition(
+            firstVisibleItemPosition = autoCompleteScrollState.firstVisibleItemPosition,
+            itemOffsetTop = autoCompleteScrollState.itemOffsetTop,
+        )
     }
 
     private fun checkMovedBeyondInitialUrl(searchInput: String): Boolean {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
@@ -10,6 +10,7 @@ import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggesti
 import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion.AutoCompleteSearchSuggestion
 import com.duckduckgo.browser.api.autocomplete.AutoCompleteSettings
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command.ShowKeyboard
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command.SubmitChat
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command.SubmitSearch
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.InputFieldCommand
@@ -659,15 +660,13 @@ class InputScreenViewModelTest {
     }
 
     @Test
-    fun `when restoreAutoCompleteScrollPosition called then RestoreAutoCompleteScrollPosition command sent`() = runTest {
+    fun `when restoreAutoCompleteScrollPosition called then RestoreAutoCompleteScrollPosition command sent and keyboard shown`() = runTest {
         val viewModel = createViewModel()
 
         viewModel.storeAutoCompleteScrollPosition(firstVisibleItemPosition = 123, itemOffsetTop = 456)
         viewModel.restoreAutoCompleteScrollPosition()
 
-        assertEquals(
-            SearchCommand.RestoreAutoCompleteScrollPosition(123, 456),
-            viewModel.searchTabCommand.value,
-        )
+        assertEquals(SearchCommand.RestoreAutoCompleteScrollPosition(123, 456), viewModel.searchTabCommand.value)
+        assertEquals(ShowKeyboard, viewModel.command.value)
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
@@ -13,6 +13,7 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command.SubmitChat
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command.SubmitSearch
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.InputFieldCommand
+import com.duckduckgo.duckchat.impl.inputscreen.ui.command.SearchCommand
 import com.duckduckgo.duckchat.impl.inputscreen.ui.state.SubmitButtonIcon
 import com.duckduckgo.duckchat.impl.inputscreen.ui.viewmodel.InputScreenViewModel
 import com.duckduckgo.history.api.NavigationHistory
@@ -655,5 +656,18 @@ class InputScreenViewModelTest {
             // Should not receive any additional commands
             expectNoEvents()
         }
+    }
+
+    @Test
+    fun `when restoreAutoCompleteScrollPosition called then RestoreAutoCompleteScrollPosition command sent`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.storeAutoCompleteScrollPosition(firstVisibleItemPosition = 123, itemOffsetTop = 456)
+        viewModel.restoreAutoCompleteScrollPosition()
+
+        assertEquals(
+            SearchCommand.RestoreAutoCompleteScrollPosition(123, 456),
+            viewModel.searchTabCommand.value,
+        )
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1210893251369089?focus=true

### Description

- Scrolls back to the same position in the autocomplete list after deleting an item.

### Steps to test this PR

- [x] Enable "Search Input" in “Settings” > “Duck.ai"
- [x] Search for something
- [x] Search for the same thing and long press the history item in autocomplete
- [x] Remove the item
- [x] Verify that the list returns to the same position after the item is removed

This should also be the same if you dismiss/cancel the dialog.