### PR TITLE
PIR: Add tests for set address, name and birth year handlers

### DIFF
--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebSetAddressAtIndexInCurrentUserProfileMessageHandlerTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebSetAddressAtIndexInCurrentUserProfileMessageHandlerTest.kt
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.dashboard.messaging.handlers
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.js.messaging.api.JsMessageCallback
+import com.duckduckgo.js.messaging.api.JsMessaging
+import com.duckduckgo.pir.impl.dashboard.messaging.PirDashboardWebMessages
+import com.duckduckgo.pir.impl.dashboard.messaging.handlers.PirMessageHandlerUtils.createJsMessage
+import com.duckduckgo.pir.impl.dashboard.messaging.handlers.PirMessageHandlerUtils.verifyResponse
+import com.duckduckgo.pir.impl.dashboard.state.PirWebOnboardingStateHolder
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class PirWebSetAddressAtIndexInCurrentUserProfileMessageHandlerTest {
+
+    private lateinit var testee: PirWebSetAddressAtIndexInCurrentUserProfileMessageHandler
+
+    private val mockPirWebOnboardingStateHolder: PirWebOnboardingStateHolder = mock()
+    private val mockJsMessaging: JsMessaging = mock()
+    private val mockJsMessageCallback: JsMessageCallback = mock()
+
+    @Before
+    fun setUp() {
+        testee = PirWebSetAddressAtIndexInCurrentUserProfileMessageHandler(
+            pirWebOnboardingStateHolder = mockPirWebOnboardingStateHolder,
+        )
+    }
+
+    @Test
+    fun whenMessageIsSetThenReturnsCorrectMessage() {
+        assertEquals(PirDashboardWebMessages.SET_ADDRESS_AT_INDEX_IN_CURRENT_USER_PROFILE, testee.message)
+    }
+
+    @Test
+    fun whenProcessWithValidAddressAndIndexThenSetsAddressAndSendsSuccessResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"index": 0, "address": {"city": "New York", "state": "NY"}}""",
+            method = PirDashboardWebMessages.SET_ADDRESS_AT_INDEX_IN_CURRENT_USER_PROFILE,
+        )
+        whenever(mockPirWebOnboardingStateHolder.setAddressAtIndex(0, "New York", "NY")).thenReturn(true)
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder).setAddressAtIndex(0, "New York", "NY")
+        verifyResponse(jsMessage, true, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithValidAddressWithWhitespaceThenTrimsAndSetsAddress() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"index": 1, "address": {"city": "  Los Angeles  ", "state": "  CA  "}}""",
+            method = PirDashboardWebMessages.SET_ADDRESS_AT_INDEX_IN_CURRENT_USER_PROFILE,
+        )
+        whenever(mockPirWebOnboardingStateHolder.setAddressAtIndex(1, "Los Angeles", "CA")).thenReturn(true)
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder).setAddressAtIndex(1, "Los Angeles", "CA")
+        verifyResponse(jsMessage, true, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithMissingIndexThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"address": {"city": "Chicago", "state": "IL"}}""",
+            method = PirDashboardWebMessages.SET_ADDRESS_AT_INDEX_IN_CURRENT_USER_PROFILE,
+        )
+        whenever(mockPirWebOnboardingStateHolder.setAddressAtIndex(0, "Chicago", "IL")).thenReturn(true)
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithBlankCityThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"index": 0, "address": {"city": "", "state": "NY"}}""",
+            method = PirDashboardWebMessages.SET_ADDRESS_AT_INDEX_IN_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithWhitespaceCityThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"index": 0, "address": {"city": "   ", "state": "NY"}}""",
+            method = PirDashboardWebMessages.SET_ADDRESS_AT_INDEX_IN_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithBlankStateThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"index": 0, "address": {"city": "New York", "state": ""}}""",
+            method = PirDashboardWebMessages.SET_ADDRESS_AT_INDEX_IN_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithWhitespaceStateThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"index": 0, "address": {"city": "New York", "state": "   "}}""",
+            method = PirDashboardWebMessages.SET_ADDRESS_AT_INDEX_IN_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithBothBlankCityAndStateThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"index": 0, "address": {"city": "", "state": ""}}""",
+            method = PirDashboardWebMessages.SET_ADDRESS_AT_INDEX_IN_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithMissingCityThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"index": 0, "address": {"state": "NY"}}""",
+            method = PirDashboardWebMessages.SET_ADDRESS_AT_INDEX_IN_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithMissingStateThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"index": 0, "address": {"city": "New York"}}""",
+            method = PirDashboardWebMessages.SET_ADDRESS_AT_INDEX_IN_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithMissingAddressObjectThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"index": 0}""",
+            method = PirDashboardWebMessages.SET_ADDRESS_AT_INDEX_IN_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithDuplicateAddressThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"index": 0, "address": {"city": "New York", "state": "NY"}}""",
+            method = PirDashboardWebMessages.SET_ADDRESS_AT_INDEX_IN_CURRENT_USER_PROFILE,
+        )
+        whenever(mockPirWebOnboardingStateHolder.setAddressAtIndex(0, "New York", "NY")).thenReturn(false)
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder).setAddressAtIndex(0, "New York", "NY")
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithInvalidIndexThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"index": 5, "address": {"city": "New York", "state": "NY"}}""",
+            method = PirDashboardWebMessages.SET_ADDRESS_AT_INDEX_IN_CURRENT_USER_PROFILE,
+        )
+        whenever(mockPirWebOnboardingStateHolder.setAddressAtIndex(5, "New York", "NY")).thenReturn(false)
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder).setAddressAtIndex(5, "New York", "NY")
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithInvalidJsonThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """invalid json""",
+            method = PirDashboardWebMessages.SET_ADDRESS_AT_INDEX_IN_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithEmptyJsonThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{}""",
+            method = PirDashboardWebMessages.SET_ADDRESS_AT_INDEX_IN_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithNullJsonThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = null,
+            method = PirDashboardWebMessages.SET_ADDRESS_AT_INDEX_IN_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setAddressAtIndex(any(), any(), any())
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+}

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebSetBirthYearForCurrentUserProfileTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebSetBirthYearForCurrentUserProfileTest.kt
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.dashboard.messaging.handlers
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.js.messaging.api.JsMessageCallback
+import com.duckduckgo.js.messaging.api.JsMessaging
+import com.duckduckgo.pir.impl.dashboard.messaging.PirDashboardWebMessages
+import com.duckduckgo.pir.impl.dashboard.messaging.handlers.PirMessageHandlerUtils.createJsMessage
+import com.duckduckgo.pir.impl.dashboard.messaging.handlers.PirMessageHandlerUtils.verifyResponse
+import com.duckduckgo.pir.impl.dashboard.state.PirWebOnboardingStateHolder
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+@RunWith(AndroidJUnit4::class)
+class PirWebSetBirthYearForCurrentUserProfileTest {
+
+    private lateinit var testee: PirWebSetBirthYearForCurrentUserProfile
+
+    private val mockPirWebOnboardingStateHolder: PirWebOnboardingStateHolder = mock()
+    private val mockJsMessaging: JsMessaging = mock()
+    private val mockJsMessageCallback: JsMessageCallback = mock()
+
+    @Before
+    fun setUp() {
+        testee = PirWebSetBirthYearForCurrentUserProfile(
+            pirWebOnboardingStateHolder = mockPirWebOnboardingStateHolder,
+        )
+    }
+
+    @Test
+    fun whenMessageIsSetThenReturnsCorrectMessage() {
+        assertEquals(
+            PirDashboardWebMessages.SET_BIRTH_YEAR_FOR_CURRENT_USER_PROFILE,
+            testee.message,
+        )
+    }
+
+    @Test
+    fun whenProcessWithValidYearThenSetsBirthYearAndSendsSuccessResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"year": 1990}""",
+            method = PirDashboardWebMessages.SET_BIRTH_YEAR_FOR_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder).setBirthYear(1990)
+        verifyResponse(jsMessage, true, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithDifferentValidYearThenSetsBirthYearAndSendsSuccessResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"year": 1985}""",
+            method = PirDashboardWebMessages.SET_BIRTH_YEAR_FOR_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder).setBirthYear(1985)
+        verifyResponse(jsMessage, true, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithZeroYearThenSetsBirthYearAndSendsSuccessResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"year": 0}""",
+            method = PirDashboardWebMessages.SET_BIRTH_YEAR_FOR_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder).setBirthYear(0)
+        verifyResponse(jsMessage, true, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithNegativeYearThenSetsBirthYearAndSendsSuccessResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"year": -1}""",
+            method = PirDashboardWebMessages.SET_BIRTH_YEAR_FOR_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder).setBirthYear(-1)
+        verifyResponse(jsMessage, true, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithLargeYearThenSetsBirthYearAndSendsSuccessResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"year": 2030}""",
+            method = PirDashboardWebMessages.SET_BIRTH_YEAR_FOR_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder).setBirthYear(2030)
+        verifyResponse(jsMessage, true, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithMissingYearThenDefaultsToZeroAndSendsSuccessResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{}""",
+            method = PirDashboardWebMessages.SET_BIRTH_YEAR_FOR_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder).setBirthYear(0)
+        verifyResponse(jsMessage, true, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithNonNumericYearThenDefaultsToZeroAndSendsSuccessResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"year": "invalid"}""",
+            method = PirDashboardWebMessages.SET_BIRTH_YEAR_FOR_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder).setBirthYear(0)
+        verifyResponse(jsMessage, true, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithFloatYearThenTruncatesToIntegerAndSendsSuccessResponse() {
+        // Given - Note: JSON parsing may handle this differently, but testing the case
+        val jsMessage = createJsMessage(
+            paramsJson = """{"year": 1990.5}""",
+            method = PirDashboardWebMessages.SET_BIRTH_YEAR_FOR_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then - The exact behavior depends on JSON parsing, but it should set some value
+        verify(mockPirWebOnboardingStateHolder).setBirthYear(org.mockito.kotlin.any())
+        verifyResponse(jsMessage, true, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithNullYearThenDefaultsToZeroAndSendsSuccessResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"year": null}""",
+            method = PirDashboardWebMessages.SET_BIRTH_YEAR_FOR_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder).setBirthYear(0)
+        verifyResponse(jsMessage, true, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithInvalidJsonThenDefaultsToZeroAndSendsSuccessResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """invalid json""",
+            method = PirDashboardWebMessages.SET_BIRTH_YEAR_FOR_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder).setBirthYear(0)
+        verifyResponse(jsMessage, true, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithNullJsonThenDefaultsToZeroAndSendsSuccessResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = null,
+            method = PirDashboardWebMessages.SET_BIRTH_YEAR_FOR_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder).setBirthYear(0)
+        verifyResponse(jsMessage, true, mockJsMessaging)
+    }
+}

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebSetNameAtIndexInCurrentUserProfileMessageHandlerTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebSetNameAtIndexInCurrentUserProfileMessageHandlerTest.kt
@@ -1,0 +1,449 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.dashboard.messaging.handlers
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.js.messaging.api.JsMessageCallback
+import com.duckduckgo.js.messaging.api.JsMessaging
+import com.duckduckgo.pir.impl.dashboard.messaging.PirDashboardWebMessages.SET_NAME_AT_INDEX_IN_CURRENT_USER_PROFILE
+import com.duckduckgo.pir.impl.dashboard.messaging.handlers.PirMessageHandlerUtils.createJsMessage
+import com.duckduckgo.pir.impl.dashboard.messaging.handlers.PirMessageHandlerUtils.verifyResponse
+import com.duckduckgo.pir.impl.dashboard.state.PirWebOnboardingStateHolder
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class PirWebSetNameAtIndexInCurrentUserProfileMessageHandlerTest {
+
+    private lateinit var testee: PirWebSetNameAtIndexInCurrentUserProfileMessageHandler
+
+    private val mockPirWebOnboardingStateHolder: PirWebOnboardingStateHolder = mock()
+    private val mockJsMessaging: JsMessaging = mock()
+    private val mockJsMessageCallback: JsMessageCallback = mock()
+
+    @Before
+    fun setUp() {
+        testee = PirWebSetNameAtIndexInCurrentUserProfileMessageHandler(
+            pirWebOnboardingStateHolder = mockPirWebOnboardingStateHolder,
+        )
+    }
+
+    @Test
+    fun whenMessageIsSetThenReturnsCorrectMessage() {
+        assertEquals(SET_NAME_AT_INDEX_IN_CURRENT_USER_PROFILE, testee.message)
+    }
+
+    @Test
+    fun whenProcessWithValidNameAndIndexThenSetsNameAndSendsSuccessResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"index": 0, "name": {"first": "John", "middle": "Michael", "last": "Doe"}}""",
+            method = SET_NAME_AT_INDEX_IN_CURRENT_USER_PROFILE,
+        )
+        whenever(
+            mockPirWebOnboardingStateHolder.setNameAtIndex(
+                0,
+                "John",
+                "Michael",
+                "Doe",
+            ),
+        ).thenReturn(true)
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder).setNameAtIndex(0, "John", "Michael", "Doe")
+        verifyResponse(jsMessage, true, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithValidNameWithoutMiddleNameThenSetsNameAndSendsSuccessResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"index": 1, "name": {"first": "Jane", "last": "Smith"}}""",
+            method = SET_NAME_AT_INDEX_IN_CURRENT_USER_PROFILE,
+        )
+        whenever(mockPirWebOnboardingStateHolder.setNameAtIndex(1, "Jane", "", "Smith")).thenReturn(
+            true,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder).setNameAtIndex(1, "Jane", "", "Smith")
+        verifyResponse(jsMessage, true, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithValidNameWithEmptyMiddleNameThenSetsNameAndSendsSuccessResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"index": 0, "name": {"first": "Bob", "middle": "", "last": "Johnson"}}""",
+            method = SET_NAME_AT_INDEX_IN_CURRENT_USER_PROFILE,
+        )
+        whenever(
+            mockPirWebOnboardingStateHolder.setNameAtIndex(
+                0,
+                "Bob",
+                "",
+                "Johnson",
+            ),
+        ).thenReturn(true)
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder).setNameAtIndex(0, "Bob", "", "Johnson")
+        verifyResponse(jsMessage, true, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithValidNameWithWhitespaceThenTrimsAndSetsName() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"index": 2, "name": {"first": "  Alice  ", "middle": "  Marie  ", "last": "  Brown  "}}""",
+            method = SET_NAME_AT_INDEX_IN_CURRENT_USER_PROFILE,
+        )
+        whenever(
+            mockPirWebOnboardingStateHolder.setNameAtIndex(
+                2,
+                "Alice",
+                "Marie",
+                "Brown",
+            ),
+        ).thenReturn(true)
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder).setNameAtIndex(2, "Alice", "Marie", "Brown")
+        verifyResponse(jsMessage, true, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithMissingIndexThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"name": {"first": "Charlie", "last": "Wilson"}}""",
+            method = SET_NAME_AT_INDEX_IN_CURRENT_USER_PROFILE,
+        )
+        whenever(
+            mockPirWebOnboardingStateHolder.setNameAtIndex(
+                0,
+                "Charlie",
+                "",
+                "Wilson",
+            ),
+        ).thenReturn(true)
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
+            any(),
+            any(),
+            any(),
+            any(),
+        )
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithBlankFirstNameThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"index": 0, "name": {"first": "", "last": "Doe"}}""",
+            method = SET_NAME_AT_INDEX_IN_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
+            any(),
+            any(),
+            any(),
+            any(),
+        )
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithWhitespaceFirstNameThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"index": 0, "name": {"first": "   ", "last": "Doe"}}""",
+            method = SET_NAME_AT_INDEX_IN_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
+            any(),
+            any(),
+            any(),
+            any(),
+        )
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithBlankLastNameThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"index": 0, "name": {"first": "John", "last": ""}}""",
+            method = SET_NAME_AT_INDEX_IN_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
+            any(),
+            any(),
+            any(),
+            any(),
+        )
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithWhitespaceLastNameThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"index": 0, "name": {"first": "John", "last": "   "}}""",
+            method = SET_NAME_AT_INDEX_IN_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
+            any(),
+            any(),
+            any(),
+            any(),
+        )
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithBothBlankFirstAndLastNameThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"index": 0, "name": {"first": "", "last": ""}}""",
+            method = SET_NAME_AT_INDEX_IN_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
+            any(),
+            any(),
+            any(),
+            any(),
+        )
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithMissingFirstNameThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"index": 0, "name": {"last": "Doe"}}""",
+            method = SET_NAME_AT_INDEX_IN_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
+            any(),
+            any(),
+            any(),
+            any(),
+        )
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithMissingLastNameThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"index": 0, "name": {"first": "John"}}""",
+            method = SET_NAME_AT_INDEX_IN_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
+            any(),
+            any(),
+            any(),
+            any(),
+        )
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithMissingNameObjectThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"index": 0}""",
+            method = SET_NAME_AT_INDEX_IN_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
+            any(),
+            any(),
+            any(),
+            any(),
+        )
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithDuplicateNameThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"index": 0, "name": {"first": "John", "middle": "Michael", "last": "Doe"}}""",
+            method = SET_NAME_AT_INDEX_IN_CURRENT_USER_PROFILE,
+        )
+        whenever(
+            mockPirWebOnboardingStateHolder.setNameAtIndex(
+                0,
+                "John",
+                "Michael",
+                "Doe",
+            ),
+        ).thenReturn(false)
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder).setNameAtIndex(0, "John", "Michael", "Doe")
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithInvalidIndexThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{"index": 5, "name": {"first": "John", "last": "Doe"}}""",
+            method = SET_NAME_AT_INDEX_IN_CURRENT_USER_PROFILE,
+        )
+        whenever(mockPirWebOnboardingStateHolder.setNameAtIndex(5, "John", "", "Doe")).thenReturn(
+            false,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder).setNameAtIndex(5, "John", "", "Doe")
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithInvalidJsonThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """invalid json""",
+            method = SET_NAME_AT_INDEX_IN_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
+            any(),
+            any(),
+            any(),
+            any(),
+        )
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithEmptyJsonThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = """{}""",
+            method = SET_NAME_AT_INDEX_IN_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
+            any(),
+            any(),
+            any(),
+            any(),
+        )
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+
+    @Test
+    fun whenProcessWithNullJsonThenSendsErrorResponse() {
+        // Given
+        val jsMessage = createJsMessage(
+            paramsJson = null,
+            method = SET_NAME_AT_INDEX_IN_CURRENT_USER_PROFILE,
+        )
+
+        // When
+        testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
+
+        // Then
+        verify(mockPirWebOnboardingStateHolder, org.mockito.kotlin.never()).setNameAtIndex(
+            any(),
+            any(),
+            any(),
+            any(),
+        )
+        verifyResponse(jsMessage, false, mockJsMessaging)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211137752462442?focus=true

### Description
Adds tests for `PirWebSetAddressAtIndexInCurrentUserProfileMessageHandler`, `PirWebSetBirthYearForCurrentUserProfile` and `PirWebSetNameAtIndexInCurrentUserProfileMessageHandler`.
It's necessary to run them with `AndroidJUnit4` runner as we need access to `JSONObject`.

### Steps to test this PR
Run unit tests in `PirWebSetAddressAtIndexInCurrentUserProfileMessageHandler`, `PirWebSetBirthYearForCurrentUserProfile` and `PirWebSetNameAtIndexInCurrentUserProfileMessageHandler`.

### UI changes
No UI changes