### PR TITLE
Ensure bulk saves also trigger the password saved listeners

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/PasswordStoreEventListener.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/PasswordStoreEventListener.kt
@@ -22,10 +22,10 @@ import com.duckduckgo.di.scopes.AppScope
 @ContributesPluginPoint(AppScope::class)
 interface PasswordStoreEventListener {
     /**
-     * Called when a credential is added to the password store
+     * Called when credentials are added to the password store
      * This includes one being automatically saved, the user manually saving one, or one being imported via sync.
      *
-     * @param id the id of the credential that was added
+     * @param newCredentialIds the list of IDs for added credentials
      */
-    fun onCredentialAdded(id: Long) {}
+    fun onCredentialAdded(newCredentialIds: List<Long>) {}
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/engagement/EngagementPasswordAddedListener.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/engagement/EngagementPasswordAddedListener.kt
@@ -43,7 +43,7 @@ class EngagementPasswordAddedListener @Inject constructor(
     private var credentialAdded = false
 
     @Synchronized
-    override fun onCredentialAdded(id: Long) {
+    override fun onCredentialAdded(newCredentialIds: List<Long>) {
         if (credentialAdded) return
 
         credentialAdded = true

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsSync.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/sync/CredentialsSync.kt
@@ -115,7 +115,8 @@ class CredentialsSync @Inject constructor(
             credentialsSyncMetadata.addOrUpdate(
                 CredentialsSyncMetadataEntity(syncId = remoteId, localId = autofillId, deleted_at = null, modified_at = null),
             )
-            passwordStoreEventPlugins.getPlugins().forEach { it.onCredentialAdded(autofillId) }
+            val credentialList = listOf(autofillId)
+            passwordStoreEventPlugins.getPlugins().forEach { it.onCredentialAdded(credentialList) }
         }
     }
 

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/engagement/EngagementPasswordAddedListenerTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/engagement/EngagementPasswordAddedListenerTest.kt
@@ -30,21 +30,21 @@ class EngagementPasswordAddedListenerTest {
     @Test
     fun whenDaysInstalledLessThan7ThenPixelSent() {
         whenever(userBrowserProperties.daysSinceInstalled()).thenReturn(0)
-        testee.onCredentialAdded(0)
+        testee.onCredentialAdded(listOf(0))
         verifyPixelSentOnce()
     }
 
     @Test
     fun whenDaysInstalledExactly7ThenPixelNotSent() {
         whenever(userBrowserProperties.daysSinceInstalled()).thenReturn(7)
-        testee.onCredentialAdded(0)
+        testee.onCredentialAdded(listOf(0))
         verifyPixelNotSent()
     }
 
     @Test
     fun whenDaysInstalledAbove7ThenPixelNotSent() {
         whenever(userBrowserProperties.daysSinceInstalled()).thenReturn(10)
-        testee.onCredentialAdded(0)
+        testee.onCredentialAdded(listOf(0))
         verifyPixelNotSent()
     }
 
@@ -52,7 +52,7 @@ class EngagementPasswordAddedListenerTest {
     fun whenCalledMultipleTimesThenOnlySendsPixelOnce() {
         whenever(userBrowserProperties.daysSinceInstalled()).thenReturn(0)
         repeat(10) {
-            testee.onCredentialAdded(0)
+            testee.onCredentialAdded(listOf(0))
         }
         verifyPixelSentOnce()
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1210974473587922?focus=true 

### Description
- We have a `PasswordStoreEventListener` plugin which allows other code to be notified when a password has been saved
- This is called for individual password saves, but bulk insertions doesn't trigger it

### Steps to test this PR

Suggested logcat filter: `m_autofill_onboardeduser`

### Required testing

#### Importing passwords from Google Passwords
- [ ] Fresh install on a device with a modern `WebView` (e.g.., not an old emulator)
- [ ] Visit Password management screen (`Overflow -> Passwords`) and choose to `Import Passwords From Google`
- [ ] Go through the flow until success
- [ ] Verify `m_autofill_onboardeduser` is in the logs

### Optional extra testing (functionality unchanged)

#### Manually adding a credential
- [ ] Fresh install, visit Password management screen and manually add a password
- [ ] Verify `m_autofill_onboardeduser` is in the logs. 

#### Saving a credential from website autofill
- [ ] Fresh install, visit https://fill.dev/form/login-simple, add username and password (>= 4 characters) and login
- [ ] Save when prompted
- [ ] Verify `m_autofill_onboardeduser` is in the logs. 

#### Manually adding a credential
- [ ] Fresh install, visit Password management screen and manually add a password
- [ ] Verify `m_autofill_onboardeduser` is in the logs. 
