### PR TITLE
Adjust VPN menu item dismiss behavior

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -4416,6 +4416,9 @@ class BrowserTabViewModel @Inject constructor(
             VpnMenuState.NotSubscribed -> {
                 command.value = LaunchPrivacyPro("https://duckduckgo.com/pro?origin=funnel_appmenu_android".toUri())
             }
+            VpnMenuState.NotSubscribedNoPill -> {
+                command.value = LaunchPrivacyPro("https://duckduckgo.com/pro?origin=funnel_appmenu_android".toUri())
+            }
             is VpnMenuState.Subscribed -> {
                 command.value = LaunchVpnManagement
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/menu/BrowserPopupMenu.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/menu/BrowserPopupMenu.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.app.browser.menu.BrowserPopupMenu.ResourceType.BOTTOM
 import com.duckduckgo.app.browser.menu.BrowserPopupMenu.ResourceType.TOP
 import com.duckduckgo.app.browser.viewstate.BrowserViewState
 import com.duckduckgo.app.browser.viewstate.VpnMenuState
+import com.duckduckgo.common.ui.view.StatusIndicatorView
 import com.duckduckgo.common.ui.menu.PopupMenu
 import com.duckduckgo.common.ui.view.MenuItemView
 import com.duckduckgo.mobile.android.R.drawable
@@ -360,51 +361,66 @@ class BrowserPopupMenu(
             VpnMenuState.NotSubscribed -> {
                 vpnMenuItem.isVisible = shouldShowVpnMenuItem
                 if (shouldShowVpnMenuItem) {
-                    configureVpnMenuItemForNotSubscribed()
+                    val (tryForFreePill, statusIndicator, menuItemView) = getVpnMenuViews()
+                    configureVpnMenuItemForNotSubscribed(tryForFreePill, statusIndicator, menuItemView)
+                }
+            }
+            VpnMenuState.NotSubscribedNoPill -> {
+                vpnMenuItem.isVisible = shouldShowVpnMenuItem
+                if (shouldShowVpnMenuItem) {
+                    val (tryForFreePill, statusIndicator, menuItemView) = getVpnMenuViews()
+                    configureVpnMenuItemForNotSubscribedNoPill(tryForFreePill, statusIndicator, menuItemView)
                 }
             }
             is VpnMenuState.Subscribed -> {
                 vpnMenuItem.isVisible = shouldShowVpnMenuItem
                 if (shouldShowVpnMenuItem) {
-                    configureVpnMenuItemForSubscribed(viewState.vpnMenuState.isVpnEnabled)
+                    val (tryForFreePill, statusIndicator, menuItemView) = getVpnMenuViews()
+                    configureVpnMenuItemForSubscribed(tryForFreePill, statusIndicator, menuItemView, viewState.vpnMenuState.isVpnEnabled)
                 }
             }
         }
     }
 
-    private fun configureVpnMenuItemForNotSubscribed() {
-        val tryForFreePill = when (popupMenuResourceType) {
-            TOP -> topBinding.includeVpnMenuItem.tryForFreePill
-            BOTTOM -> bottomBinding.includeVpnMenuItem.tryForFreePill
-        }
-        val statusIndicator = when (popupMenuResourceType) {
-            TOP -> topBinding.includeVpnMenuItem.statusIndicator
-            BOTTOM -> bottomBinding.includeVpnMenuItem.statusIndicator
-        }
-        val menuItemView = when (popupMenuResourceType) {
-            TOP -> topBinding.includeVpnMenuItem.menuItemView
-            BOTTOM -> bottomBinding.includeVpnMenuItem.menuItemView
-        }
+    private fun getVpnMenuViews() = when (popupMenuResourceType) {
+        TOP -> Triple(
+            topBinding.includeVpnMenuItem.tryForFreePill,
+            topBinding.includeVpnMenuItem.statusIndicator,
+            topBinding.includeVpnMenuItem.menuItemView
+        )
+        BOTTOM -> Triple(
+            bottomBinding.includeVpnMenuItem.tryForFreePill,
+            bottomBinding.includeVpnMenuItem.statusIndicator,
+            bottomBinding.includeVpnMenuItem.menuItemView
+        )
+    }
 
+    private fun configureVpnMenuItemForNotSubscribed(
+        tryForFreePill: View,
+        statusIndicator: StatusIndicatorView,
+        menuItemView: MenuItemView
+    ) {
         tryForFreePill.isVisible = true
         statusIndicator.isVisible = false
         menuItemView.setIcon(drawable.ic_vpn_unlocked_24)
     }
 
-    private fun configureVpnMenuItemForSubscribed(isVpnEnabled: Boolean) {
-        val tryForFreePill = when (popupMenuResourceType) {
-            TOP -> topBinding.includeVpnMenuItem.tryForFreePill
-            BOTTOM -> bottomBinding.includeVpnMenuItem.tryForFreePill
-        }
-        val statusIndicator = when (popupMenuResourceType) {
-            TOP -> topBinding.includeVpnMenuItem.statusIndicator
-            BOTTOM -> bottomBinding.includeVpnMenuItem.statusIndicator
-        }
-        val menuItemView = when (popupMenuResourceType) {
-            TOP -> topBinding.includeVpnMenuItem.menuItemView
-            BOTTOM -> bottomBinding.includeVpnMenuItem.menuItemView
-        }
+    private fun configureVpnMenuItemForNotSubscribedNoPill(
+        tryForFreePill: View,
+        statusIndicator: StatusIndicatorView,
+        menuItemView: MenuItemView
+    ) {
+        tryForFreePill.isVisible = false
+        statusIndicator.isVisible = false
+        menuItemView.setIcon(drawable.ic_vpn_unlocked_24)
+    }
 
+    private fun configureVpnMenuItemForSubscribed(
+        tryForFreePill: View,
+        statusIndicator: StatusIndicatorView,
+        menuItemView: MenuItemView,
+        isVpnEnabled: Boolean
+    ) {
         tryForFreePill.isVisible = false
         statusIndicator.isVisible = true
         statusIndicator.setStatus(isVpnEnabled)

--- a/app/src/main/java/com/duckduckgo/app/browser/menu/BrowserPopupMenu.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/menu/BrowserPopupMenu.kt
@@ -38,10 +38,10 @@ class BrowserPopupMenu(
     layoutInflater: LayoutInflater,
     private val popupMenuResourceType: ResourceType,
 ) : PopupMenu(
-        layoutInflater,
-        resourceId = if (popupMenuResourceType == TOP) R.layout.popup_window_browser_menu else R.layout.popup_window_browser_menu_bottom,
-        width = context.resources.getDimensionPixelSize(R.dimen.browserPopupMenuWidth),
-    ) {
+    layoutInflater,
+    resourceId = if (popupMenuResourceType == TOP) R.layout.popup_window_browser_menu else R.layout.popup_window_browser_menu_bottom,
+    width = context.resources.getDimensionPixelSize(R.dimen.browserPopupMenuWidth),
+) {
     private val topBinding = PopupWindowBrowserMenuBinding.bind(contentView)
     private val bottomBinding = PopupWindowBrowserMenuBottomBinding.bind(contentView)
 

--- a/app/src/main/java/com/duckduckgo/app/browser/menu/BrowserPopupMenu.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/menu/BrowserPopupMenu.kt
@@ -28,9 +28,9 @@ import com.duckduckgo.app.browser.menu.BrowserPopupMenu.ResourceType.BOTTOM
 import com.duckduckgo.app.browser.menu.BrowserPopupMenu.ResourceType.TOP
 import com.duckduckgo.app.browser.viewstate.BrowserViewState
 import com.duckduckgo.app.browser.viewstate.VpnMenuState
-import com.duckduckgo.common.ui.view.StatusIndicatorView
 import com.duckduckgo.common.ui.menu.PopupMenu
 import com.duckduckgo.common.ui.view.MenuItemView
+import com.duckduckgo.common.ui.view.StatusIndicatorView
 import com.duckduckgo.mobile.android.R.drawable
 
 class BrowserPopupMenu(
@@ -38,18 +38,19 @@ class BrowserPopupMenu(
     layoutInflater: LayoutInflater,
     private val popupMenuResourceType: ResourceType,
 ) : PopupMenu(
-    layoutInflater,
-    resourceId = if (popupMenuResourceType == TOP) R.layout.popup_window_browser_menu else R.layout.popup_window_browser_menu_bottom,
-    width = context.resources.getDimensionPixelSize(R.dimen.browserPopupMenuWidth),
-) {
+        layoutInflater,
+        resourceId = if (popupMenuResourceType == TOP) R.layout.popup_window_browser_menu else R.layout.popup_window_browser_menu_bottom,
+        width = context.resources.getDimensionPixelSize(R.dimen.browserPopupMenuWidth),
+    ) {
     private val topBinding = PopupWindowBrowserMenuBinding.bind(contentView)
     private val bottomBinding = PopupWindowBrowserMenuBottomBinding.bind(contentView)
 
     init {
-        contentView = when (popupMenuResourceType) {
-            TOP -> topBinding.root
-            BOTTOM -> bottomBinding.root
-        }
+        contentView =
+            when (popupMenuResourceType) {
+                TOP -> topBinding.root
+                BOTTOM -> bottomBinding.root
+            }
     }
 
     internal val backMenuItem: View by lazy {
@@ -311,13 +312,14 @@ class BrowserPopupMenu(
         addToHomeMenuItem.isVisible = viewState.addToHomeVisible && viewState.addToHomeEnabled && !displayedInCustomTabScreen
         privacyProtectionMenuItem.isVisible = viewState.canChangePrivacyProtection
         privacyProtectionMenuItem.label {
-            context.getText(
-                if (viewState.isPrivacyProtectionDisabled) {
-                    R.string.enablePrivacyProtection
-                } else {
-                    R.string.disablePrivacyProtection
-                },
-            ).toString()
+            context
+                .getText(
+                    if (viewState.isPrivacyProtectionDisabled) {
+                        R.string.enablePrivacyProtection
+                    } else {
+                        R.string.disablePrivacyProtection
+                    },
+                ).toString()
         }
         privacyProtectionMenuItem.setIcon(
             if (viewState.isPrivacyProtectionDisabled) drawable.ic_shield_16 else drawable.ic_shield_disabled_16,
@@ -382,23 +384,26 @@ class BrowserPopupMenu(
         }
     }
 
-    private fun getVpnMenuViews() = when (popupMenuResourceType) {
-        TOP -> Triple(
-            topBinding.includeVpnMenuItem.tryForFreePill,
-            topBinding.includeVpnMenuItem.statusIndicator,
-            topBinding.includeVpnMenuItem.menuItemView
-        )
-        BOTTOM -> Triple(
-            bottomBinding.includeVpnMenuItem.tryForFreePill,
-            bottomBinding.includeVpnMenuItem.statusIndicator,
-            bottomBinding.includeVpnMenuItem.menuItemView
-        )
-    }
+    private fun getVpnMenuViews() =
+        when (popupMenuResourceType) {
+            TOP ->
+                Triple(
+                    topBinding.includeVpnMenuItem.tryForFreePill,
+                    topBinding.includeVpnMenuItem.statusIndicator,
+                    topBinding.includeVpnMenuItem.menuItemView,
+                )
+            BOTTOM ->
+                Triple(
+                    bottomBinding.includeVpnMenuItem.tryForFreePill,
+                    bottomBinding.includeVpnMenuItem.statusIndicator,
+                    bottomBinding.includeVpnMenuItem.menuItemView,
+                )
+        }
 
     private fun configureVpnMenuItemForNotSubscribed(
         tryForFreePill: View,
         statusIndicator: StatusIndicatorView,
-        menuItemView: MenuItemView
+        menuItemView: MenuItemView,
     ) {
         tryForFreePill.isVisible = true
         statusIndicator.isVisible = false
@@ -408,7 +413,7 @@ class BrowserPopupMenu(
     private fun configureVpnMenuItemForNotSubscribedNoPill(
         tryForFreePill: View,
         statusIndicator: StatusIndicatorView,
-        menuItemView: MenuItemView
+        menuItemView: MenuItemView,
     ) {
         tryForFreePill.isVisible = false
         statusIndicator.isVisible = false
@@ -419,7 +424,7 @@ class BrowserPopupMenu(
         tryForFreePill: View,
         statusIndicator: StatusIndicatorView,
         menuItemView: MenuItemView,
-        isVpnEnabled: Boolean
+        isVpnEnabled: Boolean,
     ) {
         tryForFreePill.isVisible = false
         statusIndicator.isVisible = true

--- a/app/src/main/java/com/duckduckgo/app/browser/menu/VpnMenuStateProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/menu/VpnMenuStateProvider.kt
@@ -39,7 +39,6 @@ class VpnMenuStateProviderImpl @Inject constructor(
     private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
     private val vpnMenuStore: VpnMenuStore,
 ) : VpnMenuStateProvider {
-
     override fun getVpnMenuState(): Flow<VpnMenuState> {
         return combine(
             subscriptions.getSubscriptionStatusFlow(),
@@ -68,12 +67,11 @@ class VpnMenuStateProviderImpl @Inject constructor(
     }
 }
 
-private fun SubscriptionStatus.isActive(): Boolean {
-    return when (this) {
+private fun SubscriptionStatus.isActive(): Boolean =
+    when (this) {
         SubscriptionStatus.AUTO_RENEWABLE,
         SubscriptionStatus.NOT_AUTO_RENEWABLE,
         SubscriptionStatus.GRACE_PERIOD,
         -> true
         else -> false
     }
-}

--- a/app/src/main/java/com/duckduckgo/app/browser/menu/VpnMenuStateProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/menu/VpnMenuStateProvider.kt
@@ -60,7 +60,7 @@ class VpnMenuStateProviderImpl @Inject constructor(
                     if (vpnMenuStore.canShowVpnMenuForNotSubscribed()) {
                         VpnMenuState.NotSubscribed
                     } else {
-                        VpnMenuState.Hidden
+                        VpnMenuState.NotSubscribedNoPill
                     }
                 }
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/viewstate/BrowserViewState.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/viewstate/BrowserViewState.kt
@@ -65,9 +65,14 @@ data class BrowserViewState(
 
 sealed class VpnMenuState {
     data object Hidden : VpnMenuState()
+
     data object NotSubscribed : VpnMenuState()
+
     data object NotSubscribedNoPill : VpnMenuState()
-    data class Subscribed(val isVpnEnabled: Boolean) : VpnMenuState()
+
+    data class Subscribed(
+        val isVpnEnabled: Boolean,
+    ) : VpnMenuState()
 }
 
 sealed class HighlightableButton {
@@ -78,17 +83,15 @@ sealed class HighlightableButton {
 
     data object Gone : HighlightableButton()
 
-    fun isHighlighted(): Boolean {
-        return when (this) {
+    fun isHighlighted(): Boolean =
+        when (this) {
             is Visible -> this.highlighted
             is Gone -> false
         }
-    }
 
-    fun isEnabled(): Boolean {
-        return when (this) {
+    fun isEnabled(): Boolean =
+        when (this) {
             is Visible -> this.enabled
             is Gone -> false
         }
-    }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/viewstate/BrowserViewState.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/viewstate/BrowserViewState.kt
@@ -66,6 +66,7 @@ data class BrowserViewState(
 sealed class VpnMenuState {
     data object Hidden : VpnMenuState()
     data object NotSubscribed : VpnMenuState()
+    data object NotSubscribedNoPill : VpnMenuState()
     data class Subscribed(val isVpnEnabled: Boolean) : VpnMenuState()
 }
 

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelVpnMenuTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelVpnMenuTest.kt
@@ -36,7 +36,6 @@ import org.mockito.kotlin.whenever
 import kotlin.time.Duration.Companion.milliseconds
 
 class BrowserTabViewModelVpnMenuTest {
-
     @get:Rule
     var coroutinesTestRule = CoroutineTestRule()
 
@@ -55,114 +54,123 @@ class BrowserTabViewModelVpnMenuTest {
     }
 
     @Test
-    fun `when VPN menu state changes to NotSubscribed then flow emits NotSubscribed`() = runTest {
-        val vpnMenuStateFlow = flowOf(VpnMenuState.NotSubscribed)
-        whenever(mockVpnMenuStateProvider.getVpnMenuState()).thenReturn(vpnMenuStateFlow)
+    fun `when VPN menu state changes to NotSubscribed then flow emits NotSubscribed`() =
+        runTest {
+            val vpnMenuStateFlow = flowOf(VpnMenuState.NotSubscribed)
+            whenever(mockVpnMenuStateProvider.getVpnMenuState()).thenReturn(vpnMenuStateFlow)
 
-        mockVpnMenuStateProvider.getVpnMenuState().test {
-            val state = awaitItem()
-            assertEquals(VpnMenuState.NotSubscribed, state)
-            awaitComplete()
+            mockVpnMenuStateProvider.getVpnMenuState().test {
+                val state = awaitItem()
+                assertEquals(VpnMenuState.NotSubscribed, state)
+                awaitComplete()
+            }
         }
-    }
 
     @Test
-    fun `when VPN menu state changes to Subscribed with VPN enabled then flow emits correct state`() = runTest {
-        val vpnMenuStateFlow = flowOf(VpnMenuState.Subscribed(isVpnEnabled = true))
-        whenever(mockVpnMenuStateProvider.getVpnMenuState()).thenReturn(vpnMenuStateFlow)
+    fun `when VPN menu state changes to Subscribed with VPN enabled then flow emits correct state`() =
+        runTest {
+            val vpnMenuStateFlow = flowOf(VpnMenuState.Subscribed(isVpnEnabled = true))
+            whenever(mockVpnMenuStateProvider.getVpnMenuState()).thenReturn(vpnMenuStateFlow)
 
-        mockVpnMenuStateProvider.getVpnMenuState().test {
-            val state = awaitItem()
-            assertEquals(VpnMenuState.Subscribed(isVpnEnabled = true), state)
-            awaitComplete()
+            mockVpnMenuStateProvider.getVpnMenuState().test {
+                val state = awaitItem()
+                assertEquals(VpnMenuState.Subscribed(isVpnEnabled = true), state)
+                awaitComplete()
+            }
         }
-    }
 
     @Test
-    fun `when VPN menu state changes to Subscribed with VPN disabled then flow emits correct state`() = runTest {
-        val vpnMenuStateFlow = flowOf(VpnMenuState.Subscribed(isVpnEnabled = false))
-        whenever(mockVpnMenuStateProvider.getVpnMenuState()).thenReturn(vpnMenuStateFlow)
+    fun `when VPN menu state changes to Subscribed with VPN disabled then flow emits correct state`() =
+        runTest {
+            val vpnMenuStateFlow = flowOf(VpnMenuState.Subscribed(isVpnEnabled = false))
+            whenever(mockVpnMenuStateProvider.getVpnMenuState()).thenReturn(vpnMenuStateFlow)
 
-        mockVpnMenuStateProvider.getVpnMenuState().test {
-            val state = awaitItem()
-            assertEquals(VpnMenuState.Subscribed(isVpnEnabled = false), state)
-            awaitComplete()
+            mockVpnMenuStateProvider.getVpnMenuState().test {
+                val state = awaitItem()
+                assertEquals(VpnMenuState.Subscribed(isVpnEnabled = false), state)
+                awaitComplete()
+            }
         }
-    }
 
     @Test
-    fun `when VPN menu state changes to Hidden then flow emits Hidden`() = runTest {
-        val vpnMenuStateFlow = flowOf(VpnMenuState.Hidden)
-        whenever(mockVpnMenuStateProvider.getVpnMenuState()).thenReturn(vpnMenuStateFlow)
+    fun `when VPN menu state changes to Hidden then flow emits Hidden`() =
+        runTest {
+            val vpnMenuStateFlow = flowOf(VpnMenuState.Hidden)
+            whenever(mockVpnMenuStateProvider.getVpnMenuState()).thenReturn(vpnMenuStateFlow)
 
-        mockVpnMenuStateProvider.getVpnMenuState().test {
-            val state = awaitItem()
-            assertEquals(VpnMenuState.Hidden, state)
-            awaitComplete()
+            mockVpnMenuStateProvider.getVpnMenuState().test {
+                val state = awaitItem()
+                assertEquals(VpnMenuState.Hidden, state)
+                awaitComplete()
+            }
         }
-    }
 
     @Test
-    fun `when VPN menu state provider is called then it returns the expected flow`() = runTest {
-        val vpnMenuStateFlow = flowOf(VpnMenuState.Hidden)
-        whenever(mockVpnMenuStateProvider.getVpnMenuState()).thenReturn(vpnMenuStateFlow)
+    fun `when VPN menu state provider is called then it returns the expected flow`() =
+        runTest {
+            val vpnMenuStateFlow = flowOf(VpnMenuState.Hidden)
+            whenever(mockVpnMenuStateProvider.getVpnMenuState()).thenReturn(vpnMenuStateFlow)
 
-        mockVpnMenuStateProvider.getVpnMenuState().test {
-            val state = awaitItem()
-            assertEquals(VpnMenuState.Hidden, state)
-            awaitComplete()
+            mockVpnMenuStateProvider.getVpnMenuState().test {
+                val state = awaitItem()
+                assertEquals(VpnMenuState.Hidden, state)
+                awaitComplete()
+            }
         }
-    }
 
     @Test
-    fun `when VPN menu clicked and user not subscribed then launches Privacy Pro command`() = runTest {
-        testee.setVpnMenuState(VpnMenuState.NotSubscribed)
+    fun `when VPN menu clicked and user not subscribed then launches Privacy Pro command`() =
+        runTest {
+            testee.setVpnMenuState(VpnMenuState.NotSubscribed)
 
-        testee.onVpnMenuClicked()
+            testee.onVpnMenuClicked()
 
-        testee.commands.test {
-            val command = awaitItem()
-            assertTrue("Expected LaunchPrivacyPro command", command is Command.LaunchPrivacyPro)
-            cancelAndIgnoreRemainingEvents()
+            testee.commands.test {
+                val command = awaitItem()
+                assertTrue("Expected LaunchPrivacyPro command", command is Command.LaunchPrivacyPro)
+                cancelAndIgnoreRemainingEvents()
+            }
         }
-    }
 
     @Test
-    fun `when VPN menu clicked and user subscribed with VPN enabled then launches VPN management`() = runTest {
-        testee.setVpnMenuState(VpnMenuState.Subscribed(isVpnEnabled = true))
+    fun `when VPN menu clicked and user subscribed with VPN enabled then launches VPN management`() =
+        runTest {
+            testee.setVpnMenuState(VpnMenuState.Subscribed(isVpnEnabled = true))
 
-        testee.onVpnMenuClicked()
+            testee.onVpnMenuClicked()
 
-        testee.commands.test {
-            val command = awaitItem()
-            assertEquals(Command.LaunchVpnManagement, command)
-            cancelAndIgnoreRemainingEvents()
+            testee.commands.test {
+                val command = awaitItem()
+                assertEquals(Command.LaunchVpnManagement, command)
+                cancelAndIgnoreRemainingEvents()
+            }
         }
-    }
 
     @Test
-    fun `when VPN menu clicked and user subscribed with VPN disabled then launches VPN management`() = runTest {
-        testee.setVpnMenuState(VpnMenuState.Subscribed(isVpnEnabled = false))
+    fun `when VPN menu clicked and user subscribed with VPN disabled then launches VPN management`() =
+        runTest {
+            testee.setVpnMenuState(VpnMenuState.Subscribed(isVpnEnabled = false))
 
-        testee.onVpnMenuClicked()
+            testee.onVpnMenuClicked()
 
-        testee.commands.test {
-            val command = awaitItem()
-            assertEquals(Command.LaunchVpnManagement, command)
-            cancelAndIgnoreRemainingEvents()
+            testee.commands.test {
+                val command = awaitItem()
+                assertEquals(Command.LaunchVpnManagement, command)
+                cancelAndIgnoreRemainingEvents()
+            }
         }
-    }
 
     @Test
-    fun `when VPN menu clicked and state is hidden then no command is emitted`() = runTest {
-        testee.setVpnMenuState(VpnMenuState.Hidden)
+    fun `when VPN menu clicked and state is hidden then no command is emitted`() =
+        runTest {
+            testee.setVpnMenuState(VpnMenuState.Hidden)
 
-        testee.onVpnMenuClicked()
+            testee.onVpnMenuClicked()
 
-        testee.commands.test(timeout = 1000.milliseconds) {
-            expectNoEvents()
+            testee.commands.test(timeout = 1000.milliseconds) {
+                expectNoEvents()
+            }
         }
-    }
 
     /**
      * Test implementation of BrowserTabViewModel that only includes the parts needed for VPN menu testing
@@ -180,6 +188,10 @@ class BrowserTabViewModelVpnMenuTest {
         fun onVpnMenuClicked() {
             when (currentVpnMenuState) {
                 VpnMenuState.NotSubscribed -> {
+                    val mockUri = org.mockito.kotlin.mock<Uri>()
+                    _commands.tryEmit(Command.LaunchPrivacyPro(mockUri))
+                }
+                VpnMenuState.NotSubscribedNoPill -> {
                     val mockUri = org.mockito.kotlin.mock<Uri>()
                     _commands.tryEmit(Command.LaunchPrivacyPro(mockUri))
                 }

--- a/app/src/test/java/com/duckduckgo/app/browser/menu/BrowserPopupMenuVpnTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/menu/BrowserPopupMenuVpnTest.kt
@@ -26,7 +26,6 @@ import org.junit.Test
  * and what state it should be in, without requiring complex UI mocking.
  */
 class BrowserPopupMenuVpnTest {
-
     @Test
     fun `when VPN state is Hidden then menu item should not be visible regardless of browser state`() {
         val vpnMenuState = VpnMenuState.Hidden
@@ -164,11 +163,13 @@ class BrowserPopupMenuVpnTest {
     ) {
         val shouldShowVpnMenuItem = !browserShowing && !displayedInCustomTabScreen
 
-        val actualVisible = when (vpnMenuState) {
-            VpnMenuState.Hidden -> false
-            VpnMenuState.NotSubscribed -> shouldShowVpnMenuItem
-            is VpnMenuState.Subscribed -> shouldShowVpnMenuItem
-        }
+        val actualVisible =
+            when (vpnMenuState) {
+                VpnMenuState.Hidden -> false
+                VpnMenuState.NotSubscribed -> shouldShowVpnMenuItem
+                VpnMenuState.NotSubscribedNoPill -> shouldShowVpnMenuItem
+                is VpnMenuState.Subscribed -> shouldShowVpnMenuItem
+            }
 
         assertEquals(
             "VPN menu visibility should be $expectedVisible for state $vpnMenuState, " +
@@ -178,25 +179,33 @@ class BrowserPopupMenuVpnTest {
         )
     }
 
-    private fun getVpnMenuConfiguration(vpnMenuState: VpnMenuState): VpnMenuConfiguration {
-        return when (vpnMenuState) {
-            VpnMenuState.Hidden -> VpnMenuConfiguration(
-                showTryForFreePill = false,
-                showStatusIndicator = false,
-                statusIndicatorOn = false,
-            )
-            VpnMenuState.NotSubscribed -> VpnMenuConfiguration(
-                showTryForFreePill = true,
-                showStatusIndicator = false,
-                statusIndicatorOn = false,
-            )
-            is VpnMenuState.Subscribed -> VpnMenuConfiguration(
-                showTryForFreePill = false,
-                showStatusIndicator = true,
-                statusIndicatorOn = vpnMenuState.isVpnEnabled,
-            )
+    private fun getVpnMenuConfiguration(vpnMenuState: VpnMenuState): VpnMenuConfiguration =
+        when (vpnMenuState) {
+            VpnMenuState.Hidden ->
+                VpnMenuConfiguration(
+                    showTryForFreePill = false,
+                    showStatusIndicator = false,
+                    statusIndicatorOn = false,
+                )
+            VpnMenuState.NotSubscribed ->
+                VpnMenuConfiguration(
+                    showTryForFreePill = true,
+                    showStatusIndicator = false,
+                    statusIndicatorOn = false,
+                )
+            VpnMenuState.NotSubscribedNoPill ->
+                VpnMenuConfiguration(
+                    showTryForFreePill = false,
+                    showStatusIndicator = false,
+                    statusIndicatorOn = false,
+                )
+            is VpnMenuState.Subscribed ->
+                VpnMenuConfiguration(
+                    showTryForFreePill = false,
+                    showStatusIndicator = true,
+                    statusIndicatorOn = vpnMenuState.isVpnEnabled,
+                )
         }
-    }
 
     private data class VpnMenuConfiguration(
         val showTryForFreePill: Boolean,

--- a/app/src/test/java/com/duckduckgo/app/browser/menu/VpnMenuStateProviderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/menu/VpnMenuStateProviderTest.kt
@@ -37,7 +37,6 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
 class VpnMenuStateProviderTest {
-
     @get:Rule
     val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
 
@@ -70,209 +69,224 @@ class VpnMenuStateProviderTest {
     }
 
     @Test
-    fun `when user has active subscription with NetP entitlement and VPN connected then return Subscribed with VPN enabled`() = runTest {
-        whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.AUTO_RENEWABLE))
-        whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(NetP)))
-        whenever(connectionState.isConnected()).thenReturn(true)
-        whenever(networkProtectionState.getConnectionStateFlow()).thenReturn(flowOf(connectionState))
+    fun `when user has active subscription with NetP entitlement and VPN connected then return Subscribed with VPN enabled`() =
+        runTest {
+            whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.AUTO_RENEWABLE))
+            whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(NetP)))
+            whenever(connectionState.isConnected()).thenReturn(true)
+            whenever(networkProtectionState.getConnectionStateFlow()).thenReturn(flowOf(connectionState))
 
-        testee.getVpnMenuState().test {
-            val state = awaitItem()
-            assertEquals(VpnMenuState.Subscribed(isVpnEnabled = true), state)
-            cancelAndIgnoreRemainingEvents()
+            testee.getVpnMenuState().test {
+                val state = awaitItem()
+                assertEquals(VpnMenuState.Subscribed(isVpnEnabled = true), state)
+                cancelAndIgnoreRemainingEvents()
+            }
         }
-    }
 
     @Test
-    fun `when user has active subscription with NetP entitlement and VPN disconnected then return Subscribed with VPN disabled`() = runTest {
-        whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.AUTO_RENEWABLE))
-        whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(NetP)))
-        whenever(connectionState.isConnected()).thenReturn(false)
-        whenever(networkProtectionState.getConnectionStateFlow()).thenReturn(flowOf(connectionState))
+    fun `when user has active subscription with NetP entitlement and VPN disconnected then return Subscribed with VPN disabled`() =
+        runTest {
+            whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.AUTO_RENEWABLE))
+            whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(NetP)))
+            whenever(connectionState.isConnected()).thenReturn(false)
+            whenever(networkProtectionState.getConnectionStateFlow()).thenReturn(flowOf(connectionState))
 
-        testee.getVpnMenuState().test {
-            val state = awaitItem()
-            assertEquals(VpnMenuState.Subscribed(isVpnEnabled = false), state)
-            cancelAndIgnoreRemainingEvents()
+            testee.getVpnMenuState().test {
+                val state = awaitItem()
+                assertEquals(VpnMenuState.Subscribed(isVpnEnabled = false), state)
+                cancelAndIgnoreRemainingEvents()
+            }
         }
-    }
 
     @Test
-    fun `when user has NOT_AUTO_RENEWABLE subscription with NetP entitlement and VPN connected then return Subscribed with VPN enabled`() = runTest {
-        whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.NOT_AUTO_RENEWABLE))
-        whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(NetP)))
-        whenever(connectionState.isConnected()).thenReturn(true)
-        whenever(networkProtectionState.getConnectionStateFlow()).thenReturn(flowOf(connectionState))
-        testee.getVpnMenuState().test {
-            val state = awaitItem()
-            assertEquals(VpnMenuState.Subscribed(isVpnEnabled = true), state)
-            cancelAndIgnoreRemainingEvents()
+    fun `when user has NOT_AUTO_RENEWABLE subscription with NetP entitlement and VPN connected then return Subscribed with VPN enabled`() =
+        runTest {
+            whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.NOT_AUTO_RENEWABLE))
+            whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(NetP)))
+            whenever(connectionState.isConnected()).thenReturn(true)
+            whenever(networkProtectionState.getConnectionStateFlow()).thenReturn(flowOf(connectionState))
+            testee.getVpnMenuState().test {
+                val state = awaitItem()
+                assertEquals(VpnMenuState.Subscribed(isVpnEnabled = true), state)
+                cancelAndIgnoreRemainingEvents()
+            }
         }
-    }
 
     @Test
-    fun `when user has GRACE_PERIOD subscription with NetP entitlement and VPN connected then return Subscribed with VPN enabled`() = runTest {
-        whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.GRACE_PERIOD))
-        whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(NetP)))
-        whenever(connectionState.isConnected()).thenReturn(true)
-        whenever(networkProtectionState.getConnectionStateFlow()).thenReturn(flowOf(connectionState))
-        testee.getVpnMenuState().test {
-            val state = awaitItem()
-            assertEquals(VpnMenuState.Subscribed(isVpnEnabled = true), state)
-            cancelAndIgnoreRemainingEvents()
+    fun `when user has GRACE_PERIOD subscription with NetP entitlement and VPN connected then return Subscribed with VPN enabled`() =
+        runTest {
+            whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.GRACE_PERIOD))
+            whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(NetP)))
+            whenever(connectionState.isConnected()).thenReturn(true)
+            whenever(networkProtectionState.getConnectionStateFlow()).thenReturn(flowOf(connectionState))
+            testee.getVpnMenuState().test {
+                val state = awaitItem()
+                assertEquals(VpnMenuState.Subscribed(isVpnEnabled = true), state)
+                cancelAndIgnoreRemainingEvents()
+            }
         }
-    }
 
     @Test
-    fun `when user has active subscription but no NetP entitlement then return Hidden`() = runTest {
-        whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.AUTO_RENEWABLE))
-        whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(emptyList()))
-        whenever(connectionState.isConnected()).thenReturn(true)
-        whenever(networkProtectionState.getConnectionStateFlow()).thenReturn(flowOf(connectionState))
-        testee.getVpnMenuState().test {
-            val state = awaitItem()
-            assertEquals(VpnMenuState.Hidden, state)
-            cancelAndIgnoreRemainingEvents()
+    fun `when user has active subscription but no NetP entitlement then return Hidden`() =
+        runTest {
+            whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.AUTO_RENEWABLE))
+            whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(emptyList()))
+            whenever(connectionState.isConnected()).thenReturn(true)
+            whenever(networkProtectionState.getConnectionStateFlow()).thenReturn(flowOf(connectionState))
+            testee.getVpnMenuState().test {
+                val state = awaitItem()
+                assertEquals(VpnMenuState.Hidden, state)
+                cancelAndIgnoreRemainingEvents()
+            }
         }
-    }
 
     @Test
-    fun `when user has no active subscription then return NotSubscribed`() = runTest {
-        whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.INACTIVE))
-        whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(emptyList()))
-        whenever(connectionState.isConnected()).thenReturn(false)
-        whenever(networkProtectionState.getConnectionStateFlow()).thenReturn(flowOf(connectionState))
-        testee.getVpnMenuState().test {
-            val state = awaitItem()
-            assertEquals(VpnMenuState.NotSubscribed, state)
-            cancelAndIgnoreRemainingEvents()
+    fun `when user has no active subscription then return NotSubscribed`() =
+        runTest {
+            whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.INACTIVE))
+            whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(emptyList()))
+            whenever(connectionState.isConnected()).thenReturn(false)
+            whenever(networkProtectionState.getConnectionStateFlow()).thenReturn(flowOf(connectionState))
+            testee.getVpnMenuState().test {
+                val state = awaitItem()
+                assertEquals(VpnMenuState.NotSubscribed, state)
+                cancelAndIgnoreRemainingEvents()
+            }
         }
-    }
 
     @Test
