### PR TITLE
New address bar option choice screen pixels

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -36,10 +36,16 @@ import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.api.DuckChatSettingsNoParams
 import com.duckduckgo.duckchat.impl.feature.AIChatImageUploadFeature
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
-import com.duckduckgo.duckchat.impl.inputscreen.newaddressbaroption.ChoiceSelectionCallback
+import com.duckduckgo.duckchat.impl.inputscreen.newaddressbaroption.NewAddressBarCallback
 import com.duckduckgo.duckchat.impl.inputscreen.newaddressbaroption.NewAddressBarOptionBottomSheetDialogFactory
+import com.duckduckgo.duckchat.impl.inputscreen.newaddressbaroption.NewAddressBarSelection
+import com.duckduckgo.duckchat.impl.inputscreen.newaddressbaroption.NewAddressBarSelection.SEARCH_AND_AI
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_CONFIRMED
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_DISPLAYED
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_NOT_NOW
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelParameters
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelParameters.NEW_ADDRESS_BAR_SELECTION
 import com.duckduckgo.duckchat.impl.repository.DuckChatFeatureRepository
 import com.duckduckgo.duckchat.impl.ui.DuckChatWebViewActivityWithParams
 import com.duckduckgo.navigation.api.GlobalActivityStarter
@@ -527,11 +533,25 @@ class RealDuckChat @Inject constructor(
         newAddressBarOptionBottomSheetDialogFactory.create(
             context = context,
             isDarkThemeEnabled = isDarkThemeEnabled,
-            choiceSelectionCallback = object : ChoiceSelectionCallback {
-                override fun onSearchAndDuckAiSelected() {
-                    appCoroutineScope.launch {
-                        setInputScreenUserSetting(true)
+            newAddressBarCallback = object : NewAddressBarCallback {
+                override fun onDisplayed() {
+                    pixel.fire(DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_DISPLAYED)
+                }
+
+                override fun onConfirmed(selection: NewAddressBarSelection) {
+                    if (selection == SEARCH_AND_AI) {
+                        appCoroutineScope.launch {
+                            setInputScreenUserSetting(true)
+                        }
                     }
+                    pixel.fire(
+                        pixel = DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_CONFIRMED,
+                        parameters = mapOf(NEW_ADDRESS_BAR_SELECTION to selection.value),
+                    )
+                }
+
+                override fun onNotNow() {
+                    pixel.fire(DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_NOT_NOW)
                 }
             },
         ).show()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/newaddressbaroption/NewAddressBarOptionBottomSheetDialog.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/newaddressbaroption/NewAddressBarOptionBottomSheetDialog.kt
@@ -30,20 +30,29 @@ import com.airbnb.lottie.LottieDrawable
 import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.databinding.BottomSheetNewAddressBarOptionBinding
+import com.duckduckgo.duckchat.impl.inputscreen.newaddressbaroption.NewAddressBarSelection.SEARCH_AND_AI
+import com.duckduckgo.duckchat.impl.inputscreen.newaddressbaroption.NewAddressBarSelection.SEARCH_ONLY
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.shape.CornerFamily
 import com.google.android.material.shape.MaterialShapeDrawable
 
-interface ChoiceSelectionCallback {
-    fun onSearchAndDuckAiSelected()
+enum class NewAddressBarSelection(val value: String) {
+    SEARCH_ONLY("search_only"),
+    SEARCH_AND_AI("search_and_ai"),
+}
+
+interface NewAddressBarCallback {
+    fun onDisplayed()
+    fun onConfirmed(selection: NewAddressBarSelection)
+    fun onNotNow()
 }
 
 @SuppressLint("NoBottomSheetDialog")
 class NewAddressBarOptionBottomSheetDialog(
     private val context: Context,
     private val isDarkThemeEnabled: Boolean,
-    private val choiceSelectionCallback: ChoiceSelectionCallback?,
+    private val newAddressBarCallback: NewAddressBarCallback?,
 ) : BottomSheetDialog(context) {
 
     private val binding: BottomSheetNewAddressBarOptionBinding =
@@ -62,6 +71,7 @@ class NewAddressBarOptionBottomSheetDialog(
 
         setOnShowListener {
             setRoundCorners()
+            newAddressBarCallback?.onDisplayed()
         }
 
         setOnCancelListener {
@@ -73,14 +83,14 @@ class NewAddressBarOptionBottomSheetDialog(
         setupSelectionLogic()
 
         binding.newAddressBarOptionBottomSheetDialogPrimaryButton.setOnClickListener {
-            if (searchAndDuckAiSelected) {
-                choiceSelectionCallback?.onSearchAndDuckAiSelected()
-            }
+            val selection = if (searchAndDuckAiSelected) SEARCH_AND_AI else SEARCH_ONLY
+            newAddressBarCallback?.onConfirmed(selection)
             restoreOrientation()
             dismiss()
         }
 
         binding.newAddressBarOptionBottomSheetDialogGhostButton.setOnClickListener {
+            newAddressBarCallback?.onNotNow()
             restoreOrientation()
             dismiss()
         }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/newaddressbaroption/NewAddressBarOptionBottomSheetDialogFactory.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/newaddressbaroption/NewAddressBarOptionBottomSheetDialogFactory.kt
@@ -25,7 +25,7 @@ interface NewAddressBarOptionBottomSheetDialogFactory {
     fun create(
         context: Context,
         isDarkThemeEnabled: Boolean,
-        choiceSelectionCallback: ChoiceSelectionCallback?,
+        newAddressBarCallback: NewAddressBarCallback?,
     ): NewAddressBarOptionBottomSheetDialog
 }
 
@@ -35,12 +35,12 @@ class RealNewAddressBarOptionBottomSheetDialogFactory @Inject constructor() : Ne
     override fun create(
         context: Context,
         isDarkThemeEnabled: Boolean,
-        choiceSelectionCallback: ChoiceSelectionCallback?,
+        newAddressBarCallback: NewAddressBarCallback?,
     ): NewAddressBarOptionBottomSheetDialog {
         return NewAddressBarOptionBottomSheetDialog(
             context = context,
             isDarkThemeEnabled = isDarkThemeEnabled,
-            choiceSelectionCallback = choiceSelectionCallback,
+            newAddressBarCallback = newAddressBarCallback,
         )
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -68,6 +68,9 @@ import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_IS_ENABLED
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_KEYBOARD_RETURN_PRESSED
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_MENU_SETTING_OFF
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_MENU_SETTING_ON
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_CONFIRMED
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_DISPLAYED
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_NOT_NOW
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_OPEN
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_OPEN_BROWSER_MENU
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_OPEN_HISTORY
@@ -189,6 +192,9 @@ enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
     DUCK_CHAT_EXPERIMENTAL_LEGACY_OMNIBAR_BACK_BUTTON_PRESSED("m_aichat_legacy_omnibar_back_button_pressed"),
     DUCK_CHAT_KEYBOARD_RETURN_PRESSED("m_aichat_duckai_keyboard_return_pressed"),
     DUCK_CHAT_EXPERIMENTAL_OMNIBAR_DAILY_RETENTION("m_aichat_experimental_omnibar_daily_retention"),
+    DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_DISPLAYED("m_aichat_new_address_bar_picker_displayed"),
+    DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_CONFIRMED("m_aichat_new_address_bar_picker_confirmed"),
+    DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_NOT_NOW("m_aichat_new_address_bar_picker_not_now"),
 }
 
 object DuckChatPixelParameters {
@@ -196,6 +202,7 @@ object DuckChatPixelParameters {
     const val DELTA_TIMESTAMP_PARAMETERS = "delta-timestamp-minutes"
     const val INPUT_SCREEN_MODE = "mode"
     const val TEXT_LENGTH_BUCKET = "text_length_bucket"
+    const val NEW_ADDRESS_BAR_SELECTION = "selection"
 }
 
 @ContributesMultibinding(AppScope::class)
@@ -259,6 +266,9 @@ class DuckChatParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin
             DUCK_CHAT_EXPERIMENTAL_OMNIBAR_FLOATING_RETURN_PRESSED.pixelName to PixelParameter.removeAtb(),
             DUCK_CHAT_EXPERIMENTAL_LEGACY_OMNIBAR_BACK_BUTTON_PRESSED.pixelName to PixelParameter.removeAtb(),
             DUCK_CHAT_EXPERIMENTAL_OMNIBAR_DAILY_RETENTION.pixelName to PixelParameter.removeAtb(),
+            DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_DISPLAYED.pixelName to PixelParameter.removeAtb(),
+            DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_CONFIRMED.pixelName to PixelParameter.removeAtb(),
+            DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_NOT_NOW.pixelName to PixelParameter.removeAtb(),
         )
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211358524399131?focus=true

### Description

- Adds pixels to the new address bar option choice screen

### Steps to test this PR

_Search & Duck.ai_
- [x] Fresh install the app
- [x] Complete onboarding (Use "I’ve been here before", **not** “Skip Onboarding”) and kill the app
- [x] Verify: `m_aichat_new_address_bar_picker_displayed`
- [x] Select “Search & Duck.ai"
- [x] Verify pixel sent: `m_aichat_new_address_bar_picker_confirmed with params: {selection=search_and_ai}`

_Search_
- [x] Fresh install the app
- [x] Complete onboarding (Use "I’ve been here before", **not** “Skip Onboarding”) and kill the app
- [x] Select “Search"
- [x] Verify pixel sent: `m_aichat_new_address_bar_picker_confirmed with params: {selection=search_only}`

_Search_
- [x] Fresh install the app
- [x] Complete onboarding (Use "I’ve been here before", **not** “Skip Onboarding”) and kill the app
- [x] Select “Not Now"
- [x] Verify pixel sent: `m_aichat_new_address_bar_picker_not_now`