### PR TITLE
add Input Screen E2E tests

### DIFF
--- a/.github/workflows/input-screen-e2e-tests.yml
+++ b/.github/workflows/input-screen-e2e-tests.yml
@@ -1,0 +1,79 @@
+name: Input Screen End-to-End tests
+
+on:
+  schedule:
+    - cron: '0 5 * * *' # run at 5 AM UTC
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  instrumentation_tests:
+    runs-on: ubuntu-latest
+    name: End-to-End tests
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up JDK version
+        uses: actions/setup-java@v4
+        with:
+          java-version-file: .github/.java-version
+          distribution: 'adopt'
+
+      - name: Create folder
+        if: always()
+        run: mkdir apk
+
+      - name: Decode keys
+        uses: davidSchuppa/base64Secret-toFile-action@v2
+        with:
+          secret: ${{ secrets.FAKE_RELEASE_PROPERTIES }}
+          fileName: ddg_android_build.properties
+          destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
+
+      - name: Decode key file
+        uses: davidSchuppa/base64Secret-toFile-action@v2
+        with:
+          secret: ${{ secrets.FAKE_RELEASE_KEY }}
+          fileName: android
+          destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Assemble the project
+        run: ./gradlew assembleInternalRelease -Pforce-default-variant
+
+      - name: Move APK to new folder
+        if: always()
+        run: find . -name "*.apk"  -exec mv '{}' apk/internalRelease.apk \;
+
+      - name: Input Screen Maestro run
+        uses: mobile-dev-inc/action-maestro-cloud@v1.9.8
+        timeout-minutes: 120
+        with:
+          api-key: ${{ secrets.ROBIN_API_KEY }}
+          project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
+          name: inputScreen_${{ github.sha }}
+          timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
+          app-file: apk/internalRelease.apk
+          android-api-level: 30
+          workspace: .maestro
+          include-tags: inputScreenTest
+
+      - name: Create Asana task when workflow failed
+        if: ${{ failure() }}
+        uses: honeycombio/gha-create-asana-task@main
+        with:
+          asana-secret: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          asana-workspace-id: ${{ secrets.GH_ASANA_WORKSPACE_ID }}
+          asana-project-id: ${{ secrets.GH_ASANA_AOR_PROJECT_ID }}
+          asana-section-id: ${{ secrets.GH_ASANA_INCOMING_ID }}
+          asana-task-name: GH Workflow Failure - Input Screen E2E tests
+          asana-task-description: The Input Screen end-to-end workflow has failed. See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}

--- a/.maestro/input_screen/input_screen_chat_mode.yaml
+++ b/.maestro/input_screen/input_screen_chat_mode.yaml
@@ -1,0 +1,38 @@
+appId: com.duckduckgo.mobile.android
+name: "Input Screen Chat Mode test"
+tags:
+  - inputScreenTest
+---
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
+          stopApp: true
+      - runFlow: ../shared/skip_all_onboarding.yaml
+
+      # enable the Input Screen
+      - runFlow: ../shared/open_ai_settings_screen.yaml
+      - tapOn:
+          id: "trailingSwitch"
+          childOf:
+            id: "duckAiInputScreenEnabledToggle"
+      - action: back
+      - action: back
+
+      # verify that Duck.ai web view is opened when submitting a query in chat mode
+      - tapOn:
+          id: "omnibarTextInput"
+      - assertVisible:
+          id: "inputModeWidget"
+      - tapOn:
+          text: "Duck.ai"
+      - assertVisible:
+          text: "Ask Duck.ai"
+      - inputText: "hey"
+      - tapOn:
+          id: "actionSend"
+      - assertVisible:
+          text: "Duck.ai"
+          childOf:
+            id: "toolbar"

--- a/.maestro/input_screen/input_screen_preference_management.yaml
+++ b/.maestro/input_screen/input_screen_preference_management.yaml
@@ -1,0 +1,60 @@
+appId: com.duckduckgo.mobile.android
+name: "Input Screen user preferences test"
+tags:
+  - inputScreenTest
+---
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
+          stopApp: true
+      - runFlow: ../shared/skip_all_onboarding.yaml
+      - tapOn:
+          id: "omnibarTextInput"
+
+      # verify that the Input Screen is disabled by default
+      - assertNotVisible:
+          id: "inputModeWidget"
+
+      # enable the Input Screen
+      - runFlow: ../shared/open_ai_settings_screen.yaml
+      - tapOn:
+          id: "trailingSwitch"
+          childOf:
+            id: "duckAiInputScreenEnabledToggle"
+      - action: back
+      - action: back
+
+      # verify that the Input Screen doesn't automatically open when on new tab page
+      - assertNotVisible:
+          id: "inputModeWidget"
+      - assertVisible:
+          id: "omnibarTextInput"
+          focused: false
+
+      # verify that the Input Screen opens when tapping on the omnibar
+      - tapOn:
+          id: "omnibarTextInput"
+      - assertVisible:
+          id: "inputModeWidget"
+
+      # disable global AI setting and verify the Input Screen is disabled
+      - action: back
+      - runFlow: ../shared/open_ai_settings_screen.yaml
+      - tapOn:
+          id: "trailingSwitch"
+          index: 0
+      - action: back
+      - action: back
+      - assertVisible:
+          id: "omnibarTextInput"
+          focused: true
+      - assertNotVisible:
+          id: "inputModeWidget"
+
+      # verify that the Input Screen doesn't open when tapping on the omnibar
+      - tapOn:
+          id: "omnibarTextInput"
+      - assertNotVisible:
+          id: "inputModeWidget"

