### PR TITLE
fix an issue where creating a new line in Chat Mode wouldn't expand the input box

### DIFF
--- a/duckchat/duckchat-impl/src/main/res/layout/view_input_mode_switch_widget.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_input_mode_switch_widget.xml
@@ -52,7 +52,8 @@
 
     <FrameLayout
         android:layout_width="0dp"
-        android:layout_height="@dimen/toolbarSize"
+        android:layout_height="wrap_content"
+        android:minHeight="@dimen/toolbarSize"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/spacer">


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1211196787859247?focus=true

### Description
Fixes a regression from https://github.com/duckduckgo/Android/pull/6686 where the input box would be prohibited from expanding when new lines were added in Chat Mode.

### Steps to test this PR

- [x] Enabled the new Input Screen.
- [x] Go to the Chat Mode, type some text and use the "new line" button.
- [x] Verify a new line is added and the input box expands to accommodate it.
- [x] Verify that while transitioning between NTP and Input Screen all the content shifts together, aligned with the transition, without any jumps.