### PR TITLE
fix Input Screen content offset when compared with NTP

### DIFF
--- a/duckchat/duckchat-impl/src/main/res/layout/view_input_mode_switch_widget.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_input_mode_switch_widget.xml
@@ -50,64 +50,70 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"/>
 
-    <com.google.android.material.card.MaterialCardView
-        android:id="@+id/inputModeWidgetCard"
-        style="@style/Widget.DuckDuckGo.OmnibarCardView"
+    <FrameLayout
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="@dimen/omnibarCardMarginHorizontal"
-        android:layout_marginTop="@dimen/omnibarCardMarginTop"
-        android:layout_marginBottom="@dimen/omnibarCardMarginBottom"
-        app:strokeColor="?attr/daxColorAccentBlue"
-        app:strokeWidth="@dimen/omnibarOutlineWidth"
-        app:cardElevation="0dp"
-        app:layout_constraintTop_toBottomOf="@id/spacer"
+        android:layout_height="@dimen/toolbarSize"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent">
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/spacer">
 
-        <LinearLayout
-            android:id="@+id/inputModeWidgetCardContent"
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/inputModeWidgetCard"
+            style="@style/Widget.DuckDuckGo.OmnibarCardView"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:padding="@dimen/keyline_0">
+            android:layout_height="match_parent"
+            android:layout_marginHorizontal="@dimen/omnibarCardMarginHorizontal"
+            android:layout_marginTop="@dimen/omnibarCardMarginTop"
+            android:layout_marginBottom="@dimen/omnibarCardMarginBottom"
+            app:strokeColor="?attr/daxColorAccentBlue"
+            app:strokeWidth="@dimen/omnibarOutlineWidth"
+            app:cardElevation="0dp">
 
-            <EditText
-                android:id="@+id/inputField"
-                android:layout_width="0dp"
+            <LinearLayout
+                android:id="@+id/inputModeWidgetCardContent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:layout_marginStart="@dimen/keyline_4"
-                android:layout_weight="1"
-                android:background="@null"
-                android:fontFamily="sans-serif"
-                android:gravity="start|top"
-                android:hint="@string/input_screen_search_hint"
-                android:lineSpacingMultiplier="1.2"
-                android:minHeight="@dimen/toolbarIcon"
-                android:paddingVertical="@dimen/keyline_2"
-                android:textColor="?attr/daxColorPrimaryText"
-                android:textColorHighlight="?attr/daxOmnibarTextColorHighlight"
-                android:textColorHint="?attr/daxColorSecondaryText"
-                android:textCursorDrawable="@drawable/text_cursor"
-                android:textSize="16sp"
-                android:textStyle="normal"
-                android:maxLines="1" />
+                android:orientation="horizontal"
+                android:padding="@dimen/keyline_0">
 
-            <ImageView
-                android:id="@+id/inputFieldClearText"
-                android:layout_width="@dimen/toolbarIcon"
-                android:layout_height="@dimen/toolbarIcon"
-                android:layout_gravity="top"
-                android:background="@drawable/selectable_item_experimental_background"
-                android:gravity="center"
-                android:importantForAccessibility="no"
-                android:padding="@dimen/keyline_1"
-                android:scaleType="centerInside"
-                android:visibility="gone"
-                app:srcCompat="@drawable/ic_close_circle_small_secondary_24" />
+                <EditText
+                    android:id="@+id/inputField"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    android:layout_marginStart="@dimen/keyline_4"
+                    android:layout_weight="1"
+                    android:background="@null"
+                    android:fontFamily="sans-serif"
+                    android:gravity="start|top"
+                    android:hint="@string/input_screen_search_hint"
+                    android:lineSpacingMultiplier="1.2"
+                    android:minHeight="@dimen/toolbarIcon"
+                    android:paddingVertical="@dimen/keyline_2"
+                    android:textColor="?attr/daxColorPrimaryText"
+                    android:textColorHighlight="?attr/daxOmnibarTextColorHighlight"
+                    android:textColorHint="?attr/daxColorSecondaryText"
+                    android:textCursorDrawable="@drawable/text_cursor"
+                    android:textSize="16sp"
+                    android:textStyle="normal"
+                    android:maxLines="1" />
 
-        </LinearLayout>
+                <ImageView
+                    android:id="@+id/inputFieldClearText"
+                    android:layout_width="@dimen/toolbarIcon"
+                    android:layout_height="@dimen/toolbarIcon"
+                    android:layout_gravity="top"
+                    android:background="@drawable/selectable_item_experimental_background"
+                    android:gravity="center"
+                    android:importantForAccessibility="no"
+                    android:padding="@dimen/keyline_1"
+                    android:scaleType="centerInside"
+                    android:visibility="gone"
+                    app:srcCompat="@drawable/ic_close_circle_small_secondary_24" />
 
