### PR TITLE
Text does not always expand upon touch (Input Screen)

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
@@ -89,6 +89,9 @@ class InputModeWidget @JvmOverloads constructor(
                 beginChangeBoundsTransition()
                 inputField.maxLines = if (value) MAX_LINES else 1
                 inputField.setHorizontallyScrolling(!value)
+                inputField.post {
+                    inputField.requestLayout()
+                }
             }
         }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1210902938749434?focus=true

### Description

- Fixes a bug where the text does not always immediately expand to fill the Input Field upon touch.

### Steps to test this PR

- [ ] Go to a long URL (An amazon listing works)
- [ ] Verify that the text expands to fill the input field upon touch
