### PR TITLE
Move Duck.ai settings pixels to ViewModel

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -261,41 +261,21 @@ class RealDuckChat @Inject constructor(
     }
 
     override suspend fun setEnableDuckChatUserSetting(enabled: Boolean) {
-        if (enabled) {
-            pixel.fire(DuckChatPixelName.DUCK_CHAT_USER_ENABLED)
-        } else {
-            pixel.fire(DuckChatPixelName.DUCK_CHAT_USER_DISABLED)
-        }
         duckChatFeatureRepository.setDuckChatUserEnabled(enabled)
         cacheUserSettings()
     }
 
     override suspend fun setInputScreenUserSetting(enabled: Boolean) {
-        if (enabled) {
-            pixel.fire(DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_ADDRESS_BAR_SETTING_ON)
-        } else {
-            pixel.fire(DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_ADDRESS_BAR_SETTING_OFF)
-        }
         duckChatFeatureRepository.setInputScreenUserSetting(enabled)
         cacheUserSettings()
     }
 
     override suspend fun setShowInBrowserMenuUserSetting(showDuckChat: Boolean) = withContext(dispatchers.io()) {
-        if (showDuckChat) {
-            pixel.fire(DuckChatPixelName.DUCK_CHAT_MENU_SETTING_ON)
-        } else {
-            pixel.fire(DuckChatPixelName.DUCK_CHAT_MENU_SETTING_OFF)
-        }
         duckChatFeatureRepository.setShowInBrowserMenu(showDuckChat)
         cacheUserSettings()
     }
 
     override suspend fun setShowInAddressBarUserSetting(showDuckChat: Boolean) = withContext(dispatchers.io()) {
-        if (showDuckChat) {
-            pixel.fire(DuckChatPixelName.DUCK_CHAT_SEARCHBAR_SETTING_ON)
-        } else {
-            pixel.fire(DuckChatPixelName.DUCK_CHAT_SEARCHBAR_SETTING_OFF)
-        }
         duckChatFeatureRepository.setShowInAddressBar(showDuckChat)
         cacheUserSettings()
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatSettingsViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatSettingsViewModel.kt
@@ -83,24 +83,44 @@ class DuckChatSettingsViewModel @Inject constructor(
 
     fun onDuckChatUserEnabledToggled(checked: Boolean) {
         viewModelScope.launch {
+            if (checked) {
+                pixel.fire(DuckChatPixelName.DUCK_CHAT_USER_ENABLED)
+            } else {
+                pixel.fire(DuckChatPixelName.DUCK_CHAT_USER_DISABLED)
+            }
             duckChat.setEnableDuckChatUserSetting(checked)
         }
     }
 
     fun onDuckAiInputScreenToggled(checked: Boolean) {
         viewModelScope.launch {
+            if (checked) {
+                pixel.fire(DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_ADDRESS_BAR_SETTING_ON)
+            } else {
+                pixel.fire(DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_ADDRESS_BAR_SETTING_OFF)
+            }
             duckChat.setInputScreenUserSetting(checked)
         }
     }
 
     fun onShowDuckChatInMenuToggled(checked: Boolean) {
         viewModelScope.launch {
+            if (checked) {
+                pixel.fire(DuckChatPixelName.DUCK_CHAT_MENU_SETTING_ON)
+            } else {
+                pixel.fire(DuckChatPixelName.DUCK_CHAT_MENU_SETTING_OFF)
+            }
             duckChat.setShowInBrowserMenuUserSetting(checked)
         }
     }
 
     fun onShowDuckChatInAddressBarToggled(checked: Boolean) {
         viewModelScope.launch {
+            if (checked) {
+                pixel.fire(DuckChatPixelName.DUCK_CHAT_SEARCHBAR_SETTING_ON)
+            } else {
+                pixel.fire(DuckChatPixelName.DUCK_CHAT_SEARCHBAR_SETTING_OFF)
+            }
             duckChat.setShowInAddressBarUserSetting(checked)
         }
     }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -31,7 +31,6 @@ import com.duckduckgo.common.ui.experiments.visual.store.ExperimentalThemingData
 import com.duckduckgo.duckchat.api.DuckChatSettingsNoParams
 import com.duckduckgo.duckchat.impl.feature.AIChatImageUploadFeature
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
-import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.duckchat.impl.repository.DuckChatFeatureRepository
 import com.duckduckgo.duckchat.impl.ui.DuckChatWebViewActivityWithParams
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
@@ -60,7 +59,6 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.spy
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -123,33 +121,9 @@ class RealDuckChatTest {
     }
 
     @Test
-    fun whenSetShowInBrowserMenuSetTrueThenPixelOnIsSent() = runTest {
-        testee.setShowInBrowserMenuUserSetting(true)
-        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_MENU_SETTING_ON)
-    }
-
-    @Test
-    fun whenSetShowInBrowserMenuSetFalseThenPixelOffIsSent() = runTest {
-        testee.setShowInBrowserMenuUserSetting(false)
-        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_MENU_SETTING_OFF)
-    }
-
-    @Test
     fun whenSetShowInBrowserMenuUserSettingThenRepositorySetCalled() = runTest {
         testee.setShowInBrowserMenuUserSetting(true)
         verify(mockDuckChatFeatureRepository).setShowInBrowserMenu(true)
-    }
-
-    @Test
-    fun whenSetShowInAddressBarSetTrueThenPixelOnIsSent() = runTest {
-        testee.setShowInAddressBarUserSetting(true)
-        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_SEARCHBAR_SETTING_ON)
-    }
-
-    @Test
-    fun whenSetShowInAddressBarSetFalseThenPixelOffIsSent() = runTest {
-        testee.setShowInAddressBarUserSetting(false)
-        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_SEARCHBAR_SETTING_OFF)
     }
 
     @Test
