### PR TITLE
Fix regression to autocomplete top padding (Input Screen)

### DIFF
--- a/duckchat/duckchat-impl/src/main/res/layout/fragment_input_screen.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/fragment_input_screen.xml
@@ -36,6 +36,7 @@
         android:layout_width="@dimen/ntpDaxLogoIconWidth"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/homeTabDdgLogoTopMargin"
+        android:paddingTop="@dimen/inputScreenContentTopOffset"
         android:adjustViewBounds="true"
         android:maxWidth="180dp"
         android:maxHeight="180dp"

--- a/duckchat/duckchat-impl/src/main/res/layout/fragment_search_tab.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/fragment_search_tab.xml
@@ -25,7 +25,8 @@
     <androidx.core.widget.NestedScrollView
         android:id="@+id/newTabContainerScrollView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:layout_marginTop="@dimen/inputScreenContentTopOffset">
 
         <FrameLayout
             android:id="@+id/newTabContainerLayout"

--- a/duckchat/duckchat-impl/src/main/res/layout/view_input_mode_switch_widget.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_input_mode_switch_widget.xml
@@ -7,22 +7,22 @@
         style="@style/Widget.DuckChat.TabLayout.Rounded"
         android:layout_width="wrap_content"
         android:layout_height="@dimen/inputModeSwitchHeight"
-        app:layout_constrainedWidth="true"
-        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constrainedWidth="true">
 
         <com.google.android.material.tabs.TabItem
             android:id="@+id/tabSearch"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout="@layout/view_search_tab_indicator" />
+            android:layout="@layout/view_search_tab_indicator"/>
 
         <com.google.android.material.tabs.TabItem
             android:id="@+id/tabDuckAi"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout="@layout/view_chat_tab_indicator" />
+            android:layout="@layout/view_chat_tab_indicator"/>
 
     </com.duckduckgo.duckchat.impl.inputscreen.ui.view.InputModeTabLayout>
 
@@ -37,83 +37,77 @@
         android:importantForAccessibility="no"
         android:padding="@dimen/keyline_2"
         android:scaleType="center"
-        app:layout_constraintBottom_toBottomOf="@id/inputModeSwitch"
+        app:srcCompat="@drawable/ic_arrow_left_24"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="@id/inputModeSwitch"
-        app:srcCompat="@drawable/ic_arrow_left_24" />
+        app:layout_constraintBottom_toBottomOf="@id/inputModeSwitch"/>
 
     <Space
         android:id="@+id/spacer"
         android:layout_width="0dp"
         android:layout_height="10dp"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/inputModeSwitch"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/inputModeSwitch" />
+        app:layout_constraintEnd_toEndOf="parent"/>
 
-    <FrameLayout
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/inputModeWidgetCard"
+        style="@style/Widget.DuckDuckGo.OmnibarCardView"
         android:layout_width="0dp"
-        android:layout_height="@dimen/toolbarSize"
-        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/omnibarCardMarginHorizontal"
+        android:layout_marginTop="@dimen/omnibarCardMarginTop"
+        android:layout_marginBottom="@dimen/omnibarCardMarginBottom"
+        app:strokeColor="?attr/daxColorAccentBlue"
+        app:strokeWidth="@dimen/omnibarOutlineWidth"
+        app:cardElevation="0dp"
+        app:layout_constraintTop_toBottomOf="@id/spacer"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/spacer">
+        app:layout_constraintEnd_toEndOf="parent">
 
-        <com.google.android.material.card.MaterialCardView
-            android:id="@+id/inputModeWidgetCard"
-            style="@style/Widget.DuckDuckGo.OmnibarCardView"
+        <LinearLayout
+            android:id="@+id/inputModeWidgetCardContent"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_marginHorizontal="@dimen/omnibarCardMarginHorizontal"
-            android:layout_marginTop="@dimen/omnibarCardMarginTop"
-            android:layout_marginBottom="@dimen/omnibarCardMarginBottom"
-            app:cardElevation="0dp"
-            app:strokeColor="?attr/daxColorAccentBlue"
-            app:strokeWidth="@dimen/omnibarOutlineWidth">
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:padding="@dimen/keyline_0">
 
-            <LinearLayout
-                android:id="@+id/inputModeWidgetCardContent"
-                android:layout_width="match_parent"
+            <EditText
+                android:id="@+id/inputField"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:padding="@dimen/keyline_0">
+                android:layout_gravity="center_vertical"
+                android:layout_marginStart="@dimen/keyline_4"
+                android:layout_weight="1"
+                android:background="@null"
+                android:fontFamily="sans-serif"
+                android:gravity="start|top"
+                android:hint="@string/input_screen_search_hint"
+                android:lineSpacingMultiplier="1.2"
+                android:minHeight="@dimen/toolbarIcon"
+                android:paddingVertical="@dimen/keyline_2"
+                android:textColor="?attr/daxColorPrimaryText"
+                android:textColorHighlight="?attr/daxOmnibarTextColorHighlight"
+                android:textColorHint="?attr/daxColorSecondaryText"
+                android:textCursorDrawable="@drawable/text_cursor"
+                android:textSize="16sp"
+                android:textStyle="normal"
+                android:maxLines="1" />
 
