### PR TITLE
Skip new address bar option when onboarding is skipped

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/newaddressbaroption/NewAddressBarOptionManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newaddressbaroption/NewAddressBarOptionManager.kt
@@ -42,6 +42,7 @@ interface NewAddressBarOptionManager {
         activity: DuckDuckGoActivity,
         isLaunchedFromExternal: Boolean,
     )
+    suspend fun setAsShown()
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -71,6 +72,10 @@ class RealNewAddressBarOptionManager @Inject constructor(
                 }
             }
         }
+    }
+
+    override suspend fun setAsShown() {
+        newAddressBarOptionDataStore.setAsShown()
     }
 
     private suspend fun validate(

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModel.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.onboarding.ui
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.app.browser.newaddressbaroption.RealNewAddressBarOptionManager
 import com.duckduckgo.app.onboarding.store.AppStage
 import com.duckduckgo.app.onboarding.store.UserStageStore
 import com.duckduckgo.app.onboarding.ui.page.OnboardingPageFragment
@@ -39,6 +40,7 @@ class OnboardingViewModel @Inject constructor(
     private val onboardingSkipper: OnboardingSkipper,
     private val appBuildConfig: AppBuildConfig,
     private val onboardingDesignExperimentManager: OnboardingDesignExperimentManager,
+    private val newAddressBarOptionManager: RealNewAddressBarOptionManager,
 ) : ViewModel() {
 
     private val _viewState = MutableStateFlow(ViewState())
@@ -94,6 +96,7 @@ class OnboardingViewModel @Inject constructor(
 
     suspend fun devOnlyFullyCompleteAllOnboarding() {
         onboardingSkipper.markOnboardingAsCompleted()
+        newAddressBarOptionManager.setAsShown()
     }
 
     companion object {

--- a/app/src/test/java/com/duckduckgo/app/browser/newaddressbaroption/NewAddressBarOptionManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/newaddressbaroption/NewAddressBarOptionManagerTest.kt
@@ -268,6 +268,13 @@ class NewAddressBarOptionManagerTest {
         assertEquals(true, darkThemeCaptor.firstValue)
     }
 
+    @Test
+    fun `when setAsShown is called then data store setAsShown is called`() = runTest {
+        testee.setAsShown()
+
+        verify(newAddressBarOptionDataStoreMock).setAsShown()
+    }
+
     private suspend fun setupAllConditionsMet() {
         whenever(duckChatMock.isEnabled()).thenReturn(true)
         whenever(userStageStoreMock.getUserAppStage()).thenReturn(AppStage.ESTABLISHED)

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/OnboardingViewModelTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.onboarding.ui
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.duckduckgo.app.browser.newaddressbaroption.RealNewAddressBarOptionManager
 import com.duckduckgo.app.onboarding.store.AppStage
 import com.duckduckgo.app.onboarding.store.UserStageStore
 import com.duckduckgo.app.onboarding.ui.FullOnboardingSkipper.ViewState
@@ -52,6 +53,8 @@ class OnboardingViewModelTest {
 
     private val onboardingDesignExperimentManager: OnboardingDesignExperimentManager = mock()
 
+    private val newAddressBarOptionManager: RealNewAddressBarOptionManager = mock()
+
     private val testee: OnboardingViewModel by lazy {
         OnboardingViewModel(
             userStageStore = userStageStore,
@@ -60,6 +63,7 @@ class OnboardingViewModelTest {
             onboardingSkipper = onboardingSkipper,
             appBuildConfig = appBuildConfig,
             onboardingDesignExperimentManager = onboardingDesignExperimentManager,
+            newAddressBarOptionManager = newAddressBarOptionManager,
         )
     }
 
@@ -121,6 +125,14 @@ class OnboardingViewModelTest {
 
         verify(onboardingDesignExperimentManager).enroll()
         verify(pageLayout).buildPageBlueprints()
+    }
+
+    @Test
+    fun whenDevOnlyFullyCompleteAllOnboardingCalledThenMarkOnboardingAsCompletedAndSetAsShown() = runTest {
+        testee.devOnlyFullyCompleteAllOnboarding()
+
+        verify(onboardingSkipper).markOnboardingAsCompleted()
+        verify(newAddressBarOptionManager).setAsShown()
     }
 
     private fun configureSkipperFlow() = runTest {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1211370918087169?focus=true

### Description

- Skips the new address bar option when skipping onboarding 

### Steps to test this PR

- [ ] Skip onboarding
- [ ] Kill the app
- [ ] Verify that the new address bar option choice screen does not show
