### PR TITLE
Search icon should be a right arrow when opened with URL (Input Screen)

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
@@ -109,6 +109,8 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
         configureVoice()
         configureObservers()
 
+        binding.inputModeWidget.init()
+
         requireActivity().onBackPressedDispatcher.addCallback(
             viewLifecycleOwner,
             object : OnBackPressedCallback(true) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
@@ -109,13 +109,15 @@ class InputModeWidget @JvmOverloads constructor(
         configureTabBehavior()
         applyModeSpecificInputBehaviour(isSearchTab = true)
         configureShadow()
-
-        onSearchSelected?.invoke()
     }
 
     fun provideInitialText(text: String) {
         originalText = text
         this.text = text
+    }
+
+    fun init() {
+        onSearchSelected?.invoke()
     }
 
     private fun configureClickListeners() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1210902938749438?focus=true

### Description

- When Input Screen launched with URL, the action button should have a right arrow icon.

### Steps to test this PR

- [x] Enable "Search Input" in “Settings” > “Duck.ai"
- [x] Enter a URL and search
- [x] Tap the omnibar again to open the Input Screen
- [x] Verify that the action button has a right arrow icon
