### PR TITLE
do not display Dax logo if favorites are loading

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageView.kt
@@ -153,7 +153,7 @@ class NewTabLegacyPageView @JvmOverloads constructor(
             }
         }
 
-        if (viewState.favourites.isEmpty()) {
+        if (viewState.favourites.isNullOrEmpty()) {
             binding.focusedFavourites.gone()
         } else {
             binding.focusedFavourites.show()

--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageViewModel.kt
@@ -75,17 +75,18 @@ class NewTabLegacyPageViewModel @AssistedInject constructor(
         val message: RemoteMessage? = null,
         val newMessage: Boolean = false,
         val onboardingComplete: Boolean = false,
-        val favourites: List<Favorite> = emptyList(),
+        val favourites: List<Favorite>? = null,
         val lowPriorityMessage: LowPriorityMessage? = null,
     ) {
 
-        private val hasContentThatDisplacesHomoLogo = onboardingComplete &&
+        private val isLoadingContent = favourites == null
+        private val hasContentThatDisplacesHomeLogo = onboardingComplete &&
             message != null ||
-            favourites.isNotEmpty()
+            favourites?.isNotEmpty() == true
         private val hasLowPriorityMessage = lowPriorityMessage != null
 
-        val shouldShowLogo = !hasContentThatDisplacesHomoLogo && showDaxLogo
-        val hasContent = shouldShowLogo || hasContentThatDisplacesHomoLogo || appTpEnabled || hasLowPriorityMessage
+        val shouldShowLogo = !isLoadingContent && !hasContentThatDisplacesHomeLogo && showDaxLogo
+        val hasContent = isLoadingContent || (shouldShowLogo || hasContentThatDisplacesHomeLogo || appTpEnabled || hasLowPriorityMessage)
     }
 
     private data class ViewStateSnapshot(

--- a/app/src/test/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/newtab/NewTabLegacyPageViewModelTest.kt
@@ -37,6 +37,7 @@ import com.duckduckgo.remote.messaging.api.RemoteMessageModel
 import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.savedsites.api.models.SavedSite
 import com.duckduckgo.sync.api.engine.SyncEngine
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -109,7 +110,7 @@ class NewTabLegacyPageViewModelTest {
         testee.viewState.test {
             expectMostRecentItem().also {
                 assertEquals(it.message, remoteMessage)
-                assertTrue(it.favourites.isEmpty())
+                assertTrue(it.favourites?.isEmpty() == true)
                 assertTrue(it.newMessage)
                 assertFalse(it.onboardingComplete)
             }
@@ -127,7 +128,7 @@ class NewTabLegacyPageViewModelTest {
         testee.viewState.test {
             expectMostRecentItem().also {
                 assertEquals(it.message, remoteMessage)
-                assertTrue(it.favourites.isEmpty())
+                assertTrue(it.favourites?.isEmpty() == true)
                 assertTrue(it.newMessage)
                 assertFalse(it.onboardingComplete)
             }
@@ -145,7 +146,7 @@ class NewTabLegacyPageViewModelTest {
         testee.viewState.test {
             expectMostRecentItem().also {
                 assertEquals(it.message, remoteMessage)
-                assertTrue(it.favourites.isEmpty())
+                assertTrue(it.favourites?.isEmpty() == true)
                 assertTrue(it.newMessage)
                 assertTrue(it.onboardingComplete)
             }
@@ -400,6 +401,25 @@ class NewTabLegacyPageViewModelTest {
             expectMostRecentItem().also {
                 assertFalse(it.shouldShowLogo)
                 assertTrue(it.hasContent)
+            }
+        }
+    }
+
+    @Test
+    fun `when favourites loading, then hide logo but still report content`() = runTest {
+        val favouritesFlow = MutableSharedFlow<List<SavedSite.Favorite>>(replay = 0)
+        val remoteMessageFlow = MutableSharedFlow<RemoteMessage?>(replay = 0)
+        whenever(mockSavedSitesRepository.getFavorites()).thenReturn(favouritesFlow)
+        whenever(mockRemoteMessageModel.getActiveMessages()).thenReturn(remoteMessageFlow)
+
+        testee = createTestee()
+        testee.onStart(mockLifecycleOwner)
+
+        testee.viewState.test {
+            expectMostRecentItem().also {
+                assertFalse(it.shouldShowLogo)
+                assertTrue(it.hasContent)
+                assertNull(it.favourites)
             }
         }
     }

--- a/new-tab-page/new-tab-page-api/src/main/java/com/duckduckgo/newtabpage/api/NewTabPagePlugin.kt
+++ b/new-tab-page/new-tab-page-api/src/main/java/com/duckduckgo/newtabpage/api/NewTabPagePlugin.kt
@@ -31,7 +31,7 @@ interface NewTabPagePlugin : ActivePlugin {
      * This method returns a [View] that will be used as the NewTabPage content
      * @param context The context to create the view with
      * @param showLogo Whether to show the logo in the new tab page
-     * @param onHasContent Optional callback to notify when the view has content
+     * @param onHasContent Optional callback to notify when the view has content. View assumes it has content while loading data.
      * @return [View]
      */
     fun getView(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1211121230931120?focus=true

### Description
Changes the NTP logic to not display Dax logo until favorites are loaded, and then only show the logo if favorites are empty.

### Steps to test this PR

- [x] Clean install the app.
- [x] Verify Dax shows on NTP.
- [x] Enable AppTP.
- [x] Verify Dax shows on NTP.
- [x] Add favorites (you can use Settings -> Developer Settings -> Tabs and Saved Sites).
- [x] Verify Dax doesn't show on NTP.
- [x] Go to a website and try to open a new tab, verify that while the NTP loads, there's no Dax logo flicker.
- [x] Go to Settings -> AI Features and enabled the experimental address bar.
- [x] Go to NTP and click on the omnibar to open the Input Screen.
- [x] Verify favorites are shown on the Input Screen and there's no Dax logo flicker during the transition (favorites themselves will flicker a little).
