### PR TITLE
automatically launch the Input Screen when New Tab Page opened

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1100,19 +1100,23 @@ class BrowserTabFragment :
 
     private fun configureInputScreenLauncher() {
         omnibar.configureInputScreenLaunchListener { query ->
-            val intent = globalActivityStarter.startIntent(
-                requireContext(),
-                InputScreenActivityParams(query = query),
-            )
-            val enterTransition = browserAndInputScreenTransitionProvider.getInputScreenEnterAnimation()
-            val exitTransition = browserAndInputScreenTransitionProvider.getBrowserExitAnimation()
-            val options = ActivityOptionsCompat.makeCustomAnimation(
-                requireActivity(),
-                enterTransition,
-                exitTransition,
-            )
-            inputScreenLauncher.launch(intent, options)
+            launchInputScreen(query)
         }
+    }
+
+    private fun launchInputScreen(query: String) {
+        val intent = globalActivityStarter.startIntent(
+            requireContext(),
+            InputScreenActivityParams(query = query),
+        )
+        val enterTransition = browserAndInputScreenTransitionProvider.getInputScreenEnterAnimation()
+        val exitTransition = browserAndInputScreenTransitionProvider.getBrowserExitAnimation()
+        val options = ActivityOptionsCompat.makeCustomAnimation(
+            requireActivity(),
+            enterTransition,
+            exitTransition,
+        )
+        inputScreenLauncher.launch(intent, options)
     }
 
     private fun configureNavigationBar() {
@@ -2202,6 +2206,12 @@ class BrowserTabFragment :
 
             is Command.StartTrackersExperimentShieldPopAnimation -> showTrackersExperimentShieldPopAnimation()
             is Command.RefreshOmnibar -> renderer.refreshOmnibar()
+            is Command.LaunchInputScreen -> {
+                // if the fire button is used, prevent automatically launching the input screen until the process reloads
+                if ((requireActivity() as? BrowserActivity)?.isDataClearingInProgress == false) {
+                    launchInputScreen(query = "")
+                }
+            }
             else -> {
                 // NO OP
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -375,6 +375,7 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flatMapLatest
@@ -737,12 +738,11 @@ class BrowserTabViewModel @Inject constructor(
             .flatMapLatest { inputScreenEnabled ->
                 if (inputScreenEnabled) {
                     tabRepository.flowSelectedTab
-                        .map { selectedTab -> selectedTab?.tabId }
-                        .distinctUntilChanged() // only observe when the tab changes and ignore further updates
-                        .filter { selectedTabId ->
+                        .distinctUntilChangedBy { selectedTab -> selectedTab?.tabId } // only observe when the tab changes and ignore further updates
+                        .filter { selectedTab ->
                             // if the tab managed by this view model has just been activated, and it's a new tab (it has no URL), then fire an event
-                            val isActiveTab = selectedTabId == tabId
-                            isActiveTab && tabRepository.getTab(tabId)?.url.isNullOrBlank()
+                            val isActiveTab = selectedTab?.tabId == tabId
+                            isActiveTab && selectedTab?.url.isNullOrBlank()
                         }
                 } else {
                     flowOf()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -742,12 +742,7 @@ class BrowserTabViewModel @Inject constructor(
                         .filter { selectedTabId ->
                             // if the tab managed by this view model has just been activated, and it's a new tab (it has no URL), then fire an event
                             val isActiveTab = selectedTabId == tabId
-                            if (isActiveTab) {
-                                val thisTab = tabRepository.getTab(tabId)
-                                thisTab != null && thisTab.url.isNullOrBlank()
-                            } else {
-                                false
-                            }
+                            isActiveTab && tabRepository.getTab(tabId)?.url.isNullOrBlank()
                         }
                 } else {
                     flowOf()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -105,6 +105,7 @@ import com.duckduckgo.app.browser.commands.Command.LaunchAddWidget
 import com.duckduckgo.app.browser.commands.Command.LaunchAutofillSettings
 import com.duckduckgo.app.browser.commands.Command.LaunchBookmarksActivity
 import com.duckduckgo.app.browser.commands.Command.LaunchFireDialogFromOnboardingDialog
+import com.duckduckgo.app.browser.commands.Command.LaunchInputScreen
 import com.duckduckgo.app.browser.commands.Command.LaunchNewTab
 import com.duckduckgo.app.browser.commands.Command.LaunchPopupMenu
 import com.duckduckgo.app.browser.commands.Command.LaunchPrivacyPro
@@ -375,7 +376,9 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -394,6 +397,7 @@ import org.json.JSONObject
 
 private const val SCAM_PROTECTION_REPORT_ERROR_URL = "https://duckduckgo.com/malicious-site-protection/report-error?url="
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @ContributesViewModel(FragmentScope::class)
 class BrowserTabViewModel @Inject constructor(
     private val statisticsUpdater: StatisticsUpdater,
@@ -725,6 +729,34 @@ class BrowserTabViewModel @Inject constructor(
         additionalDefaultBrowserPrompts.showSetAsDefaultPopupMenuItem
             .onEach {
                 browserViewState.value = currentBrowserViewState().copy(showSelectDefaultBrowserMenuItem = it)
+            }
+            .launchIn(viewModelScope)
+
+        // observe when user open a new tab page and launch the input screen
+        duckAiFeatureState.showInputScreen
+            .flatMapLatest { inputScreenEnabled ->
+                if (inputScreenEnabled) {
+                    tabRepository.flowSelectedTab
+                        .map { selectedTab -> selectedTab?.tabId }
+                        .distinctUntilChanged() // only observe when the tab changes and ignore further updates
+                        .filter { selectedTabId ->
+                            // if the tab managed by this view model has just been activated, and it's a new tab (it has no URL), then fire an event
+                            val isActiveTab = selectedTabId == tabId
+                            if (isActiveTab) {
+                                val thisTab = tabRepository.getTab(tabId)
+                                thisTab != null && thisTab.url.isNullOrBlank()
+                            } else {
+                                false
+                            }
+                        }
+                } else {
+                    flowOf()
+                }
+            }
+            .flowOn(dispatchers.main()) // don't use the immediate dispatcher so that the tabId field has a chance to initialize
+            .onEach {
+                // whenever an event fires, so the user switched to a new tab page, launch the input screen
+                command.value = LaunchInputScreen
             }
             .launchIn(viewModelScope)
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
@@ -279,4 +279,5 @@ sealed class Command {
     data object LaunchBookmarksActivity : Command()
     data object StartTrackersExperimentShieldPopAnimation : Command()
     data object RefreshOmnibar : Command()
+    data object LaunchInputScreen : Command()
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1211056807546917?focus=true

### Description
With this PR, whenever a New Tab Page is opened, the Input Screen will be launched automatically.

Implementing this had some challenges given how complex and fragile the keyboard management implementation is.

I couldn't rely on the `BrowserTabFragment#onViewVisible`, which is currently used to auto-focus on the omnibar, because that's getting called whenever the fragment is resumed. So, if the logic to open the Input Screen was part of this function, closing the Input Screen (which is a separate activity) would resume the fragment and open the Input Screen again, resulting in a loop.

Instead, I added the logic to observe whenever the tab changes and dispatch a command to launch the Input Screen when user switches to a New Tab Page (this tab has no URL). This logic lives as part of each `BrowserTabFragment` so that the current active fragment, if it's a new tab page, can launch the Input Screen and then listen for its results.

### Steps to test this PR

- [x] Install a clean build of the app.
- [x] Verify that opening a new tab page focuses on the omnibar automatically.
- [x] Open a web page or SERP and verify that switching to a page doesn't focus on the omnibar automatically.
- [x] Go to Settings -> AI Features and enable the Experimental Address bar.
- [x] Go back to the browser and verify that creating a New Tab opens the Input Screen automatically.
- [x] Back out from the Input Screen and verify you can see the New Tab Page.
- [x] Go to another tab with a web page or SERP and verify that the Input Screen doesn't open automatically.
- [x] Go back to the existing New Tab card in the tab switcher and verify that the Input Screen Opens automatically.
- [x] Close the app.
- [x] Reopen the app.
- [x] Verify that the Input Screen launches automatically (because you're still on a New Tab Page).
- [x] Use the fire button and verify that the Input Screen automatically opens only after the fire animation finishes and the process restarts.

### UI changes

https://github.com/user-attachments/assets/11bf872d-bc09-46b4-9ecf-77a4a843a064

