### PR TITLE
Replace duckai ff by filtering subscription entitlements

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -36,9 +36,6 @@ interface DuckChatFeature {
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
-    fun duckAiPlus(): Toggle
-
     /**
      * @return `true` when the remote config has the "duckAiButtonInBrowser" Duck.ai button in browser
      * sub-feature flag enabled

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/subscription/DuckAiPlusSettingsViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/subscription/DuckAiPlusSettingsViewModel.kt
@@ -24,7 +24,6 @@ import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ViewScope
-import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.subscription.DuckAiPlusSettingsViewModel.ViewState.SettingState
 import com.duckduckgo.duckchat.impl.subscription.DuckAiPlusSettingsViewModel.ViewState.SettingState.Disabled
 import com.duckduckgo.duckchat.impl.subscription.DuckAiPlusSettingsViewModel.ViewState.SettingState.Hidden
@@ -48,7 +47,6 @@ import kotlinx.coroutines.launch
 @ContributesViewModel(ViewScope::class)
 class DuckAiPlusSettingsViewModel @Inject constructor(
     private val subscriptions: Subscriptions,
-    private val duckChatFeature: DuckChatFeature,
     private val dispatcherProvider: DispatcherProvider,
 ) : ViewModel(), DefaultLifecycleObserver {
 
@@ -79,11 +77,6 @@ class DuckAiPlusSettingsViewModel @Inject constructor(
         super.onCreate(owner)
 
         viewModelScope.launch(dispatcherProvider.io()) {
-            if (duckChatFeature.duckAiPlus().isEnabled().not()) {
-                _viewState.update { it.copy(settingState = Hidden) }
-                return@launch
-            }
-
             subscriptions.getEntitlementStatus().map { entitlements ->
                 entitlements.any { product ->
                     product == DuckAiPlus

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/subscription/DuckAiPlusSettingsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/subscription/DuckAiPlusSettingsViewModelTest.kt
@@ -3,11 +3,8 @@ package com.duckduckgo.duckchat.impl.subscription
 import android.annotation.SuppressLint
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
-import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.subscription.DuckAiPlusSettingsViewModel.Command.OpenDuckAiPlusSettings
 import com.duckduckgo.duckchat.impl.subscription.DuckAiPlusSettingsViewModel.ViewState.SettingState
-import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
-import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.subscriptions.api.Product
 import com.duckduckgo.subscriptions.api.SubscriptionStatus
 import com.duckduckgo.subscriptions.api.Subscriptions
@@ -25,27 +22,12 @@ class DuckAiPlusSettingsViewModelTest {
     val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
 
     private val subscriptions: Subscriptions = mock()
-    private val duckChatFeature = FakeFeatureToggleFactory.create(DuckChatFeature::class.java).also {
-        it.duckAiPlus().setRawStoredState(State(true))
-    }
 
     private val viewModel: DuckAiPlusSettingsViewModel by lazy {
         DuckAiPlusSettingsViewModel(
             subscriptions = subscriptions,
-            duckChatFeature = duckChatFeature,
             dispatcherProvider = coroutineTestRule.testDispatcherProvider,
         )
-    }
-
-    @Test
-    fun `when feature flag is disabled then SettingState is Hidden`() = runTest {
-        duckChatFeature.duckAiPlus().setRawStoredState(State(false))
-        whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(Product.DuckAiPlus)))
-        whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.AUTO_RENEWABLE)
-
-        viewModel.viewState.test {
-            assertEquals(SettingState.Hidden, expectMostRecentItem().settingState)
-        }
     }
 
     @Test

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -36,6 +36,7 @@ import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.subscriptions.api.Product
+import com.duckduckgo.subscriptions.api.Product.DuckAiPlus
 import com.duckduckgo.subscriptions.api.SubscriptionStatus
 import com.duckduckgo.subscriptions.api.Subscriptions
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.BUY_URL
@@ -49,10 +50,12 @@ import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import dagger.Lazy
 import dagger.SingleInstanceIn
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
@@ -61,6 +64,7 @@ class RealSubscriptions @Inject constructor(
     private val subscriptionsManager: SubscriptionsManager,
     private val globalActivityStarter: GlobalActivityStarter,
     private val pixel: SubscriptionPixelSender,
+    private val subscriptionsFeature: Lazy<PrivacyProFeature>,
 ) : Subscriptions {
     override suspend fun isSignedIn(): Boolean =
         subscriptionsManager.isSignedIn()
@@ -73,7 +77,13 @@ class RealSubscriptions @Inject constructor(
     }
 
     override fun getEntitlementStatus(): Flow<List<Product>> {
-        return subscriptionsManager.entitlements
+        return subscriptionsManager.entitlements.map { list ->
+            if (subscriptionsFeature.get().duckAiPlus().isEnabled().not()) {
+                list.filterNot { entitlement -> entitlement == DuckAiPlus }
+            } else {
+                list
+            }
+        }
     }
 
     override suspend fun isEligible(): Boolean {
@@ -94,7 +104,13 @@ class RealSubscriptions @Inject constructor(
     override suspend fun getAvailableProducts(): Set<Product> {
         return subscriptionsManager.getFeatures()
             .mapNotNull { feature -> Product.entries.firstOrNull { it.value == feature } }
-            .toSet()
+            .let {
+                if (subscriptionsFeature.get().duckAiPlus().isEnabled().not()) {
+                    it.filterNot { feature -> feature == DuckAiPlus }
+                } else {
+                    it
+                }
+            }.toSet()
     }
 
     override fun launchPrivacyPro(context: Context, uri: Uri?) {

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/settings/views/ProSettingView.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/settings/views/ProSettingView.kt
@@ -172,10 +172,10 @@ class ProSettingView @JvmOverloads constructor(
             }
             else -> {
                 with(binding) {
-                    if (viewState.duckAiEnabled) {
+                    if (viewState.duckAiPlusAvailable) {
                         subscriptionBuy.setPrimaryText(context.getString(R.string.subscriptionSettingSubscribeSecure))
                     } else {
-                        subscriptionBuy.setPrimaryText(context.getString(R.string.subscriptionSettingSubscribe))
+                        subscriptionBuy.setPrimaryText(context.getString(R.string.subscriptionSettingSubscribeRebranding))
                     }
                     subscriptionBuy.setSecondaryText(getSubscriptionSecondaryText(viewState))
                     subscriptionGet.setText(getActionButtonText(viewState))

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/settings/views/ProSettingViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/settings/views/ProSettingViewModel.kt
@@ -73,7 +73,6 @@ class ProSettingViewModel @Inject constructor(
     data class ViewState(
         val status: SubscriptionStatus = UNKNOWN,
         val region: SubscriptionRegion? = null,
-        val duckAiEnabled: Boolean = false,
         val rebrandingEnabled: Boolean = false,
         val duckAiPlusAvailable: Boolean = false,
         val freeTrialEligible: Boolean = false,
@@ -121,7 +120,6 @@ class ProSettingViewModel @Inject constructor(
                         viewState.value.copy(
                             status = subscriptionStatus,
                             region = region,
-                            duckAiEnabled = duckAiEnabled,
                             rebrandingEnabled = rebrandingEnabled,
                             duckAiPlusAvailable = duckAiAvailable,
                             freeTrialEligible = subscriptionsManager.isFreeTrialEligible(),

--- a/subscriptions/subscriptions-impl/src/main/res/values/donottranslate.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values/donottranslate.xml
@@ -41,4 +41,5 @@
     <string name="addToDeviceSecondaryTextWithoutEmailRebranding">Add your subscription to your other devices via Google Play or by linking an email address.</string>
     <string name="addToDeviceSecondaryTextWithEmailRebranding">Use the email above to add your subscription on your other devices in the DuckDuckGo app. Go to Settings > Subscription Settings > I Have a Subscription.</string>
     <string name="subscriptionSettingRebrandingMessage">Privacy Pro is now just called the DuckDuckGo subscription</string>"
+    <string name="subscriptionSettingSubscribeRebranding">Protect your connection and identity with one subscription.</string>
 </resources>

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.subscriptions.impl
 
+import android.annotation.SuppressLint
 import android.content.Intent
 import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
 import androidx.core.net.toUri
@@ -24,8 +25,11 @@ import androidx.test.platform.app.InstrumentationRegistry
 import app.cash.turbine.test
 import com.duckduckgo.browser.api.ui.BrowserScreens.SettingsScreenNoParams
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.navigation.api.GlobalActivityStarter.ActivityParams
+import com.duckduckgo.subscriptions.api.Product.DuckAiPlus
 import com.duckduckgo.subscriptions.api.Product.NetP
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.AUTO_RENEWABLE
 import com.duckduckgo.subscriptions.api.SubscriptionStatus.UNKNOWN
@@ -52,6 +56,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 @RunWith(AndroidJUnit4::class)
+@SuppressLint("DenyListedApi")
 class RealSubscriptionsTest {
 
     @get:Rule
@@ -63,6 +68,7 @@ class RealSubscriptionsTest {
     private val globalActivityStarter: GlobalActivityStarter = mock()
     private val pixel: SubscriptionPixelSender = mock()
     private lateinit var subscriptions: RealSubscriptions
+    private val subscriptionFeature: PrivacyProFeature = FakeFeatureToggleFactory.create(PrivacyProFeature::class.java)
 
     private val testSubscriptionOfferList = listOf(
         SubscriptionOffer(
@@ -77,7 +83,7 @@ class RealSubscriptionsTest {
     fun before() = runTest {
         whenever(mockSubscriptionsManager.canSupportEncryption()).thenReturn(true)
         whenever(mockSubscriptionsManager.getSubscriptionOffer()).thenReturn(emptyList())
-        subscriptions = RealSubscriptions(mockSubscriptionsManager, globalActivityStarter, pixel)
+        subscriptions = RealSubscriptions(mockSubscriptionsManager, globalActivityStarter, pixel, { subscriptionFeature })
     }
 
     @Test
@@ -105,6 +111,34 @@ class RealSubscriptionsTest {
     }
 
     @Test
+    fun whenGetEntitlementStatusHasEntitlementDuckaiButFFDisabledThenReturnRemoveFromList() = runTest {
+        subscriptionFeature.duckAiPlus().setRawStoredState(State(false))
+        whenever(mockSubscriptionsManager.subscriptionStatus()).thenReturn(AUTO_RENEWABLE)
+        whenever(mockSubscriptionsManager.entitlements).thenReturn(flowOf(listOf(NetP, DuckAiPlus)))
+
+        subscriptions.getEntitlementStatus().test {
+            val entitlements = awaitItem()
+            assertFalse(entitlements.contains(DuckAiPlus))
+            assertTrue(entitlements.size == 1)
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenGetEntitlementStatusHasEntitlementDuckaiAndFFEnabledThenReturnList() = runTest {
+        subscriptionFeature.duckAiPlus().setRawStoredState(State(true))
+        whenever(mockSubscriptionsManager.subscriptionStatus()).thenReturn(AUTO_RENEWABLE)
+        whenever(mockSubscriptionsManager.entitlements).thenReturn(flowOf(listOf(NetP, DuckAiPlus)))
+
+        subscriptions.getEntitlementStatus().test {
+            val entitlements = awaitItem()
+            assertTrue(entitlements.contains(DuckAiPlus))
+            assertTrue(entitlements.size == 2)
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
     fun whenGetEntitlementStatusHasNoEntitlementAndEnabledAndActiveThenReturnEmptyList() = runTest {
         whenever(mockSubscriptionsManager.subscriptionStatus()).thenReturn(AUTO_RENEWABLE)
         whenever(mockSubscriptionsManager.entitlements).thenReturn(flowOf(emptyList()))
@@ -113,6 +147,28 @@ class RealSubscriptionsTest {
             assertTrue(awaitItem().isEmpty())
             cancelAndConsumeRemainingEvents()
         }
+    }
+
+    @Test
+    fun whenGetAvailableProductsHasDuckaiButFFDisabledThenReturnRemoveFromList() = runTest {
+        subscriptionFeature.duckAiPlus().setRawStoredState(State(false))
+        val subsProducts = setOf(NetP, DuckAiPlus).map { it.value }.toSet()
+        whenever(mockSubscriptionsManager.getFeatures()).thenReturn(subsProducts)
+
+        val products = subscriptions.getAvailableProducts()
+        assertFalse(products.contains(DuckAiPlus))
+        assertTrue(products.size == 1)
+    }
+
+    @Test
+    fun whenGetAvailableProductsHasDuckaiAndFFEnabledThenReturnList() = runTest {
+        subscriptionFeature.duckAiPlus().setRawStoredState(State(true))
+        val subsProducts = setOf(NetP, DuckAiPlus).map { it.value }.toSet()
+        whenever(mockSubscriptionsManager.getFeatures()).thenReturn(subsProducts)
+
+        val products = subscriptions.getAvailableProducts()
+        assertTrue(products.contains(DuckAiPlus))
+        assertTrue(products.size == 2)
     }
 
     @Test

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsTest.kt
@@ -83,7 +83,13 @@ class RealSubscriptionsTest {
     fun before() = runTest {
         whenever(mockSubscriptionsManager.canSupportEncryption()).thenReturn(true)
         whenever(mockSubscriptionsManager.getSubscriptionOffer()).thenReturn(emptyList())
-        subscriptions = RealSubscriptions(mockSubscriptionsManager, globalActivityStarter, pixel, { subscriptionFeature })
+        subscriptions = RealSubscriptions(
+            mockSubscriptionsManager,
+            globalActivityStarter,
+            pixel,
+            { subscriptionFeature },
+            coroutineRule.testDispatcherProvider,
+        )
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1149059203486286/task/1210908317304409?focus=true 

### Description
Replace duckai FF by relying on subscription ff and filtering entitlements

### Steps to test this PR

_Feature 1_
- [x] Fresh install this branch
- [x] Go to settings
- [ ] No trace of Duckai in subscription settings (even FF is enabled, BE is not returning the product/entitlement)
- [x] Purchase the subscription
- [x] Duck.ai is not listed (even FF is enabled, BE is not returning the product/entitlement)

_Feature 2_
- [x] Cancel your subscription and remove account
- [x] Apply patch attached in https://app.asana.com/1/137249556945/project/1149059203486286/task/1210908317304409?focus=true 
- [x] Fresh install this branch
- [x] Go to settings
- [x] Duckai in subscription settings (FF is enabled, BE is returning the product/entitlement)
- [x] Purchase the subscription
- [x] Duck.ai is listed (FF is enabled, BE is returning the product/entitlement)
- [x] Go to Feature flags inventory
- [x] Disable duckaiplus inside privacyPro
- [x] restart the app
- [x] Duckai is not shown in settings (FF is disabled, BE is returning the product/entitlement but we filter)
- [x] Cancel the subscription and remove
- [x] We don't mention duck.ai in subscription settings (FF is disabled, BE is returning the product/entitlement but we filter)

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
