### PR TITLE
Add Input Screen pixels

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -271,6 +271,11 @@ class RealDuckChat @Inject constructor(
     }
 
     override suspend fun setInputScreenUserSetting(enabled: Boolean) {
+        if (enabled) {
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_ADDRESS_BAR_SETTING_ON)
+        } else {
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_ADDRESS_BAR_SETTING_OFF)
+        }
         duckChatFeatureRepository.setInputScreenUserSetting(enabled)
         cacheUserSettings()
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatDailyPixelSender.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatDailyPixelSender.kt
@@ -60,6 +60,11 @@ class DuckChatDailyPixelSender @Inject constructor(
                 parameters = mapOf(PixelParameter.IS_ENABLED to duckChatFeatureRepository.shouldShowInAddressBar().toString()),
                 type = Daily(),
             )
+            pixel.fire(
+                pixel = DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_ADDRESS_BAR_IS_ENABLED_DAILY,
+                parameters = mapOf(PixelParameter.IS_ENABLED to duckChatFeatureRepository.isInputScreenUserSettingEnabled().toString()),
+                type = Daily(),
+            )
         }
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -30,6 +30,9 @@ import com.duckduckgo.duckchat.impl.ReportMetric.USER_DID_SUBMIT_FIRST_PROMPT
 import com.duckduckgo.duckchat.impl.ReportMetric.USER_DID_SUBMIT_PROMPT
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_ADDRESS_BAR_IS_ENABLED_DAILY
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_BROWSER_MENU_IS_ENABLED_DAILY
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_ADDRESS_BAR_IS_ENABLED_DAILY
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_ADDRESS_BAR_SETTING_OFF
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_ADDRESS_BAR_SETTING_ON
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_EXPERIMENT_SEARCHBAR_BUTTON_OPEN
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_IS_ENABLED_DAILY
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_MENU_SETTING_OFF
@@ -103,6 +106,8 @@ enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
     DUCK_CHAT_MENU_SETTING_ON("aichat_menu_setting_on"),
     DUCK_CHAT_SEARCHBAR_SETTING_OFF("aichat_searchbar_setting_off"),
     DUCK_CHAT_SEARCHBAR_SETTING_ON("aichat_searchbar_setting_on"),
+    DUCK_CHAT_EXPERIMENTAL_ADDRESS_BAR_SETTING_OFF("aichat_experimental_address_bar_setting_off"),
+    DUCK_CHAT_EXPERIMENTAL_ADDRESS_BAR_SETTING_ON("aichat_experimental_address_bar_setting_on"),
     DUCK_CHAT_SETTINGS_PRESSED("settings_aichat_pressed"),
     DUCK_CHAT_SETTINGS_DISPLAYED("m_aichat_settings_displayed"),
     DUCK_CHAT_SEARCHBAR_BUTTON_OPEN("aichat_searchbar_button_open"),
@@ -110,6 +115,7 @@ enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
     DUCK_CHAT_IS_ENABLED_DAILY("aichat_is_enabled_daily"),
     DUCK_CHAT_BROWSER_MENU_IS_ENABLED_DAILY("aichat_browser_menu_is_enabled_daily"),
     DUCK_CHAT_ADDRESS_BAR_IS_ENABLED_DAILY("aichat_address_bar_is_enabled_daily"),
+    DUCK_CHAT_EXPERIMENTAL_ADDRESS_BAR_IS_ENABLED_DAILY("aichat_experimental_address_bar_is_enabled_daily"),
     DUCK_CHAT_SEARCH_ASSIST_SETTINGS_BUTTON_CLICKED("aichat_search_assist_settings_button_clicked"),
     DUCK_CHAT_START_NEW_CONVERSATION("aichat_start_new_conversation"),
     DUCK_CHAT_START_NEW_CONVERSATION_BUTTON_CLICKED("aichat_start_new_conversation_button_clicked"),
@@ -139,6 +145,8 @@ class DuckChatParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin
             DUCK_CHAT_MENU_SETTING_ON.pixelName to PixelParameter.removeAtb(),
             DUCK_CHAT_SEARCHBAR_SETTING_OFF.pixelName to PixelParameter.removeAtb(),
             DUCK_CHAT_SEARCHBAR_SETTING_ON.pixelName to PixelParameter.removeAtb(),
+            DUCK_CHAT_EXPERIMENTAL_ADDRESS_BAR_SETTING_OFF.pixelName to PixelParameter.removeAtb(),
+            DUCK_CHAT_EXPERIMENTAL_ADDRESS_BAR_SETTING_ON.pixelName to PixelParameter.removeAtb(),
             DUCK_CHAT_SETTINGS_PRESSED.pixelName to PixelParameter.removeAtb(),
             DUCK_CHAT_SETTINGS_DISPLAYED.pixelName to PixelParameter.removeAtb(),
             DUCK_CHAT_SEARCHBAR_BUTTON_OPEN.pixelName to PixelParameter.removeAtb(),
@@ -146,6 +154,7 @@ class DuckChatParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin
             DUCK_CHAT_IS_ENABLED_DAILY.pixelName to PixelParameter.removeAtb(),
             DUCK_CHAT_BROWSER_MENU_IS_ENABLED_DAILY.pixelName to PixelParameter.removeAtb(),
             DUCK_CHAT_ADDRESS_BAR_IS_ENABLED_DAILY.pixelName to PixelParameter.removeAtb(),
