### PR TITLE
Onboarding Design Experiment: Final fixes

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -3174,8 +3174,10 @@ class BrowserTabFragment :
         daxBubbleCta.hideDaxBubbleCta(binding)
         hideDaxBubbleCta()
         if (onboardingDesignExperimentManager.isBuckEnrolledAndEnabled()) {
-            if (daxBubbleCta is DaxBubbleCta.DaxEndCta) {
-                hideBuckEndAnimation()
+            when (daxBubbleCta) {
+                is DaxBubbleCta.DaxIntroSearchOptionsCta -> hideBuckMagnifyingGlassAnimation()
+                is DaxBubbleCta.DaxEndCta -> hideBuckEndAnimation()
+                else -> Unit
             }
         }
         renderer.showNewTab()
@@ -4520,12 +4522,15 @@ class BrowserTabFragment :
             }
 
             if (onboardingDesignExperimentManager.isBuckEnrolledAndEnabled()) {
-                if (configuration is DaxIntroVisitSiteOptionsCta && context?.resources?.getBoolean(R.bool.show_wing_animation) == true) {
-                    lifecycleScope.launch {
-                        with(newBrowserTab.wingAnimation) {
-                            delay(2.5.seconds)
-                            show()
-                            playAnimation()
+                if (configuration is DaxIntroVisitSiteOptionsCta) {
+                    hideBuckMagnifyingGlassAnimation()
+                    if (context?.resources?.getBoolean(R.bool.show_wing_animation) == true) {
+                        lifecycleScope.launch {
+                            with(newBrowserTab.wingAnimation) {
+                                delay(2.5.seconds)
+                                show()
+                                playAnimation()
+                            }
                         }
                     }
                 }
@@ -4734,6 +4739,10 @@ class BrowserTabFragment :
             newBrowserTab.buckMagnifyingGlassAnimation.isVisible = true
             newBrowserTab.buckMagnifyingGlassAnimation.playAnimation()
         }
+    }
+
+    private fun hideBuckMagnifyingGlassAnimation() {
+        newBrowserTab.buckMagnifyingGlassAnimation.isGone = true
     }
 
     private fun hideBuckEndAnimation() {

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -485,7 +485,8 @@ sealed class OnboardingDaxDialogCta(
                 onboardingDesignExperimentManager.isBbEnrolledAndEnabled() -> {
                     setBBOnboardingDialogView(
                         title = getTrackersDescription(context, trackers),
-                        description = context.getString(R.string.bbOnboardingTrackersBlockedDialogDescription),
+                        description = context.getString(R.string.bbOnboardingTrackersBlockedDialogDescription)
+                            .getStringForOmnibarPosition(settingsDataStore.omnibarPosition),
                         primaryCtaText = buttonText?.let { context.getString(it) },
                         binding = binding,
                         onTypingAnimationFinished = onTypingAnimationFinished,

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -912,11 +912,14 @@ sealed class OnboardingDaxDialogCta(
 
                     optionsViews.forEachIndexed { index, buttonView ->
                         options[index].setOptionView(buttonView)
-                        buttonView.animate().alpha(MAX_ALPHA).duration = DAX_DIALOG_APPEARANCE_ANIMATION
-                        buttonView.setOnClickListener {
-                            onSuggestedOptionClicked?.invoke(options[index], index)
-                            wingAnimation.gone()
-                        }
+                        buttonView.animate().alpha(MAX_ALPHA)
+                            .setDuration(DAX_DIALOG_APPEARANCE_ANIMATION)
+                            .withEndAction {
+                                buttonView.setOnClickListener {
+                                    onSuggestedOptionClicked?.invoke(options[index], index)
+                                    wingAnimation.gone()
+                                }
+                            }
                     }
 
                     showAndPlayWingAnimation()
@@ -1004,10 +1007,13 @@ sealed class OnboardingDaxDialogCta(
 
                     optionsViews.forEachIndexed { index, buttonView ->
                         options[index].setOptionView(buttonView)
-                        buttonView.animate().alpha(MAX_ALPHA).duration = DAX_DIALOG_APPEARANCE_ANIMATION
-                        buttonView.setOnClickListener {
-                            onSuggestedOptionClicked?.invoke(options[index], index)
-                        }
+                        buttonView.animate().alpha(MAX_ALPHA)
+                            .setDuration(DAX_DIALOG_APPEARANCE_ANIMATION)
+                            .withEndAction {
+                                buttonView.setOnClickListener {
+                                    onSuggestedOptionClicked?.invoke(options[index], index)
+                                }
+                            }
                     }
                 }
 

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BbWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BbWelcomePage.kt
@@ -273,6 +273,7 @@ class BbWelcomePage : OnboardingPageFragment(R.layout.content_onboarding_welcome
                             }
 
                             val titleText = getString(R.string.highlightsPreOnboardingDaxDialog1TitleBb)
+                            binding.daxDialogCta.initial.dialogTitleInvisible.text = titleText
 
                             afterTypingAnimation = {
                                 binding.daxDialogCta.initial.dialogTitle.finishAnimation()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207908166761516/task/1211042630873651?focus=true

### Description

This PR fixes several animation issues in the onboarding experience:

1. Added proper handling for hiding the Buck magnifying glass animation when showing DaxIntroSearchOptionsCta
2. Fixed the BB shield animating up as the text animation starts playing
3. Fixed a bug where click listeners were being set before animations completed

### Steps to test this PR

_BB Fixes_
- [x] Verify the shield does not move up as the text animation plays on the initial onboarding screen

_Buck Fixes_
- [x] Verify that the Buck magnifying glass animation properly hides when dismissing on new tabbing after "Try a Search"
- [x] Confirm that click listeners on search and site suggestion options only activate after animations complete. Tap them when they are not visible.

### UI changes
N/A