### PR TITLE
Improve sync observability around disabling

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
@@ -564,6 +564,8 @@ class AppSyncAccountRepository @Inject constructor(
     }
 
     override fun deleteAccount(): Result<Boolean> {
+        syncPixels.fireUserConfirmedToTurnOffSyncAndDelete(connectedDevicesCached.size)
+
         val token = syncStore.token.takeUnless {
             it.isNullOrEmpty()
         } ?: return Error(reason = "Delete account: Token Empty").alsoFireDeleteAccountErrorPixel()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModel.kt
@@ -264,6 +264,8 @@ class SyncActivityViewModel @Inject constructor(
 
     fun onTurnOffSyncConfirmed(connectedDevice: ConnectedDevice) {
         viewModelScope.launch(dispatchers.io()) {
+            syncPixels.fireUserConfirmedToTurnOffSync()
+
             viewState.value = viewState.value.hideAccount()
             when (val result = syncAccountRepository.logout(connectedDevice.deviceId)) {
                 is Error -> {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
@@ -883,6 +883,32 @@ class AppSyncAccountRepositoryTest {
         }
     }
 
+    @Test
+    fun whenAccountDeletedWithASingleConnectedDeviceThenPixelFired() {
+        prepareForExchangeSuccess()
+        whenever(syncApi.deleteAccount(token)).thenReturn(deleteAccountSuccess)
+        configureAsSignedWithConnectedDevices(1)
+        syncRepo.deleteAccount()
+        verify(syncPixels).fireUserConfirmedToTurnOffSyncAndDelete(eq(1))
+    }
+
+    @Test
+    fun whenAccountDeletedWithMultipleConnectedDevicesThenPixelFired() {
+        prepareForExchangeSuccess()
+        whenever(syncApi.deleteAccount(token)).thenReturn(deleteAccountSuccess)
+        configureAsSignedWithConnectedDevices(10)
+        syncRepo.deleteAccount()
+        verify(syncPixels).fireUserConfirmedToTurnOffSyncAndDelete(eq(10))
+    }
+
+    @Test
+    fun whenAccountDeletedWithNoConnectedDevicesThenPixelFired() {
+        prepareForExchangeSuccess()
+        whenever(syncApi.deleteAccount(token)).thenReturn(deleteAccountSuccess)
+        syncRepo.deleteAccount()
+        verify(syncPixels).fireUserConfirmedToTurnOffSyncAndDelete(eq(0))
+    }
+
     private fun configureUrlWrappedCodeFeatureFlagState(enabled: Boolean) {
         syncFeature.syncSetupBarcodeIsUrlBased().setRawStoredState(State(enable = enabled))
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModelTest.kt
@@ -264,6 +264,16 @@ class SyncActivityViewModelTest {
     }
 
     @Test
+    fun whenTurnOffSyncConfirmedThenPixelFired() = runTest {
+        whenever(syncAccountRepository.getThisConnectedDevice()).thenReturn(connectedDevice)
+        whenever(syncAccountRepository.logout(deviceId)).thenReturn(Result.Success(true))
+
+        testee.onTurnOffSyncConfirmed(connectedDevice)
+
+        verify(syncPixels).fireUserConfirmedToTurnOffSync()
+    }
+
+    @Test
     fun whenLogoutSuccessThenUpdateViewState() = runTest {
         givenAuthenticatedUser()
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211103035810276?focus=true 

### Description
Adds a pixel for when sync is disabled, and one for when it is disabled with account deletion.

### Steps to test this PR
Add logcat filter `Pixel url request:.*sync_disabled`

- [x] Enable sync (`Settings -> Sync & Backup -> Sync and Back Up This Device`)
- [x] Tap `Turn Off Sync & Backup` and confirm. Verify `sync_disabled` pixel in logs.
- [x] Enable sync again
- [x] Tap `Turn Off and Delete Server Data` and confirm. 
- [x] Verify `sync_disabledanddeleted` pixel in logs, and it has param `connected_devices`
