### PR TITLE
Use http client with cache support on subscriptions feature endpoint

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/fire/AppCacheClearer.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/AppCacheClearer.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import com.duckduckgo.app.browser.favicon.FileBasedFaviconPersister.Companion.FAVICON_PERSISTED_DIR
 import com.duckduckgo.app.global.api.NetworkApiCache
 import com.duckduckgo.app.global.file.FileDeleter
+import com.duckduckgo.subscriptions.impl.services.SubscriptionNetworkModule.Companion.SUBSCRIPTION_CACHE_FILE
 
 interface AppCacheClearer {
 
@@ -52,7 +53,10 @@ class AndroidAppCacheClearer(
          */
         private const val NETWORK_CACHE_DIR = NetworkApiCache.FILE_NAME
 
+        // TODO: We need to allow other modules to contribute this list
+        // https://app.asana.com/1/137249556945/project/1149059203486286/task/1210997578538480?focus=true
         private val FILENAMES_EXCLUDED_FROM_DELETION = listOf(
+            SUBSCRIPTION_CACHE_FILE,
             WEBVIEW_CACHE_DIR,
             WEBVIEW_CACHE_DIR_LEGACY,
             NETWORK_CACHE_DIR,

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -252,6 +252,9 @@ interface PrivacyProFeature {
 
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun subscriptionAIFeaturesRebranding(): Toggle
+
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun useClientWithCacheForFeatures(): Toggle
 }
 
 @ContributesBinding(AppScope::class)

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionFeaturesFetcher.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionFeaturesFetcher.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.subscriptions.impl.SubscriptionsConstants.BASIC_SUBSCRIPTION
 import com.duckduckgo.subscriptions.impl.billing.PlayBillingManager
 import com.duckduckgo.subscriptions.impl.repository.AuthRepository
+import com.duckduckgo.subscriptions.impl.services.SubscriptionsCachedService
 import com.duckduckgo.subscriptions.impl.services.SubscriptionsService
 import com.squareup.anvil.annotations.ContributesMultibinding
 import javax.inject.Inject
@@ -41,6 +42,7 @@ class SubscriptionFeaturesFetcher @Inject constructor(
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val playBillingManager: PlayBillingManager,
     private val subscriptionsService: SubscriptionsService,
+    private val subscriptionsCachedService: SubscriptionsCachedService,
     private val authRepository: AuthRepository,
     private val privacyProFeature: PrivacyProFeature,
     private val dispatcherProvider: DispatcherProvider,
@@ -80,7 +82,11 @@ class SubscriptionFeaturesFetcher @Inject constructor(
                 }
             }
             ?.forEach { basePlanId ->
-                val features = subscriptionsService.features(basePlanId).features
+                val features = if (privacyProFeature.useClientWithCacheForFeatures().isEnabled()) {
+                    subscriptionsCachedService.features(basePlanId).features
+                } else {
+                    subscriptionsService.features(basePlanId).features
+                }
                 logcat { "Subscription features for base plan $basePlanId fetched: $features" }
                 if (features.isNotEmpty()) {
                     authRepository.setFeatures(basePlanId, features.toSet())

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/services/SubscriptionNetworkModule.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/services/SubscriptionNetworkModule.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.services
+
+import android.annotation.SuppressLint
+import android.content.Context
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesTo
+import dagger.Lazy
+import dagger.Module
+import dagger.Provides
+import dagger.SingleInstanceIn
+import java.io.File
+import javax.inject.Named
+import javax.inject.Qualifier
+import okhttp3.Cache
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+
+@Module
+@ContributesTo(AppScope::class)
+class SubscriptionNetworkModule {
+
+    @Retention(AnnotationRetention.BINARY)
+    @Qualifier
+    private annotation class SubscriptionCachedClient
+
+    @Provides
+    @SubscriptionCachedClient
+    @SingleInstanceIn(AppScope::class)
+    fun provideSubscriptionsCustomCacheHttpClient(
+        context: Context,
+        @Named("api") okHttpClient: OkHttpClient,
+    ): OkHttpClient {
+        val cacheLocation = File(context.cacheDir, SUBSCRIPTION_CACHE_FILE)
+        val cacheSize: Long = 128 * 1024 // 128KB, responses are 1kb so this is more than enough
+        val cache = Cache(cacheLocation, cacheSize)
+        return okHttpClient.newBuilder()
+            .cache(cache)
+            .build()
+    }
+
+    @Provides
+    @SingleInstanceIn(AppScope::class)
+    @SuppressLint("NoRetrofitCreateMethodCallDetector")
+    fun providesSubscriptionsCachedService(
+        @Named(value = "api") retrofit: Retrofit,
+        @SubscriptionCachedClient customClient: Lazy<OkHttpClient>,
+    ): SubscriptionsCachedService {
+        val customRetrofit = retrofit.newBuilder()
+            .callFactory { customClient.get().newCall(it) }
+            .build()
+
+        return customRetrofit.create(SubscriptionsCachedService::class.java)
+    }
+
+    companion object {
+        const val SUBSCRIPTION_CACHE_FILE = "subscriptionsCache"
+    }
+}

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/services/SubscriptionsCachedService.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/services/SubscriptionsCachedService.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.services
+
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+interface SubscriptionsCachedService {
+    @GET("https://subscriptions.duckduckgo.com/api/products/{sku}/features")
+    suspend fun features(@Path("sku") sku: String): FeaturesResponse
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1210997377644545?focus=true 

### Description
Adds cache support to subscription feature endpoints.
It uses custom one to avoid being affected by other network requests and have a better cache hit rate.
Also adds the file as fire button exception, same we do for the other api requests

### Steps to test this PR

_Feature 1_
- [x] Add the following to your logcat filter `message~:"Subscription features for base plan|Subscriptions response came from"`
- [x] Checkout this branch
- [x] Apply patch attached in https://app.asana.com/1/137249556945/project/488551667048375/task/1210997377644545?focus=true
- [x] Fresh install
- [x] Check in the logs you hit the Network and you receive the features
- [x] Fire button
- [x] Check in the logs you hit the Cache
- [x] Kill the app manually, open it again
- [x] Check in the logs you hit the Cache

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
