### PR TITLE
Avoid crash on onQuickAccessListChanged

### DIFF
--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionViewModel.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionViewModel.kt
@@ -119,7 +119,11 @@ class FavouritesNewTabSectionViewModel @Inject constructor(
             if (favourites.size == newList.size) {
                 savedSitesRepository.updateWithPosition(newList.map { it })
             } else {
-                val updatedList = newList.plus(favourites.takeLast(favourites.size - newList.size))
+                val updatedList = if (favourites.size > newList.size) {
+                    newList.plus(favourites.takeLast(favourites.size - newList.size))
+                } else {
+                    newList
+                }
                 savedSitesRepository.updateWithPosition(updatedList.map { it })
             }
         }

--- a/saved-sites/saved-sites-impl/src/test/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionViewModelTests.kt
+++ b/saved-sites/saved-sites-impl/src/test/java/com/duckduckgo/savedsites/impl/newtab/FavouritesNewTabSectionViewModelTests.kt
@@ -94,13 +94,56 @@ class FavouritesNewTabSectionViewModelTests {
     }
 
     @Test
-    fun whenItemsChangedThenRepositoryUpdated() {
+    fun whenItemsChangedWithSameItemsThenRepositoryUpdated() {
         whenever(mockSavedSitesRepository.getFavoritesSync()).thenReturn(listOf(favorite1, favorite2))
         val itemsChanged = listOf(favorite2, favorite1)
 
         testee.onQuickAccessListChanged(itemsChanged)
 
         verify(mockSavedSitesRepository).updateWithPosition(itemsChanged)
+    }
+
+    @Test
+    fun whenItemsChangedSavedSitesEmptyThenRepositoryUpdated() {
+        whenever(mockSavedSitesRepository.getFavoritesSync()).thenReturn(emptyList())
+        val itemsChanged = listOf(favorite1, favorite2)
+
+        testee.onQuickAccessListChanged(itemsChanged)
+
+        verify(mockSavedSitesRepository).updateWithPosition(itemsChanged)
+    }
+
+    @Test
+    fun whenItemsChangedNewListIsEmptyThenRepositoryUpdated() {
+        val storedFavorites = listOf(favorite1, favorite2)
+        whenever(mockSavedSitesRepository.getFavoritesSync()).thenReturn(storedFavorites)
+        val itemsChanged = emptyList<Favorite>()
+
+        testee.onQuickAccessListChanged(itemsChanged)
+
+        verify(mockSavedSitesRepository).updateWithPosition(storedFavorites)
+    }
+
+    @Test
+    fun whenItemsChangedLessSavedSitesThenRepositoryUpdated() {
+        val storedFavorites = listOf(favorite1)
+        whenever(mockSavedSitesRepository.getFavoritesSync()).thenReturn(storedFavorites)
+        val itemsChanged = listOf(favorite1, favorite2)
+
+        testee.onQuickAccessListChanged(itemsChanged)
+
+        verify(mockSavedSitesRepository).updateWithPosition(itemsChanged)
+    }
+
+    @Test
+    fun whenItemsChangedMoreSavedSitesThenRepositoryUpdated() {
+        val storedFavorites = listOf(favorite1, favorite2)
+        whenever(mockSavedSitesRepository.getFavoritesSync()).thenReturn(storedFavorites)
+        val itemsChanged = listOf(favorite1)
+
+        testee.onQuickAccessListChanged(itemsChanged)
+
+        verify(mockSavedSitesRepository).updateWithPosition(listOf(favorite1, favorite2))
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1210908558625303?focus=true 

### Description

`onQuickAccessListChanged` always assumed that `favourites` size is greater than `newList`. However from the crash logs we've seen tells us that that is not the case. The current solution results to f`avourites.takeLast` being called with a negative value.

To fix this, we only add items to the `newlist` if the `favourites` size is actually bigger.

### Steps to test this PR
Smoke test dragging favourites in the new tab screen