### PR TITLE
apply draft text when canceling Input Screen action while on SERP

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -921,7 +921,7 @@ class BrowserTabFragment :
 
             RESULT_CANCELED -> {
                 data.getStringExtra(InputScreenActivityResultParams.CANCELED_DRAFT_PARAM)?.let { query ->
-                    omnibar.setDraftTextIfNtp(query)
+                    omnibar.setDraftTextIfNtpOrSerp(query)
                 }
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
@@ -463,7 +463,7 @@ class Omnibar(
         newOmnibar.decorate(Decoration.NewTabScrollingState(canScrollUp, canScrollDown, topOfPage))
     }
 
-    fun setDraftTextIfNtp(query: String) {
-        newOmnibar.setDraftTextIfNtp(query)
+    fun setDraftTextIfNtpOrSerp(query: String) {
+        newOmnibar.setDraftTextIfNtpOrSerp(query)
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -1038,8 +1038,8 @@ open class OmnibarLayout @JvmOverloads constructor(
         omnibarTextListener?.onTrackersCountFinished()
     }
 
-    fun setDraftTextIfNtp(query: String) {
-        viewModel.setDraftTextIfNtp(query)
+    fun setDraftTextIfNtpOrSerp(query: String) {
+        viewModel.setDraftTextIfNtpOrSerp(query)
     }
 
     private fun enableTextInputClickCatcher(enabled: Boolean) {

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -841,8 +841,10 @@ class OmnibarLayoutViewModel @Inject constructor(
         // }
     }
 
-    fun setDraftTextIfNtp(query: String) {
-        if (_viewState.value.viewMode is NewTab) {
+    fun setDraftTextIfNtpOrSerp(query: String) {
+        val isNtp = _viewState.value.viewMode is NewTab
+        val isSerp = _viewState.value.viewMode is Browser && duckDuckGoUrlDetector.isDuckDuckGoQueryUrl(_viewState.value.url)
+        if (isNtp || isSerp) {
             _viewState.update {
                 it.copy(
                     omnibarText = query,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1210964284781033?focus=true

### Description
Ensures that Input Screen behavior when it comes to canceling draft text while on SERP is consistent with production.

### Steps to test this PR
 - [ ] Search for anything.
 - [ ] On SERP, open the Input Screen.
 - [ ] Type a new text into the input field and back out.
 - [ ] Verify that the drafted text replaced the previous search query in the omnibar. 