-    fun `when user has EXPIRED subscription then return NotSubscribed`() = runTest {
-        whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.EXPIRED))
-        whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(emptyList()))
-        whenever(connectionState.isConnected()).thenReturn(false)
-        whenever(networkProtectionState.getConnectionStateFlow()).thenReturn(flowOf(connectionState))
-        testee.getVpnMenuState().test {
-            val state = awaitItem()
-            assertEquals(VpnMenuState.NotSubscribed, state)
-            cancelAndIgnoreRemainingEvents()
+    fun `when user has EXPIRED subscription then return NotSubscribed`() =
+        runTest {
+            whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.EXPIRED))
+            whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(emptyList()))
+            whenever(connectionState.isConnected()).thenReturn(false)
+            whenever(networkProtectionState.getConnectionStateFlow()).thenReturn(flowOf(connectionState))
+            testee.getVpnMenuState().test {
+                val state = awaitItem()
+                assertEquals(VpnMenuState.NotSubscribed, state)
+                cancelAndIgnoreRemainingEvents()
+            }
         }
-    }
 
     @Test
-    fun `when user has UNKNOWN subscription status then return NotSubscribed`() = runTest {
-        whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.UNKNOWN))
-        whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(emptyList()))
-        whenever(connectionState.isConnected()).thenReturn(false)
-        whenever(networkProtectionState.getConnectionStateFlow()).thenReturn(flowOf(connectionState))
-        testee.getVpnMenuState().test {
-            val state = awaitItem()
-            assertEquals(VpnMenuState.NotSubscribed, state)
-            cancelAndIgnoreRemainingEvents()
+    fun `when user has UNKNOWN subscription status then return NotSubscribed`() =
+        runTest {
+            whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.UNKNOWN))
+            whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(emptyList()))
+            whenever(connectionState.isConnected()).thenReturn(false)
+            whenever(networkProtectionState.getConnectionStateFlow()).thenReturn(flowOf(connectionState))
+            testee.getVpnMenuState().test {
+                val state = awaitItem()
+                assertEquals(VpnMenuState.NotSubscribed, state)
+                cancelAndIgnoreRemainingEvents()
+            }
         }
