### PR TITLE
Hide new line button in Search Input Mode

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
@@ -169,6 +169,7 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
             } else {
                 it.showChatLogo
             }
+            binding.actionNewLine.isVisible = it.newLineButtonVisible
         }.launchIn(lifecycleScope)
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/state/InputScreenVisibilityState.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/state/InputScreenVisibilityState.kt
@@ -21,4 +21,5 @@ data class InputScreenVisibilityState(
     val autoCompleteSuggestionsVisible: Boolean,
     val showChatLogo: Boolean,
     val showSearchLogo: Boolean,
+    val newLineButtonVisible: Boolean,
 )

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
@@ -387,6 +387,10 @@ class InputScreenViewModel @AssistedInject constructor(
                 it.copy(newLineButtonVisible = true)
             }
         }
+        if (userSelectedMode == SEARCH) {
+            fireModeSwitchedPixel()
+        }
+        userSelectedMode = CHAT
     }
 
     fun onSearchSelected() {
@@ -395,13 +399,6 @@ class InputScreenViewModel @AssistedInject constructor(
                 it.copy(newLineButtonVisible = false)
             }
         }
-        if (userSelectedMode == SEARCH) {
-            fireModeSwitchedPixel()
-        }
-        userSelectedMode = CHAT
-    }
-
-    fun onSearchSelected() {
         if (userSelectedMode == CHAT) {
             fireModeSwitchedPixel()
         }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
@@ -124,6 +124,7 @@ class InputScreenViewModel @AssistedInject constructor(
             autoCompleteSuggestionsVisible = false,
             showChatLogo = true,
             showSearchLogo = true,
+            newLineButtonVisible = false,
         ),
     )
     val visibilityState: StateFlow<InputScreenVisibilityState> = _visibilityState.asStateFlow()
@@ -381,6 +382,17 @@ class InputScreenViewModel @AssistedInject constructor(
         viewModelScope.launch {
             _submitButtonIconState.update {
                 it.copy(icon = SubmitButtonIcon.SEND)
+            }
+            _visibilityState.update {
+                it.copy(newLineButtonVisible = true)
+            }
+        }
+    }
+
+    fun onSearchSelected() {
+        viewModelScope.launch {
+            _visibilityState.update {
+                it.copy(newLineButtonVisible = false)
             }
         }
         if (userSelectedMode == SEARCH) {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
@@ -913,4 +913,18 @@ class InputScreenViewModelTest {
         verify(pixel, never()).fire(DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_SESSION_BOTH_MODES)
         verify(pixel, never()).fire(DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_SESSION_BOTH_MODES_DAILY, type = Daily())
     }
+
+    @Test
+    fun `when onChatSelected then new line button is visible`() {
+        val viewModel = createViewModel()
+        viewModel.onChatSelected()
+        assertTrue(viewModel.visibilityState.value.newLineButtonVisible)
+    }
+
+    @Test
+    fun `when onSearchSelected then new line button is not visible`() {
+        val viewModel = createViewModel()
+        viewModel.onSearchSelected()
+        assertFalse(viewModel.visibilityState.value.newLineButtonVisible)
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211147839324405?focus=true

### Description

- Removes the new line button from the search input mode.

### Steps to test this PR

- [ ] Navigate to the Input Screen
- [ ] Verify that the new line button is hidden in Search Mode
- [ ] Verify that the new line button is visible in Duck.ai Mode

### UI changes
| Before  | After |
| ------ | ----- |
<img width="1080" height="2340" alt="Screenshot_20250826_131115" src="https://github.com/user-attachments/assets/0d16b8e1-451c-4c02-9250-8e60dfb89c48" />|<img width="1080" height="2340" alt="Screenshot_20250826_131134" src="https://github.com/user-attachments/assets/4b9337f9-de62-4be7-b154-c98aa161dff6" />
