### PR TITLE
Fix typing animation crash in B&B / Buck onboarding

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BbWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BbWelcomePage.kt
@@ -587,10 +587,10 @@ class BbWelcomePage : OnboardingPageFragment(R.layout.content_onboarding_welcome
     }
 
     private fun scheduleTypingAnimation(textView: TypeAnimationTextView, text: String, afterAnimation: () -> Unit = {}) {
-        textView.postDelayed(
-            { textView.startTypingAnimation(text, afterAnimation = afterAnimation) },
-            ANIMATION_DURATION,
-        )
+        viewLifecycleOwner.lifecycleScope.launch {
+            delay(ANIMATION_DURATION)
+            textView.startTypingAnimation(text, afterAnimation = afterAnimation)
+        }
     }
 
     private fun showDefaultBrowserDialog(intent: Intent) {

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BuckWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BuckWelcomePage.kt
@@ -73,8 +73,10 @@ import com.duckduckgo.common.utils.extensions.html
 import com.duckduckgo.common.utils.extensions.preventWidows
 import com.duckduckgo.di.scopes.FragmentScope
 import javax.inject.Inject
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 
 @InjectWith(FragmentScope::class)
 class BuckWelcomePage : OnboardingPageFragment(R.layout.content_onboarding_welcome_page_buck) {
@@ -458,10 +460,10 @@ class BuckWelcomePage : OnboardingPageFragment(R.layout.content_onboarding_welco
     }
 
     private fun scheduleTypingAnimation(textView: TypeAnimationTextView, text: String, afterAnimation: () -> Unit = {}) {
-        textView.postDelayed(
-            { textView.startTypingAnimation(text, afterAnimation = afterAnimation) },
-            ANIMATION_DURATION,
-        )
+        viewLifecycleOwner.lifecycleScope.launch {
+            delay(ANIMATION_DURATION)
+            textView.startTypingAnimation(text, afterAnimation = afterAnimation)
+        }
     }
 
     private fun showDefaultBrowserDialog(intent: Intent) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211147346596759?focus=true

### Description

This PR prevents typing animations in pre-browser onboarding from being started after the view is destroyed.

### Steps to test this PR

- [ ] Smoke test B&B / Buck pre-browser onboarding.

### No UI changes
