### PR TITLE
Update content scope scripts to version 11.18.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
@@ -538,7 +538,7 @@
     ]
   );
   var platformSupport = {
-    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "duckAiListener"],
+    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "duckAiListener", "pageContext"],
     "apple-isolated": [
       "duckPlayer",
       "duckPlayerNative",
@@ -546,8 +546,7 @@
       "performanceMetrics",
       "clickToLoad",
       "messageBridge",
-      "favicon",
-      "pageContext"
+      "favicon"
     ],
     android: [...baseFeatures, "webCompat", "breakageReporting", "duckPlayer", "messageBridge"],
     "android-broker-protection": ["brokerProtection"],
@@ -572,7 +571,9 @@
       "brokerProtection",
       "breakageReporting",
       "messageBridge",
-      "webCompat"
+      "webCompat",
+      "pageContext",
+      "duckAiListener"
     ],
     firefox: ["cookie", ...baseFeatures, "clickToLoad"],
     chrome: ["cookie", ...baseFeatures, "clickToLoad"],
@@ -3532,6 +3533,40 @@
     get isDebug() {
       return this.args?.debug || false;
     }
+    get shouldLog() {
+      return this.isDebug;
+    }
+    /**
+     * Logging utility for this feature (Stolen some inspo from DuckPlayer logger, will unify in the future)
+     */
+    get log() {
+      const shouldLog = this.shouldLog;
+      const prefix = `${this.name.padEnd(20, " ")} |`;
+      return {
+        // These are getters to have the call site be the reported line number.
+        get info() {
+          if (!shouldLog) {
+            return () => {
+            };
+          }
+          return console.log.bind(console, prefix);
+        },
+        get warn() {
+          if (!shouldLog) {
+            return () => {
+            };
+          }
+          return console.warn.bind(console, prefix);
+        },
+        get error() {
+          if (!shouldLog) {
+            return () => {
+            };
+          }
+          return console.error.bind(console, prefix);
+        }
+      };
+    }
     get desktopModeEnabled() {
       return this.args?.desktopModeEnabled || false;
     }
@@ -4249,6 +4284,14 @@
       }
     });
     historyMethodProxy.overload();
+    const historyMethodProxyReplace = new DDGProxy(urlChangedInstance, History.prototype, "replaceState", {
+      apply(target, thisArg, args) {
+        const changeResult = DDGReflect.apply(target, thisArg, args);
+        handleURLChange("replace");
+        return changeResult;
+      }
+    });
+    historyMethodProxyReplace.overload();
     window.addEventListener("popstate", () => {
       handleURLChange("traverse");
     });

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -2037,7 +2037,7 @@
     ]
   );
   var platformSupport = {
-    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "duckAiListener"],
+    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "duckAiListener", "pageContext"],
     "apple-isolated": [
       "duckPlayer",
       "duckPlayerNative",
@@ -2045,8 +2045,7 @@
       "performanceMetrics",
       "clickToLoad",
       "messageBridge",
-      "favicon",
-      "pageContext"
+      "favicon"
     ],
     android: [...baseFeatures, "webCompat", "breakageReporting", "duckPlayer", "messageBridge"],
     "android-broker-protection": ["brokerProtection"],
@@ -2071,7 +2070,9 @@
       "brokerProtection",
       "breakageReporting",
       "messageBridge",
-      "webCompat"
+      "webCompat",
+      "pageContext",
+      "duckAiListener"
     ],
     firefox: ["cookie", ...baseFeatures, "clickToLoad"],
     chrome: ["cookie", ...baseFeatures, "clickToLoad"],
@@ -5075,6 +5076,40 @@
     }
     get isDebug() {
       return this.args?.debug || false;
+    }
+    get shouldLog() {
+      return this.isDebug;
+    }
+    /**
+     * Logging utility for this feature (Stolen some inspo from DuckPlayer logger, will unify in the future)
+     */
+    get log() {
+      const shouldLog = this.shouldLog;
+      const prefix = `${this.name.padEnd(20, " ")} |`;
+      return {
+        // These are getters to have the call site be the reported line number.
+        get info() {
+          if (!shouldLog) {
+            return () => {
+            };
+          }
+          return console.log.bind(console, prefix);
+        },
+        get warn() {
+          if (!shouldLog) {
+            return () => {
+            };
+          }
+          return console.warn.bind(console, prefix);
+        },
+        get error() {
+          if (!shouldLog) {
+            return () => {
+            };
+          }
+          return console.error.bind(console, prefix);
+        }
+      };
     }
     get desktopModeEnabled() {
       return this.args?.desktopModeEnabled || false;
@@ -8948,6 +8983,14 @@
       }
     });
     historyMethodProxy.overload();
