### PR TITLE
Update DuckChat.isEnabled to check config flag and user pref

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
@@ -105,7 +105,7 @@ class SpecialUrlDetectorImpl(
 
         val uri = uriString.toUri()
 
-        if (duckChat.isEnabled() && duckChat.isDuckChatUrl(uri)) {
+        if (duckChat.isDuckChatUrl(uri)) {
             return UrlType.ShouldLaunchDuckChatLink
         }
 

--- a/app/src/test/java/com/duckduckgo/app/browser/SpecialUrlDetectorImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/SpecialUrlDetectorImplTest.kt
@@ -485,10 +485,9 @@ class SpecialUrlDetectorImplTest {
     }
 
     @Test
-    fun whenDuckChatIsEnabledAndIsDuckChatUrlThenReturnShouldLaunchDuckChatLink() = runTest {
-        whenever(mockDuckChat.isEnabled()).thenReturn(true)
+    fun whenIsDuckChatUrlThenReturnShouldLaunchDuckChatLink() = runTest {
         whenever(mockDuckChat.isDuckChatUrl(any())).thenReturn(true)
-        val type = testee.determineType("https://example.com")
+        val type = testee.determineType("https://duck.ai")
         whenever(mockPackageManager.resolveActivity(any(), eq(PackageManager.MATCH_DEFAULT_ONLY))).thenReturn(null)
         whenever(mockPackageManager.queryIntentActivities(any(), anyInt())).thenReturn(
             listOf(
@@ -501,9 +500,8 @@ class SpecialUrlDetectorImplTest {
     }
 
     @Test
-    fun whenDuckChatIsDisabledAndIsDuckChatUrlThenDoNotReturnShouldLaunchDuckChatLink() = runTest {
-        whenever(mockDuckChat.isEnabled()).thenReturn(false)
-        whenever(mockDuckChat.isDuckChatUrl(any())).thenReturn(true)
+    fun whenIsNotDuckChatUrlThenDoNotReturnShouldLaunchDuckChatLink() = runTest {
+        whenever(mockDuckChat.isDuckChatUrl(any())).thenReturn(false)
         val type = testee.determineType("https://example.com")
         whenever(mockPackageManager.resolveActivity(any(), eq(PackageManager.MATCH_DEFAULT_ONLY))).thenReturn(null)
         whenever(mockPackageManager.queryIntentActivities(any(), anyInt())).thenReturn(

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
@@ -23,7 +23,7 @@ import android.net.Uri
  */
 interface DuckChat {
     /**
-     * Checks whether DuckChat is enabled based on remote config flag.
+     * Checks whether DuckChat is enabled based on remote config flag and user preference.
      * Uses a cached value - does not perform disk I/O.
      *
      * @return true if DuckChat is enabled, false otherwise.

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
@@ -111,7 +111,7 @@ class RealDuckChatJSHelper @Inject constructor(
     ): JsCallbackData {
         val jsonPayload = JSONObject().apply {
             put(PLATFORM, ANDROID)
-            put(IS_HANDOFF_ENABLED, duckChat.isEnabled())
+            put(IS_HANDOFF_ENABLED, duckChat.isDuckChatFeatureEnabled())
             put(PAYLOAD, runBlocking { dataStore.fetchAndClearUserPreferences() })
         }
         return JsCallbackData(jsonPayload, featureName, method, id)
@@ -124,7 +124,7 @@ class RealDuckChatJSHelper @Inject constructor(
     ): JsCallbackData {
         val jsonPayload = JSONObject().apply {
             put(PLATFORM, ANDROID)
-            put(IS_HANDOFF_ENABLED, duckChat.isEnabled())
+            put(IS_HANDOFF_ENABLED, duckChat.isDuckChatFeatureEnabled())
             put(SUPPORTS_CLOSING_AI_CHAT, true)
             put(SUPPORTS_OPENING_SETTINGS, true)
             put(SUPPORTS_NATIVE_CHAT_INPUT, false)

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -133,13 +133,39 @@ class RealDuckChatTest {
     }
 
     @Test
-    fun whenDuckChatIsEnabledThenReturnTrue() = runTest {
+    fun whenDuckChatFeatureEnabledAndUserEnabledThenIsEnabledReturnsTrue() = runTest {
+        duckChatFeature.self().setRawStoredState(State(true))
+        whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
+
+        testee.onPrivacyConfigDownloaded()
+
         assertTrue(testee.isEnabled())
     }
 
     @Test
-    fun whenDuckChatIsDisabledThenReturnFalse() = runTest {
+    fun whenDuckChatFeatureDisabledAndUserEnabledThenIsEnabledReturnsFalse() = runTest {
         duckChatFeature.self().setRawStoredState(State(false))
+        whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
+
+        testee.onPrivacyConfigDownloaded()
+
+        assertFalse(testee.isEnabled())
+    }
+
+    @Test
+    fun whenDuckChatFeatureEnabledAndUserDisabledThenIsEnabledReturnsFalse() = runTest {
+        duckChatFeature.self().setRawStoredState(State(true))
+        whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(false)
+
+        testee.onPrivacyConfigDownloaded()
+
+        assertFalse(testee.isEnabled())
+    }
+
+    @Test
+    fun whenDuckChatFeatureDisabledAndUserDisabledThenIsEnabledReturnsFalse() = runTest {
+        duckChatFeature.self().setRawStoredState(State(false))
+        whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(false)
 
         testee.onPrivacyConfigDownloaded()
 
@@ -375,6 +401,14 @@ class RealDuckChatTest {
     @Test
     fun whenIsNotDuckDuckGoHostAndDuckChatEnabledThenIsNotDuckChatUrl() {
         assertFalse(testee.isDuckChatUrl("https://example.com/?ia=chat".toUri()))
+    }
+
+    @Test
+    fun whenDuckChatFeatureDisabledThenIsDuckChatUrlReturnsFalse() {
+        duckChatFeature.self().setRawStoredState(State(enable = false))
+        testee.onPrivacyConfigDownloaded()
+
+        assertFalse(testee.isDuckChatUrl("https://duckduckgo.com/?ia=chat".toUri()))
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
@@ -74,12 +74,12 @@ class RealDuckChatJSHelperTest {
     }
 
     @Test
-    fun whenGetAIChatNativeHandoffDataAndDuckChatEnabledThenReturnJsCallbackDataWithDuckChatEnabled() = runTest {
+    fun whenGetAIChatNativeHandoffDataAndDuckChatFeatureEnabledThenReturnJsCallbackDataWithDuckChatEnabled() = runTest {
         val featureName = "aiChat"
         val method = "getAIChatNativeHandoffData"
         val id = "123"
 
-        whenever(mockDuckChat.isEnabled()).thenReturn(true)
+        whenever(mockDuckChat.isDuckChatFeatureEnabled()).thenReturn(true)
         whenever(mockDataStore.fetchAndClearUserPreferences()).thenReturn("preferences")
 
         val result = testee.processJsCallbackMessage(featureName, method, id, null)
@@ -99,12 +99,12 @@ class RealDuckChatJSHelperTest {
     }
 
     @Test
-    fun whenGetAIChatNativeHandoffDataAndDuckChatDisabledThenReturnJsCallbackDataWithDuckChatDisabled() = runTest {
+    fun whenGetAIChatNativeHandoffDataAndDuckChatFeatureDisabledThenReturnJsCallbackDataWithDuckChatDisabled() = runTest {
         val featureName = "aiChat"
         val method = "getAIChatNativeHandoffData"
         val id = "123"
 
-        whenever(mockDuckChat.isEnabled()).thenReturn(false)
+        whenever(mockDuckChat.isDuckChatFeatureEnabled()).thenReturn(false)
         whenever(mockDataStore.fetchAndClearUserPreferences()).thenReturn("preferences")
 
         val result = testee.processJsCallbackMessage(featureName, method, id, null)
@@ -129,7 +129,7 @@ class RealDuckChatJSHelperTest {
         val method = "getAIChatNativeHandoffData"
         val id = "123"
 
-        whenever(mockDuckChat.isEnabled()).thenReturn(true)
+        whenever(mockDuckChat.isDuckChatFeatureEnabled()).thenReturn(true)
         whenever(mockDataStore.fetchAndClearUserPreferences()).thenReturn(null)
 
         val result = testee.processJsCallbackMessage(featureName, method, id, null)
@@ -159,12 +159,12 @@ class RealDuckChatJSHelperTest {
     }
 
     @Test
-    fun whenGetAIChatNativeConfigValuesAndDuckChatEnabledThenReturnJsCallbackDataWithDuckChatEnabled() = runTest {
+    fun whenGetAIChatNativeConfigValuesAndDuckChatFeatureEnabledThenReturnJsCallbackDataWithDuckChatEnabled() = runTest {
         val featureName = "aiChat"
         val method = "getAIChatNativeConfigValues"
         val id = "123"
 
-        whenever(mockDuckChat.isEnabled()).thenReturn(true)
+        whenever(mockDuckChat.isDuckChatFeatureEnabled()).thenReturn(true)
 
         val result = testee.processJsCallbackMessage(featureName, method, id, null)
 
@@ -186,12 +186,12 @@ class RealDuckChatJSHelperTest {
     }
 
     @Test
-    fun whenGetAIChatNativeConfigValuesAndDuckChatDisabledThenReturnJsCallbackDataWithDuckChatDisabled() = runTest {
+    fun whenGetAIChatNativeConfigValuesAndDuckChatFeatureDisabledThenReturnJsCallbackDataWithDuckChatDisabled() = runTest {
         val featureName = "aiChat"
         val method = "getAIChatNativeConfigValues"
         val id = "123"
 
-        whenever(mockDuckChat.isEnabled()).thenReturn(false)
+        whenever(mockDuckChat.isDuckChatFeatureEnabled()).thenReturn(false)
 
         val result = testee.processJsCallbackMessage(featureName, method, id, null)
 
@@ -350,7 +350,7 @@ class RealDuckChatJSHelperTest {
         val method = "getAIChatNativeConfigValues"
         val id = "123"
 
-        whenever(mockDuckChat.isEnabled()).thenReturn(true)
+        whenever(mockDuckChat.isDuckChatFeatureEnabled()).thenReturn(true)
         whenever(mockDuckChat.isImageUploadEnabled()).thenReturn(true)
 
         val result = testee.processJsCallbackMessage(featureName, method, id, null)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1211088838900418?focus=true

### Description

- Modifies `DuckChat.isEnabled` to check the config flag and user pref.

### Steps to test this PR

_Sanity check_
- [x] Disable Duck.ai user setting
- [x] Verify that Duck.ai is disabled
- [x] Enable Duck.ai user setting
- [x] Verify that Duck.ai is enabled
- [x] In feature flag inventory, disable `aiChat` feature flag
- [x] Restart the app
- [x] Verify that Duck.ai is disabled