### PR TITLE
Update content scope scripts to version 11.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.13.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.3.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.12.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.13.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#66c1c3555f2b61c0ab0efccf1bfe8358230d12e5",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#8d591b82e9cd44fdb09a98b41e958f0a7bc1ad48",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.13.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.3.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.12.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.13.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run