### PR TITLE
Ensure gradle wrapper is used in internal builds

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -97,20 +97,20 @@ jobs:
       - name: Clean project
         if: steps.check_for_changes.outputs.has_changes == 'true'
         run: |
-          gradle clean          
+          ./gradlew clean          
 
       - name: Assemble the bundle
         env:
           NETP_DEBUG_SERVER_TOKEN: ${{ secrets.NETP_DEBUG_SERVER_TOKEN }}
           MALICIOUS_SITE_PROTECTION_AUTH_TOKEN: ${{ secrets.MALICIOUS_SITE_PROTECTION_AUTH_TOKEN }}
         if: steps.check_for_changes.outputs.has_changes == 'true'
-        run: gradle bundleInternalRelease -PversionNameSuffix=-nightly -PuseUploadSigning -PlatestTag=${{ steps.get_latest_tag.outputs.latest_tag }} -Pbuild-date-time
+        run: ./gradlew bundleInternalRelease -PversionNameSuffix=-nightly -PuseUploadSigning -PlatestTag=${{ steps.get_latest_tag.outputs.latest_tag }} -Pbuild-date-time
 
       - name: Generate nightly version name
         if: steps.check_for_changes.outputs.has_changes == 'true'
         id: generate_version_name
         run: |
-          output=$(gradle getBuildVersionName -PversionNameSuffix=-nightly -PlatestTag=${{ steps.get_latest_tag.outputs.latest_tag }} --quiet | tail -n 1)
+          output=$(./gradlew getBuildVersionName -PversionNameSuffix=-nightly -PlatestTag=${{ steps.get_latest_tag.outputs.latest_tag }} --quiet | tail -n 1)
           echo "version=$output" >> $GITHUB_OUTPUT
 
       - name: Capture App Bundle Path


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/608920331025315/task/1211012979872021?focus=true 

### Description
The internal builds GHA workflow is using `gradle` instead of the gradle wrapper `gradlew`
- This means it might use a different version of gradle than we expect to use
- This just started happening; this job failed because it picked up Gradle 9 and had issues using it while the rest of the CI jobs use Grade 8

### Steps to test this PR
- [ ] QA the change