### PR TITLE
PIR: Add tests for AddAddress and AddName message handlers

### DIFF
--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirMessageHandlerUtils.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirMessageHandlerUtils.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.dashboard.messaging.handlers
+
+import com.duckduckgo.js.messaging.api.JsCallbackData
+import com.duckduckgo.js.messaging.api.JsMessage
+import com.duckduckgo.js.messaging.api.JsMessaging
+import com.duckduckgo.pir.impl.dashboard.messaging.PirDashboardWebConstants
+import com.duckduckgo.pir.impl.dashboard.messaging.PirDashboardWebMessages
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.verify
+
+object PirMessageHandlerUtils {
+
+    fun createJsMessage(
+        paramsJson: String?,
+        method: PirDashboardWebMessages,
+    ): JsMessage {
+        val params = if (paramsJson != null) {
+            try {
+                JSONObject(paramsJson)
+            } catch (e: Exception) {
+                JSONObject()
+            }
+        } else {
+            JSONObject()
+        }
+
+        return JsMessage(
+            context = PirDashboardWebConstants.SCRIPT_CONTEXT_NAME,
+            featureName = PirDashboardWebConstants.SCRIPT_FEATURE_NAME,
+            method = method.messageName,
+            id = "123",
+            params = params,
+        )
+    }
+
+    fun verifyResponse(
+        jsMessage: JsMessage,
+        success: Boolean,
+        mockJsMessaging: JsMessaging,
+    ) {
+        val callbackDataCaptor = argumentCaptor<JsCallbackData>()
+        verify(mockJsMessaging).onResponse(callbackDataCaptor.capture())
+
+        val callbackData = callbackDataCaptor.firstValue
+        assertEquals(jsMessage.featureName, callbackData.featureName)
+        assertEquals(jsMessage.method, callbackData.method)
+        assertEquals(jsMessage.id ?: "", callbackData.id)
+
+        // Verify the response JSON contains expected success response
+        assertTrue(callbackData.params.has("success"))
+        assertEquals(success, callbackData.params.getBoolean("success"))
+        assertTrue(callbackData.params.has("version"))
+        assertEquals(PirDashboardWebConstants.SCRIPT_API_VERSION, callbackData.params.getInt("version"))
+    }
+}

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebAddAddressToCurrentUserProfileMessageHandlerTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebAddAddressToCurrentUserProfileMessageHandlerTest.kt
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.dashboard.messaging.handlers
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.js.messaging.api.JsMessageCallback
+import com.duckduckgo.js.messaging.api.JsMessaging
+import com.duckduckgo.pir.impl.dashboard.messaging.PirDashboardWebMessages
+import com.duckduckgo.pir.impl.dashboard.messaging.handlers.PirMessageHandlerUtils.createJsMessage
+import com.duckduckgo.pir.impl.dashboard.messaging.handlers.PirMessageHandlerUtils.verifyResponse
+import com.duckduckgo.pir.impl.dashboard.state.PirWebOnboardingStateHolder
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class PirWebAddAddressToCurrentUserProfileMessageHandlerTest {
+
+    private lateinit var testee: PirWebAddAddressToCurrentUserProfileMessageHandler
+
+    private val mockPirWebOnboardingStateHolder: PirWebOnboardingStateHolder = mock()
+    private val mockJsMessaging: JsMessaging = mock()
+    private val mockJsMessageCallback: JsMessageCallback = mock()
+
+    @Before
+    fun setUp() {
+        testee = PirWebAddAddressToCurrentUserProfileMessageHandler(
+            pirWebOnboardingStateHolder = mockPirWebOnboardingStateHolder,
+        )
+    }
+
+    @Test
+    fun whenMessageIsSetThenReturnsCorrectMessage() {
+        assertEquals(PirDashboardWebMessages.ADD_ADDRESS_TO_CURRENT_USER_PROFILE, testee.message)
+    }
+
+    @Test
+    fun whenProcessWithValidAddressThenAddsAddressAndSendsSuccessResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"city": "New York", "state": "NY"}""",
+            method = PirDashboardWebMessages.ADD_ADDRESS_TO_CURRENT_USER_PROFILE,
+        )
+        whenever(mockPirWebOnboardingStateHolder.addAddress("New York", "NY")).thenReturn(true)
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder).addAddress("New York", "NY")
+        verifyResponse(jsMessage, true, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithValidAddressWithWhitespaceThenTrimsAndAddsAddress() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"city": "  Los Angeles  ", "state": "  CA  "}""",
+            method = PirDashboardWebMessages.ADD_ADDRESS_TO_CURRENT_USER_PROFILE,
+        )
+        whenever(mockPirWebOnboardingStateHolder.addAddress("Los Angeles", "CA")).thenReturn(true)
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder).addAddress("Los Angeles", "CA")
+        verifyResponse(jsMessage, true, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithBlankCityThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"city": "", "state": "NY"}""",
+            method = PirDashboardWebMessages.ADD_ADDRESS_TO_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addAddress(any(), any())
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithWhitespaceCityThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"city": "   ", "state": "NY"}""",
+            method = PirDashboardWebMessages.ADD_ADDRESS_TO_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addAddress(any(), any())
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithBlankStateThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"city": "New York", "state": ""}""",
+            method = PirDashboardWebMessages.ADD_ADDRESS_TO_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addAddress(any(), any())
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithWhitespaceStateThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"city": "New York", "state": "   "}""",
+            method = PirDashboardWebMessages.ADD_ADDRESS_TO_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addAddress(any(), any())
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithBothBlankCityAndStateThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"city": "", "state": ""}""",
+            method = PirDashboardWebMessages.ADD_ADDRESS_TO_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addAddress(any(), any())
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithMissingCityThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"state": "NY"}""",
+            method = PirDashboardWebMessages.ADD_ADDRESS_TO_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addAddress(any(), any())
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithMissingStateThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"city": "New York"}""",
+            method = PirDashboardWebMessages.ADD_ADDRESS_TO_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addAddress(any(), any())
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithDuplicateAddressThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"city": "New York", "state": "NY"}""",
+            method = PirDashboardWebMessages.ADD_ADDRESS_TO_CURRENT_USER_PROFILE,
+        )
+        whenever(mockPirWebOnboardingStateHolder.addAddress("New York", "NY")).thenReturn(false)
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder).addAddress("New York", "NY")
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithInvalidJsonThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """invalid json""",
+            method = PirDashboardWebMessages.ADD_ADDRESS_TO_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addAddress(any(), any())
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithEmptyJsonThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{}""",
+            method = PirDashboardWebMessages.ADD_ADDRESS_TO_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addAddress(any(), any())
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithNullJsonThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = null,
+            method = PirDashboardWebMessages.ADD_ADDRESS_TO_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addAddress(any(), any())
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+}

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebAddNameToCurrentUserProfileMessageHandlerTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebAddNameToCurrentUserProfileMessageHandlerTest.kt
@@ -1,0 +1,352 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.dashboard.messaging.handlers
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.js.messaging.api.JsMessageCallback
+import com.duckduckgo.js.messaging.api.JsMessaging
+import com.duckduckgo.pir.impl.dashboard.messaging.PirDashboardWebMessages
+import com.duckduckgo.pir.impl.dashboard.messaging.handlers.PirMessageHandlerUtils.createJsMessage
+import com.duckduckgo.pir.impl.dashboard.state.PirWebOnboardingStateHolder
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class PirWebAddNameToCurrentUserProfileMessageHandlerTest {
+
+    private lateinit var testee: PirWebAddNameToCurrentUserProfileMessageHandler
+
+    private val mockPirWebOnboardingStateHolder: PirWebOnboardingStateHolder = mock()
+    private val mockJsMessaging: JsMessaging = mock()
+    private val mockJsMessageCallback: JsMessageCallback = mock()
+
+    @Before
+    fun setUp() {
+        testee = PirWebAddNameToCurrentUserProfileMessageHandler(
+            pirWebOnboardingStateHolder = mockPirWebOnboardingStateHolder,
+        )
+    }
+
+    @Test
+    fun whenMessageIsSetThenReturnsCorrectMessage() {
+        assertEquals(PirDashboardWebMessages.ADD_NAME_TO_CURRENT_USER_PROFILE, testee.message)
+    }
+
+    @Test
+    fun whenProcessWithValidNameWithMiddleNameThenAddsNameAndSendsSuccessResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"first": "John", "middle": "Michael", "last": "Doe"}""",
+            method = PirDashboardWebMessages.ADD_NAME_TO_CURRENT_USER_PROFILE,
+        )
+        whenever(mockPirWebOnboardingStateHolder.addName("John", "Michael", "Doe")).thenReturn(true)
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder).addName("John", "Michael", "Doe")
+        PirMessageHandlerUtils.verifyResponse(jsMessage, true, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithValidNameWithoutMiddleNameThenAddsNameAndSendsSuccessResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"first": "Jane", "last": "Smith"}""",
+            method = PirDashboardWebMessages.ADD_NAME_TO_CURRENT_USER_PROFILE,
+        )
+        whenever(mockPirWebOnboardingStateHolder.addName("Jane", "", "Smith")).thenReturn(true)
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder).addName("Jane", "", "Smith")
+        PirMessageHandlerUtils.verifyResponse(jsMessage, true, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithValidNameWithEmptyMiddleNameThenAddsNameAndSendsSuccessResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"first": "Bob", "middle": "", "last": "Johnson"}""",
+            method = PirDashboardWebMessages.ADD_NAME_TO_CURRENT_USER_PROFILE,
+        )
+        whenever(mockPirWebOnboardingStateHolder.addName("Bob", "", "Johnson")).thenReturn(true)
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder).addName("Bob", "", "Johnson")
+        PirMessageHandlerUtils.verifyResponse(jsMessage, true, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithValidNameWithWhitespaceThenTrimsAndAddsName() {
+        // Given
+        val jsMessage =
+            createJsMessage(
+                paramsJson = """{"first": "  Alice  ", "middle": "  Marie  ", "last": "  Brown  "}""",
+                method = PirDashboardWebMessages.ADD_NAME_TO_CURRENT_USER_PROFILE,
+            )
+        whenever(
+            mockPirWebOnboardingStateHolder.addName(
+                "Alice",
+                "Marie",
+                "Brown",
+            ),
+        ).thenReturn(true)
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder).addName("Alice", "Marie", "Brown")
+        PirMessageHandlerUtils.verifyResponse(jsMessage, true, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithBlankFirstNameThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"first": "", "last": "Doe"}""",
+            method = PirDashboardWebMessages.ADD_NAME_TO_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addName(
+            any(),
+            any(),
+            any(),
+        )
+        PirMessageHandlerUtils.verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithWhitespaceFirstNameThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"first": "   ", "last": "Doe"}""",
+            method = PirDashboardWebMessages.ADD_NAME_TO_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addName(
+            any(),
+            any(),
+            any(),
+        )
+        PirMessageHandlerUtils.verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithBlankLastNameThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"first": "John", "last": ""}""",
+            method = PirDashboardWebMessages.ADD_NAME_TO_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addName(
+            any(),
+            any(),
+            any(),
+        )
+        PirMessageHandlerUtils.verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithWhitespaceLastNameThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"first": "John", "last": "   "}""",
+            method = PirDashboardWebMessages.ADD_NAME_TO_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addName(
+            any(),
+            any(),
+            any(),
+        )
+        PirMessageHandlerUtils.verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithBothBlankFirstAndLastNameThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"first": "", "last": ""}""",
+            method = PirDashboardWebMessages.ADD_NAME_TO_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addName(
+            any(),
+            any(),
+            any(),
+        )
+        PirMessageHandlerUtils.verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithMissingFirstNameThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"last": "Doe"}""",
+            method = PirDashboardWebMessages.ADD_NAME_TO_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addName(
+            any(),
+            any(),
+            any(),
+        )
+        PirMessageHandlerUtils.verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithMissingLastNameThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"first": "John"}""",
+            method = PirDashboardWebMessages.ADD_NAME_TO_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addName(
+            any(),
+            any(),
+            any(),
+        )
+        PirMessageHandlerUtils.verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithDuplicateNameThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"first": "John", "middle": "Michael", "last": "Doe"}""",
+            method = PirDashboardWebMessages.ADD_NAME_TO_CURRENT_USER_PROFILE,
+        )
+        whenever(
+            mockPirWebOnboardingStateHolder.addName(
+                "John",
+                "Michael",
+                "Doe",
+            ),
+        ).thenReturn(false)
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder).addName("John", "Michael", "Doe")
+        PirMessageHandlerUtils.verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithInvalidJsonThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """invalid json""",
+            method = PirDashboardWebMessages.ADD_NAME_TO_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addName(
+            any(),
+            any(),
+            any(),
+        )
+        PirMessageHandlerUtils.verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithEmptyJsonThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{}""",
+            method = PirDashboardWebMessages.ADD_NAME_TO_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addName(
+            any(),
+            any(),
+            any(),
+        )
+        PirMessageHandlerUtils.verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithNullJsonThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = null,
+            method = PirDashboardWebMessages.ADD_NAME_TO_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).addName(
+            any(),
+            any(),
+            any(),
+        )
+        PirMessageHandlerUtils.verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211134926977200?focus=true

### Description
Adds tests for `PirWebAddAddressToCurrentUserProfileMessageHandler` and `PirWebAddNameToCurrentUserProfileMessageHandler`.
It's necessary to run them with `AndroidJUnit4` runner as we need access to `JSONObject`.

### Steps to test this PR
Run unit tests in `PirWebAddAddressToCurrentUserProfileMessageHandler` and `PirWebAddNameToCurrentUserProfileMessageHandler`

### UI changes
No UI changes