### PR TITLE
Update content scope scripts to version 11.3.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
@@ -3877,7 +3877,7 @@
         navigations.set(event.target, event.navigationType);
       });
       globalThis.navigation.addEventListener("navigatesuccess", (event) => {
-        const navigationType = navigations.get(event.target) || "unknown";
+        const navigationType = navigations.get(event.target);
         handleURLChange(navigationType);
         navigations.delete(event.target);
       });
@@ -3896,7 +3896,7 @@
     });
     historyMethodProxy.overload();
     window.addEventListener("popstate", () => {
-      handleURLChange("popState");
+      handleURLChange("traverse");
     });
   }
 

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -8575,7 +8575,7 @@
         navigations.set(event.target, event.navigationType);
       });
       globalThis.navigation.addEventListener("navigatesuccess", (event) => {
-        const navigationType = navigations.get(event.target) || "unknown";
+        const navigationType = navigations.get(event.target);
         handleURLChange(navigationType);
         navigations.delete(event.target);
       });
@@ -8594,7 +8594,7 @@
     });
     historyMethodProxy.overload();
     window.addEventListener("popstate", () => {
-      handleURLChange("popState");
+      handleURLChange("traverse");
     });
   }
 

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -9355,7 +9355,7 @@
         navigations.set(event.target, event.navigationType);
       });
       globalThis.navigation.addEventListener("navigatesuccess", (event) => {
-        const navigationType = navigations.get(event.target) || "unknown";
+        const navigationType = navigations.get(event.target);
         handleURLChange(navigationType);
         navigations.delete(event.target);
       });
@@ -9374,7 +9374,7 @@
     });
     historyMethodProxy.overload();
     window.addEventListener("popstate", () => {
-      handleURLChange("popState");
+      handleURLChange("traverse");
     });
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.10.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.2.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.2.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.3.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.10.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.10.0.tgz",
-      "integrity": "sha512-bAJrq6TWBV0spomClVyF7VV4CVHkNTdgFcSHqHWJXWwoHY5CxXXGKJkEcAEIxqdIiFA0AfwslbNy91vbJSt76w==",
+      "version": "14.10.1",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.10.1.tgz",
+      "integrity": "sha512-UIoMI8y09MzlQfj+cbKFfDCXmh9EesDviW/ethrVGx0xhpv991P/pL8wBZyce+DrezFYa47nFuULS+nu7wAuCw==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#77e36add0994600bb11f1d4199b2104f141c5b02",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#9eea407ad208e8c021f4182d03274effa344e3b1",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -280,13 +280,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
-      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.0.tgz",
+      "integrity": "sha512-3xyG3pMCq3oYCNg7/ZP+E1ooTaGB4cG8JWRsqqOYQdbWNY4zbaV0Ennrd7stjiJEFZCaybcIgpTjJWHRfBSIDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.8.0"
+        "undici-types": "~7.10.0"
       }
     },
     "node_modules/@types/resolve": {
@@ -667,24 +667,24 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.10.tgz",
-      "integrity": "sha512-z7PilFbUHwd+IlQ72D0aHDpqykUUpe9yvwa5k/rFvFLmpvNmWqHEIHoSYwE5sA5LZU4bTTIjhDZEjURHc8f2ag==",
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.11.tgz",
+      "integrity": "sha512-65eeOpBwWBabh0XqT+zB0vEllq/V3XcrF2fhgMXWWFfNw1yxEjeYg9Vv/B/UNozd0CTR/TohO1ubfn6O6mBW3w==",
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.10.tgz",
-      "integrity": "sha512-5qrQCSbJwrSlO4Rg/KFLnyMhkv5ngTeFh0pRYxEr5q+8eh0gguXqCO+RvzOEMEKqasR9XPYkSPTaoPUx0UBv8w==",
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.11.tgz",
+      "integrity": "sha512-sRNdw7r83Ea16IYr8MMaGGv0Tk4kJktFi1T/vHB5NQXmeeOPhdTVlyOu3qYktzOS82y6dZSlkmzfS4bjZ9oynQ==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.10"
+        "tldts-core": "^7.0.11"
       }
     },
     "node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.10.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.2.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.2.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.3.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run