### PR TITLE
Hide keyboard in unfocussed state when Input Screen enabled

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -2633,6 +2633,16 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenUserPressesBackAndGoesToHomeWithInputScreenEnabledThenKeyboardNotShown() {
+        whenever(mockDuckAiFeatureState.showInputScreen).thenReturn(MutableStateFlow(true))
+
+        setupNavigation(isBrowsing = true, canGoBack = false, skipHome = false)
+        testee.onUserPressedBack()
+
+        assertCommandNotIssued<ShowKeyboard>()
+    }
+
+    @Test
     fun whenUserPressesBackOnATabWithASourceTabThenDeleteCurrentAndSelectSource() =
         runTest {
             selectedTabLiveData.value = TabEntity("TAB_ID", "https://example.com", position = 0, sourceTabId = "TAB_ID_SOURCE")

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1429,7 +1429,9 @@ class BrowserTabViewModel @Inject constructor(
             }
             return true
         } else if (!skipHome && !isCustomTab) {
-            command.value = ShowKeyboard
+            if (!duckAiFeatureState.showInputScreen.value) {
+                command.value = ShowKeyboard
+            }
             navigateHome()
             return true
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211370636939092?focus=true

### Description

- Hides the keyboard in the unfocussed state when the Input Screen is enabled.

### Steps to test this PR

_Input Screen enabled_
- [x] Create a new tab and go to a web page
- [x] Go back
- [x] Verify that the keyboard is not shown

_Input Screen disabled_
- [x] Create a new tab and go to a web page
- [x] Go back
- [x] Verify that the keyboard is shown and the omnibar is focussed
