### PR TITLE
Fix disable Duck.ai in Duck.ai onboarding

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -320,11 +320,12 @@ class RealDuckChat @Inject constructor(
     }
 
     override fun openDuckChatSettings() {
-        // todo what happens with this interaction? closeDuckChat() would go back to browser activity
         val intent = globalActivityStarter.startIntent(context, DuckChatSettingsNoParams)
         intent?.flags = Intent.FLAG_ACTIVITY_NEW_TASK
         context.startActivity(intent)
-        closeDuckChat()
+        appCoroutineScope.launch {
+            closeChatFlow.emit(Unit)
+        }
     }
 
     override fun closeDuckChat() {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -414,6 +414,15 @@ class RealDuckChatTest {
     fun whenOpenDuckChatSettingsCalledThenGlobalActivityStarterCalledWithDuckChatSettings() = runTest {
         whenever(mockGlobalActivityStarter.startIntent(any(), any<ActivityParams>())).thenReturn(Intent())
 
+        val testLifecycleOwner = TestLifecycleOwner(initialState = CREATED)
+
+        var onCloseCalled = false
+        testee.observeCloseEvent(testLifecycleOwner) {
+            onCloseCalled = true
+        }
+
+        testLifecycleOwner.currentState = Lifecycle.State.STARTED
+
         testee.openDuckChatSettings()
 
         verify(mockGlobalActivityStarter).startIntent(mockContext, DuckChatSettingsNoParams)
@@ -424,7 +433,9 @@ class RealDuckChatTest {
 
         assertEquals(Intent.FLAG_ACTIVITY_NEW_TASK, capturedIntent.flags)
 
-        verify(testee).closeDuckChat()
+        advanceUntilIdle()
+
+        assertTrue(onCloseCalled)
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1210939806484672?focus=true

### Description

- Fixes the "Disable Duck.ai" button on the Duck.ai onboarding screen.

### Steps to test this PR

- [x] Fresh install
- [x] Go to Duck.ai and click “Disable Duck.ai"
- [x] Verify that it navigates to the Duck.ai settings screen
