### PR TITLE
fixes an issue where Dax icon wasn't in sync when transitioning from unfocused to focused Input Screen state

### DIFF
--- a/duckchat/duckchat-impl/src/main/res/layout/fragment_input_screen.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/fragment_input_screen.xml
@@ -34,7 +34,7 @@
         android:id="@+id/ddgLogoContainer"
         android:layout_width="180dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/homeTabDdgLogoTopMargin"
+        android:layout_marginTop="84dp"
         android:paddingTop="@dimen/inputScreenContentTopOffset"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1211437241434767?focus=true

### Description
Fixes an issue where Dax icon wasn't in sync when transitioning from unfocused to focused Input Screen state

### Steps to test this PR

- [ ] Open Input Screen from NTP without favorites (Dax visible).
- [ ] Verify Dax transitions smoothly between the screens.

_before_

https://github.com/user-attachments/assets/a1b1549f-ad52-496d-9d59-4723bc8f4b7d

_after_


https://github.com/user-attachments/assets/0799810a-e35a-49f3-801d-47d29cf98414


