### PR TITLE
Fix AppTP scrolling behavior on the Input Screen

### DIFF
--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/tabs/DevTabsActivity.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/tabs/DevTabsActivity.kt
@@ -25,11 +25,15 @@ import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.ActivityDevTabsBinding
+import com.duckduckgo.app.dev.settings.tabs.DevTabsViewModel.Command
+import com.duckduckgo.app.dev.settings.tabs.DevTabsViewModel.Command.NoMoreCandidatesForBookmarks
+import com.duckduckgo.app.dev.settings.tabs.DevTabsViewModel.Command.NoMoreCandidatesForFavorites
 import com.duckduckgo.app.dev.settings.tabs.DevTabsViewModel.ViewState
 import com.duckduckgo.app.notification.NotificationFactory
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.ActivityScope
+import com.google.android.material.snackbar.Snackbar
 import javax.inject.Inject
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -66,7 +70,16 @@ class DevTabsActivity : DuckDuckGoActivity() {
             viewModel.clearBookmarks()
         }
 
+        binding.addFavoritesButton.setOnClickListener {
+            viewModel.addFavorites(binding.favoritesCount.text.toInt())
+        }
+
+        binding.clearFavoritesButton.setOnClickListener {
+            viewModel.clearFavorites()
+        }
+
         observeViewState()
