### PR TITLE
Fix: Voice search button not displayed when short URL configured

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -578,7 +578,7 @@ class OmnibarLayoutViewModel @Inject constructor(
                 showVoiceSearch = shouldShowVoiceSearch(
                     hasFocus = hasFocus,
                     query = query,
-                    hasQueryChanged = true,
+                    hasQueryChanged = query != updatedQuery,
                     urlLoaded = _viewState.value.url,
                 ),
             )

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -1901,4 +1901,23 @@ class OmnibarLayoutViewModelTest {
             expectNoEvents()
         }
     }
+
+    @Test
+    fun whenInputStateChangedAndClearingQueryThenHasQueryChangedTruePassedToVoiceSearchAvailability() = runTest {
+        var capturedHasQueryChanged: Boolean? = null
+        whenever(voiceSearchAvailability.shouldShowVoiceSearch(any(), any(), any(), any())).thenAnswer { invocation ->
+            capturedHasQueryChanged = invocation.getArgument(2)
+            true
+        }
+
+        // First set a non-empty query
+        testee.onInputStateChanged("initial", hasFocus = true, clearQuery = false, deleteLastCharacter = false)
+        // Then clear the query which should set hasQueryChanged = true because updatedQuery retains previous value
+        testee.onInputStateChanged("", hasFocus = true, clearQuery = true, deleteLastCharacter = false)
+
+        testee.viewState.test {
+            awaitItem()
+            assertTrue(capturedHasQueryChanged == true)
+        }
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/715106103902962/task/1211257529601162?focus=true

### Description

This fixes a bug when the voice search button would not show up if full URL was disabled.

### Steps to test this PR

- [x] First enable the microphone permission in the app settings
- [x] Go to Settings -> General
- [x] Enable the Private Voice Search toggle
- [x] Go to Settings -> Appearance
- [x] Disable Show Full Site Address toggle
- [x] Go to the browser and navigate to some site
- [x] Tap on the omnibar address bar
- [x] Notice the text is focused and the voice search button is displayed