-    </com.google.android.material.card.MaterialCardView>
+            </LinearLayout>
+
+        </com.google.android.material.card.MaterialCardView>
+
+    </FrameLayout>
 </merge>

--- a/duckchat/duckchat-impl/src/main/res/layout/view_input_mode_switch_widget.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_input_mode_switch_widget.xml
@@ -7,22 +7,22 @@
         style="@style/Widget.DuckChat.TabLayout.Rounded"
         android:layout_width="wrap_content"
         android:layout_height="@dimen/inputModeSwitchHeight"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constrainedWidth="true"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constrainedWidth="true">
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
         <com.google.android.material.tabs.TabItem
             android:id="@+id/tabSearch"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout="@layout/view_search_tab_indicator"/>
+            android:layout="@layout/view_search_tab_indicator" />
 
         <com.google.android.material.tabs.TabItem
             android:id="@+id/tabDuckAi"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout="@layout/view_chat_tab_indicator"/>
+            android:layout="@layout/view_chat_tab_indicator" />
 
     </com.duckduckgo.duckchat.impl.inputscreen.ui.view.InputModeTabLayout>
 
@@ -37,24 +37,24 @@
         android:importantForAccessibility="no"
         android:padding="@dimen/keyline_2"
         android:scaleType="center"
-        app:srcCompat="@drawable/ic_arrow_left_24"
+        app:layout_constraintBottom_toBottomOf="@id/inputModeSwitch"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="@id/inputModeSwitch"
-        app:layout_constraintBottom_toBottomOf="@id/inputModeSwitch"/>
+        app:srcCompat="@drawable/ic_arrow_left_24" />
 
     <Space
         android:id="@+id/spacer"
         android:layout_width="0dp"
         android:layout_height="10dp"
-        app:layout_constraintTop_toBottomOf="@id/inputModeSwitch"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"/>
+        app:layout_constraintTop_toBottomOf="@id/inputModeSwitch" />
 
     <FrameLayout
         android:layout_width="0dp"
         android:layout_height="@dimen/toolbarSize"
-        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/spacer">
 
         <com.google.android.material.card.MaterialCardView
@@ -65,9 +65,9 @@
             android:layout_marginHorizontal="@dimen/omnibarCardMarginHorizontal"
             android:layout_marginTop="@dimen/omnibarCardMarginTop"
             android:layout_marginBottom="@dimen/omnibarCardMarginBottom"
+            app:cardElevation="0dp"
             app:strokeColor="?attr/daxColorAccentBlue"
-            app:strokeWidth="@dimen/omnibarOutlineWidth"
-            app:cardElevation="0dp">
+            app:strokeWidth="@dimen/omnibarOutlineWidth">
 
             <LinearLayout
                 android:id="@+id/inputModeWidgetCardContent"
@@ -88,6 +88,7 @@
                     android:gravity="start|top"
                     android:hint="@string/input_screen_search_hint"
                     android:lineSpacingMultiplier="1.2"
+                    android:maxLines="1"
                     android:minHeight="@dimen/toolbarIcon"
                     android:paddingVertical="@dimen/keyline_2"
                     android:textColor="?attr/daxColorPrimaryText"
@@ -95,8 +96,7 @@
                     android:textColorHint="?attr/daxColorSecondaryText"
                     android:textCursorDrawable="@drawable/text_cursor"
                     android:textSize="16sp"
-                    android:textStyle="normal"
-                    android:maxLines="1" />
+                    android:textStyle="normal" />
 
                 <ImageView
                     android:id="@+id/inputFieldClearText"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1210973894973725?focus=true

### Description
Fixes a misalignment of Input Screen's content with the NTP content. To resolve the issue, I'm adding a container that matches the height of the regular omnibar into the Input Mode Widget to ensure that the space it occupies is consistent with the omnibar which makes the content underneath remain at the same offset from the input box.

### Steps to test this PR

- [ ] Enable Input Screen and verify that while transitioning between NTP and Input Screen all the content shifts together, aligned with the transition, without any jumps.

If you want to try a slowed down transition to get a closer look at the details, try this diff:
```diff
diff --git a/duckchat/duckchat-api/src/main/res/values/animation-settings.xml b/duckchat/duckchat-api/src/main/res/values/animation-settings.xml
index d7d1c61813..a4198ca8a6 100644
--- a/duckchat/duckchat-api/src/main/res/values/animation-settings.xml
+++ b/duckchat/duckchat-api/src/main/res/values/animation-settings.xml
@@ -16,5 +16,5 @@
   -->
 
 <resources>
-    <integer name="input_screen_slide_animation_duration_ms">200</integer>
+    <integer name="input_screen_slide_animation_duration_ms">2000</integer>
 </resources>
```

### UI changes

_before_

https://github.com/user-attachments/assets/054b56a6-e44e-4a60-929e-e4edc4c63c2e

_after_

https://github.com/user-attachments/assets/c2e06b1d-71c3-40ee-8b56-c0ed1c8b51d4
