### PR TITLE
remove bounds animation for buttons on the Input Screen

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
@@ -236,6 +236,9 @@ class InputModeWidget @JvmOverloads constructor(
                 root,
                 ChangeBounds().apply {
                     duration = EXPAND_COLLAPSE_TRANSITION_DURATION
+                    excludeTarget(R.id.actionSend, true)
+                    excludeTarget(R.id.actionNewLine, true)
+                    excludeTarget(R.id.actionVoice, true)
                 },
             )
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1210977218249614?focus=true

### Description
Excludes FABs from the bounds animation on the Input Screen.

### Steps to test this PR

- [ ] Enable the new Input Screen.
- [ ] Enable voice search.
- [ ] Open Input Screen and switch to Duck.ai tab.
- [ ] Type something in.
- [ ] Verify you see 2 buttons - new line and submit.
- [ ] Click "clear text" button in the input box.
- [ ] Verify you see 2 buttons - voice search and new line - and here was no animation to change from the previous set of buttons.
