### PR TITLE
Remove self-reference from BrowserTabFragment#viewModel init

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -625,7 +625,6 @@ class BrowserTabFragment :
     private val viewModel: BrowserTabViewModel by lazy {
         val viewModel = ViewModelProvider(this, viewModelFactory)[BrowserTabViewModel::class.java]
         viewModel.loadData(tabId, initialUrl, skipHome, isLaunchedFromExternalApp)
-        launchDownloadMessagesJob()
         viewModel
     }
 
@@ -1061,6 +1060,8 @@ class BrowserTabFragment :
         if (swipingTabsFeature.isEnabled) {
             disableSwipingOutsideTheOmnibar()
         }
+
+        launchDownloadMessagesJob()
     }
 
     private fun updateOrDeleteWebViewPreview() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1211082171468041?focus=true

### Description

Moved the `launchDownloadMessagesJob()` call from the ViewModel creation to the `onActivityCreated` lifecycle method in `BrowserTabFragment`. This removes the self-reference from BrowserTabFragment#viewModel init.

### Steps to test this PR

_ViewModel init lazy block called once_
- [x] Checkout this branch. 
- [x] Add a log at line [627](https://github.com/duckduckgo/Android/blob/7c0c92e1412403475e87da00f685d1c5e7771f71/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt#L627), something like:
`logcat { "BrowserTabViewModel lazy block -- ${System.identityHashCode(viewModel)}" }`
- [x] Install from this branch.
- [x] Filter logcat by `BrowserTabViewModel lazy block`
- [x] Open a few tabs an notice the message in logcat is called only once per tab created. 
- [x] Go back to a previously opened tab and notice the message is not printed in logcat.
 
_Download Messages_
- [x] Start a download and verify that download Snackbars (download started and download finished) appear correctly.
- [x] Test with multiple downloads. Ie. download a test file from https://www.thinkbroadband.com/download or download an image by long tapping on it and selecting the download action.

### NO UI changes