### PR TITLE
Update content scope scripts to version 11.2.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
@@ -3864,16 +3864,22 @@
     }
     urlChangeListeners.add(listener);
   }
-  function handleURLChange() {
+  function handleURLChange(navigationType = "unknown") {
     for (const listener of urlChangeListeners) {
-      listener();
+      listener(navigationType);
     }
   }
   function listenForURLChanges() {
     const urlChangedInstance = new ContentFeature("urlChanged", {}, {});
     if ("navigation" in globalThis && "addEventListener" in globalThis.navigation) {
-      globalThis.navigation.addEventListener("navigatesuccess", () => {
-        handleURLChange();
+      const navigations = /* @__PURE__ */ new WeakMap();
+      globalThis.navigation.addEventListener("navigate", (event) => {
+        navigations.set(event.target, event.navigationType);
+      });
+      globalThis.navigation.addEventListener("navigatesuccess", (event) => {
+        const navigationType = navigations.get(event.target) || "unknown";
+        handleURLChange(navigationType);
+        navigations.delete(event.target);
       });
       return;
     }
@@ -3883,13 +3889,14 @@
     const historyMethodProxy = new DDGProxy(urlChangedInstance, History.prototype, "pushState", {
       apply(target, thisArg, args) {
         const changeResult = DDGReflect.apply(target, thisArg, args);
-        handleURLChange();
+        console.log("pushstate event");
+        handleURLChange("push");
         return changeResult;
       }
     });
     historyMethodProxy.overload();
     window.addEventListener("popstate", () => {
-      handleURLChange();
+      handleURLChange("popState");
     });
   }
 
@@ -3934,9 +3941,9 @@
       if (!isFeatureBroken(args, featureName) || alwaysInitExtensionFeatures(args, featureName)) {
         featureInstance.callInit(args);
         if (featureInstance.listenForUrlChanges || featureInstance.urlChanged) {
-          registerForURLChanges(() => {
+          registerForURLChanges((navigationType) => {
             featureInstance.recomputeSiteObject();
-            featureInstance?.urlChanged();
+            featureInstance?.urlChanged(navigationType);
           });
         }
       }

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -8562,16 +8562,22 @@
     }
     urlChangeListeners.add(listener);
   }
-  function handleURLChange() {
+  function handleURLChange(navigationType = "unknown") {
     for (const listener of urlChangeListeners) {
-      listener();
+      listener(navigationType);
     }
   }
   function listenForURLChanges() {
     const urlChangedInstance = new ContentFeature("urlChanged", {}, {});
     if ("navigation" in globalThis && "addEventListener" in globalThis.navigation) {
-      globalThis.navigation.addEventListener("navigatesuccess", () => {
-        handleURLChange();
+      const navigations = /* @__PURE__ */ new WeakMap();
+      globalThis.navigation.addEventListener("navigate", (event) => {
+        navigations.set(event.target, event.navigationType);
+      });
+      globalThis.navigation.addEventListener("navigatesuccess", (event) => {
+        const navigationType = navigations.get(event.target) || "unknown";
+        handleURLChange(navigationType);
+        navigations.delete(event.target);
       });
       return;
     }
@@ -8581,13 +8587,14 @@
     const historyMethodProxy = new DDGProxy(urlChangedInstance, History.prototype, "pushState", {
       apply(target, thisArg, args) {
         const changeResult = DDGReflect.apply(target, thisArg, args);
-        handleURLChange();
+        console.log("pushstate event");
+        handleURLChange("push");
         return changeResult;
       }
     });
     historyMethodProxy.overload();
     window.addEventListener("popstate", () => {
-      handleURLChange();
+      handleURLChange("popState");
     });
   }
 
@@ -8632,9 +8639,9 @@
       if (!isFeatureBroken(args, featureName) || alwaysInitExtensionFeatures(args, featureName)) {
         featureInstance.callInit(args);
         if (featureInstance.listenForUrlChanges || featureInstance.urlChanged) {
-          registerForURLChanges(() => {
+          registerForURLChanges((navigationType) => {
             featureInstance.recomputeSiteObject();
-            featureInstance?.urlChanged();
+            featureInstance?.urlChanged(navigationType);
           });
         }
       }

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -5810,6 +5810,7 @@
   }
 
   // src/features/navigator-interface.js
+  var store = {};
   var NavigatorInterface = class extends ContentFeature {
     load(args) {
       if (this.matchConditionalFeatureSetting("privilegedDomains").length) {
@@ -5840,7 +5841,11 @@
              * @throws {Error}
              */
             createMessageBridge(featureName) {
-              return createPageWorldBridge(featureName, args.messageSecret);
+              const existingBridge = store[featureName];
+              if (existingBridge) return existingBridge;
+              const bridge = createPageWorldBridge(featureName, args.messageSecret);
+              store[featureName] = bridge;
+              return bridge;
             }
           },
           enumerable: true,
@@ -9337,16 +9342,22 @@
     }
     urlChangeListeners.add(listener);
   }
-  function handleURLChange() {
+  function handleURLChange(navigationType = "unknown") {
     for (const listener of urlChangeListeners) {
-      listener();
+      listener(navigationType);
     }
   }
   function listenForURLChanges() {
     const urlChangedInstance = new ContentFeature("urlChanged", {}, {});
     if ("navigation" in globalThis && "addEventListener" in globalThis.navigation) {
-      globalThis.navigation.addEventListener("navigatesuccess", () => {
-        handleURLChange();
+      const navigations = /* @__PURE__ */ new WeakMap();
+      globalThis.navigation.addEventListener("navigate", (event) => {
+        navigations.set(event.target, event.navigationType);
+      });
+      globalThis.navigation.addEventListener("navigatesuccess", (event) => {
+        const navigationType = navigations.get(event.target) || "unknown";
+        handleURLChange(navigationType);
+        navigations.delete(event.target);
       });
       return;
     }
@@ -9356,13 +9367,14 @@
     const historyMethodProxy = new DDGProxy(urlChangedInstance, History.prototype, "pushState", {
       apply(target, thisArg, args) {
         const changeResult = DDGReflect.apply(target, thisArg, args);
-        handleURLChange();
+        console.log("pushstate event");
+        handleURLChange("push");
         return changeResult;
       }
     });
     historyMethodProxy.overload();
     window.addEventListener("popstate", () => {
-      handleURLChange();
+      handleURLChange("popState");
     });
   }
 
@@ -9407,9 +9419,9 @@
       if (!isFeatureBroken(args, featureName) || alwaysInitExtensionFeatures(args, featureName)) {
         featureInstance2.callInit(args);
         if (featureInstance2.listenForUrlChanges || featureInstance2.urlChanged) {
-          registerForURLChanges(() => {
+          registerForURLChanges((navigationType) => {
             featureInstance2.recomputeSiteObject();
-            featureInstance2?.urlChanged();
+            featureInstance2?.urlChanged(navigationType);
           });
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.10.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.2.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.0.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.2.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#347bb9d63b5d2e7d07ad5be5a3a470af409f26eb",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#77e36add0994600bb11f1d4199b2104f141c5b02",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -405,9 +405,9 @@
       }
     },
     "node_modules/immutable-json-patch": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/immutable-json-patch/-/immutable-json-patch-6.0.1.tgz",
-      "integrity": "sha512-BHL/cXMjwFZlTOffiWNdY8ZTvNyYLrutCnWxrcKPHr5FqpAb6vsO6WWSPnVSys3+DruFN6lhHJJPHi8uELQL5g==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/immutable-json-patch/-/immutable-json-patch-6.0.2.tgz",
+      "integrity": "sha512-KwCA5DXJiyldda8SPha1zB+6+vbEi5/jRRcYii/6yFXlyu9ZjiSH/wPq8Ri2Hk8iGjjTMcHW3Z21S4MOpl7sOw==",
       "license": "ISC"
     },
     "node_modules/is-builtin-module": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.10.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.2.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.0.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.2.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1210945464995929/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run