--- a/.maestro/input_screen/input_screen_search_mode.yaml
+++ b/.maestro/input_screen/input_screen_search_mode.yaml
@@ -1,0 +1,130 @@
+appId: com.duckduckgo.mobile.android
+name: "Input Screen Search Mode test"
+tags:
+  - inputScreenTest
+---
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
+          stopApp: true
+      - runFlow: ../shared/skip_all_onboarding.yaml
+
+      # enable the Input Screen
+      - runFlow: ../shared/open_ai_settings_screen.yaml
+      - tapOn:
+          id: "trailingSwitch"
+          childOf:
+            id: "duckAiInputScreenEnabledToggle"
+      - action: back
+      - action: back
+
+      # verify that autocomplete suggestions are shown when typing in the Input Screen
+      - tapOn:
+          id: "omnibarTextInput"
+      - assertVisible:
+          id: "inputModeWidget"
+      - inputText: "redd"
+      - assertVisible:
+          id: "autoCompleteSuggestionsList"
+      - assertVisible:
+          text: "reddit"
+
+      # verify that submitting a search query opens SERP
+      - tapOn:
+          id: "actionSend"
+      - assertNotVisible:
+          id: "inputModeWidget"
+      - assertVisible:
+          id: "browserLayout"
+      - assertVisible:
+          text: "reddit"
+
+      # add the page to favorites (for future assertions)
+      - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
+      - tapOn:
+          text: "add bookmark"
+      - runFlow: ../shared/browser_screen/click_on_menu_button.yaml
+      - tapOn:
+          text: "bookmarks"
+      - tapOn:
+          id: "com.duckduckgo.mobile.android:id/trailingIcon"
+          index: 0
+      - tapOn:
+          text: "add to favorites"
+      - action: back
+
+      # verify that re-opening the Input Screen from SERP pre-fills the last search query and runs autocomplete immediately
+      - tapOn:
+          id: "omnibarTextInput"
+      - assertVisible:
+          id: "inputModeWidget"
+      - assertVisible:
+          text: "redd"
+      - assertVisible:
+          id: "autoCompleteSuggestionsList"
+      - assertVisible:
+          text: "reddit.com"
+
+      # verify that clearing the Input Screen text and submitting a URL opens the web page
+      - tapOn:
+          id: "inputFieldClearText"
+      - inputText: "eff.org"
+      - tapOn:
+          id: "actionSend"
+      - assertNotVisible:
+          id: "inputModeWidget"
+      - assertVisible:
+          id: "browserLayout"
+      - assertVisible:
+          text: "https://www.eff.org/"
+          childOf:
+            id: "singleOmnibar"
+
+      # verify that favorites are shown when opening the Input Screen from a web page and autocomplete is suppressed
+      - tapOn:
+          id: "omnibarTextInput"
+      - assertNotVisible:
+          id: "autoCompleteSuggestionsList"
+      - assertVisible:
+          text: "redd at DuckDuckGo"
+          childOf:
+            id: "focusedFavourites"
+
+      # verify that typing shows autocomplete again
+      - inputText: "amazo"
+      - assertVisible:
+          id: "autoCompleteSuggestionsList"
+      - assertVisible:
+          text: "amazon.com"
+
+      # verify that tapping on a suggestion opens the web page
+      - tapOn:
+          text: "amazon.com"
+      - assertNotVisible:
+          id: "inputModeWidget"
+      - assertVisible:
+          id: "browserLayout"
+      - assertVisible:
+          text: "https://www.amazon.com/"
+          childOf:
+            id: "singleOmnibar"
+
+      # verify that tapping on a favorite opens the web page (SERP in this case)
+      - tapOn:
+          id: "omnibarTextInput"
+      - tapOn:
+          id: "quickAccessFavicon"
+          childOf:
+            id: "focusedFavourites"
+      - assertNotVisible:
+          id: "inputModeWidget"
+      - assertVisible:
+          id: "browserLayout"
+      - assertVisible:
+          text: "redd"
+          childOf:
+            id: "singleOmnibar"
+      - assertVisible:
+          text: "reddit"

--- a/.maestro/shared/open_ai_settings_screen.yaml
+++ b/.maestro/shared/open_ai_settings_screen.yaml
@@ -1,0 +1,8 @@
+appId: com.duckduckgo.mobile.android
+---
+- runFlow: ../shared/browser_screen/click_on_menu_button.yaml
+- tapOn: "Settings"
+- scrollUntilVisible:
+   element: "AI Features"
+   direction: DOWN
+- tapOn: "AI Features"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1210960956306860?focus=true

### Description
Adds basic Input Screen E2E tests.

### Steps to test this PR

QA optional, but if you want to verify the flows, run:
```
./gradlew installInternalRelease
maestro test --include-tags inputScreenTest .maestro
```
