### PR TITLE
Update Maestro autofill tests to cater for promo showing

### DIFF
--- a/.maestro/autofill/3_autofill_prompted_to_save_creds_on_form.yaml
+++ b/.maestro/autofill/3_autofill_prompted_to_save_creds_on_form.yaml
@@ -23,6 +23,12 @@ tags:
 
         - tapOn:
             id: "username"
+
+        - runFlow: steps/decline_in_browser_password_import.promo.yaml
+
+        - tapOn:
+            id: "username"
+
         - inputText: "user"
         - tapOn:
             id: "password"

--- a/.maestro/autofill/backfillingUsername/multi_step_login_username_backfilled.yaml
+++ b/.maestro/autofill/backfillingUsername/multi_step_login_username_backfilled.yaml
@@ -22,6 +22,9 @@ tags:
 
       # simulate a partial login form by first submitting just the username
       - tapOn: "Username"
+      - runFlow: ../steps/decline_in_browser_password_import.promo.yaml
+      - tapOn: "Username"
+
       - inputText: "usernameFromBackfill"
       - pressKey: Back
 

--- a/.maestro/autofill/backfillingUsername/multi_step_login_username_not_backfilled_if_provided_explicitly.yaml
+++ b/.maestro/autofill/backfillingUsername/multi_step_login_username_not_backfilled_if_provided_explicitly.yaml
@@ -22,6 +22,9 @@ tags:
 
       # simulate a partial login form by first submitting just the username
       - tapOn: "Username"
+      - runFlow: ../steps/decline_in_browser_password_import.promo.yaml
+      - tapOn: "Username"
+
       - inputText: "usernameFromBackfill"
       - pressKey: Back
 

--- a/.maestro/autofill/backfillingUsername/multi_step_registration_username_backfilled_password_autogenerated.yaml
+++ b/.maestro/autofill/backfillingUsername/multi_step_registration_username_backfilled_password_autogenerated.yaml
@@ -22,6 +22,9 @@ tags:
 
       # simulate a partial form submission by first submitting just the username
       - tapOn: "Username"
+      - runFlow: ../steps/decline_in_browser_password_import.promo.yaml
+      - tapOn: "Username"
+
       - inputText: "usernameFromBackfill"
       - pressKey: Back
 

--- a/.maestro/autofill/backfillingUsername/multi_step_registration_username_backfilled_password_manually_entered.yaml
+++ b/.maestro/autofill/backfillingUsername/multi_step_registration_username_backfilled_password_manually_entered.yaml
@@ -22,7 +22,11 @@ tags:
 
       # simulate a partial form submission by first submitting just the username
       - tapOn: "Username"
+      - runFlow: ../steps/decline_in_browser_password_import.promo.yaml
+      - tapOn: "Username"
       - inputText: "usernameFromBackfill"
+      - tapOn: "Username"
+
       - pressKey: Back
 
       - tapOn:

--- a/.maestro/autofill/backfillingUsername/password_reset_flow_autogenerated_password.yaml
+++ b/.maestro/autofill/backfillingUsername/password_reset_flow_autogenerated_password.yaml
@@ -22,6 +22,9 @@ tags:
 
       # simulate a partial login form by first submitting just the username
       - tapOn: "Username"
+      - runFlow: ../steps/decline_in_browser_password_import.promo.yaml
+      - tapOn: "Username"
+
       - inputText: "usernameFromBackfill"
       - pressKey: Back
 

--- a/.maestro/autofill/backfillingUsername/password_reset_flow_for_existing_credential_generated_password.yaml
+++ b/.maestro/autofill/backfillingUsername/password_reset_flow_for_existing_credential_generated_password.yaml
@@ -22,6 +22,9 @@ tags:
 
       # simulate a partial login form by first submitting just the username
       - tapOn: "Username"
+      - runFlow: ../steps/decline_in_browser_password_import.promo.yaml
+      - tapOn: "Username"
+
       - inputText: "existingUser"
       - pressKey: Back
 

--- a/.maestro/autofill/steps/decline_in_browser_password_import.promo.yaml
+++ b/.maestro/autofill/steps/decline_in_browser_password_import.promo.yaml
@@ -1,0 +1,9 @@
+appId: com.duckduckgo.mobile.android
+---
+
+# dismiss any offers to autofill from existing credentials
+- runFlow:
+    when:
+      visible: "Bring your passwords from Google to DuckDuckGo"
+    commands:
+      - tapOn: "Don't Ask Again"

--- a/.maestro/autofill/steps/search_logins.yaml
+++ b/.maestro/autofill/steps/search_logins.yaml
@@ -16,6 +16,16 @@ name: "Autofill: Search credentials"
     commands:
       - tapOn: "No thanks"
 
+- runFlow:
+    when:
+      visible: "Bring your passwords from
+
+        Google to DuckDuckGo"
+    commands:
+        - tapOn:
+            id: "com.duckduckgo.mobile.android:id/close"
+
+
 - tapOn:
     id: searchLogins
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211013100415552/task/1211065390493169?focus=true 

### Description
Update maestro e2e autofills tests to handle in-browser password import dialog showing up

### Steps to test this PR

- [x] QA optional / [tested on CI](https://app.maestro.dev/project/proj_01htg54rdtfwx8rgbzv03cxkpf/maestro-test/app/app_01hkqhj1thevwtn9ym8a2ctn2r/upload/mupload_01k2mhe362ed4b6y0ydftyp6h7?sort=name&status=all) already
- [ ] [optional] If you want to run locally, you can do `maestro test .maestro --include-tags autofillNoAuthTests,autofillPasswordGeneration,autofillBackfillingUsername` after building an APK with `-Pautofill-disable-auth-requirement -Pforce-default-variant -Pskip-onboarding`