### PR TITLE
Update content scope scripts to version 11.5.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
@@ -1817,7 +1817,8 @@
         copy2[symbol] = value[symbol];
       });
       return copy2;
-    } else if (isJSONObject(value)) {
+    }
+    if (isJSONObject(value)) {
       const copy2 = {
         ...value
       };
@@ -1825,18 +1826,16 @@
         copy2[symbol] = value[symbol];
       });
       return copy2;
-    } else {
-      return value;
     }
+    return value;
   }
   function applyProp(object, key, value) {
     if (object[key] === value) {
       return object;
-    } else {
-      const updatedObject = shallowClone(object);
-      updatedObject[key] = value;
-      return updatedObject;
     }
+    const updatedObject = shallowClone(object);
+    updatedObject[key] = value;
+    return updatedObject;
   }
   function getIn(object, path) {
     let value = object;
@@ -1845,7 +1844,7 @@
       if (isJSONObject(value)) {
         value = value[path[i]];
       } else if (isJSONArray(value)) {
-        value = value[parseInt(path[i])];
+        value = value[Number.parseInt(path[i])];
       } else {
         value = void 0;
       }
@@ -1862,15 +1861,13 @@
     const updatedValue = setIn(object ? object[key] : void 0, path.slice(1), value, createPath);
     if (isJSONObject(object) || isJSONArray(object)) {
       return applyProp(object, key, updatedValue);
-    } else {
-      if (createPath) {
-        const newObject = IS_INTEGER_REGEX.test(key) ? [] : {};
-        newObject[key] = updatedValue;
-        return newObject;
-      } else {
-        throw new Error("Path does not exist");
-      }
     }
+    if (createPath) {
+      const newObject = IS_INTEGER_REGEX.test(key) ? [] : {};
+      newObject[key] = updatedValue;
+      return newObject;
+    }
+    throw new Error("Path does not exist");
   }
   var IS_INTEGER_REGEX = /^\d+$/;
   function updateIn(object, path, transform) {
@@ -1895,16 +1892,15 @@
       const key2 = path[0];
       if (!(key2 in object)) {
         return object;
-      } else {
-        const updatedObject = shallowClone(object);
-        if (isJSONArray(updatedObject)) {
-          updatedObject.splice(parseInt(key2), 1);
-        }
-        if (isJSONObject(updatedObject)) {
-          delete updatedObject[key2];
-        }
-        return updatedObject;
       }
+      const updatedObject = shallowClone(object);
+      if (isJSONArray(updatedObject)) {
+        updatedObject.splice(Number.parseInt(key2), 1);
+      }
+      if (isJSONObject(updatedObject)) {
+        delete updatedObject[key2];
+      }
+      return updatedObject;
     }
     const key = path[0];
     const updatedValue = deleteIn(object[key], path.slice(1));
@@ -1915,10 +1911,10 @@
     const index = path[path.length - 1];
     return updateIn(document2, parentPath, (items) => {
       if (!Array.isArray(items)) {
-        throw new TypeError("Array expected at path " + JSON.stringify(parentPath));
+        throw new TypeError(`Array expected at path ${JSON.stringify(parentPath)}`);
       }
       const updatedItems = shallowClone(items);
-      updatedItems.splice(parseInt(index), 0, value);
+      updatedItems.splice(Number.parseInt(index), 0, value);
       return updatedItems;
     });
   }
