### PR TITLE
Update content scope scripts to version 11.29.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -7403,6 +7403,16 @@
       return deviceInfo;
     }
     /**
+     * Helper to wrap a promise with timeout
+     * @param {Promise} promise - Promise to wrap
+     * @param {number} timeoutMs - Timeout in milliseconds
+     * @returns {Promise} Promise that rejects on timeout
+     */
+    withTimeout(promise, timeoutMs) {
+      const timeout = new Promise((_resolve, reject) => setTimeout(() => reject(new Error("Request timeout")), timeoutMs));
+      return Promise.race([promise, timeout]);
+    }
+    /**
      * Fixes device enumeration to handle permission prompts gracefully
      */
     deviceEnumerationFix() {
@@ -7417,8 +7427,12 @@
          * @returns {Promise<MediaDeviceInfo[]>}
          */
         apply: async (target, thisArg, args) => {
+          const settings = this.getFeatureSetting("enumerateDevices") || {};
+          const timeoutEnabled = settings.timeoutEnabled !== false;
+          const timeoutMs = settings.timeoutMs ?? 2e3;
           try {
-            const response = await this.messaging.request(MSG_DEVICE_ENUMERATION, {});
+            const messagingPromise = this.messaging.request(MSG_DEVICE_ENUMERATION, {});
+            const response = timeoutEnabled ? await this.withTimeout(messagingPromise, timeoutMs) : await messagingPromise;
             if (response.willPrompt) {
               const devices = [];
               if (response.videoInput) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.19.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.3.1",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.28.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.29.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1758095627"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.22.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.22.0.tgz",
-      "integrity": "sha512-1LEB8bh5B6dcpX9d88t4ptsd5NNsRPQbNpwvcLDRvcyCRVkhmjGQAnMHn0dFYK7koKy/tVnn71US4pUsauEYMA==",
+      "version": "14.27.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.27.0.tgz",
+      "integrity": "sha512-hG0J9wzolV+DMAKOvK2NKltTdla3SdXG90tq4M80vleXx3YJnqqh/V0O1A9vnYW6GSuwXMScsUkz/B9zMDwAcg==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#87df3ed9149d0ff3f2afac66d701e15c0994a792",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#8da9e218fc7e35afe8ad748cd7e0d7eddccec54d",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -667,18 +667,18 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.15.tgz",
-      "integrity": "sha512-YBkp2VfS9VTRMPNL2PA6PMESmxV1JEVoAr5iBlZnB5JG3KUrWzNCB3yNNkRa2FZkqClaBgfNYCp8PgpYmpjkZw==",
+      "version": "7.0.16",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.16.tgz",
+      "integrity": "sha512-XHhPmHxphLi+LGbH0G/O7dmUH9V65OY20R7vH8gETHsp5AZCjBk9l8sqmRKLaGOxnETU7XNSDUPtewAy/K6jbA==",
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.15.tgz",
-      "integrity": "sha512-c84d1wOROTR7prEN9NaYWBDmXdpZMEQ4VYARkIW4Q2r4PFURu0wP1OL/ancR9eD1bKF4p7LP5ktvkP/t5ZhiEg==",
+      "version": "7.0.16",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.0.16.tgz",
+      "integrity": "sha512-ZAAIaD4KpdU6l8A0Sf0FI9mD2RZSW41cEu4DQD/i9EMZTR3txaWyWecQpTSJF62tI9/rc9+vdtopWFmdC9XMjA==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.15"
+        "tldts-core": "^7.0.16"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.19.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.3.1",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.28.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.29.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1758095627"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1211484160461076/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run