### PR TITLE
Enable Gradle configuration cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
 
       - name: Run Android Tests
         if: steps.check-alignment.outcome == 'success'
-        run: ./gradlew runFlankAndroidTests
+        run: ./gradlew runFlankAndroidTests --no-configuration-cache
 
       - name: Bundle the Android CI tests report
         if: |

--- a/.github/workflows/external-ref-tests.yml
+++ b/.github/workflows/external-ref-tests.yml
@@ -98,7 +98,7 @@ jobs:
         run: ./gradlew androidTestsBuild
 
       - name: Run Android Tests
-        run: ./gradlew runFlankAndroidTests
+        run: ./gradlew runFlankAndroidTests --no-configuration-cache
 
       - name: Bundle the Android CI tests report
         if: always()

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -141,7 +141,7 @@ jobs:
         run: ./gradlew androidTestsBuild
 
       - name: Run Android Tests
-        run: ./gradlew runFlankAndroidTests
+        run: ./gradlew runFlankAndroidTests --no-configuration-cache
 
       - name: Bundle the Android CI tests report
         if: always()

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,6 +20,7 @@ org.gradle.caching=true
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 org.gradle.parallel=true
 org.gradle.configureondemand=true
+org.gradle.configuration-cache=true
 android.defaults.buildfeatures.buildconfig=true
 android.nonFinalResIds=false
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207908166761516/task/1211090750035753?focus=true

### Description
Enable Gradle configuration cache by adding `org.gradle.configuration-cache=true` to gradle.properties. This optimization will speed up build times by caching the configuration phase of the build process.

### Steps to test this PR

_Build Performance_
- [ ] Run a clean build and verify it completes successfully
- [ ] Run a second build and verify it's faster due to the configuration cache
- [ ] Check the build logs for confirmation that configuration cache is being used

### UI changes
No UI changes in this PR.