### PR TITLE
Disable Gradle configuration cache for Flank privacy tests in CI

### DIFF
--- a/.github/workflows/external-css-tests.yml
+++ b/.github/workflows/external-css-tests.yml
@@ -58,7 +58,7 @@ jobs:
         run: ./gradlew androidTestsBuild
 
       - name: Run Android Tests
-        run: ./gradlew runFlankPrivacyTests
+        run: ./gradlew runFlankPrivacyTests --no-configuration-cache
 
       - name: Bundle the Android CI tests report
         if: always()

--- a/.github/workflows/privacy.yml
+++ b/.github/workflows/privacy.yml
@@ -58,7 +58,7 @@ jobs:
         run: ./gradlew androidTestsBuild
 
       - name: Run Android Tests
-        run: ./gradlew runFlankPrivacyTests
+        run: ./gradlew runFlankPrivacyTests --no-configuration-cache
 
       - name: Bundle the Android CI tests report
         if: always()


### PR DESCRIPTION
Task/Issue URL: 

### Description

I already did this for android tests but missed the fact privacy tests would need this

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