+    const historyMethodProxyReplace = new DDGProxy(urlChangedInstance, History.prototype, "replaceState", {
+      apply(target, thisArg, args) {
+        const changeResult = DDGReflect.apply(target, thisArg, args);
+        handleURLChange("replace");
+        return changeResult;
+      }
+    });
+    historyMethodProxyReplace.overload();
     window.addEventListener("popstate", () => {
       handleURLChange("traverse");
     });

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -1366,7 +1366,7 @@
     ]
   );
   var platformSupport = {
-    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "duckAiListener"],
+    apple: ["webCompat", "duckPlayerNative", ...baseFeatures, "duckAiListener", "pageContext"],
     "apple-isolated": [
       "duckPlayer",
       "duckPlayerNative",
@@ -1374,8 +1374,7 @@
       "performanceMetrics",
       "clickToLoad",
       "messageBridge",
-      "favicon",
-      "pageContext"
+      "favicon"
     ],
     android: [...baseFeatures, "webCompat", "breakageReporting", "duckPlayer", "messageBridge"],
     "android-broker-protection": ["brokerProtection"],
@@ -1400,7 +1399,9 @@
       "brokerProtection",
       "breakageReporting",
       "messageBridge",
-      "webCompat"
+      "webCompat",
+      "pageContext",
+      "duckAiListener"
     ],
     firefox: ["cookie", ...baseFeatures, "clickToLoad"],
     chrome: ["cookie", ...baseFeatures, "clickToLoad"],
@@ -4916,6 +4917,40 @@
     get isDebug() {
       return this.args?.debug || false;
     }
+    get shouldLog() {
+      return this.isDebug;
+    }
+    /**
+     * Logging utility for this feature (Stolen some inspo from DuckPlayer logger, will unify in the future)
+     */
+    get log() {
+      const shouldLog = this.shouldLog;
+      const prefix = `${this.name.padEnd(20, " ")} |`;
+      return {
+        // These are getters to have the call site be the reported line number.
+        get info() {
+          if (!shouldLog) {
+            return () => {
+            };
+          }
+          return console.log.bind(console, prefix);
+        },
+        get warn() {
+          if (!shouldLog) {
+            return () => {
+            };
+          }
+          return console.warn.bind(console, prefix);
+        },
+        get error() {
+          if (!shouldLog) {
+            return () => {
+            };
+          }
+          return console.error.bind(console, prefix);
+        }
+      };
+    }
     get desktopModeEnabled() {
       return this.args?.desktopModeEnabled || false;
     }
@@ -6221,6 +6256,7 @@
   var modifiedElements = /* @__PURE__ */ new WeakMap();
   var appliedRules = /* @__PURE__ */ new Set();
   var shouldInjectStyleTag = false;
+  var styleTagInjected = false;
   var mediaAndFormSelectors = "video,canvas,embed,object,audio,map,form,input,textarea,select,option,button";
   var hideTimeouts = [0, 100, 300, 500, 1e3, 2e3, 3e3];
   var unhideTimeouts = [1250, 2250, 3e3];