@@ -1945,7 +1941,7 @@
     return path.map(compileJSONPointerProp).join("");
   }
   function compileJSONPointerProp(pathProp) {
-    return "/" + String(pathProp).replace(/~/g, "~0").replace(/\//g, "~1");
+    return `/${String(pathProp).replace(/~/g, "~0").replace(/\//g, "~1")}`;
   }
 
   // ../node_modules/immutable-json-patch/lib/esm/immutableJSONPatch.js
@@ -1954,7 +1950,7 @@
     for (let i = 0; i < operations.length; i++) {
       validateJSONPatchOperation(operations[i]);
       let operation = operations[i];
-      if (options && options.before) {
+      if (options?.before) {
         const result = options.before(updatedDocument, operation);
         if (result !== void 0) {
           if (result.document !== void 0) {
@@ -1983,9 +1979,9 @@
       } else if (operation.op === "test") {
         test(updatedDocument, path, operation.value);
       } else {
-        throw new Error("Unknown JSONPatch operation " + JSON.stringify(operation));
+        throw new Error(`Unknown JSONPatch operation ${JSON.stringify(operation)}`);
       }
-      if (options && options.after) {
+      if (options?.after) {
         const result = options.after(updatedDocument, operation, previousDocument);
         if (result !== void 0) {
           updatedDocument = result;
@@ -1995,7 +1991,7 @@
     return updatedDocument;
   }
   function replace(document2, path, value) {
-    return setIn(document2, path, value);
+    return existsIn(document2, path) ? setIn(document2, path, value) : document2;
   }
   function remove(document2, path) {
     return deleteIn(document2, path);
@@ -2003,18 +1999,15 @@
   function add(document2, path, value) {
     if (isArrayItem(document2, path)) {
       return insertAt(document2, path, value);
-    } else {
-      return setIn(document2, path, value);
     }
+    return setIn(document2, path, value);
   }
   function copy(document2, path, from) {
     const value = getIn(document2, from);
     if (isArrayItem(document2, path)) {
       return insertAt(document2, path, value);
-    } else {
-      const value2 = getIn(document2, from);
-      return setIn(document2, path, value2);
     }
+    return setIn(document2, path, value);
   }
   function move(document2, path, from) {
     const value = getIn(document2, from);
@@ -2051,14 +2044,14 @@
   function validateJSONPatchOperation(operation) {
     const ops = ["add", "remove", "replace", "copy", "move", "test"];
     if (!ops.includes(operation.op)) {
-      throw new Error("Unknown JSONPatch op " + JSON.stringify(operation.op));
+      throw new Error(`Unknown JSONPatch op ${JSON.stringify(operation.op)}`);
     }
     if (typeof operation.path !== "string") {
-      throw new Error('Required property "path" missing or not a string in operation ' + JSON.stringify(operation));
+      throw new Error(`Required property "path" missing or not a string in operation ${JSON.stringify(operation)}`);
     }
     if (operation.op === "copy" || operation.op === "move") {
       if (typeof operation.from !== "string") {
-        throw new Error('Required property "from" missing or not a string in operation ' + JSON.stringify(operation));
+        throw new Error(`Required property "from" missing or not a string in operation ${JSON.stringify(operation)}`);
       }
     }
   }
@@ -2888,6 +2881,13 @@
       return __privateGet(this, _args)?.featureSettings;
     }
     /**
+     * Getter for injectName, will be overridden by subclasses (namely ContentFeature)
+     * @returns {string | undefined}
+     */
+    get injectName() {
+      return void 0;
+    }
+    /**
      * Given a config key, interpret the value as a list of conditionals objects, and return the elements that match the current page
      * Consider in your feature using patchSettings instead as per `getFeatureSetting`.
      * @param {string} featureKeyName
@@ -2925,6 +2925,10 @@
      * @property {object} [experiment]
      * @property {string} [experiment.experimentName]
      * @property {string} [experiment.cohort]
+     * @property {object} [context]
+     * @property {boolean} [context.frame] - true if the condition applies to frames
+     * @property {boolean} [context.top] - true if the condition applies to the top frame
+     * @property {string} [injectName] - the inject name to match against (e.g., "apple-isolated")
      */
     /**
      * Takes multiple conditional blocks and returns true if any apply.
@@ -2946,9 +2950,11 @@
     _matchConditionalBlock(conditionBlock) {
       const conditionChecks = {
         domain: this._matchDomainConditional,
+        context: this._matchContextConditional,
         urlPattern: this._matchUrlPatternConditional,
         experiment: this._matchExperimentConditional,
-        minSupportedVersion: this._matchMinSupportedVersion
+        minSupportedVersion: this._matchMinSupportedVersion,
+        injectName: this._matchInjectNameConditional
       };
       for (const key in conditionBlock) {
         if (!conditionChecks[key]) {
@@ -2985,6 +2991,22 @@
       });
     }
     /**
+     * Takes a condition block and returns true if the current context matches the context.
+     * @param {ConditionBlock} conditionBlock
+     * @returns {boolean}
+     */
+    _matchContextConditional(conditionBlock) {
+      if (!conditionBlock.context) return false;
+      const isFrame = window.self !== window.top;
+      if (conditionBlock.context.frame && isFrame) {
+        return true;
+      }
+      if (conditionBlock.context.top && !isFrame) {
+        return true;
+      }
+      return false;
+    }
+    /**
      * Takes a condtion block and returns true if the current url matches the urlPattern.
      * @param {ConditionBlock} conditionBlock
      * @returns {boolean}
@@ -3011,6 +3033,17 @@
         return false;
       }
       return matchHostname(domain, conditionBlock.domain);
+    }
+    /**
+     * Takes a condition block and returns true if the current inject name matches the injectName.
+     * @param {ConditionBlock} conditionBlock
+     * @returns {boolean}
+     */
+    _matchInjectNameConditional(conditionBlock) {
+      if (!conditionBlock.injectName) return false;
+      const currentInjectName = this.injectName;
+      if (!currentInjectName) return false;
+      return conditionBlock.injectName === currentInjectName;
     }
     /**
      * Takes a condition block and returns true if the platform version satisfies the `minSupportedFeature`
@@ -3889,7 +3922,6 @@
     const historyMethodProxy = new DDGProxy(urlChangedInstance, History.prototype, "pushState", {
       apply(target, thisArg, args) {
         const changeResult = DDGReflect.apply(target, thisArg, args);
-        console.log("pushstate event");
         handleURLChange("push");
         return changeResult;
       }

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -3316,9 +3316,6 @@
   // ../node_modules/immutable-json-patch/lib/esm/index.js
   init_define_import_meta_trackerLookup();
 
-  // ../node_modules/immutable-json-patch/lib/esm/immutableJSONPatch.js
-  init_define_import_meta_trackerLookup();
-
   // ../node_modules/immutable-json-patch/lib/esm/immutabilityHelpers.js
   init_define_import_meta_trackerLookup();
 
@@ -3355,7 +3352,8 @@
         copy2[symbol] = value[symbol];
       });
       return copy2;
-    } else if (isJSONObject(value)) {
+    }
+    if (isJSONObject(value)) {
       const copy2 = {
         ...value
       };
@@ -3363,18 +3361,16 @@
         copy2[symbol] = value[symbol];
       });
       return copy2;
-    } else {
-      return value;
     }
+    return value;
   }
   function applyProp(object, key, value) {
     if (object[key] === value) {
       return object;
-    } else {
-      const updatedObject = shallowClone(object);
-      updatedObject[key] = value;
-      return updatedObject;
     }
+    const updatedObject = shallowClone(object);
+    updatedObject[key] = value;
+    return updatedObject;
   }
   function getIn(object, path) {
     let value = object;
@@ -3383,7 +3379,7 @@
       if (isJSONObject(value)) {
         value = value[path[i]];
       } else if (isJSONArray(value)) {
-        value = value[parseInt(path[i])];
+        value = value[Number.parseInt(path[i])];
       } else {
         value = void 0;
       }
@@ -3400,15 +3396,13 @@
     const updatedValue = setIn(object ? object[key] : void 0, path.slice(1), value, createPath);
     if (isJSONObject(object) || isJSONArray(object)) {
       return applyProp(object, key, updatedValue);
-    } else {
-      if (createPath) {
-        const newObject = IS_INTEGER_REGEX.test(key) ? [] : {};
-        newObject[key] = updatedValue;
-        return newObject;
-      } else {
-        throw new Error("Path does not exist");
-      }
     }
+    if (createPath) {
+      const newObject = IS_INTEGER_REGEX.test(key) ? [] : {};
+      newObject[key] = updatedValue;
+      return newObject;
+    }
+    throw new Error("Path does not exist");
   }
   var IS_INTEGER_REGEX = /^\d+$/;
   function updateIn(object, path, transform) {
@@ -3433,16 +3427,15 @@
       const key2 = path[0];
       if (!(key2 in object)) {
         return object;
-      } else {
-        const updatedObject = shallowClone(object);
-        if (isJSONArray(updatedObject)) {
-          updatedObject.splice(parseInt(key2), 1);
-        }
-        if (isJSONObject(updatedObject)) {
-          delete updatedObject[key2];
-        }
-        return updatedObject;
       }
+      const updatedObject = shallowClone(object);
+      if (isJSONArray(updatedObject)) {
+        updatedObject.splice(Number.parseInt(key2), 1);
+      }
+      if (isJSONObject(updatedObject)) {
+        delete updatedObject[key2];
+      }
+      return updatedObject;
     }
     const key = path[0];
     const updatedValue = deleteIn(object[key], path.slice(1));
@@ -3453,10 +3446,10 @@
     const index = path[path.length - 1];
     return updateIn(document2, parentPath, (items) => {
       if (!Array.isArray(items)) {
-        throw new TypeError("Array expected at path " + JSON.stringify(parentPath));
+        throw new TypeError(`Array expected at path ${JSON.stringify(parentPath)}`);
       }
       const updatedItems = shallowClone(items);
-      updatedItems.splice(parseInt(index), 0, value);
+      updatedItems.splice(Number.parseInt(index), 0, value);
       return updatedItems;
     });
   }
@@ -3473,6 +3466,9 @@
     return existsIn(document2[path[0]], path.slice(1));
   }
 
+  // ../node_modules/immutable-json-patch/lib/esm/immutableJSONPatch.js
+  init_define_import_meta_trackerLookup();
+
   // ../node_modules/immutable-json-patch/lib/esm/jsonPointer.js
   init_define_import_meta_trackerLookup();
   function parseJSONPointer(pointer) {
@@ -3484,7 +3480,7 @@
     return path.map(compileJSONPointerProp).join("");
   }
   function compileJSONPointerProp(pathProp) {
-    return "/" + String(pathProp).replace(/~/g, "~0").replace(/\//g, "~1");
+    return `/${String(pathProp).replace(/~/g, "~0").replace(/\//g, "~1")}`;
   }
 
   // ../node_modules/immutable-json-patch/lib/esm/immutableJSONPatch.js
@@ -3493,7 +3489,7 @@
     for (let i = 0; i < operations.length; i++) {
       validateJSONPatchOperation(operations[i]);
       let operation = operations[i];
-      if (options && options.before) {
+      if (options?.before) {
         const result = options.before(updatedDocument, operation);
         if (result !== void 0) {
           if (result.document !== void 0) {
@@ -3522,9 +3518,9 @@
       } else if (operation.op === "test") {
         test(updatedDocument, path, operation.value);
       } else {
-        throw new Error("Unknown JSONPatch operation " + JSON.stringify(operation));
+        throw new Error(`Unknown JSONPatch operation ${JSON.stringify(operation)}`);
       }
-      if (options && options.after) {
+      if (options?.after) {
         const result = options.after(updatedDocument, operation, previousDocument);
         if (result !== void 0) {
           updatedDocument = result;
@@ -3534,7 +3530,7 @@
     return updatedDocument;
   }
   function replace(document2, path, value) {
-    return setIn(document2, path, value);
+    return existsIn(document2, path) ? setIn(document2, path, value) : document2;
   }
   function remove(document2, path) {
     return deleteIn(document2, path);
@@ -3542,18 +3538,15 @@
   function add(document2, path, value) {
     if (isArrayItem(document2, path)) {
       return insertAt(document2, path, value);
-    } else {
-      return setIn(document2, path, value);
     }
+    return setIn(document2, path, value);
   }
   function copy(document2, path, from) {
     const value = getIn(document2, from);
     if (isArrayItem(document2, path)) {
       return insertAt(document2, path, value);
-    } else {
-      const value2 = getIn(document2, from);
-      return setIn(document2, path, value2);
     }
+    return setIn(document2, path, value);
   }
   function move(document2, path, from) {
     const value = getIn(document2, from);
@@ -3590,14 +3583,14 @@
   function validateJSONPatchOperation(operation) {
     const ops = ["add", "remove", "replace", "copy", "move", "test"];
     if (!ops.includes(operation.op)) {
-      throw new Error("Unknown JSONPatch op " + JSON.stringify(operation.op));
+      throw new Error(`Unknown JSONPatch op ${JSON.stringify(operation.op)}`);
     }
     if (typeof operation.path !== "string") {
-      throw new Error('Required property "path" missing or not a string in operation ' + JSON.stringify(operation));
+      throw new Error(`Required property "path" missing or not a string in operation ${JSON.stringify(operation)}`);
     }
     if (operation.op === "copy" || operation.op === "move") {
       if (typeof operation.from !== "string") {
-        throw new Error('Required property "from" missing or not a string in operation ' + JSON.stringify(operation));
+        throw new Error(`Required property "from" missing or not a string in operation ${JSON.stringify(operation)}`);
       }
     }
   }
@@ -4431,6 +4424,13 @@
       return __privateGet(this, _args)?.featureSettings;
     }
     /**
+     * Getter for injectName, will be overridden by subclasses (namely ContentFeature)
+     * @returns {string | undefined}
+     */
+    get injectName() {
+      return void 0;
+    }
+    /**
      * Given a config key, interpret the value as a list of conditionals objects, and return the elements that match the current page
      * Consider in your feature using patchSettings instead as per `getFeatureSetting`.
      * @param {string} featureKeyName
@@ -4468,6 +4468,10 @@
      * @property {object} [experiment]
      * @property {string} [experiment.experimentName]
      * @property {string} [experiment.cohort]
+     * @property {object} [context]
+     * @property {boolean} [context.frame] - true if the condition applies to frames
+     * @property {boolean} [context.top] - true if the condition applies to the top frame
+     * @property {string} [injectName] - the inject name to match against (e.g., "apple-isolated")
      */
     /**
      * Takes multiple conditional blocks and returns true if any apply.
@@ -4489,9 +4493,11 @@
     _matchConditionalBlock(conditionBlock) {
       const conditionChecks = {
         domain: this._matchDomainConditional,
+        context: this._matchContextConditional,
         urlPattern: this._matchUrlPatternConditional,
         experiment: this._matchExperimentConditional,
-        minSupportedVersion: this._matchMinSupportedVersion
+        minSupportedVersion: this._matchMinSupportedVersion,
+        injectName: this._matchInjectNameConditional
       };
       for (const key in conditionBlock) {
         if (!conditionChecks[key]) {
@@ -4528,6 +4534,22 @@
       });
     }
     /**
+     * Takes a condition block and returns true if the current context matches the context.
+     * @param {ConditionBlock} conditionBlock
+     * @returns {boolean}
+     */
+    _matchContextConditional(conditionBlock) {
+      if (!conditionBlock.context) return false;
+      const isFrame = window.self !== window.top;
+      if (conditionBlock.context.frame && isFrame) {
+        return true;
+      }
+      if (conditionBlock.context.top && !isFrame) {
+        return true;
+      }
+      return false;
+    }
+    /**
      * Takes a condtion block and returns true if the current url matches the urlPattern.
      * @param {ConditionBlock} conditionBlock
      * @returns {boolean}
@@ -4554,6 +4576,17 @@
         return false;
       }
       return matchHostname(domain, conditionBlock.domain);
+    }
+    /**
+     * Takes a condition block and returns true if the current inject name matches the injectName.
+     * @param {ConditionBlock} conditionBlock
+     * @returns {boolean}
+     */
+    _matchInjectNameConditional(conditionBlock) {
+      if (!conditionBlock.injectName) return false;
+      const currentInjectName = this.injectName;
+      if (!currentInjectName) return false;
+      return conditionBlock.injectName === currentInjectName;
     }
     /**
      * Takes a condition block and returns true if the platform version satisfies the `minSupportedFeature`
@@ -8587,7 +8620,6 @@
     const historyMethodProxy = new DDGProxy(urlChangedInstance, History.prototype, "pushState", {
       apply(target, thisArg, args) {
         const changeResult = DDGReflect.apply(target, thisArg, args);
-        console.log("pushstate event");
         handleURLChange("push");
         return changeResult;
       }

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -3156,9 +3156,6 @@
   // ../node_modules/immutable-json-patch/lib/esm/index.js
   init_define_import_meta_trackerLookup();
 
-  // ../node_modules/immutable-json-patch/lib/esm/immutableJSONPatch.js
-  init_define_import_meta_trackerLookup();
-
   // ../node_modules/immutable-json-patch/lib/esm/immutabilityHelpers.js
   init_define_import_meta_trackerLookup();
 
@@ -3195,7 +3192,8 @@
         copy2[symbol] = value[symbol];
       });
       return copy2;
-    } else if (isJSONObject(value)) {
+    }
+    if (isJSONObject(value)) {
       const copy2 = {
         ...value
       };
@@ -3203,18 +3201,16 @@
         copy2[symbol] = value[symbol];
       });
       return copy2;
-    } else {
-      return value;
     }
+    return value;
   }
   function applyProp(object, key, value) {
     if (object[key] === value) {
       return object;
-    } else {
-      const updatedObject = shallowClone(object);
-      updatedObject[key] = value;
-      return updatedObject;
     }
+    const updatedObject = shallowClone(object);
+    updatedObject[key] = value;
+    return updatedObject;
   }
   function getIn(object, path) {
     let value = object;
@@ -3223,7 +3219,7 @@
       if (isJSONObject(value)) {
         value = value[path[i]];
       } else if (isJSONArray(value)) {
-        value = value[parseInt(path[i])];
+        value = value[Number.parseInt(path[i])];
       } else {
         value = void 0;
       }
@@ -3240,15 +3236,13 @@
     const updatedValue = setIn(object ? object[key] : void 0, path.slice(1), value, createPath);
     if (isJSONObject(object) || isJSONArray(object)) {
       return applyProp(object, key, updatedValue);
-    } else {
-      if (createPath) {
-        const newObject = IS_INTEGER_REGEX.test(key) ? [] : {};
-        newObject[key] = updatedValue;
-        return newObject;
-      } else {
-        throw new Error("Path does not exist");
-      }
     }
+    if (createPath) {
+      const newObject = IS_INTEGER_REGEX.test(key) ? [] : {};
+      newObject[key] = updatedValue;
+      return newObject;
+    }
+    throw new Error("Path does not exist");
   }
   var IS_INTEGER_REGEX = /^\d+$/;
   function updateIn(object, path, transform) {
@@ -3273,16 +3267,15 @@
       const key2 = path[0];
       if (!(key2 in object)) {
         return object;
-      } else {
-        const updatedObject = shallowClone(object);
-        if (isJSONArray(updatedObject)) {
-          updatedObject.splice(parseInt(key2), 1);
-        }
-        if (isJSONObject(updatedObject)) {
-          delete updatedObject[key2];
-        }
-        return updatedObject;
       }
+      const updatedObject = shallowClone(object);
+      if (isJSONArray(updatedObject)) {
+        updatedObject.splice(Number.parseInt(key2), 1);
+      }
+      if (isJSONObject(updatedObject)) {
+        delete updatedObject[key2];
+      }
+      return updatedObject;
     }
     const key = path[0];
     const updatedValue = deleteIn(object[key], path.slice(1));
@@ -3293,10 +3286,10 @@
     const index = path[path.length - 1];
     return updateIn(document2, parentPath, (items) => {
       if (!Array.isArray(items)) {
-        throw new TypeError("Array expected at path " + JSON.stringify(parentPath));
+        throw new TypeError(`Array expected at path ${JSON.stringify(parentPath)}`);
       }
       const updatedItems = shallowClone(items);
-      updatedItems.splice(parseInt(index), 0, value);
+      updatedItems.splice(Number.parseInt(index), 0, value);
       return updatedItems;
     });
   }
@@ -3313,6 +3306,9 @@
     return existsIn(document2[path[0]], path.slice(1));
   }
 
+  // ../node_modules/immutable-json-patch/lib/esm/immutableJSONPatch.js
+  init_define_import_meta_trackerLookup();
+
   // ../node_modules/immutable-json-patch/lib/esm/jsonPointer.js
   init_define_import_meta_trackerLookup();
   function parseJSONPointer(pointer) {
@@ -3324,7 +3320,7 @@
     return path.map(compileJSONPointerProp).join("");
   }
   function compileJSONPointerProp(pathProp) {
-    return "/" + String(pathProp).replace(/~/g, "~0").replace(/\//g, "~1");
+    return `/${String(pathProp).replace(/~/g, "~0").replace(/\//g, "~1")}`;
   }
 
   // ../node_modules/immutable-json-patch/lib/esm/immutableJSONPatch.js
@@ -3333,7 +3329,7 @@
     for (let i = 0; i < operations.length; i++) {
       validateJSONPatchOperation(operations[i]);
       let operation = operations[i];
-      if (options && options.before) {
+      if (options?.before) {
         const result = options.before(updatedDocument, operation);
         if (result !== void 0) {
           if (result.document !== void 0) {
@@ -3362,9 +3358,9 @@
       } else if (operation.op === "test") {
         test(updatedDocument, path, operation.value);
       } else {
-        throw new Error("Unknown JSONPatch operation " + JSON.stringify(operation));
+        throw new Error(`Unknown JSONPatch operation ${JSON.stringify(operation)}`);
       }
-      if (options && options.after) {
+      if (options?.after) {
         const result = options.after(updatedDocument, operation, previousDocument);
         if (result !== void 0) {
           updatedDocument = result;
@@ -3374,7 +3370,7 @@
     return updatedDocument;
   }
   function replace(document2, path, value) {
-    return setIn(document2, path, value);
+    return existsIn(document2, path) ? setIn(document2, path, value) : document2;
   }
   function remove(document2, path) {
     return deleteIn(document2, path);
@@ -3382,18 +3378,15 @@
   function add(document2, path, value) {
     if (isArrayItem(document2, path)) {
       return insertAt(document2, path, value);
-    } else {
-      return setIn(document2, path, value);
     }
+    return setIn(document2, path, value);
   }
   function copy(document2, path, from) {
     const value = getIn(document2, from);
     if (isArrayItem(document2, path)) {
       return insertAt(document2, path, value);
-    } else {
-      const value2 = getIn(document2, from);
-      return setIn(document2, path, value2);
     }
+    return setIn(document2, path, value);
   }
   function move(document2, path, from) {
     const value = getIn(document2, from);
@@ -3430,14 +3423,14 @@
   function validateJSONPatchOperation(operation) {
     const ops = ["add", "remove", "replace", "copy", "move", "test"];
     if (!ops.includes(operation.op)) {
-      throw new Error("Unknown JSONPatch op " + JSON.stringify(operation.op));
+      throw new Error(`Unknown JSONPatch op ${JSON.stringify(operation.op)}`);
     }
     if (typeof operation.path !== "string") {
-      throw new Error('Required property "path" missing or not a string in operation ' + JSON.stringify(operation));
+      throw new Error(`Required property "path" missing or not a string in operation ${JSON.stringify(operation)}`);
     }
     if (operation.op === "copy" || operation.op === "move") {
       if (typeof operation.from !== "string") {
-        throw new Error('Required property "from" missing or not a string in operation ' + JSON.stringify(operation));
+        throw new Error(`Required property "from" missing or not a string in operation ${JSON.stringify(operation)}`);
       }
     }
   }
@@ -4271,6 +4264,13 @@
       return __privateGet(this, _args)?.featureSettings;
     }
     /**
+     * Getter for injectName, will be overridden by subclasses (namely ContentFeature)
+     * @returns {string | undefined}
+     */
+    get injectName() {
+      return void 0;
+    }
+    /**
      * Given a config key, interpret the value as a list of conditionals objects, and return the elements that match the current page
      * Consider in your feature using patchSettings instead as per `getFeatureSetting`.
      * @param {string} featureKeyName
@@ -4308,6 +4308,10 @@
      * @property {object} [experiment]
      * @property {string} [experiment.experimentName]
      * @property {string} [experiment.cohort]
+     * @property {object} [context]
+     * @property {boolean} [context.frame] - true if the condition applies to frames
+     * @property {boolean} [context.top] - true if the condition applies to the top frame
+     * @property {string} [injectName] - the inject name to match against (e.g., "apple-isolated")
      */
     /**
      * Takes multiple conditional blocks and returns true if any apply.
@@ -4329,9 +4333,11 @@
     _matchConditionalBlock(conditionBlock) {
       const conditionChecks = {
         domain: this._matchDomainConditional,
+        context: this._matchContextConditional,
         urlPattern: this._matchUrlPatternConditional,
         experiment: this._matchExperimentConditional,
-        minSupportedVersion: this._matchMinSupportedVersion
+        minSupportedVersion: this._matchMinSupportedVersion,
+        injectName: this._matchInjectNameConditional
       };
       for (const key in conditionBlock) {
         if (!conditionChecks[key]) {
@@ -4368,6 +4374,22 @@
       });
     }
     /**
+     * Takes a condition block and returns true if the current context matches the context.
+     * @param {ConditionBlock} conditionBlock
+     * @returns {boolean}
+     */
+    _matchContextConditional(conditionBlock) {
+      if (!conditionBlock.context) return false;
+      const isFrame = window.self !== window.top;
+      if (conditionBlock.context.frame && isFrame) {
+        return true;
+      }
+      if (conditionBlock.context.top && !isFrame) {
+        return true;
+      }
+      return false;
+    }
+    /**
      * Takes a condtion block and returns true if the current url matches the urlPattern.
      * @param {ConditionBlock} conditionBlock
      * @returns {boolean}
@@ -4394,6 +4416,17 @@
         return false;
       }
       return matchHostname(domain, conditionBlock.domain);
+    }
+    /**
+     * Takes a condition block and returns true if the current inject name matches the injectName.
+     * @param {ConditionBlock} conditionBlock
+     * @returns {boolean}
+     */
+    _matchInjectNameConditional(conditionBlock) {
+      if (!conditionBlock.injectName) return false;
+      const currentInjectName = this.injectName;
+      if (!currentInjectName) return false;
+      return conditionBlock.injectName === currentInjectName;
     }
     /**
      * Takes a condition block and returns true if the platform version satisfies the `minSupportedFeature`
@@ -6383,7 +6416,7 @@
       if (this.getFeatureSettingEnabled("modifyCookies")) {
         this.modifyCookies();
       }
-      if (this.getFeatureSettingEnabled("disableDeviceEnumeration") || this.getFeatureSettingEnabled("disableDeviceEnumerationFrames")) {
+      if (this.getFeatureSettingEnabled("disableDeviceEnumeration")) {
         this.preventDeviceEnumeration();
       }
       if (this.getFeatureSettingEnabled("enumerateDevices")) {
@@ -9367,7 +9400,6 @@
     const historyMethodProxy = new DDGProxy(urlChangedInstance, History.prototype, "pushState", {
       apply(target, thisArg, args) {
         const changeResult = DDGReflect.apply(target, thisArg, args);
-        console.log("pushstate event");
         handleURLChange("push");
         return changeResult;
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.12.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.2.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.3.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.5.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#9eea407ad208e8c021f4182d03274effa344e3b1",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#9dacc8aad23ddeef84a444704772ac934bb6f367",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -72,7 +72,7 @@
         "types-generator"
       ],
       "dependencies": {
-        "immutable-json-patch": "^6.0.1",
+        "immutable-json-patch": "^6.0.2",
         "urlpattern-polyfill": "^10.1.0"
       }
     },
@@ -128,9 +128,9 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
-      "integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -149,9 +149,9 @@
       }
     },
     "node_modules/@jridgewell/source-map": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.10.tgz",
-      "integrity": "sha512-0pPkgz9dY+bijgistcTTJ5mR+ocqRXLuhXHYdzoMmmoJ2C9S46RCm2GMUbatPEUK9Yjy26IrAy8D/M00lLkv+Q==",
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -160,16 +160,16 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
-      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.29",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
-      "integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
+      "version": "0.3.30",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
+      "integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -280,9 +280,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.2.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.0.tgz",
-      "integrity": "sha512-3xyG3pMCq3oYCNg7/ZP+E1ooTaGB4cG8JWRsqqOYQdbWNY4zbaV0Ennrd7stjiJEFZCaybcIgpTjJWHRfBSIDw==",
+      "version": "24.2.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
+      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.12.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.2.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.3.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.5.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1211047523970703/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run