### PR TITLE
Omit Cookie downloads header when empty rather than empty string

### DIFF
--- a/downloads/downloads-impl/build.gradle
+++ b/downloads/downloads-impl/build.gradle
@@ -86,6 +86,7 @@ dependencies {
     testImplementation 'app.cash.turbine:turbine:_'
     testImplementation Testing.robolectric
     testImplementation project(path: ':common-test')
+    testImplementation project(':feature-toggles-test')
 
     coreLibraryDesugaring Android.tools.desugarJdkLibs
 }

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DownloadFileService.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DownloadFileService.kt
@@ -35,7 +35,7 @@ interface DownloadFileService {
     @Streaming
     @GET
     fun downloadFile(
-        @Header("Cookie") cookie: String,
+        @Header("Cookie") cookie: String?,
         @Url urlString: String,
     ): Call<ResponseBody>
 }

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/feature/FileDownloadFeature.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/feature/FileDownloadFeature.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.downloads.impl.feature
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
+
+/**
+ * This is the class that represents file download feature flags and kill switches
+ */
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "androidFileDownloadFeature",
+)
+interface FileDownloadFeature {
+
+    // self() is required, but it is not currently used in the codebase
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun self(): Toggle
+
+    // This kill switch can be used to revert to the old behaviour of sending an empty Cookie header instead of omitting it
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun omitEmptyCookieHeader(): Toggle
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211033344698349?focus=true 

### Description
From https://github.com/duckduckgo/Android/issues/6516, investigated and found that empty `Cookie` HTTP headers are tripping up Calibre's web server. 
- Empty `Cookie` headers are legal but there are some sparse reports of web servers failing to parse them
- Rather than an empty `Cookie` header, we can just omit sending it at all

That fixes the problem for Calibre (and i'm sure a few other services). Fixes https://github.com/duckduckgo/Android/issues/6516.

Feature flagged so we can revert to the existing behaviour if we notice problems because of this change.

### Steps to test this PR

- [x] Test some downloads still succeed as normal (e.g., https://file-examples.com/)
- [ ] [Optional]: 
    - [ ] [install Calibre](https://calibre-ebook.com/download)
    - [ ] Tap the `Connect/share` button
    - [ ] `Start content server`
    - [ ] Browse to the URL from the Android device running this fixed branch, and download the sample book
