### PR TITLE
Respect SERP duck.ai setting

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoRequestRewriter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoRequestRewriter.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.app.referral.AppReferrerDataStore
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.common.utils.AppUrl.ParamKey
 import com.duckduckgo.common.utils.AppUrl.ParamValue
+import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.experiments.api.VariantManager
 import logcat.logcat
 
@@ -35,6 +36,7 @@ class DuckDuckGoRequestRewriter(
     private val statisticsStore: StatisticsDataStore,
     private val variantManager: VariantManager,
     private val appReferrerDataStore: AppReferrerDataStore,
+    private val duckChat: DuckChat,
 ) : RequestRewriter {
 
     override fun rewriteRequestWithCustomQueryParams(request: Uri): Uri {
@@ -74,6 +76,9 @@ class DuckDuckGoRequestRewriter(
         val sourceValue = if (appReferrerDataStore.installedFromEuAuction) ParamValue.SOURCE_EU_AUCTION else ParamValue.SOURCE
 
         builder.appendQueryParameter(ParamKey.HIDE_SERP, ParamValue.HIDE_SERP)
+        if (!duckChat.isEnabled()) {
+            builder.appendQueryParameter(ParamKey.HIDE_DUCK_AI, ParamValue.HIDE_DUCK_AI)
+        }
         builder.appendQueryParameter(ParamKey.SOURCE, sourceValue)
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoRequestRewriter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoRequestRewriter.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.browser
 
 import android.net.Uri
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.referral.AppReferrerDataStore
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.common.utils.AppUrl.ParamKey
@@ -37,7 +38,10 @@ class DuckDuckGoRequestRewriter(
     private val variantManager: VariantManager,
     private val appReferrerDataStore: AppReferrerDataStore,
     private val duckChat: DuckChat,
+    private val androidConfigFeatures: AndroidBrowserConfigFeature,
 ) : RequestRewriter {
+
+    private val hideDuckAiSerpKillSwitch by lazy { androidConfigFeatures.hideDuckAiInSerpKillSwitch().isEnabled() }
 
     override fun rewriteRequestWithCustomQueryParams(request: Uri): Uri {
         val builder = Uri.Builder()
@@ -76,7 +80,7 @@ class DuckDuckGoRequestRewriter(
         val sourceValue = if (appReferrerDataStore.installedFromEuAuction) ParamValue.SOURCE_EU_AUCTION else ParamValue.SOURCE
 
         builder.appendQueryParameter(ParamKey.HIDE_SERP, ParamValue.HIDE_SERP)
-        if (!duckChat.isEnabled()) {
+        if (!duckChat.isEnabled() && hideDuckAiSerpKillSwitch) {
             builder.appendQueryParameter(ParamKey.HIDE_DUCK_AI, ParamValue.HIDE_DUCK_AI)
         }
         builder.appendQueryParameter(ParamKey.SOURCE, sourceValue)

--- a/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
@@ -112,8 +112,9 @@ class BrowserModule {
         variantManager: VariantManager,
         appReferrerDataStore: AppReferrerDataStore,
         duckChat: DuckChat,
+        androidBrowserConfigFeature: AndroidBrowserConfigFeature,
     ): RequestRewriter {
-        return DuckDuckGoRequestRewriter(urlDetector, statisticsStore, variantManager, appReferrerDataStore, duckChat)
+        return DuckDuckGoRequestRewriter(urlDetector, statisticsStore, variantManager, appReferrerDataStore, duckChat, androidBrowserConfigFeature)
     }
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
@@ -111,8 +111,9 @@ class BrowserModule {
         statisticsStore: StatisticsDataStore,
         variantManager: VariantManager,
         appReferrerDataStore: AppReferrerDataStore,
+        duckChat: DuckChat,
     ): RequestRewriter {
-        return DuckDuckGoRequestRewriter(urlDetector, statisticsStore, variantManager, appReferrerDataStore)
+        return DuckDuckGoRequestRewriter(urlDetector, statisticsStore, variantManager, appReferrerDataStore, duckChat)
     }
 
     @Provides

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -158,4 +158,7 @@ interface AndroidBrowserConfigFeature {
      */
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun handleIntentScheme(): Toggle
+
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun hideDuckAiInSerpKillSwitch(): Toggle
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/DuckDuckGoRequestRewriterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/DuckDuckGoRequestRewriterTest.kt
@@ -23,6 +23,8 @@ import com.duckduckgo.app.referral.AppReferrerDataStore
 import com.duckduckgo.app.statistics.model.Atb
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.common.utils.AppUrl.ParamKey
+import com.duckduckgo.common.utils.AppUrl.ParamValue
+import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.experiments.api.VariantManager
 import org.junit.Assert.*
 import org.junit.Before
@@ -38,18 +40,21 @@ class DuckDuckGoRequestRewriterTest {
     private val mockStatisticsStore: StatisticsDataStore = mock()
     private val mockVariantManager: VariantManager = mock()
     private val mockAppReferrerDataStore: AppReferrerDataStore = mock()
+    private val duckChat: DuckChat = mock()
     private lateinit var builder: Uri.Builder
-    private val currentUrl = "http://www.duckduckgo.com"
 
     @Before
     fun before() {
         whenever(mockVariantManager.getVariantKey()).thenReturn("")
         whenever(mockAppReferrerDataStore.installedFromEuAuction).thenReturn(false)
+        whenever(duckChat.isEnabled()).thenReturn(true)
+
         testee = DuckDuckGoRequestRewriter(
             DuckDuckGoUrlDetectorImpl(),
             mockStatisticsStore,
             mockVariantManager,
             mockAppReferrerDataStore,
+            duckChat,
         )
         builder = Uri.Builder()
     }
@@ -95,6 +100,25 @@ class DuckDuckGoRequestRewriterTest {
 
         val uri = builder.build()
         assertTrue(uri.queryParameterNames.contains(ParamKey.HIDE_SERP))
+    }
+
+    @Test
+    fun whenDuckAiIsDisabledThenHideSerpDuckChat() {
+        whenever(duckChat.isEnabled()).thenReturn(false)
+        testee.addCustomQueryParams(builder)
+
+        val uri = builder.build()
+        assertTrue(uri.queryParameterNames.contains(ParamKey.HIDE_DUCK_AI))
+        assertEquals(ParamValue.HIDE_DUCK_AI, uri.getQueryParameter(ParamKey.HIDE_DUCK_AI))
+    }
+
+    @Test
+    fun whenDuckAiIsEnabledThenDoNotHideSerpDuckChat() {
+        whenever(duckChat.isEnabled()).thenReturn(true)
+        testee.addCustomQueryParams(builder)
+
+        val uri = builder.build()
+        assertFalse(uri.queryParameterNames.contains(ParamKey.HIDE_DUCK_AI))
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/QueryUrlConverterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/QueryUrlConverterTest.kt
@@ -16,14 +16,18 @@
 
 package com.duckduckgo.app.browser
 
+import android.annotation.SuppressLint
 import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.browser.omnibar.QueryOrigin
 import com.duckduckgo.app.browser.omnibar.QueryUrlConverter
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.referral.AppReferrerDataStore
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.experiments.api.VariantManager
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
@@ -32,18 +36,21 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
 @RunWith(AndroidJUnit4::class)
+@SuppressLint("DenyListedApi") // fake toggle store
 class QueryUrlConverterTest {
 
     private var mockStatisticsStore: StatisticsDataStore = mock()
     private val variantManager: VariantManager = mock()
     private val mockAppReferrerDataStore: AppReferrerDataStore = mock()
     private val duckChat: DuckChat = mock()
+    private val androidBrowserConfigFeature: AndroidBrowserConfigFeature = FakeFeatureToggleFactory.create(AndroidBrowserConfigFeature::class.java)
     private val requestRewriter = DuckDuckGoRequestRewriter(
         DuckDuckGoUrlDetectorImpl(),
         mockStatisticsStore,
         variantManager,
         mockAppReferrerDataStore,
         duckChat,
+        androidBrowserConfigFeature,
     )
     private val testee: QueryUrlConverter = QueryUrlConverter(requestRewriter)
 
@@ -51,6 +58,7 @@ class QueryUrlConverterTest {
     fun setup() {
         whenever(variantManager.getVariantKey()).thenReturn("")
         whenever(duckChat.isEnabled()).thenReturn(true)
+        androidBrowserConfigFeature.hideDuckAiInSerpKillSwitch().setRawStoredState(State(true))
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/QueryUrlConverterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/QueryUrlConverterTest.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.app.browser.omnibar.QueryOrigin
 import com.duckduckgo.app.browser.omnibar.QueryUrlConverter
 import com.duckduckgo.app.referral.AppReferrerDataStore
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
+import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.experiments.api.VariantManager
 import org.junit.Assert.*
 import org.junit.Before
@@ -36,17 +37,20 @@ class QueryUrlConverterTest {
     private var mockStatisticsStore: StatisticsDataStore = mock()
     private val variantManager: VariantManager = mock()
     private val mockAppReferrerDataStore: AppReferrerDataStore = mock()
+    private val duckChat: DuckChat = mock()
     private val requestRewriter = DuckDuckGoRequestRewriter(
         DuckDuckGoUrlDetectorImpl(),
         mockStatisticsStore,
         variantManager,
         mockAppReferrerDataStore,
+        duckChat,
     )
     private val testee: QueryUrlConverter = QueryUrlConverter(requestRewriter)
 
     @Before
     fun setup() {
         whenever(variantManager.getVariantKey()).thenReturn("")
+        whenever(duckChat.isEnabled()).thenReturn(true)
     }
 
     @Test

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/AppUrl.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/AppUrl.kt
@@ -39,6 +39,7 @@ class AppUrl {
         const val EMAIL = "email"
         const val COUNTRY = "co"
         const val HIDE_SERP = "ko"
+        const val HIDE_DUCK_AI = "kbg"
         const val VERTICAL = "ia"
         const val VERTICAL_REWRITE = "iar"
     }
@@ -47,6 +48,7 @@ class AppUrl {
         const val SOURCE = "ddg_android"
         const val SOURCE_EU_AUCTION = "ddg_androideu"
         const val HIDE_SERP = "-1"
+        const val HIDE_DUCK_AI = "-1"
         const val CHAT_VERTICAL = "chat"
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1209671977594486/task/1211122605729914?focus=true

### Description
Respect duck.ai setting in SERP

### Steps to test this PR

_Test_
- [x] install from this branch and launch the app
- [x] go to settings -> AI features and enable duck.ai "search only"
- [x] go back to SERP and search for eg. "hello"
- [x] verify that the duck.ai icon appears in SERP
- [x] go to settings -> AI features and enable duck.ai "search & duck.ai"
- [x] go back to SERP and search for eg. "hello"
- [x] verify that the duck.ai icon appears in SERP
- [x] go to settings -> AI features and disable duck.ai
- [x] go back to SERP and search for eg. "hello"
- [x] verify that the duck.ai icon does not appear in SERP