-                <EditText
-                    android:id="@+id/inputField"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_vertical"
-                    android:layout_marginStart="@dimen/keyline_4"
-                    android:layout_weight="1"
-                    android:background="@null"
-                    android:fontFamily="sans-serif"
-                    android:gravity="start|top"
-                    android:hint="@string/input_screen_search_hint"
-                    android:lineSpacingMultiplier="1.2"
-                    android:maxLines="1"
-                    android:minHeight="@dimen/toolbarIcon"
-                    android:paddingVertical="@dimen/keyline_2"
-                    android:textColor="?attr/daxColorPrimaryText"
-                    android:textColorHighlight="?attr/daxOmnibarTextColorHighlight"
-                    android:textColorHint="?attr/daxColorSecondaryText"
-                    android:textCursorDrawable="@drawable/text_cursor"
-                    android:textSize="16sp"
-                    android:textStyle="normal" />
+            <ImageView
+                android:id="@+id/inputFieldClearText"
+                android:layout_width="@dimen/toolbarIcon"
+                android:layout_height="@dimen/toolbarIcon"
+                android:layout_gravity="top"
+                android:background="@drawable/selectable_item_experimental_background"
+                android:gravity="center"
+                android:importantForAccessibility="no"
+                android:padding="@dimen/keyline_1"
+                android:scaleType="centerInside"
+                android:visibility="gone"
+                app:srcCompat="@drawable/ic_close_circle_small_secondary_24" />
 
-                <ImageView
-                    android:id="@+id/inputFieldClearText"
-                    android:layout_width="@dimen/toolbarIcon"
-                    android:layout_height="@dimen/toolbarIcon"
-                    android:layout_gravity="top"
-                    android:background="@drawable/selectable_item_experimental_background"
-                    android:gravity="center"
-                    android:importantForAccessibility="no"
-                    android:padding="@dimen/keyline_1"
-                    android:scaleType="centerInside"
-                    android:visibility="gone"
-                    app:srcCompat="@drawable/ic_close_circle_small_secondary_24" />
+        </LinearLayout>
 
-            </LinearLayout>
-
-        </com.google.android.material.card.MaterialCardView>
-
-    </FrameLayout>
+    </com.google.android.material.card.MaterialCardView>
 </merge>

--- a/duckchat/duckchat-impl/src/main/res/layout/view_input_mode_switch_widget.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_input_mode_switch_widget.xml
@@ -52,8 +52,7 @@
 
     <FrameLayout
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:minHeight="@dimen/toolbarSize"
+        android:layout_height="@dimen/toolbarSize"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/spacer">

--- a/duckchat/duckchat-impl/src/main/res/values/dimens.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/dimens.xml
@@ -20,4 +20,5 @@
     <dimen name="inputModeTabIndicatorHorizontalInset">2dp</dimen>
     <dimen name="inputModeTabIndicatorElevation">5dp</dimen>
     <dimen name="inputScreenUserPrefToggleSpacing">16dp</dimen>
+    <dimen name="inputScreenContentTopOffset">12dp</dimen>
 </resources>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1211224065958257?focus=true

### Description

- Fixes an issue where the autocomplete list is clipped and the top padding is too large.
- Adds `12dp` top padding/margin to the logo/NTP content to remove the jump on transition.

### Steps to test this PR

- [x] Verify that the logo/content transitions smoothly
- [x] Verify that the autocomplete list has the correct top padding and doesn’t clip

### UI changes
| Before  | After |
| ------ | ----- |
<img width="1080" height="352" alt="Screenshot_20250903_164702" src="https://github.com/user-attachments/assets/e12f623f-c361-423e-97d1-76680775b4d7" />|<img width="1080" height="323" alt="Screenshot_20250903_164744" src="https://github.com/user-attachments/assets/ac7d1926-4b00-412c-929b-b15305c61b4a" />

| Before  | After |
| ------ | ----- |
<img width="1080" height="260" alt="Screenshot_20250903_164430" src="https://github.com/user-attachments/assets/0da3e4e4-ac94-4be3-b0cb-3f645add63fb" />|<img width="1080" height="231" alt="Screenshot_20250903_164418" src="https://github.com/user-attachments/assets/e9abafa7-1dcc-4342-8661-753d6f96fd53" />
