### PR TITLE
Launch device auth settings differently for TCL devices

### DIFF
--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementDisabledMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementDisabledMode.kt
@@ -25,9 +25,11 @@ import android.provider.Settings.ACTION_BIOMETRIC_ENROLL
 import android.provider.Settings.ACTION_FINGERPRINT_ENROLL
 import android.provider.Settings.ACTION_SECURITY_SETTINGS
 import android.provider.Settings.ACTION_SETTINGS
+import android.provider.Settings.EXTRA_BIOMETRIC_AUTHENTICATORS_ALLOWED
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.biometric.BiometricManager.Authenticators.DEVICE_CREDENTIAL
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.autofill.impl.databinding.FragmentAutofillManagementDisabledBinding
@@ -67,22 +69,29 @@ class AutofillManagementDisabledMode : DuckDuckGoFragment() {
 
     @SuppressLint("InlinedApi", "DEPRECATION")
     private fun launchDeviceAuthEnrollment() {
+        logcat { "Launching device authentication enrollment. Manufacturer=[${appBuildConfig.manufacturer}],sdkInt=[${appBuildConfig.sdkInt}]" }
+
         when {
             appBuildConfig.manufacturer == "Xiaomi" -> {
                 // Issue on Xiaomi: https://stackoverflow.com/questions/68484485/intent-action-fingerprint-enroll-on-redmi-results-in-exception
-                SYSTEM_SETTINGS_ACTION.safeLaunchSettingsActivity(tryFallback = false)
+                Intent(SYSTEM_SETTINGS_ACTION).safeLaunchSettingsActivity(tryFallback = false)
             }
 
             appBuildConfig.sdkInt >= Build.VERSION_CODES.R -> {
-                ACTION_BIOMETRIC_ENROLL.safeLaunchSettingsActivity(tryFallback = true)
+                val intent = Intent(ACTION_BIOMETRIC_ENROLL)
+                if (appBuildConfig.manufacturer.equals("TCL", ignoreCase = true)) {
+                    // https://app.asana.com/1/137249556945/project/1200930669568058/task/1210133000985922?focus=true
+                    intent.putExtra(EXTRA_BIOMETRIC_AUTHENTICATORS_ALLOWED, DEVICE_CREDENTIAL)
+                }
+                intent.safeLaunchSettingsActivity(tryFallback = true)
             }
 
             appBuildConfig.sdkInt >= Build.VERSION_CODES.P -> {
-                ACTION_FINGERPRINT_ENROLL.safeLaunchSettingsActivity(tryFallback = true)
+                Intent(ACTION_FINGERPRINT_ENROLL).safeLaunchSettingsActivity(tryFallback = true)
             }
 
             else -> {
-                ACTION_SECURITY_SETTINGS.safeLaunchSettingsActivity(tryFallback = true)
+                Intent(ACTION_SECURITY_SETTINGS).safeLaunchSettingsActivity(tryFallback = true)
             }
         }
 
@@ -93,13 +102,13 @@ class AutofillManagementDisabledMode : DuckDuckGoFragment() {
      * Attempt to launch the given activity.
      * If it fails because the activity wasn't found, try launching the main settings activity if tryFallback=true.
      */
-    private fun String.safeLaunchSettingsActivity(tryFallback: Boolean) {
+    private fun Intent.safeLaunchSettingsActivity(tryFallback: Boolean) {
         try {
-            requireActivity().startActivity(Intent(this))
+            requireActivity().startActivity(this)
         } catch (e: ActivityNotFoundException) {
             logcat(WARN) { "${e.asLog()}. Trying fallback? $tryFallback" }
             if (tryFallback) {
-                SYSTEM_SETTINGS_ACTION.safeLaunchSettingsActivity(tryFallback = false)
+                Intent(SYSTEM_SETTINGS_ACTION).safeLaunchSettingsActivity(tryFallback = false)
             }
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200930669568058/task/1210133000985922?focus=true 

### Description
Changes the way the system activity for setting up device auth is launched on `TCL`-manufactured devices. 
- Observed them behaving strangely in that they would not show the system device auth activity
- In the logs, noticed them stating `no hardware available` 
- After investigating, concluded they are mishandling the provided flags around biometrics capabilities and not handling the `or` flag properly

We don't require biometrics to be in place; only `credentials`. So for TCL devices as a workaround will provide the intent extra to indicate we only need `credentials`. 

### Steps to test this PR

- [x] Disable device auth and visit password management (`Overflow -> Passwords`)
- [x] Tap `Set up in Settings` button
- [x] Verify you see the system settings to set up pin/password/fingerprint etc...
- [ ] You won't have a TCL device so will need to just QA-optional that change; i've tested it with a real device.