### PR TITLE
fix an issue where links opening in new tab would also open the Input Screen

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -448,6 +448,8 @@ class BrowserTabViewModelTest {
 
     private val mockDuckAiFeatureStateInputScreenFlow = MutableStateFlow(false)
 
+    private val mockDuckAiFeatureStateInputScreenOpenAutomaticallyFlow = MutableStateFlow(false)
+
     private val mockAppBuildConfig: AppBuildConfig = mock()
 
     private val mockDuckDuckGoUrlDetector: DuckDuckGoUrlDetector = mock()
@@ -645,6 +647,7 @@ class BrowserTabViewModelTest {
         whenever(subscriptions.isEligible()).thenReturn(false)
         whenever(mockDuckAiFeatureState.showPopupMenuShortcut).thenReturn(MutableStateFlow(false))
         whenever(mockDuckAiFeatureState.showInputScreen).thenReturn(mockDuckAiFeatureStateInputScreenFlow)
+        whenever(mockDuckAiFeatureState.showInputScreenAutomaticallyOnNewTab).thenReturn(mockDuckAiFeatureStateInputScreenOpenAutomaticallyFlow)
         whenever(mockOnboardingDesignExperimentManager.isModifiedControlEnrolledAndEnabled()).thenReturn(false)
         whenever(mockOnboardingDesignExperimentManager.isBuckEnrolledAndEnabled()).thenReturn(false)
         whenever(mockOnboardingDesignExperimentManager.isBbEnrolledAndEnabled()).thenReturn(false)
@@ -6992,7 +6995,7 @@ class BrowserTabViewModelTest {
         flowSelectedTab.emit(initialTab)
 
         testee.loadData(tabId = ntpTabId, initialUrl = null, skipHome = false, isExternal = false)
-        mockDuckAiFeatureStateInputScreenFlow.emit(true)
+        mockDuckAiFeatureStateInputScreenOpenAutomaticallyFlow.emit(true)
 
         flowSelectedTab.emit(ntpTab)
 
@@ -7005,7 +7008,7 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenInputScreenDisabledAndSwitchToNewTabThenLaunchInputScreenCommandTriggered() = runTest {
+    fun whenInputScreenDisabledAndSwitchToNewTabThenLaunchInputScreenCommandNotTriggered() = runTest {
         val initialTabId = "initial-tab"
         val initialTab = TabEntity(tabId = initialTabId, url = "https://example.com", title = "EX", skipHome = false, viewed = true, position = 0)
         val ntpTabId = "ntp-tab"
@@ -7015,7 +7018,7 @@ class BrowserTabViewModelTest {
         flowSelectedTab.emit(initialTab)
 
         testee.loadData(tabId = ntpTabId, initialUrl = null, skipHome = false, isExternal = false)
-        mockDuckAiFeatureStateInputScreenFlow.emit(false)
+        mockDuckAiFeatureStateInputScreenOpenAutomaticallyFlow.emit(false)
 
         flowSelectedTab.emit(ntpTab)
 
@@ -7038,7 +7041,7 @@ class BrowserTabViewModelTest {
         flowSelectedTab.emit(initialTab)
 
         testee.loadData(tabId = targetTabId, initialUrl = null, skipHome = false, isExternal = false)
-        mockDuckAiFeatureStateInputScreenFlow.emit(true)
+        mockDuckAiFeatureStateInputScreenOpenAutomaticallyFlow.emit(true)
 
         flowSelectedTab.emit(targetTab)
 
@@ -7061,7 +7064,7 @@ class BrowserTabViewModelTest {
         flowSelectedTab.emit(initialTab)
 
         testee.loadData(tabId = initialTabId, initialUrl = null, skipHome = false, isExternal = false)
-        mockDuckAiFeatureStateInputScreenFlow.emit(true)
+        mockDuckAiFeatureStateInputScreenOpenAutomaticallyFlow.emit(true)
 
         flowSelectedTab.emit(ntpTab)
 
@@ -7084,10 +7087,10 @@ class BrowserTabViewModelTest {
         flowSelectedTab.emit(initialTab)
 
         testee.loadData(tabId = ntpTabId, initialUrl = null, skipHome = false, isExternal = false)
-        mockDuckAiFeatureStateInputScreenFlow.emit(false)
+        mockDuckAiFeatureStateInputScreenOpenAutomaticallyFlow.emit(false)
 
         flowSelectedTab.emit(ntpTab)
-        mockDuckAiFeatureStateInputScreenFlow.emit(true)
+        mockDuckAiFeatureStateInputScreenOpenAutomaticallyFlow.emit(true)
 
         verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
         val commands = commandCaptor.allValues
@@ -7109,7 +7112,7 @@ class BrowserTabViewModelTest {
         flowSelectedTab.emit(initialTab)
 
         testee.loadData(tabId = ntpTabId, initialUrl = null, skipHome = false, isExternal = false)
-        mockDuckAiFeatureStateInputScreenFlow.emit(true)
+        mockDuckAiFeatureStateInputScreenOpenAutomaticallyFlow.emit(true)
 
         flowSelectedTab.emit(ntpTab)
 
@@ -7132,7 +7135,7 @@ class BrowserTabViewModelTest {
         flowSelectedTab.emit(initialTab)
 
         testee.loadData(tabId = ntpTabId, initialUrl = null, skipHome = false, isExternal = false)
-        mockDuckAiFeatureStateInputScreenFlow.emit(true)
+        mockDuckAiFeatureStateInputScreenOpenAutomaticallyFlow.emit(true)
 
         flowSelectedTab.emit(ntpTab)
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -738,9 +738,10 @@ class BrowserTabViewModel @Inject constructor(
             .filter { selectedTab ->
                 // fire event when activating a genuinely new tab
                 // (has no URL and wasn't opened from another tab)
+                val showInputScreenAutomatically = duckAiFeatureState.showInputScreenAutomaticallyOnNewTab.value
                 val isActiveTab = ::tabId.isInitialized && selectedTab?.tabId == tabId
                 val isOpenedFromAnotherTab = selectedTab?.sourceTabId != null
-                duckAiFeatureState.showInputScreen.value && isActiveTab && selectedTab?.url.isNullOrBlank() && !isOpenedFromAnotherTab
+                showInputScreenAutomatically && isActiveTab && selectedTab?.url.isNullOrBlank() && !isOpenedFromAnotherTab
             }
             .flowOn(dispatchers.main()) // don't use the immediate dispatcher so that the tabId field has a chance to initialize
             .onEach {

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckAiFeatureState.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckAiFeatureState.kt
@@ -31,6 +31,11 @@ interface DuckAiFeatureState {
     val showInputScreen: StateFlow<Boolean>
 
     /**
+     * Indicates whether opening a New Tab should automatically open the Input Screen. This will only be enabled if [showInputScreen] is also enabled.
+     */
+    val showInputScreenAutomaticallyOnNewTab: StateFlow<Boolean>
+
+    /**
      * Indicates whether the Duck AI shortcut should be shown in the popup menus in the main browser tabs as well as on the tab switcher screen.
      */
     val showPopupMenuShortcut: StateFlow<Boolean>

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -229,6 +229,7 @@ class RealDuckChat @Inject constructor(
     private val closeChatFlow = MutableSharedFlow<Unit>(replay = 0)
     private val _showSettings = MutableStateFlow(false)
     private val _showInputScreen = MutableStateFlow(false)
+    private val _showInputScreenAutomaticallyOnNewTab = MutableStateFlow(false)
     private val _showInBrowserMenu = MutableStateFlow(false)
     private val _showInAddressBar = MutableStateFlow(false)
     private val _showOmnibarShortcutInAllStates = MutableStateFlow(false)
@@ -242,6 +243,7 @@ class RealDuckChat @Inject constructor(
     private var isDuckChatFeatureEnabled = false
     private var isDuckAiInBrowserEnabled = false
     private var duckAiInputScreen = false
+    private var duckAiInputScreenOpenAutomaticallyEnabled = false
     private var isDuckChatUserEnabled = false
     private var duckChatLink = DUCK_CHAT_WEB_LINK
     private var bangRegex: Regex? = null
@@ -363,6 +365,8 @@ class RealDuckChat @Inject constructor(
     override val showSettings: StateFlow<Boolean> = _showSettings.asStateFlow()
 
     override val showInputScreen: StateFlow<Boolean> = _showInputScreen.asStateFlow()
+
+    override val showInputScreenAutomaticallyOnNewTab: StateFlow<Boolean> = _showInputScreenAutomaticallyOnNewTab.asStateFlow()
 
     override val showPopupMenuShortcut: StateFlow<Boolean> = _showInBrowserMenu.asStateFlow()
 
@@ -539,6 +543,7 @@ class RealDuckChat @Inject constructor(
             _showSettings.value = featureEnabled
             isDuckAiInBrowserEnabled = duckChatFeature.duckAiButtonInBrowser().isEnabled()
             duckAiInputScreen = duckChatFeature.duckAiInputScreen().isEnabled()
+            duckAiInputScreenOpenAutomaticallyEnabled = duckChatFeature.showInputScreenAutomaticallyOnNewTab().isEnabled()
 
             val settingsString = duckChatFeature.self().getSettings()
             val settingsJson = settingsString?.let {
@@ -567,6 +572,8 @@ class RealDuckChat @Inject constructor(
         val showInputScreen = isInputScreenFeatureAvailable() && isDuckChatFeatureEnabled && isDuckChatUserEnabled &&
             experimentalThemingDataStore.isSingleOmnibarEnabled.value && duckChatFeatureRepository.isInputScreenUserSettingEnabled()
         _showInputScreen.emit(showInputScreen)
+
+        _showInputScreenAutomaticallyOnNewTab.value = showInputScreen && duckAiInputScreenOpenAutomaticallyEnabled
 
         val showInBrowserMenu = duckChatFeatureRepository.shouldShowInBrowserMenu() &&
             isDuckChatFeatureEnabled && isDuckChatUserEnabled

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -59,4 +59,11 @@ interface DuckChatFeature {
      */
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun duckAiInputScreen(): Toggle
+
+    /**
+     * @return `true` when the Input Screen should open automatically when user creates a New Tab
+     * If the remote feature is not present defaults to `enabled`
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun showInputScreenAutomaticallyOnNewTab(): Toggle
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -768,6 +768,38 @@ class RealDuckChatTest {
         assertTrue(testee.showSettings.value)
     }
 
+    @Test
+    fun `when input screen disabled then don't show input screen automatically`() = runTest {
+        duckChatFeature.duckAiInputScreen().setRawStoredState(State(false))
+        duckChatFeature.showInputScreenAutomaticallyOnNewTab().setRawStoredState(State(true))
+
+        testee.onPrivacyConfigDownloaded()
+
+        assertFalse(testee.showInputScreenAutomaticallyOnNewTab.value)
+    }
+
+    @Test
+    fun `when input screen enabled but feature disabled then don't show input screen automatically`() = runTest {
+        duckChatFeature.duckAiInputScreen().setRawStoredState(State(true))
+        whenever(mockDuckChatFeatureRepository.observeInputScreenUserSettingEnabled()).thenReturn(flowOf(true))
+        duckChatFeature.showInputScreenAutomaticallyOnNewTab().setRawStoredState(State(false))
+
+        testee.onPrivacyConfigDownloaded()
+
+        assertFalse(testee.showInputScreenAutomaticallyOnNewTab.value)
+    }
+
+    @Test
+    fun `when input screen enabled and feature flag enabled then show input screen automatically`() = runTest {
+        duckChatFeature.duckAiInputScreen().setRawStoredState(State(true))
+        whenever(mockDuckChatFeatureRepository.observeInputScreenUserSettingEnabled()).thenReturn(flowOf(true))
+        duckChatFeature.showInputScreenAutomaticallyOnNewTab().setRawStoredState(State(true))
+
+        testee.onPrivacyConfigDownloaded()
+
+        assertTrue(testee.showInputScreenAutomaticallyOnNewTab.value)
+    }
+
     companion object {
         val SETTINGS_JSON = """
         {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/715106103902962/task/1211121759515670?focus=true

### Description
Fixes an issue where links that open in a new tab would also open the Input Screen automatically.

### Steps to test this PR

- [x] Go to a page that has links which open in a new tab, for example, go to [w3schools links section](https://www.w3schools.com/html//html_links.asp) and use the "Try It Yourself" button. This should open the content in a new tab but the Input Screen should not be opened.
- [x] Create a new tab manually and verify that Input Screen opens automatically.
- [x] Go to Settings -> Feature Flag Inventory -> Search for "showInputScreenAutomatically" and disable the feature.
- [x] Force close and restart the app.
- [x] Verify that creating a new tab doesn't automatically open the Input Screen.
