### PR TITLE
[Web Tracking Protection] Add a feature flag

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/webtrackingprotection/WebTrackingProtectionViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/webtrackingprotection/WebTrackingProtectionViewModel.kt
@@ -41,6 +41,7 @@ class WebTrackingProtectionViewModel @Inject constructor(
     private val gpc: Gpc,
     private val featureToggle: FeatureToggle,
     private val pixel: Pixel,
+    private val webTrackingProtectionsGridFeature: WebTrackingProtectionsGridFeature,
 ) : ViewModel() {
 
     data class ViewState(
@@ -87,6 +88,10 @@ class WebTrackingProtectionViewModel @Inject constructor(
     }
 
     private fun getProtectionItems(): List<FeatureGridItem> {
+        if (!webTrackingProtectionsGridFeature.self().isEnabled()) {
+            return emptyList()
+        }
+
         return listOf(
             FeatureGridItem(
                 iconRes = R.drawable.ic_shield_protection,

--- a/app/src/main/java/com/duckduckgo/app/webtrackingprotection/WebTrackingProtectionsGridFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/webtrackingprotection/WebTrackingProtectionsGridFeature.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.webtrackingprotection
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
+
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "webTrackingProtectionsGrid",
+)
+interface WebTrackingProtectionsGridFeature {
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun self(): Toggle
+}

--- a/app/src/main/java/com/duckduckgo/app/webtrackingprotection/WebTrackingProtectionsGridFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/webtrackingprotection/WebTrackingProtectionsGridFeature.kt
@@ -26,6 +26,6 @@ import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
     featureName = "webTrackingProtectionsGrid",
 )
 interface WebTrackingProtectionsGridFeature {
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 }

--- a/app/src/main/res/layout/activity_web_tracking_protection.xml
+++ b/app/src/main/res/layout/activity_web_tracking_protection.xml
@@ -95,7 +95,10 @@
                 app:primaryText="@string/settingsPrivacyProtectionAllowlist" />
 
             <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+                android:id="@+id/protectionsListDivider"
                 android:layout_width="match_parent"
+                android:visibility="gone"
+                tools:visibility="visible"
                 android:layout_height="wrap_content" />
 
             <com.duckduckgo.common.ui.view.text.DaxTextView
@@ -106,6 +109,8 @@
                 android:layout_marginTop="@dimen/keyline_3"
                 android:layout_marginBottom="6dp"
                 android:gravity="start"
+                android:visibility="gone"
+                tools:visibility="visible"
                 android:text="@string/webTrackingProtectionExplanationTitle"
                 android:textColor="?daxColorTertiaryText"
                 app:typography="h4" />
@@ -114,6 +119,8 @@
                 android:id="@+id/protectionsList"
                 android:layout_width="match_parent"
                 android:overScrollMode="never"
+                android:visibility="gone"
+                tools:visibility="visible"
                 android:paddingHorizontal="10dp"
                 android:layout_height="match_parent" />
 

--- a/app/src/main/res/layout/item_feature_grid.xml
+++ b/app/src/main/res/layout/item_feature_grid.xml
@@ -21,6 +21,7 @@
     app:cardElevation="0dp"
     app:cardCornerRadius="@dimen/largeShapeCornerRadius"
     android:layout_margin="6dp"
+    app:cardBackgroundColor="?attr/daxColorSurface"
     app:strokeWidth="@dimen/horizontalDividerHeight"
     app:strokeColor="?attr/daxColorLines"
     android:layout_height="wrap_content">

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -188,8 +188,8 @@
     <string name="webTrackingProtectionActivityTitle">Защита от проследяване в мрежата</string>
     <string name="webTrackingProtectionLearnMoreTitle">Защита от проследяване в мрежата</string>
     <string name="webTrackingProtectionTitle">Защита от проследяване в мрежата</string>
+    <string name="webTrackingProtectionDescriptionNew"><![CDATA[DuckDuckGo автоматично блокира скритите тракери, докато сърфирате в мрежата.\n<a href=\"\">Научете повече</a>]]></string>
     <string name="webTrackingProtectionExplanationDescription"><![CDATA[Браузърът DuckDuckGo предоставя защити от проследяване, които винаги са активни.\n<a href=\"\">Научете повече</a>]]></string>
-    <string name="webTrackingProtectionExplanationAlternativeDescription"><![CDATA[Браузърът DuckDuckGo предоставя защита от проследяване, която помага да запазиш данните си в безопасност, докато сърфираш.\n<a href=\"\">Научи повече</a>]]></string>
     <string name="webTrackingProtectionExplanationTitle">Как защитаваме теб</string>
     <string name="webTrackingProtectionThirdPartyTrackersTitle">Блокира тракерите на трети страни</string>
     <string name="webTrackingProtectionThirdPartyTrackersDescription">Помага да се блокират бисквитките на 3-ти страни, които ви проследяват от сайт на сайт, като предотвратява зареждането на тракери на 3-ти страни от самото начало.</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -190,8 +190,8 @@
     <string name="webTrackingProtectionActivityTitle">Ochrana před sledováním na webu</string>
     <string name="webTrackingProtectionLearnMoreTitle">Ochrana před sledováním na webu</string>
     <string name="webTrackingProtectionTitle">Ochrana před sledováním na webu</string>
+    <string name="webTrackingProtectionDescriptionNew"><![CDATA[DuckDuckGo automaticky blokuje skryté trackery při procházení webu.\n<a href=\"\">Další informace</a>]]></string>
     <string name="webTrackingProtectionExplanationDescription"><![CDATA[Prohlížeč DuckDuckGo poskytuje ochranu proti sledování, která je neustále zapnutá.\n<a href=\"\">Další informace</a>]]></string>
-    <string name="webTrackingProtectionExplanationAlternativeDescription"><![CDATA[Prohlížeč DuckDuckGo chrání před sledováním a pomáhá tak udržovat tvoje data na webu v bezpečí.\n<a href=\"\">Další informace</a>]]></string>
     <string name="webTrackingProtectionExplanationTitle">Jak tě chráníme</string>
     <string name="webTrackingProtectionThirdPartyTrackersTitle">Blokuje trackery třetích stran</string>
     <string name="webTrackingProtectionThirdPartyTrackersDescription">Pomáhá blokovat cookies třetích stran, které se tě snaží sledovat napříč různými weby tím, že brání načítání trackerů třetích stran.</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -188,8 +188,8 @@
     <string name="webTrackingProtectionActivityTitle">Beskyttelse mod sporing på nettet</string>
     <string name="webTrackingProtectionLearnMoreTitle">Beskyttelse mod sporing på nettet</string>
     <string name="webTrackingProtectionTitle">Beskyttelse mod sporing på nettet</string>
+    <string name="webTrackingProtectionDescriptionNew"><![CDATA[DuckDuckGo blokerer automatisk skjulte trackere, når du surfer på nettet.\n<a href=\"\">Mere info</a>]]></string>
     <string name="webTrackingProtectionExplanationDescription"><![CDATA[DuckDuckGo-browseren giver sporingbeskyttelse, som altid er aktiv.\n<a href=\"\">Mere info</a>]]></string>
-    <string name="webTrackingProtectionExplanationAlternativeDescription"><![CDATA[DuckDuckGo-browseren giver sporingsbeskyttelse, der hjælper med at beskytte dine data, når du surfer.\n<a href=\"\">Mere info</a>]]></string>
     <string name="webTrackingProtectionExplanationTitle">Sådan beskytter vi dig</string>
     <string name="webTrackingProtectionThirdPartyTrackersTitle">Bloker tredjeparts-trackere</string>
     <string name="webTrackingProtectionThirdPartyTrackersDescription">Hjælper med at blokere tredjepartscookies, der tracker dig fra websted til websted, ved at forhindre tredjepartstrackere i at blive indlæst.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -188,8 +188,8 @@
     <string name="webTrackingProtectionActivityTitle">Web Tracking Protection</string>
     <string name="webTrackingProtectionLearnMoreTitle">Web Tracking Protection</string>
     <string name="webTrackingProtectionTitle">Web Tracking Protection</string>
+    <string name="webTrackingProtectionDescriptionNew"><![CDATA[DuckDuckGo blockiert automatisch versteckte Tracker, während du browst.\n<a href=\"\">Mehr erfahren</a>]]></string>
     <string name="webTrackingProtectionExplanationDescription"><![CDATA[Der DuckDuckGo-Browser bietet Tracking-Schutz, der immer aktiv ist.\n<a href=\"\">Mehr erfahren</a>]]></string>
-    <string name="webTrackingProtectionExplanationAlternativeDescription"><![CDATA[Der DuckDuckGo-Browser bietet Tracking-Schutz, der hilft, deine Daten beim Surfen sicher zu halten.\n<a href=\"\">Mehr erfahren</a>]]></string>
     <string name="webTrackingProtectionExplanationTitle">Wie wir dich schützen</string>
     <string name="webTrackingProtectionThirdPartyTrackersTitle">Blockiert Tracker von Drittanbietern</string>
     <string name="webTrackingProtectionThirdPartyTrackersDescription">Hilft Cookies von Drittanbietern zu blockieren, die dich von Website zu Website tracken, indem das Laden von Drittanbieter-Trackern verhindert wird.</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -188,8 +188,8 @@
     <string name="webTrackingProtectionActivityTitle">Προστασία παρακολούθησης ιστού</string>
     <string name="webTrackingProtectionLearnMoreTitle">Προστασία παρακολούθησης ιστού</string>
     <string name="webTrackingProtectionTitle">Προστασία παρακολούθησης ιστού</string>
+    <string name="webTrackingProtectionDescriptionNew"><![CDATA[Το DuckDuckGo αποκλείει αυτόματα κρυφές εφαρμογές παρακολούθησης καθώς περιηγείστε στο διαδίκτυο.\n<a href=\"\">Μάθετε περισσότερα</a>]]></string>
     <string name="webTrackingProtectionExplanationDescription"><![CDATA[Το πρόγραμμα περιήγησης DuckDuckGo παρέχει προστασίες παρακολούθησης, οι οποίες είναι πάντα ενεργές.\n<a href=\"\">Μάθετε περισσότερα</a>]]></string>
-    <string name="webTrackingProtectionExplanationAlternativeDescription"><![CDATA[Το πρόγραμμα περιήγησης DuckDuckGo παρέχει προστασίες παρακολούθησης που βοηθούν να διατηρείτε τα δεδομένα σας ασφαλή κατά την περιήγησή σας.\n<a href=\"\">Μάθετε περισσότερα</a>]]></string>
     <string name="webTrackingProtectionExplanationTitle">Πώς σας προστατεύουμε</string>
     <string name="webTrackingProtectionThirdPartyTrackersTitle">Αποκλείει τις εφαρμογές παρακολούθησης τρίτων</string>
     <string name="webTrackingProtectionThirdPartyTrackersDescription">Βοηθά στον αποκλεισμό των cookie τρίτων μερών που σας παρακολουθούν από ιστότοπο σε ιστότοπο, εμποδίζοντας εξαρχής τη φόρτωση των εφαρμογών παρακολούθησης τρίτων μερών.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -188,8 +188,8 @@
     <string name="webTrackingProtectionActivityTitle">Protección de rastreo en la web</string>
     <string name="webTrackingProtectionLearnMoreTitle">Protección de rastreo en la web</string>
     <string name="webTrackingProtectionTitle">Protección de rastreo en la web</string>
+    <string name="webTrackingProtectionDescriptionNew"><![CDATA[DuckDuckGo bloquea automáticamente los rastreadores ocultos mientras navegas por la web.\n<a href=\"\">Más información</a>]]></string>
     <string name="webTrackingProtectionExplanationDescription"><![CDATA[El navegador DuckDuckGo proporciona protecciones de rastreo que están siempre activas.\n<a href=\"\">Más información</a>]]></string>
-    <string name="webTrackingProtectionExplanationAlternativeDescription"><![CDATA[El navegador DuckDuckGo ofrece protecciones de rastreo que ayudan a mantener tus datos seguros mientras navegas.\n<a href=\"\">Más información</a>]]></string>
     <string name="webTrackingProtectionExplanationTitle">Cómo te protegemos</string>
     <string name="webTrackingProtectionThirdPartyTrackersTitle">Bloquea rastreadores de terceros</string>
     <string name="webTrackingProtectionThirdPartyTrackersDescription">Ayuda a bloquear las cookies de terceros que te rastrean de un sitio a otro al impedir que los rastreadores de terceros se carguen desde el principio.</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -188,8 +188,8 @@
     <string name="webTrackingProtectionActivityTitle">Veebijälgimise kaitse</string>
     <string name="webTrackingProtectionLearnMoreTitle">Veebijälgimise kaitse</string>
     <string name="webTrackingProtectionTitle">Veebijälgimise kaitse</string>
+    <string name="webTrackingProtectionDescriptionNew"><![CDATA[DuckDuckGo blokeerib automaatselt peidetud jälgijaid, kui sa veebis sirvid.\n<a href=\"\">Loe edasi</a>]]></string>
     <string name="webTrackingProtectionExplanationDescription"><![CDATA[DuckDuckGo brauser pakub jälgimiskaitseid, mis on alati aktiivsed.\n<a href=\"\">Loe edasi</a>]]></string>
-    <string name="webTrackingProtectionExplanationAlternativeDescription"><![CDATA[DuckDuckGo brauser pakub jälgimiskaitseid, mis aitavad su andmeid sirvimise ajal kaitsta.\n<a href=\"\">Loe edasi</a>]]></string>
     <string name="webTrackingProtectionExplanationTitle">Kuidas me sind kaitseme</string>
     <string name="webTrackingProtectionThirdPartyTrackersTitle">Blokeerib kolmanda poole jälgurid</string>
     <string name="webTrackingProtectionThirdPartyTrackersDescription">Aitab blokeerida kolmanda poole küpsiseid, mis jälgivad sind lehelt lehele, takistades kolmanda poole jälgijate laadimist.</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -188,8 +188,8 @@
     <string name="webTrackingProtectionActivityTitle">Verkkoseurannan suojaus</string>
     <string name="webTrackingProtectionLearnMoreTitle">Verkkoseurannan suojaus</string>
     <string name="webTrackingProtectionTitle">Verkkoseurannan suojaus</string>
+    <string name="webTrackingProtectionDescriptionNew"><![CDATA[DuckDuckGo estää automaattisesti piilotetut jäljittäjät, kun selaat verkkoa.\n<a href=\"\">Lue lisää</a>]]></string>
     <string name="webTrackingProtectionExplanationDescription"><![CDATA[DuckDuckGo-selain tarjoaa aina käytössä olevan seurantasuojauksen.\n<a href=\"\">Lue lisää</a>]]></string>
-    <string name="webTrackingProtectionExplanationAlternativeDescription"><![CDATA[DuckDuckGo-selain tarjoaa seurantasuojausta, joka auttaa pitämään tietosi turvassa selaillessasi.\n<a href=\"\">Lue lisää</a>]]></string>
     <string name="webTrackingProtectionExplanationTitle">Näin suojaamme sinua</string>
     <string name="webTrackingProtectionThirdPartyTrackersTitle">Estää kolmannen osapuolen seuraimet</string>
     <string name="webTrackingProtectionThirdPartyTrackersDescription">Auttaa estämään kolmannen osapuolen evästeitä, jotka seuraavat sinua sivustolta toiselle, estämällä kolmannen osapuolen seurantatoimintoja latautumasta.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -188,8 +188,8 @@
     <string name="webTrackingProtectionActivityTitle">Protection contre le pistage sur le Web</string>
     <string name="webTrackingProtectionLearnMoreTitle">Protection contre le pistage sur le Web</string>
     <string name="webTrackingProtectionTitle">Protection contre le pistage sur le Web</string>
+    <string name="webTrackingProtectionDescriptionNew"><![CDATA[DuckDuckGo bloque automatiquement les traqueurs cachés lorsque vous naviguez sur le Web.\n<a href=\"\">En savoir plus</a>]]></string>
     <string name="webTrackingProtectionExplanationDescription"><![CDATA[Le navigateur DuckDuckGo fournit des protections contre le pistage qui sont toujours actives.\n<a href=\"\">En savoir plus</a>]]></string>
-    <string name="webTrackingProtectionExplanationAlternativeDescription"><![CDATA[Le navigateur DuckDuckGo fournit des protections contre le pistage qui permettent de sécuriser vos données pendant que vous naviguez.\n<a href=\"\">En savoir plus</a>]]></string>
     <string name="webTrackingProtectionExplanationTitle">Comment nous vous protégeons</string>
     <string name="webTrackingProtectionThirdPartyTrackersTitle">Bloque les traqueurs tiers</string>
     <string name="webTrackingProtectionThirdPartyTrackersDescription">Permet de bloquer les cookies tiers qui vous suivent d\'un site à l\'autre en empêchant dès le départ le chargement des traqueurs tiers.</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -190,8 +190,8 @@
     <string name="webTrackingProtectionActivityTitle">Zaštita od praćenja na webu</string>
     <string name="webTrackingProtectionLearnMoreTitle">Zaštita od praćenja na webu</string>
     <string name="webTrackingProtectionTitle">Zaštita od praćenja na webu</string>
+    <string name="webTrackingProtectionDescriptionNew"><![CDATA[DuckDuckGo automatski blokira skrivene alate za praćenje dok \"surfaš\" po internetu.\n<a href=\"\">Saznaj više</a>]]></string>
     <string name="webTrackingProtectionExplanationDescription"><![CDATA[Preglednik DuckDuckGo pruža zaštite od praćenja koje su uvijek aktivne.\n<a href=\"\">Saznaj više</a>]]></string>
-    <string name="webTrackingProtectionExplanationAlternativeDescription"><![CDATA[Preglednik DuckDuckGo pruža zaštitu od praćenja koja pomaže da tvoji podaci budu sigurni dok pregledavaš web.\n<a href=\"\">Saznaj više</a>]]></string>
     <string name="webTrackingProtectionExplanationTitle">Kako te štitimo</string>
     <string name="webTrackingProtectionThirdPartyTrackersTitle">Blokira alate za praćenje trećih strana</string>
     <string name="webTrackingProtectionThirdPartyTrackersDescription">Pomaže u blokiranju kolačića trećih strana koji te prate od stranice do stranice sprječavanjem učitavanja alata za praćenje trećih strana.</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -188,8 +188,8 @@
     <string name="webTrackingProtectionActivityTitle">Webes követés elleni védelem</string>
     <string name="webTrackingProtectionLearnMoreTitle">Webes követés elleni védelem</string>
     <string name="webTrackingProtectionTitle">Webes követés elleni védelem</string>
+    <string name="webTrackingProtectionDescriptionNew"><![CDATA[A DuckDuckGo böngészés közben automatikusan blokkolja a rejtett nyomkövetőket.\n<a href=\"\">További részletek</a>]]></string>
     <string name="webTrackingProtectionExplanationDescription"><![CDATA[A DuckDuckGo böngésző nyomkövetés elleni védelmi megoldásokat kínál, amelyek mindig aktívak.\n<a href=\"\">További részletek</a>]]></string>
-    <string name="webTrackingProtectionExplanationAlternativeDescription"><![CDATA[A DuckDuckGo böngésző nyomkövetés elleni védelmet biztosít, hogy biztonságban legyenek az adataid böngészés közben.\n<a href=\"\">További részletek</a>]]></string>
     <string name="webTrackingProtectionExplanationTitle">Így védünk téged</string>
     <string name="webTrackingProtectionThirdPartyTrackersTitle">Blokkolja a harmadik féltől származó nyomkövetőket</string>
     <string name="webTrackingProtectionThirdPartyTrackersDescription">A harmadik féltől származó nyomkövetők betöltésének megakadályozásával segít blokkolni a téged webhelyről webhelyre követő harmadik féltől származó sütiket.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -188,8 +188,8 @@
     <string name="webTrackingProtectionActivityTitle">Protezione dal tracciamento web</string>
     <string name="webTrackingProtectionLearnMoreTitle">Protezione dal tracciamento web</string>
     <string name="webTrackingProtectionTitle">Protezione dal tracciamento web</string>
+    <string name="webTrackingProtectionDescriptionNew"><![CDATA[DuckDuckGo blocca automaticamente i sistemi di tracciamento nascosti mentre navighi sul web.\n<a href=\"\">Ulteriori informazioni</a>]]></string>
     <string name="webTrackingProtectionExplanationDescription"><![CDATA[Il browser DuckDuckGo fornisce protezioni dal tracciamento, che sono sempre attive.\n<a href=\"\">Ulteriori informazioni</a>]]></string>
-    <string name="webTrackingProtectionExplanationAlternativeDescription"><![CDATA[Il browser DuckDuckGo fornisce protezioni dal tracciamento che contribuiscono a mantenere i dati al sicuro durante la navigazione.\n<a href=\"\">Ulteriori informazioni</a>]]></string>
     <string name="webTrackingProtectionExplanationTitle">Come proteggiamo</string>
     <string name="webTrackingProtectionThirdPartyTrackersTitle">Blocca i sistemi di tracciamento di terze parti</string>
     <string name="webTrackingProtectionThirdPartyTrackersDescription">Aiuta a bloccare i cookie di terze parti che ti tracciano da un sito all\'altro, impedendo il caricamento dei sistemi di tracciamento di terze parti fin dall\'inizio.</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -190,8 +190,8 @@
     <string name="webTrackingProtectionActivityTitle">Apsauga nuo žiniatinklio sekimo</string>
     <string name="webTrackingProtectionLearnMoreTitle">Apsauga nuo žiniatinklio sekimo</string>
     <string name="webTrackingProtectionTitle">Apsauga nuo žiniatinklio sekimo</string>
+    <string name="webTrackingProtectionDescriptionNew"><![CDATA[„DuckDuckGo“ automatiškai blokuoja paslėptas stebėjimo priemones naršant internete.\n<a href=\"\">Sužinoti daugiau</a>]]></string>
     <string name="webTrackingProtectionExplanationDescription"><![CDATA[\"DuckDuckGo\" naršyklėje yra visada aktyvi stebėjimo apsauga.\n<a href=\"\">Sužinoti daugiau</a>]]></string>
-    <string name="webTrackingProtectionExplanationAlternativeDescription"><![CDATA[„DuckDuckGo“ naršyklė teikia sekimo apsaugos funkcijas, kurios padeda apsaugoti jūsų duomenis naršant.\n<a href=\"\">Sužinoti daugiau</a>]]></string>
     <string name="webTrackingProtectionExplanationTitle">Kaip jus saugome</string>
     <string name="webTrackingProtectionThirdPartyTrackersTitle">Blokuoja trečiųjų šalių stebėjimo priemones</string>
     <string name="webTrackingProtectionThirdPartyTrackersDescription">Padeda blokuoti 3‑iųjų šalių slapukus, kurie seka jus iš vienos svetainės į kitą, neleidžiant įkelti 3‑iųjų šalių sekimo įrenginių.</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -189,8 +189,8 @@
     <string name="webTrackingProtectionActivityTitle">Tīmekļa izsekošanas aizsardzība</string>
     <string name="webTrackingProtectionLearnMoreTitle">Tīmekļa izsekošanas aizsardzība</string>
     <string name="webTrackingProtectionTitle">Tīmekļa izsekošanas aizsardzība</string>
+    <string name="webTrackingProtectionDescriptionNew"><![CDATA[DuckDuckGo automātiski bloķē slēptos izsekotājus tīmekļa pārlūkošanas laikā.\n<a href=\"\">Uzzināt vairāk</a>]]></string>
     <string name="webTrackingProtectionExplanationDescription"><![CDATA[DuckDuckGo pārlūkprogramma nodrošina izsekošanas aizsardzības, kas vienmēr ir aktīvas.\n<a href=\"\">Uzzināt vairāk</a>]]></string>
-    <string name="webTrackingProtectionExplanationAlternativeDescription"><![CDATA[DuckDuckGo pārlūkprogramma nodrošina izsekošanas aizsardzību, kas pārlūkošanas laikā palīdz saglabāt tavu datu drošību.\n<a href=\"\">Uzzināt vairāk</a>]]></string>
     <string name="webTrackingProtectionExplanationTitle">Kā mēs tevi aizsargājam</string>
     <string name="webTrackingProtectionThirdPartyTrackersTitle">Bloķē trešo pušu izsekotājus</string>
     <string name="webTrackingProtectionThirdPartyTrackersDescription">Palīdz bloķēt trešo pušu sīkfailus, kas izseko tevi no vietnes uz vietni un neļauj ielādēt trešo pušu izsekotājus.</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -188,8 +188,8 @@
     <string name="webTrackingProtectionActivityTitle">Beskyttelse mot nettsporing</string>
     <string name="webTrackingProtectionLearnMoreTitle">Beskyttelse mot nettsporing</string>
     <string name="webTrackingProtectionTitle">Beskyttelse mot nettsporing</string>
+    <string name="webTrackingProtectionDescriptionNew"><![CDATA[DuckDuckGo blokkerer automatisk skjulte sporere når du surfer på nettet.\n<a href=\"\">Finn ut mer</a>]]></string>
     <string name="webTrackingProtectionExplanationDescription"><![CDATA[DuckDuckGo-nettleseren gir deg sporingsbeskyttelser, som alltid er aktive.\n<a href=\"\">Finn ut mer</a>]]></string>
-    <string name="webTrackingProtectionExplanationAlternativeDescription"><![CDATA[DuckDuckGo-nettleseren har sporingsbeskyttelser som holder dataene dine trygge mens du surfer.\n<a href=\"\">Finn ut mer</a>]]></string>
     <string name="webTrackingProtectionExplanationTitle">Slik beskytter vi deg</string>
     <string name="webTrackingProtectionThirdPartyTrackersTitle">Blokkerer tredjepartssporere</string>
     <string name="webTrackingProtectionThirdPartyTrackersDescription">Bidrar til å blokkere tredjeparts informasjonskapsler som sporer deg fra nettsted til nettsted ved å forhindre at tredjepartssporere lastes i det hele tatt.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -188,8 +188,8 @@
     <string name="webTrackingProtectionActivityTitle">Bescherming tegen webtracking</string>
     <string name="webTrackingProtectionLearnMoreTitle">Bescherming tegen webtracking</string>
     <string name="webTrackingProtectionTitle">Bescherming tegen webtracking</string>
+    <string name="webTrackingProtectionDescriptionNew"><![CDATA[DuckDuckGo blokkeert automatisch verborgen trackers terwijl je op het web surft.\n<a href=\"\">Meer informatie</a>]]></string>
     <string name="webTrackingProtectionExplanationDescription"><![CDATA[De DuckDuckGo-browser biedt bescherming tegen tracking die altijd actief is.\n<a href=\"\">Meer informatie</a>]]></string>
-    <string name="webTrackingProtectionExplanationAlternativeDescription"><![CDATA[De DuckDuckGo-browser biedt bescherming tegen tracking, zodat je gegevens veilig blijven terwijl je surft.\n<a href=\"\">Meer informatie</a>]]></string>
     <string name="webTrackingProtectionExplanationTitle">Hoe wij je beschermen</string>
     <string name="webTrackingProtectionThirdPartyTrackersTitle">Blokkeert trackers van derden</string>
     <string name="webTrackingProtectionThirdPartyTrackersDescription">Helpt bij het blokkeren van cookies van derden die je op elke website volgen door te voorkomen dat trackers van derden überhaupt worden geladen.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -190,8 +190,8 @@
     <string name="webTrackingProtectionActivityTitle">Ochrona przed śledzeniem w sieci</string>
     <string name="webTrackingProtectionLearnMoreTitle">Ochrona przed śledzeniem w sieci</string>
     <string name="webTrackingProtectionTitle">Ochrona przed śledzeniem w sieci</string>
+    <string name="webTrackingProtectionDescriptionNew"><![CDATA[Podczas przeglądania stron internetowych DuckDuckGo automatycznie blokuje ukryte mechanizmy śledzące.\n<a href=\"\">Dowiedz się więcej</a>]]></string>
     <string name="webTrackingProtectionExplanationDescription"><![CDATA[Przeglądarka DuckDuckGo zapewnia ochronę przed śledzeniem, która jest zawsze aktywna.\n<a href=\"\">Dowiedz się więcej</a>]]></string>
-    <string name="webTrackingProtectionExplanationAlternativeDescription"><![CDATA[Przeglądarka DuckDuckGo zapewnia ochronę przed śledzeniem, która pomaga chronić Twoje dane podczas przeglądania.\n<a href=\"\">Dowiedz się więcej</a>]]></string>
     <string name="webTrackingProtectionExplanationTitle">W jaki sposób Cię chronimy</string>
     <string name="webTrackingProtectionThirdPartyTrackersTitle">Blokuje mechanizmy śledzące innych firm</string>
     <string name="webTrackingProtectionThirdPartyTrackersDescription">Pomaga blokować pliki cookie innych firm, które śledzą Twoją aktywność na stronach, poprzez uniemożliwienie ładowania mechanizmów śledzących innych firm.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -188,8 +188,8 @@
     <string name="webTrackingProtectionActivityTitle">Proteção contra rastreamento na internet</string>
     <string name="webTrackingProtectionLearnMoreTitle">Proteção contra rastreamento na internet</string>
     <string name="webTrackingProtectionTitle">Proteção contra rastreamento na internet</string>
+    <string name="webTrackingProtectionDescriptionNew"><![CDATA[O DuckDuckGo bloqueia automaticamente os rastreadores ocultos enquanto navegas na Internet.\n<a href=\"\">Sabe mais</a>]]></string>
     <string name="webTrackingProtectionExplanationDescription"><![CDATA[O navegador DuckDuckGo fornece proteções contra rastreamento, que estão sempre ativas.\n<a href=\"\">Sabe mais</a>]]></string>
-    <string name="webTrackingProtectionExplanationAlternativeDescription"><![CDATA[O navegador DuckDuckGo fornece proteções contra rastreamento que ajudam a manter os teus dados seguros enquanto navegas.\n<a href=\"\">Sabe mais</a>]]></string>
     <string name="webTrackingProtectionExplanationTitle">Como te protegemos</string>
     <string name="webTrackingProtectionThirdPartyTrackersTitle">Bloqueia rastreadores de terceiros</string>
     <string name="webTrackingProtectionThirdPartyTrackersDescription">Ajuda a bloquear cookies de terceiros que te rastreiam de site para site, impedindo que os rastreadores de terceiros sejam carregados desde o início.</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -189,8 +189,8 @@
     <string name="webTrackingProtectionActivityTitle">Protecție împotriva urmăririi pe web</string>
     <string name="webTrackingProtectionLearnMoreTitle">Protecție împotriva urmăririi pe web</string>
     <string name="webTrackingProtectionTitle">Protecție împotriva urmăririi pe web</string>
+    <string name="webTrackingProtectionDescriptionNew"><![CDATA[DuckDuckGo blochează automat tehnologiile de urmărire ascunse în timp ce navighezi pe web.\n<a href=\"\">Află mai multe</a>]]></string>
     <string name="webTrackingProtectionExplanationDescription"><![CDATA[Browserul DuckDuckGo oferă instrumente de protecție împotriva urmăririi, care sunt mereu active.\n<a href=\"\">Află mai multe</a>]]></string>
-    <string name="webTrackingProtectionExplanationAlternativeDescription"><![CDATA[Browserul DuckDuckGo oferă protecții împotriva urmăririi care te ajută să-ți păstrezi datele în siguranță în timp ce navighezi.\n<a href=\"\">Află mai multe</a>]]></string>
     <string name="webTrackingProtectionExplanationTitle">Cum te protejăm</string>
     <string name="webTrackingProtectionThirdPartyTrackersTitle">Blochează tehnologiile de urmărire terță parte</string>
     <string name="webTrackingProtectionThirdPartyTrackersDescription">Ajută la blocarea modulelor cookie terțe care te urmăresc de la un site la altul, împiedicând încărcarea instrumentelor de urmărire terțe de la bun început.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -190,8 +190,8 @@
     <string name="webTrackingProtectionActivityTitle">Защита от отслеживания онлайн</string>
     <string name="webTrackingProtectionLearnMoreTitle">Защита от отслеживания онлайн</string>
     <string name="webTrackingProtectionTitle">Защита от отслеживания онлайн</string>
-    <string name="webTrackingProtectionExplanationDescription"><![CDATA[Функции защиты от отслеживания в составе DuckDuckGo работают без остановки.\n<a href=\"\">Подробнее...</a>]]></string>
-    <string name="webTrackingProtectionExplanationAlternativeDescription"><![CDATA[При просмотре веб-страниц браузер DuckDuckGo обеспечивает защиту от отслеживания, сохраняя ваши данные в безопасности.\n<a href=\"\">Подробнее</a>]]></string>
+    <string name="webTrackingProtectionDescriptionNew"><![CDATA[DuckDuckGo автоматически блокирует скрытые трекеры, пока вы посещаете сайты.\n<a href=\"\">Подробнее…</a>]]></string>
+    <string name="webTrackingProtectionExplanationDescription"><![CDATA[Функции защиты от отслеживания в составе DuckDuckGo работают без остановки.\n<a href=\"\">Подробнее…</a>]]></string>
     <string name="webTrackingProtectionExplanationTitle">Как мы вас защищаем</string>
     <string name="webTrackingProtectionThirdPartyTrackersTitle">Блокировка сторонних трекеров</string>
     <string name="webTrackingProtectionThirdPartyTrackersDescription">Не дает сторонним трекерам даже загрузиться, чтобы они не отслеживали ваши перемещения с сайта на сайт.</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -190,8 +190,8 @@
     <string name="webTrackingProtectionActivityTitle">Ochrana pred sledovaním webu</string>
     <string name="webTrackingProtectionLearnMoreTitle">Ochrana pred sledovaním webu</string>
     <string name="webTrackingProtectionTitle">Ochrana pred sledovaním webu</string>
+    <string name="webTrackingProtectionDescriptionNew"><![CDATA[DuckDuckGo pri prehliadaní webu automaticky blokuje skryté sledovače.\n<a href=\"\">Zisti viac</a>]]></string>
     <string name="webTrackingProtectionExplanationDescription"><![CDATA[Prehliadač DuckDuckGo poskytuje ochrany proti sledovaniu, ktoré sú vždy aktívne.\n<a href=\"\">Zisti viac</a>]]></string>
-    <string name="webTrackingProtectionExplanationAlternativeDescription"><![CDATA[Prehliadač DuckDuckGo poskytuje ochrany proti sledovaniu, ktoré pomáhajú chrániť tvoje údaje počas prehliadania.\n<a href=\"\">Zisti viac</a>]]></string>
     <string name="webTrackingProtectionExplanationTitle">Ako ťa chránime</string>
     <string name="webTrackingProtectionThirdPartyTrackersTitle">Blokuje sledovanie tretích strán</string>
     <string name="webTrackingProtectionThirdPartyTrackersDescription">Pomáha blokovať súbory cookie tretích strán, ktoré ťa sledujú naprieč lokalitami tým, že zabraňuje načítaniu sledovacích zariadení tretích strán už na začiatku.</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -190,8 +190,8 @@
     <string name="webTrackingProtectionActivityTitle">Zaščita pred spletnim sledenjem</string>
     <string name="webTrackingProtectionLearnMoreTitle">Zaščita pred spletnim sledenjem</string>
     <string name="webTrackingProtectionTitle">Zaščita pred spletnim sledenjem</string>
+    <string name="webTrackingProtectionDescriptionNew"><![CDATA[DuckDuckGo samodejno blokira skrite sledilnike med brskanjem po spletu.\n<a href=\"\">Več o tem</a>]]></string>
     <string name="webTrackingProtectionExplanationDescription"><![CDATA[Brskalnik DuckDuckGo nudi zaščito pred sledenjem, ki je vedno aktivna.\n<a href=\"\">Več o tem</a>]]></string>
-    <string name="webTrackingProtectionExplanationAlternativeDescription"><![CDATA[Brskalnik DuckDuckGo nudi zaščito pred sledenjem, ki pomaga zagotavljati varnost vaših podatkov med brskanjem.\n<a href=\"\">Več o tem</a>]]></string>
     <string name="webTrackingProtectionExplanationTitle">Kako vas ščitimo</string>
     <string name="webTrackingProtectionThirdPartyTrackersTitle">Blokira sledilnike tretjih oseb</string>
     <string name="webTrackingProtectionThirdPartyTrackersDescription">Pomaga blokirati piškotke tretjih oseb, ki vam sledijo od enega do drugega spletnega mesta, in sicer s preprečevanjem, da bi se sledilniki tretjih oseb sploh naložili.</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -188,8 +188,8 @@
     <string name="webTrackingProtectionActivityTitle">Web Tracking Protection</string>
     <string name="webTrackingProtectionLearnMoreTitle">Web Tracking Protection</string>
     <string name="webTrackingProtectionTitle">Web Tracking Protection</string>
+    <string name="webTrackingProtectionDescriptionNew"><![CDATA[DuckDuckGo blockerar automatiskt dolda spårare när du surfar på webben.\n<a href=\"\">Läs mer</a>]]></string>
     <string name="webTrackingProtectionExplanationDescription"><![CDATA[DuckDuckGo-webbläsaren erbjuder spårningsskydd som alltid är aktiva.\n<a href=\"\">Läs mer</a>]]></string>
-    <string name="webTrackingProtectionExplanationAlternativeDescription"><![CDATA[DuckDuckGo-webbläsaren erbjuder spårningsskydd som bidrar till att hålla dina data säkra när du surfar.\n<a href=\"\">Läs mer</a>]]></string>
     <string name="webTrackingProtectionExplanationTitle">Hur vi skyddar dig</string>
     <string name="webTrackingProtectionThirdPartyTrackersTitle">Blockerar spårare från tredje part</string>
     <string name="webTrackingProtectionThirdPartyTrackersDescription">Hjälper till att blockera tredjepartscookies som spårar dig från webbplats till webbplats genom att förhindra att tredjepartsspårare laddas.</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -188,8 +188,8 @@
     <string name="webTrackingProtectionActivityTitle">Web İzleme Koruması</string>
     <string name="webTrackingProtectionLearnMoreTitle">Web İzleme Koruması</string>
     <string name="webTrackingProtectionTitle">Web İzleme Koruması</string>
+    <string name="webTrackingProtectionDescriptionNew"><![CDATA[DuckDuckGo, web\'de gezinirken gizli izleyicileri otomatik olarak engeller.\n<a href=\"\">Daha Fazla Bilgi</a>]]></string>
     <string name="webTrackingProtectionExplanationDescription"><![CDATA[DuckDuckGo tarayıcısı, her zaman etkin olan izleme korumaları sunar.\n<a href=\"\">Daha Fazla Bilgi</a>]]></string>
-    <string name="webTrackingProtectionExplanationAlternativeDescription"><![CDATA[DuckDuckGo tarayıcısı, gezinirken verilerinizi güvende tutmaya yardımcı olan izleme korumaları sağlar.\n<a href=\"\">Daha Fazla Bilgi</a>]]></string>
     <string name="webTrackingProtectionExplanationTitle">Sizi Nasıl Koruyoruz?</string>
     <string name="webTrackingProtectionThirdPartyTrackersTitle">Üçüncü taraf izleyicileri engeller</string>
     <string name="webTrackingProtectionThirdPartyTrackersDescription">Üçüncü taraf izleyicilerin yüklenmesini baştan engelleyerek, sizi siteden siteye takip eden üçüncü taraf çerezlerini engellemeye yardımcı olur.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -187,8 +187,8 @@
     <string name="webTrackingProtectionActivityTitle">Web Tracking Protection</string>
     <string name="webTrackingProtectionLearnMoreTitle">Web Tracking Protection</string>
     <string name="webTrackingProtectionTitle">Web Tracking Protection</string>
+    <string name="webTrackingProtectionDescriptionNew"><![CDATA[DuckDuckGo automatically blocks hidden trackers as you browse the web.\n<a href="">Learn More</a>]]></string>
     <string name="webTrackingProtectionExplanationDescription"><![CDATA[The DuckDuckGo browser provides tracking protections, which are always active.\n<a href="">Learn More</a>]]></string>
-    <string name="webTrackingProtectionExplanationAlternativeDescription"><![CDATA[The DuckDuckGo browser provides tracking protections that help keep your data safe as you browse.\n<a href="">Learn More</a>]]></string>
     <string name="webTrackingProtectionExplanationTitle">How We Protect You</string>
     <string name="webTrackingProtectionThirdPartyTrackersTitle">Blocks 3rd-party trackers</string>
     <string name="webTrackingProtectionThirdPartyTrackersDescription">Helps block 3rd-party cookies that track you from site to site by preventing 3rd-party trackers from loading in the first place.</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1211299694094696?focus=true

### Description
Adds the new grid behind a feature flag (`"webTrackingProtectionsGrid"`)

### Steps to test this PR

_Verify default behavior_
- [x] Go to Settings -> Web Tracking Protection
- [x] Verify that you don't see the grid (before image)
- [x] Verify that the screen description copy matches the before image

_Verify new behavior_
- [x] Go to Settings -> Feature Flag Inventory -> Enable `"webTrackingProtectionsGrid"`
- [x] Go to Settings -> Web Tracking Protection
- [x] Verify that you see the new grid UI (after image)
- [x] Verify that the screen description copy matches the after image


### UI changes
| Before  | After |
| ------ | ----- |
| <img width="1280" height="2856" alt="Screenshot_20250909_135122" src="https://github.com/user-attachments/assets/dfa869c5-00f3-4506-8b36-6fd361f75bd0" /> | <img width="1280" height="2856" alt="Screenshot_20250909_135151" src="https://github.com/user-attachments/assets/3504b10f-97fb-4dfa-a8b1-565547949dea" /> |
