### PR TITLE
Fix nightly builds to ensure they get the version number correctly

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -110,7 +110,7 @@ jobs:
         if: steps.check_for_changes.outputs.has_changes == 'true'
         id: generate_version_name
         run: |
-          output=$(./gradlew getBuildVersionName -PversionNameSuffix=-nightly -PlatestTag=${{ steps.get_latest_tag.outputs.latest_tag }} --quiet | tail -n 1)
+          output=$(./gradlew --no-configuration-cache getBuildVersionName -PversionNameSuffix=-nightly -PlatestTag=${{ steps.get_latest_tag.outputs.latest_tag }} --quiet | tail -n 1)
           echo "version=$output" >> $GITHUB_OUTPUT
 
       - name: Capture App Bundle Path


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211121590401637?focus=true 

### Description
our ` getBuildVersionName` gradle task is trying to call `buildVersionName()` which is defined in the `ext` block, but configuration cache doesn't allow tasks to access project extensions during execution phase.

This PR changes the nightly job which uses that task to pass `--no-configuration-cache` to bypass it.

### Steps to test this PR

- QA optional
- [Optional] you can check that while the existing 
    - `./gradlew getBuildVersionName -PversionNameSuffix=-nightly -PlatestTag=5.245.0.1-nightly` fails, 
    - `./gradlew --no-configuration-cache getBuildVersionName -PversionNameSuffix=-nightly -PlatestTag=5.245.0.1-nightly` succeeds