### PR TITLE
Update autofill to 18.3.1

### DIFF
--- a/node_modules/@duckduckgo/autofill/dist/autofill-debug.js
+++ b/node_modules/@duckduckgo/autofill/dist/autofill-debug.js
@@ -1812,6 +1812,9 @@ Source: "${matchedFrom}"`;
     });
     return foundInShadow;
   }
+  function isGoogleAccountsDomain() {
+    return window.location.hostname === "accounts.google.com";
+  }
 
   // src/Form/countryNames.js
   var COUNTRY_CODES_TO_NAMES = {
@@ -3821,6 +3824,9 @@ Source: "${matchedFrom}"`;
     "cardbenefitservices.com": {
       "password-rules": "minlength: 7; maxlength: 100; required: lower, upper; required: digit;"
     },
+    "cardcash.com": {
+      "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!$%&*?@];"
+    },
     "carrefour.it": {
       "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&*?@_];"
     },
@@ -4241,8 +4247,14 @@ Source: "${matchedFrom}"`;
     "ichunqiu.com": {
       "password-rules": "minlength: 8; maxlength: 20; required: lower; required: upper; required: digit;"
     },
+    "id.nfpa.org": {
+      "password-rules": `minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [-"^#$%&'()*+:=@[_|{}~]];`
+    },
     "id.sonyentertainmentnetwork.com": {
       "password-rules": "minlength: 8; maxlength: 30; required: lower, upper; required: digit; allowed: [-!@#^&*=+;:];"
+    },
+    "id.westfield.com": {
+      "password-rules": "minlength: 9; maxlength: 20; required: lower; required: upper; required: digit; required: [!\"#&'()*,./:;?@[\\^_`{|}~];"
     },
     "identity.codesignal.com": {
       "password-rules": "minlength: 14; required: digit; required: lower, upper; required: [!#$%&*@^]"
@@ -4406,11 +4418,17 @@ Source: "${matchedFrom}"`;
     "myaccess.dmdc.osd.mil": {
       "password-rules": "minlength: 9; maxlength: 20; required: lower; required: upper; required: digit; allowed: [-@_#!&$`%*+()./,;~:{}|?>=<^'[]];"
     },
