### PR TITLE
Update content scope scripts to version 11.15.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
@@ -1567,7 +1567,6 @@
     constructor(config, messagingContext) {
       this.messagingContext = messagingContext;
       this.config = config;
-      this.config.sendInitialPing(messagingContext);
     }
     /**
      * @param {NotificationMessage} msg
@@ -3519,6 +3518,11 @@
        * @type {boolean}
        */
       __publicField(this, "listenForUpdateChanges", false);
+      /**
+       * Set this to true if you wish to receive configuration updates from initial ping responses (Android only).
+       * @type {boolean}
+       */
+      __publicField(this, "listenForConfigUpdates", false);
       /** @type {ImportMeta} */
       __privateAdd(this, _importConfig);
       this.setArgs(this.args);
@@ -3673,6 +3677,14 @@
      * @deprecated - use messaging instead.
      */
     update() {
+    }
+    /**
+     * Called when user preferences are merged from initial ping response. (Android only)
+     * Override this method in your feature to handle user preference updates.
+     * This only happens once during initialization when the platform responds with user-specific settings.
+     * @param {object} _updatedConfig - The configuration with merged user preferences
+     */
+    onUserPreferencesMerged(_updatedConfig) {
     }
     /**
      * Register a flag that will be added to page breakage reports

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -3087,7 +3087,6 @@
     constructor(config, messagingContext) {
       this.messagingContext = messagingContext;
       this.config = config;
-      this.config.sendInitialPing(messagingContext);
     }
     /**
      * @param {NotificationMessage} msg
@@ -5063,6 +5062,11 @@
        * @type {boolean}
        */
       __publicField(this, "listenForUpdateChanges", false);
+      /**
+       * Set this to true if you wish to receive configuration updates from initial ping responses (Android only).
+       * @type {boolean}
+       */
+      __publicField(this, "listenForConfigUpdates", false);
       /** @type {ImportMeta} */
       __privateAdd(this, _importConfig);
       this.setArgs(this.args);
@@ -5217,6 +5221,14 @@
      * @deprecated - use messaging instead.
      */
     update() {
+    }
+    /**
+     * Called when user preferences are merged from initial ping response. (Android only)
+     * Override this method in your feature to handle user preference updates.
+     * This only happens once during initialization when the platform responds with user-specific settings.
+     * @param {object} _updatedConfig - The configuration with merged user preferences
+     */
+    onUserPreferencesMerged(_updatedConfig) {
     }
     /**
      * Register a flag that will be added to page breakage reports

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -2927,7 +2927,6 @@
     constructor(config, messagingContext) {
       this.messagingContext = messagingContext;
       this.config = config;
-      this.config.sendInitialPing(messagingContext);
     }
     /**
      * @param {NotificationMessage} msg
@@ -4903,6 +4902,11 @@
        * @type {boolean}
        */
       __publicField(this, "listenForUpdateChanges", false);
+      /**
+       * Set this to true if you wish to receive configuration updates from initial ping responses (Android only).
+       * @type {boolean}
+       */
+      __publicField(this, "listenForConfigUpdates", false);
       /** @type {ImportMeta} */
       __privateAdd(this, _importConfig);
       this.setArgs(this.args);
@@ -5057,6 +5061,14 @@
      * @deprecated - use messaging instead.
      */
     update() {
+    }
+    /**
+     * Called when user preferences are merged from initial ping response. (Android only)
+     * Override this method in your feature to handle user preference updates.
+     * This only happens once during initialization when the platform responds with user-specific settings.
+     * @param {object} _updatedConfig - The configuration with merged user preferences
+     */
+    onUserPreferencesMerged(_updatedConfig) {
     }
     /**
      * Register a flag that will be added to page breakage reports
@@ -6690,6 +6702,8 @@
       __privateAdd(this, _activeShareRequest, null);
       /** @type {Promise<any> | null} */
       __privateAdd(this, _activeScreenLockRequest, null);
+      // Opt in to receive configuration updates from initial ping responses
+      __publicField(this, "listenForConfigUpdates", true);
     }
     init() {
       if (this.getFeatureSettingEnabled("windowSizing")) {
@@ -6723,9 +6737,6 @@
       if (this.getFeatureSettingEnabled("webShare")) {
         this.shimWebShare();
       }
-      if (this.getFeatureSettingEnabled("viewportWidth")) {
-        this.viewportWidthFix();
-      }
       if (this.getFeatureSettingEnabled("screenLock")) {
         this.screenLockFix();
       }
@@ -6740,6 +6751,19 @@
       }
       if (this.getFeatureSettingEnabled("enumerateDevices")) {
         this.deviceEnumerationFix();
+      }
+    }
+    /**
+     * Handle user preference updates when merged during initialization.
+     * Re-applies viewport fixes if viewport configuration has changed.
+     * @param {object} _updatedConfig - The configuration with merged user preferences
+     */
+    onUserPreferencesMerged(_updatedConfig) {
+      if (this.getFeatureSettingEnabled("viewportWidth")) {
+        if (!this._viewportWidthFixApplied) {
+          this.viewportWidthFix();
+          this._viewportWidthFixApplied = true;
+        }
       }
     }
     /** Shim Web Share API in Android WebView */

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
@@ -879,7 +879,6 @@
     constructor(config, messagingContext) {
       this.messagingContext = messagingContext;
       this.config = config;
-      this.config.sendInitialPing(messagingContext);
     }
     /**
      * @param {NotificationMessage} msg

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.19.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.3.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.14.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.15.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#5d65eb4df2b661932b6d14dd494be8a6edbe9122",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#92aa73fdef3c280b46feb0a40d468fac44edcbdc",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.19.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.3.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.14.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.15.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1211219459188341/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [x] All tests must pass
- [x] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run