### PR TITLE
Duck.ai: Use a shortcut that is added from the widget picker

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -249,6 +249,19 @@
             android:resizeableActivity="true" />
 
         <activity
+            android:name="com.duckduckgo.widget.DuckAiPinShortcutActivity"
+            android:exported="true"
+            android:launchMode="singleTask"
+            android:icon="@drawable/duckai_64"
+            android:label="@string/duckAiOnlyPinShortcutLabel"
+            android:theme="@style/Theme.AppCompat.Transparent.NoActionBar">
+            <intent-filter>
+                <action android:name="android.intent.action.CREATE_SHORTCUT" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+
+        <activity
             android:name="com.duckduckgo.app.dispatchers.IntentDispatcherActivity"
             android:theme="@style/Theme.AppCompat.Transparent.NoActionBar"
             android:exported="true">

--- a/app/src/main/java/com/duckduckgo/widget/DuckAiPinShortcutActivity.kt
+++ b/app/src/main/java/com/duckduckgo/widget/DuckAiPinShortcutActivity.kt
@@ -1,0 +1,51 @@
+package com.duckduckgo.widget
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.drawable.IconCompat
+import com.duckduckgo.app.browser.BrowserActivity
+import com.duckduckgo.app.browser.R
+
+/**
+ * This activity is capable of handling requests to create a shortcut.
+ * Exists purely to be able to add the Duck.ai shortcut on the home screen from the widget picker.
+ */
+class DuckAiPinShortcutActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        if (ShortcutManagerCompat.isRequestPinShortcutSupported(this)) {
+            val shortcutInfo = createShortcutInfo(this)
+            ShortcutManagerCompat.reportShortcutUsed(this, SHORTCUT_ID)
+            setResult(RESULT_OK, ShortcutManagerCompat.createShortcutResultIntent(this, shortcutInfo))
+        } else {
+            setResult(RESULT_OK)
+        }
+
+        finish()
+    }
+
+    private fun createShortcutInfo(context: Context): ShortcutInfoCompat {
+        val shortLabel = getString(com.duckduckgo.duckchat.impl.R.string.duck_chat_title)
+
+        val shortcutIntent = BrowserActivity.intent(context, openDuckChat = true, duckChatSessionActive = true).apply {
+            action = Intent.ACTION_VIEW
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        }
+
+        return ShortcutInfoCompat.Builder(context, SHORTCUT_ID)
+            .setShortLabel(shortLabel)
+            .setIcon(IconCompat.createWithResource(context, R.drawable.duckai_64))
+            .setIntent(shortcutIntent)
+            .build()
+    }
+
+    companion object {
+        private const val SHORTCUT_ID = "duck_ai_from_widget_picker"
+    }
+}

--- a/app/src/main/java/com/duckduckgo/widget/DuckAiPinShortcutActivity.kt
+++ b/app/src/main/java/com/duckduckgo/widget/DuckAiPinShortcutActivity.kt
@@ -31,7 +31,7 @@ class DuckAiPinShortcutActivity : AppCompatActivity() {
     }
 
     private fun createShortcutInfo(context: Context): ShortcutInfoCompat {
-        val shortLabel = getString(com.duckduckgo.duckchat.impl.R.string.duck_chat_title)
+        val shortLabel = getString(R.string.duckAiOnlyPinShortcutLabel)
 
         val shortcutIntent = BrowserActivity.intent(context, openDuckChat = true, duckChatSessionActive = true).apply {
             action = Intent.ACTION_VIEW

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -68,4 +68,5 @@
     <string name="searchOnlyWidgetDescription">Quickly launch a private search with DuckDuckGo.</string>
     <string name="searchAndFavoritesWidgetDescription">Search or visit your favorite sites privately with one tap. Voice Search and Duck.ai available if enabled.</string>
     <string name="searchWidgetDescription">Search privately with DuckDuckGo or ask Duck.ai. Voice Search and Duck.ai available if enabled.</string>
+    <string name="duckAiOnlyPinShortcutLabel">Duck.ai</string>
 </resources>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211289267231652?focus=true

### Description
Added the ability to create a Duck.ai shortcut on the home screen directly from the widget picker. This implementation includes a new transparent activity `DuckAiPinShortcutActivity` that handles shortcut creation requests and registers the shortcut with the system.

### Steps to test this PR

_Duck.ai Shortcut Creation_
- [x] Install from this branch.
- [x] Open the widget picker on your Android device (long tap on the app icon).
- [x] Find and select the Duck.ai shortcut option.
- [x] Verify the shortcut is created on your home screen with the Duck.ai icon.
- [x] Tap the shortcut and confirm it opens directly to Duck.ai.

### UI changes
Check screenshots attached on task URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211289267231652?focus=true