-    }
 
     @Test
-    fun `when user has WAITING subscription status then return NotSubscribed`() = runTest {
-        whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.WAITING))
-        whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(emptyList()))
-        whenever(connectionState.isConnected()).thenReturn(false)
-        whenever(networkProtectionState.getConnectionStateFlow()).thenReturn(flowOf(connectionState))
-        testee.getVpnMenuState().test {
-            val state = awaitItem()
-            assertEquals(VpnMenuState.NotSubscribed, state)
-            cancelAndIgnoreRemainingEvents()
+    fun `when user has WAITING subscription status then return NotSubscribed`() =
+        runTest {
+            whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.WAITING))
+            whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(emptyList()))
+            whenever(connectionState.isConnected()).thenReturn(false)
+            whenever(networkProtectionState.getConnectionStateFlow()).thenReturn(flowOf(connectionState))
+            testee.getVpnMenuState().test {
+                val state = awaitItem()
+                assertEquals(VpnMenuState.NotSubscribed, state)
+                cancelAndIgnoreRemainingEvents()
+            }
         }
-    }
 
     @Test
-    fun `when VPN connection state is disconnected then state shows VPN disabled`() = runTest {
-        whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.AUTO_RENEWABLE))
-        whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(NetP)))
-        whenever(connectionState.isConnected()).thenReturn(false)
-        whenever(networkProtectionState.getConnectionStateFlow()).thenReturn(flowOf(connectionState))
+    fun `when VPN connection state is disconnected then state shows VPN disabled`() =
+        runTest {
+            whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.AUTO_RENEWABLE))
+            whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(NetP)))
+            whenever(connectionState.isConnected()).thenReturn(false)
+            whenever(networkProtectionState.getConnectionStateFlow()).thenReturn(flowOf(connectionState))
 
