### PR TITLE
do not open the Input Screen when user pref toggled on and immediately off

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -7073,6 +7073,30 @@ class BrowserTabViewModelTest {
         )
     }
 
+    @Test
+    fun whenInputScreenPrefChangesToEnabledThenLaunchInputScreenCommandNotTriggered() = runTest {
+        val initialTabId = "initial-tab"
+        val initialTab = TabEntity(tabId = initialTabId, url = "https://example.com", title = "EX", skipHome = false, viewed = true, position = 0)
+        val ntpTabId = "ntp-tab"
+        val ntpTab = TabEntity(tabId = ntpTabId, url = null, title = "", skipHome = false, viewed = true, position = 0)
+        whenever(mockTabRepository.getTab(initialTabId)).thenReturn(initialTab)
+        whenever(mockTabRepository.getTab(ntpTabId)).thenReturn(ntpTab)
+        flowSelectedTab.emit(initialTab)
+
+        testee.loadData(ntpTabId, null, false, false)
+        mockDuckAiFeatureStateInputScreenFlow.emit(false)
+
+        flowSelectedTab.emit(ntpTab)
+        mockDuckAiFeatureStateInputScreenFlow.emit(true)
+
+        verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
+        val commands = commandCaptor.allValues
+        assertFalse(
+            "LaunchInputScreen command should NOT be triggered when preference is toggled",
+            commands.any { it is Command.LaunchInputScreen },
+        )
+    }
+
     private fun aCredential(): LoginCredentials {
         return LoginCredentials(domain = null, username = null, password = null)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1211091584703241?focus=true

### Description
Fixes an issue where toggling the experimental address bar on and then immediately off again in "AI Features" settings still caused the Input Screen to open when returning to the browser (if left on a New Tab Page).

#### Root Cause
The Input Screen preferences flow in the `BrowserTabViewModel` (and its nested flow that launches the Input Screen on NTP) was being restarted every time the preference changed. As a result, toggling the setting caused a re-evaluation, which queued a command to launch the Input Screen when returning to the browser.

#### Fix
Instead of observing the Input Screen preference flow directly, we now filter out events when the preference is disabled. This prevents unnecessary re-evaluations on every toggle, while still ensuring that whenever the tab changes, the current preference state is correctly respected.

### Steps to test this PR

- [ ] Install a clean build of the app.
- [ ] Open a new tab and ensure that the address bar gets focused but the Input Screen doesn't open.
- [ ] Go to Settings -> AI Features
- [ ] Enabled Experimental Address Bar
- [ ] Disabled Experimental Address Bar
- [ ] Go back to the browser and verify that Input Screen is not opened
- [ ] (optional) Try some additional test steps from https://github.com/duckduckgo/Android/pull/6604 to ensure that the feature still works as expected otherwise
