### PR TITLE
show Duck.ai fragment immediately if opened from outside of the BrowserActivity

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -212,6 +212,18 @@ open class BrowserActivity : DuckDuckGoActivity() {
 
     private var duckAiFragment: DuckChatWebViewFragment? = null
 
+    /**
+     * Whether [duckAiFragment] should animate in.
+     *
+     * True only if [BrowserActivity] has been visible (`STARTED`) for at least [DUCK_AI_ANIM_READY_DELAY_MS].
+     * Otherwise, the fragment is shown immediately (e.g., when the activity was just launched from elsewhere) to avoid janky transitions.
+     *
+     * Delay is required because [onNewIntent] (which shows Duck.ai) always runs after [onStart].
+     * We must ensure the animation is executed only if the activity was already visible before the intent was delivered.
+     */
+    private var duckAiShouldAnimate: Boolean = false
+    private var duckAiAnimDelayJob: Job? = null
+
     private var _currentTab: BrowserTabFragment? = null
     private var currentTab: BrowserTabFragment?
         get() {
@@ -382,10 +394,21 @@ open class BrowserActivity : DuckDuckGoActivity() {
         }
     }
 
+    override fun onStart() {
+        super.onStart()
+        duckAiAnimDelayJob = lifecycleScope.launch {
+            delay(DUCK_AI_ANIM_READY_DELAY_MS)
+            duckAiShouldAnimate = true
+        }
+    }
+
     override fun onStop() {
         openMessageInNewTabJob?.cancel()
 
         super.onStop()
+
+        duckAiAnimDelayJob?.cancel()
+        duckAiShouldAnimate = false
     }
 
     override fun onDestroy() {
@@ -564,7 +587,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
         if (intent.getBooleanExtra(OPEN_DUCK_CHAT, false)) {
             isDuckChatVisible = true
             val duckChatSessionActive = intent.getBooleanExtra(DUCK_CHAT_SESSION_ACTIVE, false)
-            viewModel.openDuckChat(intent.getStringExtra(DUCK_CHAT_URL), duckChatSessionActive)
+            viewModel.openDuckChat(intent.getStringExtra(DUCK_CHAT_URL), duckChatSessionActive, withTransition = duckAiShouldAnimate)
             return
         }
 
@@ -705,7 +728,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
             is Command.ShowSystemDefaultAppsActivity -> showSystemDefaultAppsActivity(command.intent)
             is Command.ShowSystemDefaultBrowserDialog -> showSystemDefaultBrowserDialog(command.intent)
             is Command.ShowUndoDeleteTabsMessage -> showTabsDeletedSnackbar(command.tabIds)
-            is Command.OpenDuckChat -> openDuckChat(command.duckChatUrl, command.duckChatSessionActive)
+            is Command.OpenDuckChat -> openDuckChat(command.duckChatUrl, command.duckChatSessionActive, command.withTransition)
             Command.LaunchTabSwitcher -> currentTab?.launchTabSwitcherAfterTabsUndeleted()
         }
     }
