### PR TITLE
Ensure observability of system autofill event

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -113,6 +113,7 @@ import com.duckduckgo.app.browser.applinks.AppLinksLauncher
 import com.duckduckgo.app.browser.applinks.AppLinksSnackBarConfigurator
 import com.duckduckgo.app.browser.autocomplete.BrowserAutoCompleteSuggestionsAdapter
 import com.duckduckgo.app.browser.autocomplete.SuggestionItemDecoration
+import com.duckduckgo.app.browser.autofill.SystemAutofillEngagement
 import com.duckduckgo.app.browser.commands.Command
 import com.duckduckgo.app.browser.commands.Command.OpenBrokenSiteLearnMore
 import com.duckduckgo.app.browser.commands.Command.ReportBrokenSiteError
@@ -616,6 +617,9 @@ class BrowserTabFragment :
 
     @Inject
     lateinit var autofillFragmentResultListeners: PluginPoint<AutofillFragmentResultsPlugin>
+
+    @Inject
+    lateinit var systemAutofillEngagement: SystemAutofillEngagement
 
     private var isActiveTab: Boolean = false
 
@@ -3344,6 +3348,10 @@ class BrowserTabFragment :
     }
 
     private fun configureWebViewForAutofill(it: DuckDuckGoWebView) {
+        it.setSystemAutofillCallback {
+            systemAutofillEngagement.onSystemAutofillEvent()
+        }
+
         browserAutofill.addJsInterface(it, autofillCallback, this, null, tabId)
 
         autofillFragmentResultListeners.getPlugins().forEach { plugin ->
@@ -3905,6 +3913,7 @@ class BrowserTabFragment :
     private fun destroyWebView() {
         if (::webViewContainer.isInitialized) webViewContainer.removeAllViews()
         webView?.let {
+            it.removeSystemAutofillCallback()
             webViewClient.destroy(it)
             it.destroy()
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoWebView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoWebView.kt
@@ -21,7 +21,9 @@ import android.content.Context
 import android.os.Message
 import android.print.PrintDocumentAdapter
 import android.util.AttributeSet
+import android.util.SparseArray
 import android.view.MotionEvent
+import android.view.autofill.AutofillValue
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputConnection
 import android.webkit.DownloadListener
@@ -61,6 +63,7 @@ class DuckDuckGoWebView : WebView, NestedScrollingChild3 {
     private var enableSwipeRefreshCallback: ((Boolean) -> Unit)? = null
     private var hasGestureFinished = true
     private var canSwipeToRefresh = true
+    private var systemAutofillCallback: (() -> Unit)? = null
 
     private var lastY: Int = 0
     private var lastDeltaY: Int = 0
@@ -191,6 +194,20 @@ class DuckDuckGoWebView : WebView, NestedScrollingChild3 {
     override fun setFindListener(listener: FindListener?) {
         if (!isDestroyed) {
             super.setFindListener(listener)
+        }
+    }
+
+    override fun autofill(value: AutofillValue?) {
+        if (!isDestroyed) {
+            super.autofill(value)
+            systemAutofillCallback?.invoke()
+        }
+    }
+
+    override fun autofill(values: SparseArray<AutofillValue?>) {
+        if (!isDestroyed) {
+            super.autofill(values)
+            systemAutofillCallback?.invoke()
         }
     }
 
@@ -409,6 +426,14 @@ class DuckDuckGoWebView : WebView, NestedScrollingChild3 {
 
     fun removeEnableSwipeRefreshCallback() {
         enableSwipeRefreshCallback = null
+    }
+
+    fun setSystemAutofillCallback(callback: () -> Unit) {
+        systemAutofillCallback = callback
+    }
+
+    fun removeSystemAutofillCallback() {
+        systemAutofillCallback = null
     }
 
     private fun enableSwipeRefresh(enable: Boolean) {

--- a/app/src/main/java/com/duckduckgo/app/browser/autofill/SystemAutofillEngagement.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/autofill/SystemAutofillEngagement.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.autofill
+
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
+import com.duckduckgo.autofill.api.AutofillFeature
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import logcat.LogPriority.VERBOSE
+import logcat.logcat
+
+interface SystemAutofillEngagement {
+    fun onSystemAutofillEvent()
+}
+
+@ContributesBinding(AppScope::class)
+class RealSystemAutofillEngagement @Inject constructor(
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val dispatchers: DispatcherProvider,
+    private val autofillFeature: AutofillFeature,
+    private val pixel: Pixel,
+) : SystemAutofillEngagement {
+
+    override fun onSystemAutofillEvent() {
+        logcat(VERBOSE) { "System autofill event received" }
+        appCoroutineScope.launch(dispatchers.io()) {
+            if (autofillFeature.canDetectSystemAutofillEngagement().isEnabled()) {
+                pixel.fire(AutofillPixelNames.AUTOFILL_SYSTEM_AUTOFILL_USED, type = Daily())
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/browser/autofill/RealSystemAutofillEngagementTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/autofill/RealSystemAutofillEngagementTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.autofill
+
+import android.annotation.SuppressLint
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
+import com.duckduckgo.autofill.api.AutofillFeature
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SYSTEM_AUTOFILL_USED
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+
+@SuppressLint("DenyListedApi")
+class RealSystemAutofillEngagementTest {
+
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule()
+    private val pixel: Pixel = mock()
+    private val dispatchers: DispatcherProvider = coroutineTestRule.testDispatcherProvider
+    private val feature = FakeFeatureToggleFactory.create(AutofillFeature::class.java)
+
+    private lateinit var testee: RealSystemAutofillEngagement
+
+    @Before
+    fun setup() {
+        testee = RealSystemAutofillEngagement(
+            appCoroutineScope = coroutineTestRule.testScope,
+            dispatchers = dispatchers,
+            autofillFeature = feature,
+            pixel = pixel,
+        )
+    }
+
+    @Test
+    fun whenFeatureEnabledThenPixelFired() = runTest {
+        feature.canDetectSystemAutofillEngagement().setRawStoredState(State(true))
+        testee.onSystemAutofillEvent()
+        verify(pixel).fire(AUTOFILL_SYSTEM_AUTOFILL_USED, type = Daily())
+    }
+
+    @Test
+    fun whenFeatureDisabledThenPixelNotFired() = runTest {
+        feature.canDetectSystemAutofillEngagement().setRawStoredState(State(false))
+        testee.onSystemAutofillEvent()
+        verify(pixel, never()).fire(AUTOFILL_SYSTEM_AUTOFILL_USED, type = Daily())
+    }
+}

--- a/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillFeature.kt
+++ b/autofill/autofill-api/src/main/java/com/duckduckgo/autofill/api/AutofillFeature.kt
@@ -160,4 +160,7 @@ interface AutofillFeature {
 
     @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.TRUE)
     fun canReAuthenticateGoogleLoginsAutomatically(): Toggle
+
+    @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.TRUE)
+    fun canDetectSystemAutofillEngagement(): Toggle
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/pixel/AutofillPixelNames.kt
@@ -62,6 +62,7 @@ import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SITE_BREAK
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SITE_BREAKAGE_REPORT_CONFIRMATION_DISPLAYED
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SYNC_DESKTOP_PASSWORDS_CTA_BUTTON
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SYNC_DESKTOP_PASSWORDS_OVERFLOW_MENU
+import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.AUTOFILL_SYSTEM_AUTOFILL_USED
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.EMAIL_TOOLTIP_DISMISSED
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.EMAIL_USE_ADDRESS
 import com.duckduckgo.autofill.impl.pixel.AutofillPixelNames.EMAIL_USE_ALIAS
@@ -206,6 +207,8 @@ enum class AutofillPixelNames(override val pixelName: String) : Pixel.PixelName 
 
     AUTOFILL_SETTINGS_OPENED("autofill_settings_opened"),
     AUTOFILL_NEVER_SAVE_FOR_THIS_SITE_OVERFLOW_MENU("autofill_reset_excluded_overflow_menu_tapped"),
+
+    AUTOFILL_SYSTEM_AUTOFILL_USED("autofill_systemautofill_used"),
 }
 
 object AutofillPixelParameters {
@@ -281,6 +284,7 @@ object AutofillPixelsRequiringDataCleaning : PixelParamRemovalPlugin {
             AUTOFILL_NEVER_SAVE_FOR_THIS_SITE_OVERFLOW_MENU.pixelName to PixelParameter.removeAtb(),
 
             AUTOFILL_IMPORT_GOOGLE_PASSWORDS_MAIN_APP_SETTINGS_HIDDEN.pixelName to PixelParameter.removeAtb(),
+            AUTOFILL_SYSTEM_AUTOFILL_USED.pixelName to PixelParameter.removeAtb(),
         )
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/608920331025315/task/1211357591806022?focus=true 

### Description
Adds pixel to system autofill events.

### Steps to test this PR

Logcat filter: `autofill_systemautofill_used`

- [x] Make sure you have a System Autofill provider set up (e.g., Google Passwords, 1Password, Bitwarden etc...) 
- [x] Add a saved login credential to the system autofill provider for `fill.dev`
- [x] Visit https://fill.dev/form/login-simple and tap on the username or password fields. Accept the system autofill provider's suggestion
- [x] Verify `autofill_systemautofill_used`
- [x] Repeat on another field (refresh the page if required) and verify `autofill_systemautofill_used` is ignored (pixel type is `daily`)


#### With feature flag disabled
- [x] Fresh install
- [x] Use feature flag inventory to disable `canDetectSystemAutofillEngagement`
- [x] Follow test steps from before and verify you don't see `autofill_systemautofill_used` in the logcat at all