### PR TITLE
Set background of Input Mode Widget

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
@@ -36,6 +36,7 @@ import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.content.withStyledAttributes
 import androidx.core.view.isVisible
 import androidx.core.widget.doAfterTextChanged
 import androidx.core.widget.doOnTextChanged
@@ -43,6 +44,7 @@ import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.view.addBottomShadow
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.mobile.android.R as CommonR
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.tabs.TabLayout
 
@@ -111,6 +113,11 @@ class InputModeWidget @JvmOverloads constructor(
         configureTabBehavior()
         applyModeSpecificInputBehaviour(isSearchTab = true)
         configureShadow()
+
+        context.withStyledAttributes(0, intArrayOf(CommonR.attr.daxColorBackground)) {
+            setBackgroundColor(getColor(0, 0))
+        }
+        outlineProvider = null
     }
 
     fun provideInitialText(text: String) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
@@ -36,7 +36,6 @@ import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import androidx.constraintlayout.widget.ConstraintLayout
-import androidx.core.content.withStyledAttributes
 import androidx.core.view.isVisible
 import androidx.core.widget.doAfterTextChanged
 import androidx.core.widget.doOnTextChanged
@@ -44,7 +43,6 @@ import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.view.addBottomShadow
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.duckchat.impl.R
-import com.duckduckgo.mobile.android.R as CommonR
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.tabs.TabLayout
 
@@ -113,11 +111,6 @@ class InputModeWidget @JvmOverloads constructor(
         configureTabBehavior()
         applyModeSpecificInputBehaviour(isSearchTab = true)
         configureShadow()
-
-        context.withStyledAttributes(0, intArrayOf(CommonR.attr.daxColorBackground)) {
-            setBackgroundColor(getColor(0, 0))
-        }
-        outlineProvider = null
     }
 
     fun provideInitialText(text: String) {

--- a/duckchat/duckchat-impl/src/main/res/drawable/input_mode_widget_background_gradient.xml
+++ b/duckchat/duckchat-impl/src/main/res/drawable/input_mode_widget_background_gradient.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape>
+            <gradient
+                android:angle="270"
+                android:centerColor="?attr/daxColorBackground"
+                android:centerY="0.8"
+                android:endColor="@android:color/transparent"
+                android:startColor="?attr/daxColorBackground"
+                android:type="linear" />
+        </shape>
+    </item>
+</layer-list>

--- a/duckchat/duckchat-impl/src/main/res/layout/fragment_input_screen.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/fragment_input_screen.xml
@@ -25,7 +25,7 @@
         android:id="@+id/inputModeWidget"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/keyline_2"
+        android:paddingTop="@dimen/keyline_2"
         android:elevation="1dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/duckchat/duckchat-impl/src/main/res/layout/fragment_input_screen.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/fragment_input_screen.xml
@@ -25,7 +25,6 @@
         android:id="@+id/inputModeWidget"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:paddingTop="@dimen/keyline_2"
         android:elevation="1dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/duckchat/duckchat-impl/src/main/res/layout/view_input_mode_switch_widget.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_input_mode_switch_widget.xml
@@ -2,11 +2,22 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:theme="@style/Widget.DuckDuckGo.ToolbarTheme">
 
+    <View
+        android:id="@+id/backgroundLayer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="@drawable/input_mode_widget_background_gradient"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
     <com.duckduckgo.duckchat.impl.inputscreen.ui.view.InputModeTabLayout
         android:id="@+id/inputModeSwitch"
         style="@style/Widget.DuckChat.TabLayout.Rounded"
         android:layout_width="wrap_content"
         android:layout_height="@dimen/inputModeSwitchHeight"
+        android:layout_marginTop="@dimen/keyline_2"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1211244094853968?focus=true

### Description
- Fixes an issue where content is visible behind the input when scrolling under certain scenarios.

### Steps to test this PR

- [x] Fresh install
- [x] Submit “hello" search query
- [x] Tap the omnibar again
- [x] With the “Same privacy…” card visible, scroll up
- [x] Verify that the content does not scroll under the Input Mode Widget