### PR TITLE
Update content scope scripts to version 11.16.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -4082,28 +4082,42 @@
       if (window.Notification) {
         return;
       }
+      const NotificationConstructor = function Notification() {
+        throw new TypeError("Failed to construct 'Notification': Illegal constructor");
+      };
+      const wrappedNotification = wrapToString(
+        NotificationConstructor,
+        NotificationConstructor,
+        "function Notification() { [native code] }"
+      );
       this.defineProperty(window, "Notification", {
-        value: () => {
-        },
+        value: wrappedNotification,
         writable: true,
         configurable: true,
         enumerable: false
       });
-      this.defineProperty(window.Notification, "requestPermission", {
-        value: () => {
-          return Promise.resolve("denied");
-        },
-        writable: true,
+      this.defineProperty(window.Notification, "permission", {
+        value: "denied",
+        writable: false,
         configurable: true,
         enumerable: true
       });
-      this.defineProperty(window.Notification, "permission", {
-        get: () => "denied",
-        configurable: true,
-        enumerable: false
-      });
       this.defineProperty(window.Notification, "maxActions", {
         get: () => 2,
+        configurable: true,
+        enumerable: true
+      });
+      const requestPermissionFunc = function requestPermission() {
+        return Promise.resolve("denied");
+      };
+      const wrappedRequestPermission = wrapToString(
+        requestPermissionFunc,
+        requestPermissionFunc,
+        "function requestPermission() { [native code] }"
+      );
+      this.defineProperty(window.Notification, "requestPermission", {
+        value: wrappedRequestPermission,
+        writable: true,
         configurable: true,
         enumerable: true
       });

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -6817,28 +6817,42 @@
       if (window.Notification) {
         return;
       }
+      const NotificationConstructor = function Notification() {
+        throw new TypeError("Failed to construct 'Notification': Illegal constructor");
+      };
+      const wrappedNotification = wrapToString(
+        NotificationConstructor,
+        NotificationConstructor,
+        "function Notification() { [native code] }"
+      );
       this.defineProperty(window, "Notification", {
-        value: () => {
-        },
+        value: wrappedNotification,
         writable: true,
         configurable: true,
         enumerable: false
       });
-      this.defineProperty(window.Notification, "requestPermission", {
-        value: () => {
-          return Promise.resolve("denied");
-        },
-        writable: true,
+      this.defineProperty(window.Notification, "permission", {
+        value: "denied",
+        writable: false,
         configurable: true,
         enumerable: true
       });
-      this.defineProperty(window.Notification, "permission", {
-        get: () => "denied",
-        configurable: true,
-        enumerable: false
-      });
       this.defineProperty(window.Notification, "maxActions", {
         get: () => 2,
+        configurable: true,
+        enumerable: true
+      });
+      const requestPermissionFunc = function requestPermission() {
+        return Promise.resolve("denied");
+      };
+      const wrappedRequestPermission = wrapToString(
+        requestPermissionFunc,
+        requestPermissionFunc,
+        "function requestPermission() { [native code] }"
+      );
+      this.defineProperty(window.Notification, "requestPermission", {
+        value: wrappedRequestPermission,
+        writable: true,
         configurable: true,
         enumerable: true
       });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.19.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.3.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.15.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.16.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.19.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.19.0.tgz",
-      "integrity": "sha512-VOxY5KcPbrS9J3eeHHSUFslrBPNg4j2nzHU8jKIJ1ovb5hbHQTAU0lOrdL3Q4Q2kN12HH/sAJumNCKGOh3JobA==",
+      "version": "14.20.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.20.0.tgz",
+      "integrity": "sha512-ZlPmxdlta0076zdd9iWA7i4Rz9KK3BWdbImbSWB1puiEdLIM2PiPcF5hgIGg43XGXZpjjdfenudZMQjIwstDwQ==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#92aa73fdef3c280b46feb0a40d468fac44edcbdc",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#2ce4f1466af69d4a4a4b96e79da2e5ceaff200fc",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -280,9 +280,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
-      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
+      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -667,18 +667,18 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.12",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.12.tgz",
-      "integrity": "sha512-3K76aXywJFduGRsOYoY5JzINLs/WMlOkeDwPL+8OCPq2Rh39gkSDtWAxdJQlWjpun/xF/LHf29yqCi6VC/rHDA==",
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.13.tgz",
+      "integrity": "sha512-Td0LeWLgXJGsikI4mO82fRexgPCEyTcwWiXJERF/GBHX3Dm+HQq/wx4HnYowCbiwQ8d+ENLZc+ktbZw8H+0oEA==",
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "7.0.12",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.12.tgz",
-      "integrity": "sha512-riDDp/JrJJuh/2GV1Tgg6OnOwcWlgleBKi4/xkhd0DW7tvvmNjmWXCh2nj7Z2G1k9S/AGN4RiiPRbvhGJUCxeg==",
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.13.tgz",
+      "integrity": "sha512-JSJMjSV1EIq7JBgi3jG9A2jDpChkrboQrPiITES2y0riVPf55dw2jfOpDUTjG1FJTDb2f2CnKzA8TaZX1QdHqw==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.12"
+        "tldts-core": "^7.0.13"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.19.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.3.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.15.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.16.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run