### PR TITLE
Fix Onboarding Experiment nice-to-haves 

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BbWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BbWelcomePage.kt
@@ -65,6 +65,7 @@ import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.FragmentViewModelFactory
 import com.duckduckgo.common.utils.extensions.html
+import com.duckduckgo.common.utils.extensions.preventWidows
 import com.duckduckgo.di.scopes.FragmentScope
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.milliseconds
@@ -392,7 +393,7 @@ class BbWelcomePage : OnboardingPageFragment(R.layout.content_onboarding_welcome
 
                     val contentViews = with(binding.daxDialogCta.addressBarPosition) { listOf(option1, option2) }
                     contentViews.forEach { view -> view.alpha = MIN_ALPHA }
-                    val titleText = getString(R.string.highlightsPreOnboardingAddressBarTitle)
+                    val titleText = getString(R.string.highlightsPreOnboardingAddressBarTitle).preventWidows()
 
                     val (topImage, bottomImage) = if (appTheme.isLightModeEnabled()) {
                         R.drawable.bb_address_bar_top_light to R.drawable.bb_address_bar_bottom_light

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BuckWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BuckWelcomePage.kt
@@ -70,6 +70,7 @@ import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.FragmentViewModelFactory
 import com.duckduckgo.common.utils.extensions.html
+import com.duckduckgo.common.utils.extensions.preventWidows
 import com.duckduckgo.di.scopes.FragmentScope
 import javax.inject.Inject
 import kotlinx.coroutines.flow.launchIn
@@ -368,7 +369,7 @@ class BuckWelcomePage : OnboardingPageFragment(R.layout.content_onboarding_welco
 
                             val contentViews = with(binding.daxDialogCta.addressBarPosition) { listOf(option1, option2) }
                             contentViews.forEach { view -> view.alpha = MIN_ALPHA }
-                            val titleText = getString(R.string.highlightsPreOnboardingAddressBarTitle)
+                            val titleText = getString(R.string.highlightsPreOnboardingAddressBarTitle).preventWidows()
 
                             afterTypingAnimation = {
                                 binding.daxDialogCta.addressBarPosition.option1.setOnClickListener {

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePage.kt
@@ -59,6 +59,7 @@ import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.FragmentViewModelFactory
 import com.duckduckgo.common.utils.extensions.html
+import com.duckduckgo.common.utils.extensions.preventWidows
 import com.duckduckgo.di.scopes.FragmentScope
 import javax.inject.Inject
 import kotlinx.coroutines.flow.launchIn
@@ -299,7 +300,13 @@ class WelcomePage : OnboardingPageFragment(R.layout.content_onboarding_welcome_p
                     binding.daxDialogCta.progressBarText.text = "2 / 2"
                     binding.daxDialogCta.progressBar.show()
                     binding.daxDialogCta.progressBar.progress = 2
-                    val ctaText = it.getString(R.string.highlightsPreOnboardingAddressBarTitle)
+                    val ctaText = it.getString(R.string.highlightsPreOnboardingAddressBarTitle).run {
+                        if (onboardingDesignExperimentToggles.modifiedControl().isEnabled()) {
+                            preventWidows()
+                        } else {
+                            this
+                        }
+                    }
                     binding.daxDialogCta.hiddenTextCta.text = ctaText.html(it)
                     binding.daxDialogCta.primaryCta.alpha = MIN_ALPHA
                     binding.daxDialogCta.addressBarPosition.root.show()

--- a/app/src/main/res/layout/content_onboarding_welcome_page_buck.xml
+++ b/app/src/main/res/layout/content_onboarding_welcome_page_buck.xml
@@ -59,15 +59,18 @@
 
             <TextView
                     android:id="@+id/welcomeTitle"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
+                    android:layout_width="match_parent"
+                    android:layout_height="80dp"
                     android:layout_marginHorizontal="@dimen/keyline_5"
                     android:gravity="start"
                     android:text="@string/onboardingWelcomeTitle"
-                    android:fontFamily="@font/pangea_semibold"
+                    app:fontFamily="@font/pangea_semibold"
                     android:includeFontPadding="false"
                     android:textColor="@color/buckColorPrimaryText"
-                    android:textSize="40sp"
+                    app:autoSizeTextType="uniform"
+                    app:autoSizeStepGranularity="2sp"
+                    app:autoSizeMinTextSize="24sp"
+                    app:autoSizeMaxTextSize="40sp"
                     android:lineSpacingExtra="-10sp"
                     tools:ignore="DeprecatedWidgetInXml,InvalidColorAttribute" />
 

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/extensions/StringExtensions.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/extensions/StringExtensions.kt
@@ -88,7 +88,6 @@ fun String.compareSemanticVersion(targetVersion: String): Int? {
     return 0
 }
 
-
 private const val NON_BREAKING_SPACE = '\u00A0'
 
 /**

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/extensions/StringExtensions.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/extensions/StringExtensions.kt
@@ -87,3 +87,33 @@ fun String.compareSemanticVersion(targetVersion: String): Int? {
     }
     return 0
 }
+
+
+private const val NON_BREAKING_SPACE = '\u00A0'
+
+/**
+ * Prevents typographic widows by replacing the last space with a non-breaking space.
+ *
+ * A "widow" in typography refers to a single word that appears alone on the last line
+ * of a paragraph or text block, which is considered poor typography as it creates
+ * visual imbalance and awkward spacing.
+ *
+ * This function finds the last space character in the string and replaces it with
+ * a non-breaking space (U+00A0) to ensure the last two words stay together on the
+ * same line, preventing the final word from becoming orphaned.
+ *
+ * @return A new string with the last space replaced by a non-breaking space,
+ *         or the original string if no space is found or if the space is at the end
+ *
+ * @see <a href="https://en.wikipedia.org/wiki/Widows_and_orphans">Widows and orphans typography</a>
+ */
+fun String.preventWidows(): String {
+    val lastSpaceIndex = this.lastIndexOf(' ')
+    // Ensure there is a space and it's not the last character
+    if (lastSpaceIndex > 0 && lastSpaceIndex < this.length - 1) {
+        val builder = StringBuilder(this)
+        builder.setCharAt(lastSpaceIndex, NON_BREAKING_SPACE)
+        return builder.toString()
+    }
+    return this
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207908166761516/task/1210943043006448?focus=true

### Description

Fixes
- Orphaned "Bar" word on omnibar top or bottom picker screen
- Title on "Welcome Screen" wrapping to next line via autosizing the title

### Steps to test this PR

_Welcome Screen title sizing_
- [x] Open buck onboarding on a variety of phone sizes e.g. Small/Medium/Pixel 9 Pro emulators
- [x] Ensure the welcome screen title is always two lines and never wraps

_Address bar orphaning_
- [x] Open buck onboarding on a large phone e.g. Pixel 9 Pro XL
- [x] Get tot he omnibar position selector
- [x] Ensure that "Address Bar" is on a new line


### UI changes
| Before  | After |
| ------ | ----- |
<img width="720" height="1280" alt="Screenshot_20250731_110223" src="https://github.com/user-attachments/assets/05a1cb90-bf5e-491b-a9bf-92b7ee5bf87e" />|<img width="720" height="1280" alt="Screenshot_20250731_110245" src="https://github.com/user-attachments/assets/99991ec5-2fb7-4f29-8eee-3b5b00b857ef" />|
<img width="1344" height="2992" alt="Screenshot_20250801_110734" src="https://github.com/user-attachments/assets/e3405173-d69b-4d06-8c5c-9ed2addb00f2" />|<img width="1344" height="2992" alt="Screenshot_20250801_110508" src="https://github.com/user-attachments/assets/20919803-b136-4fc2-bdbc-b9034ab0a19a" />|
