### PR TITLE
Restore system-level password manager integration

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -29,6 +29,7 @@ import android.os.SystemClock
 import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.View
+import android.view.View.IMPORTANT_FOR_AUTOFILL_YES
 import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.ActivityResult
@@ -121,6 +122,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import logcat.LogPriority.ERROR
 import logcat.LogPriority.INFO
 import logcat.LogPriority.VERBOSE
@@ -1083,6 +1085,8 @@ open class BrowserActivity : DuckDuckGoActivity() {
             tabPager.registerOnPageChangeCallback(onTabPageChangeListener)
             tabPager.setPageTransformer(MarginPageTransformer(resources.getDimension(com.duckduckgo.mobile.android.R.dimen.keyline_1).toPx().toInt()))
 
+            configureViewPagerForSystemAutofill(tabPager)
+
             savedInstanceState?.getBundle(KEY_TAB_PAGER_STATE)?.let {
                 tabPagerAdapter.restore(it)
             }
@@ -1090,6 +1094,25 @@ open class BrowserActivity : DuckDuckGoActivity() {
 
         binding.fragmentContainer.isVisible = !swipingTabsFeature.isEnabled
         tabPager.isVisible = swipingTabsFeature.isEnabled
+    }
+
+    private fun configureViewPagerForSystemAutofill(viewPager: ViewPager2) {
+        lifecycleScope.launch {
+            val applyAutofillFix = withContext(dispatcherProvider.io()) {
+                swipingTabsFeature.applyAutofillFixEnabled()
+            }
+
+            // Configure the internal RecyclerView - wait for layout to complete
+            if (applyAutofillFix) {
+                logcat(VERBOSE) { "Applying autofill fix to ViewPager2" }
+
+                viewPager.post {
+                    (viewPager.getChildAt(0) as? androidx.recyclerview.widget.RecyclerView)?.let {
+                        it.importantForAutofill = IMPORTANT_FOR_AUTOFILL_YES
+                    }
+                }
+            }
+        }
     }
 
     private val Intent.launchedFromRecents: Boolean

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/tabs/SwipingTabsFeature.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/tabs/SwipingTabsFeature.kt
@@ -35,4 +35,7 @@ interface SwipingTabsFeature {
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     @InternalAlwaysEnabled
     fun enabledForUsers(): Toggle
+
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun applyAutofillFix(): Toggle
 }

--- a/common/common-ui/src/main/java/com/duckduckgo/common/ui/tabs/SwipingTabsFeatureProvider.kt
+++ b/common/common-ui/src/main/java/com/duckduckgo/common/ui/tabs/SwipingTabsFeatureProvider.kt
@@ -22,9 +22,13 @@ import javax.inject.Inject
 
 @SingleInstanceIn(AppScope::class)
 class SwipingTabsFeatureProvider @Inject constructor(
-    swipingTabsFeature: SwipingTabsFeature,
+    private val swipingTabsFeature: SwipingTabsFeature,
 ) {
     val isEnabled: Boolean by lazy {
         swipingTabsFeature.self().isEnabled() && swipingTabsFeature.enabledForUsers().isEnabled()
+    }
+
+    fun applyAutofillFixEnabled(): Boolean {
+        return swipingTabsFeature.applyAutofillFix().isEnabled()
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/608920331025315/task/1211346135005875?focus=true 

### Description
When `swipingTabs` FF is enabled, the integration between the web view and the system-level autofill service is not working. To fix it, we need to ensure the `RecyclerView` inside of the `ViewPager` is configured as being important for autofill.

Logcat filter: `Applying autofill fix to ViewPager2`

### Steps to test this PR

#### Feature flag enabled (default)
- [x] Go to device settings and setup an autofill provider (can be Google Password Manager, 1Password, Bitwarden etc...)
- [x] In your chosen password manager, add a credential for https://fill.dev
- [x] In our app visit, https://fill.dev/form/login-simple and tap on the username field
- [x] Verify you see `Applying autofill fix to ViewPager2` in the logs
- [x] Verify you can autofill from the system autofill provider

#### Feature flag disabled
- [x] Visit feature flag inventory and disable `applyAutofillFix`
- [x] Back button all the way out of the app (or swipe it away) as `BrowserActivity` needs recreated
- [x] In our app visit, https://fill.dev/form/login-simple and tap on the username field
- [x] Verify you **don't** see `Applying autofill fix to ViewPager2` in the logs