### PR TITLE
Include more autofill maestro tests in CI job

### DIFF
--- a/.github/workflows/e2e-nightly-autofill.yml
+++ b/.github/workflows/e2e-nightly-autofill.yml
@@ -60,12 +60,25 @@ jobs:
         with:
           api-key: ${{ secrets.ROBIN_API_KEY }}
           project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
-          name: autofill_${{ github.sha }}
+          name: autofill_critical_path_${{ github.sha }}
           timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           app-file: apk/release.apk
           android-api-level: 30
           workspace: .maestro
           include-tags: autofillNoAuthTests
+
+      - name: Autofill web flows
+        uses: mobile-dev-inc/action-maestro-cloud@v1.9.8
+        timeout-minutes: 120
+        with:
+          api-key: ${{ secrets.ROBIN_API_KEY }}
+          project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
+          name: autofill_secondary_functionality_${{ github.sha }}
+          timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
+          app-file: apk/release.apk
+          android-api-level: 30
+          workspace: .maestro
+          include-tags: autofillBackfillingUsername,autofillPasswordGeneration
 
       - name: Create Asana task when workflow failed
         if: ${{ failure() }}
@@ -75,6 +88,6 @@ jobs:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
           asana-section: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
-          asana-task-name: GH Workflow Failure - Autofill Critical Path E2E Flows (Robin)
-          asana-task-description: Autofill critical path tests have failed. See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}
+          asana-task-name: GH Workflow Failure - Autofill E2E Flows (Robin)
+          asana-task-description: Autofill tests have failed. See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}
           action: 'create-asana-task'


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/608920331025315/task/1211065314424892?focus=true 

### Description
Adds more autofill tests into CI 
- autofillBackfillingUsername
- autofillPasswordGeneration

### Steps to test this PR
- [ ] QA optional
- [ ] Tested in CI here: https://github.com/duckduckgo/Android/actions/runs/16991285305