### PR TITLE
Update content scope scripts to version 11.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.13.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.3.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.6.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.7.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.14.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.14.0.tgz",
-      "integrity": "sha512-0z+o6XXQYZJe2JxWfMzTzpL9dthSFcJzG0NNqK+SxVmH1nTTwe7MjY11CP9FbPt3l8R6AvnkEPGw1w30sEtvkw==",
+      "version": "14.14.1",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.14.1.tgz",
+      "integrity": "sha512-hXHK9uKiPLT3Z4LWyhrMSE+tb1y7+Lvr+hs3JP/xyBmg02YlI82rl2o8/fQDa+HT9TWMYvjOzlzxBqfADC41sg==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#4d3fcb75781f0ed3a7aef1b86330d499a2639071",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#21f48aee920f05e158615e5d09941bdbf0277287",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -89,33 +89,33 @@
       "license": "Apache-2.0"
     },
     "node_modules/@ghostery/adblocker": {
-      "version": "2.11.3",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.11.3.tgz",
-      "integrity": "sha512-uNblOHFagpi7yz1nOmhPvmK1QWWzOV7K9sTNy7SDM+i1FZkfSJYCPyFBlioV15GNVm/cRfMWW7LyZKWCnQ2+sQ==",
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.11.5.tgz",
+      "integrity": "sha512-rJ3N+3XPy1SEeEaeQKowYT/R/Tt1ac9cqYSin1igLY7XqIaGdCYq3tQjBQQ4Vx6ZM2ic412aM84hAKn+D/EDvA==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-content": "^2.11.3",
-        "@ghostery/adblocker-extended-selectors": "^2.11.3",
+        "@ghostery/adblocker-content": "^2.11.5",
+        "@ghostery/adblocker-extended-selectors": "^2.11.5",
         "@ghostery/url-parser": "^1.3.0",
         "@remusao/guess-url-type": "^2.1.0",
         "@remusao/small": "^2.1.0",
         "@remusao/smaz": "^2.2.0",
-        "tldts-experimental": "^7.0.0"
+        "tldts-experimental": "^7.0.12"
       }
     },
     "node_modules/@ghostery/adblocker-content": {
-      "version": "2.11.3",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.11.3.tgz",
-      "integrity": "sha512-Es3Mm86JStRdyl0o2/YXZot8C41dWChgY7Et3pu8Bll3+MTp+fjnXwD/a8ic1TD6UYHXPqpUU7b9f6OWa0Twnw==",
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.11.5.tgz",
+      "integrity": "sha512-7mDOic2lJGxHtmqcbME/oi4XnygYbJ0vgCj/7KedHzhTR8/w/HLpkEQRFiEAKRxQMrEfLVXy+m171Yeia3TaRw==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-extended-selectors": "^2.11.3"
+        "@ghostery/adblocker-extended-selectors": "^2.11.5"
       }
     },
     "node_modules/@ghostery/adblocker-extended-selectors": {
-      "version": "2.11.3",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.11.3.tgz",
-      "integrity": "sha512-+d/AZ1oIXy+WP+ogd9behZ3c136pSdt7QmwODNODeXPgEJJggersuLiKRDsBlG+nqy03gaTt5Vo7qk3rYa7cyA==",
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.11.5.tgz",
+      "integrity": "sha512-O0Diq8pgFeC+IUnS8Ud00aHLHv87djFiXwfUPBiwmwmS8eNRj0FnaRYFd/Du4Xu4pgNe8lkD+OVsBMtG1DGwSw==",
       "license": "MPL-2.0"
     },
     "node_modules/@ghostery/url-parser": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.13.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.3.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.6.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.7.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1211119424578630/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run