@@ -457,23 +431,21 @@ class RealDuckChatTest {
     }
 
     @Test
-    fun whenSetEnableDuckChatUserSettingTrueThenEnabledPixelSentAndRepositoryUpdated() = runTest {
+    fun whenSetEnableDuckChatUserSettingTrueThenRepositoryUpdated() = runTest {
         whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
 
         testee.setEnableDuckChatUserSetting(true)
 
-        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_USER_ENABLED)
         verify(mockDuckChatFeatureRepository).setDuckChatUserEnabled(true)
         assertTrue(testee.isDuckChatUserEnabled())
     }
 
     @Test
-    fun whenSetEnableDuckChatUserSettingFalseThenDisabledPixelSentAndRepositoryUpdated() = runTest {
+    fun whenSetEnableDuckChatUserSettingFalseThenRepositoryUpdated() = runTest {
         whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(false)
 
         testee.setEnableDuckChatUserSetting(false)
 
-        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_USER_DISABLED)
         verify(mockDuckChatFeatureRepository).setDuckChatUserEnabled(false)
         assertFalse(testee.isDuckChatUserEnabled())
     }
@@ -674,23 +646,17 @@ class RealDuckChatTest {
     }
 
     @Test
-    fun `when enable input screen user setting then repository updated and pixel fired`() = runTest {
+    fun `when enable input screen user setting then repository updated`() = runTest {
         testee.setInputScreenUserSetting(true)
 
-        val inOrder = inOrder(mockDuckChatFeatureRepository, mockPixel)
-        inOrder.verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_ADDRESS_BAR_SETTING_ON)
-        inOrder.verify(mockDuckChatFeatureRepository).setInputScreenUserSetting(true)
-        inOrder.verify(mockDuckChatFeatureRepository).isInputScreenUserSettingEnabled()
+        verify(mockDuckChatFeatureRepository).setInputScreenUserSetting(true)
     }
 
     @Test
-    fun `when disable input screen user setting then repository updated and pixel fired`() = runTest {
+    fun `when disable input screen user setting then repository updated`() = runTest {
         testee.setInputScreenUserSetting(false)
 
-        val inOrder = inOrder(mockDuckChatFeatureRepository, mockPixel)
-        inOrder.verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_ADDRESS_BAR_SETTING_OFF)
-        inOrder.verify(mockDuckChatFeatureRepository).setInputScreenUserSetting(false)
-        inOrder.verify(mockDuckChatFeatureRepository).isInputScreenUserSettingEnabled()
+        verify(mockDuckChatFeatureRepository).setInputScreenUserSetting(false)
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/DuckChatSettingsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/DuckChatSettingsViewModelTest.kt
@@ -271,4 +271,52 @@ class DuckChatSettingsViewModelTest {
         testee.duckChatSearchAISettingsClicked()
         verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_SEARCH_ASSIST_SETTINGS_BUTTON_CLICKED)
     }
+
+    @Test
+    fun `when onDuckChatUserEnabledToggled true then enabled pixel fired`() = runTest {
+        testee.onDuckChatUserEnabledToggled(true)
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_USER_ENABLED)
+    }
+
+    @Test
+    fun `when onDuckChatUserEnabledToggled false then disabled pixel fired`() = runTest {
+        testee.onDuckChatUserEnabledToggled(false)
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_USER_DISABLED)
+    }
+
+    @Test
+    fun `when onDuckAiInputScreenToggled true then on pixel fired`() = runTest {
+        testee.onDuckAiInputScreenToggled(true)
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_ADDRESS_BAR_SETTING_ON)
+    }
+
+    @Test
+    fun `when onDuckAiInputScreenToggled false then off pixel fired`() = runTest {
+        testee.onDuckAiInputScreenToggled(false)
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_ADDRESS_BAR_SETTING_OFF)
+    }
+
+    @Test
+    fun `when onShowDuckChatInMenuToggled true then on pixel fired`() = runTest {
+        testee.onShowDuckChatInMenuToggled(true)
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_MENU_SETTING_ON)
+    }
+
+    @Test
+    fun `when onShowDuckChatInMenuToggled false then off pixel fired`() = runTest {
+        testee.onShowDuckChatInMenuToggled(false)
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_MENU_SETTING_OFF)
+    }
+
+    @Test
+    fun `when onShowDuckChatInAddressBarToggled true then on pixel fired`() = runTest {
+        testee.onShowDuckChatInAddressBarToggled(true)
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_SEARCHBAR_SETTING_ON)
+    }
+
+    @Test
+    fun `when onShowDuckChatInAddressBarToggled false then off pixel fired`() = runTest {
+        testee.onShowDuckChatInAddressBarToggled(false)
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_SEARCHBAR_SETTING_OFF)
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211021941669121?focus=true

### Description

- Moves settings pixels from `RealDuckChat` to `DuckChatSettingsViewModel`

### Steps to test this PR

- [x] Disable Duck.ai
- [x] Verify `aichat_disabled` is sent
- [x] Enable Duck.ai
- [x] Verify `aichat_enabled` is sent
- [x] Enable Experimental Address Bar
- [x] Verify `aichat_experimental_address_bar_setting_on` is sent
- [x] Disable Experimental Address Bar
- [x] Verify `aichat_experimental_address_bar_setting_off` is sent
- [x] Disable Browser Menu
- [x] Verify `aichat_menu_setting_off` is sent
- [x] Enable Browser Menu
- [x] Verify `aichat_menu_setting_on` is sent
- [x] Disable Address Bar
- [x] Verify `aichat_searchbar_setting_off` is sent
- [x] Enable Address Bar
- [x] Verify `aichat_searchbar_setting_on` is sent