-        testee.getVpnMenuState().test {
-            val state = awaitItem()
-            assertEquals(VpnMenuState.Subscribed(isVpnEnabled = false), state)
-            cancelAndIgnoreRemainingEvents()
+            testee.getVpnMenuState().test {
+                val state = awaitItem()
+                assertEquals(VpnMenuState.Subscribed(isVpnEnabled = false), state)
+                cancelAndIgnoreRemainingEvents()
+            }
         }
-    }
 
     @Test
-    fun `when subscription status is active with entitlements then state shows subscribed`() = runTest {
-        whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.AUTO_RENEWABLE))
-        whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(NetP)))
-        whenever(connectionState.isConnected()).thenReturn(true)
-        whenever(networkProtectionState.getConnectionStateFlow()).thenReturn(flowOf(connectionState))
+    fun `when subscription status is active with entitlements then state shows subscribed`() =
+        runTest {
+            whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.AUTO_RENEWABLE))
+            whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(NetP)))
+            whenever(connectionState.isConnected()).thenReturn(true)
+            whenever(networkProtectionState.getConnectionStateFlow()).thenReturn(flowOf(connectionState))
 
-        testee.getVpnMenuState().test {
-            val state = awaitItem()
-            assertEquals(VpnMenuState.Subscribed(isVpnEnabled = true), state)
-            cancelAndIgnoreRemainingEvents()
+            testee.getVpnMenuState().test {
+                val state = awaitItem()
+                assertEquals(VpnMenuState.Subscribed(isVpnEnabled = true), state)
+                cancelAndIgnoreRemainingEvents()
+            }
         }
