### PR TITLE
Update content scope scripts to version 11.24.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -373,6 +373,9 @@
     };
   }
   function getPlatformVersion(preferences) {
+    if (preferences.platform?.version !== void 0 && preferences.platform?.version !== "") {
+      return preferences.platform.version;
+    }
     if (preferences.versionNumber) {
       return preferences.versionNumber;
     }

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillPasswordImport.js
@@ -355,6 +355,9 @@
     };
   }
   function getPlatformVersion(preferences) {
+    if (preferences.platform?.version !== void 0 && preferences.platform?.version !== "") {
+      return preferences.platform.version;
+    }
     if (preferences.versionNumber) {
       return preferences.versionNumber;
     }
@@ -3811,13 +3814,14 @@
   var BACKGROUND_COLOR_START = "rgba(85, 127, 243, 0.10)";
   var BACKGROUND_COLOR_END = "rgba(85, 127, 243, 0.25)";
   var OVERLAY_ID = "ddg-password-import-overlay";
-  var _exportButtonSettings, _settingsButtonSettings, _signInButtonSettings, _elementToCenterOn, _currentOverlay, _currentElementConfig, _domLoaded, _tappedElements;
+  var _exportButtonSettings, _settingsButtonSettings, _signInButtonSettings, _exportConfirmButtonSettings, _elementToCenterOn, _currentOverlay, _currentElementConfig, _domLoaded, _tappedElements;
   var AutofillPasswordImport = class extends ContentFeature {
     constructor() {
       super(...arguments);
       __privateAdd(this, _exportButtonSettings);
       __privateAdd(this, _settingsButtonSettings);
       __privateAdd(this, _signInButtonSettings);
+      __privateAdd(this, _exportConfirmButtonSettings);
       /** @type {HTMLElement|Element|SVGElement|null} */
       __privateAdd(this, _elementToCenterOn);
       /** @type {HTMLElement|null} */
@@ -3898,6 +3902,43 @@
       return __privateGet(this, _domLoaded);
     }
     /**
+     * @returns {Promise<Element|HTMLElement|null>}
+     */
+    async runWithRetry(fn) {
+      try {
+        return await withExponentialBackoff(fn);
+      } catch {
+        return null;
+      }
+    }
+    /**
+     * @returns {Promise<ElementConfig | null>}
+     */
+    async getExportConfirmElementAndStyle() {
+      const exportConfirmElement = await this.findExportConfirmElement();
+      const shouldAutotap = __privateGet(this, _exportConfirmButtonSettings)?.shouldAutotap && exportConfirmElement != null;
+      return shouldAutotap ? {
+        animationStyle: null,
+        element: exportConfirmElement,
+        shouldTap: true,
+        shouldWatchForRemoval: false,
+        tapOnce: false
+      } : null;
+    }
+    /**
+     * @returns {Promise<ElementConfig | null>}
+     */
+    async getExportElementAndStyle() {
+      const element = await this.findExportElement();
+      return element != null ? {
+        animationStyle: this.exportButtonAnimationStyle,
+        element,
+        shouldTap: __privateGet(this, _exportButtonSettings)?.shouldAutotap ?? false,
+        shouldWatchForRemoval: true,
+        tapOnce: true
+      } : null;
+    }
+    /**
      * Takes a path and returns the element and style to animate.
      * @param {string} path
      * @returns {Promise<ElementConfig | null>}
@@ -3913,14 +3954,12 @@
           tapOnce: false
         } : null;
       } else if (path === "/options") {
-        const element = await this.findExportElement();
-        return element != null ? {
-          animationStyle: this.exportButtonAnimationStyle,
-          element,
-          shouldTap: __privateGet(this, _exportButtonSettings)?.shouldAutotap ?? false,
-          shouldWatchForRemoval: true,
-          tapOnce: true
-        } : null;
+        const isExportButtonTapped = this.currentElementConfig?.element != null && __privateGet(this, _tappedElements).has(this.currentElementConfig?.element);
+        if (isExportButtonTapped) {
+          return await this.getExportConfirmElementAndStyle();
+        } else {
+          return await this.getExportElementAndStyle();
+        }
       } else if (path === "/intro") {
         const element = await this.findSignInButton();
         return element != null ? {
@@ -4072,6 +4111,9 @@
     autotapElement(element) {
       element.click();
     }
+    async findExportConfirmElement() {
+      return await this.runWithRetry(() => document.querySelector(this.exportConfirmButtonSelector));
+    }
     /**
      * On passwords.google.com the export button is in a container that is quite ambiguious.
      * To solve for that we first try to find the container and then the button inside it.
@@ -4086,7 +4128,7 @@
       const findWithLabel = () => {
         return document.querySelector(this.exportButtonLabelTextSelector);
       };
-      return await withExponentialBackoff(() => findInContainer() ?? findWithLabel());
+      return await this.runWithRetry(() => findInContainer() ?? findWithLabel());
     }
     /**
      * @returns {Promise<HTMLElement|Element|null>}
@@ -4096,13 +4138,13 @@
         const settingsButton = document.querySelector(this.settingsButtonSelector);
         return settingsButton;
       };
-      return await withExponentialBackoff(fn);
+      return await this.runWithRetry(fn);
     }
     /**
      * @returns {Promise<HTMLElement|Element|null>}
      */
     async findSignInButton() {
-      return await withExponentialBackoff(() => document.querySelector(this.signinButtonSelector));
+      return await this.runWithRetry(() => document.querySelector(this.signinButtonSelector));
     }
     /**
      * @param {Event} event
@@ -4118,7 +4160,7 @@
     setCurrentElementConfig(config) {
       if (config != null) {
         __privateSet(this, _currentElementConfig, config);
-        this.setElementToCenterOn(config.element, config.animationStyle);
+        if (config.animationStyle != null) this.setElementToCenterOn(config.element, config.animationStyle);
       }
     }
     /**
@@ -4127,7 +4169,12 @@
      * @returns {boolean}
      */
     isSupportedPath(path) {
-      return [__privateGet(this, _exportButtonSettings)?.path, __privateGet(this, _settingsButtonSettings)?.path, __privateGet(this, _signInButtonSettings)?.path].includes(path);
+      return [
+        __privateGet(this, _exportButtonSettings)?.path,
+        __privateGet(this, _settingsButtonSettings)?.path,
+        __privateGet(this, _signInButtonSettings)?.path,
+        __privateGet(this, _exportConfirmButtonSettings)?.path
+      ].includes(path);
     }
     async handlePath(path) {
       this.removeOverlayIfNeeded();
@@ -4151,12 +4198,14 @@
      */
     async animateOrTapElement() {
       const { element, animationStyle, shouldTap, shouldWatchForRemoval } = this.currentElementConfig ?? {};
-      if (element != null && animationStyle != null) {
+      if (element != null) {
         if (shouldTap) {
           this.autotapElement(element);
         } else {
-          await this.domLoaded;
-          this.animateElement(element, animationStyle);
+          if (animationStyle != null) {
+            await this.domLoaded;
+            this.animateElement(element, animationStyle);
+          }
         }
         if (shouldWatchForRemoval) {
           this.observeElementRemoval(element, () => {
@@ -4170,6 +4219,12 @@
      */
     get exportButtonContainerSelector() {
       return __privateGet(this, _exportButtonSettings)?.selectors?.join(",");
+    }
+    /**
+     * @returns {string}
+     */
+    get exportConfirmButtonSelector() {
+      return __privateGet(this, _exportConfirmButtonSettings)?.selectors?.join(",");
     }
     /**
      * @returns {string}
@@ -4205,6 +4260,7 @@
       __privateSet(this, _exportButtonSettings, this.getFeatureSetting("exportButton"));
       __privateSet(this, _signInButtonSettings, this.getFeatureSetting("signInButton"));
       __privateSet(this, _settingsButtonSettings, this.getFeatureSetting("settingsButton"));
+      __privateSet(this, _exportConfirmButtonSettings, this.getFeatureSetting("exportConfirmButton"));
     }
     urlChanged() {
       this.handlePath(window.location.pathname);
@@ -4235,6 +4291,7 @@
   _exportButtonSettings = new WeakMap();
   _settingsButtonSettings = new WeakMap();
   _signInButtonSettings = new WeakMap();
+  _exportConfirmButtonSettings = new WeakMap();
   _elementToCenterOn = new WeakMap();
   _currentOverlay = new WeakMap();
   _currentElementConfig = new WeakMap();

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -1879,6 +1879,9 @@
     };
   }
   function getPlatformVersion(preferences) {
+    if (preferences.platform?.version !== void 0 && preferences.platform?.version !== "") {
+      return preferences.platform.version;
+    }
     if (preferences.versionNumber) {
       return preferences.versionNumber;
     }

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -1208,6 +1208,9 @@
     };
   }
   function getPlatformVersion(preferences) {
+    if (preferences.platform?.version !== void 0 && preferences.platform?.version !== "") {
+      return preferences.platform.version;
+    }
     if (preferences.versionNumber) {
       return preferences.versionNumber;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.19.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.3.1",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.21.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.24.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#3262c6adb0971d6d899de896c1ff9861d11b8ea3",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#178f44812e94e5060ac6e14f4a43a584939a1d49",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -667,18 +667,18 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.13",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.13.tgz",
-      "integrity": "sha512-Td0LeWLgXJGsikI4mO82fRexgPCEyTcwWiXJERF/GBHX3Dm+HQq/wx4HnYowCbiwQ8d+ENLZc+ktbZw8H+0oEA==",
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.14.tgz",
+      "integrity": "sha512-viZGNK6+NdluOJWwTO9olaugx0bkKhscIdriQQ+lNNhwitIKvb+SvhbYgnCz6j9p7dX3cJntt4agQAKMXLjJ5g==",
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "7.0.13",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.13.tgz",
-      "integrity": "sha512-JSJMjSV1EIq7JBgi3jG9A2jDpChkrboQrPiITES2y0riVPf55dw2jfOpDUTjG1FJTDb2f2CnKzA8TaZX1QdHqw==",
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.14.tgz",
+      "integrity": "sha512-sZ90eUcfG6Wm4dUCnloL6fuWyV1T+QmeluFYhFApMpb9hnd+/BeBBl6lt7fuf0ACEXmUh6QfyrwCNFC4HNzTnA==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.13"
+        "tldts-core": "^7.0.14"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.19.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.3.1",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.21.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.24.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1751029573"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1211338978225871/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run