### PR TITLE
Fix subscription activation url

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/internal/SubscriptionsUrlProvider.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/internal/SubscriptionsUrlProvider.kt
@@ -35,7 +35,7 @@ class RealSubscriptionsUrlProvider @Inject constructor(
 
     override val welcomeUrl: String = "${subscriptionsBaseUrl.subscriptionsBaseUrl}/welcome"
 
-    override val activateUrl: String = "${subscriptionsBaseUrl.subscriptionsBaseUrl}/subscriptions/activation-flow"
+    override val activateUrl: String = "${subscriptionsBaseUrl.subscriptionsBaseUrl}/activation-flow"
 
     override val manageUrl: String = "${subscriptionsBaseUrl.subscriptionsBaseUrl}/manage"
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1210974305229051?focus=true

### Description
The subscription activation URL had an extra `/subscriptions/` in the URL causing a loop where you can't activate the subscription

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
