### PR TITLE
Fix: Close button in select mode

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherAdapter.kt
@@ -236,10 +236,12 @@ class TabSwitcherAdapter(
                     holder.selectionIndicator.contentDescription = holder.rootView.resources.getString(R.string.tabNotSelectedIndicator)
                 }
                 holder.selectionIndicator.show()
+                holder.close.isClickable = false
                 holder.close.hide()
             }
             else -> {
                 holder.selectionIndicator.hide()
+                holder.close.isClickable = true
                 holder.close.show()
             }
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1211324182553062?focus=true

### Description

Fixes an issue when tapping on the selection indicator in select mode would close the tab.

### Steps to test this PR

- [ ] Go to the tab switcher
- [ ] Tap on the menu button -> Select Tabs
- [ ] Tap on the circle (in the corner) on one of the tabs
- [ ] Verify the tab is selected, not closed
- [ ] Exit the selection mode
- [ ] Tap on the close button on one of the tabs
- [ ] Verify it closes the tab