### PR TITLE
update Duck.ai icon (omnibar) click behavior

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -6190,9 +6190,51 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenOnDuckChatOmnibarButtonClickedThenOpenDuckChat() {
-        testee.onDuckChatOmnibarButtonClicked("example")
-        verify(mockDuckChat).openDuckChatWithAutoPrompt("example")
+    fun whenOnDuckChatOmnibarButtonClickedWithFocusThenOpenDuckChatWithAutoPrompt() {
+        testee.onDuckChatOmnibarButtonClicked(query = "example", hasFocus = true, isNtp = false)
+        verify(mockDuckChat).openDuckChatWithAutoPrompt(query = "example")
+    }
+
+    @Test
+    fun whenOnDuckChatOmnibarButtonClickedWithoutFocusThenOpenDuckChat() {
+        testee.onDuckChatOmnibarButtonClicked(query = "example", hasFocus = false, isNtp = false)
+        verify(mockDuckChat).openDuckChat()
+    }
+
+    @Test
+    fun whenOnDuckChatOmnibarButtonClickedWithNullQueryAndFocusThenOpenDuckChatWithAutoPrompt() {
+        testee.onDuckChatOmnibarButtonClicked(query = null, hasFocus = true, isNtp = false)
+        verify(mockDuckChat).openDuckChatWithAutoPrompt(query = "")
+    }
+
+    @Test
+    fun whenOnDuckChatOmnibarButtonClickedWithNullQueryWithoutFocusThenOpenDuckChat() {
+        testee.onDuckChatOmnibarButtonClicked(query = null, hasFocus = false, isNtp = false)
+        verify(mockDuckChat).openDuckChat()
+    }
+
+    @Test
+    fun whenOnDuckChatOmnibarButtonClickedWhenOnNtpWithNullQueryAndWithFocusThenOpenDuckChat() {
+        testee.onDuckChatOmnibarButtonClicked(query = null, hasFocus = true, isNtp = true)
+        verify(mockDuckChat).openDuckChat()
+    }
+
+    @Test
+    fun whenOnDuckChatOmnibarButtonClickedWhenOnNtpWithBlankQueryAndWithFocusThenOpenDuckChat() {
+        testee.onDuckChatOmnibarButtonClicked(query = " ", hasFocus = true, isNtp = true)
+        verify(mockDuckChat).openDuckChat()
+    }
+
+    @Test
+    fun whenOnDuckChatOmnibarButtonClickedWhenOnNtpWithQueryAndWithFocusThenOpenDuckChatWithAutoPrompt() {
+        testee.onDuckChatOmnibarButtonClicked(query = "example", hasFocus = true, isNtp = true)
+        verify(mockDuckChat).openDuckChatWithAutoPrompt(query = "example")
+    }
+
+    @Test
+    fun whenOnDuckChatOmnibarButtonClickedWhenOnNtpWithQueryAndWithoutFocusThenOpenDuckChat() {
+        testee.onDuckChatOmnibarButtonClicked(query = "example", hasFocus = false, isNtp = true)
+        verify(mockDuckChat).openDuckChat()
     }
 
     @Test
@@ -6457,91 +6499,6 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenOpenDuckChatWithNonEmptyQueryThenOpenWithAutoPrompt() = runTest {
-        val query = "example"
-
-        testee.openDuckChat("example")
-
-        verify(mockDuckChat).openDuckChatWithAutoPrompt(query)
-        verify(mockDuckChat, never()).openDuckChat()
-    }
-
-    @Test
-    fun whenOpenDuckChatWithEmptyStringQueryThenOpenDuckChat() = runTest {
-        testee.openDuckChat("")
-
-        verify(mockDuckChat).openDuckChat()
-        verify(mockDuckChat, never()).openDuckChatWithAutoPrompt(any())
-    }
-
-    @Test
-    fun whenOpenDuckChatWithNullQueryThenOpenDuckChat() = runTest {
-        testee.openDuckChat(null)
-
-        verify(mockDuckChat).openDuckChat()
-        verify(mockDuckChat, never()).openDuckChatWithAutoPrompt(any())
-    }
-
-    @Test
-    fun whenOpenDuckChatWithQueryEqualToUrlThenOpenDuckChat() = runTest {
-        val url = "https://example.com"
-        loadUrl(url)
-
-        testee.openDuckChat(url)
-
-        verify(mockDuckChat).openDuckChat()
-        verify(mockDuckChat, never()).openDuckChatWithAutoPrompt(any())
-    }
-
-    @Test
-    fun whenOpenDuckChatWithLastSubmittedUserQueryThenOpenDuckChatWithQuery() = runTest {
-        val query = "example"
-        testee.setLastSubmittedUserQuery(query)
-
-        testee.openDuckChat(query)
-
-        verify(mockDuckChat).openDuckChatWithPrefill(query)
-        verify(mockDuckChat, never()).openDuckChat()
-        verify(mockDuckChat, never()).openDuckChatWithAutoPrompt(any())
-    }
-
-    @Test
-    fun whenLastSubmittedUserQueryIsNullAndOmnibarHasSameTextThenOpenDuckChatWithAutoPrompt() = runTest {
-        val query = "example"
-        testee.omnibarViewState.value = omnibarViewState().copy(omnibarText = "example", queryOrFullUrl = "example")
-
-        testee.openDuckChat(query)
-
-        verify(mockDuckChat).openDuckChatWithPrefill(query)
-        verify(mockDuckChat, never()).openDuckChatWithAutoPrompt(any())
-    }
-
-    @Test
-    fun whenLastSubmittedUserQueryIsNullAndOmnibarHasNewTextThenOpenDuckChatWithAutoPrompt() = runTest {
-        val query = "example"
-        testee.omnibarViewState.value = omnibarViewState().copy(omnibarText = "foo", queryOrFullUrl = "foo")
-
-        testee.openDuckChat(query)
-
-        verify(mockDuckChat).openDuckChatWithAutoPrompt(query)
-        verify(mockDuckChat, never()).openDuckChat()
-    }
-
-    @Test
-    fun whenLastSubmittedUserQueryDiffersFromNewQueryThenOpenWithAutoPrompt() = runTest {
-        val query = "example"
-        testee.setLastSubmittedUserQuery("foo")
-        testee.setLastSubmittedUserChatQuery("foo")
-        testee.omnibarViewState.value = omnibarViewState().copy(omnibarText = "")
-
-        testee.openDuckChat(query)
-
-        verify(mockDuckChat).openDuckChatWithAutoPrompt(query)
-        verify(mockDuckChat, never()).openDuckChat()
-        verify(mockDuckChat, never()).openDuckChatWithPrefill(query)
-    }
-
-    @Test
     fun whenProcessJsCallbackMessageForSubscriptionsThenSendCommand() = runTest {
         val jsCallbackData = JsCallbackData(JSONObject(), "", "", "")
         whenever(mockSubscriptionsJSHelper.processJsCallbackMessage(anyString(), anyString(), anyOrNull(), anyOrNull())).thenReturn(jsCallbackData)
@@ -6741,85 +6698,6 @@ class BrowserTabViewModelTest {
 
         // Verify loading state reflects the completed navigation
         assertFalse(loadingViewState().isLoading)
-    }
-
-    @Test
-    fun whenOpeningDuckChatWithMatchingQueryOrFullUrlValueThenOpenDuckChat() = runTest {
-        val query = "example"
-        testee.omnibarViewState.value = omnibarViewState().copy(omnibarText = query, queryOrFullUrl = query)
-
-        testee.openDuckChat(query)
-
-        verify(mockDuckChat).openDuckChatWithPrefill(query)
-        verify(mockDuckChat, never()).openDuckChat()
-        verify(mockDuckChat, never()).openDuckChatWithAutoPrompt(any())
-    }
-
-    @Test
-    fun whenOpeningDuckChatWithDifferentQueryOrFullUrlValueThenOpenDuckChatWithAutoPrompt() = runTest {
-        val query = "example"
-        testee.omnibarViewState.value = omnibarViewState().copy(omnibarText = "something else", queryOrFullUrl = "something else")
-        testee.setLastSubmittedUserQuery("test")
-        testee.setLastSubmittedUserChatQuery("test")
-
-        testee.openDuckChat(query)
-
-        verify(mockDuckChat).openDuckChatWithAutoPrompt(query)
-        verify(mockDuckChat, never()).openDuckChatWithPrefill(any())
-        verify(mockDuckChat, never()).openDuckChat()
-    }
-
-    @Test
-    fun whenOpeningDuckChatWithoutSubmittingAPreviousSearchThenOpenDuckChatWithPrefill() = runTest {
-        val query = "example"
-        testee.omnibarViewState.value = omnibarViewState().copy(omnibarText = "example", queryOrFullUrl = "example")
-
-        testee.openDuckChat(query)
-
-        verify(mockDuckChat).openDuckChatWithPrefill(query)
-        verify(mockDuckChat, never()).openDuckChatWithAutoPrompt(any())
-        verify(mockDuckChat, never()).openDuckChat()
-    }
-
-    @Test
-    fun whenOpeningDuckChatChangingOmnibarThenOpenDuckChatWithAutoPrompt() = runTest {
-        val query = "example"
-        testee.omnibarViewState.value = omnibarViewState().copy(omnibarText = "something else", queryOrFullUrl = "something else")
-
-        testee.openDuckChat(query)
-
-        verify(mockDuckChat).openDuckChatWithAutoPrompt(query)
-        verify(mockDuckChat, never()).openDuckChatWithPrefill(any())
-        verify(mockDuckChat, never()).openDuckChat()
-    }
-
-    @Test
-    fun whenOpeningDuckChatAfterSubmittingASearchThenOpenDuckChatWithPrefill() = runTest {
-        val query = "example"
-        testee.omnibarViewState.value = omnibarViewState().copy(omnibarText = "example", queryOrFullUrl = "example")
-
-        testee.setLastSubmittedUserQuery("test")
-
-        testee.openDuckChat(query)
-
-        verify(mockDuckChat).openDuckChatWithPrefill(query)
-        verify(mockDuckChat, never()).openDuckChatWithAutoPrompt(any())
-        verify(mockDuckChat, never()).openDuckChat()
-    }
-
-    @Test
-    fun whenOpeningDuckChatAfterSubmittingASearchAndChatThenOpenDuckChatWithAutoPrompt() = runTest {
-        val query = "example"
-        testee.omnibarViewState.value = omnibarViewState().copy(omnibarText = "example", queryOrFullUrl = "example")
-
-        testee.setLastSubmittedUserQuery("test")
-        testee.setLastSubmittedUserChatQuery("test")
-
-        testee.openDuckChat(query)
-
-        verify(mockDuckChat).openDuckChatWithAutoPrompt(query)
-        verify(mockDuckChat, never()).openDuckChatWithPrefill(any())
-        verify(mockDuckChat, never()).openDuckChat()
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1209,8 +1209,8 @@ class BrowserTabFragment :
         voiceSearchLauncher.launch(requireActivity())
     }
 
-    private fun onOmnibarDuckChatPressed(query: String) {
-        viewModel.onDuckChatOmnibarButtonClicked(query)
+    private fun onOmnibarDuckChatPressed(query: String, hasFocus: Boolean, isNtp: Boolean) {
+        viewModel.onDuckChatOmnibarButtonClicked(query = query, hasFocus = hasFocus, isNtp = isNtp)
     }
 
     private fun configureCustomTab() {
@@ -2887,7 +2887,9 @@ class BrowserTabFragment :
                         pixel.fire(DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_LEGACY_OMNIBAR_AICHAT_BUTTON_PRESSED)
                         pixel.fire(DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_LEGACY_OMNIBAR_AICHAT_BUTTON_PRESSED_DAILY, type = Daily())
                     }
-                    onOmnibarDuckChatPressed(omnibar.getText())
+                    val hasFocus = omnibar.omnibarTextInput.hasFocus()
+                    val isNtp = omnibar.viewMode == ViewMode.NewTab
+                    onOmnibarDuckChatPressed(query = omnibar.getText(), hasFocus = hasFocus, isNtp = isNtp)
                 }
             },
         )