-    }
 
     @Test
-    fun `when feature flag is disabled then return Hidden regardless of subscription status`() = runTest {
-        whenever(featureToggle.isEnabled()).thenReturn(false)
-        whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.AUTO_RENEWABLE))
-        whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(NetP)))
-        whenever(connectionState.isConnected()).thenReturn(true)
-        whenever(networkProtectionState.getConnectionStateFlow()).thenReturn(flowOf(connectionState))
+    fun `when feature flag is disabled then return Hidden regardless of subscription status`() =
+        runTest {
+            whenever(featureToggle.isEnabled()).thenReturn(false)
+            whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.AUTO_RENEWABLE))
+            whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(NetP)))
+            whenever(connectionState.isConnected()).thenReturn(true)
+            whenever(networkProtectionState.getConnectionStateFlow()).thenReturn(flowOf(connectionState))
 
-        testee.getVpnMenuState().test {
-            val state = awaitItem()
-            assertEquals(VpnMenuState.Hidden, state)
-            cancelAndIgnoreRemainingEvents()
+            testee.getVpnMenuState().test {
+                val state = awaitItem()
+                assertEquals(VpnMenuState.Hidden, state)
+                cancelAndIgnoreRemainingEvents()
+            }
         }
-    }
 
     @Test
