### PR TITLE
Fix incorrect handling of chrome://... and/or edge://... type of URLs

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
@@ -195,6 +195,10 @@ class SpecialUrlDetectorImpl(
     private fun buildIntent(uriString: String, intentFlags: Int): UrlType {
         return try {
             val intent = Intent.parseUri(uriString, intentFlags)
+            // only proceed if something can handle it
+            if (intent == null || packageManager.resolveActivity(intent, 0) == null) {
+                return UrlType.Unknown(uriString)
+            }
 
             if (externalAppIntentFlagsFeature.self().isEnabled()) {
                 intent.addCategory(Intent.CATEGORY_BROWSABLE)

--- a/app/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/SpecialUrlDetector.kt
@@ -81,7 +81,9 @@ class SpecialUrlDetectorImpl(
                 } else {
                     URI_ANDROID_APP_SCHEME
                 }
-                checkForIntent(scheme, uriString, intentFlags)
+                // if there's no redirects (initiatingUrl = null) then it's user initiated
+                val userInitiated = initiatingUrl == null
+                checkForIntent(scheme, uriString, intentFlags, userInitiated)
             }
         }
     }
@@ -183,35 +185,36 @@ class SpecialUrlDetectorImpl(
         scheme: String,
         uriString: String,
         intentFlags: Int,
+        userInitiated: Boolean,
     ): UrlType {
+        fun buildIntent(uriString: String, intentFlags: Int, userInitiated: Boolean): UrlType {
+            return try {
+                val intent = Intent.parseUri(uriString, intentFlags)
+                // only proceed if something can handle it
+                if (userInitiated && (intent == null || packageManager.resolveActivity(intent, 0) == null)) {
+                    return UrlType.Unknown(uriString)
+                }
+
+                if (externalAppIntentFlagsFeature.self().isEnabled()) {
+                    intent.addCategory(Intent.CATEGORY_BROWSABLE)
+                    intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                }
+
+                val fallbackUrl = intent.getStringExtra(EXTRA_FALLBACK_URL)
+                val fallbackIntent = buildFallbackIntent(fallbackUrl)
+                UrlType.NonHttpAppLink(uriString = uriString, intent = intent, fallbackUrl = fallbackUrl, fallbackIntent = fallbackIntent)
+            } catch (e: URISyntaxException) {
+                logcat(WARN) { "Failed to parse uri $uriString: ${e.asLog()}" }
+                return UrlType.Unknown(uriString)
+            }
+        }
+
         val validUriSchemeRegex = Regex("[a-z][a-zA-Z\\d+.-]+")
         if (scheme.matches(validUriSchemeRegex)) {
-            return buildIntent(uriString, intentFlags)
+            return buildIntent(uriString, intentFlags, userInitiated)
         }
 
         return UrlType.SearchQuery(uriString)
-    }
-
-    private fun buildIntent(uriString: String, intentFlags: Int): UrlType {
-        return try {
-            val intent = Intent.parseUri(uriString, intentFlags)
-            // only proceed if something can handle it
-            if (intent == null || packageManager.resolveActivity(intent, 0) == null) {
-                return UrlType.Unknown(uriString)
-            }
-
-            if (externalAppIntentFlagsFeature.self().isEnabled()) {
-                intent.addCategory(Intent.CATEGORY_BROWSABLE)
-                intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
-            }
-
-            val fallbackUrl = intent.getStringExtra(EXTRA_FALLBACK_URL)
-            val fallbackIntent = buildFallbackIntent(fallbackUrl)
-            UrlType.NonHttpAppLink(uriString = uriString, intent = intent, fallbackUrl = fallbackUrl, fallbackIntent = fallbackIntent)
-        } catch (e: URISyntaxException) {
-            logcat(WARN) { "Failed to parse uri $uriString: ${e.asLog()}" }
-            return UrlType.Unknown(uriString)
-        }
     }
 
     private fun buildFallbackIntent(fallbackUrl: String?): Intent? {

--- a/app/src/test/java/com/duckduckgo/app/browser/SpecialUrlDetectorImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/SpecialUrlDetectorImplTest.kt
@@ -293,6 +293,7 @@ class SpecialUrlDetectorImplTest {
     @Test
     fun whenUrlIsCustomUriSchemeThenNonHttpAppLinkTypeDetectedWithAdditionalIntentFlags() {
         externalAppIntentFlagsFeature.self().setRawStoredState(State(true))
+        whenever(mockPackageManager.resolveActivity(any(), anyInt())).thenReturn(ResolveInfo())
         val type = testee.determineType("myapp:foo bar") as NonHttpAppLink
         assertEquals("myapp:foo bar", type.uriString)
         assertEquals(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP, type.intent.flags)
@@ -300,8 +301,18 @@ class SpecialUrlDetectorImplTest {
     }
 
     @Test
+    fun whenUrlIsCustomUriSchemeAndNoResolveInfoThenUnknownTypeDetected() {
+        externalAppIntentFlagsFeature.self().setRawStoredState(State(true))
+        whenever(mockPackageManager.resolveActivity(any(), anyInt())).thenReturn(null)
+        val expected = Unknown::class
+        val actual = testee.determineType("myapp:foo bar")
+        assertEquals(expected, actual::class)
+    }
+
+    @Test
     fun whenUrlIsCustomUriSchemeThenNonHttpAppLinkTypeDetectedWithoutAdditionalIntentFlags() {
         externalAppIntentFlagsFeature.self().setRawStoredState(State(false))
+        whenever(mockPackageManager.resolveActivity(any(), anyInt())).thenReturn(ResolveInfo())
         val type = testee.determineType("myapp:foo bar") as NonHttpAppLink
         assertEquals("myapp:foo bar", type.uriString)
         assertEquals(0, type.intent.flags)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211244094852892?focus=true

### Description
Fix the way that we handle non http URI requests. The first attempts fixed it but also introduced a bug because we should only look at user initiated requests, and not redirects.

This fix should do that

### Steps to test this PR
- [ ] repeat tests in https://github.com/duckduckgo/Android/pull/6687
- [ ] ensure the [side effect issue](https://app.asana.com/1/137249556945/project/1206777341262243/task/1211202801652410) doesn't repro anymore
