### PR TITLE
remove nested material cards in tab switcher adapter

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
@@ -36,6 +36,7 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestManager
 import com.bumptech.glide.load.Transformation
 import com.bumptech.glide.load.engine.Resource
+import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.ItemTabGridBinding
@@ -74,6 +75,7 @@ import java.io.File
 import java.security.MessageDigest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import logcat.LogPriority.ERROR
 import logcat.LogPriority.VERBOSE
 import logcat.logcat
 
@@ -398,10 +400,18 @@ class TabSwitcherAdapter(
                     return@launch
                 }
 
-                glide.load(cachedWebViewPreview)
-                    .transition(DrawableTransitionOptions.withCrossFade())
-                    .optionalTransform(fitAndClipBottom())
-                    .into(tabPreview)
+                try {
+                    glide.load(cachedWebViewPreview)
+                        .transition(DrawableTransitionOptions.withCrossFade())
+                        .transform(
+                            fitAndClipBottom(),
+                            RoundedCorners(tabPreview.context.resources.getDimensionPixelSize(CommonR.dimen.smallShapeCornerRadius)),
+                        )
+                        .into(tabPreview)
+                } catch (e: Exception) {
+                    logcat(ERROR) { "Error loading tab preview for ${tab.tabId}: ${e.message}" }
+                    glide.load(AndroidR.drawable.ic_dax_icon_72).into(tabPreview)
+                }
             }
         } else {
             glide.clear(tabPreview)

--- a/app/src/main/res/layout/item_tab_grid_new.xml
+++ b/app/src/main/res/layout/item_tab_grid_new.xml
@@ -94,25 +94,16 @@
             app:typography="h5"
             tools:text="Slashdot" />
 
-        <com.google.android.material.card.MaterialCardView
+        <ImageView
+            android:id="@+id/tabPreview"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:cardCornerRadius="@dimen/keyline_2"
-            app:cardElevation="@dimen/keyline_empty"
+            android:layout_height="@dimen/gridItemPreviewHeightNew"
             android:layout_marginTop="6dp"
+            android:importantForAccessibility="no"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/close">
-
-            <ImageView
-                android:id="@+id/tabPreview"
-                android:layout_width="match_parent"
-                android:layout_height="@dimen/gridItemPreviewHeightNew"
-                android:importantForAccessibility="no"
-                android:scaleType="center" />
-
-        </com.google.android.material.card.MaterialCardView>
+            app:layout_constraintTop_toBottomOf="@id/close" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1210935007420667?focus=true

### Description
Removes nested `MaterialCardView` that was used only to apply rounded corners to the image. Now, we're using glide transformation instead.

### Steps to test this PR

Verify that tab switcher previews look exactly the same before and after the change.