-    fun `when feature flag is disabled and user not subscribed then return Hidden`() = runTest {
-        whenever(featureToggle.isEnabled()).thenReturn(false)
-        whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.INACTIVE))
-        whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(emptyList()))
-        whenever(connectionState.isConnected()).thenReturn(false)
-        whenever(networkProtectionState.getConnectionStateFlow()).thenReturn(flowOf(connectionState))
+    fun `when feature flag is disabled and user not subscribed then return Hidden`() =
+        runTest {
+            whenever(featureToggle.isEnabled()).thenReturn(false)
+            whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.INACTIVE))
+            whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(emptyList()))
+            whenever(connectionState.isConnected()).thenReturn(false)
+            whenever(networkProtectionState.getConnectionStateFlow()).thenReturn(flowOf(connectionState))
 
-        testee.getVpnMenuState().test {
-            val state = awaitItem()
-            assertEquals(VpnMenuState.Hidden, state)
-            cancelAndIgnoreRemainingEvents()
+            testee.getVpnMenuState().test {
+                val state = awaitItem()
+                assertEquals(VpnMenuState.Hidden, state)
+                cancelAndIgnoreRemainingEvents()
+            }
         }
-    }
 
     @Test
-    fun `when user not subscribed and frequency cap not reached then return NotSubscribed`() = runTest {
-        whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.INACTIVE))
-        whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(emptyList()))
-        whenever(connectionState.isConnected()).thenReturn(false)
-        whenever(networkProtectionState.getConnectionStateFlow()).thenReturn(flowOf(connectionState))
-        whenever(vpnMenuStore.canShowVpnMenuForNotSubscribed()).thenReturn(true)
+    fun `when user not subscribed and frequency cap not reached then return NotSubscribed`() =
+        runTest {
+            whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.INACTIVE))
+            whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(emptyList()))
+            whenever(connectionState.isConnected()).thenReturn(false)
+            whenever(networkProtectionState.getConnectionStateFlow()).thenReturn(flowOf(connectionState))
+            whenever(vpnMenuStore.canShowVpnMenuForNotSubscribed()).thenReturn(true)
 
