### PR TITLE
decrease Input Screen's autocomplete debounce to 100 ms

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
@@ -176,7 +176,7 @@ class InputScreenViewModel @AssistedInject constructor(
         .flatMapLatest { shouldShow ->
             if (shouldShow) {
                 merge(
-                    searchInputTextState.debounceExceptFirst(300),
+                    searchInputTextState.debounceExceptFirst(timeoutMillis = 100),
                     refreshSuggestions.map { searchInputTextState.value },
                 ).flatMapLatest { autoComplete.autoComplete(it) }
             } else {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1211163531745283?focus=true

### Description
Decreases Input Screen's autocomplete debounce to 100 ms

### Steps to test this PR

QA optional. If you can, verify autocomplete works as expected while on the Input Screen.
