### PR TITLE
Enable singleOmnibarFeature by default

### DIFF
--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/experiments/visual/ExperimentalThemingFeature.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/experiments/visual/ExperimentalThemingFeature.kt
@@ -30,8 +30,7 @@ interface ExperimentalThemingFeature {
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun self(): Toggle
 
-    @Toggle.InternalAlwaysEnabled
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun singleOmnibarFeature(): Toggle
 
     enum class ExperimentalThemingCohortName(override val cohortName: String) : CohortName {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1211021941669104?focus=true

### Description

- Sets the `singleOmnibarFeature` to true by default.

### Steps to test this PR

- [ ] Fresh install the app
- [ ] Verify that the new omnibar is visible
