### PR TITLE
[Web Tracking Protection] Add staggered grid of web protections

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/webtrackingprotection/WebTrackingProtectionActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/webtrackingprotection/WebTrackingProtectionActivity.kt
@@ -35,9 +35,6 @@ import com.duckduckgo.app.browser.databinding.ActivityWebTrackingProtectionBindi
 import com.duckduckgo.app.globalprivacycontrol.ui.GlobalPrivacyControlActivity
 import com.duckduckgo.app.privacy.ui.AllowListActivity
 import com.duckduckgo.app.webtrackingprotection.WebTrackingProtectionViewModel.Command
-import com.duckduckgo.app.webtrackingprotection.WebTrackingProtectionViewModel.Command.LaunchAllowList
-import com.duckduckgo.app.webtrackingprotection.WebTrackingProtectionViewModel.Command.LaunchGlobalPrivacyControl
-import com.duckduckgo.app.webtrackingprotection.WebTrackingProtectionViewModel.Command.LaunchLearnMoreWebPage
 import com.duckduckgo.app.webtrackingprotection.list.FeatureGridAdapter
 import com.duckduckgo.browser.api.ui.BrowserScreens.WebViewActivityWithParams
 import com.duckduckgo.common.ui.DuckDuckGoActivity
@@ -149,9 +146,9 @@ class WebTrackingProtectionActivity : DuckDuckGoActivity() {
 
     private fun processCommand(it: Command) {
         when (it) {
-            is LaunchLearnMoreWebPage -> launchLearnMoreWebPage(it.url)
-            is LaunchGlobalPrivacyControl -> launchGlobalPrivacyControl()
-            is LaunchAllowList -> launchAllowList()
+            is Command.LaunchLearnMoreWebPage -> launchLearnMoreWebPage(it.url)
+            is Command.LaunchGlobalPrivacyControl -> launchGlobalPrivacyControl()
+            is Command.LaunchAllowList -> launchAllowList()
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/webtrackingprotection/WebTrackingProtectionViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/webtrackingprotection/WebTrackingProtectionViewModel.kt
@@ -19,8 +19,10 @@ package com.duckduckgo.app.webtrackingprotection
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.webtrackingprotection.list.FeatureGridItem
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.Gpc
@@ -43,6 +45,7 @@ class WebTrackingProtectionViewModel @Inject constructor(
 
     data class ViewState(
         val globalPrivacyControlEnabled: Boolean = false,
+        val protectionItems: List<FeatureGridItem> = emptyList(),
     )
 
     sealed class Command {
@@ -59,6 +62,7 @@ class WebTrackingProtectionViewModel @Inject constructor(
             viewState.emit(
                 ViewState(
                     globalPrivacyControlEnabled = gpc.isEnabled() && featureToggle.isFeatureEnabled(PrivacyFeatureName.GpcFeatureName.value),
+                    protectionItems = getProtectionItems(),
                 ),
             )
         }
@@ -80,6 +84,56 @@ class WebTrackingProtectionViewModel @Inject constructor(
     fun onManageAllowListSelected() {
         viewModelScope.launch { command.send(Command.LaunchAllowList) }
         pixel.fire(AppPixelName.SETTINGS_MANAGE_ALLOWLIST)
+    }
+
+    private fun getProtectionItems(): List<FeatureGridItem> {
+        return listOf(
+            FeatureGridItem(
+                iconRes = R.drawable.ic_shield_protection,
+                titleRes = R.string.webTrackingProtectionThirdPartyTrackersTitle,
+                descriptionRes = R.string.webTrackingProtectionThirdPartyTrackersDescription,
+            ),
+            FeatureGridItem(
+                iconRes = R.drawable.ic_ads_tracking_blocked,
+                titleRes = R.string.webTrackingProtectionTargetedAdsTitle,
+                descriptionRes = R.string.webTrackingProtectionTargetedAdsDescription,
+            ),
+            FeatureGridItem(
+                iconRes = R.drawable.ic_fingerprint,
+                titleRes = R.string.webTrackingProtectionFingerprintTrackingTitle,
+                descriptionRes = R.string.webTrackingProtectionFingerprintTrackingDescription,
+            ),
+            FeatureGridItem(
+                iconRes = R.drawable.ic_link_blocked,
+                titleRes = R.string.webTrackingProtectionLinkTrackingTitle,
+                descriptionRes = R.string.webTrackingProtectionLinkTrackingDescription,
+            ),
+            FeatureGridItem(
+                iconRes = R.drawable.ic_profile_secure,
+                titleRes = R.string.webTrackingProtectionReferrerTrackingTitle,
+                descriptionRes = R.string.webTrackingProtectionReferrerTrackingDescription,
+            ),
+            FeatureGridItem(
+                iconRes = R.drawable.ic_cookie_blocked,
+                titleRes = R.string.webTrackingProtectionFirstPartyCookiesTitle,
+                descriptionRes = R.string.webTrackingProtectionFirstPartyCookiesDescription,
+            ),
+            FeatureGridItem(
+                iconRes = R.drawable.ic_device_laptop_secure,
+                titleRes = R.string.webTrackingProtectionDnsCnameCloakingTitle,
+                descriptionRes = R.string.webTrackingProtectionDnsCnameCloakingDescription,
+            ),
+            FeatureGridItem(
+                iconRes = R.drawable.ic_eye_blocked,
+                titleRes = R.string.webTrackingProtectionGoogleAmpTrackingTitle,
+                descriptionRes = R.string.webTrackingProtectionGoogleAmpTrackingDescription,
+            ),
+            FeatureGridItem(
+                iconRes = R.drawable.ic_popup_blocked,
+                titleRes = R.string.webTrackingProtectionGoogleSigninPopupsTitle,
+                descriptionRes = R.string.webTrackingProtectionGoogleSigninPopupsDescription,
+            ),
+        )
     }
 
     companion object {

--- a/app/src/main/java/com/duckduckgo/app/webtrackingprotection/list/FeatureGridAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/webtrackingprotection/list/FeatureGridAdapter.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.webtrackingprotection.list
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.duckduckgo.app.browser.databinding.ItemFeatureGridBinding
+import com.duckduckgo.app.webtrackingprotection.list.FeatureGridAdapter.GridItemViewHolder
+
+class FeatureGridAdapter : ListAdapter<FeatureGridItem, GridItemViewHolder>(FeatureGridItemDiffCallback()) {
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int,
+    ): GridItemViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        return GridItemViewHolder(ItemFeatureGridBinding.inflate(inflater, parent, false))
+    }
+
+    override fun onBindViewHolder(
+        holder: GridItemViewHolder,
+        position: Int,
+    ) {
+        holder.bind(getItem(position))
+    }
+
+    class GridItemViewHolder(private val binding: ItemFeatureGridBinding) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(item: FeatureGridItem) {
+            binding.icon.setImageResource(item.iconRes)
+            binding.title.setText(item.titleRes)
+            binding.description.setText(item.descriptionRes)
+        }
+    }
+
+    private class FeatureGridItemDiffCallback : DiffUtil.ItemCallback<FeatureGridItem>() {
+
+        override fun areItemsTheSame(
+            oldItem: FeatureGridItem,
+            newItem: FeatureGridItem,
+        ): Boolean = oldItem == newItem
+
+        override fun areContentsTheSame(
+            oldItem: FeatureGridItem,
+            newItem: FeatureGridItem,
+        ): Boolean = oldItem == newItem
+    }
+}
+
+data class FeatureGridItem(
+    @DrawableRes val iconRes: Int,
+    @StringRes val titleRes: Int,
+    @StringRes val descriptionRes: Int,
+)

--- a/app/src/main/res/drawable/background_feature_grid_item_icon.xml
+++ b/app/src/main/res/drawable/background_feature_grid_item_icon.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2025 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+
+    <stroke
+        android:width="@dimen/horizontalDividerHeight"
+        android:color="?attr/daxColorContainer" />
+
+    <solid android:color="?attr/daxColorSurface" />
+</shape>

--- a/app/src/main/res/drawable/ic_ads_tracking_blocked.xml
+++ b/app/src/main/res/drawable/ic_ads_tracking_blocked.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Copyright (c) 2025 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <path
+      android:pathData="M12.5,9a3.5,3.5 0,1 1,0 7,3.5 3.5,0 0,1 0,-7ZM12,1a4,4 0,0 1,4 4v2.697c0,0.565 -0.753,0.887 -1.25,0.619L14.75,5A2.75,2.75 0,0 0,12 2.25L4,2.25A2.75,2.75 0,0 0,1.25 5v6A2.75,2.75 0,0 0,4 13.75h3.917c0.156,0.576 -0.228,1.25 -0.824,1.25L4,15a4,4 0,0 1,-4 -4L0,5a4,4 0,0 1,4 -4h8ZM10.375,11.875a0.5,0.5 0,0 0,-0.5 0.5v0.25a0.5,0.5 0,0 0,0.5 0.5h4.25a0.5,0.5 0,0 0,0.5 -0.5v-0.25a0.5,0.5 0,0 0,-0.5 -0.5h-4.25ZM7.348,5.075a4.085,4.085 0,0 1,2.614 0.36c0.85,0.42 1.65,1.153 2.37,2.246l0.046,0.07a4.74,4.74 0,0 0,-1.359 0.235c-0.4,-0.535 -0.803,-0.919 -1.197,-1.187a1.997,1.997 0,0 1,-0.105 1.851c-0.307,0.223 -0.586,0.48 -0.832,0.769a2,2 0,0 1,-2.76 -2.49c-0.605,0.41 -1.12,0.96 -1.468,1.524a0.625,0.625 0,1 1,-1.064 -0.656c0.736,-1.193 2.115,-2.413 3.755,-2.723Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"/>
+</vector>

--- a/app/src/main/res/drawable/ic_cookie_blocked.xml
+++ b/app/src/main/res/drawable/ic_cookie_blocked.xml
@@ -1,0 +1,29 @@
+<!--
+  ~ Copyright (c) 2025 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <group>
+    <clip-path
+        android:pathData="M0,0h16v16H0z"/>
+    <path
+        android:pathData="M8.294,0.006c0.492,0.018 0.831,0.43 0.831,0.869a6,6 0,0 0,6 6c0.425,0 0.826,0.318 0.867,0.785 0.004,0.113 0.008,0.227 0.008,0.34 0,0.491 -0.604,0.704 -1.023,0.447a4.708,4.708 0,0 0,-0.235 -0.135c0.003,-0.066 0.006,-0.131 0.007,-0.197a7.291,7.291 0,0 1,-0.538 -0.048,4.725 4.725,0 0,0 -1.353,-0.303A7.255,7.255 0,0 1,7.885 1.25a6.75,6.75 0,1 0,0.427 13.492c0.042,0.08 0.088,0.158 0.135,0.234C8.704,15.397 8.491,16 8,16A8,8 0,1 1,8.294 0.006ZM12.5,9a3.5,3.5 0,1 1,0 7,3.5 3.5,0 0,1 0,-7ZM10.375,11.875a0.5,0.5 0,0 0,-0.5 0.5v0.25a0.5,0.5 0,0 0,0.5 0.5h4.25a0.5,0.5 0,0 0,0.5 -0.5v-0.25a0.5,0.5 0,0 0,-0.5 -0.5h-4.25ZM6.75,11a0.75,0.75 0,1 1,0 1.5,0.75 0.75,0 0,1 0,-1.5ZM3.75,8a0.75,0.75 0,1 1,0 1.5,0.75 0.75,0 0,1 0,-1.5ZM7.75,7a0.75,0.75 0,1 1,0 1.5,0.75 0.75,0 0,1 0,-1.5ZM5.75,4a0.75,0.75 0,1 1,0 1.5,0.75 0.75,0 0,1 0,-1.5Z"
+        android:fillColor="?attr/daxColorPrimaryIcon"/>
+  </group>
+</vector>

--- a/app/src/main/res/drawable/ic_device_laptop_secure.xml
+++ b/app/src/main/res/drawable/ic_device_laptop_secure.xml
@@ -1,0 +1,41 @@
+<!--
+  ~ Copyright (c) 2025 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <group>
+    <clip-path
+        android:pathData="M0,0h16v16H0z"/>
+    <path
+        android:pathData="M3,2a2,2 0,0 0,-2 2v8.5H0.75a0.75,0.75 0,0 0,0 1.5h7.625v-1.636c0,-0.308 0.066,-0.6 0.185,-0.864H2.5V4a0.5,0.5 0,0 1,0.5 -0.5h10a0.5,0.5 0,0 1,0.5 0.5v2.706a3.5,3.5 0,0 1,1.5 0.735V4a2,2 0,0 0,-2 -2z"
+        android:fillColor="?attr/daxColorPrimaryIcon"
+        android:fillType="evenOdd"/>
+    <path
+        android:pathData="M10.25,12.364c0,-0.126 0.102,-0.228 0.227,-0.228h4.546c0.125,0 0.227,0.102 0.227,0.228v2.727a0.227,0.227 0,0 1,-0.227 0.227h-4.546a0.227,0.227 0,0 1,-0.227 -0.227z"
+        android:fillColor="?attr/daxColorPrimaryIcon"/>
+    <path
+        android:pathData="M9.5,12.364c0,-0.54 0.438,-0.978 0.977,-0.978h4.546c0.54,0 0.977,0.438 0.977,0.978v2.727c0,0.54 -0.438,0.977 -0.977,0.977h-4.546a0.977,0.977 0,0 1,-0.977 -0.977zM11,12.886v1.682h3.5v-1.682z"
+        android:fillColor="?attr/daxColorPrimaryIcon"
+        android:fillType="evenOdd"/>
+    <path
+        android:pathData="M12.75,9.25c-0.491,0 -0.84,0.377 -0.84,0.782v1.877h-1.5v-1.877c0,-1.287 1.074,-2.282 2.34,-2.282s2.34,0.995 2.34,2.282v1.877h-1.5v-1.877c0,-0.405 -0.349,-0.782 -0.84,-0.782"
+        android:fillColor="?attr/daxColorPrimaryIcon"
+        android:fillType="evenOdd"/>
+  </group>
+</vector>

--- a/app/src/main/res/drawable/ic_eye_blocked.xml
+++ b/app/src/main/res/drawable/ic_eye_blocked.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Copyright (c) 2025 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <path
+      android:pathData="M12.5,9a3.5,3.5 0,1 1,0 7,3.5 3.5,0 0,1 0,-7ZM8.001,2.125c4.607,0 7.212,3.558 7.849,5.696l0.06,0.203 -0.075,0.199c-0.127,0.332 -0.548,0.415 -0.85,0.23a4.74,4.74 0,0 0,-0.498 -0.267c0.034,-0.072 0.067,-0.14 0.096,-0.207 -0.63,-1.799 -2.833,-4.604 -6.582,-4.604 -3.725,0 -5.93,2.834 -6.575,4.588 0.854,1.759 2.785,4.532 6.326,4.656l0.002,0.055c0.022,0.605 -0.418,1.196 -1.016,1.102C2.93,13.177 0.956,9.948 0.183,8.26L0.08,8.043l0.072,-0.228C0.787,5.76 3.387,2.125 8,2.125ZM10.375,11.875a0.5,0.5 0,0 0,-0.5 0.5v0.25a0.5,0.5 0,0 0,0.5 0.5h4.25a0.5,0.5 0,0 0,0.5 -0.5v-0.25a0.5,0.5 0,0 0,-0.5 -0.5h-4.25ZM8.001,5A3,3 0,0 1,11 7.992,4.76 4.76,0 0,0 7.993,11a2.999,2.999 0,0 1,0.008 -6Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"/>
+</vector>

--- a/app/src/main/res/drawable/ic_fingerprint.xml
+++ b/app/src/main/res/drawable/ic_fingerprint.xml
@@ -1,0 +1,30 @@
+<!--
+  ~ Copyright (c) 2025 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <group>
+    <clip-path
+        android:pathData="M0,0h16v16H0z"/>
+    <path
+        android:pathData="M4.97,0.687a7.92,7.92 0,0 1,6.528 0.212,0.75 0.75,0 0,1 -0.663,1.345 6,6 0,0 0,-0.38 -0.172l0.287,-0.692 -0.287,0.692a6.417,6.417 0,0 0,-8.872 5.929v3.166a0.75,0.75 0,0 1,-1.5 0V8.001A7.92,7.92 0,0 1,4.97 0.687M5.99,3.15a5.25,5.25 0,0 1,6.86 2.84l-0.692,0.288 0.692,-0.287c0.264,0.637 0.4,1.32 0.4,2.009v5.167a0.75,0.75 0,0 1,-1.5 0V8a3.75,3.75 0,1 0,-7.5 0v5.167a0.75,0.75 0,0 1,-1.5 0V8a5.25,5.25 0,0 1,3.24 -4.85m7.784,0.54a0.75,0.75 0,0 1,1.028 0.26A7.9,7.9 0,0 1,15.917 8v3.167a0.75,0.75 0,0 1,-1.5 0V8.001a6.4,6.4 0,0 0,-0.489 -2.456l0.693,-0.287 -0.693,0.287a6.4,6.4 0,0 0,-0.415 -0.827,0.75 0.75,0 0,1 0.26,-1.028ZM7.01,5.613a2.583,2.583 0,0 1,3.376 1.398l-0.693,0.287 0.693,-0.287c0.13,0.313 0.196,0.65 0.196,0.988v7.084a0.75,0.75 0,0 1,-1.5 0V7.999a1.083,1.083 0,0 0,-2.166 0v0.5a0.75,0.75 0,0 1,-1.5 0V8A2.58,2.58 0,0 1,7.01 5.613m-0.844,5.178a0.75,0.75 0,0 1,0.75 0.75v3.542a0.75,0.75 0,0 1,-1.5 0V11.54a0.75,0.75 0,0 1,0.75 -0.75Z"
+        android:fillColor="?attr/daxColorPrimaryIcon"
+        android:fillType="evenOdd"/>
+  </group>
+</vector>

--- a/app/src/main/res/drawable/ic_link_blocked.xml
+++ b/app/src/main/res/drawable/ic_link_blocked.xml
@@ -1,0 +1,30 @@
+<!--
+  ~ Copyright (c) 2025 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <group>
+    <clip-path
+        android:pathData="M0,0h16v16H0z"/>
+    <path
+        android:pathData="M8.814,2.023a3.62,3.62 0,0 1,5.122 0l0.041,0.04a3.62,3.62 0,0 1,0 5.123l-0.425,0.425a5,5 0,0 0,-2.126 0.005l1.49,-1.49a2.12,2.12 0,0 0,0 -3.001l-0.04,-0.042a2.12,2.12 0,0 0,-3.001 0l-0.697,0.697a0.75,0.75 0,0 1,-1.06 -1.06zM8.421,9.608a2.1,2.1 0,0 1,-1.37 -0.618l-0.02,-0.02a0.75,0.75 0,0 0,-1.061 1.06l0.02,0.02a3.6,3.6 0,0 0,1.734 0.966c0.158,-0.509 0.395,-0.983 0.697,-1.408m-0.898,2.411a0.75,0.75 0,0 0,-0.7 0.2l-0.72,0.72a2.12,2.12 0,0 1,-3 0l-0.042,-0.041a2.12,2.12 0,0 1,0 -3.001l2.836,-2.836a2.12,2.12 0,0 1,3 0l0.021,0.02a0.75,0.75 0,0 0,1.06 -1.06L9.959,6a3.62,3.62 0,0 0,-5.122 0L2,8.835a3.62,3.62 0,0 0,0 5.122l0.042,0.042a3.62,3.62 0,0 0,5.122 0l0.447,-0.448a5,5 0,0 1,-0.088 -1.533ZM12.5,16a3.5,3.5 0,1 0,0 -7,3.5 3.5,0 0,0 0,7m2.5,-4h-5v1h5z"
+        android:fillColor="?attr/daxColorPrimaryIcon"
+        android:fillType="evenOdd"/>
+  </group>
+</vector>

--- a/app/src/main/res/drawable/ic_popup_blocked.xml
+++ b/app/src/main/res/drawable/ic_popup_blocked.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Copyright (c) 2025 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <path
+      android:pathData="M12.5,9a3.5,3.5 0,1 1,0 7,3.5 3.5,0 0,1 0,-7ZM0,10.635a4.126,4.126 0,0 0,4 3.115h3.917c0.157,0.576 -0.227,1.25 -0.824,1.25L4,15a4,4 0,0 1,-4 -4v-0.365ZM10.375,11.875a0.5,0.5 0,0 0,-0.5 0.5v0.25a0.5,0.5 0,0 0,0.5 0.5h4.25a0.5,0.5 0,0 0,0.5 -0.5v-0.25a0.5,0.5 0,0 0,-0.5 -0.5h-4.25ZM10.511,1A3.49,3.49 0,0 1,14 4.49v2.394c0,0.545 -0.54,0.931 -1.083,0.884a4.655,4.655 0,0 0,-0.167 -0.012L12.75,4.489a2.24,2.24 0,0 0,-2.24 -2.239L3.49,2.25a2.24,2.24 0,0 0,-2.24 2.24L1.25,8A2.75,2.75 0,0 0,4 10.75h4.084A4.718,4.718 0,0 0,7.776 12L4,12a4,4 0,0 1,-4 -4L0,4.49A3.49,3.49 0,0 1,3.49 1h7.02Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"/>
+</vector>

--- a/app/src/main/res/drawable/ic_profile_secure.xml
+++ b/app/src/main/res/drawable/ic_profile_secure.xml
@@ -1,0 +1,41 @@
+<!--
+  ~ Copyright (c) 2025 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <group>
+    <clip-path
+        android:pathData="M0,0h16v16H0z"/>
+    <path
+        android:pathData="m9.239,10.665 l0.045,-0.033v-0.6q0.002,-0.457 0.114,-0.874A6.2,6.2 0,0 0,8 9c0.608,0 1.174,-0.18 1.646,-0.492a3.4,3.4 0,0 1,1.07 -1.234A3,3 0,1 0,8 9a6.2,6.2 0,0 0,-5.227 2.863,6.5 6.5,0 1,1 11.66,-4.808 3.43,3.43 0,0 1,1.533 1.696,8 8,0 1,0 -7.393,7.229 2.1,2.1 0,0 1,-0.197 -0.89v-0.6a6.47,6.47 0,0 1,-4.531 -1.492,4.704 4.704,0 0,1 5.395,-2.333ZM9.5,6a1.5,1.5 0,1 1,-3 0,1.5 1.5,0 0,1 3,0"
+        android:fillColor="?attr/daxColorPrimaryIcon"
+        android:fillType="evenOdd"/>
+    <path
+        android:pathData="M10.25,12.364c0,-0.126 0.102,-0.228 0.227,-0.228h4.546c0.125,0 0.227,0.102 0.227,0.228v2.727a0.227,0.227 0,0 1,-0.227 0.227h-4.546a0.227,0.227 0,0 1,-0.227 -0.227z"
+        android:fillColor="?attr/daxColorPrimaryIcon"/>
+    <path
+        android:pathData="M9.5,12.364c0,-0.54 0.438,-0.978 0.977,-0.978h4.546c0.54,0 0.977,0.438 0.977,0.978v2.727c0,0.54 -0.438,0.977 -0.977,0.977h-4.546a0.977,0.977 0,0 1,-0.977 -0.977zM11,12.886v1.682h3.5v-1.682z"
+        android:fillColor="?attr/daxColorPrimaryIcon"
+        android:fillType="evenOdd"/>
+    <path
+        android:pathData="M12.75,9.25c-0.491,0 -0.84,0.377 -0.84,0.782v1.877h-1.5v-1.877c0,-1.287 1.074,-2.282 2.34,-2.282s2.34,0.995 2.34,2.282v1.877h-1.5v-1.877c0,-0.405 -0.349,-0.782 -0.84,-0.782"
+        android:fillColor="?attr/daxColorPrimaryIcon"
+        android:fillType="evenOdd"/>
+  </group>
+</vector>

--- a/app/src/main/res/drawable/ic_shield_protection.xml
+++ b/app/src/main/res/drawable/ic_shield_protection.xml
@@ -1,0 +1,30 @@
+<!--
+  ~ Copyright (c) 2025 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <group>
+    <clip-path
+        android:pathData="M0,0h16v16H0z"/>
+    <path
+        android:pathData="M10.061,0.88a3,3 0,0 0,-4.2 -0.02l-0.99,0.962a1,1 0,0 1,-0.988 0.239l-0.275,-0.084a2.75,2.75 0,0 0,-3.55 2.564L0.009,6.553a9.125,9.125 0,0 0,5.264 8.49l1.406,0.655a3.124,3.124 0,0 0,2.643 0l1.405,-0.656a9.125,9.125 0,0 0,5.264 -8.489l-0.05,-2.038a2.75,2.75 0,0 0,-3.525 -2.572l-0.42,0.124a1,1 0,0 1,-0.987 -0.248L10.061,0.88ZM8.625,1.397c0.202,0.085 0.392,0.208 0.557,0.372l0.948,0.938a2.25,2.25 0,0 0,2.218 0.56l0.42,-0.125a1.5,1.5 0,0 1,1.924 1.403l0.05,2.038a7.875,7.875 0,0 1,-4.543 7.326l-1.406,0.656a1.83,1.83 0,0 1,-0.168 0.07L8.625,1.396ZM7.375,1.36a1.744,1.744 0,0 0,-0.643 0.397l-0.991,0.962a2.25,2.25 0,0 1,-2.222 0.537l-0.275,-0.083a1.5,1.5 0,0 0,-1.937 1.399L1.26,6.583A7.875,7.875 0,0 0,5.8 13.91l1.406,0.656c0.055,0.026 0.111,0.05 0.168,0.07L7.374,1.36Z"
+        android:fillColor="?attr/daxColorPrimaryIcon"
+        android:fillType="evenOdd"/>
+  </group>
+</vector>

--- a/app/src/main/res/layout/activity_web_tracking_protection.xml
+++ b/app/src/main/res/layout/activity_web_tracking_protection.xml
@@ -25,7 +25,7 @@
         android:id="@+id/includeToolbar"
         layout="@layout/include_default_toolbar" />
 
-    <ScrollView
+    <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior"
@@ -94,6 +94,29 @@
                 android:layout_height="wrap_content"
                 app:primaryText="@string/settingsPrivacyProtectionAllowlist" />
 
+            <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/protectionsTitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/keyline_4"
+                android:layout_marginTop="@dimen/keyline_3"
+                android:layout_marginBottom="6dp"
+                android:gravity="start"
+                android:text="@string/webTrackingProtectionExplanationTitle"
+                android:textColor="?daxColorTertiaryText"
+                app:typography="h4" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/protectionsList"
+                android:layout_width="match_parent"
+                android:overScrollMode="never"
+                android:paddingHorizontal="10dp"
+                android:layout_height="match_parent" />
+
         </LinearLayout>
-    </ScrollView>
+    </androidx.core.widget.NestedScrollView>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/item_feature_grid.xml
+++ b/app/src/main/res/layout/item_feature_grid.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2025 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<com.google.android.material.card.MaterialCardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    app:cardElevation="0dp"
+    app:cardCornerRadius="@dimen/largeShapeCornerRadius"
+    android:layout_margin="6dp"
+    app:strokeWidth="@dimen/horizontalDividerHeight"
+    app:strokeColor="?attr/daxColorLines"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="@dimen/keyline_2"
+        android:orientation="vertical">
+
+        <ImageView
+            android:id="@+id/icon"
+            android:layout_width="@dimen/listItemImageLargeSize"
+            android:layout_height="@dimen/listItemImageLargeSize"
+            android:background="@drawable/background_feature_grid_item_icon"
+            android:contentDescription="@string/faviconContentDescription"
+            android:padding="@dimen/keyline_2"
+            android:src="@drawable/ic_dax_icon" />
+
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+            android:id="@+id/title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/keyline_1"
+            android:layout_marginTop="@dimen/keyline_2"
+            app:typography="h5"
+            tools:text="@string/webTrackingProtectionThirdPartyTrackersTitle" />
+
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+            android:id="@+id/description"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/keyline_1"
+            android:layout_marginTop="@dimen/keyline_1"
+            android:layout_marginBottom="@dimen/keyline_2"
+            app:textType="secondary"
+            app:typography="caption"
+            tools:text="@string/webTrackingProtectionThirdPartyTrackersDescription" />
+
+    </LinearLayout>
+
+
+</com.google.android.material.card.MaterialCardView>
+
+

--- a/app/src/main/res/layout/item_feature_grid.xml
+++ b/app/src/main/res/layout/item_feature_grid.xml
@@ -13,7 +13,6 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-
 <com.google.android.material.card.MaterialCardView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -63,7 +62,4 @@
 
     </LinearLayout>
 
-
 </com.google.android.material.card.MaterialCardView>
-
-

--- a/app/src/test/java/com/duckduckgo/app/webtrackingprotection/WebTrackingProtectionViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/webtrackingprotection/WebTrackingProtectionViewModelTest.kt
@@ -129,4 +129,17 @@ internal class WebTrackingProtectionViewModelTest {
             cancelAndConsumeRemainingEvents()
         }
     }
+
+    @Test
+    fun whenInitialisedThenProtectionsListPresent() = runTest {
+        whenever(mockFeatureToggle.isFeatureEnabled(eq(PrivacyFeatureName.GpcFeatureName.value), any())).thenReturn(false)
+        whenever(mockGpc.isEnabled()).thenReturn(true)
+
+        testee.viewState().test {
+            val item = awaitItem()
+            assertFalse(item.globalPrivacyControlEnabled)
+            assertEquals(9, item.protectionItems.size)
+            cancelAndConsumeRemainingEvents()
+        }
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1211162971317398?focus=true

### Description
Adds a staggered grid of protections that are always on to Web Tracking Protection screen.

### Steps to test this PR

- [ ] Go to Settings -> Web Tracking Protection
- [ ] Verify the description under the "Web Tracking Protection" title matches [copy spec](https://app.asana.com/1/137249556945/project/38424471409662/task/1210874321016131?focus=true)
- [ ] Verify you see the grid of new protection cards/items
- [ ] Verify that the design (margins, paddings, text styles, icons) matches [Figma](https://www.figma.com/design/ir88vAgIL2Mz87BBFiTAQB/O-E-Protections-List?node-id=245-5321&m=dev)
- [ ] Verify the copies matches [copy spec](https://app.asana.com/1/137249556945/project/38424471409662/task/1210874321016131?focus=true)
- [ ] Rotate device to landscape and verify that layout and paddings are still correct
- [ ] Go to Settings -> Appearance and change theme (light/dark) to opposite of what you had now 
- [ ] Verify the designs match in both themes [Figma](https://www.figma.com/design/ir88vAgIL2Mz87BBFiTAQB/O-E-Protections-List?node-id=245-5321&m=dev)

### UI changes
| Before  | After (light) | After (dark) |
| - | - | - | 
| <img src="https://github.com/user-attachments/assets/732ffe21-a203-434c-9b97-f43a9c17f42e" /> | <img   src="https://github.com/user-attachments/assets/0cf46ead-ba45-445f-8a3c-d7d2406f6b16" /> | <img src="https://github.com/user-attachments/assets/7a128369-a016-47e0-9dc9-4b1c085ee297" /> |


