### PR TITLE
Fix fallback subscriptions

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -387,7 +387,7 @@ class BrowserWebViewClientTest {
 
         assertFalse(fakePostMessageWrapperPlugins.plugin.postMessageCalled)
 
-        testee.postContentScopeMessage(data)
+        testee.postContentScopeMessage(data, webView)
 
         assertTrue(fakePostMessageWrapperPlugins.plugin.postMessageCalled)
     }
@@ -1383,7 +1383,7 @@ class BrowserWebViewClientTest {
         var postMessageCalled = false
             private set
 
-        override fun postMessage(message: SubscriptionEventData) {
+        override fun postMessage(message: SubscriptionEventData, webView: WebView) {
             postMessageCalled = true
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1197,7 +1197,9 @@ class BrowserTabFragment :
 
     private fun postBreakageReportingEvent() {
         val eventData = createBreakageReportingEventData()
-        webViewClient.postContentScopeMessage(eventData)
+        webView?.let {
+            webViewClient.postContentScopeMessage(eventData, it)
+        }
     }
 
     private fun onFireButtonPressed() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -769,10 +769,11 @@ class BrowserWebViewClient @Inject constructor(
 
     fun postContentScopeMessage(
         eventData: SubscriptionEventData,
+        webView: WebView,
     ) {
         postMessageWrapperPlugins.getPlugins()
             .firstOrNull { it.context == "contentScopeScripts" }
-            ?.postMessage(eventData)
+            ?.postMessage(eventData, webView)
     }
 }
 

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsPostMessageWrapperPlugin.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsPostMessageWrapperPlugin.kt
@@ -47,14 +47,13 @@ class ContentScopeScriptsPostMessageWrapperPlugin @Inject constructor(
             if (webViewCompatContentScopeScripts.isEnabled()) {
                 webMessagingPlugin.postMessage(message)
             } else {
-                val subscriptionEvent = SubscriptionEvent(
-                    context = webMessagingPlugin.context,
-                    featureName = message.featureName,
-                    subscriptionName = message.subscriptionName,
-                    params = message.params,
-                )
                 jsMessageHelper.sendSubscriptionEvent(
-                    subscriptionEvent = subscriptionEvent,
+                    subscriptionEvent = SubscriptionEvent(
+                        context = webMessagingPlugin.context,
+                        featureName = message.featureName,
+                        subscriptionName = message.subscriptionName,
+                        params = message.params,
+                    ),
                     callbackName = coreContentScopeScripts.callbackName,
                     secret = coreContentScopeScripts.secret,
                     webView = webView,

--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsPostMessageWrapperPluginTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsPostMessageWrapperPluginTest.kt
@@ -1,14 +1,20 @@
 package com.duckduckgo.contentscopescripts.impl.messaging
 
+import android.webkit.WebView
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.contentscopescripts.impl.CoreContentScopeScripts
 import com.duckduckgo.contentscopescripts.impl.WebViewCompatContentScopeScripts
+import com.duckduckgo.js.messaging.api.JsMessageHelper
+import com.duckduckgo.js.messaging.api.SubscriptionEvent
 import com.duckduckgo.js.messaging.api.SubscriptionEventData
 import com.duckduckgo.js.messaging.api.WebMessagingPlugin
 import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -18,26 +24,44 @@ class ContentScopeScriptsPostMessageWrapperPluginTest {
     var coroutineRule = CoroutineTestRule()
 
     private val mockWebMessagingPlugin: WebMessagingPlugin = mock()
-    private val mockContentScopeScriptsJsMessaging: ContentScopeScriptsJsMessaging = mock()
+    private val mockJsHelper: JsMessageHelper = mock()
+    private val mockCoreContentScopeScripts: CoreContentScopeScripts = mock()
     private val mockWebViewCompatContentScopeScripts: WebViewCompatContentScopeScripts = mock()
+    private val mockWebView: WebView = mock()
+    private val mockJsonObject: JSONObject = mock()
     private val subscriptionEventData = SubscriptionEventData(
         featureName = "testFeature",
         subscriptionName = "testSubscription",
-        params = JSONObject(),
+        params = mockJsonObject,
+    )
+    private val subscriptionEvent = SubscriptionEvent(
+        context = "contentScopeScripts",
+        featureName = "testFeature",
+        subscriptionName = "testSubscription",
+        params = mockJsonObject,
     )
 
     val testee = ContentScopeScriptsPostMessageWrapperPlugin(
         webMessagingPlugin = mockWebMessagingPlugin,
-        contentScopeScriptsJsMessaging = mockContentScopeScriptsJsMessaging,
+        jsMessageHelper = mockJsHelper,
+        coreContentScopeScripts = mockCoreContentScopeScripts,
         webViewCompatContentScopeScripts = mockWebViewCompatContentScopeScripts,
         coroutineScope = coroutineRule.testScope,
     )
+
+    @Before
+    fun setup() {
+        whenever(mockCoreContentScopeScripts.callbackName).thenReturn("callbackName")
+        whenever(mockCoreContentScopeScripts.secret).thenReturn("secret")
+        whenever(mockWebMessagingPlugin.context).thenReturn("contentScopeScripts")
+        whenever(mockJsonObject.toString()).thenReturn("{}")
+    }
 
     @Test
     fun whenWebViewCompatContentScopeScriptsIsEnabledThenPostMessageToWebMessagingPlugin() = runTest {
         whenever(mockWebViewCompatContentScopeScripts.isEnabled()).thenReturn(true)
 
-        testee.postMessage(subscriptionEventData)
+        testee.postMessage(subscriptionEventData, mockWebView)
 
         verify(mockWebMessagingPlugin).postMessage(subscriptionEventData)
     }
@@ -46,8 +70,13 @@ class ContentScopeScriptsPostMessageWrapperPluginTest {
     fun whenWebViewCompatContentScopeScriptsIsNotEnabledThenPostMessageToContentScopeScriptsJsMessaging() = runTest {
         whenever(mockWebViewCompatContentScopeScripts.isEnabled()).thenReturn(false)
 
-        testee.postMessage(subscriptionEventData)
+        testee.postMessage(subscriptionEventData, mockWebView)
 
-        verify(mockContentScopeScriptsJsMessaging).sendSubscriptionEvent(subscriptionEventData)
+        verify(mockJsHelper).sendSubscriptionEvent(
+            any(),
+            any(),
+            any(),
+            any(),
+        )
     }
 }

--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsPostMessageWrapperPluginTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsPostMessageWrapperPluginTest.kt
@@ -14,7 +14,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
-import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -73,10 +73,10 @@ class ContentScopeScriptsPostMessageWrapperPluginTest {
         testee.postMessage(subscriptionEventData, mockWebView)
 
         verify(mockJsHelper).sendSubscriptionEvent(
-            any(),
-            any(),
-            any(),
-            any(),
+            eq(subscriptionEvent),
+            eq("callbackName"),
+            eq("secret"),
+            eq(mockWebView),
         )
     }
 }

--- a/js-messaging/js-messaging-api/src/main/java/com/duckduckgo/js/messaging/api/PostMessageWrapperPlugin.kt
+++ b/js-messaging/js-messaging-api/src/main/java/com/duckduckgo/js/messaging/api/PostMessageWrapperPlugin.kt
@@ -16,8 +16,10 @@
 
 package com.duckduckgo.js.messaging.api
 
+import android.webkit.WebView
+
 interface PostMessageWrapperPlugin {
-    fun postMessage(message: SubscriptionEventData)
+    fun postMessage(message: SubscriptionEventData, webView: WebView)
 
     val context: String
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1211382186881405?focus=true

### Description
Fallback for subscriptions when new APIs not enabled was failing due to injecting different instances in the fragment and the messaging wrapper, so WebView was not initialized and messages were never sent

### Steps to test this PR

_Feature 1_
- [ ] Add a log in `JsMessageHelper#sendSubscriptionEvent`
- [ ] Disable `useNewWebCompatApis`
- [ ] Load a site
- [ ] Open menu
- [ ] Check the log is shown for breakage report values

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
