### PR TITLE
Fix: Use the previous pixel to measure Duck.ai discovery in tab switcher

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -589,7 +589,7 @@ class TabSwitcherViewModel @Inject constructor(
     fun onDuckAIButtonClicked() {
         viewModelScope.launch {
             val params = duckChat.createWasUsedBeforePixelParams()
-            pixel.fire(DuckChatPixelName.DUCK_CHAT_OPEN_NEW_TAB_MENU, parameters = params)
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_OPEN_TAB_SWITCHER_FAB, parameters = params)
 
             duckChat.openDuckChat()
         }

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -845,7 +845,7 @@ class TabSwitcherViewModelTest {
 
         testee.onDuckAIButtonClicked()
 
-        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_OPEN_NEW_TAB_MENU, mapOf("was_used_before" to "0"))
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_OPEN_TAB_SWITCHER_FAB, mapOf("was_used_before" to "0"))
         verify(duckChatMock).openDuckChat()
     }
 
@@ -855,7 +855,7 @@ class TabSwitcherViewModelTest {
 
         testee.onDuckAIButtonClicked()
 
-        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_OPEN_NEW_TAB_MENU, mapOf("was_used_before" to "1"))
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_OPEN_TAB_SWITCHER_FAB, mapOf("was_used_before" to "1"))
         verify(duckChatMock).openDuckChat()
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1211066471579596?focus=true

### Description

This PR changes the pixel sent when the Duck.ai toolbar button is clicked to `aichat_open_tab_switcher_fab`.

### Steps to test this PR

- [ ] Go to the tab switcher
- [ ] Tap on the Duck.ai button
- [ ] Verify the `aichat_open_tab_switcher_fab` pixel is sent
