### PR TITLE
Update content scope scripts to version 11.6.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -514,7 +514,7 @@
         return global ? result || [] : result && result[0];
       };
       XRegExp.matchChain = function(str, chain) {
-        return function recurseChain(values, level) {
+        return (function recurseChain(values, level) {
           var item = chain[level].regex ? chain[level] : { regex: chain[level] };
           var matches = [];
           function addMatch(match) {
@@ -531,7 +531,7 @@
             XRegExp.forEach(values[i], item.regex, addMatch);
           }
           return level === chain.length - 1 || !matches.length ? matches : recurseChain(matches, level + 1);
-        }([str], 0);
+        })([str], 0);
       };
       XRegExp.replace = function(str, search, replacement, scope) {
         var isRegex = XRegExp.isRegExp(search);

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -6331,7 +6331,10 @@
   function canShare(data) {
     if (typeof data !== "object") return false;
     if (!("url" in data) && !("title" in data) && !("text" in data)) return false;
-    if ("files" in data) return false;
+    if ("files" in data) {
+      if (!Array.isArray(data.files)) return false;
+      if (data.files.length > 0) return false;
+    }
     if ("title" in data && typeof data.title !== "string") return false;
     if ("text" in data && typeof data.text !== "string") return false;
     if ("url" in data) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.13.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.3.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.5.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.6.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.13.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.13.0.tgz",
-      "integrity": "sha512-G+xx5+nVynFN9lVxedaoZP7CO5W/P1eb0DWc/XKh0MCItFHBZqXzSXx2t8mukHqMkOsLjF6edRhVBn77DV4+yA==",
+      "version": "14.14.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.14.0.tgz",
+      "integrity": "sha512-0z+o6XXQYZJe2JxWfMzTzpL9dthSFcJzG0NNqK+SxVmH1nTTwe7MjY11CP9FbPt3l8R6AvnkEPGw1w30sEtvkw==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#9dacc8aad23ddeef84a444704772ac934bb6f367",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#4d3fcb75781f0ed3a7aef1b86330d499a2639071",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -280,9 +280,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.2.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
-      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -667,18 +667,18 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.11.tgz",
-      "integrity": "sha512-65eeOpBwWBabh0XqT+zB0vEllq/V3XcrF2fhgMXWWFfNw1yxEjeYg9Vv/B/UNozd0CTR/TohO1ubfn6O6mBW3w==",
+      "version": "7.0.12",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.12.tgz",
+      "integrity": "sha512-3K76aXywJFduGRsOYoY5JzINLs/WMlOkeDwPL+8OCPq2Rh39gkSDtWAxdJQlWjpun/xF/LHf29yqCi6VC/rHDA==",
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.11.tgz",
-      "integrity": "sha512-sRNdw7r83Ea16IYr8MMaGGv0Tk4kJktFi1T/vHB5NQXmeeOPhdTVlyOu3qYktzOS82y6dZSlkmzfS4bjZ9oynQ==",
+      "version": "7.0.12",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.12.tgz",
+      "integrity": "sha512-riDDp/JrJJuh/2GV1Tgg6OnOwcWlgleBKi4/xkhd0DW7tvvmNjmWXCh2nj7Z2G1k9S/AGN4RiiPRbvhGJUCxeg==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.11"
+        "tldts-core": "^7.0.12"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.13.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.3.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.5.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.6.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1211097811485365/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [x] All tests must pass
- [x] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run