+    "mybam.bcbsnm.com": {
+      "password-rules": "minlength: 8; maxlength: 64; max-consecutive: 2; required: lower; required: upper; required: digit; allowed: [!#$%&()*@[^{}~];"
+    },
     "mygoodtogo.com": {
       "password-rules": "minlength: 8; maxlength: 16; required: lower, upper, digit;"
     },
     "myhealthrecord.com": {
       "password-rules": "minlength: 8; maxlength: 20; allowed: lower, upper, digit, [_.!$*=];"
+    },
+    "mypatientvisit.com": {
+      "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&*+.;?@^_~];"
     },
     "mypay.dfas.mil": {
       "password-rules": "minlength: 9; maxlength: 30; required: lower; required: upper; required: digit; required: [#@$%^!*+=_];"
@@ -6142,7 +6160,7 @@ Source: "${matchedFrom}"`;
       const areAllFormValuesKnown = Object.keys(formValues[dataType] || {}).every(
         (subtype) => formValues[dataType][subtype] === data[subtype]
       );
-      if (areAllFormValuesKnown) {
+      if (areAllFormValuesKnown || isGoogleAccountsDomain()) {
         this.shouldPromptToStoreData = false;
         this.shouldAutoSubmit = this.device.globalConfig.isMobileApp;
       } else {
@@ -6281,7 +6299,7 @@ Source: "${matchedFrom}"`;
       if (this.device.globalConfig.isMobileApp && this.device.credentialsImport.isAvailable()) {
         return false;
       }
-      return Date.now() - this.initTimeStamp <= 1500;
+      return isGoogleAccountsDomain() || Date.now() - this.initTimeStamp <= 1500;
     }
     /**
      * Call this to scan once and then watch for changes.
@@ -16697,7 +16715,7 @@ Source: "${matchedFrom}"`;
       const { form, input, click, trigger } = params;
       if (document.visibilityState !== "visible" && trigger !== "postSignup") return;
       if (trigger === "autoprompt" && !this.globalConfig.isMobileApp) return;
-      if (trigger === "autoprompt" && this.autopromptFired) return;
+      if (trigger === "autoprompt" && this.autopromptFired && !isGoogleAccountsDomain()) return;
       form.activeInput = input;
       this.activeForm = form;
       const inputType = getInputType(input);

--- a/node_modules/@duckduckgo/autofill/dist/autofill.js
+++ b/node_modules/@duckduckgo/autofill/dist/autofill.js
@@ -1808,6 +1808,9 @@ Source: "${matchedFrom}"`;
     });
     return foundInShadow;
   }
+  function isGoogleAccountsDomain() {
+    return window.location.hostname === "accounts.google.com";
+  }
 
   // src/Form/countryNames.js
   var COUNTRY_CODES_TO_NAMES = {
@@ -3817,6 +3820,9 @@ Source: "${matchedFrom}"`;
     "cardbenefitservices.com": {
       "password-rules": "minlength: 7; maxlength: 100; required: lower, upper; required: digit;"
     },
+    "cardcash.com": {
+      "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!$%&*?@];"
+    },
     "carrefour.it": {
       "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&*?@_];"
     },
@@ -4237,8 +4243,14 @@ Source: "${matchedFrom}"`;
     "ichunqiu.com": {
       "password-rules": "minlength: 8; maxlength: 20; required: lower; required: upper; required: digit;"
     },
+    "id.nfpa.org": {
+      "password-rules": `minlength: 8; maxlength: 16; required: lower; required: upper; required: digit; required: [-"^#$%&'()*+:=@[_|{}~]];`
+    },
     "id.sonyentertainmentnetwork.com": {
       "password-rules": "minlength: 8; maxlength: 30; required: lower, upper; required: digit; allowed: [-!@#^&*=+;:];"
+    },
+    "id.westfield.com": {
+      "password-rules": "minlength: 9; maxlength: 20; required: lower; required: upper; required: digit; required: [!\"#&'()*,./:;?@[\\^_`{|}~];"
     },
     "identity.codesignal.com": {
       "password-rules": "minlength: 14; required: digit; required: lower, upper; required: [!#$%&*@^]"
@@ -4402,11 +4414,17 @@ Source: "${matchedFrom}"`;
     "myaccess.dmdc.osd.mil": {
       "password-rules": "minlength: 9; maxlength: 20; required: lower; required: upper; required: digit; allowed: [-@_#!&$`%*+()./,;~:{}|?>=<^'[]];"
     },
+    "mybam.bcbsnm.com": {
+      "password-rules": "minlength: 8; maxlength: 64; max-consecutive: 2; required: lower; required: upper; required: digit; allowed: [!#$%&()*@[^{}~];"
+    },
     "mygoodtogo.com": {
       "password-rules": "minlength: 8; maxlength: 16; required: lower, upper, digit;"
     },
     "myhealthrecord.com": {
       "password-rules": "minlength: 8; maxlength: 20; allowed: lower, upper, digit, [_.!$*=];"
+    },
+    "mypatientvisit.com": {
+      "password-rules": "minlength: 8; required: lower; required: upper; required: digit; required: [!#$%&*+.;?@^_~];"
     },
     "mypay.dfas.mil": {
       "password-rules": "minlength: 9; maxlength: 30; required: lower; required: upper; required: digit; required: [#@$%^!*+=_];"
@@ -6138,7 +6156,7 @@ Source: "${matchedFrom}"`;
       const areAllFormValuesKnown = Object.keys(formValues[dataType] || {}).every(
         (subtype) => formValues[dataType][subtype] === data[subtype]
       );
-      if (areAllFormValuesKnown) {
+      if (areAllFormValuesKnown || isGoogleAccountsDomain()) {
         this.shouldPromptToStoreData = false;
         this.shouldAutoSubmit = this.device.globalConfig.isMobileApp;
       } else {
@@ -6277,7 +6295,7 @@ Source: "${matchedFrom}"`;
       if (this.device.globalConfig.isMobileApp && this.device.credentialsImport.isAvailable()) {
         return false;
       }
-      return Date.now() - this.initTimeStamp <= 1500;
+      return isGoogleAccountsDomain() || Date.now() - this.initTimeStamp <= 1500;
     }
     /**
      * Call this to scan once and then watch for changes.
@@ -12219,7 +12237,7 @@ Source: "${matchedFrom}"`;
       const { form, input, click, trigger } = params;
       if (document.visibilityState !== "visible" && trigger !== "postSignup") return;
       if (trigger === "autoprompt" && !this.globalConfig.isMobileApp) return;
-      if (trigger === "autoprompt" && this.autopromptFired) return;
+      if (trigger === "autoprompt" && this.autopromptFired && !isGoogleAccountsDomain()) return;
       form.activeInput = input;
       this.activeForm = form;
       const inputType = getInputType(input);

--- a/node_modules/@duckduckgo/autofill/dist/shared-credentials.json
+++ b/node_modules/@duckduckgo/autofill/dist/shared-credentials.json
@@ -233,6 +233,15 @@
     ]
   },
   {
+    "from": [
+      "dq.com"
+    ],
+    "to": [
+      "dairyqueen.com"
+    ],
+    "fromDomainsAreObsoleted": true
+  },
+  {
     "shared": [
       "drivethrucards.com",
       "drivethrucomics.com",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.19.0",
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.3.0",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.3.1",
         "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.21.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
@@ -58,7 +58,7 @@
       }
     },
     "node_modules/@duckduckgo/autofill": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#252082be808ece0ab91d60a27e18bfcf10dcec1b",
+      "resolved": "git+ssh://git@github.com/duckduckgo/duckduckgo-autofill.git#123b64c7c78f492a1a3e6f60a8f891557a23a2eb",
       "hasInstallScript": true,
       "license": "Apache-2.0"
     },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.19.0",
-    "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.3.0",
+    "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.3.1",
     "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.21.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1211327838125206
Autofill Release: https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/18.3.1


## Description
Updates Autofill to version [18.3.1](https://github.com/duckduckgo/duckduckgo-autofill/releases/tag/18.3.1).

### Autofill 18.3.1 release notes
## What's Changed
* Update password-related json files by @daxmobile in https://github.com/duckduckgo/duckduckgo-autofill/pull/899
* [Autosubmit/Autoprompt] Force autoprompt and submit on accounts.google.com by @dbajpeyi in https://github.com/duckduckgo/duckduckgo-autofill/pull/901


**Full Changelog**: https://github.com/duckduckgo/duckduckgo-autofill/compare/18.3.0...18.3.1

## Steps to test
This release has been tested during autofill development. For smoke test steps see [this task](https://app.asana.com/0/1198964220583541/1200583647142330/f).