### PR TITLE
Expand Input Field to fill space

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
@@ -244,6 +244,8 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
         onInputFieldClicked = {
             viewModel.onInputFieldTouched()
         }
+
+        setConstraintViewId(R.id.fabsTopBarrier)
     }
 
     private fun submitChatQuery(query: String) {

--- a/duckchat/duckchat-impl/src/main/res/layout/fragment_input_screen.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/fragment_input_screen.xml
@@ -106,4 +106,12 @@
         app:srcCompat="@drawable/ic_microphone_24"
         app:tint="?attr/daxColorPrimaryIcon" />
 
+    <androidx.constraintlayout.widget.Barrier
+        android:id="@+id/fabsTopBarrier"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:barrierDirection="top"
+        app:constraint_referenced_ids="actionSend,actionNewLine,actionVoice"
+        app:barrierAllowsGoneWidgets="true" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1210931783913729?focus=true

### Description

- Removes the height restriction on the Input Field so that it can expand to use all of the available space.

### Steps to test this PR

- [ ] Type in the Duck.ai Input Field until it fills all available space
- [ ] Verify that the field stops expanding before the fabs
- [ ] Hide the keyboard
- [ ] Tap the new line button
- [ ] Verify that the field does not expand past its current height
- [ ] Copy the text and clear the field
- [ ] Go to search and paste the text
- [ ] Verify that the field expands as expected
