### PR TITLE
Fix docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,7 +41,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
 
       - name: Execute Gradle build
-        run: ./gradlew dokkaHtmlMultiModule
+        run: ./gradlew dokkaHtmlMultiModule --no-configuration-cache # Dokka 1.8.20 is not compatible with configuration cache. 2.x is.
 
       - name: Copy files
         run: |


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207908166761516/task/1211121173888857

### Description

Disable Gradle configuration cache for Dokka compatibility

### Steps to test this PR

- [ ] Run ` ./gradlew dokkaHtmlMultiModule --no-configuration-cache`
- [ ] It should complete and there should be no config-cache warnings or errors

### UI changes
N/A
