### PR TITLE
Add exclusion for Duck Address setup URL so it won't show import promo

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/InBrowserImportPromo.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/InBrowserImportPromo.kt
@@ -53,7 +53,7 @@ class RealInBrowserImportPromo @Inject constructor(
                 return@withContext false
             }
 
-            if (url == null) {
+            if (url == null || url.isExcludedFromPromo()) {
                 return@withContext false
             }
 
@@ -93,6 +93,10 @@ class RealInBrowserImportPromo @Inject constructor(
         }
     }
 
+    private fun String.isExcludedFromPromo(): Boolean {
+        return this.startsWith(EMAIL_PROTECTION_SETTINGS_URL_PREFIX)
+    }
+
     private fun featureEnabled(): Boolean {
         if (autofillFeature.self().isEnabled().not()) return false
         if (autofillFeature.canPromoteImportGooglePasswordsInBrowser().isEnabled().not()) return false
@@ -102,5 +106,6 @@ class RealInBrowserImportPromo @Inject constructor(
     companion object {
         const val MAX_PROMO_SHOWN_COUNT = 5
         const val MAX_CREDENTIALS_FOR_PROMO = 25
+        private const val EMAIL_PROTECTION_SETTINGS_URL_PREFIX = "https://duckduckgo.com/email/"
     }
 }

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/RealInBrowserImportPromoTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/RealInBrowserImportPromoTest.kt
@@ -292,6 +292,20 @@ class RealInBrowserImportPromoParameterizedTest(
                     expected = true,
                     description = "eligible: promo not previously shown for url",
                 ),
+                CanShowPromoTestCase(
+                    credentialsAvailableForCurrentPage = false,
+                    url = "https://duckduckgo.com/email/login",
+                    inBrowserPromoFeatureEnabled = true,
+                    autofillFeatureEnabled = true,
+                    hasEverImportedPasswords = false,
+                    hasDeclinedPromo = false,
+                    credentialCount = 0,
+                    promoShownCount = 0,
+                    webViewSupportsImportingPasswords = true,
+                    promoPreviouslyShownForUrl = false,
+                    expected = false,
+                    description = "ineligible: promo won't show for Email Protection URLs",
+                ),
             )
         }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/608920331025315/task/1210976518417926?focus=true 

### Description
Excludes Email Protection setup pages from showing password import prompts.

### Steps to test this PR

- QA optional
- If you want to test, can fresh install, then can access Email Protection set up pages and confirm promo doesn't show