### PR TITLE
Onboarding Design Experiment Setup

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -168,6 +168,7 @@ import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.onboarding.store.UserStageStore
 import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.ExtendedOnboardingFeatureToggles
 import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentManager
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.pixels.AppPixelName.AUTOCOMPLETE_BANNER_SHOWN
 import com.duckduckgo.app.pixels.AppPixelName.DUCK_PLAYER_SETTING_ALWAYS_DUCK_PLAYER
 import com.duckduckgo.app.pixels.AppPixelName.DUCK_PLAYER_SETTING_ALWAYS_OVERLAY_YOUTUBE
@@ -289,6 +290,7 @@ import com.duckduckgo.subscriptions.api.Subscriptions
 import com.duckduckgo.subscriptions.api.SubscriptionsJSHelper
 import com.duckduckgo.sync.api.favicons.FaviconsFetchingPrompt
 import com.duckduckgo.voice.api.VoiceSearchAvailabilityPixelLogger
+import dagger.Lazy
 import java.io.File
 import java.math.BigInteger
 import java.security.cert.X509Certificate

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -5560,31 +5560,6 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun givenPrivacyShieldHighlightedWhenShieldIconSelectedThenStopPulse() = runTest {
-        val cta = DaxTrackersBlockedCta(
-            onboardingStore = mockOnboardingStore,
-            appInstallStore = mockAppInstallStore,
-            trackers = emptyList(),
-            settingsDataStore = mockSettingsDataStore,
-            onboardingDesignExperimentToggles = mockOnboardingDesignExperimentToggles,
-        )
-        testee.ctaViewState.value = ctaViewState().copy(cta = cta)
-
-        testee.onPrivacyShieldSelected()
-        assertTrue(!browserViewState().showPrivacyShield.isHighlighted())
-    }
-
-    @Test
-    fun givenPrivacyShieldHighlightedWhenShieldIconSelectedThenSendPixel() = runTest {
-        whenever(mockUserBrowserProperties.daysSinceInstalled()).thenReturn(0)
-        testee.browserViewState.value = browserViewState().copy(showPrivacyShield = HighlightableButton.Visible(highlighted = true))
-        val testParams = mapOf("daysSinceInstall" to "0", "from_onboarding" to "true")
-
-        testee.onPrivacyShieldSelected()
-        verify(mockPixel).fire(pixel = PrivacyDashboardPixels.PRIVACY_DASHBOARD_FIRST_TIME_OPENED, parameters = testParams, type = Unique())
-    }
-
-    @Test
     fun whenUserDismissDaxTrackersBlockedDialogThenFinishPrivacyShieldPulse() {
         val cta = DaxTrackersBlockedCta(
             onboardingStore = mockOnboardingStore,

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -168,8 +168,6 @@ import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.onboarding.store.UserStageStore
 import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.ExtendedOnboardingFeatureToggles
 import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentManager
-import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentToggles
-import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.pixels.AppPixelName.AUTOCOMPLETE_BANNER_SHOWN
 import com.duckduckgo.app.pixels.AppPixelName.DUCK_PLAYER_SETTING_ALWAYS_DUCK_PLAYER
 import com.duckduckgo.app.pixels.AppPixelName.DUCK_PLAYER_SETTING_ALWAYS_OVERLAY_YOUTUBE
@@ -290,9 +288,7 @@ import com.duckduckgo.subscriptions.api.SubscriptionRebrandingFeatureToggle
 import com.duckduckgo.subscriptions.api.Subscriptions
 import com.duckduckgo.subscriptions.api.SubscriptionsJSHelper
 import com.duckduckgo.sync.api.favicons.FaviconsFetchingPrompt
-import com.duckduckgo.voice.api.VoiceSearchAvailability
 import com.duckduckgo.voice.api.VoiceSearchAvailabilityPixelLogger
-import dagger.Lazy
 import java.io.File
 import java.math.BigInteger
 import java.security.cert.X509Certificate
@@ -6643,7 +6639,7 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenSetOnboardingDialogBackgroundWithBuckOnboardingEnabledAndLightModeEnabledThenSetOnboardingDialogBackgroundColorCommandIssuedWithCorrectColor() {
+    fun whenSetOnboardingDialogBackgroundWithBuckOnboardingAndLightModeEnabledThenSetOnboardingDialogBackgroundColorCommandIssuedWithCorrectColor() {
         whenever(mockOnboardingDesignExperimentManager.isBuckEnrolledAndEnabled()).thenReturn(true)
 
         testee.setOnboardingDialogBackground(lightModeEnabled = true)
@@ -6654,7 +6650,7 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenSetOnboardingDialogBackgroundWithBuckOnboardingEnabledAndDarkModeEnabledThenSetOnboardingDialogBackgroundColorCommandIssuedWithCorrectColor() {
+    fun whenSetOnboardingDialogBackgroundWithBuckOnboardinAndDarkModeEnabledThenSetOnboardingDialogBackgroundColorCommandIssuedWithCorrectColor() {
         whenever(mockOnboardingDesignExperimentManager.isBuckEnrolledAndEnabled()).thenReturn(true)
 
         testee.setOnboardingDialogBackground(lightModeEnabled = false)
@@ -6937,7 +6933,6 @@ class BrowserTabViewModelTest {
 
         verify(mockOnboardingDesignExperimentManager).fireSiteSuggestionOptionSelectedPixel(1)
     }
-
 
     @Test
     fun whenUserSubmittedQueryNotSuggestedSearchOptionThenFireSearchOrNavCustomPixel() = runTest {

--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -37,7 +37,7 @@ import com.duckduckgo.app.onboarding.store.AppStage
 import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.onboarding.store.UserStageStore
 import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.ExtendedOnboardingFeatureToggles
-import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentToggles
+import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentManager
 import com.duckduckgo.app.pixels.AppPixelName.*
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.privacy.model.HttpsStatus
@@ -125,7 +125,7 @@ class CtaViewModelTest {
     private val mockSenseOfProtectionExperiment: SenseOfProtectionExperiment = mock()
     private val mockOnboardingHomeScreenWidgetExperiment: OnboardingHomeScreenWidgetExperiment = mock()
 
-    private val mockOnboardingDesignExperimentToggles: OnboardingDesignExperimentToggles = mock()
+    private val mockOnboardingDesignExperimentManager: OnboardingDesignExperimentManager = mock()
 
     private val mockRebrandingFeatureToggle: SubscriptionRebrandingFeatureToggle = mock()
 
@@ -165,9 +165,9 @@ class CtaViewModelTest {
         whenever(mockBrokenSitePrompt.isFeatureEnabled()).thenReturn(false)
         whenever(mockBrokenSitePrompt.getUserRefreshPatterns()).thenReturn(emptySet())
         whenever(mockSubscriptions.isEligible()).thenReturn(false)
-        whenever(mockOnboardingDesignExperimentToggles.modifiedControl()).thenReturn(mockDisabledToggle)
-        whenever(mockOnboardingDesignExperimentToggles.buckOnboarding()).thenReturn(mockDisabledToggle)
-        whenever(mockOnboardingDesignExperimentToggles.bbOnboarding()).thenReturn(mockDisabledToggle)
+        whenever(mockOnboardingDesignExperimentManager.isModifiedControlEnrolledAndEnabled()).thenReturn(false)
+        whenever(mockOnboardingDesignExperimentManager.isBuckEnrolledAndEnabled()).thenReturn(false)
+        whenever(mockOnboardingDesignExperimentManager.isBbEnrolledAndEnabled()).thenReturn(false)
 
         testee = CtaViewModel(
             appInstallStore = mockAppInstallStore,
@@ -187,7 +187,7 @@ class CtaViewModelTest {
             brokenSitePrompt = mockBrokenSitePrompt,
             senseOfProtectionExperiment = mockSenseOfProtectionExperiment,
             onboardingHomeScreenWidgetExperiment = mockOnboardingHomeScreenWidgetExperiment,
-            onboardingDesignExperimentToggles = mockOnboardingDesignExperimentToggles,
+            onboardingDesignExperimentManager = mockOnboardingDesignExperimentManager,
             rebrandingFeatureToggle = mockRebrandingFeatureToggle,
         )
     }
@@ -276,7 +276,7 @@ class CtaViewModelTest {
     fun whenCtaDismissedAndAllDaxOnboardingCtasShownThenStageCompleted() = runTest {
         givenDaxOnboardingActive()
         givenShownDaxOnboardingCtas(requiredDaxOnboardingCtas)
-        testee.onUserDismissedCta(OnboardingDaxDialogCta.DaxSerpCta(mockOnboardingStore, mockAppInstallStore, mockOnboardingDesignExperimentToggles))
+        testee.onUserDismissedCta(OnboardingDaxDialogCta.DaxSerpCta(mockOnboardingStore, mockAppInstallStore, mockOnboardingDesignExperimentManager))
         verify(mockUserStageStore).stageCompleted(AppStage.DAX_ONBOARDING)
     }
 
@@ -828,14 +828,14 @@ class CtaViewModelTest {
 
     @Test
     fun whenCtaShownIfCtaIsNotMarkedAsReadOnShowThenCtaNotInsertedInDatabase() = runTest {
-        testee.onCtaShown(OnboardingDaxDialogCta.DaxSerpCta(mockOnboardingStore, mockAppInstallStore, mockOnboardingDesignExperimentToggles))
+        testee.onCtaShown(OnboardingDaxDialogCta.DaxSerpCta(mockOnboardingStore, mockAppInstallStore, mockOnboardingDesignExperimentManager))
 
         verify(mockDismissedCtaDao, never()).insert(DismissedCta(CtaId.DAX_DIALOG_SERP))
     }
 
     @Test
     fun whenCtaShownIfCtaIsMarkedAsReadOnShowThenCtaInsertedInDatabase() = runTest {
-        testee.onCtaShown(OnboardingDaxDialogCta.DaxEndCta(mockOnboardingStore, mockAppInstallStore, mockOnboardingDesignExperimentToggles))
+        testee.onCtaShown(OnboardingDaxDialogCta.DaxEndCta(mockOnboardingStore, mockAppInstallStore, mockOnboardingDesignExperimentManager))
 
         verify(mockDismissedCtaDao).insert(DismissedCta(CtaId.DAX_END))
     }
@@ -882,9 +882,9 @@ class CtaViewModelTest {
         whenever(mockSubscriptions.isEligible()).thenReturn(true)
         whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockEnabledToggle)
         whenever(mockExtendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockEnabledToggle)
-        whenever(mockOnboardingDesignExperimentToggles.modifiedControl()).thenReturn(mockDisabledToggle)
-        whenever(mockOnboardingDesignExperimentToggles.buckOnboarding()).thenReturn(mockDisabledToggle)
-        whenever(mockOnboardingDesignExperimentToggles.bbOnboarding()).thenReturn(mockDisabledToggle)
+        whenever(mockOnboardingDesignExperimentManager.isModifiedControlEnrolledAndEnabled()).thenReturn(false)
+        whenever(mockOnboardingDesignExperimentManager.isBuckEnrolledAndEnabled()).thenReturn(false)
+        whenever(mockOnboardingDesignExperimentManager.isBbEnrolledAndEnabled()).thenReturn(false)
         whenever(mockExtendedOnboardingFeatureToggles.freeTrialCopy()).thenReturn(mockDisabledToggle)
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO_VISIT_SITE)).thenReturn(true)
@@ -898,9 +898,9 @@ class CtaViewModelTest {
     @Test
     fun givenPrivacyProCtaExperimentWhenRefreshCtaOnHomeTabAndModifiedControlOnboardingExperimentEnabledThenDoNotReturnPrivacyProCta() = runTest {
         givenDaxOnboardingActive()
-        whenever(mockOnboardingDesignExperimentToggles.modifiedControl()).thenReturn(mockEnabledToggle)
-        whenever(mockOnboardingDesignExperimentToggles.buckOnboarding()).thenReturn(mockDisabledToggle)
-        whenever(mockOnboardingDesignExperimentToggles.bbOnboarding()).thenReturn(mockDisabledToggle)
+        whenever(mockOnboardingDesignExperimentManager.isModifiedControlEnrolledAndEnabled()).thenReturn(true)
+        whenever(mockOnboardingDesignExperimentManager.isBuckEnrolledAndEnabled()).thenReturn(false)
+        whenever(mockOnboardingDesignExperimentManager.isBbEnrolledAndEnabled()).thenReturn(false)
         whenever(mockOnboardingHomeScreenWidgetExperiment.isOnboardingHomeScreenWidgetExperiment()).thenReturn(false)
         whenever(mockSubscriptions.isEligible()).thenReturn(true)
         whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockEnabledToggle)
@@ -917,8 +917,9 @@ class CtaViewModelTest {
     @Test
     fun givenPrivacyProCtaExperimentWhenRefreshCtaOnHomeTabAndBuckOnboardingExperimentEnabledThenDoNotReturnPrivacyProCta() = runTest {
         givenDaxOnboardingActive()
-        whenever(mockOnboardingDesignExperimentToggles.buckOnboarding()).thenReturn(mockEnabledToggle)
-        whenever(mockOnboardingDesignExperimentToggles.bbOnboarding()).thenReturn(mockDisabledToggle)
+        whenever(mockOnboardingDesignExperimentManager.isBuckEnrolledAndEnabled()).thenReturn(true)
+        whenever(mockOnboardingDesignExperimentManager.isModifiedControlEnrolledAndEnabled()).thenReturn(false)
+        whenever(mockOnboardingDesignExperimentManager.isBbEnrolledAndEnabled()).thenReturn(false)
         whenever(mockOnboardingHomeScreenWidgetExperiment.isOnboardingHomeScreenWidgetExperiment()).thenReturn(false)
         whenever(mockSubscriptions.isEligible()).thenReturn(true)
         whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockEnabledToggle)
@@ -935,8 +936,9 @@ class CtaViewModelTest {
     @Test
     fun givenPrivacyProCtaExperimentWhenRefreshCtaOnHomeTabAndBBOnboardingExperimentEnabledThenDoNotReturnPrivacyProCta() = runTest {
         givenDaxOnboardingActive()
-        whenever(mockOnboardingDesignExperimentToggles.bbOnboarding()).thenReturn(mockEnabledToggle)
-        whenever(mockOnboardingDesignExperimentToggles.buckOnboarding()).thenReturn(mockDisabledToggle)
+        whenever(mockOnboardingDesignExperimentManager.isBbEnrolledAndEnabled()).thenReturn(true)
+        whenever(mockOnboardingDesignExperimentManager.isModifiedControlEnrolledAndEnabled()).thenReturn(false)
+        whenever(mockOnboardingDesignExperimentManager.isBuckEnrolledAndEnabled()).thenReturn(false)
         whenever(mockOnboardingHomeScreenWidgetExperiment.isOnboardingHomeScreenWidgetExperiment()).thenReturn(false)
         whenever(mockSubscriptions.isEligible()).thenReturn(true)
         whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockEnabledToggle)

--- a/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -882,9 +882,7 @@ class CtaViewModelTest {
         whenever(mockSubscriptions.isEligible()).thenReturn(true)
         whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockEnabledToggle)
         whenever(mockExtendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockEnabledToggle)
-        whenever(mockOnboardingDesignExperimentManager.isModifiedControlEnrolledAndEnabled()).thenReturn(false)
-        whenever(mockOnboardingDesignExperimentManager.isBuckEnrolledAndEnabled()).thenReturn(false)
-        whenever(mockOnboardingDesignExperimentManager.isBbEnrolledAndEnabled()).thenReturn(false)
+        whenever(mockOnboardingDesignExperimentManager.isAnyExperimentEnrolledAndEnabled()).thenReturn(false)
         whenever(mockExtendedOnboardingFeatureToggles.freeTrialCopy()).thenReturn(mockDisabledToggle)
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO_VISIT_SITE)).thenReturn(true)
@@ -896,50 +894,11 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun givenPrivacyProCtaExperimentWhenRefreshCtaOnHomeTabAndModifiedControlOnboardingExperimentEnabledThenDoNotReturnPrivacyProCta() = runTest {
+    fun givenPrivacyProCtaExperimentWhenRefreshCtaOnHomeTabAndExperimentEnabledThenDoNotReturnPrivacyProCta() = runTest {
         givenDaxOnboardingActive()
-        whenever(mockOnboardingDesignExperimentManager.isModifiedControlEnrolledAndEnabled()).thenReturn(true)
-        whenever(mockOnboardingDesignExperimentManager.isBuckEnrolledAndEnabled()).thenReturn(false)
-        whenever(mockOnboardingDesignExperimentManager.isBbEnrolledAndEnabled()).thenReturn(false)
+        whenever(mockOnboardingDesignExperimentManager.isAnyExperimentEnrolledAndEnabled()).thenReturn(true)
         whenever(mockOnboardingHomeScreenWidgetExperiment.isOnboardingHomeScreenWidgetExperiment()).thenReturn(false)
-        whenever(mockSubscriptions.isEligible()).thenReturn(true)
-        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockEnabledToggle)
-        whenever(mockExtendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockEnabledToggle)
-        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
-        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO_VISIT_SITE)).thenReturn(true)
-        whenever(mockDismissedCtaDao.exists(CtaId.DAX_END)).thenReturn(true)
-        whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
-
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
-        assertFalse(value is DaxBubbleCta.DaxPrivacyProCta)
-    }
-
-    @Test
-    fun givenPrivacyProCtaExperimentWhenRefreshCtaOnHomeTabAndBuckOnboardingExperimentEnabledThenDoNotReturnPrivacyProCta() = runTest {
-        givenDaxOnboardingActive()
-        whenever(mockOnboardingDesignExperimentManager.isBuckEnrolledAndEnabled()).thenReturn(true)
-        whenever(mockOnboardingDesignExperimentManager.isModifiedControlEnrolledAndEnabled()).thenReturn(false)
-        whenever(mockOnboardingDesignExperimentManager.isBbEnrolledAndEnabled()).thenReturn(false)
-        whenever(mockOnboardingHomeScreenWidgetExperiment.isOnboardingHomeScreenWidgetExperiment()).thenReturn(false)
-        whenever(mockSubscriptions.isEligible()).thenReturn(true)
-        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockEnabledToggle)
-        whenever(mockExtendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockEnabledToggle)
-        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
-        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO_VISIT_SITE)).thenReturn(true)
-        whenever(mockDismissedCtaDao.exists(CtaId.DAX_END)).thenReturn(true)
-        whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
-
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
-        assertFalse(value is DaxBubbleCta.DaxPrivacyProCta)
-    }
-
-    @Test
-    fun givenPrivacyProCtaExperimentWhenRefreshCtaOnHomeTabAndBBOnboardingExperimentEnabledThenDoNotReturnPrivacyProCta() = runTest {
-        givenDaxOnboardingActive()
-        whenever(mockOnboardingDesignExperimentManager.isBbEnrolledAndEnabled()).thenReturn(true)
-        whenever(mockOnboardingDesignExperimentManager.isModifiedControlEnrolledAndEnabled()).thenReturn(false)
-        whenever(mockOnboardingDesignExperimentManager.isBuckEnrolledAndEnabled()).thenReturn(false)
-        whenever(mockOnboardingHomeScreenWidgetExperiment.isOnboardingHomeScreenWidgetExperiment()).thenReturn(false)
+        whenever(mockExtendedOnboardingFeatureToggles.freeTrialCopy()).thenReturn(mockDisabledToggle)
         whenever(mockSubscriptions.isEligible()).thenReturn(true)
         whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockEnabledToggle)
         whenever(mockExtendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockEnabledToggle)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -4438,7 +4438,10 @@ class BrowserTabFragment :
                             setOnOptionClicked(
                                 onboardingExperimentEnabled = true,
                                 configuration = configuration,
-                            ) { userEnteredQuery(it.link) }
+                            ) { option, index ->
+                                userEnteredQuery(option.link)
+                                viewModel.onUserSelectedOnboardingDialogOption(configuration, index)
+                            }
                         }
                     }
                     else -> {
@@ -4446,7 +4449,10 @@ class BrowserTabFragment :
                             setOnOptionClicked(
                                 onboardingExperimentEnabled = onboardingDesignExperimentManager.isModifiedControlEnrolledAndEnabled(),
                                 configuration = configuration,
-                            ) { userEnteredQuery(it.link) }
+                            ) { option, index ->
+                                userEnteredQuery(option.link)
+                                viewModel.onUserSelectedOnboardingDialogOption(configuration, index)
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -198,7 +198,6 @@ import com.duckduckgo.app.global.view.NonDismissibleBehavior
 import com.duckduckgo.app.global.view.launchDefaultAppActivity
 import com.duckduckgo.app.global.view.renderIfChanged
 import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentManager
-import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentToggles
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -239,7 +239,6 @@ import com.duckduckgo.app.global.model.domain
 import com.duckduckgo.app.global.model.domainMatchesUrl
 import com.duckduckgo.app.location.data.LocationPermissionType
 import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentManager
-import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentToggles
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.pixels.AppPixelName.AUTOCOMPLETE_BANNER_DISMISSED
 import com.duckduckgo.app.pixels.AppPixelName.AUTOCOMPLETE_BANNER_SHOWN

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -238,6 +238,7 @@ import com.duckduckgo.app.global.model.SiteFactory
 import com.duckduckgo.app.global.model.domain
 import com.duckduckgo.app.global.model.domainMatchesUrl
 import com.duckduckgo.app.location.data.LocationPermissionType
+import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentManager
 import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentToggles
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.pixels.AppPixelName.AUTOCOMPLETE_BANNER_DISMISSED
@@ -470,9 +471,9 @@ class BrowserTabViewModel @Inject constructor(
     private val siteHttpErrorHandler: HttpCodeSiteErrorHandler,
     private val senseOfProtectionExperiment: SenseOfProtectionExperiment,
     private val subscriptionsJSHelper: SubscriptionsJSHelper,
-    private val onboardingDesignExperimentToggles: OnboardingDesignExperimentToggles,
     private val tabManager: TabManager,
     private val addressDisplayFormatter: AddressDisplayFormatter,
+    private val onboardingDesignExperimentManager: OnboardingDesignExperimentManager,
 ) : WebViewClientListener,
     EditSavedSiteListener,
     DeleteBookmarkListener,
@@ -882,7 +883,7 @@ class BrowserTabViewModel @Inject constructor(
             viewModelScope.launch {
                 val cta = refreshCta()
                 showOrHideKeyboard(cta)
-                if (onboardingDesignExperimentToggles.buckOnboarding().isEnabled()) {
+                if (onboardingDesignExperimentManager.isBuckEnrolledAndEnabled()) {
                     when (cta) {
                         is DaxBubbleCta.DaxIntroSearchOptionsCta -> {
                             // Let the keyboard show before showing the animation, using insets were problematic
@@ -4101,10 +4102,10 @@ class BrowserTabViewModel @Inject constructor(
 
     fun setBrowserBackground(lightModeEnabled: Boolean) {
         when {
-            onboardingDesignExperimentToggles.buckOnboarding().isEnabled() -> {
+            onboardingDesignExperimentManager.isBuckEnrolledAndEnabled() -> {
                 command.value = SetBrowserBackgroundColor(getBuckOnboardingExperimentBackgroundColor(lightModeEnabled))
             }
-            onboardingDesignExperimentToggles.bbOnboarding().isEnabled() -> {
+            onboardingDesignExperimentManager.isBbEnrolledAndEnabled() -> {
                 // TODO if BB wins the we should rename the function to SetBubbleDialogBackground
                 command.value = Command.SetBubbleDialogBackground(getBBBackgroundResource(lightModeEnabled))
             }
@@ -4123,10 +4124,10 @@ class BrowserTabViewModel @Inject constructor(
 
     fun setOnboardingDialogBackground(lightModeEnabled: Boolean) {
         when {
-            onboardingDesignExperimentToggles.buckOnboarding().isEnabled() -> {
+            onboardingDesignExperimentManager.isBuckEnrolledAndEnabled() -> {
                 command.value = SetOnboardingDialogBackgroundColor(getBuckOnboardingExperimentBackgroundColor(lightModeEnabled))
             }
-            onboardingDesignExperimentToggles.bbOnboarding().isEnabled() -> {
+            onboardingDesignExperimentManager.isBbEnrolledAndEnabled() -> {
                 command.value = SetOnboardingDialogBackground(getBBBackgroundResource(lightModeEnabled))
             }
             else -> {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -3938,20 +3938,6 @@ class BrowserTabViewModel @Inject constructor(
         }
     }
 
-    fun onPrivacyShieldSelected() {
-        if (currentBrowserViewState().showPrivacyShield.isHighlighted()) {
-            browserViewState.value = currentBrowserViewState().copy(showPrivacyShield = HighlightableButton.Visible(highlighted = false))
-            pixel.fire(
-                pixel = PrivacyDashboardPixels.PRIVACY_DASHBOARD_FIRST_TIME_OPENED,
-                parameters = mapOf(
-                    "daysSinceInstall" to userBrowserProperties.daysSinceInstalled().toString(),
-                    "from_onboarding" to "true",
-                ),
-                type = Unique(),
-            )
-        }
-    }
-
     fun onOnboardingDaxTypingAnimationFinished() {
         if (currentBrowserViewState().browserShowing && currentBrowserViewState().maliciousSiteBlocked.not()) {
             browserViewState.value = currentBrowserViewState().copy(showPrivacyShield = HighlightableButton.Visible(highlighted = true))

--- a/app/src/main/java/com/duckduckgo/app/browser/PulseAnimation.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/PulseAnimation.kt
@@ -29,7 +29,7 @@ import androidx.core.view.doOnLayout
 import androidx.core.view.isVisible
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentToggles
+import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentManager
 import com.duckduckgo.common.ui.view.setAllParentsClip
 import com.duckduckgo.common.utils.ConflatedJob
 import kotlinx.coroutines.CoroutineScope
@@ -40,7 +40,7 @@ import kotlinx.coroutines.launch
 @SuppressLint("NoLifecycleObserver") // we don't observe app lifecycle
 class PulseAnimation(
     private val lifecycleOwner: LifecycleOwner,
-    private val onboardingDesignExperimentToggles: OnboardingDesignExperimentToggles,
+    private val onboardingDesignExperimentManager: OnboardingDesignExperimentManager,
 ) : DefaultLifecycleObserver {
 
     private var pulseAnimation: AnimatorSet = AnimatorSet()
@@ -146,11 +146,11 @@ class PulseAnimation(
                 highlightImageView.setImageResource(R.drawable.ic_circle_pulse_green)
                 gravity = Gravity.START
             }
-            onboardingDesignExperimentToggles.buckOnboarding().isEnabled() -> {
+            onboardingDesignExperimentManager.isBuckEnrolledAndEnabled() -> {
                 highlightImageView.setImageResource(R.drawable.ic_circle_pulse_buck)
                 gravity = Gravity.CENTER
             }
-            onboardingDesignExperimentToggles.bbOnboarding().isEnabled() -> {
+            onboardingDesignExperimentManager.isBbEnrolledAndEnabled() -> {
                 highlightImageView.setImageResource(R.drawable.ic_circle_pulse_bb)
                 gravity = Gravity.CENTER
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/navigation/bar/view/BrowserNavigationBarView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/navigation/bar/view/BrowserNavigationBarView.kt
@@ -50,7 +50,7 @@ import com.duckduckgo.app.browser.navigation.bar.view.BrowserNavigationBarViewMo
 import com.duckduckgo.app.browser.omnibar.experiments.FadeOmnibarLayout
 import com.duckduckgo.app.browser.omnibar.model.OmnibarPosition
 import com.duckduckgo.app.browser.webview.TopOmnibarBrowserContainerLayoutBehavior
-import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentToggles
+import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentManager
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.ViewViewModelFactory
@@ -69,7 +69,7 @@ class BrowserNavigationBarView @JvmOverloads constructor(
 ) : FrameLayout(context, attrs, defStyle), AttachedBehavior {
 
     @Inject
-    lateinit var onboardingDesignExperimentToggles: OnboardingDesignExperimentToggles
+    lateinit var onboardingDesignExperimentManager: OnboardingDesignExperimentManager
 
     private var showShadows: Boolean = false
 
@@ -117,7 +117,7 @@ class BrowserNavigationBarView @JvmOverloads constructor(
     }
 
     private val pulseAnimation: PulseAnimation by lazy {
-        PulseAnimation(lifecycleOwner, onboardingDesignExperimentToggles)
+        PulseAnimation(lifecycleOwner, onboardingDesignExperimentManager)
     }
 
     val popupMenuAnchor: View = binding.menuButton

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -87,7 +87,7 @@ import com.duckduckgo.app.browser.viewstate.LoadingViewState
 import com.duckduckgo.app.browser.viewstate.OmnibarViewState
 import com.duckduckgo.app.global.model.PrivacyShield
 import com.duckduckgo.app.global.view.renderIfChanged
-import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentToggles
+import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentManager
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.trackerdetection.model.Entity
 import com.duckduckgo.common.ui.DuckDuckGoActivity
@@ -190,7 +190,7 @@ open class OmnibarLayout @JvmOverloads constructor(
     lateinit var omnibarAnimationManager: OmnibarAnimationManager
 
     @Inject
-    lateinit var onboardingDesignExperimentToggles: OnboardingDesignExperimentToggles
+    lateinit var onboardingDesignExperimentManager: OnboardingDesignExperimentManager
 
     private var previousTransitionState: TransitionState? = null
 
@@ -199,7 +199,7 @@ open class OmnibarLayout @JvmOverloads constructor(
     }
 
     private val pulseAnimation: PulseAnimation by lazy {
-        PulseAnimation(lifecycleOwner, onboardingDesignExperimentToggles)
+        PulseAnimation(lifecycleOwner, onboardingDesignExperimentManager)
     }
 
     private var omnibarTextListener: Omnibar.TextListener? = null

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -780,15 +780,19 @@ sealed class OnboardingDaxDialogCta(
                     showBuckOnboardingCta(
                         binding = binding,
                         onTypingAnimationFinished = onTypingAnimationFinished,
-                        onSuggestedOptionClicked = onSuggestedOptionClicked,
+                        onSuggestedOptionClicked = { option, index ->
+                            onSuggestedOptionClicked?.invoke(option)
+                            onSiteSuggestionOptionClicked.invoke(index)
+                        }
                     )
                 }
                 onboardingDesignExperimentManager.isBbEnrolledAndEnabled() -> {
                     showBBOnboardingCta(
                         binding = binding,
                         onTypingAnimationFinished = onTypingAnimationFinished,
-                        onSuggestedOptionClicked = { option ->
+                        onSuggestedOptionClicked = { option, index ->
                             onSuggestedOptionClicked?.invoke(option)
+                            onSiteSuggestionOptionClicked.invoke(index)
                             with(binding.includeOnboardingInContextBBDialog) {
                                 dialogTextCta.text = ""
                                 hiddenTextCta.text = ""
@@ -838,7 +842,10 @@ sealed class OnboardingDaxDialogCta(
 
                                 with(buttonView) {
                                     modifiedControlOption.setOptionView(this)
-                                    setOnClickListener { onSuggestedOptionClicked?.invoke(modifiedControlOption) }
+                                    setOnClickListener {
+                                        onSuggestedOptionClicked?.invoke(modifiedControlOption)
+                                        onSiteSuggestionOptionClicked.invoke(index)
+                                    }
                                     animate().alpha(MAX_ALPHA).duration = DAX_DIALOG_APPEARANCE_ANIMATION
                                 }
                             }
@@ -875,7 +882,7 @@ sealed class OnboardingDaxDialogCta(
         private fun showBuckOnboardingCta(
             binding: FragmentBrowserTabBinding,
             onTypingAnimationFinished: () -> Unit,
-            onSuggestedOptionClicked: ((DaxDialogIntroOption) -> Unit)?,
+            onSuggestedOptionClicked: ((DaxDialogIntroOption, index: Int) -> Unit)?,
         ) {
             val context = binding.root.context
             val buckDialogBinding = binding.includeOnboardingInContextBuckDialog
@@ -907,7 +914,7 @@ sealed class OnboardingDaxDialogCta(
                         options[index].setOptionView(buttonView)
                         buttonView.animate().alpha(MAX_ALPHA).duration = DAX_DIALOG_APPEARANCE_ANIMATION
                         buttonView.setOnClickListener {
-                            onSuggestedOptionClicked?.invoke(options[index])
+                            onSuggestedOptionClicked?.invoke(options[index], index)
                             wingAnimation.gone()
                         }
                     }
@@ -955,7 +962,7 @@ sealed class OnboardingDaxDialogCta(
         private fun showBBOnboardingCta(
             binding: FragmentBrowserTabBinding,
             onTypingAnimationFinished: () -> Unit,
-            onSuggestedOptionClicked: ((DaxDialogIntroOption) -> Unit)?,
+            onSuggestedOptionClicked: ((DaxDialogIntroOption, index: Int) -> Unit)?,
         ) {
             val binding = binding.includeOnboardingInContextBBDialog
             val context = binding.root.context
@@ -999,7 +1006,7 @@ sealed class OnboardingDaxDialogCta(
                         options[index].setOptionView(buttonView)
                         buttonView.animate().alpha(MAX_ALPHA).duration = DAX_DIALOG_APPEARANCE_ANIMATION
                         buttonView.setOnClickListener {
-                            onSuggestedOptionClicked?.invoke(options[index])
+                            onSuggestedOptionClicked?.invoke(options[index], index)
                         }
                     }
                 }
@@ -1522,7 +1529,7 @@ sealed class DaxBubbleCta(
     fun setOnOptionClicked(
         onboardingExperimentEnabled: Boolean = false,
         configuration: DaxBubbleCta? = null,
-        onOptionClicked: (DaxDialogIntroOption) -> Unit,
+        onOptionClicked: (DaxDialogIntroOption, index: Int?) -> Unit,
     ) {
         if (onboardingExperimentEnabled && configuration is DaxIntroVisitSiteOptionsCta) {
             val optionsWithoutRegionalNews = options?.toMutableList()?.apply {
@@ -1536,7 +1543,7 @@ sealed class DaxBubbleCta(
                     2 -> R.id.daxDialogOption3
                     else -> R.id.daxDialogOption4 // This will not be visible for the experiments
                 }
-                option.let { ctaView?.findViewById<MaterialButton>(optionView)?.setOnClickListener { onOptionClicked.invoke(option) } }
+                option.let { ctaView?.findViewById<MaterialButton>(optionView)?.setOnClickListener { onOptionClicked.invoke(option, index) } }
             }
         } else {
             options?.forEachIndexed { index, option ->
@@ -1546,7 +1553,7 @@ sealed class DaxBubbleCta(
                     2 -> R.id.daxDialogOption3
                     else -> R.id.daxDialogOption4
                 }
-                option.let { ctaView?.findViewById<MaterialButton>(optionView)?.setOnClickListener { onOptionClicked.invoke(option) } }
+                option.let { ctaView?.findViewById<MaterialButton>(optionView)?.setOnClickListener { onOptionClicked.invoke(option, index) } }
             }
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -46,7 +46,7 @@ import com.duckduckgo.app.cta.ui.DaxCta.Companion.MAX_DAYS_ALLOWED
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.global.install.daysInstalled
 import com.duckduckgo.app.onboarding.store.OnboardingStore
-import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentToggles
+import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentManager
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.pixels.AppPixelName.SITE_NOT_WORKING_SHOWN
 import com.duckduckgo.app.pixels.AppPixelName.SITE_NOT_WORKING_WEBSITE_BROKEN
@@ -385,7 +385,7 @@ sealed class OnboardingDaxDialogCta(
     class DaxSerpCta(
         override val onboardingStore: OnboardingStore,
         override val appInstallStore: AppInstallStore,
-        private val onboardingDesignExperimentToggles: OnboardingDesignExperimentToggles,
+        private val onboardingDesignExperimentManager: OnboardingDesignExperimentManager,
     ) : OnboardingDaxDialogCta(
         CtaId.DAX_DIALOG_SERP,
         R.string.highlightsOnboardingSerpDaxDialogDescription,
@@ -409,7 +409,7 @@ sealed class OnboardingDaxDialogCta(
             val context = binding.root.context
 
             when {
-                onboardingDesignExperimentToggles.buckOnboarding().isEnabled() -> {
+                onboardingDesignExperimentManager.isBuckEnrolledAndEnabled() -> {
                     setBuckOnboardingDialogView(
                         message = description?.let { context.getString(it) }.orEmpty(),
                         primaryCtaText = buttonText?.let { context.getString(it) },
@@ -418,7 +418,7 @@ sealed class OnboardingDaxDialogCta(
                         onDismissCtaClicked = onDismissCtaClicked,
                     )
                 }
-                onboardingDesignExperimentToggles.bbOnboarding().isEnabled() -> {
+                onboardingDesignExperimentManager.isBbEnrolledAndEnabled() -> {
                     setBBOnboardingDialogView(
                         description = description?.let { context.getString(it) }.orEmpty(),
                         primaryCtaText = buttonText?.let { context.getString(it) },
@@ -447,7 +447,7 @@ sealed class OnboardingDaxDialogCta(
         override val appInstallStore: AppInstallStore,
         val trackers: List<Entity>,
         val settingsDataStore: SettingsDataStore,
-        private val onboardingDesignExperimentToggles: OnboardingDesignExperimentToggles,
+        private val onboardingDesignExperimentManager : OnboardingDesignExperimentManager,
     ) : OnboardingDaxDialogCta(
         CtaId.DAX_DIALOG_TRACKERS_FOUND,
         null,
@@ -471,7 +471,7 @@ sealed class OnboardingDaxDialogCta(
             val context = binding.root.context
 
             when {
-                onboardingDesignExperimentToggles.buckOnboarding().isEnabled() -> {
+                onboardingDesignExperimentManager.isBuckEnrolledAndEnabled() -> {
                     setBuckOnboardingDialogView(
                         message = getTrackersDescription(context, trackers),
                         primaryCtaText = buttonText?.let { context.getString(it) },
@@ -482,7 +482,7 @@ sealed class OnboardingDaxDialogCta(
                     )
                 }
 
-                onboardingDesignExperimentToggles.bbOnboarding().isEnabled() -> {
+                onboardingDesignExperimentManager.isBbEnrolledAndEnabled() -> {
                     setBBOnboardingDialogView(
                         title = getTrackersDescription(context, trackers),
                         description = context.getString(R.string.bbOnboardingTrackersBlockedDialogDescription),
@@ -521,7 +521,7 @@ sealed class OnboardingDaxDialogCta(
             val size = trackers.size - trackersFiltered.size
             val quantityString =
                 if (size == 0) {
-                    if (onboardingDesignExperimentToggles.bbOnboarding().isEnabled()) {
+                    if (onboardingDesignExperimentManager.isBbEnrolledAndEnabled()) {
                         context.resources.getQuantityString(R.plurals.bbOnboardingTrackersBlockedZeroDialogTitle, trackersFiltered.size)
                             .getStringForOmnibarPosition(settingsDataStore.omnibarPosition)
                     } else {
@@ -529,7 +529,7 @@ sealed class OnboardingDaxDialogCta(
                             .getStringForOmnibarPosition(settingsDataStore.omnibarPosition)
                     }
                 } else {
-                    if (onboardingDesignExperimentToggles.bbOnboarding().isEnabled()) {
+                    if (onboardingDesignExperimentManager.isBbEnrolledAndEnabled()) {
                         context.resources.getQuantityString(R.plurals.bbOnboardingTrackersBlockedDialogTitle, size, size)
                             .getStringForOmnibarPosition(settingsDataStore.omnibarPosition)
                     } else {
@@ -537,7 +537,7 @@ sealed class OnboardingDaxDialogCta(
                             .getStringForOmnibarPosition(settingsDataStore.omnibarPosition)
                     }
                 }
-            return if (onboardingDesignExperimentToggles.bbOnboarding().isEnabled()) {
+            return if (onboardingDesignExperimentManager.isBbEnrolledAndEnabled()) {
                 "$trackersText$quantityString"
             } else {
                 "<b>$trackersText</b>$quantityString"
@@ -550,7 +550,7 @@ sealed class OnboardingDaxDialogCta(
         override val appInstallStore: AppInstallStore,
         val network: String,
         private val siteHost: String,
-        private val onboardingDesignExperimentToggles: OnboardingDesignExperimentToggles,
+        private val onboardingDesignExperimentManager : OnboardingDesignExperimentManager,
     ) : OnboardingDaxDialogCta(
         CtaId.DAX_DIALOG_NETWORK,
         null,
@@ -574,7 +574,7 @@ sealed class OnboardingDaxDialogCta(
             val context = binding.root.context
 
             when {
-                onboardingDesignExperimentToggles.buckOnboarding().isEnabled() -> {
+                onboardingDesignExperimentManager.isBuckEnrolledAndEnabled() -> {
                     setBuckOnboardingDialogView(
                         message = getTrackersDescription(context),
                         primaryCtaText = buttonText?.let { context.getString(it) },
@@ -583,7 +583,7 @@ sealed class OnboardingDaxDialogCta(
                         onDismissCtaClicked = onDismissCtaClicked,
                     )
                 }
-                onboardingDesignExperimentToggles.bbOnboarding().isEnabled() -> {
+                onboardingDesignExperimentManager.isBbEnrolledAndEnabled() -> {
                     setBBOnboardingDialogView(
                         description = getTrackersDescription(context),
                         primaryCtaText = buttonText?.let { context.getString(it) },
@@ -631,7 +631,7 @@ sealed class OnboardingDaxDialogCta(
     class DaxNoTrackersCta(
         override val onboardingStore: OnboardingStore,
         override val appInstallStore: AppInstallStore,
-        private val onboardingDesignExperimentToggles: OnboardingDesignExperimentToggles,
+        private val onboardingDesignExperimentManager : OnboardingDesignExperimentManager,
     ) : OnboardingDaxDialogCta(
         CtaId.DAX_DIALOG_OTHER,
         R.string.daxNonSerpCtaText,
@@ -655,7 +655,7 @@ sealed class OnboardingDaxDialogCta(
             val context = binding.root.context
 
             when {
-                onboardingDesignExperimentToggles.buckOnboarding().isEnabled() -> {
+                onboardingDesignExperimentManager.isBuckEnrolledAndEnabled() -> {
                     setBuckOnboardingDialogView(
                         message = description?.let { context.getString(it) }.orEmpty(),
                         primaryCtaText = buttonText?.let { context.getString(it) },
@@ -664,7 +664,7 @@ sealed class OnboardingDaxDialogCta(
                         onDismissCtaClicked = onDismissCtaClicked,
                     )
                 }
-                onboardingDesignExperimentToggles.bbOnboarding().isEnabled() -> {
+                onboardingDesignExperimentManager.isBbEnrolledAndEnabled() -> {
                     setBBOnboardingDialogView(
                         description = description?.let { context.getString(it) }.orEmpty(),
                         primaryCtaText = buttonText?.let { context.getString(it) },
@@ -691,7 +691,7 @@ sealed class OnboardingDaxDialogCta(
     class DaxFireButtonCta(
         override val onboardingStore: OnboardingStore,
         override val appInstallStore: AppInstallStore,
-        private val onboardingDesignExperimentToggles: OnboardingDesignExperimentToggles,
+        private val onboardingDesignExperimentManager: OnboardingDesignExperimentManager,
     ) : OnboardingDaxDialogCta(
         CtaId.DAX_FIRE_BUTTON,
         R.string.onboardingFireButtonDaxDialogDescription,
@@ -715,7 +715,7 @@ sealed class OnboardingDaxDialogCta(
             val context = binding.root.context
 
             when {
-                onboardingDesignExperimentToggles.buckOnboarding().isEnabled() -> {
+                onboardingDesignExperimentManager.isBuckEnrolledAndEnabled() -> {
                     setBuckOnboardingDialogView(
                         message = description?.let { context.getString(it) }.orEmpty(),
                         primaryCtaText = context.getString(R.string.onboardingFireButtonDaxDialogOkButton),
@@ -724,7 +724,7 @@ sealed class OnboardingDaxDialogCta(
                         onDismissCtaClicked = onDismissCtaClicked,
                     )
                 }
-                onboardingDesignExperimentToggles.bbOnboarding().isEnabled() -> {
+                onboardingDesignExperimentManager.isBbEnrolledAndEnabled() -> {
                     setBBOnboardingDialogView(
                         title = context.getString(R.string.bbOnboardingFireButtonDaxDialogTitle),
                         leadingDescriptionIconRes = CommonR.drawable.ic_fire_24,
@@ -753,7 +753,8 @@ sealed class OnboardingDaxDialogCta(
     class DaxSiteSuggestionsCta(
         override val onboardingStore: OnboardingStore,
         override val appInstallStore: AppInstallStore,
-        private val onboardingDesignExperimentToggles: OnboardingDesignExperimentToggles,
+        private val onboardingDesignExperimentManager : OnboardingDesignExperimentManager,
+        private val onSiteSuggestionOptionClicked: (index: Int) -> Unit, // used to fire experiment pixel
     ) : OnboardingDaxDialogCta(
         CtaId.DAX_INTRO_VISIT_SITE,
         R.string.onboardingSitesDaxDialogDescription,
@@ -775,14 +776,14 @@ sealed class OnboardingDaxDialogCta(
             onDismissCtaClicked: () -> Unit,
         ) {
             when {
-                onboardingDesignExperimentToggles.buckOnboarding().isEnabled() -> {
+                onboardingDesignExperimentManager.isBuckEnrolledAndEnabled() -> {
                     showBuckOnboardingCta(
                         binding = binding,
                         onTypingAnimationFinished = onTypingAnimationFinished,
                         onSuggestedOptionClicked = onSuggestedOptionClicked,
                     )
                 }
-                onboardingDesignExperimentToggles.bbOnboarding().isEnabled() -> {
+                onboardingDesignExperimentManager.isBbEnrolledAndEnabled() -> {
                     showBBOnboardingCta(
                         binding = binding,
                         onTypingAnimationFinished = onTypingAnimationFinished,
@@ -807,7 +808,7 @@ sealed class OnboardingDaxDialogCta(
                     daxDialog.suggestionsDialogTextCta.text = ""
                     daxDialog.suggestionsHiddenTextCta.text = daxText.html(context)
 
-                    val isModifiedControlExperimentEnabled = onboardingDesignExperimentToggles.modifiedControl().isEnabled()
+                    val isModifiedControlExperimentEnabled = onboardingDesignExperimentManager.isModifiedControlEnrolledAndEnabled()
 
                     if (isModifiedControlExperimentEnabled) {
                         daxDialog.daxDialogOption4.gone()
@@ -1023,7 +1024,7 @@ sealed class OnboardingDaxDialogCta(
     class DaxEndCta(
         override val onboardingStore: OnboardingStore,
         override val appInstallStore: AppInstallStore,
-        val onboardingDesignExperimentToggles: OnboardingDesignExperimentToggles,
+        private val onboardingDesignExperimentManager : OnboardingDesignExperimentManager,
     ) : OnboardingDaxDialogCta(
         CtaId.DAX_END,
         R.string.highlightsOnboardingEndDaxDialogDescription,
@@ -1049,7 +1050,7 @@ sealed class OnboardingDaxDialogCta(
             val context = binding.root.context
 
             when {
-                onboardingDesignExperimentToggles.buckOnboarding().isEnabled() -> {
+                onboardingDesignExperimentManager.isBuckEnrolledAndEnabled()-> {
                     setBuckOnboardingDialogView(
                         message = description?.let { context.getString(it) }.orEmpty(),
                         primaryCtaText = buttonText?.let { context.getString(it) },
@@ -1059,7 +1060,7 @@ sealed class OnboardingDaxDialogCta(
                     )
                 }
 
-                onboardingDesignExperimentToggles.bbOnboarding().isEnabled() -> {
+                onboardingDesignExperimentManager.isBbEnrolledAndEnabled() -> {
                     setBBOnboardingDialogView(
                         description = description?.let { context.getString(it) }.orEmpty(),
                         primaryCtaText = buttonText?.let { context.getString(it) },

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -1581,7 +1581,7 @@ sealed class DaxBubbleCta(
         ctaId = CtaId.DAX_INTRO,
         title = R.string.onboardingSearchDaxDialogTitle,
         description = R.string.highlightsOnboardingSearchDaxDialogDescription,
-        options = onboardingStore.getExperimentSearchOptions(),
+        options = onboardingStore.getSearchOptions(),
         shownPixel = AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
         okPixel = AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
         ctaPixelParam = Pixel.PixelValues.DAX_INITIAL_CTA,

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -447,7 +447,7 @@ sealed class OnboardingDaxDialogCta(
         override val appInstallStore: AppInstallStore,
         val trackers: List<Entity>,
         val settingsDataStore: SettingsDataStore,
-        private val onboardingDesignExperimentManager : OnboardingDesignExperimentManager,
+        private val onboardingDesignExperimentManager: OnboardingDesignExperimentManager,
     ) : OnboardingDaxDialogCta(
         CtaId.DAX_DIALOG_TRACKERS_FOUND,
         null,
@@ -550,7 +550,7 @@ sealed class OnboardingDaxDialogCta(
         override val appInstallStore: AppInstallStore,
         val network: String,
         private val siteHost: String,
-        private val onboardingDesignExperimentManager : OnboardingDesignExperimentManager,
+        private val onboardingDesignExperimentManager: OnboardingDesignExperimentManager,
     ) : OnboardingDaxDialogCta(
         CtaId.DAX_DIALOG_NETWORK,
         null,
@@ -631,7 +631,7 @@ sealed class OnboardingDaxDialogCta(
     class DaxNoTrackersCta(
         override val onboardingStore: OnboardingStore,
         override val appInstallStore: AppInstallStore,
-        private val onboardingDesignExperimentManager : OnboardingDesignExperimentManager,
+        private val onboardingDesignExperimentManager: OnboardingDesignExperimentManager,
     ) : OnboardingDaxDialogCta(
         CtaId.DAX_DIALOG_OTHER,
         R.string.daxNonSerpCtaText,
@@ -753,7 +753,7 @@ sealed class OnboardingDaxDialogCta(
     class DaxSiteSuggestionsCta(
         override val onboardingStore: OnboardingStore,
         override val appInstallStore: AppInstallStore,
-        private val onboardingDesignExperimentManager : OnboardingDesignExperimentManager,
+        private val onboardingDesignExperimentManager: OnboardingDesignExperimentManager,
         private val onSiteSuggestionOptionClicked: (index: Int) -> Unit, // used to fire experiment pixel
     ) : OnboardingDaxDialogCta(
         CtaId.DAX_INTRO_VISIT_SITE,
@@ -783,7 +783,7 @@ sealed class OnboardingDaxDialogCta(
                         onSuggestedOptionClicked = { option, index ->
                             onSuggestedOptionClicked?.invoke(option)
                             onSiteSuggestionOptionClicked.invoke(index)
-                        }
+                        },
                     )
                 }
                 onboardingDesignExperimentManager.isBbEnrolledAndEnabled() -> {
@@ -1031,7 +1031,7 @@ sealed class OnboardingDaxDialogCta(
     class DaxEndCta(
         override val onboardingStore: OnboardingStore,
         override val appInstallStore: AppInstallStore,
-        private val onboardingDesignExperimentManager : OnboardingDesignExperimentManager,
+        private val onboardingDesignExperimentManager: OnboardingDesignExperimentManager,
     ) : OnboardingDaxDialogCta(
         CtaId.DAX_END,
         R.string.highlightsOnboardingEndDaxDialogDescription,
@@ -1057,7 +1057,7 @@ sealed class OnboardingDaxDialogCta(
             val context = binding.root.context
 
             when {
-                onboardingDesignExperimentManager.isBuckEnrolledAndEnabled()-> {
+                onboardingDesignExperimentManager.isBuckEnrolledAndEnabled() -> {
                     setBuckOnboardingDialogView(
                         message = description?.let { context.getString(it) }.orEmpty(),
                         primaryCtaText = buttonText?.let { context.getString(it) },

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -225,7 +225,12 @@ class CtaViewModel @Inject constructor(
     suspend fun getSiteSuggestionsDialogCta(onSiteSuggestionOptionClicked: (index: Int) -> Unit): OnboardingDaxDialogCta? {
         return withContext(dispatchers.io()) {
             if (!daxOnboardingActive() || !canShowDaxIntroVisitSiteCta()) return@withContext null
-            OnboardingDaxDialogCta.DaxSiteSuggestionsCta(onboardingStore, appInstallStore, onboardingDesignExperimentManager, onSiteSuggestionOptionClicked)
+            OnboardingDaxDialogCta.DaxSiteSuggestionsCta(
+                onboardingStore,
+                appInstallStore,
+                onboardingDesignExperimentManager,
+                onSiteSuggestionOptionClicked,
+            )
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -38,7 +38,7 @@ import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.onboarding.store.UserStageStore
 import com.duckduckgo.app.onboarding.store.daxOnboardingActive
 import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.ExtendedOnboardingFeatureToggles
-import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentToggles
+import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentManager
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -88,7 +88,7 @@ class CtaViewModel @Inject constructor(
     private val brokenSitePrompt: BrokenSitePrompt,
     private val senseOfProtectionExperiment: SenseOfProtectionExperiment,
     private val onboardingHomeScreenWidgetExperiment: OnboardingHomeScreenWidgetExperiment,
-    private val onboardingDesignExperimentToggles: OnboardingDesignExperimentToggles,
+    private val onboardingDesignExperimentManager: OnboardingDesignExperimentManager,
     private val rebrandingFeatureToggle: SubscriptionRebrandingFeatureToggle,
 ) {
     @ExperimentalCoroutinesApi
@@ -218,21 +218,21 @@ class CtaViewModel @Inject constructor(
     suspend fun getFireDialogCta(): OnboardingDaxDialogCta? {
         return withContext(dispatchers.io()) {
             if (!daxOnboardingActive() || daxDialogFireEducationShown()) return@withContext null
-            OnboardingDaxDialogCta.DaxFireButtonCta(onboardingStore, appInstallStore, onboardingDesignExperimentToggles)
+            OnboardingDaxDialogCta.DaxFireButtonCta(onboardingStore, appInstallStore, onboardingDesignExperimentManager)
         }
     }
 
-    suspend fun getSiteSuggestionsDialogCta(): OnboardingDaxDialogCta? {
+    suspend fun getSiteSuggestionsDialogCta(onSiteSuggestionOptionClicked: (index: Int) -> Unit): OnboardingDaxDialogCta? {
         return withContext(dispatchers.io()) {
             if (!daxOnboardingActive() || !canShowDaxIntroVisitSiteCta()) return@withContext null
-            OnboardingDaxDialogCta.DaxSiteSuggestionsCta(onboardingStore, appInstallStore, onboardingDesignExperimentToggles)
+            OnboardingDaxDialogCta.DaxSiteSuggestionsCta(onboardingStore, appInstallStore, onboardingDesignExperimentManager, onSiteSuggestionOptionClicked)
         }
     }
 
     suspend fun getEndStaticDialogCta(): OnboardingDaxDialogCta.DaxEndCta? {
         return withContext(dispatchers.io()) {
             if (!daxOnboardingActive() && daxDialogEndShown()) return@withContext null
-            return@withContext OnboardingDaxDialogCta.DaxEndCta(onboardingStore, appInstallStore, onboardingDesignExperimentToggles)
+            return@withContext OnboardingDaxDialogCta.DaxEndCta(onboardingStore, appInstallStore, onboardingDesignExperimentManager)
         }
     }
 
@@ -254,7 +254,7 @@ class CtaViewModel @Inject constructor(
             // Site suggestions
             canShowDaxIntroVisitSiteCta() && !extendedOnboardingFeatureToggles.noBrowserCtas().isEnabled() -> {
                 DaxBubbleCta.DaxIntroVisitSiteOptionsCta(onboardingStore, appInstallStore).apply {
-                    isModifiedControlOnboardingExperimentEnabled = onboardingDesignExperimentToggles.modifiedControl().isEnabled()
+                    isModifiedControlOnboardingExperimentEnabled = onboardingDesignExperimentManager.isModifiedControlEnrolledAndEnabled()
                 }
             }
 
@@ -264,7 +264,7 @@ class CtaViewModel @Inject constructor(
             }
 
             // Privacy Pro
-            canShowPrivacyProCta() && !isOnboardingExperimentEnabled() -> {
+            canShowPrivacyProCta() && !onboardingDesignExperimentManager.isAnyExperimentEnrolledAndEnabled() -> {
                 val titleRes: Int = R.string.onboardingPrivacyProDaxDialogTitle
                 val descriptionRes: Int = if (rebrandingFeatureToggle.isSubscriptionRebrandingEnabled()) {
                     R.string.onboardingPrivacyProDaxDialogDescriptionRebranding
@@ -299,10 +299,6 @@ class CtaViewModel @Inject constructor(
             else -> null
         }
     }
-
-    private fun isOnboardingExperimentEnabled() = onboardingDesignExperimentToggles.buckOnboarding().isEnabled() ||
-        onboardingDesignExperimentToggles.bbOnboarding().isEnabled() ||
-        onboardingDesignExperimentToggles.modifiedControl().isEnabled()
 
     @WorkerThread
     private suspend fun canShowDaxIntroCta(): Boolean = daxOnboardingActive() && !daxDialogIntroShown() && !hideTips()
@@ -357,7 +353,7 @@ class CtaViewModel @Inject constructor(
                     appInstallStore,
                     it.orderedTrackerBlockedEntities(),
                     settingsDataStore,
-                    onboardingDesignExperimentToggles,
+                    onboardingDesignExperimentManager,
                 )
             }
 
@@ -372,7 +368,7 @@ class CtaViewModel @Inject constructor(
                             appInstallStore,
                             entity.displayName,
                             host,
-                            onboardingDesignExperimentToggles,
+                            onboardingDesignExperimentManager,
                         )
                     }
                 }
@@ -380,17 +376,17 @@ class CtaViewModel @Inject constructor(
 
             // SERP
             if (isSerpUrl(it.url) && !daxDialogSerpShown()) {
-                return OnboardingDaxDialogCta.DaxSerpCta(onboardingStore, appInstallStore, onboardingDesignExperimentToggles)
+                return OnboardingDaxDialogCta.DaxSerpCta(onboardingStore, appInstallStore, onboardingDesignExperimentManager)
             }
 
             // No trackers blocked
             if (!isSerpUrl(it.url) && !daxDialogOtherShown() && !daxDialogTrackersFoundShown() && !daxDialogNetworkShown()) {
-                return OnboardingDaxDialogCta.DaxNoTrackersCta(onboardingStore, appInstallStore, onboardingDesignExperimentToggles)
+                return OnboardingDaxDialogCta.DaxNoTrackersCta(onboardingStore, appInstallStore, onboardingDesignExperimentManager)
             }
 
             // End
             if (canShowDaxCtaEndOfJourney() && daxDialogFireEducationShown()) {
-                return OnboardingDaxDialogCta.DaxEndCta(onboardingStore, appInstallStore, onboardingDesignExperimentToggles)
+                return OnboardingDaxDialogCta.DaxEndCta(onboardingStore, appInstallStore, onboardingDesignExperimentManager)
             }
 
             return null

--- a/app/src/main/java/com/duckduckgo/app/fire/LottieFireAnimationLoader.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/LottieFireAnimationLoader.kt
@@ -49,7 +49,7 @@ class LottieFireAnimationLoader constructor(
     override fun preloadSelectedAnimation() {
         appCoroutineScope.launch(dispatchers.io()) {
             if (animationEnabled()) {
-                if (onboardingDesignExperimentManager.isAnyExperimentEnabled()) {
+                if (onboardingDesignExperimentManager.isAnyExperimentEnrolledAndEnabled()) {
                     // If experiment is successful delete this chain as we can just update HeroFire res id
                     val selectedFireAnimation = settingsDataStore.selectedFireAnimation
                     val resId = onboardingExperimentFireAnimationHelper.getSelectedFireAnimationResId(selectedFireAnimation)

--- a/app/src/main/java/com/duckduckgo/app/global/view/FireDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/FireDialog.kt
@@ -32,7 +32,6 @@ import androidx.core.view.WindowInsetsCompat.Type
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.core.view.updatePadding
 import com.airbnb.lottie.RenderMode
-import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.SheetFireClearDataBinding
 import com.duckduckgo.app.firebutton.FireButtonStore
 import com.duckduckgo.app.global.events.db.UserEventKey
@@ -142,7 +141,7 @@ class FireDialog(
     }
 
     private fun configureFireAnimationView() {
-        if (onboardingDesignExperimentManager.isAnyExperimentEnabled()) {
+        if (onboardingDesignExperimentManager.isAnyExperimentEnrolledAndEnabled()) {
             val selectedFireAnimation = settingsDataStore.selectedFireAnimation
             val resId = onboardingExperimentFireAnimationHelper.getSelectedFireAnimationResId(selectedFireAnimation)
 

--- a/app/src/main/java/com/duckduckgo/app/onboarding/store/OnboardingStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/store/OnboardingStore.kt
@@ -21,8 +21,6 @@ import com.duckduckgo.app.cta.ui.DaxBubbleCta.DaxDialogIntroOption
 interface OnboardingStore {
     var onboardingDialogJourney: String?
 
-    @Deprecated(message = "Parameter used for a temporary pixel")
     fun getSearchOptions(): List<DaxDialogIntroOption>
     fun getSitesOptions(): List<DaxDialogIntroOption>
-    fun getExperimentSearchOptions(): List<DaxDialogIntroOption>
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/store/OnboardingStoreImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/store/OnboardingStoreImpl.kt
@@ -63,18 +63,9 @@ class OnboardingStoreImpl @Inject constructor(
                 },
             ),
             DaxDialogIntroOption(
-                optionText = context.getString(R.string.onboardingSearchDaxDialogOption3),
-                iconRes = drawable.ic_find_search_16,
-                link = context.getString(R.string.onboardingSearchDaxDialogOption3),
-            ),
-            DaxDialogIntroOption(
                 optionText = context.getString(R.string.onboardingSearchDaxDialogOption4),
                 iconRes = drawable.ic_wand_16,
-                link = if (country == "US") {
-                    context.getString(R.string.onboardingSearchQueryOption4US)
-                } else {
-                    context.getString(R.string.onboardingSearchQueryOption4)
-                },
+                link = "!image ${context.getString(R.string.highlightsOnboardingSearchQueryOption4)}",
             ),
         )
     }
@@ -168,41 +159,6 @@ class OnboardingStoreImpl @Inject constructor(
                 optionText = context.getString(R.string.onboardingSitesDaxDialogOption4),
                 iconRes = drawable.ic_wand_16,
                 link = site4Query,
-            ),
-        )
-    }
-
-    override fun getExperimentSearchOptions(): List<DaxDialogIntroOption> {
-        val country = Locale.getDefault().country
-        val language = Locale.getDefault().language
-
-        return listOf(
-            DaxDialogIntroOption(
-                optionText = if (language == "en") {
-                    context.getString(R.string.onboardingSearchDaxDialogOption1English)
-                } else {
-                    context.getString(R.string.onboardingSearchDaxDialogOption1)
-                },
-                iconRes = drawable.ic_find_search_16,
-                link = if (language == "en") "how to say duck in spanish" else context.getString(R.string.onboardingSearchQueryOption1),
-            ),
-            DaxDialogIntroOption(
-                optionText = if (country == "US") {
-                    context.getString(R.string.onboardingSearchDaxDialogOption2US)
-                } else {
-                    context.getString(R.string.onboardingSearchDaxDialogOption2)
-                },
-                iconRes = drawable.ic_find_search_16,
-                link = if (country == "US") {
-                    context.getString(R.string.onboardingSearchDaxDialogOption2US)
-                } else {
-                    context.getString(R.string.onboardingSearchDaxDialogOption2)
-                },
-            ),
-            DaxDialogIntroOption(
-                optionText = context.getString(R.string.onboardingSearchDaxDialogOption4),
-                iconRes = drawable.ic_wand_16,
-                link = "!image ${context.getString(R.string.highlightsOnboardingSearchQueryOption4)}",
             ),
         )
     }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingActivity.kt
@@ -19,9 +19,11 @@ package com.duckduckgo.app.onboarding.ui
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.lifecycle.Lifecycle.State.CREATED
 import androidx.lifecycle.Lifecycle.State.STARTED
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.databinding.ActivityOnboardingBinding
@@ -49,9 +51,14 @@ class OnboardingActivity : DuckDuckGoActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
-        configurePager()
         configureSkipButton()
         observeViewModel()
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(CREATED) {
+                configurePager()
+            }
+        }
     }
 
     fun onContinueClicked() {
@@ -75,7 +82,7 @@ class OnboardingActivity : DuckDuckGoActivity() {
         finish()
     }
 
-    private fun configurePager() {
+    private suspend fun configurePager() {
         viewModel.initializePages()
 
         viewPageAdapter = PagerAdapter(supportFragmentManager, viewModel)

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingPageManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingPageManager.kt
@@ -32,6 +32,8 @@ import com.duckduckgo.app.onboarding.ui.page.WelcomePage
 interface OnboardingPageManager {
     fun pageCount(): Int
     fun buildPageBlueprints()
+    fun buildPageBlueprintsBb()
+    fun buildPageBlueprintsBuck()
     fun buildPage(position: Int): OnboardingPageFragment?
 }
 
@@ -53,6 +55,16 @@ class OnboardingPageManagerWithTrackerBlocking(
         if (shouldShowDefaultBrowserPage()) {
             pages.add((DefaultBrowserBlueprint))
         }
+    }
+
+    override fun buildPageBlueprintsBb() {
+        pages.clear()
+        pages += BbWelcomePageBlueprint
+    }
+
+    override fun buildPageBlueprintsBuck() {
+        pages.clear()
+        pages += BuckWelcomePageBlueprint
     }
 
     override fun buildPage(position: Int): OnboardingPageFragment? {

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.onboarding.store.AppStage
 import com.duckduckgo.app.onboarding.store.UserStageStore
 import com.duckduckgo.app.onboarding.ui.page.OnboardingPageFragment
+import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentManager
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
@@ -37,13 +38,26 @@ class OnboardingViewModel @Inject constructor(
     private val dispatchers: DispatcherProvider,
     private val onboardingSkipper: OnboardingSkipper,
     private val appBuildConfig: AppBuildConfig,
+    private val onboardingDesignExperimentManager: OnboardingDesignExperimentManager,
 ) : ViewModel() {
 
     private val _viewState = MutableStateFlow(ViewState())
     val viewState = _viewState.asStateFlow()
 
-    fun initializePages() {
-        pageLayoutManager.buildPageBlueprints()
+    suspend fun initializePages() {
+        onboardingDesignExperimentManager.enroll()
+
+        when {
+            onboardingDesignExperimentManager.isBbEnrolledAndEnabled() -> {
+                pageLayoutManager.buildPageBlueprintsBb()
+            }
+            onboardingDesignExperimentManager.isBuckEnrolledAndEnabled() -> {
+                pageLayoutManager.buildPageBlueprintsBuck()
+            }
+            else -> {
+                pageLayoutManager.buildPageBlueprints()
+            }
+        }
     }
 
     fun pageCount(): Int {

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/WelcomePage.kt
@@ -51,7 +51,7 @@ import com.duckduckgo.app.onboarding.ui.page.WelcomePageViewModel.Command.ShowDe
 import com.duckduckgo.app.onboarding.ui.page.WelcomePageViewModel.Command.ShowInitialDialog
 import com.duckduckgo.app.onboarding.ui.page.WelcomePageViewModel.Command.ShowInitialReinstallUserDialog
 import com.duckduckgo.app.onboarding.ui.page.WelcomePageViewModel.Command.ShowSkipOnboardingOption
-import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentToggles
+import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentManager
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.ui.store.AppTheme
 import com.duckduckgo.common.ui.view.gone
@@ -79,7 +79,7 @@ class WelcomePage : OnboardingPageFragment(R.layout.content_onboarding_welcome_p
     lateinit var appTheme: AppTheme
 
     @Inject
-    lateinit var onboardingDesignExperimentToggles: OnboardingDesignExperimentToggles
+    lateinit var onboardingDesignExperimentManager: OnboardingDesignExperimentManager
 
     private val binding: ContentOnboardingWelcomePageBinding by viewBinding()
     private val viewModel by lazy {
@@ -146,7 +146,7 @@ class WelcomePage : OnboardingPageFragment(R.layout.content_onboarding_welcome_p
             },
         )
 
-        if (onboardingDesignExperimentToggles.modifiedControl().isEnabled()) {
+        if (onboardingDesignExperimentManager.isModifiedControlEnrolledAndEnabled()) {
             scheduleWelcomeAnimation()
         } else {
             requestNotificationsPermissions()
@@ -301,7 +301,7 @@ class WelcomePage : OnboardingPageFragment(R.layout.content_onboarding_welcome_p
                     binding.daxDialogCta.progressBar.show()
                     binding.daxDialogCta.progressBar.progress = 2
                     val ctaText = it.getString(R.string.highlightsPreOnboardingAddressBarTitle).run {
-                        if (onboardingDesignExperimentToggles.modifiedControl().isEnabled()) {
+                        if (onboardingDesignExperimentManager.isModifiedControlEnrolledAndEnabled()) {
                             preventWidows()
                         } else {
                             this

--- a/app/src/main/java/com/duckduckgo/app/onboardingdesignexperiment/OnboardingDesignExperimentCountDataStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboardingdesignexperiment/OnboardingDesignExperimentCountDataStore.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboardingdesignexperiment
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import com.duckduckgo.app.onboardingdesignexperiment.di.OnboardingVisitCount
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+
+interface OnboardingDesignExperimentCountDataStore {
+    suspend fun increaseSiteVisitCount(): Int
+    suspend fun getSiteVisitCount(): Int
+    suspend fun increaseSerpVisitCount(): Int
+    suspend fun getSerpVisitCount(): Int
+}
+
+private const val KEY_SITE_VISIT_COUNT = "site_visit_count"
+private const val KEY_SERP_VISIT_COUNT = "serp_visit_count"
+
+@ContributesBinding(AppScope::class)
+@SingleInstanceIn(AppScope::class)
+class SharedPreferencesOnboardingDesignExperimentCountDataStore @Inject constructor(
+        private val dispatcherProvider: DispatcherProvider,
+        @OnboardingVisitCount private val store: DataStore<Preferences>,
+) : OnboardingDesignExperimentCountDataStore {
+
+    override suspend fun increaseSiteVisitCount(): Int {
+        return withContext(dispatcherProvider.io()) {
+            val currentCount = getSiteVisitCount()
+            store.edit { preferences ->
+                preferences[intPreferencesKey(KEY_SITE_VISIT_COUNT)] = currentCount + 1
+            }
+            currentCount + 1
+        }
+    }
+
+    override suspend fun getSiteVisitCount(): Int {
+        return withContext(dispatcherProvider.io()) {
+            store.data.map { preferences ->
+                preferences[intPreferencesKey(KEY_SITE_VISIT_COUNT)] ?: 0
+            }.firstOrNull() ?: 0
+        }
+    }
+
+    override suspend fun increaseSerpVisitCount(): Int {
+        return withContext(dispatcherProvider.io()) {
+            val currentCount = getSerpVisitCount()
+            store.edit { preferences ->
+                preferences[intPreferencesKey(KEY_SERP_VISIT_COUNT)] = currentCount + 1
+            }
+            currentCount + 1
+        }
+    }
+
+    override suspend fun getSerpVisitCount(): Int {
+        return withContext(dispatcherProvider.io()) {
+            store.data.map { preferences ->
+                preferences[intPreferencesKey(KEY_SERP_VISIT_COUNT)] ?: 0
+            }.firstOrNull() ?: 0
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/onboardingdesignexperiment/OnboardingDesignExperimentCountDataStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboardingdesignexperiment/OnboardingDesignExperimentCountDataStore.kt
@@ -43,8 +43,8 @@ private const val KEY_SERP_VISIT_COUNT = "serp_visit_count"
 @ContributesBinding(AppScope::class)
 @SingleInstanceIn(AppScope::class)
 class SharedPreferencesOnboardingDesignExperimentCountDataStore @Inject constructor(
-        private val dispatcherProvider: DispatcherProvider,
-        @OnboardingVisitCount private val store: DataStore<Preferences>,
+    private val dispatcherProvider: DispatcherProvider,
+    @OnboardingVisitCount private val store: DataStore<Preferences>,
 ) : OnboardingDesignExperimentCountDataStore {
 
     override suspend fun increaseSiteVisitCount(): Int {

--- a/app/src/main/java/com/duckduckgo/app/onboardingdesignexperiment/OnboardingDesignExperimentManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboardingdesignexperiment/OnboardingDesignExperimentManager.kt
@@ -188,17 +188,17 @@ class RealOnboardingDesignExperimentManager @Inject constructor(
     }
 
     override suspend fun fireInContextDialogShownPixel(cta: Cta?) {
-        when(cta) {
+        when (cta) {
             is DaxBubbleCta -> {
-                when(cta) {
+                when (cta) {
                     is DaxBubbleCta.DaxIntroSearchOptionsCta -> fireTryASearchDisplayedPixel()
                     is DaxBubbleCta.DaxIntroVisitSiteOptionsCta -> fireVisitSitePromptDisplayedNewTabPixel()
                     is DaxBubbleCta.DaxEndCta -> fireFinalOnboardingScreenDisplayedPixel()
                     is DaxBubbleCta.DaxPrivacyProCta -> Unit // No pixel for this CTA
                 }
             }
-            is OnboardingDaxDialogCta ->{
-                when(cta) {
+            is OnboardingDaxDialogCta -> {
+                when (cta) {
                     is OnboardingDaxDialogCta.DaxSerpCta -> fireMessageOnSerpDisplayedPixel()
                     is OnboardingDaxDialogCta.DaxSiteSuggestionsCta -> fireVisitSitePromptDisplayedAdjacentPixel()
                     is OnboardingDaxDialogCta.DaxTrackersBlockedCta -> fireTrackersBlockedMessageDisplayedPixel()
@@ -215,9 +215,9 @@ class RealOnboardingDesignExperimentManager @Inject constructor(
         cta: Cta,
         index: Int,
     ) {
-        when(cta) {
+        when (cta) {
             is DaxBubbleCta.DaxIntroSearchOptionsCta -> {
-                when(index) {
+                when (index) {
                     0 -> fireFirstSearchSuggestionPixel()
                     1 -> fireSecondSearchSuggestionPixel()
                     2 -> fireThirdSearchSuggestionPixel()
@@ -225,22 +225,23 @@ class RealOnboardingDesignExperimentManager @Inject constructor(
                 }
             }
             is DaxBubbleCta.DaxIntroVisitSiteOptionsCta,
-            is OnboardingDaxDialogCta.DaxSiteSuggestionsCta -> fireSiteSuggestionOptionSelectedPixel(index)
+            is OnboardingDaxDialogCta.DaxSiteSuggestionsCta,
+            -> fireSiteSuggestionOptionSelectedPixel(index)
         }
     }
 
     override suspend fun fireSiteSuggestionOptionSelectedPixel(index: Int) {
-            when(index) {
-                0 -> fireFirstSiteSuggestionPixel()
-                1 -> fireSecondSiteSuggestionPixel()
-                2 -> fireThirdSiteSuggestionPixel()
-                else -> Unit // only 3 options are available
-            }
+        when (index) {
+            0 -> fireFirstSiteSuggestionPixel()
+            1 -> fireSecondSiteSuggestionPixel()
+            2 -> fireThirdSiteSuggestionPixel()
+            else -> Unit // only 3 options are available
+        }
     }
 
     override suspend fun onWebPageFinishedLoading(url: String?) {
         if (url == null) return
-        if(duckDuckGoUrlDetector.isDuckDuckGoUrl(url)) {
+        if (duckDuckGoUrlDetector.isDuckDuckGoUrl(url)) {
             fireSecondSerpVisitPixel()
         } else {
             fireSecondSiteVisitPixel()

--- a/app/src/main/java/com/duckduckgo/app/onboardingdesignexperiment/OnboardingDesignExperimentManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboardingdesignexperiment/OnboardingDesignExperimentManager.kt
@@ -131,6 +131,34 @@ class RealOnboardingDesignExperimentManager @Inject constructor(
     override fun isBbEnrolledAndEnabled(): Boolean = isExperimentEnabled == true &&
         onboardingDesignExperimentCohort == BB
 
+    override suspend fun fireIntroScreenDisplayedPixel() {
+        onboardingExperimentMetricsPixelPlugin.getIntroScreenDisplayedMetric()?.fire()
+    }
+
+    override suspend fun fireComparisonScreenDisplayedPixel() {
+        onboardingExperimentMetricsPixelPlugin.getComparisonScreenDisplayedMetric()?.fire()
+    }
+
+    override suspend fun fireChooseBrowserPixel() {
+        onboardingExperimentMetricsPixelPlugin.getChooseBrowserMetric()?.fire()
+    }
+
+    override suspend fun fireSetDefaultRatePixel() {
+        onboardingExperimentMetricsPixelPlugin.getSetDefaultRateMetric()?.fire()
+    }
+
+    override suspend fun fireSetAddressBarDisplayedPixel() {
+        onboardingExperimentMetricsPixelPlugin.getSetAddressBarDisplayedMetric()?.fire()
+    }
+
+    override suspend fun fireAddressBarSetTopPixel() {
+        onboardingExperimentMetricsPixelPlugin.getAddressBarSetTopMetric()?.fire()
+    }
+
+    override suspend fun fireAddressBarSetBottomPixel() {
+        onboardingExperimentMetricsPixelPlugin.getAddressBarSetBottomMetric()?.fire()
+    }
+
 
     override fun isAnyExperimentEnabled() =
         onboardingDesignExperimentToggles.buckOnboarding().isEnabled() ||

--- a/app/src/main/java/com/duckduckgo/app/onboardingdesignexperiment/OnboardingDesignExperimentManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboardingdesignexperiment/OnboardingDesignExperimentManager.kt
@@ -16,20 +16,152 @@
 
 package com.duckduckgo.app.onboardingdesignexperiment
 
+import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.app.browser.DuckDuckGoUrlDetector
+import com.duckduckgo.app.cta.ui.Cta
+import com.duckduckgo.app.cta.ui.DaxBubbleCta
+import com.duckduckgo.app.cta.ui.OnboardingDaxDialogCta
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentToggles.OnboardingDesignExperimentCohort
+import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentToggles.OnboardingDesignExperimentCohort.BB
+import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentToggles.OnboardingDesignExperimentCohort.BUCK
+import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentToggles.OnboardingDesignExperimentCohort.MODIFIED_CONTROL
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.device.DeviceInfo
+import com.duckduckgo.common.utils.device.DeviceInfo.FormFactor.TABLET
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.MetricsPixel
+import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
 import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 interface OnboardingDesignExperimentManager {
-    fun isAnyExperimentEnabled(): Boolean
+    suspend fun enroll()
+    fun isAnyExperimentEnrolledAndEnabled(): Boolean
+    fun isModifiedControlEnrolledAndEnabled(): Boolean
+    fun isBuckEnrolledAndEnabled(): Boolean
+    fun isBbEnrolledAndEnabled(): Boolean
+    suspend fun fireIntroScreenDisplayedPixel()
+    suspend fun fireComparisonScreenDisplayedPixel()
+    suspend fun fireChooseBrowserPixel()
+    suspend fun fireSetDefaultRatePixel()
+    suspend fun fireSetAddressBarDisplayedPixel()
+    suspend fun fireAddressBarSetTopPixel()
+    suspend fun fireAddressBarSetBottomPixel()
+    suspend fun fireSearchOrNavCustomPixel()
+    suspend fun firePrivacyDashClickedFromOnboardingPixel()
+    suspend fun fireFireButtonClickedFromOnboardingPixel()
+    suspend fun fireInContextDialogShownPixel(cta: Cta?)
+    suspend fun fireOptionSelectedPixel(cta: Cta, index: Int)
+    suspend fun fireSiteSuggestionOptionSelectedPixel(index: Int)
+    suspend fun onWebPageFinishedLoading(url: String?)
 }
 
-@ContributesBinding(AppScope::class)
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = MainProcessLifecycleObserver::class,
+)
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = PrivacyConfigCallbackPlugin::class,
+)
+@ContributesBinding(
+    scope = AppScope::class,
+    boundType = OnboardingDesignExperimentManager::class,
+)
+@SingleInstanceIn(AppScope::class)
 class RealOnboardingDesignExperimentManager @Inject constructor(
+    @AppCoroutineScope private val coroutineScope: CoroutineScope,
+    private val dispatcherProvider: DispatcherProvider,
     private val onboardingDesignExperimentToggles: OnboardingDesignExperimentToggles,
-) : OnboardingDesignExperimentManager {
+    private val onboardingExperimentMetricsPixelPlugin: OnboardingExperimentMetricsPixelPlugin,
+    private val onboardingDesignExperimentCountDataStore: OnboardingDesignExperimentCountDataStore,
+    private val pixel: Pixel,
+    private val appBuildConfig: AppBuildConfig,
+    private val deviceInfo: DeviceInfo,
+    private val duckDuckGoUrlDetector: DuckDuckGoUrlDetector,
+) : OnboardingDesignExperimentManager, MainProcessLifecycleObserver, PrivacyConfigCallbackPlugin {
+
+    private var isExperimentEnabled: Boolean? = null
+    private var onboardingDesignExperimentCohort: OnboardingDesignExperimentCohort? = null
+
+    override fun onCreate(owner: LifecycleOwner) {
+        coroutineScope.launch {
+            setCachedProperties()
+        }
+    }
+
+    override fun onPrivacyConfigDownloaded() {
+        coroutineScope.launch {
+            setCachedProperties()
+        }
+    }
+
+    /**
+     * Enrolls the user in the onboarding design experiment if they are eligible.
+     * Eligibility is determined by the device's Android version, form factor, and whether the user is a returning user.
+     */
+    override suspend fun enroll() {
+        withContext(dispatcherProvider.io()) {
+            if (isEligibleForEnrolment()) {
+                onboardingDesignExperimentToggles.onboardingDesignExperimentAug25().enroll()
+                setCachedProperties()
+            }
+        }
+    }
+
+    override fun isAnyExperimentEnrolledAndEnabled() = isModifiedControlEnrolledAndEnabled() ||
+        isBuckEnrolledAndEnabled() ||
+        isBbEnrolledAndEnabled()
+
+    override fun isModifiedControlEnrolledAndEnabled(): Boolean = isExperimentEnabled == true &&
+        onboardingDesignExperimentCohort == MODIFIED_CONTROL
+
+    override fun isBuckEnrolledAndEnabled(): Boolean = isExperimentEnabled == true &&
+        onboardingDesignExperimentCohort == BUCK
+
+    override fun isBbEnrolledAndEnabled(): Boolean = isExperimentEnabled == true &&
+        onboardingDesignExperimentCohort == BB
+
 
     override fun isAnyExperimentEnabled() =
         onboardingDesignExperimentToggles.buckOnboarding().isEnabled() ||
             onboardingDesignExperimentToggles.bbOnboarding().isEnabled()
+    private suspend fun isEligibleForEnrolment(): Boolean = isAtLeastAndroid11() && !isTablet() && !isReturningUser()
+
+    private fun isTablet(): Boolean =
+        deviceInfo.formFactor() == TABLET
+
+    private suspend fun isReturningUser(): Boolean =
+        appBuildConfig.isAppReinstall()
+
+    private fun isAtLeastAndroid11(): Boolean =
+        appBuildConfig.sdkInt >= 30
+
+    private suspend fun setCachedProperties() {
+        withContext(dispatcherProvider.io()) {
+            onboardingDesignExperimentCohort = getEnrolledAndEnabledExperimentCohort()
+            isExperimentEnabled = onboardingDesignExperimentToggles.onboardingDesignExperimentAug25().isEnabled()
+        }
+    }
+
+    private suspend fun getEnrolledAndEnabledExperimentCohort(): OnboardingDesignExperimentCohort? {
+        val cohort = onboardingDesignExperimentToggles.onboardingDesignExperimentAug25().getCohort()
+
+        return when (cohort?.name) {
+            MODIFIED_CONTROL.cohortName -> MODIFIED_CONTROL
+            BUCK.cohortName -> BUCK
+            BB.cohortName -> BB
+            else -> null
+        }
+    }
+
 }

--- a/app/src/main/java/com/duckduckgo/app/onboardingdesignexperiment/OnboardingDesignExperimentToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboardingdesignexperiment/OnboardingDesignExperimentToggles.kt
@@ -19,8 +19,13 @@ package com.duckduckgo.app.onboardingdesignexperiment
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentToggles.Companion.BASE_EXPERIMENT_NAME
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.ConversionWindow
+import com.duckduckgo.feature.toggles.api.MetricsPixel
+import com.duckduckgo.feature.toggles.api.MetricsPixelPlugin
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
@@ -53,18 +58,321 @@ interface OnboardingDesignExperimentToggles {
     }
 }
 
+@ContributesMultibinding(AppScope::class)
+class OnboardingExperimentMetricsPixelPlugin @Inject constructor(
+    private val onboardingDesignExperimentToggles: OnboardingDesignExperimentToggles,
+) : MetricsPixelPlugin {
 
-    /**
-     * Toggle for enabling or disabling the "buckOnboarding" design experiment.
-     * Default value: false (disabled).
-     */
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
-    fun buckOnboarding(): Toggle
+    override suspend fun getMetrics(): List<MetricsPixel> {
+        val toggle = onboardingDesignExperimentToggles.onboardingDesignExperimentAug25()
+        val conversionWindow = listOf(
+            ConversionWindow(lowerWindow = 0, upperWindow = 0),
+            ConversionWindow(lowerWindow = 1, upperWindow = 1),
+            ConversionWindow(lowerWindow = 0, upperWindow = 7),
+            ConversionWindow(lowerWindow = 0, upperWindow = 14),
+        )
 
-    /**
-     * Toggle for enabling or disabling the "bbOnboarding" design experiment.
-     * Default value: false (disabled).
-     */
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
-    fun bbOnboarding(): Toggle
+        return listOf(
+            MetricsPixel(
+                metric = METRIC_INTRO_SCREEN_DISPLAYED,
+                value = "1",
+                toggle = toggle,
+                conversionWindow = conversionWindow,
+            ),
+            MetricsPixel(
+                metric = METRIC_COMPARISON_SCREEN_DISPLAYED,
+                value = "1",
+                toggle = toggle,
+                conversionWindow = conversionWindow,
+            ),
+            MetricsPixel(
+                metric = METRIC_CHOOSE_BROWSER,
+                value = "1",
+                toggle = toggle,
+                conversionWindow = conversionWindow,
+            ),
+            MetricsPixel(
+                metric = METRIC_SET_DEFAULT_RATE,
+                value = "1",
+                toggle = toggle,
+                conversionWindow = conversionWindow,
+            ),
+            MetricsPixel(
+                metric = METRIC_SET_ADDRESS_BAR_DISPLAYED,
+                value = "1",
+                toggle = toggle,
+                conversionWindow = conversionWindow,
+            ),
+            MetricsPixel(
+                metric = METRIC_ADDRESS_BAR_SET_TOP,
+                value = "1",
+                toggle = toggle,
+                conversionWindow = conversionWindow,
+            ),
+            MetricsPixel(
+                metric = METRIC_ADDRESS_BAR_SET_BOTTOM,
+                value = "1",
+                toggle = toggle,
+                conversionWindow = conversionWindow,
+            ),
+            MetricsPixel(
+                metric = METRIC_TRY_A_SEARCH_DISPLAYED,
+                value = "1",
+                toggle = toggle,
+                conversionWindow = conversionWindow,
+            ),
+            MetricsPixel(
+                metric = METRIC_FIRST_SEARCH_SUGGESTION,
+                value = "1",
+                toggle = toggle,
+                conversionWindow = conversionWindow,
+            ),
+            MetricsPixel(
+                metric = METRIC_SECOND_SEARCH_SUGGESTION,
+                value = "1",
+                toggle = toggle,
+                conversionWindow = conversionWindow,
+            ),
+            MetricsPixel(
+                metric = METRIC_THIRD_SEARCH_SUGGESTION,
+                value = "1",
+                toggle = toggle,
+                conversionWindow = conversionWindow,
+            ),
+            MetricsPixel(
+                metric = METRIC_SEARCH_OR_NAV_CUSTOM,
+                value = "1",
+                toggle = toggle,
+                conversionWindow = conversionWindow,
+            ),
+            MetricsPixel(
+                metric = METRIC_MESSAGE_ON_SERP_DISPLAYED,
+                value = "1",
+                toggle = toggle,
+                conversionWindow = conversionWindow,
+            ),
+            MetricsPixel(
+                metric = METRIC_VISIT_SITE_PROMPT_DISPLAYED_ADJACENT,
+                value = "1",
+                toggle = toggle,
+                conversionWindow = conversionWindow,
+            ),
+            MetricsPixel(
+                metric = METRIC_VISIT_SITE_PROMPT_DISPLAYED_NEW_TAB,
+                value = "1",
+                toggle = toggle,
+                conversionWindow = conversionWindow,
+            ),
+            MetricsPixel(
+                metric = METRIC_FIRST_SITE_SUGGESTION,
+                value = "1",
+                toggle = toggle,
+                conversionWindow = conversionWindow,
+            ),
+            MetricsPixel(
+                metric = METRIC_SECOND_SITE_SUGGESTION,
+                value = "1",
+                toggle = toggle,
+                conversionWindow = conversionWindow,
+            ),
+            MetricsPixel(
+                metric = METRIC_THIRD_SITE_SUGGESTION,
+                value = "1",
+                toggle = toggle,
+                conversionWindow = conversionWindow,
+            ),
+            MetricsPixel(
+                metric = METRIC_TRACKERS_BLOCKED_MESSAGE_DISPLAYED,
+                value = "1",
+                toggle = toggle,
+                conversionWindow = conversionWindow,
+            ),
+            MetricsPixel(
+                metric = METRIC_NO_TRACKERS_MESSAGE_DISPLAYED,
+                value = "1",
+                toggle = toggle,
+                conversionWindow = conversionWindow,
+            ),
+            MetricsPixel(
+                metric = METRIC_TRACKER_NETWORK_MESSAGE_DISPLAYED,
+                value = "1",
+                toggle = toggle,
+                conversionWindow = conversionWindow,
+            ),
+            MetricsPixel(
+                metric = METRIC_PRIVACY_DASH_CLICKED_FROM_ONBOARDING,
+                value = "1",
+                toggle = toggle,
+                conversionWindow = conversionWindow,
+            ),
+            MetricsPixel(
+                metric = METRIC_FIRE_BUTTON_PROMPT_DISPLAYED,
+                value = "1",
+                toggle = toggle,
+                conversionWindow = conversionWindow,
+            ),
+            MetricsPixel(
+                metric = METRIC_FIRE_BUTTON_CLICKED_FROM_ONBOARDING,
+                value = "1",
+                toggle = toggle,
+                conversionWindow = conversionWindow,
+            ),
+            MetricsPixel(
+                metric = METRIC_FINAL_ONBOARDING_SCREEN_DISPLAYED,
+                value = "1",
+                toggle = toggle,
+                conversionWindow = conversionWindow,
+            ),
+            MetricsPixel(
+                metric = METRIC_SECOND_SITE_VISIT,
+                value = "2",
+                toggle = toggle,
+                conversionWindow = conversionWindow,
+            ),
+            MetricsPixel(
+                metric = METRIC_SECOND_SERP_VISIT,
+                value = "2",
+                toggle = toggle,
+                conversionWindow = conversionWindow,
+            ),
+        )
+    }
+
+    suspend fun getIntroScreenDisplayedMetric(): MetricsPixel? {
+        return this.getMetrics().firstOrNull { it.metric == METRIC_INTRO_SCREEN_DISPLAYED }
+    }
+
+    suspend fun getComparisonScreenDisplayedMetric(): MetricsPixel? {
+        return this.getMetrics().firstOrNull { it.metric == METRIC_COMPARISON_SCREEN_DISPLAYED }
+    }
+
+    suspend fun getChooseBrowserMetric(): MetricsPixel? {
+        return this.getMetrics().firstOrNull { it.metric == METRIC_CHOOSE_BROWSER }
+    }
+
+    suspend fun getSetDefaultRateMetric(): MetricsPixel? {
+        return this.getMetrics().firstOrNull { it.metric == METRIC_SET_DEFAULT_RATE }
+    }
+
+    suspend fun getSetAddressBarDisplayedMetric(): MetricsPixel? {
+        return this.getMetrics().firstOrNull { it.metric == METRIC_SET_ADDRESS_BAR_DISPLAYED }
+    }
+
+    suspend fun getAddressBarSetTopMetric(): MetricsPixel? {
+        return this.getMetrics().firstOrNull { it.metric == METRIC_ADDRESS_BAR_SET_TOP }
+    }
+
+    suspend fun getAddressBarSetBottomMetric(): MetricsPixel? {
+        return this.getMetrics().firstOrNull { it.metric == METRIC_ADDRESS_BAR_SET_BOTTOM }
+    }
+
+    suspend fun getTryASearchDisplayedMetric(): MetricsPixel? {
+        return this.getMetrics().firstOrNull { it.metric == METRIC_TRY_A_SEARCH_DISPLAYED }
+    }
+
+    suspend fun getFirstSearchSuggestionMetric(): MetricsPixel? {
+        return this.getMetrics().firstOrNull { it.metric == METRIC_FIRST_SEARCH_SUGGESTION }
+    }
+
+    suspend fun getSecondSearchSuggestionMetric(): MetricsPixel? {
+        return this.getMetrics().firstOrNull { it.metric == METRIC_SECOND_SEARCH_SUGGESTION }
+    }
+
+    suspend fun getThirdSearchSuggestionMetric(): MetricsPixel? {
+        return this.getMetrics().firstOrNull { it.metric == METRIC_THIRD_SEARCH_SUGGESTION }
+    }
+
+    suspend fun getSearchOrNavCustomMetric(): MetricsPixel? {
+        return this.getMetrics().firstOrNull { it.metric == METRIC_SEARCH_OR_NAV_CUSTOM }
+    }
+
+    suspend fun getMessageOnSerpDisplayedMetric(): MetricsPixel? {
+        return this.getMetrics().firstOrNull { it.metric == METRIC_MESSAGE_ON_SERP_DISPLAYED }
+    }
+
+    suspend fun getVisitSitePromptDisplayedAdjacentMetric(): MetricsPixel? {
+        return this.getMetrics().firstOrNull { it.metric == METRIC_VISIT_SITE_PROMPT_DISPLAYED_ADJACENT }
+    }
+
+    suspend fun getVisitSitePromptDisplayedNewTabMetric(): MetricsPixel? {
+        return this.getMetrics().firstOrNull { it.metric == METRIC_VISIT_SITE_PROMPT_DISPLAYED_NEW_TAB }
+    }
+
+    suspend fun getFirstSiteSuggestionMetric(): MetricsPixel? {
+        return this.getMetrics().firstOrNull { it.metric == METRIC_FIRST_SITE_SUGGESTION }
+    }
+
+    suspend fun getSecondSiteSuggestionMetric(): MetricsPixel? {
+        return this.getMetrics().firstOrNull { it.metric == METRIC_SECOND_SITE_SUGGESTION }
+    }
+
+    suspend fun getThirdSiteSuggestionMetric(): MetricsPixel? {
+        return this.getMetrics().firstOrNull { it.metric == METRIC_THIRD_SITE_SUGGESTION }
+    }
+
+    suspend fun getTrackersBlockedMessageDisplayedMetric(): MetricsPixel? {
+        return this.getMetrics().firstOrNull { it.metric == METRIC_TRACKERS_BLOCKED_MESSAGE_DISPLAYED }
+    }
+
+    suspend fun getNoTrackersMessageDisplayedMetric(): MetricsPixel? {
+        return this.getMetrics().firstOrNull { it.metric == METRIC_NO_TRACKERS_MESSAGE_DISPLAYED }
+    }
+
+    suspend fun getTrackerNetworkMessageDisplayedMetric(): MetricsPixel? {
+        return this.getMetrics().firstOrNull { it.metric == METRIC_TRACKER_NETWORK_MESSAGE_DISPLAYED }
+    }
+
+    suspend fun getPrivacyDashClickedFromOnboardingMetric(): MetricsPixel? {
+        return this.getMetrics().firstOrNull { it.metric == METRIC_PRIVACY_DASH_CLICKED_FROM_ONBOARDING }
+    }
+
+    suspend fun getFireButtonPromptDisplayedMetric(): MetricsPixel? {
+        return this.getMetrics().firstOrNull { it.metric == METRIC_FIRE_BUTTON_PROMPT_DISPLAYED }
+    }
+
+    suspend fun getFireButtonClickedFromOnboardingMetric(): MetricsPixel? {
+        return this.getMetrics().firstOrNull { it.metric == METRIC_FIRE_BUTTON_CLICKED_FROM_ONBOARDING }
+    }
+
+    suspend fun getFinalOnboardingScreenDisplayedMetric(): MetricsPixel? {
+        return this.getMetrics().firstOrNull { it.metric == METRIC_FINAL_ONBOARDING_SCREEN_DISPLAYED }
+    }
+
+    suspend fun getSecondSiteVisitMetric(): MetricsPixel? {
+        return this.getMetrics().firstOrNull { it.metric == METRIC_SECOND_SITE_VISIT }
+    }
+
+    suspend fun getSecondSerpVisitMetric(): MetricsPixel? {
+        return this.getMetrics().firstOrNull { it.metric == METRIC_SECOND_SERP_VISIT }
+    }
+
+    private companion object {
+        const val METRIC_INTRO_SCREEN_DISPLAYED = "introScreenDisplayed"
+        const val METRIC_COMPARISON_SCREEN_DISPLAYED = "comparisonScreenDisplayed"
+        const val METRIC_CHOOSE_BROWSER = "chooseBrowser"
+        const val METRIC_SET_DEFAULT_RATE = "setDefaultRate"
+        const val METRIC_SET_ADDRESS_BAR_DISPLAYED = "setAddressBarDisplayed"
+        const val METRIC_ADDRESS_BAR_SET_TOP = "addressBarSetTop"
+        const val METRIC_ADDRESS_BAR_SET_BOTTOM = "addressBarSetBottom"
+        const val METRIC_TRY_A_SEARCH_DISPLAYED = "tryASearchDisplayed"
+        const val METRIC_FIRST_SEARCH_SUGGESTION = "firstSearchSuggestion"
+        const val METRIC_SECOND_SEARCH_SUGGESTION = "secondSearchSuggestion"
+        const val METRIC_THIRD_SEARCH_SUGGESTION = "thirdSearchSuggestion"
+        const val METRIC_SEARCH_OR_NAV_CUSTOM = "searchOrNavCustom"
+        const val METRIC_MESSAGE_ON_SERP_DISPLAYED = "messageOnSERPDisplayed"
+        const val METRIC_VISIT_SITE_PROMPT_DISPLAYED_ADJACENT = "visitSitePromptDisplayedAdjacent"
+        const val METRIC_VISIT_SITE_PROMPT_DISPLAYED_NEW_TAB = "visitSitePromptDisplayedNewTab"
+        const val METRIC_FIRST_SITE_SUGGESTION = "firstSiteSuggestion"
+        const val METRIC_SECOND_SITE_SUGGESTION = "secondSiteSuggestion"
+        const val METRIC_THIRD_SITE_SUGGESTION = "thirdSiteSuggestion"
+        const val METRIC_TRACKERS_BLOCKED_MESSAGE_DISPLAYED = "trackersBlockedMessageDisplayed"
+        const val METRIC_NO_TRACKERS_MESSAGE_DISPLAYED = "noTrackersMessageDisplayed"
+        const val METRIC_TRACKER_NETWORK_MESSAGE_DISPLAYED = "trackerNetworkMessageDisplayed"
+        const val METRIC_PRIVACY_DASH_CLICKED_FROM_ONBOARDING = "privacyDashClickedFromOnboarding"
+        const val METRIC_FIRE_BUTTON_PROMPT_DISPLAYED = "fireButtonPromptDisplayed"
+        const val METRIC_FIRE_BUTTON_CLICKED_FROM_ONBOARDING = "fireButtonClickedFromOnboarding"
+        const val METRIC_FINAL_ONBOARDING_SCREEN_DISPLAYED = "finalOnboardingScreenDisplayed"
+        const val METRIC_SECOND_SITE_VISIT = "secondSiteVisit"
+        const val METRIC_SECOND_SERP_VISIT = "secondSerpVisit"
+    }
 }

--- a/app/src/main/java/com/duckduckgo/app/onboardingdesignexperiment/OnboardingDesignExperimentToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboardingdesignexperiment/OnboardingDesignExperimentToggles.kt
@@ -17,13 +17,14 @@
 package com.duckduckgo.app.onboardingdesignexperiment
 
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentToggles.Companion.BASE_EXPERIMENT_NAME
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
-    featureName = "onboardingDesignExperiment",
+    featureName = BASE_EXPERIMENT_NAME,
 )
 /**
  * Interface defining feature toggles for the onboarding design experiment.
@@ -38,12 +39,20 @@ interface OnboardingDesignExperimentToggles {
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 
-    /**
-     * Toggle for enabling or disabling the "modifiedControl" version of the design experiment.
-     * Default value: false (disabled).
-     */
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
-    fun modifiedControl(): Toggle
+    fun onboardingDesignExperimentAug25(): Toggle
+
+    enum class OnboardingDesignExperimentCohort(override val cohortName: String) : Toggle.State.CohortName {
+        MODIFIED_CONTROL("modifiedControl"),
+        BUCK("buck"),
+        BB("bb"),
+    }
+
+    companion object {
+        internal const val BASE_EXPERIMENT_NAME = "onboardingDesignExperiment"
+    }
+}
+
 
     /**
      * Toggle for enabling or disabling the "buckOnboarding" design experiment.

--- a/app/src/main/java/com/duckduckgo/app/onboardingdesignexperiment/di/OnboardingDesignExperimentModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboardingdesignexperiment/di/OnboardingDesignExperimentModule.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboardingdesignexperiment.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesTo
+import dagger.Module
+import dagger.Provides
+import javax.inject.Qualifier
+
+@ContributesTo(AppScope::class)
+@Module
+object OnboardingVisitCountDataStoreModule {
+    private val Context.onboardingExperimentVisitCountDataStore: DataStore<Preferences> by preferencesDataStore(
+        name = "onboarding_experiment_visit_count",
+    )
+
+    @Provides
+    @OnboardingVisitCount
+    fun provideOnboardingExperimentVisitCountDataStore(context: Context): DataStore<Preferences> = context.onboardingExperimentVisitCountDataStore
+}
+
+@Qualifier
+internal annotation class OnboardingVisitCount

--- a/app/src/main/java/com/duckduckgo/app/settings/FireAnimationActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/FireAnimationActivity.kt
@@ -66,7 +66,7 @@ class FireAnimationActivity : DuckDuckGoActivity() {
         fireAnimation: FireAnimation,
         fireAnimationView: LottieAnimationView,
     ) {
-        if (onboardingDesignExperimentManager.isAnyExperimentEnabled()) {
+        if (onboardingDesignExperimentManager.isAnyExperimentEnrolledAndEnabled()) {
             val resId = onboardingExperimentFireAnimationHelper.getSelectedFireAnimationResId(fireAnimation)
             fireAnimationView.setAnimation(resId)
         } else {

--- a/app/src/main/java/com/duckduckgo/app/settings/clear/OnboardingExperimentFireAnimationHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/settings/clear/OnboardingExperimentFireAnimationHelper.kt
@@ -17,11 +17,11 @@
 package com.duckduckgo.app.settings.clear
 
 import com.duckduckgo.app.browser.R
-import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentToggles
+import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentManager
 import javax.inject.Inject
 
 class OnboardingExperimentFireAnimationHelper @Inject constructor(
-    private val onboardingDesignExperimentToggles: OnboardingDesignExperimentToggles,
+    private val onboardingDesignExperimentManager: OnboardingDesignExperimentManager,
 ) {
 
     /**
@@ -31,8 +31,8 @@ class OnboardingExperimentFireAnimationHelper @Inject constructor(
     fun getSelectedFireAnimationResId(selectedFireAnimation: FireAnimation): Int {
         return if (selectedFireAnimation is FireAnimation.HeroFire) {
             when {
-                onboardingDesignExperimentToggles.buckOnboarding().isEnabled() -> R.raw.buck_experiment_fire
-                onboardingDesignExperimentToggles.bbOnboarding().isEnabled() -> R.raw.bb_experiment_fire_optimised
+                onboardingDesignExperimentManager.isBuckEnrolledAndEnabled() -> R.raw.buck_experiment_fire
+                onboardingDesignExperimentManager.isBbEnrolledAndEnabled() -> R.raw.bb_experiment_fire_optimised
                 else -> R.raw.hero_fire_inferno
             }
         } else {

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/CtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/CtaTest.kt
@@ -34,7 +34,6 @@ import com.duckduckgo.app.trackerdetection.model.Entity
 import com.duckduckgo.app.trackerdetection.model.TrackerStatus
 import com.duckduckgo.app.trackerdetection.model.TrackerType
 import com.duckduckgo.app.trackerdetection.model.TrackingEvent
-import com.duckduckgo.feature.toggles.api.Toggle
 import java.util.concurrent.TimeUnit
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -44,7 +43,6 @@ import org.junit.Test
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
-import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/OnboardingDaxDialogTests.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/OnboardingDaxDialogTests.kt
@@ -35,7 +35,7 @@ import com.duckduckgo.app.onboarding.store.AppStage
 import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.onboarding.store.UserStageStore
 import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.ExtendedOnboardingFeatureToggles
-import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentToggles
+import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentManager
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -86,7 +86,7 @@ class OnboardingDaxDialogTests {
     private val mockSubscriptions: Subscriptions = mock()
     private val mockSenseOfProtectionExperiment: SenseOfProtectionExperiment = mock()
     private val mockOnboardingHomeScreenWidgetExperiment: OnboardingHomeScreenWidgetExperiment = mock()
-    private val mockOnboardingDesignExperimentToggles: OnboardingDesignExperimentToggles = mock()
+    private val mockOnboardingDesignExperimentManager: OnboardingDesignExperimentManager = mock()
     private val mockRebrandingFeatureToggle: SubscriptionRebrandingFeatureToggle = mock()
 
     val mockEnabledToggle: Toggle = org.mockito.kotlin.mock { on { it.isEnabled() } doReturn true }
@@ -116,7 +116,7 @@ class OnboardingDaxDialogTests {
             mockBrokenSitePrompt,
             mockSenseOfProtectionExperiment,
             mockOnboardingHomeScreenWidgetExperiment,
-            mockOnboardingDesignExperimentToggles,
+            mockOnboardingDesignExperimentManager,
             mockRebrandingFeatureToggle,
         )
     }

--- a/app/src/test/java/com/duckduckgo/app/onboarding/onboardingdesignexperiment/OnboardingDesignExperimentCountDataStoreTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/onboardingdesignexperiment/OnboardingDesignExperimentCountDataStoreTest.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding.onboardingdesignexperiment
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStoreFile
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.app.onboardingdesignexperiment.SharedPreferencesOnboardingDesignExperimentCountDataStore
+import com.duckduckgo.common.test.CoroutineTestRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@ExperimentalCoroutinesApi
+@RunWith(AndroidJUnit4::class)
+class OnboardingDesignExperimentCountDataStoreTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
+
+    private lateinit var testDataStore: DataStore<Preferences>
+    private lateinit var testee: SharedPreferencesOnboardingDesignExperimentCountDataStore
+
+    @Before
+    fun setup() {
+        testDataStore = PreferenceDataStoreFactory.create(
+            scope = coroutineRule.testScope,
+            produceFile = { context.preferencesDataStoreFile("onboarding_experiment_visit_count_test") },
+        )
+        testee = SharedPreferencesOnboardingDesignExperimentCountDataStore(coroutineRule.testDispatcherProvider, testDataStore)
+    }
+
+    @Test
+    fun whenGetSiteVisitCountForNewPixelDefinition_returnsZero() = runTest {
+        val count = testee.getSiteVisitCount()
+
+        assertEquals(0, count)
+    }
+
+    @Test
+    fun whenIncreaseSiteVisitCountForPixelDefinition_returnIncrementedValue() = runTest {
+        val result = testee.increaseSiteVisitCount()
+
+        assertEquals(1, result)
+    }
+
+    @Test
+    fun whenIncreaseSiteVisitCountMultipleTimes_returnsCorrectValues() = runTest {
+        val firstIncrease = testee.increaseSiteVisitCount()
+        val secondIncrease = testee.increaseSiteVisitCount()
+        val thirdIncrease = testee.increaseSiteVisitCount()
+
+        assertEquals(1, firstIncrease)
+        assertEquals(2, secondIncrease)
+        assertEquals(3, thirdIncrease)
+    }
+
+    @Test
+    fun whenGettingSiteVisitCount_afterMultipleIncreases_returnsCorrectCount() = runTest {
+        testee.increaseSiteVisitCount()
+        testee.increaseSiteVisitCount()
+
+        val count = testee.getSiteVisitCount()
+        assertEquals(2, count)
+    }
+
+    @Test
+    fun whenGetSerpVisitCountForNewPixelDefinition_returnsZero() = runTest {
+        val count = testee.getSerpVisitCount()
+
+        assertEquals(0, count)
+    }
+
+    @Test
+    fun whenIncreaseSerpVisitCountForPixelDefinition_returnIncrementedValue() = runTest {
+        val result = testee.increaseSerpVisitCount()
+
+        assertEquals(1, result)
+    }
+
+    @Test
+    fun whenIncreaseSerpVisitCountMultipleTimes_returnsCorrectValues() = runTest {
+        val firstIncrease = testee.increaseSerpVisitCount()
+        val secondIncrease = testee.increaseSerpVisitCount()
+        val thirdIncrease = testee.increaseSerpVisitCount()
+
+        assertEquals(1, firstIncrease)
+        assertEquals(2, secondIncrease)
+        assertEquals(3, thirdIncrease)
+    }
+
+    @Test
+    fun whenGettingSerpVisitCount_afterMultipleIncreases_returnsCorrectCount() = runTest {
+        testee.increaseSerpVisitCount()
+        testee.increaseSerpVisitCount()
+
+        val count = testee.getSerpVisitCount()
+        assertEquals(2, count)
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/onboarding/onboardingdesignexperiment/OnboardingDesignExperimentManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/onboardingdesignexperiment/OnboardingDesignExperimentManagerTest.kt
@@ -166,7 +166,9 @@ class OnboardingDesignExperimentManagerTest {
         whenever(onboardingDesignExperimentToggles.onboardingDesignExperimentAug25()).thenReturn(mockToggle)
         whenever(mockToggle.isEnabled()).thenReturn(true)
         whenever(mockToggle.getCohort()).thenReturn(mockCohort)
-        whenever(mockToggle.getCohort()!!.name).thenReturn(OnboardingDesignExperimentToggles.OnboardingDesignExperimentCohort.MODIFIED_CONTROL.cohortName)
+        whenever(mockToggle.getCohort()!!.name).thenReturn(
+            OnboardingDesignExperimentToggles.OnboardingDesignExperimentCohort.MODIFIED_CONTROL.cohortName,
+        )
 
         whenever(appBuildConfig.sdkInt).thenReturn(33)
         whenever(appBuildConfig.isAppReinstall()).thenReturn(false)
@@ -383,7 +385,9 @@ class OnboardingDesignExperimentManagerTest {
 
     @Test
     fun whenFireInContextDialogShownPixelWithDaxTrackersBlockedCtaThenCorrectPixelFired() = runTest {
-        testee.fireInContextDialogShownPixel(OnboardingDaxDialogCta.DaxTrackersBlockedCta(onboardingStore, appInstallStore, emptyList(), settingsDataStore, testee))
+        testee.fireInContextDialogShownPixel(
+            OnboardingDaxDialogCta.DaxTrackersBlockedCta(onboardingStore, appInstallStore, emptyList(), settingsDataStore, testee),
+        )
         verify(onboardingExperimentMetricsPixelPlugin).getTrackersBlockedMessageDisplayedMetric()
     }
 
@@ -395,7 +399,9 @@ class OnboardingDesignExperimentManagerTest {
 
     @Test
     fun whenFireInContextDialogShownPixelWithDaxMainNetworkCtaThenCorrectPixelFired() = runTest {
-        testee.fireInContextDialogShownPixel(OnboardingDaxDialogCta.DaxMainNetworkCta(onboardingStore, appInstallStore, "Facebook", "facebook.com", testee))
+        testee.fireInContextDialogShownPixel(
+            OnboardingDaxDialogCta.DaxMainNetworkCta(onboardingStore, appInstallStore, "Facebook", "facebook.com", testee),
+        )
         verify(onboardingExperimentMetricsPixelPlugin).getTrackerNetworkMessageDisplayedMetric()
     }
 

--- a/app/src/test/java/com/duckduckgo/app/onboarding/onboardingdesignexperiment/OnboardingDesignExperimentManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/onboardingdesignexperiment/OnboardingDesignExperimentManagerTest.kt
@@ -1,0 +1,465 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding.onboardingdesignexperiment
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.browser.DuckDuckGoUrlDetector
+import com.duckduckgo.app.cta.ui.DaxBubbleCta
+import com.duckduckgo.app.cta.ui.OnboardingDaxDialogCta
+import com.duckduckgo.app.global.install.AppInstallStore
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.app.onboarding.store.OnboardingStore
+import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentCountDataStore
+import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentManager
+import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentToggles
+import com.duckduckgo.app.onboardingdesignexperiment.OnboardingExperimentMetricsPixelPlugin
+import com.duckduckgo.app.onboardingdesignexperiment.RealOnboardingDesignExperimentManager
+import com.duckduckgo.app.settings.db.SettingsDataStore
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.device.DeviceInfo
+import com.duckduckgo.common.utils.device.DeviceInfo.FormFactor.PHONE
+import com.duckduckgo.common.utils.device.DeviceInfo.FormFactor.TABLET
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class OnboardingDesignExperimentManagerTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val onboardingDesignExperimentToggles: OnboardingDesignExperimentToggles = mock()
+    private val onboardingExperimentMetricsPixelPlugin: OnboardingExperimentMetricsPixelPlugin = mock()
+    private val onboardingDesignExperimentCountDataStore: OnboardingDesignExperimentCountDataStore = mock()
+    private val pixel: Pixel = mock()
+    private val appBuildConfig: AppBuildConfig = mock()
+    private val deviceInfo: DeviceInfo = mock()
+    private val duckDuckGoUrlDetector: DuckDuckGoUrlDetector = mock()
+    private val onboardingStore: OnboardingStore = mock()
+    private val appInstallStore: AppInstallStore = mock()
+    private val settingsDataStore: SettingsDataStore = mock()
+
+    private lateinit var testee: OnboardingDesignExperimentManager
+
+    @Before
+    fun before() {
+        testee = RealOnboardingDesignExperimentManager(
+            coroutineScope = coroutineRule.testScope,
+            dispatcherProvider = coroutineRule.testDispatcherProvider,
+            onboardingDesignExperimentToggles = onboardingDesignExperimentToggles,
+            onboardingExperimentMetricsPixelPlugin = onboardingExperimentMetricsPixelPlugin,
+            onboardingDesignExperimentCountDataStore = onboardingDesignExperimentCountDataStore,
+            pixel = pixel,
+            appBuildConfig = appBuildConfig,
+            deviceInfo = deviceInfo,
+            duckDuckGoUrlDetector = duckDuckGoUrlDetector,
+        )
+    }
+
+    @Test
+    fun whenLifecycleOwnerCreatedThenCachedPropertiesAreSet() = runTest {
+        val mockToggle = mock<Toggle>()
+        val mockCohort = mock<Toggle.State.Cohort>()
+
+        whenever(onboardingDesignExperimentToggles.onboardingDesignExperimentAug25()).thenReturn(mockToggle)
+        whenever(mockToggle.isEnabled()).thenReturn(true)
+        whenever(mockToggle.getCohort()).thenReturn(mockCohort)
+        whenever(mockToggle.getCohort()!!.name).thenReturn(OnboardingDesignExperimentToggles.OnboardingDesignExperimentCohort.BUCK.cohortName)
+
+        val lifecycleObserver = testee as MainProcessLifecycleObserver
+        lifecycleObserver.onCreate(mock())
+
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        assertTrue(testee.isAnyExperimentEnrolledAndEnabled())
+        assertTrue(testee.isBuckEnrolledAndEnabled())
+    }
+
+    @Test
+    fun whenLifecycleOwnerCreatedWithDisabledExperimentThenCachedPropertiesReflectDisabledState() = runTest {
+        val mockToggle = mock<Toggle>()
+
+        whenever(onboardingDesignExperimentToggles.onboardingDesignExperimentAug25()).thenReturn(mockToggle)
+        whenever(mockToggle.isEnabled()).thenReturn(false)
+
+        val lifecycleObserver = testee as MainProcessLifecycleObserver
+        lifecycleObserver.onCreate(mock())
+
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        assertFalse(testee.isAnyExperimentEnrolledAndEnabled())
+        assertFalse(testee.isBuckEnrolledAndEnabled())
+        assertFalse(testee.isBbEnrolledAndEnabled())
+        assertFalse(testee.isModifiedControlEnrolledAndEnabled())
+    }
+
+    @Test
+    fun whenOnPrivacyConfigDownloadedThenCachedPropertiesAreSet() = runTest {
+        val mockToggle = mock<Toggle>()
+        val mockCohort = mock<Toggle.State.Cohort>()
+
+        whenever(onboardingDesignExperimentToggles.onboardingDesignExperimentAug25()).thenReturn(mockToggle)
+        whenever(mockToggle.isEnabled()).thenReturn(true)
+        whenever(mockToggle.getCohort()).thenReturn(mockCohort)
+        whenever(mockToggle.getCohort()!!.name).thenReturn(OnboardingDesignExperimentToggles.OnboardingDesignExperimentCohort.BB.cohortName)
+
+        val privacyConfigCallback = testee as PrivacyConfigCallbackPlugin
+        privacyConfigCallback.onPrivacyConfigDownloaded()
+
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        assertTrue(testee.isAnyExperimentEnrolledAndEnabled())
+        assertTrue(testee.isBbEnrolledAndEnabled())
+    }
+
+    @Test
+    fun whenOnPrivacyConfigDownloadedWithDisabledExperimentThenCachedPropertiesReflectDisabledState() = runTest {
+        val mockToggle = mock<Toggle>()
+
+        whenever(onboardingDesignExperimentToggles.onboardingDesignExperimentAug25()).thenReturn(mockToggle)
+        whenever(mockToggle.isEnabled()).thenReturn(false)
+
+        val privacyConfigCallback = testee as PrivacyConfigCallbackPlugin
+        privacyConfigCallback.onPrivacyConfigDownloaded()
+
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        assertFalse(testee.isAnyExperimentEnrolledAndEnabled())
+        assertFalse(testee.isBuckEnrolledAndEnabled())
+        assertFalse(testee.isBbEnrolledAndEnabled())
+        assertFalse(testee.isModifiedControlEnrolledAndEnabled())
+    }
+
+    @Test
+    fun whenModifiedControlEnabledThenAnyExperimentEnrolledAndEnabledReturnsTrue() = runTest {
+        val mockToggle = mock<Toggle>()
+        val mockCohort = mock<Toggle.State.Cohort>()
+
+        whenever(onboardingDesignExperimentToggles.onboardingDesignExperimentAug25()).thenReturn(mockToggle)
+        whenever(mockToggle.isEnabled()).thenReturn(true)
+        whenever(mockToggle.getCohort()).thenReturn(mockCohort)
+        whenever(mockToggle.getCohort()!!.name).thenReturn(OnboardingDesignExperimentToggles.OnboardingDesignExperimentCohort.MODIFIED_CONTROL.cohortName)
+
+        whenever(appBuildConfig.sdkInt).thenReturn(33)
+        whenever(appBuildConfig.isAppReinstall()).thenReturn(false)
+        whenever(deviceInfo.formFactor()).thenReturn(PHONE)
+
+        testee.enroll()
+
+        assertTrue(testee.isAnyExperimentEnrolledAndEnabled())
+    }
+
+    @Test
+    fun whenBuckEnabledThenAnyExperimentEnrolledAndEnabledReturnsTrue() = runTest {
+        val mockToggle = mock<Toggle>()
+        val mockCohort = mock<Toggle.State.Cohort>()
+
+        whenever(onboardingDesignExperimentToggles.onboardingDesignExperimentAug25()).thenReturn(mockToggle)
+        whenever(mockToggle.isEnabled()).thenReturn(true)
+        whenever(mockToggle.getCohort()).thenReturn(mockCohort)
+        whenever(mockToggle.getCohort()!!.name).thenReturn(OnboardingDesignExperimentToggles.OnboardingDesignExperimentCohort.BUCK.cohortName)
+
+        whenever(appBuildConfig.sdkInt).thenReturn(33)
+        whenever(appBuildConfig.isAppReinstall()).thenReturn(false)
+        whenever(deviceInfo.formFactor()).thenReturn(PHONE)
+
+        testee.enroll()
+
+        assertTrue(testee.isAnyExperimentEnrolledAndEnabled())
+    }
+
+    @Test
+    fun whenBBEnabledThenAnyExperimentEnrolledAndEnabledReturnsTrue() = runTest {
+        val mockToggle = mock<Toggle>()
+        val mockCohort = mock<Toggle.State.Cohort>()
+
+        whenever(onboardingDesignExperimentToggles.onboardingDesignExperimentAug25()).thenReturn(mockToggle)
+        whenever(mockToggle.isEnabled()).thenReturn(true)
+        whenever(mockToggle.getCohort()).thenReturn(mockCohort)
+        whenever(mockToggle.getCohort()!!.name).thenReturn(OnboardingDesignExperimentToggles.OnboardingDesignExperimentCohort.BB.cohortName)
+
+        whenever(appBuildConfig.sdkInt).thenReturn(33)
+        whenever(appBuildConfig.isAppReinstall()).thenReturn(false)
+        whenever(deviceInfo.formFactor()).thenReturn(PHONE)
+
+        testee.enroll()
+
+        assertTrue(testee.isAnyExperimentEnrolledAndEnabled())
+    }
+
+    @Test
+    fun whenDeviceIsEligibleThenUserIsAttemptedToBeEnrolled() = runTest {
+        val mockToggle = mock<Toggle>()
+        whenever(onboardingDesignExperimentToggles.onboardingDesignExperimentAug25()).thenReturn(mockToggle)
+        whenever(appBuildConfig.sdkInt).thenReturn(35)
+        whenever(appBuildConfig.isAppReinstall()).thenReturn(false)
+        whenever(deviceInfo.formFactor()).thenReturn(PHONE)
+
+        testee.enroll()
+
+        verify(mockToggle).enroll()
+    }
+
+    @Test
+    fun whenDeviceIsTabletThenUserIsNotEnrolled() = runTest {
+        val mockToggle = mock<Toggle>()
+        whenever(onboardingDesignExperimentToggles.onboardingDesignExperimentAug25()).thenReturn(mockToggle)
+        whenever(appBuildConfig.sdkInt).thenReturn(35)
+        whenever(appBuildConfig.isAppReinstall()).thenReturn(false)
+        whenever(deviceInfo.formFactor()).thenReturn(TABLET)
+
+        testee.enroll()
+
+        verify(mockToggle, never()).enroll()
+    }
+
+    @Test
+    fun whenDeviceIsOlderThanAndroid11ThenUserIsNotEnrolled() = runTest {
+        val mockToggle = mock<Toggle>()
+        whenever(onboardingDesignExperimentToggles.onboardingDesignExperimentAug25()).thenReturn(mockToggle)
+        whenever(appBuildConfig.sdkInt).thenReturn(29)
+        whenever(appBuildConfig.isAppReinstall()).thenReturn(false)
+        whenever(deviceInfo.formFactor()).thenReturn(PHONE)
+
+        testee.enroll()
+
+        verify(mockToggle, never()).enroll()
+    }
+
+    @Test
+    fun whenInstallIsReinstallThenUserIsNotEnrolled() = runTest {
+        val mockToggle = mock<Toggle>()
+        whenever(onboardingDesignExperimentToggles.onboardingDesignExperimentAug25()).thenReturn(mockToggle)
+        whenever(appBuildConfig.sdkInt).thenReturn(29)
+        whenever(appBuildConfig.isAppReinstall()).thenReturn(true)
+        whenever(deviceInfo.formFactor()).thenReturn(PHONE)
+
+        testee.enroll()
+
+        verify(mockToggle, never()).enroll()
+    }
+
+    @Test
+    fun whenWebPageFinishedLoadingWithDDGUrlThenSecondSerpVisitPixelFired() = runTest {
+        whenever(duckDuckGoUrlDetector.isDuckDuckGoUrl(any())).thenReturn(true)
+        whenever(onboardingDesignExperimentCountDataStore.getSerpVisitCount()).thenReturn(1)
+        whenever(onboardingDesignExperimentCountDataStore.increaseSerpVisitCount()).thenReturn(2)
+
+        testee.onWebPageFinishedLoading("https://duckduckgo.com")
+
+        verify(onboardingExperimentMetricsPixelPlugin).getSecondSerpVisitMetric()
+    }
+
+    @Test
+    fun whenWebPageFinishedLoadingWithNonDDGUrlThenSecondSiteVisitPixelFired() = runTest {
+        whenever(duckDuckGoUrlDetector.isDuckDuckGoUrl(any())).thenReturn(false)
+        whenever(onboardingDesignExperimentCountDataStore.getSiteVisitCount()).thenReturn(1)
+        whenever(onboardingDesignExperimentCountDataStore.increaseSiteVisitCount()).thenReturn(2)
+
+        testee.onWebPageFinishedLoading("https://example.com")
+
+        verify(onboardingExperimentMetricsPixelPlugin).getSecondSiteVisitMetric()
+    }
+
+    @Test
+    fun whenWebPageFinishedLoadingWithNullUrlThenNoPixelFired() = runTest {
+        testee.onWebPageFinishedLoading(null)
+
+        verify(onboardingExperimentMetricsPixelPlugin, never()).getSecondSerpVisitMetric()
+        verify(onboardingExperimentMetricsPixelPlugin, never()).getSecondSiteVisitMetric()
+    }
+
+    @Test
+    fun whenWebPageFinishedLoadingWithDDGUrlAndSerpVisitCountIsTwoThenNoPixelFired() = runTest {
+        whenever(duckDuckGoUrlDetector.isDuckDuckGoUrl(any())).thenReturn(true)
+        whenever(onboardingDesignExperimentCountDataStore.getSerpVisitCount()).thenReturn(2)
+
+        testee.onWebPageFinishedLoading("https://duckduckgo.com")
+
+        verify(onboardingExperimentMetricsPixelPlugin, never()).getSecondSerpVisitMetric()
+    }
+
+    @Test
+    fun whenWebPageFinishedLoadingWithNonDDGUrlAndSiteVisitCountIsTwoThenNoPixelFired() = runTest {
+        whenever(duckDuckGoUrlDetector.isDuckDuckGoUrl(any())).thenReturn(false)
+        whenever(onboardingDesignExperimentCountDataStore.getSiteVisitCount()).thenReturn(2)
+
+        testee.onWebPageFinishedLoading("https://example.com")
+
+        verify(onboardingExperimentMetricsPixelPlugin, never()).getSecondSiteVisitMetric()
+    }
+
+    @Test
+    fun whenFireSiteSuggestionOptionSelectedPixelForFirstOptionThenCorrectPixelFired() = runTest {
+        testee.fireSiteSuggestionOptionSelectedPixel(0)
+        verify(onboardingExperimentMetricsPixelPlugin).getFirstSiteSuggestionMetric()
+    }
+
+    @Test
+    fun whenFireSiteSuggestionOptionSelectedPixelForSecondOptionThenCorrectPixelFired() = runTest {
+        testee.fireSiteSuggestionOptionSelectedPixel(1)
+        verify(onboardingExperimentMetricsPixelPlugin).getSecondSiteSuggestionMetric()
+    }
+
+    @Test
+    fun whenFireSiteSuggestionOptionSelectedPixelForThirdOptionThenCorrectPixelFired() = runTest {
+        testee.fireSiteSuggestionOptionSelectedPixel(2)
+        verify(onboardingExperimentMetricsPixelPlugin).getThirdSiteSuggestionMetric()
+    }
+
+    @Test
+    fun whenFireSiteSuggestionOptionSelectedPixelForInvalidOptionThenNoPixelFired() = runTest {
+        testee.fireSiteSuggestionOptionSelectedPixel(3)
+        verify(onboardingExperimentMetricsPixelPlugin, never()).getFirstSiteSuggestionMetric()
+        verify(onboardingExperimentMetricsPixelPlugin, never()).getSecondSiteSuggestionMetric()
+        verify(onboardingExperimentMetricsPixelPlugin, never()).getThirdSiteSuggestionMetric()
+    }
+
+    @Test
+    fun whenFireInContextDialogShownPixelWithDaxIntroSearchOptionsCtaThenCorrectPixelFired() = runTest {
+        testee.fireInContextDialogShownPixel(DaxBubbleCta.DaxIntroSearchOptionsCta(onboardingStore, appInstallStore))
+        verify(onboardingExperimentMetricsPixelPlugin).getTryASearchDisplayedMetric()
+    }
+
+    @Test
+    fun whenFireInContextDialogShownPixelWithDaxIntroVisitSiteOptionsCtaThenCorrectPixelFired() = runTest {
+        testee.fireInContextDialogShownPixel(DaxBubbleCta.DaxIntroVisitSiteOptionsCta(onboardingStore, appInstallStore))
+        verify(onboardingExperimentMetricsPixelPlugin).getVisitSitePromptDisplayedNewTabMetric()
+    }
+
+    @Test
+    fun whenFireInContextDialogShownPixelWithDaxBubbleDaxEndCtaThenCorrectPixelFired() = runTest {
+        testee.fireInContextDialogShownPixel(DaxBubbleCta.DaxEndCta(onboardingStore, appInstallStore))
+        verify(onboardingExperimentMetricsPixelPlugin).getFinalOnboardingScreenDisplayedMetric()
+    }
+
+    @Test
+    fun whenFireInContextDialogShownPixelWithDaxPrivacyProCtaThenNoPixelFired() = runTest {
+        testee.fireInContextDialogShownPixel(DaxBubbleCta.DaxPrivacyProCta(onboardingStore, appInstallStore, 0, 0, 0))
+        verify(onboardingExperimentMetricsPixelPlugin, never()).getTryASearchDisplayedMetric()
+        verify(onboardingExperimentMetricsPixelPlugin, never()).getVisitSitePromptDisplayedNewTabMetric()
+        verify(onboardingExperimentMetricsPixelPlugin, never()).getFinalOnboardingScreenDisplayedMetric()
+    }
+
+    @Test
+    fun whenFireInContextDialogShownPixelWithDaxSerpCtaThenCorrectPixelFired() = runTest {
+        testee.fireInContextDialogShownPixel(OnboardingDaxDialogCta.DaxSerpCta(onboardingStore, appInstallStore, testee))
+        verify(onboardingExperimentMetricsPixelPlugin).getMessageOnSerpDisplayedMetric()
+    }
+
+    @Test
+    fun whenFireInContextDialogShownPixelWithDaxSiteSuggestionsCtaThenCorrectPixelFired() = runTest {
+        testee.fireInContextDialogShownPixel(OnboardingDaxDialogCta.DaxSiteSuggestionsCta(onboardingStore, appInstallStore, testee) {})
+        verify(onboardingExperimentMetricsPixelPlugin).getVisitSitePromptDisplayedAdjacentMetric()
+    }
+
+    @Test
+    fun whenFireInContextDialogShownPixelWithDaxTrackersBlockedCtaThenCorrectPixelFired() = runTest {
+        testee.fireInContextDialogShownPixel(OnboardingDaxDialogCta.DaxTrackersBlockedCta(onboardingStore, appInstallStore, emptyList(), settingsDataStore, testee))
+        verify(onboardingExperimentMetricsPixelPlugin).getTrackersBlockedMessageDisplayedMetric()
+    }
+
+    @Test
+    fun whenFireInContextDialogShownPixelWithDaxNoTrackersCtaThenCorrectPixelFired() = runTest {
+        testee.fireInContextDialogShownPixel(OnboardingDaxDialogCta.DaxNoTrackersCta(onboardingStore, appInstallStore, testee))
+        verify(onboardingExperimentMetricsPixelPlugin).getNoTrackersMessageDisplayedMetric()
+    }
+
+    @Test
+    fun whenFireInContextDialogShownPixelWithDaxMainNetworkCtaThenCorrectPixelFired() = runTest {
+        testee.fireInContextDialogShownPixel(OnboardingDaxDialogCta.DaxMainNetworkCta(onboardingStore, appInstallStore, "Facebook", "facebook.com", testee))
+        verify(onboardingExperimentMetricsPixelPlugin).getTrackerNetworkMessageDisplayedMetric()
+    }
+
+    @Test
+    fun whenFireInContextDialogShownPixelWithDaxFireButtonCtaThenCorrectPixelFired() = runTest {
+        testee.fireInContextDialogShownPixel(OnboardingDaxDialogCta.DaxFireButtonCta(onboardingStore, appInstallStore, testee))
+        verify(onboardingExperimentMetricsPixelPlugin).getFireButtonPromptDisplayedMetric()
+    }
+
+    @Test
+    fun whenFireInContextDialogShownPixelWithOnboardingDaxEndCtaThenCorrectPixelFired() = runTest {
+        testee.fireInContextDialogShownPixel(OnboardingDaxDialogCta.DaxEndCta(onboardingStore, appInstallStore, testee))
+        verify(onboardingExperimentMetricsPixelPlugin).getFinalOnboardingScreenDisplayedMetric()
+    }
+
+    @Test
+    fun whenFireInContextDialogShownPixelWithNullCtaThenNoPixelFired() = runTest {
+        testee.fireInContextDialogShownPixel(null)
+        verify(onboardingExperimentMetricsPixelPlugin, never()).getTryASearchDisplayedMetric()
+        verify(onboardingExperimentMetricsPixelPlugin, never()).getVisitSitePromptDisplayedNewTabMetric()
+        verify(onboardingExperimentMetricsPixelPlugin, never()).getFinalOnboardingScreenDisplayedMetric()
+        verify(onboardingExperimentMetricsPixelPlugin, never()).getMessageOnSerpDisplayedMetric()
+        verify(onboardingExperimentMetricsPixelPlugin, never()).getVisitSitePromptDisplayedAdjacentMetric()
+        verify(onboardingExperimentMetricsPixelPlugin, never()).getTrackersBlockedMessageDisplayedMetric()
+        verify(onboardingExperimentMetricsPixelPlugin, never()).getNoTrackersMessageDisplayedMetric()
+        verify(onboardingExperimentMetricsPixelPlugin, never()).getTrackerNetworkMessageDisplayedMetric()
+        verify(onboardingExperimentMetricsPixelPlugin, never()).getFireButtonPromptDisplayedMetric()
+    }
+
+    @Test
+    fun whenFireOptionSelectedPixelWithDaxIntroSearchOptionsCtaAndFirstOptionThenCorrectPixelFired() = runTest {
+        testee.fireOptionSelectedPixel(DaxBubbleCta.DaxIntroSearchOptionsCta(onboardingStore, appInstallStore), 0)
+        verify(onboardingExperimentMetricsPixelPlugin).getFirstSearchSuggestionMetric()
+    }
+
+    @Test
+    fun whenFireOptionSelectedPixelWithDaxIntroSearchOptionsCtaAndSecondOptionThenCorrectPixelFired() = runTest {
+        testee.fireOptionSelectedPixel(DaxBubbleCta.DaxIntroSearchOptionsCta(onboardingStore, appInstallStore), 1)
+        verify(onboardingExperimentMetricsPixelPlugin).getSecondSearchSuggestionMetric()
+    }
+
+    @Test
+    fun whenFireOptionSelectedPixelWithDaxIntroSearchOptionsCtaAndThirdOptionThenCorrectPixelFired() = runTest {
+        testee.fireOptionSelectedPixel(DaxBubbleCta.DaxIntroSearchOptionsCta(onboardingStore, appInstallStore), 2)
+        verify(onboardingExperimentMetricsPixelPlugin).getThirdSearchSuggestionMetric()
+    }
+
+    @Test
+    fun whenFireOptionSelectedPixelWithDaxIntroSearchOptionsCtaAndInvalidOptionThenNoPixelFired() = runTest {
+        testee.fireOptionSelectedPixel(DaxBubbleCta.DaxIntroSearchOptionsCta(onboardingStore, appInstallStore), 3)
+        verify(onboardingExperimentMetricsPixelPlugin, never()).getFirstSearchSuggestionMetric()
+        verify(onboardingExperimentMetricsPixelPlugin, never()).getSecondSearchSuggestionMetric()
+        verify(onboardingExperimentMetricsPixelPlugin, never()).getThirdSearchSuggestionMetric()
+    }
+
+    @Test
+    fun whenFireOptionSelectedPixelWithDaxIntroVisitSiteOptionsCtaThenCorrectPixelFired() = runTest {
+        testee.fireOptionSelectedPixel(DaxBubbleCta.DaxIntroVisitSiteOptionsCta(onboardingStore, appInstallStore), 0)
+        verify(onboardingExperimentMetricsPixelPlugin).getFirstSiteSuggestionMetric()
+    }
+
+    @Test
+    fun whenFireOptionSelectedPixelWithDaxSiteSuggestionsCtaThenCorrectPixelFired() = runTest {
+        testee.fireOptionSelectedPixel(OnboardingDaxDialogCta.DaxSiteSuggestionsCta(onboardingStore, appInstallStore, testee) {}, 1)
+        verify(onboardingExperimentMetricsPixelPlugin).getSecondSiteSuggestionMetric()
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModelTest.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.app.onboarding.ui.page.WelcomePageViewModel.Command.ShowDe
 import com.duckduckgo.app.onboarding.ui.page.WelcomePageViewModel.Command.ShowInitialDialog
 import com.duckduckgo.app.onboarding.ui.page.WelcomePageViewModel.Command.ShowInitialReinstallUserDialog
 import com.duckduckgo.app.onboarding.ui.page.WelcomePageViewModel.Command.ShowSkipOnboardingOption
+import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentManager
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.pixels.AppPixelName.NOTIFICATION_RUNTIME_PERMISSION_SHOWN
 import com.duckduckgo.app.pixels.AppPixelName.PREONBOARDING_BOTTOM_ADDRESS_BAR_SELECTED_UNIQUE
@@ -67,6 +68,7 @@ class WelcomePageViewModelTest {
     private val mockAppInstallStore: AppInstallStore = mock()
     private val mockSettingsDataStore: SettingsDataStore = mock()
     private val mockAppBuildConfig: AppBuildConfig = mock()
+    private val mockOnboardingDesignExperimentManager: OnboardingDesignExperimentManager = mock()
 
     private val testee: WelcomePageViewModel by lazy {
         WelcomePageViewModel(
@@ -77,6 +79,7 @@ class WelcomePageViewModelTest {
             mockSettingsDataStore,
             coroutineRule.testDispatcherProvider,
             mockAppBuildConfig,
+            mockOnboardingDesignExperimentManager,
         )
     }
 
@@ -119,6 +122,73 @@ class WelcomePageViewModelTest {
             val command = awaitItem()
             Assert.assertTrue(command is ShowComparisonChart)
         }
+    }
+
+    @Test
+    fun whenInitialDialogIsShownThenFireIntroScreenDisplayedPixel() = runTest {
+        testee.onDialogShown(PreOnboardingDialogType.INITIAL)
+
+        verify(mockOnboardingDesignExperimentManager).fireIntroScreenDisplayedPixel()
+    }
+
+    @Test
+    fun whenComparisonChartDialogIsShownThenFireComparisonScreenDisplayedPixel() = runTest {
+        testee.onDialogShown(PreOnboardingDialogType.COMPARISON_CHART)
+
+        verify(mockOnboardingDesignExperimentManager).fireComparisonScreenDisplayedPixel()
+    }
+
+    @Test
+    fun whenAddressBarPositionDialogIsShownThenFireSetAddressBarDisplayedPixel() = runTest {
+        testee.onDialogShown(PreOnboardingDialogType.ADDRESS_BAR_POSITION)
+
+        verify(mockOnboardingDesignExperimentManager).fireSetAddressBarDisplayedPixel()
+    }
+
+    @Test
+    fun givenComparisonChartDialogWhenOnPrimaryCtaClickedThenFireChooseBrowserPixel() = runTest {
+        whenever(mockDefaultRoleBrowserDialog.shouldShowDialog()).thenReturn(true)
+        testee.onPrimaryCtaClicked(PreOnboardingDialogType.COMPARISON_CHART)
+
+        verify(mockOnboardingDesignExperimentManager).fireChooseBrowserPixel()
+    }
+
+    @Test
+    fun givenComparisonChartDialogWhenDDGIsDefaultBrowserThenFireChooseBrowserPixel() = runTest {
+    whenever(mockDefaultRoleBrowserDialog.shouldShowDialog()).thenReturn(false)
+        testee.onPrimaryCtaClicked(PreOnboardingDialogType.COMPARISON_CHART)
+
+        verify(mockOnboardingDesignExperimentManager).fireChooseBrowserPixel()
+    }
+
+    @Test
+    fun whenDefaultBrowserIsSetThenFireSetDefaultRatePixel() = runTest {
+        testee.onDefaultBrowserSet()
+
+        verify(mockOnboardingDesignExperimentManager).fireSetDefaultRatePixel()
+    }
+
+    @Test
+    fun whenBottomAddressBarIsSelectedAndPrimaryCtaClickedThenFireAddressBarSetBottomPixel() = runTest {
+        testee.onAddressBarPositionOptionSelected(false)
+        testee.onPrimaryCtaClicked(PreOnboardingDialogType.ADDRESS_BAR_POSITION)
+
+        verify(mockOnboardingDesignExperimentManager).fireAddressBarSetBottomPixel()
+    }
+
+    @Test
+    fun whenTopAddressBarIsSelectedAndPrimaryCtaClickedThenFireAddressBarSetTopPixel() = runTest {
+        testee.onAddressBarPositionOptionSelected(true)
+        testee.onPrimaryCtaClicked(PreOnboardingDialogType.ADDRESS_BAR_POSITION)
+
+        verify(mockOnboardingDesignExperimentManager).fireAddressBarSetTopPixel()
+    }
+
+    @Test
+    fun whenDefaultAddressBarPositionIsKeptAndPrimaryCtaClickedThenFireAddressBarSetTopPixel() = runTest {
+        testee.onPrimaryCtaClicked(PreOnboardingDialogType.ADDRESS_BAR_POSITION)
+
+        verify(mockOnboardingDesignExperimentManager).fireAddressBarSetTopPixel()
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/WelcomePageViewModelTest.kt
@@ -155,7 +155,7 @@ class WelcomePageViewModelTest {
 
     @Test
     fun givenComparisonChartDialogWhenDDGIsDefaultBrowserThenFireChooseBrowserPixel() = runTest {
-    whenever(mockDefaultRoleBrowserDialog.shouldShowDialog()).thenReturn(false)
+        whenever(mockDefaultRoleBrowserDialog.shouldShowDialog()).thenReturn(false)
         testee.onPrimaryCtaClicked(PreOnboardingDialogType.COMPARISON_CHART)
 
         verify(mockOnboardingDesignExperimentManager).fireChooseBrowserPixel()

--- a/app/src/test/java/com/duckduckgo/app/settings/clear/OnboardingExperimentFireAnimationHelperTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/settings/clear/OnboardingExperimentFireAnimationHelperTest.kt
@@ -66,7 +66,7 @@ class OnboardingExperimentFireAnimationHelperTest {
         assertEquals(R.raw.hero_fire_inferno, result)
     }
 
-    private class FakeOnboardDesignExperimentManager(): OnboardingDesignExperimentManager {
+    private class FakeOnboardDesignExperimentManager() : OnboardingDesignExperimentManager {
 
         var bbEnabled = false
         var buckEnabled = false
@@ -132,7 +132,7 @@ class OnboardingExperimentFireAnimationHelperTest {
 
         override suspend fun fireOptionSelectedPixel(
             cta: Cta,
-            index: Int
+            index: Int,
         ) {
             TODO("Not yet implemented")
         }

--- a/app/src/test/java/com/duckduckgo/app/settings/clear/OnboardingExperimentFireAnimationHelperTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/settings/clear/OnboardingExperimentFireAnimationHelperTest.kt
@@ -2,9 +2,8 @@ package com.duckduckgo.app.settings.clear
 
 import android.annotation.SuppressLint
 import com.duckduckgo.app.browser.R
-import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentToggles
-import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
-import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.app.cta.ui.Cta
+import com.duckduckgo.app.onboardingdesignexperiment.OnboardingDesignExperimentManager
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -12,20 +11,19 @@ import org.junit.Test
 @SuppressLint("DenyListedApi")
 class OnboardingExperimentFireAnimationHelperTest {
 
-    private val fakeOnboardingDesignExperimentToggles = FakeFeatureToggleFactory.create(OnboardingDesignExperimentToggles::class.java)
-    private val helper = OnboardingExperimentFireAnimationHelper(fakeOnboardingDesignExperimentToggles)
+    private lateinit var fakeOnboardingDesignExperimentManager: FakeOnboardDesignExperimentManager
+    private lateinit var testee: OnboardingExperimentFireAnimationHelper
 
     @Before
     fun setUp() {
-        fakeOnboardingDesignExperimentToggles.self().setRawStoredState(State(false))
-        fakeOnboardingDesignExperimentToggles.buckOnboarding().setRawStoredState(State(false))
-        fakeOnboardingDesignExperimentToggles.bbOnboarding().setRawStoredState(State(false))
+        fakeOnboardingDesignExperimentManager = FakeOnboardDesignExperimentManager()
+        testee = OnboardingExperimentFireAnimationHelper(fakeOnboardingDesignExperimentManager)
     }
 
     @Test
     fun `when non hero fire animation selected then return its res id`() {
         val selectedAnimation = FireAnimation.HeroAbstract
-        val result = helper.getSelectedFireAnimationResId(selectedAnimation)
+        val result = testee.getSelectedFireAnimationResId(selectedAnimation)
         assertEquals(R.raw.hero_abstract_airstream, result)
     }
 
@@ -33,28 +31,107 @@ class OnboardingExperimentFireAnimationHelperTest {
     fun `when hero fire animation selected and no experiments enabled return stock fire animation`() {
         val selectedAnimation = FireAnimation.HeroFire
 
-        val result = helper.getSelectedFireAnimationResId(selectedAnimation)
+        val result = testee.getSelectedFireAnimationResId(selectedAnimation)
 
         assertEquals(R.raw.hero_fire_inferno, result)
     }
 
     @Test
     fun `when hero fire animation selected and buck enabled then return buck experiment fire animation`() {
-        fakeOnboardingDesignExperimentToggles.buckOnboarding().setRawStoredState(State(true))
+        fakeOnboardingDesignExperimentManager.buckEnabled = true
         val selectedAnimation = FireAnimation.HeroFire
 
-        val result = helper.getSelectedFireAnimationResId(selectedAnimation)
+        val result = testee.getSelectedFireAnimationResId(selectedAnimation)
 
         assertEquals(R.raw.buck_experiment_fire, result)
     }
 
     @Test
     fun `when hero fire animation selected and bb enabled then return bb experiment fire animation`() {
-        fakeOnboardingDesignExperimentToggles.bbOnboarding().setRawStoredState(State(true))
+        fakeOnboardingDesignExperimentManager.bbEnabled = true
         val selectedAnimation = FireAnimation.HeroFire
 
-        val result = helper.getSelectedFireAnimationResId(selectedAnimation)
+        val result = testee.getSelectedFireAnimationResId(selectedAnimation)
 
         assertEquals(R.raw.bb_experiment_fire_optimised, result)
+    }
+    private class FakeOnboardDesignExperimentManager(): OnboardingDesignExperimentManager {
+
+        var bbEnabled = false
+        var buckEnabled = false
+        var modifiedControlEnabled = false
+
+        override suspend fun enroll() {
+            TODO("Not yet implemented")
+        }
+
+        override fun isAnyExperimentEnrolledAndEnabled(): Boolean {
+            TODO("Not yet implemented")
+        }
+
+        override fun isModifiedControlEnrolledAndEnabled(): Boolean = modifiedControlEnabled
+
+        override fun isBuckEnrolledAndEnabled(): Boolean = buckEnabled
+
+        override fun isBbEnrolledAndEnabled(): Boolean = bbEnabled
+
+        override suspend fun fireIntroScreenDisplayedPixel() {
+            TODO("Not yet implemented")
+        }
+
+        override suspend fun fireComparisonScreenDisplayedPixel() {
+            TODO("Not yet implemented")
+        }
+
+        override suspend fun fireChooseBrowserPixel() {
+            TODO("Not yet implemented")
+        }
+
+        override suspend fun fireSetDefaultRatePixel() {
+            TODO("Not yet implemented")
+        }
+
+        override suspend fun fireSetAddressBarDisplayedPixel() {
+            TODO("Not yet implemented")
+        }
+
+        override suspend fun fireAddressBarSetTopPixel() {
+            TODO("Not yet implemented")
+        }
+
+        override suspend fun fireAddressBarSetBottomPixel() {
+            TODO("Not yet implemented")
+        }
+
+        override suspend fun fireSearchOrNavCustomPixel() {
+            TODO("Not yet implemented")
+        }
+
+        override suspend fun firePrivacyDashClickedFromOnboardingPixel() {
+            TODO("Not yet implemented")
+        }
+
+        override suspend fun fireFireButtonClickedFromOnboardingPixel() {
+            TODO("Not yet implemented")
+        }
+
+        override suspend fun fireInContextDialogShownPixel(cta: Cta?) {
+            TODO("Not yet implemented")
+        }
+
+        override suspend fun fireOptionSelectedPixel(
+            cta: Cta,
+            index: Int
+        ) {
+            TODO("Not yet implemented")
+        }
+
+        override suspend fun fireSiteSuggestionOptionSelectedPixel(index: Int) {
+            TODO("Not yet implemented")
+        }
+
+        override suspend fun onWebPageFinishedLoading(url: String?) {
+            TODO("Not yet implemented")
+        }
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/settings/clear/OnboardingExperimentFireAnimationHelperTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/settings/clear/OnboardingExperimentFireAnimationHelperTest.kt
@@ -55,6 +55,17 @@ class OnboardingExperimentFireAnimationHelperTest {
 
         assertEquals(R.raw.bb_experiment_fire_optimised, result)
     }
+
+    @Test
+    fun `when hero fire animation selected and modified control enabled then return stock fire animation`() {
+        fakeOnboardingDesignExperimentManager.modifiedControlEnabled = true
+        val selectedAnimation = FireAnimation.HeroFire
+
+        val result = testee.getSelectedFireAnimationResId(selectedAnimation)
+
+        assertEquals(R.raw.hero_fire_inferno, result)
+    }
+
     private class FakeOnboardDesignExperimentManager(): OnboardingDesignExperimentManager {
 
         var bbEnabled = false

--- a/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/AppUseMetricPixelsPlugin.kt
+++ b/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/AppUseMetricPixelsPlugin.kt
@@ -34,8 +34,12 @@ class AppUseMetricPixelsPlugin @Inject constructor(private val inventory: Featur
                     metric = "app_use",
                     value = "1",
                     toggle = toggle,
-                    conversionWindow = (1..7).map { ConversionWindow(lowerWindow = it, upperWindow = it) } +
-                        ConversionWindow(lowerWindow = 5, upperWindow = 7),
+                    conversionWindow = (1..14).map { ConversionWindow(lowerWindow = it, upperWindow = it) } +
+                        listOf(
+                            ConversionWindow(lowerWindow = 5, upperWindow = 7),
+                            ConversionWindow(lowerWindow = 1, upperWindow = 4),
+                            ConversionWindow(lowerWindow = 8, upperWindow = 14),
+                        )
                 ),
                 MetricsPixel(
                     metric = "app_use",

--- a/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/AppUseMetricPixelsPlugin.kt
+++ b/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/AppUseMetricPixelsPlugin.kt
@@ -39,7 +39,7 @@ class AppUseMetricPixelsPlugin @Inject constructor(private val inventory: Featur
                             ConversionWindow(lowerWindow = 5, upperWindow = 7),
                             ConversionWindow(lowerWindow = 1, upperWindow = 4),
                             ConversionWindow(lowerWindow = 8, upperWindow = 14),
-                        )
+                        ),
                 ),
                 MetricsPixel(
                     metric = "app_use",

--- a/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/SearchMetricPixelsPlugin.kt
+++ b/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/SearchMetricPixelsPlugin.kt
@@ -34,8 +34,12 @@ class SearchMetricPixelsPlugin @Inject constructor(private val inventory: Featur
                     metric = "search",
                     value = "1",
                     toggle = toggle,
-                    conversionWindow = (0..7).map { ConversionWindow(lowerWindow = it, upperWindow = it) } +
-                        ConversionWindow(lowerWindow = 5, upperWindow = 7),
+                    conversionWindow = (0..14).map { ConversionWindow(lowerWindow = it, upperWindow = it) } +
+                        listOf(
+                            ConversionWindow(lowerWindow = 1, upperWindow = 4),
+                            ConversionWindow(lowerWindow = 5, upperWindow = 7),
+                            ConversionWindow(lowerWindow = 8, upperWindow = 14),
+                        ),
                 ),
                 MetricsPixel(
                     metric = "search",
@@ -50,19 +54,25 @@ class SearchMetricPixelsPlugin @Inject constructor(private val inventory: Featur
                     metric = "search",
                     value = "6",
                     toggle = toggle,
-                    conversionWindow = listOf(
-                        ConversionWindow(lowerWindow = 5, upperWindow = 7),
-                        ConversionWindow(lowerWindow = 8, upperWindow = 15),
+                    conversionWindow = (0..14).map { ConversionWindow(lowerWindow = it, upperWindow = it) } +
+                        listOf(
+                            ConversionWindow(lowerWindow = 1, upperWindow = 4),
+                            ConversionWindow(lowerWindow = 5, upperWindow = 7),
+                            ConversionWindow(lowerWindow = 8, upperWindow = 14),
+                            ConversionWindow(lowerWindow = 8, upperWindow = 15),
+                        ),
                     ),
-                ),
                 MetricsPixel(
                     metric = "search",
                     value = "11",
                     toggle = toggle,
-                    conversionWindow = listOf(
-                        ConversionWindow(lowerWindow = 5, upperWindow = 7),
-                        ConversionWindow(lowerWindow = 8, upperWindow = 15),
-                    ),
+                    conversionWindow = (0..14).map { ConversionWindow(lowerWindow = it, upperWindow = it) } +
+                        listOf(
+                            ConversionWindow(lowerWindow = 1, upperWindow = 4),
+                            ConversionWindow(lowerWindow = 5, upperWindow = 7),
+                            ConversionWindow(lowerWindow = 8, upperWindow = 14),
+                            ConversionWindow(lowerWindow = 8, upperWindow = 15),
+                        ),
                 ),
                 MetricsPixel(
                     metric = "search",

--- a/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/SearchMetricPixelsPlugin.kt
+++ b/feature-toggles/feature-toggles-impl/src/main/java/com/duckduckgo/feature/toggles/impl/metrics/SearchMetricPixelsPlugin.kt
@@ -61,7 +61,7 @@ class SearchMetricPixelsPlugin @Inject constructor(private val inventory: Featur
                             ConversionWindow(lowerWindow = 8, upperWindow = 14),
                             ConversionWindow(lowerWindow = 8, upperWindow = 15),
                         ),
-                    ),
+                ),
                 MetricsPixel(
                     metric = "search",
                     value = "11",

--- a/privacy-config/privacy-config-impl/src/main/res/raw/privacy_config.json
+++ b/privacy-config/privacy-config-impl/src/main/res/raw/privacy_config.json
@@ -947,6 +947,28 @@
                     "reason": "Site breakage"
                 }
             ]
+        },
+        "onboardingDesignExperiment": {
+            "state": "disabled",
+            "features": {
+                "onboardingDesignExperimentAug25": {
+                    "state": "disabled",
+                    "cohorts": [
+                        {
+                            "name": "modifiedControl",
+                            "weight": 0
+                        },
+                        {
+                            "name": "buck",
+                            "weight": 0
+                        },
+                        {
+                            "name": "bb",
+                            "weight": 0
+                        }
+                    ]
+                }
+            }
         }
     },
     "unprotectedTemporary": []


### PR DESCRIPTION
### Description

This PR refactors the onboarding design experiment implementation by introducing a new `OnboardingDesignExperimentManager` that centralizes experiment-related logic. The manager handles enrollment, cohort determination, and firing experiment-specific pixels for tracking user interactions throughout the onboarding flow.

Key changes include:
- Added a data store to track site and SERP visit counts
- Implemented comprehensive pixel tracking for onboarding interactions
- Replaced direct toggle checks with manager methods for better abstraction
- Added support for tracking user interactions with onboarding dialogs and options

### Steps to test this PR

_Onboarding Experience_
- [ ] Verify new users see the appropriate onboarding experience based on experiment cohort
- [ ] Confirm that navigating through onboarding flows works correctly
- [ ] Test that site suggestions and search options function properly
- [ ] Verify fire animations display correctly based on experiment cohort

_Pixels_

Use Logcat to check for Pixels firing. 

When there are multiple options you'll need to clear data and get back to the same position.

#### **Variant – Modified Control**

Filter logs using: `experiment_metrics_onboardingDesignExperimentAug25_modifiedControl`

* [x] Intro screen shown → `introScreenDisplayed`
* [x] Comparison screen shown → `comparisonScreenDisplayed`
* [x] Tap **“Choose Browser”** → `chooseBrowser`
* [x] Accept system **Set as default** dialog → `setDefaultRate`

* [x] Address-bar-position sheet displayed → `setAddressBarDisplayed`
  * [x] Select **Top** → `addressBarSetTop`
  * [x] Select **Bottom** → `addressBarSetBottom`
  
* [x] “Try a search” bubble appears → `tryASearchDisplayed`
  * [x] Tap first suggestion → `firstSearchSuggestion`
  * [x] Tap second suggestion → `secondSearchSuggestion`
  * [x] Tap third suggestion → `thirdSearchSuggestion`
  * [x] Enter any other query → `searchOrNavCustom`
* [x] SERP message dialog appears → `messageOnSerpDisplayed`

* [x] Site-suggestion bubble (adjacent) appears → `visitSitePromptDisplayedAdjacent`
  * [x] Tap first site → `firstSiteSuggestion`
  * [x] Tap second site → `secondSiteSuggestion`
  * [x] Tap third site → `thirdSiteSuggestion`
* [x] (Clear data, get back to "Try a search" dialog, dismiss and then open a new tab) Site-suggestion bubble appears → `visitSitePromptDisplayedNewTab`
  * [x] Tap first site → `firstSiteSuggestion`
  * [x] Tap second site → `secondSiteSuggestion`
  * [x] Tap third site → `thirdSiteSuggestion`

* [x] Trackers-blocked dialog shown → `trackersBlockedMessageDisplayed`
* [x] No-trackers dialog shown → `noTrackersMessageDisplayed`
* [x] Tracker-network dialog shown → `trackerNetworkMessageDisplayed`
* [x] From a blockers dialog, tap privacy-shield → `privacyDashClickedFromOnboarding`
* [x] Fire-button education prompt displayed → `fireButtonPromptDisplayed`

  * [x] Trigger Fire action from that prompt → `fireButtonClickedFromOnboarding`
* [x] End-of-journey screen shown → `finalOnboardingScreenDisplayed`
* [x] Second non-DDG site loads → `secondSiteVisit`
* [x] Second DDG SERP loads → `secondSerpVisit`

---

#### **Variant – Buck**

Filter logs using: `experiment_metrics_onboardingDesignExperimentAug25_buck`

* [x] Intro screen shown → `introScreenDisplayed`
* [x] Comparison screen shown → `comparisonScreenDisplayed`
* [x] Tap **“Choose Browser”** → `chooseBrowser`
* [x] Accept system **Set as default** dialog → `setDefaultRate`

* [x] Address-bar-position sheet displayed → `setAddressBarDisplayed`
  * [x] Select **Top** → `addressBarSetTop`
  * [x] Select **Bottom** → `addressBarSetBottom`
  
* [x] “Try a search” bubble appears → `tryASearchDisplayed`
  * [x] Tap first suggestion → `firstSearchSuggestion`
  * [x] Tap second suggestion → `secondSearchSuggestion`
  * [x] Tap third suggestion → `thirdSearchSuggestion`
  * [x] Enter any other query → `searchOrNavCustom`
* [x] SERP message dialog appears → `messageOnSerpDisplayed`

* [x] Site-suggestion bubble (adjacent) appears → `visitSitePromptDisplayedAdjacent`
  * [x] Tap first site → `firstSiteSuggestion`
  * [x] Tap second site → `secondSiteSuggestion`
  * [x] Tap third site → `thirdSiteSuggestion`
* [x] (Clear data, get back to "Try a search" dialog, dismiss and then open a new tab) Site-suggestion bubble appears → `visitSitePromptDisplayedNewTab`
  * [x] Tap first site → `firstSiteSuggestion`
  * [x] Tap second site → `secondSiteSuggestion`
  * [x] Tap third site → `thirdSiteSuggestion`

* [x] Trackers-blocked dialog shown → `trackersBlockedMessageDisplayed`
* [x] No-trackers dialog shown → `noTrackersMessageDisplayed`
* [x] Tracker-network dialog shown → `trackerNetworkMessageDisplayed`
* [x] From a blockers dialog, tap privacy-shield → `privacyDashClickedFromOnboarding`
* [x] Fire-button education prompt displayed → `fireButtonPromptDisplayed`

  * [x] Trigger Fire action from that prompt → `fireButtonClickedFromOnboarding`
* [x] End-of-journey screen shown → `finalOnboardingScreenDisplayed`
* [x] Second non-DDG site loads → `secondSiteVisit`
* [x] Second DDG SERP loads → `secondSerpVisit`

---

#### **Variant – BB**

Filter logs using: `experiment_metrics_onboardingDesignExperimentAug25_bb`

* [x] Intro screen shown → `introScreenDisplayed`
* [x] Comparison screen shown → `comparisonScreenDisplayed`
* [x] Tap **“Choose Browser”** → `chooseBrowser`
* [x] Accept system **Set as default** dialog → `setDefaultRate`
* [x] Address-bar-position sheet displayed → `setAddressBarDisplayed`

  * [x] Select **Top** → `addressBarSetTop`
  * [x] Select **Bottom** → `addressBarSetBottom`
  
* [x] “Try a search” bubble appears → `tryASearchDisplayed`
  * [x] Tap first suggestion → `firstSearchSuggestion`
  * [x] Tap second suggestion → `secondSearchSuggestion`
  * [x] Tap third suggestion → `thirdSearchSuggestion`
  * [x] Enter any other query → `searchOrNavCustom`
* [x] SERP message dialog appears → `messageOnSerpDisplayed`

* [x] Site-suggestion bubble (adjacent) appears → `visitSitePromptDisplayedAdjacent`
  * [x] Tap first site → `firstSiteSuggestion`
  * [x] Tap second site → `secondSiteSuggestion`
  * [x] Tap third site → `thirdSiteSuggestion`
* [x] (Clear data, get back to "Try a search" dialog, dismiss and then open a new tab) Site-suggestion bubble appears → `visitSitePromptDisplayedNewTab`
  * [x] Tap first site → `firstSiteSuggestion`
  * [x] Tap second site → `secondSiteSuggestion`
  * [x] Tap third site → `thirdSiteSuggestion`

* [x] Trackers-blocked dialog shown → `trackersBlockedMessageDisplayed`
* [x] No-trackers dialog shown → `noTrackersMessageDisplayed`
* [x] Tracker-network dialog shown → `trackerNetworkMessageDisplayed`
* [x] From a blockers dialog, tap privacy-shield → `privacyDashClickedFromOnboarding`
* [x] Fire-button education prompt displayed → `fireButtonPromptDisplayed`

  * [x] Trigger Fire action from that prompt → `fireButtonClickedFromOnboarding`
* [x] End-of-journey screen shown → `finalOnboardingScreenDisplayed`
* [x] Second non-DDG site loads → `secondSiteVisit`
* [x] Second DDG SERP loads → `secondSerpVisit`

### UI changes
No UI changes in this PR - this is an internal refactoring of the experiment implementation.