### PR TITLE
Subscription webview go back action

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
@@ -237,7 +237,7 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
                     newProgress: Int,
                 ) {
                     if (newProgress == 100) {
-                        if (binding.webview.canGoBack()) {
+                        if (canGoBack()) {
                             toolbar.setNavigationIcon(R.drawable.ic_arrow_left_24)
                         } else {
                             toolbar.setNavigationIcon(R.drawable.ic_close_24)
@@ -616,8 +616,20 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
         return super.onOptionsItemSelected(item)
     }
 
-    override fun onBackPressed() {
+    private fun canGoBack(): Boolean {
         if (binding.webview.canGoBack()) {
+            binding.webview.url?.let { url ->
+                val uri = url.toUri()
+                return uri.getQueryParameter("preventBackNavigation") != "true"
+            }
+            return false
+        } else {
+            return false
+        }
+    }
+
+    override fun onBackPressed() {
+        if (canGoBack()) {
             binding.webview.goBack()
         } else {
             super.onBackPressed()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211073283656160?focus=true 

### Description
This PR changes the way navigating back works letting the FE decide in some cases when it can and cannot happen

### Steps to test this PR

- [x] Apply the staging patch and VPN into US
- [x] Go to https://duckduckgo.com/pro?featurePage=stripe
- [x] Complete the purchase using the test cards for Stripe
- [ ] On the welcome screen, the icon should be a cross rather than an arrow.
- [ ] Pressing either the cross or the back button should take you back to settings (doing this on develop would take you back to Stripe)
- [ ] Now that you are subscribe go to settings and click on "Need help with your subscription"
- [ ] On that webview navigate to some links, see how the cross turns into an arrow and if you now press it or use the back button you navigate back rather than close the screen.