+        observeCommands()
     }
 
     private fun observeViewState() {
@@ -74,9 +87,26 @@ class DevTabsActivity : DuckDuckGoActivity() {
             .launchIn(lifecycleScope)
     }
 
+    private fun observeCommands() {
+        viewModel.commands.flowWithLifecycle(lifecycle, STARTED).onEach { processCommand(it) }
+            .launchIn(lifecycleScope)
+    }
+
     private fun render(viewState: ViewState) {
         binding.tabCountHeader.text = getString(R.string.devSettingsTabsScreenHeader, viewState.tabCount)
         binding.bookmarksCountHeader.text = getString(R.string.devSettingsTabsBookmarksScreenHeader, viewState.bookmarkCount)
+        binding.favoritesCountHeader.text = getString(R.string.devSettingsTabsFavoritesScreenHeader, viewState.favoritesCount)
+    }
+
+    private fun processCommand(command: Command) {
+        when (command) {
+            NoMoreCandidatesForBookmarks -> {
+                Snackbar.make(binding.root, "No more bookmark candidates", Snackbar.LENGTH_LONG).show()
+            }
+            NoMoreCandidatesForFavorites -> {
+                Snackbar.make(binding.root, "No more favorite candidates", Snackbar.LENGTH_LONG).show()
+            }
+        }
     }
 
     companion object {

--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/tabs/DevTabsViewModel.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/tabs/DevTabsViewModel.kt
@@ -19,16 +19,22 @@ package com.duckduckgo.app.dev.settings.tabs
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.app.dev.settings.tabs.DevTabsViewModel.Command.NoMoreCandidatesForBookmarks
+import com.duckduckgo.app.dev.settings.tabs.DevTabsViewModel.Command.NoMoreCandidatesForFavorites
 import com.duckduckgo.app.tabs.model.TabDataRepository
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.savedsites.api.SavedSitesRepository
 import javax.inject.Inject
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -53,6 +59,16 @@ private val randomUrls = listOf(
     "https://debian.org",
     "https://ubuntu.com",
     "https://openbsd.org",
+    "https://letsencrypt.org",
+    "https://wikimedia.org",
+    "https://creativecommons.org",
+    "https://openstreetmap.org",
+    "https://kde.org",
+    "https://gnome.org",
+    "https://blender.org",
+    "https://python.org",
+    "https://matrix.org",
+    "https://github.com/duckduckgo/Android",
 )
 
 @ContributesViewModel(ActivityScope::class)
@@ -65,10 +81,14 @@ class DevTabsViewModel @Inject constructor(
     data class ViewState(
         val tabCount: Int = 0,
         val bookmarkCount: Int = 0,
+        val favoritesCount: Int = 0,
     )
 
     private val _viewState = MutableStateFlow(ViewState())
     val viewState = _viewState.asStateFlow()
+
+    private val _commands = Channel<Command>(capacity = Channel.CONFLATED)
+    val commands: Flow<Command> = _commands.receiveAsFlow()
 
     init {
         tabDataRepository.flowTabs
@@ -81,6 +101,13 @@ class DevTabsViewModel @Inject constructor(
         savedSitesRepository.getBookmarks()
             .onEach { bookmarks ->
                 _viewState.update { it.copy(bookmarkCount = bookmarks.count()) }
+            }
+            .flowOn(dispatcher.io())
+            .launchIn(viewModelScope)
+
+        savedSitesRepository.getFavorites()
+            .onEach { favorites ->
+                _viewState.update { it.copy(favoritesCount = favorites.count()) }
             }
             .flowOn(dispatcher.io())
             .launchIn(viewModelScope)
@@ -105,12 +132,21 @@ class DevTabsViewModel @Inject constructor(
 
     fun addBookmarks(count: Int) {
         viewModelScope.launch(dispatcher.io()) {
+            val candidates = randomUrls.filter {
+                savedSitesRepository.getBookmark(url = it) == null
+            }.toMutableSet()
             repeat(count) {
-                val randomIndex = randomUrls.indices.random()
-                savedSitesRepository.insertBookmark(
-                    title = "",
-                    url = randomUrls[randomIndex],
-                )
+                if (candidates.size > 0) {
+                    val candidate = candidates.random()
+                    savedSitesRepository.insertBookmark(
+                        title = "",
+                        url = candidate,
+                    )
+                    candidates.remove(candidate)
+                } else {
+                    _commands.trySend(NoMoreCandidatesForBookmarks)
+                    return@repeat
+                }
             }
         }
     }
@@ -119,5 +155,39 @@ class DevTabsViewModel @Inject constructor(
         viewModelScope.launch(dispatcher.io()) {
             savedSitesRepository.deleteAll()
         }
+    }
+
+    fun addFavorites(count: Int) {
+        viewModelScope.launch(dispatcher.io()) {
+            val candidates = randomUrls.filter {
+                savedSitesRepository.getFavorite(url = it) == null
+            }.toMutableSet()
+            repeat(count) {
+                if (candidates.size > 0) {
+                    val candidate = candidates.random()
+                    savedSitesRepository.insertFavorite(
+                        title = "",
+                        url = candidate,
+                    )
+                    candidates.remove(candidate)
+                } else {
+                    _commands.trySend(NoMoreCandidatesForFavorites)
+                    return@repeat
+                }
+            }
+        }
+    }
+
+    fun clearFavorites() {
+        viewModelScope.launch(dispatcher.io()) {
+            savedSitesRepository.getFavorites().firstOrNull()?.forEach {
+                savedSitesRepository.delete(it)
+            }
+        }
+    }
+
+    sealed class Command {
+        data object NoMoreCandidatesForBookmarks : Command()
+        data object NoMoreCandidatesForFavorites : Command()
     }
 }

--- a/app/src/internal/res/layout/activity_dev_tabs.xml
+++ b/app/src/internal/res/layout/activity_dev_tabs.xml
@@ -173,5 +173,78 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="8dp" />
+
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+            android:id="@+id/favoritesCountHeader"
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:gravity="center"
+            android:text="@string/devSettingsTabsFavoritesScreenHeader"
+            app:typography="caption_allCaps" />
+
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="8dp" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <com.duckduckgo.common.ui.view.listitem.OneLineListItem
+                android:id="@+id/generateFavoritesItem"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                app:layout_constraintEnd_toStartOf="@id/favoritesCount"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:primaryText="@string/devSettingsTabsScreenFavoritesToAdd" />
+
+            <com.duckduckgo.common.ui.view.text.DaxTextInput
+                android:id="@+id/favoritesCount"
+                style="@style/Widget.DuckDuckGo.TextInput"
+                android:layout_width="72dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/keyline_4"
+                android:gravity="center"
+                android:inputType="number"
+                android:text="25"
+                app:layout_constraintBottom_toBottomOf="@id/generateFavoritesItem"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/generateFavoritesItem"
+                app:layout_constraintTop_toTopOf="@id/generateFavoritesItem"
+                app:type="single_line"
+                tools:ignore="HardcodedText" />
+
+            <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+                android:id="@+id/addFavoritesButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/keyline_4"
+                android:text="@string/devSettingsTabsScreenAddFavoritesButtonText"
+                app:daxButtonSize="large" />
+
+            <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+                android:id="@+id/clearFavoritesButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/keyline_4"
+                android:text="@string/devSettingsTabsScreenClearFavoritesButtonText"
+                app:daxButtonSize="large" />
+
+            <androidx.constraintlayout.helper.widget.Flow
+                android:id="@+id/favoritesFlowView"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_marginTop="@dimen/keyline_4"
+                app:constraint_referenced_ids="addFavoritesButton,clearFavoritesButton"
+                app:flow_horizontalStyle="spread"
+                app:flow_wrapMode="chain"
+                app:layout_constraintTop_toBottomOf="@id/generateFavoritesItem" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
     </LinearLayout>
 </LinearLayout>

--- a/app/src/internal/res/values/donottranslate.xml
+++ b/app/src/internal/res/values/donottranslate.xml
@@ -54,9 +54,13 @@
     <string name="devSettingsTabsScreenAddTabsButtonText">Add Tabs</string>
     <string name="devSettingsTabsScreenClearTabsButtonText">Clear Tabs</string>
     <string name="devSettingsTabsBookmarksScreenHeader" instruction="Not translated">Current bookmarks count: %1$d</string>
+    <string name="devSettingsTabsFavoritesScreenHeader" instruction="Not translated">Current favorites count: %1$d</string>
     <string name="devSettingsTabsScreenBookmarksToAdd">Bookmarks to add</string>
+    <string name="devSettingsTabsScreenFavoritesToAdd">Favorites to add</string>
     <string name="devSettingsTabsScreenAddBookmarksButtonText">Add Bookmarks</string>
+    <string name="devSettingsTabsScreenAddFavoritesButtonText">Add Favorites</string>
     <string name="devSettingsTabsScreenClearBookmarksButtonText">Clear Bookmarks</string>
+    <string name="devSettingsTabsScreenClearFavoritesButtonText">Clear Favorites</string>
 
     <!-- Privacy Audit settings -->
     <string name="auditSettingsTitle">Audit Settings</string>

--- a/duckchat/duckchat-impl/src/main/res/layout/fragment_search_tab.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/fragment_search_tab.xml
@@ -22,7 +22,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <ScrollView
+    <androidx.core.widget.NestedScrollView
         android:id="@+id/newTabContainerScrollView"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
@@ -30,9 +30,9 @@
         <FrameLayout
             android:id="@+id/newTabContainerLayout"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="match_parent" />
 
-    </ScrollView>
+    </androidx.core.widget.NestedScrollView>
 
     <FrameLayout
         android:id="@+id/bottomFadeContainer"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1210986778088959?focus=true

### Description
Fixes an issue where the AppTP banner wouldn't scroll on the Input Screen until bounds of the scrolling container where reached.

Also adds a dev tool to create/clear favorites and improves the existing one that adds bookmarks so that it doesn't generate duplicates.

### Steps to test this PR

- [ ] Add enough favorites to cover the whole Input Screen
  - You can use a new option to generate favorites under Settings -> Developer Settings -> Tabs and Saved Sites
- [ ] Enable AppTP
- [ ] Open the Input Screen and verify that scrolling immediately scrolls the AppTP banner as well

### UI changes
_Before_

https://github.com/user-attachments/assets/701b81e1-7476-46b7-a19b-e2c08e45737c

_After_

https://github.com/user-attachments/assets/a87c5e10-fda2-4aa5-94ce-4a7aed558c1d
