### PR TITLE
fix an issue where Find In Page didn't show in Custom Tabs

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/SingleOmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/SingleOmnibarLayout.kt
@@ -26,6 +26,7 @@ import android.view.ViewTreeObserver.OnGlobalLayoutListener
 import android.view.animation.DecelerateInterpolator
 import android.widget.ImageView
 import androidx.core.content.ContextCompat
+import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import com.duckduckgo.anvil.annotations.InjectWith
@@ -164,7 +165,7 @@ class SingleOmnibarLayout @JvmOverloads constructor(
             animateOmnibarFocusedState(focused = false)
         }
 
-        omnibarCardShadow.isVisible = viewState.viewMode !is ViewMode.CustomTab
+        omnibarCardShadow.isGone = viewState.viewMode is ViewMode.CustomTab && !isFindInPageVisible
     }
 
     override fun renderButtons(viewState: ViewState) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1211147614566539?focus=true

### Description
Fixes an issue where the whole omnibar container was hidden in Custom Tab mode, which also made the Find In Page layout inaccessible.

Side note - I think the Find In Page feature state might need an update given all the workarounds that were incorporated throughout the omnibars experiments iterations. Now that we're cleaning it up in https://github.com/duckduckgo/Android/pull/6658, the next step could be cleaning up the Find In Page impl as well. 

### Steps to test this PR

- [x] Go to Settings -> Developer Settings -> Custom Tabs and open a new Custom tab.
- [x] Verify that the layout is correct and there's no misaligned "bubble" around the address bar.
- [x] Open overflow menu and select Find In Page.
- [x] Verify that the feature works correctly and can be closed/reopened and doesn't cause issue when the screen is rotated.