### PR TITLE
remove new lines from search queries submitted from the Input Screen

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
@@ -338,7 +338,8 @@ class InputScreenViewModel @AssistedInject constructor(
     }
 
     fun onSearchSubmitted(query: String) {
-        command.value = Command.SubmitSearch(query)
+        val sanitizedQuery = query.replace(oldValue = "\n", newValue = " ")
+        command.value = Command.SubmitSearch(sanitizedQuery)
         pixel.fire(DUCK_CHAT_EXPERIMENTAL_OMNIBAR_QUERY_SUBMITTED)
         pixel.fire(DUCK_CHAT_EXPERIMENTAL_OMNIBAR_QUERY_SUBMITTED_DAILY, type = Daily())
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
@@ -927,4 +927,18 @@ class InputScreenViewModelTest {
         viewModel.onSearchSelected()
         assertFalse(viewModel.visibilityState.value.newLineButtonVisible)
     }
+
+    @Test
+    fun `when onSearchSubmitted with newlines then they are replaced with spaces`() = runTest {
+        val viewModel = createViewModel()
+        val queryWithNewlines = "first line\nsecond line\nthird line"
+        val expected = "first line second line third line"
+
+        whenever(inputScreenSessionStore.hasUsedSearchMode()).thenReturn(false)
+        whenever(inputScreenSessionStore.hasUsedChatMode()).thenReturn(false)
+
+        viewModel.onSearchSubmitted(queryWithNewlines)
+
+        assertEquals(SubmitSearch(expected), viewModel.command.value)
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1210989973696534?focus=true

### Description
Sanitizes Input Screen's search query output and removes the new lines.

### Steps to test this PR

- [x] Enabled the new Input Screen.
- [x] Go to Chat Mode, type in "Duck {click new line button} Duck {click new line button} Go".
- [x] Go back to Search Mode and submit the search query.
- [x] Reopen the Input Screen and type in "Duck" in the Search Mode.
- [x] Verify that at the bottom of the suggestions list there's a history entry for "Duck Duck Go" without ellipsis or new lines.