-        testee.getVpnMenuState().test {
-            val state = awaitItem()
-            assertEquals(VpnMenuState.NotSubscribed, state)
-            cancelAndIgnoreRemainingEvents()
+            testee.getVpnMenuState().test {
+                val state = awaitItem()
+                assertEquals(VpnMenuState.NotSubscribed, state)
+                cancelAndIgnoreRemainingEvents()
+            }
         }
-    }
 
     @Test
-    fun `when user not subscribed and frequency cap reached then return Hidden`() = runTest {
-        whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.INACTIVE))
-        whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(emptyList()))
-        whenever(connectionState.isConnected()).thenReturn(false)
-        whenever(networkProtectionState.getConnectionStateFlow()).thenReturn(flowOf(connectionState))
-        whenever(vpnMenuStore.canShowVpnMenuForNotSubscribed()).thenReturn(false)
+    fun `when user not subscribed and frequency cap reached then return NotSubscribedNoPill`() =
+        runTest {
+            whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.INACTIVE))
+            whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(emptyList()))
+            whenever(connectionState.isConnected()).thenReturn(false)
+            whenever(networkProtectionState.getConnectionStateFlow()).thenReturn(flowOf(connectionState))
+            whenever(vpnMenuStore.canShowVpnMenuForNotSubscribed()).thenReturn(false)
 
