### PR TITLE
Enable passkey support in browser for internal builds

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -176,6 +176,7 @@ import com.duckduckgo.app.browser.viewstate.LoadingViewState
 import com.duckduckgo.app.browser.viewstate.OmnibarViewState
 import com.duckduckgo.app.browser.viewstate.PrivacyShieldViewState
 import com.duckduckgo.app.browser.viewstate.SavedSiteChangedViewState
+import com.duckduckgo.app.browser.webauthn.WebViewPasskeyInitializer
 import com.duckduckgo.app.browser.webshare.WebShareChooser
 import com.duckduckgo.app.browser.webview.WebContentDebugging
 import com.duckduckgo.app.browser.webview.WebViewBlobDownloadFeature
@@ -582,6 +583,9 @@ class BrowserTabFragment :
 
     @Inject
     lateinit var androidBrowserConfigFeature: AndroidBrowserConfigFeature
+
+    @Inject
+    lateinit var passkeyInitializer: WebViewPasskeyInitializer
 
     /**
      * We use this to monitor whether the user was seeing the in-context Email Protection signup prompt
@@ -3111,6 +3115,10 @@ class BrowserTabFragment :
         }
 
         WebView.setWebContentsDebuggingEnabled(webContentDebugging.isEnabled())
+
+        lifecycleScope.launch {
+            webView?.let { passkeyInitializer.configurePasskeySupport(it) }
+        }
     }
 
     private fun screenLock(data: JsCallbackData) {

--- a/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoWebView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoWebView.kt
@@ -412,6 +412,10 @@ class DuckDuckGoWebView : WebView, NestedScrollingChild3 {
         }
     }
 
+    fun isDestroyed(): Boolean {
+        return isDestroyed
+    }
+
     @SuppressLint("RequiresFeature", "AddWebMessageListenerUsage")
     suspend fun safeAddWebMessageListener(
         webViewCapabilityChecker: WebViewCapabilityChecker,

--- a/app/src/main/java/com/duckduckgo/app/browser/webauthn/WebViewPasskeyInitializer.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/webauthn/WebViewPasskeyInitializer.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.webauthn
+
+import android.annotation.SuppressLint
+import androidx.webkit.WebSettingsCompat
+import androidx.webkit.WebSettingsCompat.WEB_AUTHENTICATION_SUPPORT_FOR_BROWSER
+import androidx.webkit.WebViewFeature
+import androidx.webkit.WebViewFeature.WEB_AUTHENTICATION
+import com.duckduckgo.app.browser.DuckDuckGoWebView
+import com.duckduckgo.autofill.api.AutofillFeature
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+import kotlinx.coroutines.withContext
+import logcat.logcat
+
+interface WebViewPasskeyInitializer {
+    suspend fun configurePasskeySupport(webView: DuckDuckGoWebView)
+}
+
+@ContributesBinding(AppScope::class)
+class RealWebViewPasskeyInitializer @Inject constructor(
+    private val autofillFeature: AutofillFeature,
+    private val dispatchers: DispatcherProvider,
+) : WebViewPasskeyInitializer {
+
+    override suspend fun configurePasskeySupport(webView: DuckDuckGoWebView) {
+        if (featureFlagEnabled() && webViewCapable()) {
+            enablePasskeySupport(webView)
+        }
+    }
+
+    @SuppressLint("RequiresFeature")
+    private suspend fun enablePasskeySupport(webView: DuckDuckGoWebView) {
+        withContext(dispatchers.main()) {
+            if (!webView.isDestroyed()) {
+                WebSettingsCompat.setWebAuthenticationSupport(webView.settings, WEB_AUTHENTICATION_SUPPORT_FOR_BROWSER)
+                logcat { "Autofill-passkey: WebView passkey support (WebAuthn) enabled" }
+            }
+        }
+    }
+
+    private suspend fun featureFlagEnabled(): Boolean {
+        return withContext(dispatchers.io()) {
+            autofillFeature.passkeySupport().isEnabled()
+        }
+    }
+
+    private suspend fun webViewCapable(): Boolean {
+        return withContext(dispatchers.main()) {
+            WebViewFeature.isFeatureSupported(WEB_AUTHENTICATION)
+        }
+    }
+}

--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillFeature.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillFeature.kt
@@ -154,4 +154,7 @@ interface AutofillFeature {
 
     @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.TRUE)
     fun canShowImportOptionInAppSettings(): Toggle
+
+    @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.INTERNAL)
+    fun passkeySupport(): Toggle
 }

--- a/autofill/autofill-impl/src/main/AndroidManifest.xml
+++ b/autofill/autofill-impl/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.duckduckgo.autofill.impl">
 
+    <uses-permission android:name="android.permission.CREDENTIAL_MANAGER_SET_ORIGIN" />
+
     <application>
         <activity
             android:name=".ui.credential.management.importpassword.ImportPasswordsActivity"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203822806345703/task/1211006058270758?focus=true 

### Description
Enables `passkey` support for `internal` builds. 
- Currently the browser reports to websites that passkeys are unavailable
- With this change, we add support for passkeys that can be used to log in and register on websites. We do not store passkeys in our app, but instead allow integration with the system's passkey provider (Google Password Manager, Samsung Pass etc...)

It's `internal` only to give us some time to see if it brings issues, get internal feedback etc... 

ℹ️ Passkey support depends on which certificate is used to sign the app. As a browser we have been granted a special exemption for using APIs around origin but that relies on certificate hash matches. As such, to test this out in development you will need to [Set up debug code signing to use whitelisted certificate](https://app.asana.com/1/137249556945/task/1208295420929846?focus=true)


### Steps to test this PR

- Ensure you are testing on an up-to-date version of `WebView` and Android API. 
- If using an emulator, for best results use one with Google Play installed. 

#### Verify browser shows as supported
- [x] Follow instructions in [Set up debug code signing to use whitelisted certificate](https://app.asana.com/1/137249556945/task/1208295420929846?focus=true)
- [x] Install from this branch 
- [x] Visit https://webauthn.io; verify you **do not see** a message saying browser is unsupported. (if you do, ping me)

#### Verify you can create a new `passkey`
- [x] Enter username (e.g., `chicken`) and tap `Register`; verify you are prompted to create a passkey. 
- [x] do it. (you might be prompted to set up device password if not already set up)
- [x] Verify you see a `success` message. Tap the `Try it again` button to return.

#### Verify you can login when username already selected
- [x] Ensure your username is still filled in (e.g., `chicken`) and tap the `Authenticate` button
- [x] Verify you see the `You're logged in` page. Tap the `Try it again` button to return

#### Create a 2nd passkey for this website
- [x] Enter another username (e.g., `horse`) and tap `Register` button. Accept the prompt to create a new passkey.
- [x] Clear out the username field so it's empty
- [x] Tap on `Authenticate` button and verify you see a list of passkeys and that selecting one lets you log in