+            DUCK_CHAT_EXPERIMENTAL_ADDRESS_BAR_IS_ENABLED_DAILY.pixelName to PixelParameter.removeAtb(),
             DUCK_CHAT_SEARCH_ASSIST_SETTINGS_BUTTON_CLICKED.pixelName to PixelParameter.removeAtb(),
             DUCK_CHAT_START_NEW_CONVERSATION.pixelName to PixelParameter.removeAtb(),
             DUCK_CHAT_START_NEW_CONVERSATION_BUTTON_CLICKED.pixelName to PixelParameter.removeAtb(),

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -674,19 +674,21 @@ class RealDuckChatTest {
     }
 
     @Test
-    fun `when enable input screen user setting then repository updated`() = runTest {
+    fun `when enable input screen user setting then repository updated and pixel fired`() = runTest {
         testee.setInputScreenUserSetting(true)
 
-        val inOrder = inOrder(mockDuckChatFeatureRepository)
+        val inOrder = inOrder(mockDuckChatFeatureRepository, mockPixel)
+        inOrder.verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_ADDRESS_BAR_SETTING_ON)
         inOrder.verify(mockDuckChatFeatureRepository).setInputScreenUserSetting(true)
         inOrder.verify(mockDuckChatFeatureRepository).isInputScreenUserSettingEnabled()
     }
 
     @Test
-    fun `when disable input screen user setting then repository updated`() = runTest {
+    fun `when disable input screen user setting then repository updated and pixel fired`() = runTest {
         testee.setInputScreenUserSetting(false)
 
-        val inOrder = inOrder(mockDuckChatFeatureRepository)
+        val inOrder = inOrder(mockDuckChatFeatureRepository, mockPixel)
+        inOrder.verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_ADDRESS_BAR_SETTING_OFF)
         inOrder.verify(mockDuckChatFeatureRepository).setInputScreenUserSetting(false)
         inOrder.verify(mockDuckChatFeatureRepository).isInputScreenUserSettingEnabled()
     }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/DuckChatDailyPixelSenderTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/DuckChatDailyPixelSenderTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.pixel
+
+import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckchat.impl.repository.DuckChatFeatureRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DuckChatDailyPixelSenderTest {
+
+    @get:Rule
+    var coroutineRule = CoroutineTestRule()
+
+    private val mockPixel: Pixel = mock()
+    private val mockDuckChatFeatureRepository: DuckChatFeatureRepository = mock()
+    private val mockLifecycleOwner: LifecycleOwner = mock()
+
+    private lateinit var testee: DuckChatDailyPixelSender
+
+    @Before
+    fun setup() {
+        testee = DuckChatDailyPixelSender(
+            pixel = mockPixel,
+            duckChatFeatureRepository = mockDuckChatFeatureRepository,
+            dispatcherProvider = coroutineRule.testDispatcherProvider,
+            coroutineScope = coroutineRule.testScope,
+        )
+    }
+
+    @Test
+    fun `when onStart then fire daily pixels with correct parameters`() = runTest {
+        whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
+        whenever(mockDuckChatFeatureRepository.shouldShowInBrowserMenu()).thenReturn(false)
+        whenever(mockDuckChatFeatureRepository.shouldShowInAddressBar()).thenReturn(true)
+        whenever(mockDuckChatFeatureRepository.isInputScreenUserSettingEnabled()).thenReturn(false)
+
+        testee.onStart(mockLifecycleOwner)
+
+        advanceUntilIdle()
+
+        verify(mockPixel).fire(
+            pixel = DuckChatPixelName.DUCK_CHAT_IS_ENABLED_DAILY,
+            parameters = mapOf(PixelParameter.IS_ENABLED to "true"),
+            type = Daily(),
+        )
+        verify(mockPixel).fire(
+            pixel = DuckChatPixelName.DUCK_CHAT_BROWSER_MENU_IS_ENABLED_DAILY,
+            parameters = mapOf(PixelParameter.IS_ENABLED to "false"),
+            type = Daily(),
+        )
+        verify(mockPixel).fire(
+            pixel = DuckChatPixelName.DUCK_CHAT_ADDRESS_BAR_IS_ENABLED_DAILY,
+            parameters = mapOf(PixelParameter.IS_ENABLED to "true"),
+            type = Daily(),
+        )
+        verify(mockPixel).fire(
+            pixel = DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_ADDRESS_BAR_IS_ENABLED_DAILY,
+            parameters = mapOf(PixelParameter.IS_ENABLED to "false"),
+            type = Daily(),
+        )
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1210948174591274?focus=true

### Description
- Adds a daily pixel for the state of the “Experimental Address Bar” setting
- Sends a pixel when the “Experimental Address Bar” setting is turned on
- Sends a pixel when the “Experimental Address Bar” setting is turned off

### Steps to test this PR

- [x] Launch the app
- [x] Verify that `aichat_experimental_address_bar_is_enabled_daily` is sent
- [x] Toggle on the the “Experimental Address Bar” setting
- [x] Verify that `aichat_experimental_address_bar_setting_on` is sent
- [x] Toggle off the the “Experimental Address Bar” setting
- [x] Verify that `aichat_experimental_address_bar_setting_off` is sent

