### PR TITLE
Avoid usage of requireActivity in download callback

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1575,9 +1575,11 @@ class BrowserTabFragment :
         )
             ?.apply {
                 this.setAction(R.string.downloadsDownloadFinishedActionName) {
-                    val result = downloadsFileActions.openFile(requireActivity(), File(command.filePath))
-                    if (!result) {
-                        view.makeSnackbarWithNoBottomInset(getString(R.string.downloadsCannotOpenFileErrorMessage), Snackbar.LENGTH_LONG).show()
+                    activity?.let {
+                        val result = downloadsFileActions.openFile(it, File(command.filePath))
+                        if (!result) {
+                            view.makeSnackbarWithNoBottomInset(getString(R.string.downloadsCannotOpenFileErrorMessage), Snackbar.LENGTH_LONG).show()
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211022417452920?focus=true 

### Description
After downloading a file we have a callback which shows a snackbar; there is button on it to open the file. From a stack trace it seems possible the activity is gone and the use of `requireActivity()` results in a crash. Switching to avoiding the crash and doing nothing if the `activity` is null when we try.

Fixes https://github.com/duckduckgo/Android/issues/6557

### Steps to test this PR
- [ ] QA optional
- [ ] If you want, download a file (e.g., https://file-examples.com/index.php/sample-images-download/sample-jpg-download/) and tap on the snackbar to view it once done