@@ -2980,7 +2982,6 @@ class BrowserTabFragment :
     }
 
     private fun userEnteredQuery(query: String) {
-        viewModel.setLastSubmittedUserQuery(query)
         viewModel.onUserSubmittedQuery(query)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -573,8 +573,6 @@ class BrowserTabViewModel @Inject constructor(
     private var isProcessingTrackingLink = false
     private var isLinkOpenedInNewTab = false
     private var allowlistRefreshTriggerJob: Job? = null
-    private var lastSubmittedUserQuery: String? = null
-    private var lastSubmittedChatQuery: String? = null
 
     private val fireproofWebsitesObserver = Observer<List<FireproofWebsiteEntity>> {
         browserViewState.value = currentBrowserViewState().copy(isFireproofWebsite = isFireproofWebsite())
@@ -4197,34 +4195,20 @@ class BrowserTabViewModel @Inject constructor(
     fun onDuckChatMenuClicked() {
         viewModelScope.launch {
             command.value = HideKeyboardForChat
+            val params = duckChat.createWasUsedBeforePixelParams()
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_OPEN_BROWSER_MENU, parameters = params)
         }
-        openDuckChat(pixelName = DuckChatPixelName.DUCK_CHAT_OPEN_BROWSER_MENU)
+        duckChat.openDuckChat()
     }
 
-    fun onDuckChatOmnibarButtonClicked(query: String?) {
+    fun onDuckChatOmnibarButtonClicked(query: String?, hasFocus: Boolean, isNtp: Boolean) {
         viewModelScope.launch {
             command.value = HideKeyboardForChat
         }
-        query?.let {
-            openDuckChat(query = query)
-        } ?: openDuckChat()
-    }
-
-    private fun openDuckChat(
-        pixelName: Pixel.PixelName? = null,
-        query: String? = null,
-    ) {
-        viewModelScope.launch {
-            if (pixelName != null) {
-                val params = duckChat.createWasUsedBeforePixelParams()
-                pixel.fire(pixelName, parameters = params)
-            }
-
-            if (query?.isNotEmpty() == true) {
-                duckChat.openDuckChatWithAutoPrompt(query)
-            } else {
-                duckChat.openDuckChat()
-            }
+        when {
+            hasFocus && isNtp && query.isNullOrBlank() -> duckChat.openDuckChat()
+            hasFocus -> duckChat.openDuckChatWithAutoPrompt(query ?: "")
+            else -> duckChat.openDuckChat()
         }
     }
 
@@ -4264,30 +4248,6 @@ class BrowserTabViewModel @Inject constructor(
                 onboardingDesignExperimentManager.firePrivacyDashClickedFromOnboardingPixel()
             }
         }
-    }
-
-    fun openDuckChat(query: String?) {
-        when {
-            query.isNullOrBlank() || query == url -> duckChat.openDuckChat()
-            lastSubmittedUserQuery == null && (query != omnibarViewState.value?.queryOrFullUrl) -> duckChat.openDuckChatWithAutoPrompt(query)
-            lastSubmittedUserQuery == null && (query == omnibarViewState.value?.queryOrFullUrl) -> duckChat.openDuckChatWithPrefill(query)
-            lastSubmittedChatQuery == null -> duckChat.openDuckChatWithPrefill(query)
-            lastSubmittedChatQuery != lastSubmittedUserQuery -> duckChat.openDuckChatWithPrefill(query)
-            query == lastSubmittedUserQuery -> duckChat.openDuckChatWithPrefill(query)
-
-            else -> duckChat.openDuckChatWithAutoPrompt(query)
-        }
-        if (query != null) {
-            setLastSubmittedUserChatQuery(query)
-        }
-    }
-
-    fun setLastSubmittedUserQuery(query: String) {
-        lastSubmittedUserQuery = query
-    }
-
-    fun setLastSubmittedUserChatQuery(query: String) {
-        lastSubmittedChatQuery = query
     }
 
     fun onUserSelectedOnboardingDialogOption(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1210888855345532?focus=true

### Description
Simplifies behavior of the Duck.ai button in the omnibar.

If the button is clicked while the omnibar has focus, start a new chat and auto-prompt Duck.ai with contents of the omnibar. If the buttons is clicked withe the omnibar doesn't have focus, open existing chat if within 60 minutes of starting it, otherwise, open a new empty chat.

The only exception is New Tab Page which still opens the existing chat (if within 60 minutes since starting it) when omnibar is focused and empty.

### Steps to test this PR

- [x] Open Duck.ai and start a new chat.
- [ ] Go to New Tab Page.
  - [x] While omnibar bar **is** focused, click Duck.ai button and verify that the previous chat is opened.
  - [x] While omnibar **is not** focused, click Duck.ai button and verify that the previous chat is opened.
  - [x] Type anything into the omnibar and while omnibar bar **is** focused, click Duck.ai button and verify that a new chat is opened with auto-prompt.
- [x] Go to SERP.
  - [x] While omnibar bar **is** focused, click Duck.ai button and verify that a new chat is opened with auto-prompt.
  - [x] While omnibar bar **is not** focused, click Duck.ai button and verify that the previous chat is opened.
- [x] Go to a website.
  - [x] While omnibar bar **is** focused, click Duck.ai button and verify that a new chat is opened with auto-prompt.
  - [x] While omnibar bar **is not** focused, click Duck.ai button and verify that the previous chat is opened.
- [x] (optional) Change device's time to > 1 hour into the future.
  - [x] While omnibar bar **is not** focused, click Duck.ai button and verify that a new empty chat is opened.
