### PR TITLE
Use translated string for edit text

### DIFF
--- a/saved-sites/saved-sites-impl/src/main/res/menu/bookmark_popup_menu.xml
+++ b/saved-sites/saved-sites-impl/src/main/res/menu/bookmark_popup_menu.xml
@@ -17,7 +17,7 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
         android:id="@+id/bookmark_edit"
-        android:title="@string/newTabPageMenuEdit" />
+        android:title="@string/savedSiteDialogTitleEdit" />
     <item
         android:id="@+id/bookmark_add_to_favorites"
         android:title="@string/addToFavorites" />


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1211322673312843?focus=true

### Description
Previously, we are using newTabPageMenuEdit which is in donottranslate.xml.
I don't think we should use a non translated screen here if everything else on the page is translated.

### Steps to test this PR

- [ ] Change language to any aside from English
- [ ] Open Bookmarks and press the context menu
- [ ] Verify that all strings in the menu are translated

### UI changes
| Before  | After |
| ------ | ----- |
|(<img width="349" height="132" alt="Screenshot 2025-09-15 at 10 57 36" src="https://github.com/user-attachments/assets/2b046a0b-d33d-446d-a508-d3afb2521fcd" />)|(<img width="360" height="173" alt="Screenshot 2025-09-15 at 10 57 43" src="https://github.com/user-attachments/assets/01a00aea-1a77-4816-a045-1f51f6b1f38c" />)|