@@ -6360,6 +6396,9 @@
     return timeoutRules;
   }
   function injectStyleTag(rules) {
+    if (styleTagInjected) {
+      return;
+    }
     let selector = "";
     rules.forEach((rule, i) => {
       if (i !== rules.length - 1) {
@@ -6371,6 +6410,7 @@
     const styleTagProperties = "display:none!important;min-height:0!important;height:0!important;";
     const styleTagContents = `${forgivingSelector(selector)} {${styleTagProperties}}`;
     injectGlobalStyles(styleTagContents);
+    styleTagInjected = true;
   }
   function hideAdNodes(rules) {
     const document2 = globalThis.document;
@@ -9573,23 +9613,23 @@
         return `${eventName}-${args.messageSecret}`;
       }
       const reply = (incoming) => {
-        if (!args.messageSecret) return this.log("ignoring because args.messageSecret was absent");
+        if (!args.messageSecret) return this.log.info("ignoring because args.messageSecret was absent");
         const eventName = appendToken(incoming.name + "-" + incoming.id);
         const event = new captured2.CustomEvent(eventName, { detail: incoming });
         captured2.dispatchEvent(event);
       };
       const accept = (ClassType, callback) => {
         captured2.addEventListener(appendToken(ClassType.NAME), (e) => {
-          this.log(`${ClassType.NAME}`, JSON.stringify(e.detail));
+          this.log.info(`${ClassType.NAME}`, JSON.stringify(e.detail));
           const instance = ClassType.create(e.detail);
           if (instance) {
             callback(instance);
           } else {
-            this.log("Failed to create an instance");
+            this.log.info("Failed to create an instance");
           }
         });
       };
-      this.log(`bridge is installing...`);
+      this.log.info(`bridge is installing...`);
       accept(InstallProxy, (install) => {
         this.installProxyFor(install, args.messagingConfig, reply);
       });
@@ -9608,15 +9648,15 @@
      */
     installProxyFor(install, config, reply) {
       const { id, featureName } = install;
-      if (this.proxies.has(featureName)) return this.log("ignoring `installProxyFor` because it exists", featureName);
+      if (this.proxies.has(featureName)) return this.log.info("ignoring `installProxyFor` because it exists", featureName);
       const allowed = this.getFeatureSettingEnabled(featureName);
       if (!allowed) {
-        return this.log("not installing proxy, because", featureName, "was not enabled");
+        return this.log.info("not installing proxy, because", featureName, "was not enabled");
       }
       const ctx = { ...this.messaging.messagingContext, featureName };
       const messaging = new Messaging(ctx, config);
       this.proxies.set(featureName, messaging);
-      this.log("did install proxy for ", featureName);
+      this.log.info("did install proxy for ", featureName);
       reply(new DidInstall({ id }));
     }
     /**
@@ -9626,8 +9666,8 @@
     async proxyRequest(request, reply) {
       const { id, featureName, method, params } = request;
       const proxy = this.proxies.get(featureName);
-      if (!proxy) return this.log("proxy was not installed for ", featureName);
-      this.log("will proxy", request);
+      if (!proxy) return this.log.info("proxy was not installed for ", featureName);
+      this.log.info("will proxy", request);
       try {
         const result = await proxy.request(method, params);
         const responseEvent = new ProxyResponse({
@@ -9654,8 +9694,8 @@
     proxySubscription(subscription, reply) {
       const { id, featureName, subscriptionName } = subscription;
       const proxy = this.proxies.get(subscription.featureName);
-      if (!proxy) return this.log("proxy was not installed for", featureName);
-      this.log("will setup subscription", subscription);
+      if (!proxy) return this.log.info("proxy was not installed for", featureName);
+      this.log.info("will setup subscription", subscription);
       const prev = this.subscriptions.get(id);
       if (prev) {
         this.removeSubscription(id);
@@ -9676,7 +9716,7 @@
      */
     removeSubscription(id) {
       const unsubscribe = this.subscriptions.get(id);
-      this.log(`will remove subscription`, id);
+      this.log.info(`will remove subscription`, id);
       unsubscribe?.();
       this.subscriptions.delete(id);
     }
@@ -9685,17 +9725,9 @@
      */
     proxyNotification(notification) {
       const proxy = this.proxies.get(notification.featureName);
-      if (!proxy) return this.log("proxy was not installed for", notification.featureName);
-      this.log("will proxy notification", notification);
+      if (!proxy) return this.log.info("proxy was not installed for", notification.featureName);
+      this.log.info("will proxy notification", notification);
       proxy.notify(notification.method, notification.params);
-    }
-    /**
-     * @param {Parameters<console['log']>} args
-     */
-    log(...args) {
-      if (this.isDebug) {
-        console.log("[isolated]", ...args);
-      }
     }
     load(_args2) {
     }
@@ -9762,6 +9794,14 @@
       }
     });
     historyMethodProxy.overload();
+    const historyMethodProxyReplace = new DDGProxy(urlChangedInstance, History.prototype, "replaceState", {
+      apply(target, thisArg, args) {
+        const changeResult = DDGReflect.apply(target, thisArg, args);
+        handleURLChange("replace");
+        return changeResult;
+      }
+    });
+    historyMethodProxyReplace.overload();
     window.addEventListener("popstate", () => {
       handleURLChange("traverse");
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.19.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.3.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.16.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.18.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#2ce4f1466af69d4a4a4b96e79da2e5ceaff200fc",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#9577e15fbafe890d1bcba017ccb5f5e56ae00a90",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.19.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.3.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.16.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.18.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run