### PR TITLE
Show AppTP on the Input Screen

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageView.kt
@@ -134,21 +134,21 @@ class NewTabLegacyPageView @JvmOverloads constructor(
 
     private fun render(viewState: ViewState) {
         logcat { "New Tab: render $viewState" }
+        val hasContentThatDisplacesHomoLogo = viewState.onboardingComplete &&
+            viewState.message != null ||
+            viewState.favourites.isNotEmpty()
+        val shouldShowLogo = !hasContentThatDisplacesHomoLogo && showLogo
+        val isAppTpEnabled = viewState.appTpEnabled
+        val hasLowPriorityMessage = viewState.lowPriorityMessage != null
 
-        val isHomeBackgroundLogoVisible = (!viewState.onboardingComplete || viewState.message == null) &&
-            viewState.favourites.isEmpty()
+        val hasContent = shouldShowLogo || hasContentThatDisplacesHomoLogo || isAppTpEnabled || hasLowPriorityMessage
+        isVisible = hasContent
+        onHasContent?.invoke(hasContent)
 
-        if (!showLogo && isHomeBackgroundLogoVisible) {
-            this.gone()
-            onHasContent?.invoke(false)
+        if (shouldShowLogo) {
+            homeBackgroundLogo.showLogo()
         } else {
-            this.show()
-            onHasContent?.invoke(true)
-            if (isHomeBackgroundLogoVisible) {
-                homeBackgroundLogo.showLogo()
-            } else {
-                homeBackgroundLogo.hideLogo()
-            }
+            homeBackgroundLogo.hideLogo()
         }
         if (viewState.message != null && viewState.onboardingComplete) {
             showRemoteMessage(viewState.message, viewState.newMessage)

--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageView.kt
@@ -55,16 +55,10 @@ import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.DispatcherProvider
-import com.duckduckgo.common.utils.ViewViewModelFactory
 import com.duckduckgo.di.scopes.ViewScope
-import com.duckduckgo.duckchat.api.inputscreen.InputScreenActivityParams
-import com.duckduckgo.duckchat.impl.inputscreen.ui.viewmodel.InputScreenViewModel
-import com.duckduckgo.duckchat.impl.inputscreen.ui.viewmodel.InputScreenViewModel.InputScreenViewModelFactory
-import com.duckduckgo.duckchat.impl.inputscreen.ui.viewmodel.InputScreenViewModel.InputScreenViewModelProviderFactory
 import com.duckduckgo.mobile.android.app.tracking.ui.AppTrackingProtectionScreens.AppTrackerOnboardingActivityWithEmptyParamsParams
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.navigation.api.GlobalActivityStarter.DeeplinkActivityParams
-import com.duckduckgo.navigation.api.getActivityParams
 import com.duckduckgo.remote.messaging.api.RemoteMessage
 import dagger.android.support.AndroidSupportInjection
 import javax.inject.Inject

--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageViewModel.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.playstore.PlayStoreUtils
 import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.mobile.android.app.tracking.AppTrackingProtection
 import com.duckduckgo.remote.messaging.api.RemoteMessage
 import com.duckduckgo.remote.messaging.api.RemoteMessageModel
 import com.duckduckgo.savedsites.api.SavedSitesRepository
@@ -47,6 +48,7 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -63,6 +65,7 @@ class NewTabLegacyPageViewModel @Inject constructor(
     private val extendedOnboardingFeatureToggles: ExtendedOnboardingFeatureToggles,
     private val settingsDataStore: SettingsDataStore,
     private val lowPriorityMessagingModel: LowPriorityMessagingModel,
+    private val appTrackingProtection: AppTrackingProtection,
 ) : ViewModel(), DefaultLifecycleObserver {
 
     data class ViewState(
@@ -71,6 +74,7 @@ class NewTabLegacyPageViewModel @Inject constructor(
         val onboardingComplete: Boolean = false,
         val favourites: List<Favorite> = emptyList(),
         val lowPriorityMessage: LowPriorityMessage? = null,
+        val appTpEnabled: Boolean = false,
     )
 
     private data class ViewStateSnapshot(
@@ -134,6 +138,12 @@ class NewTabLegacyPageViewModel @Inject constructor(
                 }
                 .flowOn(dispatchers.main())
                 .launchIn(viewModelScope)
+        }
+
+        viewModelScope.launch {
+            _viewState.update {
+                it.copy(appTpEnabled = appTrackingProtection.isEnabled())
+            }
         }
     }
 

--- a/app/src/test/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageViewModelTest.kt
@@ -81,7 +81,7 @@ class NewTabLegacyPageViewModelTest {
         testee = createTestee()
     }
 
-    private fun createTestee(showLogo: Boolean = true) : NewTabLegacyPageViewModel {
+    private fun createTestee(showLogo: Boolean = true): NewTabLegacyPageViewModel {
         return NewTabLegacyPageViewModel(
             showDaxLogo = showLogo,
             dispatchers = coroutinesTestRule.testDispatcherProvider,
@@ -388,7 +388,7 @@ class NewTabLegacyPageViewModelTest {
     @Test
     fun `when favorites available, then hide logo`() = runTest {
         val favorites = listOf(
-            SavedSite.Favorite("1", "Test", "https://test.com", lastModified = "2024-01-01", 0)
+            SavedSite.Favorite("1", "Test", "https://test.com", lastModified = "2024-01-01", 0),
         )
         whenever(mockSavedSitesRepository.getFavorites()).thenReturn(flowOf(favorites))
         whenever(mockDismissedCtaDao.exists(DAX_END)).thenReturn(true)

--- a/app/src/test/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageViewModelTest.kt
@@ -29,11 +29,13 @@ import com.duckduckgo.common.ui.view.MessageCta
 import com.duckduckgo.common.utils.playstore.PlayStoreUtils
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.mobile.android.R
+import com.duckduckgo.mobile.android.app.tracking.AppTrackingProtection
 import com.duckduckgo.remote.messaging.api.Action
 import com.duckduckgo.remote.messaging.api.Content
 import com.duckduckgo.remote.messaging.api.RemoteMessage
 import com.duckduckgo.remote.messaging.api.RemoteMessageModel
 import com.duckduckgo.savedsites.api.SavedSitesRepository
+import com.duckduckgo.savedsites.api.models.SavedSite
 import com.duckduckgo.sync.api.engine.SyncEngine
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -64,17 +66,24 @@ class NewTabLegacyPageViewModelTest {
     private val mockExtendedOnboardingFeatureToggles: ExtendedOnboardingFeatureToggles = mock()
     private val mockSettingsDataStore: SettingsDataStore = mock()
     private val mockLowPriorityMessagingModel: LowPriorityMessagingModel = mock()
+    private val mockAppTrackingProtection: AppTrackingProtection = mock()
 
     private lateinit var testee: NewTabLegacyPageViewModel
 
     @Before
-    fun setUp() {
+    fun setUp() = runTest {
         val mockDisabledToggle: Toggle = mock { on { it.isEnabled() } doReturn false }
         whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
         whenever(mockSavedSitesRepository.getFavorites()).thenReturn(flowOf(emptyList()))
         whenever(mockRemoteMessageModel.getActiveMessages()).thenReturn(flowOf(null))
+        whenever(mockAppTrackingProtection.isEnabled()).thenReturn(false)
 
-        testee = NewTabLegacyPageViewModel(
+        testee = createTestee()
+    }
+
+    private fun createTestee(showLogo: Boolean = true) : NewTabLegacyPageViewModel {
+        return NewTabLegacyPageViewModel(
+            showDaxLogo = showLogo,
             dispatchers = coroutinesTestRule.testDispatcherProvider,
             remoteMessagingModel = mockRemoteMessageModel,
             playStoreUtils = mockPlaystoreUtils,
@@ -85,6 +94,7 @@ class NewTabLegacyPageViewModelTest {
             extendedOnboardingFeatureToggles = mockExtendedOnboardingFeatureToggles,
             settingsDataStore = mockSettingsDataStore,
             lowPriorityMessagingModel = mockLowPriorityMessagingModel,
+            appTrackingProtection = mockAppTrackingProtection,
         )
     }
 
@@ -295,6 +305,154 @@ class NewTabLegacyPageViewModelTest {
                 assertNull(it.message)
                 assertFalse(it.newMessage)
                 assertEquals(lowPriorityMessage, it.lowPriorityMessage)
+            }
+        }
+    }
+
+    @Test
+    fun `when onboarding finished and logo enabled, then show logo`() = runTest {
+        whenever(mockDismissedCtaDao.exists(DAX_END)).thenReturn(true)
+
+        testee.onStart(mockLifecycleOwner)
+
+        testee.viewState.test {
+            expectMostRecentItem().also {
+                assertTrue(it.shouldShowLogo)
+                assertTrue(it.hasContent)
+            }
+        }
+    }
+
+    @Test
+    fun `when onboarding finished and logo disabled, then hide logo and report no content`() = runTest {
+        val testeeWithoutLogo = createTestee(showLogo = false)
+        whenever(mockDismissedCtaDao.exists(DAX_END)).thenReturn(true)
+
+        testeeWithoutLogo.onStart(mockLifecycleOwner)
+
+        testeeWithoutLogo.viewState.test {
+            expectMostRecentItem().also {
+                assertFalse(it.shouldShowLogo)
+                assertFalse(it.hasContent)
+            }
+        }
+    }
+
+    @Test
+    fun `when AppTP enabled, then show logo`() = runTest {
+        whenever(mockAppTrackingProtection.isEnabled()).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(DAX_END)).thenReturn(true)
+
+        testee.onStart(mockLifecycleOwner)
+
+        testee.viewState.test {
+            expectMostRecentItem().also {
+                assertTrue(it.hasContent)
+                assertTrue(it.shouldShowLogo)
+            }
+        }
+    }
+
+    @Test
+    fun `when AppTP enabled and logo disabled, then hide logo`() = runTest {
+        val testeeWithoutLogo = createTestee(showLogo = false)
+        whenever(mockAppTrackingProtection.isEnabled()).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(DAX_END)).thenReturn(true)
+
+        testeeWithoutLogo.onStart(mockLifecycleOwner)
+
+        testeeWithoutLogo.viewState.test {
+            expectMostRecentItem().also {
+                assertFalse(it.shouldShowLogo)
+                assertTrue(it.hasContent)
+            }
+        }
+    }
+
+    @Test
+    fun `when onboarding complete and RMF available, then hide logo`() = runTest {
+        val remoteMessage = RemoteMessage("id1", Content.Small("", ""), emptyList(), emptyList())
+        whenever(mockRemoteMessageModel.getActiveMessages()).thenReturn(flowOf(remoteMessage))
+        whenever(mockDismissedCtaDao.exists(DAX_END)).thenReturn(true)
+
+        testee.onStart(mockLifecycleOwner)
+
+        testee.viewState.test {
+            expectMostRecentItem().also {
+                assertFalse(it.shouldShowLogo)
+                assertTrue(it.hasContent)
+            }
+        }
+    }
+
+    @Test
+    fun `when favorites available, then hide logo`() = runTest {
+        val favorites = listOf(
+            SavedSite.Favorite("1", "Test", "https://test.com", lastModified = "2024-01-01", 0)
+        )
+        whenever(mockSavedSitesRepository.getFavorites()).thenReturn(flowOf(favorites))
+        whenever(mockDismissedCtaDao.exists(DAX_END)).thenReturn(true)
+        whenever(mockAppTrackingProtection.isEnabled()).thenReturn(false)
+
+        testee.onStart(mockLifecycleOwner)
+
+        testee.viewState.test {
+            expectMostRecentItem().also {
+                assertFalse(it.shouldShowLogo)
+                assertTrue(it.hasContent)
+            }
+        }
+    }
+
+    @Test
+    fun `when low priority message available, then show logo`() = runTest {
+        val lowPriorityMessage = LowPriorityMessage.DefaultBrowserMessage(
+            message = MessageCta.Message(
+                topIllustration = R.drawable.ic_device_mobile_default,
+                title = "Set as default browser",
+                action = "Set as default",
+                action2 = "Do not ask again",
+            ),
+            onPrimaryAction = {},
+            onSecondaryAction = {},
+            onClose = {},
+            onShown = {},
+        )
+        whenever(mockLowPriorityMessagingModel.getMessage()).thenReturn(lowPriorityMessage)
+
+        testee.onStart(mockLifecycleOwner)
+
+        testee.viewState.test {
+            expectMostRecentItem().also {
+                assertTrue(it.shouldShowLogo)
+                assertTrue(it.hasContent)
+            }
+        }
+    }
+
+    @Test
+    fun `when low priority message available and logo disabled, then hide logo`() = runTest {
+        val testeeWithoutLogo = createTestee(showLogo = false)
+        val lowPriorityMessage = LowPriorityMessage.DefaultBrowserMessage(
+            message = MessageCta.Message(
+                topIllustration = R.drawable.ic_device_mobile_default,
+                title = "Set as default browser",
+                action = "Set as default",
+                action2 = "Do not ask again",
+            ),
+            onPrimaryAction = {},
+            onSecondaryAction = {},
+            onClose = {},
+            onShown = {},
+        )
+        whenever(mockLowPriorityMessagingModel.getMessage()).thenReturn(lowPriorityMessage)
+
+        testeeWithoutLogo.onStart(mockLifecycleOwner)
+
+        testeeWithoutLogo.viewState.test {
+            expectMostRecentItem().also {
+                assertFalse(it.shouldShowLogo)
+                assertTrue(it.hasContent)
             }
         }
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/tabs/SearchTabFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/tabs/SearchTabFragment.kt
@@ -104,6 +104,7 @@ class SearchTabFragment : DuckDuckGoFragment(R.layout.fragment_search_tab) {
             newTabPagePlugins.getPlugins().firstOrNull()?.let { plugin ->
                 val newTabPageView = plugin.getView(requireContext(), showLogo = false) { hasContent ->
                     viewModel.onNewTabPageContentChanged(hasContent)
+                    binding.newTabContainerLayout.isVisible = hasContent
                 }
                 binding.newTabContainerLayout.addView(newTabPageView)
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1211046517836482?focus=true

### Description
Fixes the NTP's `hasContent` callback to also report content when only AppTP is enabled (no RMF, favorites, etc). This in turn fixes the Input Screen and makes it display AppTP banners.

I also moved the logic that determined whether the Dax logo and other content should be shown on NTP into the ViewModel, so that it can be unit tested.


### Steps to test this PR

- [ ] Change RMF endpoint to a JSON Blob:
```diff
diff --git a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/network/RemoteMessagingService.kt b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/network/RemoteMessagingService.kt
index 7c0e619ba4..cd65aa542d 100644
--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/network/RemoteMessagingService.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/network/RemoteMessagingService.kt
@@ -23,6 +23,6 @@ import retrofit2.http.GET
 
 @ContributesServiceApi(AppScope::class)
 interface RemoteMessagingService {
-    @GET("https://staticcdn.duckduckgo.com/remotemessaging/config/v1/android-config.json")
+    @GET("https://www.jsonblob.com/api/1408014913447845888")
     suspend fun config(): JsonRemoteMessagingConfig
 }
```
- [x] Install a clean build of the app.
- [x] Verify that RMF (for a DuckDuckGo refresher) shows on the NTP.
- [x] Go to Settings and enabled AppTP.
- [x] Go back to NTP and verify that both RMF and AppTP are shown.
- [x] Go to Settings -> AI Features and enabled the experimental address bar.
- [x] Go back to browser and verify that both RMF and AppTP are shown when Input Screen is opened (via opening a completely new tab or clicking on the address bar).
- [x] Dismiss the RMF.
- [x] Verify that AppTP and Dax logo are visible on the New Tab Page.
- [x] Open the Input Screen and verify that only AppTP is visible.
- [x] Add a favorite.
- [x] Verify that a favorite and AppTP are visible on the NTP and in the Input Screen.
- [x] Go to settings and completely disable AppTP ("Disable and Delete Data" in the settings menu).
- [x] Verify that only a favorite is visible on the NTP and in the Input Screen.
- [x] Remove the favorite.
- [x] Verify that only Dax is visible on NTP and in the Input Screen.
