### PR TITLE
try-catch startForeground inside notifyVpnStart

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/TrackerBlockingVpnService.kt
@@ -710,12 +710,17 @@ class TrackerBlockingVpnService : VpnService(), CoroutineScope by MainScope(), V
             }
         }
 
-        ServiceCompat.startForeground(
-            this,
-            VPN_FOREGROUND_SERVICE_ID,
-            VpnEnabledNotificationBuilder.buildVpnEnabledNotification(applicationContext, vpnNotification),
-            FOREGROUND_SERVICE_TYPE_SPECIAL_USE,
-        )
+        try {
+            ServiceCompat.startForeground(
+                this,
+                VPN_FOREGROUND_SERVICE_ID,
+                VpnEnabledNotificationBuilder.buildVpnEnabledNotification(applicationContext, vpnNotification),
+                FOREGROUND_SERVICE_TYPE_SPECIAL_USE,
+            )
+        } catch (_: Throwable) {
+            // signal the error
+            return false
+        }
 
         return vpnNotification != emptyNotification
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1211418384396819?focus=true

### Description
In https://github.com/duckduckgo/Android/pull/6808 we bubbled up the `ForegroundServiceStartNotAllowedException` to notifyVpnStart function, when calling `startForeground` method.

This didn't get rid of the crashes but was a bit of an improvement.

This PR will try-catch the startForeground call and return the appropriate error so that the error path can be executed. The error path sends a pixel (m_vpn_ev_notify_start_failed_c/d) are expected to increase and will also stop the service showing the disabled notification. Which is a better UX

### Steps to test this PR

Smoke test the VPN and AppTP
