### PR TITLE
Update autoconsent to v14.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ddg-android",
       "version": "1.0.0",
       "dependencies": {
-        "@duckduckgo/autoconsent": "^14.10.0",
+        "@duckduckgo/autoconsent": "^14.12.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.2.0",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.3.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.10.1",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.10.1.tgz",
-      "integrity": "sha512-UIoMI8y09MzlQfj+cbKFfDCXmh9EesDviW/ethrVGx0xhpv991P/pL8wBZyce+DrezFYa47nFuULS+nu7wAuCw==",
+      "version": "14.12.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.12.0.tgz",
+      "integrity": "sha512-2vQZZGqzoklOzX5irLbl0E4hatrMlri9Lh80UBhqtEhoPxzHVihdEBvZ+Pfl3Q/HUkTsE67ytleEe5hREwWxxQ==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "rollup-plugin-terser": "^7.0.2"
   },
   "dependencies": {
-    "@duckduckgo/autoconsent": "^14.10.0",
+    "@duckduckgo/autoconsent": "^14.12.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.2.0",
     "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.3.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1211044562167293
Autoconsent Release: https://github.com/duckduckgo/autoconsent/releases/tag/v14.12.0


## Description
Updates Autoconsent to version [v14.12.0](https://github.com/duckduckgo/autoconsent/releases/tag/v14.12.0).

### Autoconsent v14.12.0 release notes
See release notes [here](https://github.com/duckduckgo/autoconsent/blob/v14.12.0/CHANGELOG.md)

## Steps to test
This release has been tested during Autoconsent development. You can check the release notes for more information.
1. Make sure that there's no unexpected failures in CI checks
2. (optional) smoke test some of the sites mentioned in the release notes
3. If there are problems, reach out to a CPM DRI