-        testee.getVpnMenuState().test {
-            val state = awaitItem()
-            assertEquals(VpnMenuState.Hidden, state)
-            cancelAndIgnoreRemainingEvents()
+            testee.getVpnMenuState().test {
+                val state = awaitItem()
+                assertEquals(VpnMenuState.NotSubscribedNoPill, state)
+                cancelAndIgnoreRemainingEvents()
+            }
         }
-    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1211443366455926?focus=true

### Description
Adjust VPN menu item dismiss behavior

### Steps to test this PR

_Pre-steps_
- [x] Apply PPro patch -> https://app.asana.com/1/137249556945/project/1209991789468715/task/1210448620621729?focus=true
- [x] Set device language to English (United Kingdom)

_Not Subscribed_
- [x] Fresh install
- [x] Open a new tab page
- [x] Check you see the new VPN menu item with pill "TRY FOR FREE"

_Frequency cap_
- [x] Tap on VPN menu item
- [x] Open a new tab
- [x] Open overflow menu at least 3 more times
- [x] Open a new tab
- [x] Open overflow menu
- [x] Check VPN menu item doesn't have the yellow 'TRY FOR FREE' pill anymore
- [x] Tab on VPN item
- [x] Check Subscription paywall is opened with origin "funnel_appmenu_android" (you can check this in the logcat filtering by "origin"

_no UK_
- [x] Set device country to something different to GB
- [x] Open overflow menu in a new tab page
- [x] Check VPN menu item is not there


### UI changes
| Before  | After |
| ------ | ----- |
<img width="377" height="341" alt="Screenshot 2025-09-26 at 12 21 21" src="https://github.com/user-attachments/assets/65f4acc1-c066-4a99-bda6-fe4959fbc6c1" />|<img width="379" height="386" alt="Screenshot 2025-09-26 at 12 16 23" src="https://github.com/user-attachments/assets/d58580f9-7ed6-4184-908d-67aa439459e9" />|