### PR TITLE
Update content scope scripts to version 11.30.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -4052,18 +4052,19 @@
       if (this.getFeatureSettingEnabled("enumerateDevices")) {
         this.deviceEnumerationFix();
       }
+      if (this.getFeatureSettingEnabled("viewportWidthLegacy", "disabled")) {
+        this.viewportWidthFix();
+      }
     }
     /**
      * Handle user preference updates when merged during initialization.
      * Re-applies viewport fixes if viewport configuration has changed.
+     * Used in the injectName='android-adsjs' instead of 'viewportWidthLegacy' from init.
      * @param {object} _updatedConfig - The configuration with merged user preferences
      */
     onUserPreferencesMerged(_updatedConfig) {
       if (this.getFeatureSettingEnabled("viewportWidth")) {
-        if (!this._viewportWidthFixApplied) {
-          this.viewportWidthFix();
-          this._viewportWidthFixApplied = true;
-        }
+        this.viewportWidthFix();
       }
     }
     /** Shim Web Share API in Android WebView */
@@ -4526,6 +4527,10 @@
       };
     }
     viewportWidthFix() {
+      if (this._viewportWidthFixApplied) {
+        return;
+      }
+      this._viewportWidthFixApplied = true;
       if (document.readyState === "loading") {
         document.addEventListener("DOMContentLoaded", () => this.viewportWidthFixInner());
       } else {

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -6792,18 +6792,19 @@
       if (this.getFeatureSettingEnabled("enumerateDevices")) {
         this.deviceEnumerationFix();
       }
+      if (this.getFeatureSettingEnabled("viewportWidthLegacy", "disabled")) {
+        this.viewportWidthFix();
+      }
     }
     /**
      * Handle user preference updates when merged during initialization.
      * Re-applies viewport fixes if viewport configuration has changed.
+     * Used in the injectName='android-adsjs' instead of 'viewportWidthLegacy' from init.
      * @param {object} _updatedConfig - The configuration with merged user preferences
      */
     onUserPreferencesMerged(_updatedConfig) {
       if (this.getFeatureSettingEnabled("viewportWidth")) {
-        if (!this._viewportWidthFixApplied) {
-          this.viewportWidthFix();
-          this._viewportWidthFixApplied = true;
-        }
+        this.viewportWidthFix();
       }
     }
     /** Shim Web Share API in Android WebView */
@@ -7266,6 +7267,10 @@
       };
     }
     viewportWidthFix() {
+      if (this._viewportWidthFixApplied) {
+        return;
+      }
+      this._viewportWidthFixApplied = true;
       if (document.readyState === "loading") {
         document.addEventListener("DOMContentLoaded", () => this.viewportWidthFixInner());
       } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.19.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.3.1",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.29.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.30.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1758095627"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#8da9e218fc7e35afe8ad748cd7e0d7eddccec54d",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#82d6731084f953ad52c860d97220bb1bf4cecfcd",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.19.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#18.3.1",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.29.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#11.30.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1758095627"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [x] All tests must pass
- [x] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run