### PR TITLE
Disable onboarding design experiment in privacy configuration

### DIFF
--- a/privacy-config/privacy-config-impl/src/main/res/raw/privacy_config.json
+++ b/privacy-config/privacy-config-impl/src/main/res/raw/privacy_config.json
@@ -2,28 +2,6 @@
     "readme": "https://github.com/duckduckgo/privacy-configuration",
     "version": 1652275711516,
     "features": {
-        "onboardingDesignExperiment": {
-            "state": "enabled",
-            "features": {
-                "onboardingDesignExperimentAug25": {
-                    "state": "enabled",
-                    "cohorts": [
-                        {
-                            "name": "modifiedControl",
-                            "weight": 0
-                        },
-                        {
-                            "name": "bb",
-                            "weight": 0
-                        },
-                        {
-                            "name": "buck",
-                            "weight": 0
-                        }
-                    ]
-                }
-            }
-        },
         "ampLinks": {
             "exceptions": [
                 {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1211213870765252?focus=true

### Description

Removed the `onboardingDesignExperiment` feature from the privacy configuration. This experiment with three cohorts (modifiedControl, bb, and buck) is no longer needed in the privacy config.

### Steps to test this PR

_Verify experiment removal_

- [ ] Confirm that the onboarding experience no longer uses the experimental cohorts
- [ ] Verify that the app functions correctly without the removed experiment configuration

### UI changes

No UI changes as this is a configuration update that removes an expired experiment.