### PR TITLE
Enable swiping on favorites

### DIFF
--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavoritesSwipeHandling.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/newtab/FavoritesSwipeHandling.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.savedsites.impl.newtab
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
+
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "favoritesSwipeHandling",
+)
+interface FavoritesSwipeHandling {
+    /**
+     * Kill switch for intercepting touch events in Favorites section to allow swiping
+     * If disabled remotely, the interception will not be requested
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun self(): Toggle
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1210986778088960?focus=true

### Description

- Enables swiping on favorites on the Input Screen.

### Steps to test this PR

- [x] Add some favorites
- [x] Go to the Input Screen
- [x] Swipe on the favorites
- [x] Verify that the ViewPager swipes to Duck.ai
- [x] Long press on a favorite
- [x] Verify that the Edit menu is shown
- [x] Drag a favorite
- [x] Verify that the favorite drags as expected
- [x] Go to the browser
- [x] Swipe between tabs
- [x] Verify that tabs swipe correctly
- [x] On a new tab, drag on favorites
- [x] Verify that the tabs swipe correctly

_Feature flag disabled_
- [x] In feature flag inventory, disable “favoritesSwipeHandling”
- [x] Verify that you can no longer swipe on favorites
- [x] Verify that swiping tabs still works