@@ -804,15 +827,16 @@ open class BrowserActivity : DuckDuckGoActivity() {
     private fun openDuckChat(
         url: String?,
         duckChatSessionActive: Boolean,
+        withTransition: Boolean,
     ) {
         duckAiFragment?.let { fragment ->
             if (duckChatSessionActive) {
-                restoreDuckChat(fragment)
+                restoreDuckChat(fragment, withTransition)
             } else {
-                launchNewDuckChat(url)
+                launchNewDuckChat(url, withTransition)
             }
         } ?: run {
-            launchNewDuckChat(url)
+            launchNewDuckChat(url, withTransition)
         }
 
         currentTab?.omnibar?.newOmnibar?.omnibarTextInput?.let {
@@ -820,7 +844,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
         }
     }
 
-    private fun launchNewDuckChat(duckChatUrl: String?) {
+    private fun launchNewDuckChat(duckChatUrl: String?, withTransition: Boolean) {
         val wasFragmentVisible = duckAiFragment?.isVisible ?: false
         val fragment = DuckChatWebViewFragment().apply {
             duckChatUrl?.let {
@@ -835,13 +859,17 @@ open class BrowserActivity : DuckDuckGoActivity() {
         transaction.replace(binding.duckAiFragmentContainer.id, fragment)
         transaction.commit()
 
+        // If the fragment was already visible but needs to be force-reloaded, we don't want to animate it in again.
         if (!wasFragmentVisible) {
-            // If the fragment was already visible but needs to be force-reloaded, we don't want to animate it in again.
-            animateDuckAiFragmentIn()
+            if (withTransition) {
+                animateDuckAiFragmentIn()
+            } else {
+                showDuckAiFragmentImmediately()
+            }
         }
     }
 
-    private fun restoreDuckChat(fragment: DuckChatWebViewFragment) {
+    private fun restoreDuckChat(fragment: DuckChatWebViewFragment, withTransition: Boolean) {
         if (fragment.isVisible) {
             return
         }
@@ -850,7 +878,21 @@ open class BrowserActivity : DuckDuckGoActivity() {
         transaction.show(fragment)
         transaction.commit()
 
-        animateDuckAiFragmentIn()
+        if (withTransition) {
+            animateDuckAiFragmentIn()
+        } else {
+            showDuckAiFragmentImmediately()
+        }
+    }
+
+    private fun showDuckAiFragmentImmediately() {
+        val duckAiContainer = binding.duckAiFragmentContainer
+        duckAiContainer.isVisible = true
+        duckAiContainer.alpha = 1f
+        duckAiContainer.translationX = 0f
+
+        val browserContainer = if (swipingTabsFeature.isEnabled) binding.tabPager else binding.fragmentContainer
+        browserContainer.alpha = 0f
     }
 
     private fun animateDuckAiFragmentIn() {
@@ -979,6 +1021,8 @@ open class BrowserActivity : DuckDuckGoActivity() {
         private const val KEY_TAB_PAGER_STATE = "tabPagerState"
 
         private const val DISABLE_SWIPING_DELAY = 1000L
+
+        private const val DUCK_AI_ANIM_READY_DELAY_MS = 300L
     }
 
     inner class BrowserStateRenderer {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserViewModel.kt
@@ -83,7 +83,6 @@ import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import logcat.LogPriority.INFO
 import logcat.logcat
 
@@ -134,7 +133,7 @@ class BrowserViewModel @Inject constructor(
         data class ShowSystemDefaultBrowserDialog(val intent: Intent) : Command()
         data class ShowSystemDefaultAppsActivity(val intent: Intent) : Command()
         data class ShowUndoDeleteTabsMessage(val tabIds: List<String>) : Command()
-        data class OpenDuckChat(val duckChatUrl: String?, val duckChatSessionActive: Boolean) : Command()
+        data class OpenDuckChat(val duckChatUrl: String?, val duckChatSessionActive: Boolean, val withTransition: Boolean) : Command()
     }
 
     var viewState: MutableLiveData<ViewState> = MutableLiveData<ViewState>().also {
@@ -463,13 +462,9 @@ class BrowserViewModel @Inject constructor(
         command.value = ShowUndoDeleteTabsMessage(tabIds)
     }
 
-    fun openDuckChat(duckChatUrl: String?, duckChatSessionActive: Boolean) {
+    fun openDuckChat(duckChatUrl: String?, duckChatSessionActive: Boolean, withTransition: Boolean) {
         logcat(INFO) { "Duck.ai openDuckChat duckChatSessionActive $duckChatSessionActive" }
-        viewModelScope.launch(dispatchers.io()) {
-            withContext(dispatchers.main()) {
-                command.value = OpenDuckChat(duckChatUrl, duckChatSessionActive)
-            }
-        }
+        command.value = OpenDuckChat(duckChatUrl, duckChatSessionActive, withTransition)
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1211037269945827?focus=true

### Description

Adds a check whether Duck.ai should animate in or be opened immediately. The former is only allowed if the command to open Duck.ai fragment originated while the `BrowserActivity` was already visible and can smoothly transition to the Duck.ai fragment. Otherwise, the fragment is show immediately to avoid janky transitions.

### Steps to test this PR
- [x] With the new Input Screen disabled, go to a website and click Duck.ai in the omnibar. Go back, and click the button again. Verify that Duck.ai opens with a transition.
- [x] Click the address bar, type in some text, and click the Duck.ai icon. Verify that it opens with a transition.
- [x] Go to Settings -> AI features and enabled the Input Screen.
- [x] Go back to the website and click the Duck.ai button. Verify Duck.ai opens with a transition.
- [x] Click the omnibar, switch to Duck.ai, type in and submit a prompt. Verify that Duck.ai opens immediately without a transition.
- [x] Go back and verify that the fragment closes with a transition back to the website.

_before_

https://github.com/user-attachments/assets/cdfdee2a-68cc-4377-b36d-e349a240cf0a

_after_

https://github.com/user-attachments/assets/2abcf956-400f-4568-97a4-7f22e9a8b1b2


