### PR TITLE
Apply lifecycle checks and fixes to addDocumentStartJavaScript

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -215,6 +215,7 @@ import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggesti
 import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion.AutoCompleteUrlSuggestion.AutoCompleteSwitchToTabSuggestion
 import com.duckduckgo.browser.api.autocomplete.AutoCompleteSettings
 import com.duckduckgo.browser.api.brokensite.BrokenSiteContext
+import com.duckduckgo.browser.api.webviewcompat.WebViewCompatWrapper
 import com.duckduckgo.browser.ui.omnibar.OmnibarPosition.BOTTOM
 import com.duckduckgo.browser.ui.omnibar.OmnibarPosition.TOP
 import com.duckduckgo.common.test.CoroutineTestRule
@@ -600,6 +601,8 @@ class BrowserTabViewModelTest {
 
     private var isFullSiteAddressEnabled = true
 
+    private val mockWebViewCompatWrapper: WebViewCompatWrapper = mock()
+
     @Before
     fun before() =
         runTest {
@@ -823,6 +826,7 @@ class BrowserTabViewModelTest {
                     nonHttpAppLinkChecker = nonHttpAppLinkChecker,
                     externalIntentProcessingState = mockExternalIntentProcessingState,
                     vpnMenuStateProvider = mockVpnMenuStateProvider,
+                    webViewCompatWrapper = mockWebViewCompatWrapper,
                 )
 
             testee.loadData("abc", null, false, false)

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -92,9 +92,6 @@ import com.duckduckgo.js.messaging.api.WebViewCompatMessageCallback
 import com.duckduckgo.privacy.config.api.AmpLinks
 import com.duckduckgo.subscriptions.api.Subscriptions
 import com.duckduckgo.user.agent.api.ClientBrandHintProvider
-import java.math.BigInteger
-import java.security.cert.X509Certificate
-import java.security.interfaces.RSAPublicKey
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
@@ -117,11 +114,13 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
+import java.math.BigInteger
+import java.security.cert.X509Certificate
+import java.security.interfaces.RSAPublicKey
 
 private val mockToggle: Toggle = mock()
 
 class BrowserWebViewClientTest {
-
     @get:Rule
     var coroutinesTestRule = CoroutineTestRule()
 
@@ -170,65 +169,68 @@ class BrowserWebViewClientTest {
     private val fakeAddDocumentStartJavaScriptPlugins = FakeAddDocumentStartJavaScriptPluginPoint()
     private val fakeMessagingPlugins = FakeWebMessagingPluginPoint()
     private val fakePostMessageWrapperPlugins = FakePostMessageWrapperPluginPoint()
-    private val mockAndroidFeaturesHeaderPlugin = AndroidFeaturesHeaderPlugin(
-        mockDuckDuckGoUrlDetector,
-        mockCustomHeaderGracePeriodChecker,
-        mockAndroidBrowserConfigFeature,
-        mockFeaturesHeaderProvider,
-        mock(),
-    )
+    private val mockAndroidFeaturesHeaderPlugin =
+        AndroidFeaturesHeaderPlugin(
+            mockDuckDuckGoUrlDetector,
+            mockCustomHeaderGracePeriodChecker,
+            mockAndroidBrowserConfigFeature,
+            mockFeaturesHeaderProvider,
+            mock(),
+        )
     private val mockDuckChat: DuckChat = mock()
 
     @UiThreadTest
     @Before
-    fun setup() = runTest {
-        webView = TestWebView(context)
-        whenever(mockDuckPlayer.observeShouldOpenInNewTab()).thenReturn(openInNewTabFlow)
-        whenever(mockContentScopeExperiments.getActiveExperiments()).thenReturn(listOf(mockToggle))
-        testee = BrowserWebViewClient(
-            webViewHttpAuthStore,
-            trustedCertificateStore,
-            requestRewriter,
-            specialUrlDetector,
-            requestInterceptor,
-            cookieManagerProvider,
-            loginDetector,
-            dosDetector,
-            thirdPartyCookieManager,
-            coroutinesTestRule.testScope,
-            coroutinesTestRule.testDispatcherProvider,
-            browserAutofillConfigurator,
-            ampLinks,
-            printInjector,
-            internalTestUserChecker,
-            adClickManager,
-            autoconsent,
-            pixel,
-            crashLogger,
-            jsPlugins,
-            currentTimeProvider,
-            pageLoadedHandler,
-            pagePaintedHandler,
-            navigationHistory,
-            mediaPlayback,
-            subscriptions,
-            mockDuckPlayer,
-            mockDuckDuckGoUrlDetector,
-            mockUriLoadedManager,
-            mockAndroidFeaturesHeaderPlugin,
-            mockDuckChat,
-            mockContentScopeExperiments,
-            fakeAddDocumentStartJavaScriptPlugins,
-            fakeMessagingPlugins,
-            fakePostMessageWrapperPlugins,
-        )
-        testee.webViewClientListener = listener
-        whenever(webResourceRequest.url).thenReturn(Uri.EMPTY)
-        whenever(cookieManagerProvider.get()).thenReturn(cookieManager)
-        whenever(currentTimeProvider.elapsedRealtime()).thenReturn(0)
-        whenever(webViewVersionProvider.getMajorVersion()).thenReturn("1")
-        whenever(deviceInfo.appVersion).thenReturn("1")
-    }
+    fun setup() =
+        runTest {
+            webView = TestWebView(context)
+            whenever(mockDuckPlayer.observeShouldOpenInNewTab()).thenReturn(openInNewTabFlow)
+            whenever(mockContentScopeExperiments.getActiveExperiments()).thenReturn(listOf(mockToggle))
+            testee =
+                BrowserWebViewClient(
+                    webViewHttpAuthStore,
+                    trustedCertificateStore,
+                    requestRewriter,
+                    specialUrlDetector,
+                    requestInterceptor,
+                    cookieManagerProvider,
+                    loginDetector,
+                    dosDetector,
+                    thirdPartyCookieManager,
+                    coroutinesTestRule.testScope,
+                    coroutinesTestRule.testDispatcherProvider,
+                    browserAutofillConfigurator,
+                    ampLinks,
+                    printInjector,
+                    internalTestUserChecker,
+                    adClickManager,
+                    autoconsent,
+                    pixel,
+                    crashLogger,
+                    jsPlugins,
+                    currentTimeProvider,
+                    pageLoadedHandler,
+                    pagePaintedHandler,
+                    navigationHistory,
+                    mediaPlayback,
+                    subscriptions,
+                    mockDuckPlayer,
+                    mockDuckDuckGoUrlDetector,
+                    mockUriLoadedManager,
+                    mockAndroidFeaturesHeaderPlugin,
+                    mockDuckChat,
+                    mockContentScopeExperiments,
+                    fakeAddDocumentStartJavaScriptPlugins,
+                    fakeMessagingPlugins,
+                    fakePostMessageWrapperPlugins,
+                )
+            testee.webViewClientListener = listener
+            whenever(webResourceRequest.url).thenReturn(Uri.EMPTY)
+            whenever(cookieManagerProvider.get()).thenReturn(cookieManager)
+            whenever(currentTimeProvider.elapsedRealtime()).thenReturn(0)
+            whenever(webViewVersionProvider.getMajorVersion()).thenReturn("1")
+            whenever(deviceInfo.appVersion).thenReturn("1")
+        }
 
     @UiThreadTest
     @Test
@@ -239,10 +241,11 @@ class BrowserWebViewClientTest {
 
     @UiThreadTest
     @Test
-    fun whenOnPageStartedCalledThenListenerNotified() = runTest {
-        testee.onPageStarted(webView, EXAMPLE_URL, null)
-        verify(listener).pageStarted(any(), eq(listOf(mockToggle)))
-    }
+    fun whenOnPageStartedCalledThenListenerNotified() =
+        runTest {
+            testee.onPageStarted(webView, EXAMPLE_URL, null)
+            verify(listener).pageStarted(any(), eq(listOf(mockToggle)))
+        }
 
     @UiThreadTest
     @Test
@@ -299,10 +302,11 @@ class BrowserWebViewClientTest {
 
     @UiThreadTest
     @Test
-    fun whenOnPageStartedCalledThenProcessUriForThirdPartyCookiesCalled() = runTest {
-        testee.onPageStarted(webView, EXAMPLE_URL, null)
-        verify(thirdPartyCookieManager).processUriForThirdPartyCookies(webView, EXAMPLE_URL.toUri())
-    }
+    fun whenOnPageStartedCalledThenProcessUriForThirdPartyCookiesCalled() =
+        runTest {
+            testee.onPageStarted(webView, EXAMPLE_URL, null)
+            verify(thirdPartyCookieManager).processUriForThirdPartyCookies(webView, EXAMPLE_URL.toUri())
+        }
 
     @UiThreadTest
     @Test
@@ -372,25 +376,27 @@ class BrowserWebViewClientTest {
 
     @UiThreadTest
     @Test
-    fun whenDestroyThenRemoveWebMessageListener() = runTest {
-        val mockCallback = mock<WebViewCompatMessageCallback>()
-        val webView = DuckDuckGoWebView(context)
-        testee.configureWebView(webView, mockCallback)
-        assertTrue(fakeMessagingPlugins.plugin.registered)
-        testee.destroy(webView)
-        assertFalse(fakeMessagingPlugins.plugin.registered)
-    }
+    fun whenDestroyThenRemoveWebMessageListener() =
+        runTest {
+            val mockCallback = mock<WebViewCompatMessageCallback>()
+            val webView = DuckDuckGoWebView(context)
+            testee.configureWebView(webView, mockCallback)
+            assertTrue(fakeMessagingPlugins.plugin.registered)
+            testee.destroy(webView)
+            assertFalse(fakeMessagingPlugins.plugin.registered)
+        }
 
     @Test
-    fun whenPostMessageThenCallPostContentScopeMessage() = runTest {
-        val data = SubscriptionEventData("feature", "method", JSONObject())
+    fun whenPostMessageThenCallPostContentScopeMessage() =
+        runTest {
+            val data = SubscriptionEventData("feature", "method", JSONObject())
 
-        assertFalse(fakePostMessageWrapperPlugins.plugin.postMessageCalled)
+            assertFalse(fakePostMessageWrapperPlugins.plugin.postMessageCalled)
 
-        testee.postContentScopeMessage(data, webView)
+            testee.postContentScopeMessage(data, webView)
 
-        assertTrue(fakePostMessageWrapperPlugins.plugin.postMessageCalled)
-    }
+            assertTrue(fakePostMessageWrapperPlugins.plugin.postMessageCalled)
+        }
 
     @UiThreadTest
     @Test
@@ -521,63 +527,66 @@ class BrowserWebViewClientTest {
 
     @UiThreadTest
     @Test
-    fun whenShouldOverrideWithShouldNavigateToDuckPlayerSetOriginToSerpAuto() = runTest {
-        val urlType = SpecialUrlDetector.UrlType.ShouldLaunchDuckPlayerLink("duck://player/1234".toUri())
-        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
-        whenever(webResourceRequest.isForMainFrame).thenReturn(true)
-        whenever(webResourceRequest.isRedirect).thenReturn(false)
-        whenever(webResourceRequest.url).thenReturn("www.youtube.com/watch?v=1234".toUri())
-        whenever(mockDuckDuckGoUrlDetector.isDuckDuckGoUrl(any())).thenReturn(true)
-        val mockClientProvider: ClientBrandHintProvider = mock()
-        whenever(mockClientProvider.shouldChangeBranding(any())).thenReturn(false)
-        testee.clientProvider = mockClientProvider
-        doNothing().whenever(listener).willOverrideUrl(any())
-        val mockWebView = getImmediatelyInvokedMockWebView()
-        whenever(mockWebView.url).thenReturn("www.duckduckgo.com")
-        openInNewTabFlow.emit(Off)
+    fun whenShouldOverrideWithShouldNavigateToDuckPlayerSetOriginToSerpAuto() =
+        runTest {
+            val urlType = SpecialUrlDetector.UrlType.ShouldLaunchDuckPlayerLink("duck://player/1234".toUri())
+            whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
+            whenever(webResourceRequest.isForMainFrame).thenReturn(true)
+            whenever(webResourceRequest.isRedirect).thenReturn(false)
+            whenever(webResourceRequest.url).thenReturn("www.youtube.com/watch?v=1234".toUri())
+            whenever(mockDuckDuckGoUrlDetector.isDuckDuckGoUrl(any())).thenReturn(true)
+            val mockClientProvider: ClientBrandHintProvider = mock()
+            whenever(mockClientProvider.shouldChangeBranding(any())).thenReturn(false)
+            testee.clientProvider = mockClientProvider
+            doNothing().whenever(listener).willOverrideUrl(any())
+            val mockWebView = getImmediatelyInvokedMockWebView()
+            whenever(mockWebView.url).thenReturn("www.duckduckgo.com")
+            openInNewTabFlow.emit(Off)
 
-        assertFalse(testee.shouldOverrideUrlLoading(mockWebView, webResourceRequest))
-        verify(mockDuckPlayer).setDuckPlayerOrigin(SERP_AUTO)
-    }
+            assertFalse(testee.shouldOverrideUrlLoading(mockWebView, webResourceRequest))
+            verify(mockDuckPlayer).setDuckPlayerOrigin(SERP_AUTO)
+        }
 
     @UiThreadTest
     @Test
-    fun whenShouldOverrideWithShouldNavigateToDuckPlayerButNotMainFrameDoNothing() = runTest {
-        val urlType = SpecialUrlDetector.UrlType.ShouldLaunchDuckPlayerLink("duck://player/1234".toUri())
-        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
-        whenever(webResourceRequest.isForMainFrame).thenReturn(false)
-        whenever(webResourceRequest.isRedirect).thenReturn(false)
-        whenever(webResourceRequest.url).thenReturn("www.youtube.com/watch?v=1234".toUri())
-        whenever(mockDuckDuckGoUrlDetector.isDuckDuckGoUrl(any())).thenReturn(true)
-        val mockClientProvider: ClientBrandHintProvider = mock()
-        whenever(mockClientProvider.shouldChangeBranding(any())).thenReturn(false)
-        testee.clientProvider = mockClientProvider
-        doNothing().whenever(listener).willOverrideUrl(any())
-        val mockWebView = getImmediatelyInvokedMockWebView()
-        whenever(mockWebView.url).thenReturn("www.duckduckgo.com")
-        openInNewTabFlow.emit(Off)
+    fun whenShouldOverrideWithShouldNavigateToDuckPlayerButNotMainFrameDoNothing() =
+        runTest {
+            val urlType = SpecialUrlDetector.UrlType.ShouldLaunchDuckPlayerLink("duck://player/1234".toUri())
+            whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
+            whenever(webResourceRequest.isForMainFrame).thenReturn(false)
+            whenever(webResourceRequest.isRedirect).thenReturn(false)
+            whenever(webResourceRequest.url).thenReturn("www.youtube.com/watch?v=1234".toUri())
+            whenever(mockDuckDuckGoUrlDetector.isDuckDuckGoUrl(any())).thenReturn(true)
+            val mockClientProvider: ClientBrandHintProvider = mock()
+            whenever(mockClientProvider.shouldChangeBranding(any())).thenReturn(false)
+            testee.clientProvider = mockClientProvider
+            doNothing().whenever(listener).willOverrideUrl(any())
+            val mockWebView = getImmediatelyInvokedMockWebView()
+            whenever(mockWebView.url).thenReturn("www.duckduckgo.com")
+            openInNewTabFlow.emit(Off)
 
-        assertFalse(testee.shouldOverrideUrlLoading(mockWebView, webResourceRequest))
-    }
+            assertFalse(testee.shouldOverrideUrlLoading(mockWebView, webResourceRequest))
+        }
 
     @Test
-    fun whenShouldOverrideWithWebThenDoNotAddQueryParam() = runTest {
-        val urlType = Web("www.youtube.com/watch?v=1234")
-        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
-        whenever(webResourceRequest.isForMainFrame).thenReturn(true)
-        whenever(webResourceRequest.isRedirect).thenReturn(false)
-        whenever(webResourceRequest.url).thenReturn("www.youtube.com/watch?v=1234".toUri())
-        whenever(mockDuckDuckGoUrlDetector.isDuckDuckGoUrl(any())).thenReturn(true)
-        val mockClientProvider: ClientBrandHintProvider = mock()
-        whenever(mockClientProvider.shouldChangeBranding(any())).thenReturn(false)
-        testee.clientProvider = mockClientProvider
-        doNothing().whenever(listener).willOverrideUrl(any())
-        val mockWebView = getImmediatelyInvokedMockWebView()
-        whenever(mockWebView.url).thenReturn("www.duckduckgo.com")
-        openInNewTabFlow.emit(Off)
+    fun whenShouldOverrideWithWebThenDoNotAddQueryParam() =
+        runTest {
+            val urlType = Web("www.youtube.com/watch?v=1234")
+            whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
+            whenever(webResourceRequest.isForMainFrame).thenReturn(true)
+            whenever(webResourceRequest.isRedirect).thenReturn(false)
+            whenever(webResourceRequest.url).thenReturn("www.youtube.com/watch?v=1234".toUri())
+            whenever(mockDuckDuckGoUrlDetector.isDuckDuckGoUrl(any())).thenReturn(true)
+            val mockClientProvider: ClientBrandHintProvider = mock()
+            whenever(mockClientProvider.shouldChangeBranding(any())).thenReturn(false)
+            testee.clientProvider = mockClientProvider
+            doNothing().whenever(listener).willOverrideUrl(any())
+            val mockWebView = getImmediatelyInvokedMockWebView()
+            whenever(mockWebView.url).thenReturn("www.duckduckgo.com")
+            openInNewTabFlow.emit(Off)
 
-        assertFalse(testee.shouldOverrideUrlLoading(mockWebView, webResourceRequest))
-    }
+            assertFalse(testee.shouldOverrideUrlLoading(mockWebView, webResourceRequest))
+        }
 
     @UiThreadTest
     @Test
@@ -626,98 +635,104 @@ class BrowserWebViewClientTest {
 
     @UiThreadTest
     @Test
-    fun whenShouldLaunchDuckPlayerThenOpenInNewTabAndReturnTrue() = runTest {
-        openInNewTabFlow.emit(On)
-        val urlType = SpecialUrlDetector.UrlType.ShouldLaunchDuckPlayerLink(EXAMPLE_URL.toUri())
-        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
-        whenever(webResourceRequest.url).thenReturn(EXAMPLE_URL.toUri())
-        whenever(webResourceRequest.isForMainFrame).thenReturn(true)
-        whenever(mockDuckPlayer.shouldOpenDuckPlayerInNewTab()).thenReturn(On)
-        testee.clientProvider = mock()
+    fun whenShouldLaunchDuckPlayerThenOpenInNewTabAndReturnTrue() =
+        runTest {
+            openInNewTabFlow.emit(On)
+            val urlType = SpecialUrlDetector.UrlType.ShouldLaunchDuckPlayerLink(EXAMPLE_URL.toUri())
+            whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
+            whenever(webResourceRequest.url).thenReturn(EXAMPLE_URL.toUri())
+            whenever(webResourceRequest.isForMainFrame).thenReturn(true)
+            whenever(mockDuckPlayer.shouldOpenDuckPlayerInNewTab()).thenReturn(On)
+            testee.clientProvider = mock()
 
-        assertTrue(testee.shouldOverrideUrlLoading(webView, webResourceRequest))
-        verify(listener).onShouldOverride()
-        verify(listener).openLinkInNewTab(EXAMPLE_URL.toUri())
-    }
-
-    @UiThreadTest
-    @Test
-    fun whenShouldLaunchDuckPlayerInNewTabButSameUrlThenDoNothing() = runTest {
-        openInNewTabFlow.emit(On)
-        val urlType = SpecialUrlDetector.UrlType.ShouldLaunchDuckPlayerLink(EXAMPLE_URL.toUri())
-        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
-        whenever(webResourceRequest.url).thenReturn(EXAMPLE_URL.toUri())
-        whenever(webResourceRequest.isForMainFrame).thenReturn(true)
-        whenever(mockDuckPlayer.shouldOpenDuckPlayerInNewTab()).thenReturn(On)
-        testee.clientProvider = mock()
-        (webView as TestWebView).webViewUrl = EXAMPLE_URL
-
-        assertFalse(testee.shouldOverrideUrlLoading(webView, webResourceRequest))
-        verify(listener, never()).openLinkInNewTab(EXAMPLE_URL.toUri())
-    }
+            assertTrue(testee.shouldOverrideUrlLoading(webView, webResourceRequest))
+            verify(listener).onShouldOverride()
+            verify(listener).openLinkInNewTab(EXAMPLE_URL.toUri())
+        }
 
     @UiThreadTest
     @Test
-    fun whenShouldLaunchDuckPlayerButNotMainframeThenDoNothing() = runTest {
-        openInNewTabFlow.emit(On)
-        val urlType = SpecialUrlDetector.UrlType.ShouldLaunchDuckPlayerLink(EXAMPLE_URL.toUri())
-        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
-        whenever(webResourceRequest.url).thenReturn(EXAMPLE_URL.toUri())
-        whenever(webResourceRequest.isForMainFrame).thenReturn(false)
-        whenever(mockDuckPlayer.shouldOpenDuckPlayerInNewTab()).thenReturn(On)
+    fun whenShouldLaunchDuckPlayerInNewTabButSameUrlThenDoNothing() =
+        runTest {
+            openInNewTabFlow.emit(On)
+            val urlType = SpecialUrlDetector.UrlType.ShouldLaunchDuckPlayerLink(EXAMPLE_URL.toUri())
+            whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
+            whenever(webResourceRequest.url).thenReturn(EXAMPLE_URL.toUri())
+            whenever(webResourceRequest.isForMainFrame).thenReturn(true)
+            whenever(mockDuckPlayer.shouldOpenDuckPlayerInNewTab()).thenReturn(On)
+            testee.clientProvider = mock()
+            (webView as TestWebView).webViewUrl = EXAMPLE_URL
 
-        assertFalse(testee.shouldOverrideUrlLoading(webView, webResourceRequest))
-        verify(listener).onShouldOverride()
-        verify(listener, never()).openLinkInNewTab(EXAMPLE_URL.toUri())
-    }
-
-    @UiThreadTest
-    @Test
-    fun whenShouldLaunchDuckPlayerButNotOpenInNewTabThenReturnFalse() = runTest {
-        openInNewTabFlow.emit(Off)
-        val urlType = SpecialUrlDetector.UrlType.ShouldLaunchDuckPlayerLink(EXAMPLE_URL.toUri())
-        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
-        whenever(webResourceRequest.url).thenReturn(EXAMPLE_URL.toUri())
-
-        assertFalse(testee.shouldOverrideUrlLoading(webView, webResourceRequest))
-        verify(listener).onShouldOverride()
-        verify(listener, never()).openLinkInNewTab(EXAMPLE_URL.toUri())
-    }
+            assertFalse(testee.shouldOverrideUrlLoading(webView, webResourceRequest))
+            verify(listener, never()).openLinkInNewTab(EXAMPLE_URL.toUri())
+        }
 
     @UiThreadTest
     @Test
-    fun whenShouldLaunchDuckPlayerButOpenInNewTabUnavailableThenReturnFalse() = runTest {
-        openInNewTabFlow.emit(Unavailable)
-        val urlType = SpecialUrlDetector.UrlType.ShouldLaunchDuckPlayerLink(EXAMPLE_URL.toUri())
-        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
-        whenever(webResourceRequest.url).thenReturn(EXAMPLE_URL.toUri())
+    fun whenShouldLaunchDuckPlayerButNotMainframeThenDoNothing() =
+        runTest {
+            openInNewTabFlow.emit(On)
+            val urlType = SpecialUrlDetector.UrlType.ShouldLaunchDuckPlayerLink(EXAMPLE_URL.toUri())
+            whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
+            whenever(webResourceRequest.url).thenReturn(EXAMPLE_URL.toUri())
+            whenever(webResourceRequest.isForMainFrame).thenReturn(false)
+            whenever(mockDuckPlayer.shouldOpenDuckPlayerInNewTab()).thenReturn(On)
 
-        assertFalse(testee.shouldOverrideUrlLoading(webView, webResourceRequest))
-        verify(listener).onShouldOverride()
-        verify(listener, never()).openLinkInNewTab(EXAMPLE_URL.toUri())
-    }
+            assertFalse(testee.shouldOverrideUrlLoading(webView, webResourceRequest))
+            verify(listener).onShouldOverride()
+            verify(listener, never()).openLinkInNewTab(EXAMPLE_URL.toUri())
+        }
 
     @UiThreadTest
     @Test
-    fun whenShouldOverrideWithShouldNavigateToDuckPlayerFromSerpAndOpenInNewTabThenSetOriginToSerpAuto() = runTest {
-        val urlType = SpecialUrlDetector.UrlType.ShouldLaunchDuckPlayerLink("duck://player/1234".toUri())
-        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
-        whenever(webResourceRequest.isForMainFrame).thenReturn(true)
-        whenever(webResourceRequest.isRedirect).thenReturn(false)
-        whenever(webResourceRequest.url).thenReturn("www.youtube.com/watch?v=1234".toUri())
-        whenever(mockDuckDuckGoUrlDetector.isDuckDuckGoUrl(any())).thenReturn(true)
-        val mockClientProvider: ClientBrandHintProvider = mock()
-        whenever(mockClientProvider.shouldChangeBranding(any())).thenReturn(false)
-        whenever(mockDuckPlayer.shouldOpenDuckPlayerInNewTab()).thenReturn(On)
-        testee.clientProvider = mockClientProvider
-        doNothing().whenever(listener).willOverrideUrl(any())
-        val mockWebView = getImmediatelyInvokedMockWebView()
-        whenever(mockWebView.url).thenReturn("www.duckduckgo.com")
-        openInNewTabFlow.emit(Off)
+    fun whenShouldLaunchDuckPlayerButNotOpenInNewTabThenReturnFalse() =
+        runTest {
+            openInNewTabFlow.emit(Off)
+            val urlType = SpecialUrlDetector.UrlType.ShouldLaunchDuckPlayerLink(EXAMPLE_URL.toUri())
+            whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
+            whenever(webResourceRequest.url).thenReturn(EXAMPLE_URL.toUri())
 
-        assertFalse(testee.shouldOverrideUrlLoading(mockWebView, webResourceRequest))
-        verify(mockDuckPlayer).setDuckPlayerOrigin(SERP_AUTO)
-    }
+            assertFalse(testee.shouldOverrideUrlLoading(webView, webResourceRequest))
+            verify(listener).onShouldOverride()
+            verify(listener, never()).openLinkInNewTab(EXAMPLE_URL.toUri())
+        }
+
+    @UiThreadTest
+    @Test
+    fun whenShouldLaunchDuckPlayerButOpenInNewTabUnavailableThenReturnFalse() =
+        runTest {
+            openInNewTabFlow.emit(Unavailable)
+            val urlType = SpecialUrlDetector.UrlType.ShouldLaunchDuckPlayerLink(EXAMPLE_URL.toUri())
+            whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
+            whenever(webResourceRequest.url).thenReturn(EXAMPLE_URL.toUri())
+
+            assertFalse(testee.shouldOverrideUrlLoading(webView, webResourceRequest))
+            verify(listener).onShouldOverride()
+            verify(listener, never()).openLinkInNewTab(EXAMPLE_URL.toUri())
+        }
+
+    @UiThreadTest
+    @Test
+    fun whenShouldOverrideWithShouldNavigateToDuckPlayerFromSerpAndOpenInNewTabThenSetOriginToSerpAuto() =
+        runTest {
+            val urlType = SpecialUrlDetector.UrlType.ShouldLaunchDuckPlayerLink("duck://player/1234".toUri())
+            whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
+            whenever(webResourceRequest.isForMainFrame).thenReturn(true)
+            whenever(webResourceRequest.isRedirect).thenReturn(false)
+            whenever(webResourceRequest.url).thenReturn("www.youtube.com/watch?v=1234".toUri())
+            whenever(mockDuckDuckGoUrlDetector.isDuckDuckGoUrl(any())).thenReturn(true)
+            val mockClientProvider: ClientBrandHintProvider = mock()
+            whenever(mockClientProvider.shouldChangeBranding(any())).thenReturn(false)
+            whenever(mockDuckPlayer.shouldOpenDuckPlayerInNewTab()).thenReturn(On)
+            testee.clientProvider = mockClientProvider
+            doNothing().whenever(listener).willOverrideUrl(any())
+            val mockWebView = getImmediatelyInvokedMockWebView()
+            whenever(mockWebView.url).thenReturn("www.duckduckgo.com")
+            openInNewTabFlow.emit(Off)
+
+            assertFalse(testee.shouldOverrideUrlLoading(mockWebView, webResourceRequest))
+            verify(mockDuckPlayer).setDuckPlayerOrigin(SERP_AUTO)
+        }
 
     @UiThreadTest
     @Test
@@ -1229,24 +1244,20 @@ class BrowserWebViewClientTest {
         mockUriLoadedManager.sendUriLoadedPixel()
     }
 
-    private class TestWebView(context: Context) : WebView(context) {
-
+    private class TestWebView(
+        context: Context,
+    ) : WebView(context) {
         var webViewUrl: String? = null
 
-        override fun getUrl(): String? {
-            return webViewUrl
-        }
+        override fun getUrl(): String? = webViewUrl
 
-        override fun getOriginalUrl(): String {
-            return EXAMPLE_URL
-        }
+        override fun getOriginalUrl(): String = EXAMPLE_URL
     }
 
     private class FakePluginPoint : PluginPoint<JsInjectorPlugin> {
         val plugin = FakeJsInjectorPlugin()
-        override fun getPlugins(): Collection<JsInjectorPlugin> {
-            return listOf(plugin)
-        }
+
+        override fun getPlugins(): Collection<JsInjectorPlugin> = listOf(plugin)
     }
 
     private class FakeJsInjectorPlugin : JsInjectorPlugin {
@@ -1272,7 +1283,6 @@ class BrowserWebViewClientTest {
     }
 
     private class TestBackForwardList : WebBackForwardList() {
-
         private val fakeHistory: MutableList<WebHistoryItem> = mutableListOf()
         private var fakeCurrentIndex = -1
 
@@ -1295,7 +1305,6 @@ class BrowserWebViewClientTest {
     private class TestHistoryItem(
         private val url: String,
     ) : WebHistoryItem() {
-
         override fun getUrl(): String = url
 
         override fun getOriginalUrl(): String = url
@@ -1308,19 +1317,22 @@ class BrowserWebViewClientTest {
     }
 
     fun aHandler(): SslErrorHandler {
-        val handler = mock<SslErrorHandler>().apply {
-        }
+        val handler =
+            mock<SslErrorHandler>().apply {
+            }
         return handler
     }
 
     private fun aRSASslCertificate(): SslCertificate {
-        val certificate = mock<X509Certificate>().apply {
-            val key = mock<RSAPublicKey>().apply {
-                whenever(this.algorithm).thenReturn("rsa")
-                whenever(this.modulus).thenReturn(BigInteger("1"))
+        val certificate =
+            mock<X509Certificate>().apply {
+                val key =
+                    mock<RSAPublicKey>().apply {
+                        whenever(this.algorithm).thenReturn("rsa")
+                        whenever(this.modulus).thenReturn(BigInteger("1"))
+                    }
+                whenever(this.publicKey).thenReturn(key)
             }
-            whenever(this.publicKey).thenReturn(key)
-        }
         return mock<SslCertificate>().apply {
             whenever(x509Certificate).thenReturn(certificate)
         }
@@ -1331,19 +1343,15 @@ class BrowserWebViewClientTest {
     }
 
     class FakeAddDocumentStartJavaScriptPlugin : AddDocumentStartJavaScriptPlugin {
-
         var countInitted = 0
             private set
 
-        override fun addDocumentStartJavaScript(
-            webView: WebView,
-        ) {
+        override fun addDocumentStartJavaScript(webView: WebView) {
             countInitted++
         }
     }
 
     class FakeAddDocumentStartJavaScriptPluginPoint : PluginPoint<AddDocumentStartJavaScriptPlugin> {
-
         val plugin = FakeAddDocumentStartJavaScriptPlugin()
 
         override fun getPlugins() = listOf(plugin)
@@ -1364,7 +1372,10 @@ class BrowserWebViewClientTest {
             registered = true
         }
 
-        override fun postMessage(subscriptionEventData: SubscriptionEventData) {
+        override fun postMessage(
+            webView: WebView,
+            subscriptionEventData: SubscriptionEventData,
+        ) {
         }
 
         override val context: String
@@ -1374,16 +1385,17 @@ class BrowserWebViewClientTest {
     class FakeWebMessagingPluginPoint : PluginPoint<WebMessagingPlugin> {
         val plugin = FakeWebMessagingPlugin()
 
-        override fun getPlugins(): Collection<WebMessagingPlugin> {
-            return listOf(plugin)
-        }
+        override fun getPlugins(): Collection<WebMessagingPlugin> = listOf(plugin)
     }
 
     class FakePostMessageWrapperPlugin : PostMessageWrapperPlugin {
         var postMessageCalled = false
             private set
 
-        override fun postMessage(message: SubscriptionEventData, webView: WebView) {
+        override fun postMessage(
+            message: SubscriptionEventData,
+            webView: WebView,
+        ) {
             postMessageCalled = true
         }
 
@@ -1394,8 +1406,6 @@ class BrowserWebViewClientTest {
     class FakePostMessageWrapperPluginPoint : PluginPoint<PostMessageWrapperPlugin> {
         val plugin = FakePostMessageWrapperPlugin()
 
-        override fun getPlugins(): Collection<PostMessageWrapperPlugin> {
-            return listOf(plugin)
-        }
+        override fun getPlugins(): Collection<PostMessageWrapperPlugin> = listOf(plugin)
     }
 }

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -387,18 +387,6 @@ class BrowserWebViewClientTest {
             assertTrue(fakeMessagingPlugins.plugin.registered)
         }
 
-    @UiThreadTest
-    @Test
-    fun whenDestroyThenRemoveWebMessageListener() =
-        runTest {
-            val mockCallback = mock<WebViewCompatMessageCallback>()
-            val webView = DuckDuckGoWebView(context)
-            testee.configureWebView(webView, mockCallback)
-            assertTrue(fakeMessagingPlugins.plugin.registered)
-            testee.destroy(webView)
-            assertFalse(fakeMessagingPlugins.plugin.registered)
-        }
-
     @Test
     fun whenPostMessageThenCallPostContentScopeMessage() =
         runTest {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -898,12 +898,14 @@ class BrowserTabFragment :
             contentScopeScripts.onResponse(it)
         }
 
-    private var currentWebShareReplyCallback: ((JSONObject) -> Unit)? = null
+    private var currentWebShareReplyCallback: (suspend (JSONObject) -> Unit)? = null
 
     private val webViewCompatWebShareLauncher =
         registerForActivityResult(WebViewCompatWebShareChooser()) { result ->
-            currentWebShareReplyCallback?.invoke(result)
-            currentWebShareReplyCallback = null
+            lifecycleScope.launch {
+                currentWebShareReplyCallback?.invoke(result)
+                currentWebShareReplyCallback = null
+            }
         }
 
     // Instantiating a private class that contains an implementation detail of BrowserTabFragment but is separated for tidiness
@@ -1991,19 +1993,29 @@ class BrowserTabFragment :
             is Command.ShowFireproofWebSiteConfirmation -> fireproofWebsiteConfirmation(it.fireproofWebsiteEntity)
             is Command.DeleteFireproofConfirmation -> removeFireproofWebsiteConfirmation(it.fireproofWebsiteEntity)
             is Command.RefreshAndShowPrivacyProtectionEnabledConfirmation -> {
-                webView?.let {
-                    webViewClient.configureWebView(it, null)
+                webView?.let { webView ->
+                    lifecycleScope.launch {
+                        webViewClient.configureWebView(webView, null)
+                        refresh()
+                        privacyProtectionEnabledConfirmation(it.domain)
+                    }
+                } ?: run {
+                    refresh()
+                    privacyProtectionEnabledConfirmation(it.domain)
                 }
-                refresh()
-                privacyProtectionEnabledConfirmation(it.domain)
             }
 
             is Command.RefreshAndShowPrivacyProtectionDisabledConfirmation -> {
-                webView?.let {
-                    webViewClient.configureWebView(it, null)
+                webView?.let { webView ->
+                    lifecycleScope.launch {
+                        webViewClient.configureWebView(webView, null)
+                        refresh()
+                        privacyProtectionDisabledConfirmation(it.domain)
+                    }
+                } ?: run {
+                    refresh()
+                    privacyProtectionDisabledConfirmation(it.domain)
                 }
-                refresh()
-                privacyProtectionDisabledConfirmation(it.domain)
             }
 
             is NavigationCommand.Navigate -> {
@@ -3201,28 +3213,31 @@ class BrowserTabFragment :
                     }
                 },
             )
-            webViewClient.configureWebView(
-                it,
-                object : WebViewCompatMessageCallback {
-                    override fun process(
-                        context: String,
-                        featureName: String,
-                        method: String,
-                        id: String?,
-                        data: JSONObject?,
-                        onResponse: (JSONObject) -> Unit,
-                    ) {
-                        viewModel.webViewCompatProcessJsCallbackMessage(
-                            context = context,
-                            featureName = featureName,
-                            method = method,
-                            id = id,
-                            data = data,
-                            onResponse = onResponse,
-                        )
-                    }
-                },
-            )
+            lifecycleScope.launch {
+                webViewClient.configureWebView(
+                    it,
+                    object : WebViewCompatMessageCallback {
+                        override fun process(
+                            context: String,
+                            featureName: String,
+                            method: String,
+                            id: String?,
+                            data: JSONObject?,
+                            onResponse: suspend (JSONObject) -> Unit,
+                        ) {
+                            viewModel.webViewCompatProcessJsCallbackMessage(
+                                context = context,
+                                featureName = featureName,
+                                method = method,
+                                id = id,
+                                data = data,
+                                onResponse = onResponse,
+                            )
+                        }
+                    },
+                )
+            }
+
             duckPlayerScripts.register(
                 it,
                 object : JsMessageCallback() {
@@ -3254,10 +3269,12 @@ class BrowserTabFragment :
 
     private fun webViewCompatScreenLock(
         data: JsCallbackData,
-        onResponse: (JSONObject) -> Unit,
+        onResponse: suspend (JSONObject) -> Unit,
     ) {
         val returnData = jsOrientationHandler.updateOrientation(data, this)
-        onResponse(returnData.params)
+        lifecycleScope.launch {
+            onResponse(returnData.params)
+        }
     }
 
     private fun screenUnlock() {
@@ -4006,10 +4023,12 @@ class BrowserTabFragment :
         if (::webViewContainer.isInitialized) webViewContainer.removeAllViews()
         webView?.let {
             it.removeSystemAutofillCallback()
-            webViewClient.destroy(it)
-            it.destroy()
-        }
-        webView = null
+            lifecycleScope.launch {
+                webViewClient.destroy(it)
+                it.destroy()
+                webView = null
+            }
+        } ?: run { webView = null }
     }
 
     private fun convertBlobToDataUri(blob: Command.ConvertBlobToDataUri) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -3139,7 +3139,7 @@ class BrowserTabFragment :
 
             it.setDownloadListener { url, _, contentDisposition, mimeType, _ ->
                 lifecycleScope.launch(dispatchers.main()) {
-                    viewModel.requestFileDownload(url, contentDisposition, mimeType, true, isBlobDownloadWebViewFeatureEnabled(it))
+                    viewModel.requestFileDownload(it, url, contentDisposition, mimeType, true, isBlobDownloadWebViewFeatureEnabled(it))
                 }
             }
 
@@ -3361,6 +3361,7 @@ class BrowserTabFragment :
             } else {
                 blobConverterInjector.addJsInterface(webView) { url, mimeType ->
                     viewModel.requestFileDownload(
+                        webView = webView,
                         url = url,
                         contentDisposition = null,
                         mimeType = mimeType,

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1018,9 +1018,9 @@ class BrowserTabFragment :
 
         webViewContainer = binding.webViewContainer
         configureObservers()
+        viewModel.registerWebViewListener(webViewClient, webChromeClient)
         configureWebView()
         configureSwipeRefresh()
-        viewModel.registerWebViewListener(webViewClient, webChromeClient)
         configureAutoComplete()
         configureNewTab()
         initPrivacyProtectionsPopup()
@@ -1993,9 +1993,9 @@ class BrowserTabFragment :
             is Command.ShowFireproofWebSiteConfirmation -> fireproofWebsiteConfirmation(it.fireproofWebsiteEntity)
             is Command.DeleteFireproofConfirmation -> removeFireproofWebsiteConfirmation(it.fireproofWebsiteEntity)
             is Command.RefreshAndShowPrivacyProtectionEnabledConfirmation -> {
-                webView?.let { webView ->
+                webView?.let { safeWebView ->
                     lifecycleScope.launch {
-                        webViewClient.configureWebView(webView, null)
+                        webViewClient.configureWebView(safeWebView, null)
                         refresh()
                         privacyProtectionEnabledConfirmation(it.domain)
                     }
@@ -2006,9 +2006,9 @@ class BrowserTabFragment :
             }
 
             is Command.RefreshAndShowPrivacyProtectionDisabledConfirmation -> {
-                webView?.let { webView ->
+                webView?.let { safeWebView ->
                     lifecycleScope.launch {
-                        webViewClient.configureWebView(webView, null)
+                        webViewClient.configureWebView(safeWebView, null)
                         refresh()
                         privacyProtectionDisabledConfirmation(it.domain)
                     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1999,9 +1999,6 @@ class BrowserTabFragment :
                         refresh()
                         privacyProtectionEnabledConfirmation(it.domain)
                     }
-                } ?: run {
-                    refresh()
-                    privacyProtectionEnabledConfirmation(it.domain)
                 }
             }
 
@@ -2012,9 +2009,6 @@ class BrowserTabFragment :
                         refresh()
                         privacyProtectionDisabledConfirmation(it.domain)
                     }
-                } ?: run {
-                    refresh()
-                    privacyProtectionDisabledConfirmation(it.domain)
                 }
             }
 
@@ -4023,12 +4017,9 @@ class BrowserTabFragment :
         if (::webViewContainer.isInitialized) webViewContainer.removeAllViews()
         webView?.let {
             it.removeSystemAutofillCallback()
-            lifecycleScope.launch {
-                webViewClient.destroy(it)
-                it.destroy()
-                webView = null
-            }
-        } ?: run { webView = null }
+            it.destroy()
+        }
+        webView = null
     }
 
     private fun convertBlobToDataUri(blob: Command.ConvertBlobToDataUri) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -319,6 +319,7 @@ import com.duckduckgo.duckplayer.api.DuckPlayer
 import com.duckduckgo.duckplayer.api.DuckPlayer.DuckPlayerState.ENABLED
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.history.api.NavigationHistory
+import com.duckduckgo.js.messaging.api.AddDocumentStartJavaScriptPlugin
 import com.duckduckgo.js.messaging.api.JsCallbackData
 import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed
 import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed.MALWARE
@@ -484,6 +485,7 @@ class BrowserTabViewModel @Inject constructor(
     private val externalIntentProcessingState: ExternalIntentProcessingState,
     private val vpnMenuStateProvider: VpnMenuStateProvider,
     private val webViewCompatWrapper: WebViewCompatWrapper,
+    private val addDocumentStartJavascriptPlugins: PluginPoint<AddDocumentStartJavaScriptPlugin>,
 ) : ViewModel(),
     WebViewClientListener,
     EditSavedSiteListener,
@@ -4193,6 +4195,16 @@ class BrowserTabViewModel @Inject constructor(
         val cta = currentCtaViewState().cta
         if (cta is OnboardingDaxDialogCta) {
             onDismissOnboardingDaxDialog(cta)
+        }
+    }
+
+    override fun addDocumentStartJavaScript(webView: WebView) {
+        viewModelScope.launch {
+            addDocumentStartJavascriptPlugins.getPlugins().forEach {
+                it.addDocumentStartJavaScript(
+                    webView,
+                )
+            }
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -3714,7 +3714,7 @@ class BrowserTabViewModel @Inject constructor(
         method: String,
         id: String?,
         data: JSONObject?,
-        onResponse: (JSONObject) -> Unit,
+        onResponse: suspend (JSONObject) -> Unit,
     ) {
         processGlobalMessages(
             featureName = featureName,
@@ -3741,7 +3741,7 @@ class BrowserTabViewModel @Inject constructor(
         method: String,
         id: String?,
         data: JSONObject?,
-        onResponse: (JSONObject) -> Unit,
+        onResponse: suspend (JSONObject) -> Unit,
     ) {
         when (method) {
             "addDebugFlag" -> {
@@ -3759,7 +3759,7 @@ class BrowserTabViewModel @Inject constructor(
         method: String,
         id: String?,
         data: JSONObject?,
-        onResponse: (JSONObject) -> Unit,
+        onResponse: suspend (JSONObject) -> Unit,
     ) {
         when (featureName) {
             "webCompat" -> {
@@ -3800,7 +3800,9 @@ class BrowserTabViewModel @Inject constructor(
                                     "forcedZoomEnabled" to (accessibilityViewState.value?.forceZoom ?: false),
                                 ),
                             )
-                        onResponse(response)
+                        viewModelScope.launch {
+                            onResponse(response)
+                        }
                     }
                 }
         }
@@ -3901,7 +3903,7 @@ class BrowserTabViewModel @Inject constructor(
         method: String,
         id: String,
         data: JSONObject,
-        onResponse: (JSONObject) -> Unit,
+        onResponse: suspend (JSONObject) -> Unit,
     ) {
         viewModelScope.launch(dispatchers.main()) {
             command.value = WebViewCompatWebShareRequest(JsCallbackData(data, featureName, method, id), onResponse)
@@ -3934,7 +3936,7 @@ class BrowserTabViewModel @Inject constructor(
         method: String,
         id: String,
         data: JSONObject,
-        onResponse: (JSONObject) -> Unit,
+        onResponse: suspend (JSONObject) -> Unit,
     ) {
         viewModelScope.launch(dispatchers.io()) {
             val response =
@@ -3971,9 +3973,9 @@ class BrowserTabViewModel @Inject constructor(
         method: String,
         id: String,
         data: JSONObject,
-        onResponse: (JSONObject) -> Unit,
+        onResponse: suspend (JSONObject) -> Unit,
     ) {
-        viewModelScope.launch(dispatchers.main()) {
+        viewModelScope.launch(dispatchers.io()) {
             if (androidBrowserConfig.screenLock().isEnabled()) {
                 withContext(dispatchers.main()) {
                     command.value = WebViewCompatScreenLock(JsCallbackData(data, featureName, method, id), onResponse)
@@ -3983,7 +3985,7 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     private fun screenUnlock() {
-        viewModelScope.launch(dispatchers.main()) {
+        viewModelScope.launch(dispatchers.io()) {
             if (androidBrowserConfig.screenLock().isEnabled()) {
                 withContext(dispatchers.main()) {
                     command.value = ScreenUnlock

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -3255,7 +3255,7 @@ class BrowserTabViewModel @Inject constructor(
 
     @SuppressLint("RequiresFeature", "PostMessageUsage") // it's already checked in isBlobDownloadWebViewFeatureEnabled
     private fun postMessageToConvertBlobToDataUri(webView: WebView, url: String) {
-        appCoroutineScope.launch(dispatchers.main()) {
+        viewModelScope.launch(dispatchers.main()) {
             // main because postMessage is not always safe in another thread
             for ((key, proxies) in fixedReplyProxyMap) {
                 if (sameOrigin(url.removePrefix("blob:"), key)) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -766,12 +766,6 @@ class BrowserWebViewClient @Inject constructor(
         requestInterceptor.addExemptedMaliciousSite(url, feed)
     }
 
-    suspend fun destroy(webView: DuckDuckGoWebView) {
-        webMessagingPlugins.getPlugins().forEach { plugin ->
-            plugin.unregister(webView)
-        }
-    }
-
     fun postContentScopeMessage(
         eventData: SubscriptionEventData,
         webView: WebView,

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -88,13 +88,13 @@ import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed
 import com.duckduckgo.privacy.config.api.AmpLinks
 import com.duckduckgo.subscriptions.api.Subscriptions
 import com.duckduckgo.user.agent.api.ClientBrandHintProvider
-import java.net.URI
-import javax.inject.Inject
 import kotlinx.coroutines.*
 import logcat.LogPriority.INFO
 import logcat.LogPriority.VERBOSE
 import logcat.LogPriority.WARN
 import logcat.logcat
+import java.net.URI
+import javax.inject.Inject
 
 private const val ABOUT_BLANK = "about:blank"
 
@@ -135,7 +135,6 @@ class BrowserWebViewClient @Inject constructor(
     private val webMessagingPlugins: PluginPoint<WebMessagingPlugin>,
     private val postMessageWrapperPlugins: PluginPoint<PostMessageWrapperPlugin>,
 ) : WebViewClient() {
-
     var webViewClientListener: WebViewClientListener? = null
     var clientProvider: ClientBrandHintProvider? = null
     private var lastPageStarted: String? = null
@@ -396,7 +395,10 @@ class BrowserWebViewClient @Inject constructor(
     }
 
     @UiThread
-    override fun onPageCommitVisible(webView: WebView, url: String) {
+    override fun onPageCommitVisible(
+        webView: WebView,
+        url: String,
+    ) {
         logcat(VERBOSE) { "onPageCommitVisible webViewUrl: ${webView.url} URL: $url progress: ${webView.progress}" }
         // Show only when the commit matches the tab state
         if (webView.url == url) {
@@ -471,7 +473,10 @@ class BrowserWebViewClient @Inject constructor(
         webView.settings.mediaPlaybackRequiresUserGesture = mediaPlayback.doesMediaPlaybackRequireUserGestureForUrl(url)
     }
 
-    fun configureWebView(webView: DuckDuckGoWebView, callback: WebViewCompatMessageCallback?) {
+    suspend fun configureWebView(
+        webView: DuckDuckGoWebView,
+        callback: WebViewCompatMessageCallback?,
+    ) {
         addDocumentStartJavascriptPlugins.getPlugins().forEach { plugin ->
             plugin.addDocumentStartJavaScript(webView)
         }
@@ -484,7 +489,10 @@ class BrowserWebViewClient @Inject constructor(
     }
 
     @UiThread
-    override fun onPageFinished(webView: WebView, url: String?) {
+    override fun onPageFinished(
+        webView: WebView,
+        url: String?,
+    ) {
         logcat(VERBOSE) { "onPageFinished webViewUrl: ${webView.url} URL: $url progress: ${webView.progress}" }
 
         // See https://app.asana.com/0/0/1206159443951489/f (WebView limitations)
@@ -496,10 +504,12 @@ class BrowserWebViewClient @Inject constructor(
                     webViewClientListener?.getSite(),
                 )
             }
-            addDocumentStartJavascriptPlugins.getPlugins().forEach {
-                it.addDocumentStartJavaScript(
-                    webView,
-                )
+            appCoroutineScope.launch {
+                addDocumentStartJavascriptPlugins.getPlugins().forEach {
+                    it.addDocumentStartJavaScript(
+                        webView,
+                    )
+                }
             }
 
             url?.let {
@@ -560,8 +570,8 @@ class BrowserWebViewClient @Inject constructor(
     override fun shouldInterceptRequest(
         webView: WebView,
         request: WebResourceRequest,
-    ): WebResourceResponse? {
-        return runBlocking {
+    ): WebResourceResponse? =
+        runBlocking {
             val documentUrl = withContext(dispatcherProvider.main()) { webView.url }
             withContext(dispatcherProvider.main()) {
                 loginDetector.onEvent(WebNavigationEvent.ShouldInterceptRequest(webView, request))
@@ -574,7 +584,6 @@ class BrowserWebViewClient @Inject constructor(
                 webViewClientListener,
             )
         }
-    }
 
     override fun onRenderProcessGone(
         view: WebView?,
@@ -601,9 +610,10 @@ class BrowserWebViewClient @Inject constructor(
         if (handler != null) {
             logcat(VERBOSE) { "onReceivedHttpAuthRequest - useHttpAuthUsernamePassword [${handler.useHttpAuthUsernamePassword()}]" }
             if (handler.useHttpAuthUsernamePassword()) {
-                val credentials = view?.let {
-                    webViewHttpAuthStore.getHttpAuthUsernamePassword(it, host.orEmpty(), realm.orEmpty())
-                }
+                val credentials =
+                    view?.let {
+                        webViewHttpAuthStore.getHttpAuthUsernamePassword(it, host.orEmpty(), realm.orEmpty())
+                    }
 
                 if (credentials != null) {
                     handler.proceed(credentials.username, credentials.password)
@@ -644,13 +654,14 @@ class BrowserWebViewClient @Inject constructor(
 
     private fun parseSSlErrorResponse(sslError: SslError): SslErrorResponse {
         logcat { "SSL Certificate: parseSSlErrorResponse ${sslError.primaryError}" }
-        val sslErrorType = when (sslError.primaryError) {
-            SSL_UNTRUSTED -> UNTRUSTED_HOST
-            SSL_EXPIRED -> EXPIRED
-            SSL_DATE_INVALID -> EXPIRED
-            SSL_IDMISMATCH -> WRONG_HOST
-            else -> GENERIC
-        }
+        val sslErrorType =
+            when (sslError.primaryError) {
+                SSL_UNTRUSTED -> UNTRUSTED_HOST
+                SSL_EXPIRED -> EXPIRED
+                SSL_DATE_INVALID -> EXPIRED
+                SSL_IDMISMATCH -> WRONG_HOST
+                else -> GENERIC
+            }
         return SslErrorResponse(sslError, sslErrorType, sslError.url)
     }
 
@@ -665,12 +676,13 @@ class BrowserWebViewClient @Inject constructor(
 
             val siteURL = if (view?.url != null) "${URI(view.url).scheme}://$host" else host.orEmpty()
 
-            val request = BasicAuthenticationRequest(
-                handler = handler,
-                host = host.orEmpty(),
-                realm = realm.orEmpty(),
-                site = siteURL,
-            )
+            val request =
+                BasicAuthenticationRequest(
+                    handler = handler,
+                    host = host.orEmpty(),
+                    realm = realm.orEmpty(),
+                    site = siteURL,
+                )
 
             it.requiresAuthentication(request)
         }
@@ -698,8 +710,8 @@ class BrowserWebViewClient @Inject constructor(
         super.onReceivedError(view, request, error)
     }
 
-    private fun parseErrorResponse(error: WebResourceError): WebViewErrorResponse {
-        return if (error.errorCode == ERROR_HOST_LOOKUP) {
+    private fun parseErrorResponse(error: WebResourceError): WebViewErrorResponse =
+        if (error.errorCode == ERROR_HOST_LOOKUP) {
             when (error.description) {
                 "net::ERR_NAME_NOT_RESOLVED" -> BAD_URL
                 "net::ERR_INTERNET_DISCONNECTED" -> CONNECTION
@@ -710,7 +722,6 @@ class BrowserWebViewClient @Inject constructor(
         } else {
             OMITTED
         }
-    }
 
     override fun onReceivedHttpError(
         view: WebView?,
@@ -730,8 +741,8 @@ class BrowserWebViewClient @Inject constructor(
         }
     }
 
-    private fun Int.asStringErrorCode(): String {
-        return when (this) {
+    private fun Int.asStringErrorCode(): String =
+        when (this) {
             ERROR_AUTHENTICATION -> "ERROR_AUTHENTICATION"
             ERROR_BAD_URL -> "ERROR_BAD_URL"
             ERROR_CONNECT -> "ERROR_CONNECT"
@@ -755,13 +766,15 @@ class BrowserWebViewClient @Inject constructor(
             SAFE_BROWSING_THREAT_UNWANTED_SOFTWARE -> "SAFE_BROWSING_THREAT_UNWANTED_SOFTWARE"
             else -> "ERROR_OTHER"
         }
-    }
 
-    fun addExemptedMaliciousSite(url: Uri, feed: Feed) {
+    fun addExemptedMaliciousSite(
+        url: Uri,
+        feed: Feed,
+    ) {
         requestInterceptor.addExemptedMaliciousSite(url, feed)
     }
 
-    fun destroy(webView: DuckDuckGoWebView) {
+    suspend fun destroy(webView: DuckDuckGoWebView) {
         webMessagingPlugins.getPlugins().forEach { plugin ->
             plugin.unregister(webView)
         }
@@ -771,20 +784,25 @@ class BrowserWebViewClient @Inject constructor(
         eventData: SubscriptionEventData,
         webView: WebView,
     ) {
-        postMessageWrapperPlugins.getPlugins()
+        postMessageWrapperPlugins
+            .getPlugins()
             .firstOrNull { it.context == "contentScopeScripts" }
             ?.postMessage(eventData, webView)
     }
 }
 
-enum class WebViewPixelName(override val pixelName: String) : Pixel.PixelName {
+enum class WebViewPixelName(
+    override val pixelName: String,
+) : Pixel.PixelName {
     WEB_RENDERER_GONE_CRASH("m_web_view_renderer_gone_crash"),
     WEB_RENDERER_GONE_KILLED("m_web_view_renderer_gone_killed"),
     WEB_PAGE_LOADED("m_web_view_page_loaded"),
     WEB_PAGE_PAINTED("m_web_view_page_painted"),
 }
 
-enum class WebViewErrorResponse(@StringRes val errorId: Int) {
+enum class WebViewErrorResponse(
+    @StringRes val errorId: Int,
+) {
     BAD_URL(R.string.webViewErrorBadUrl),
     CONNECTION(R.string.webViewErrorNoConnection),
     OMITTED(R.string.webViewErrorNoConnection),
@@ -792,8 +810,15 @@ enum class WebViewErrorResponse(@StringRes val errorId: Int) {
     SSL_PROTOCOL_ERROR(R.string.webViewErrorSslProtocol),
 }
 
-data class SslErrorResponse(val error: SslError, val errorType: SSLErrorType, val url: String)
-enum class SSLErrorType(@StringRes val errorId: Int) {
+data class SslErrorResponse(
+    val error: SslError,
+    val errorType: SSLErrorType,
+    val url: String,
+)
+
+enum class SSLErrorType(
+    @StringRes val errorId: Int,
+) {
     EXPIRED(R.string.sslErrorExpiredMessage),
     WRONG_HOST(R.string.sslErrorWrongHostMessage),
     UNTRUSTED_HOST(R.string.sslErrorUntrustedMessage),

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -131,7 +131,6 @@ class BrowserWebViewClient @Inject constructor(
     private val androidFeaturesHeaderPlugin: AndroidFeaturesHeaderPlugin,
     private val duckChat: DuckChat,
     private val contentScopeExperiments: ContentScopeExperiments,
-    private val addDocumentStartJavascriptPlugins: PluginPoint<AddDocumentStartJavaScriptPlugin>,
     private val webMessagingPlugins: PluginPoint<WebMessagingPlugin>,
     private val postMessageWrapperPlugins: PluginPoint<PostMessageWrapperPlugin>,
 ) : WebViewClient() {
@@ -477,9 +476,7 @@ class BrowserWebViewClient @Inject constructor(
         webView: DuckDuckGoWebView,
         callback: WebViewCompatMessageCallback?,
     ) {
-        addDocumentStartJavascriptPlugins.getPlugins().forEach { plugin ->
-            plugin.addDocumentStartJavaScript(webView)
-        }
+        webViewClientListener?.addDocumentStartJavaScript(webView)
 
         callback?.let {
             webMessagingPlugins.getPlugins().forEach { plugin ->
@@ -504,13 +501,8 @@ class BrowserWebViewClient @Inject constructor(
                     webViewClientListener?.getSite(),
                 )
             }
-            appCoroutineScope.launch {
-                addDocumentStartJavascriptPlugins.getPlugins().forEach {
-                    it.addDocumentStartJavaScript(
-                        webView,
-                    )
-                }
-            }
+
+            webViewClientListener?.addDocumentStartJavaScript(webView)
 
             url?.let {
                 // We call this for any url but it will only be processed for an internal tester verification url

--- a/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoWebView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoWebView.kt
@@ -44,6 +44,8 @@ import com.duckduckgo.app.browser.navigation.safeCopyBackForwardList
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ViewScope
 import dagger.android.support.AndroidSupportInjection
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
 import logcat.LogPriority.ERROR
 import logcat.asLog
@@ -460,6 +462,7 @@ class DuckDuckGoWebView :
         if (!isDestroyed) {
             if (::dispatcherProvider.isInitialized) {
                 withContext(dispatcherProvider.main()) {
+                    if (!isActive) return@withContext
                     WebViewCompat.addWebMessageListener(
                         this@DuckDuckGoWebView,
                         jsObjectName,
@@ -479,6 +482,7 @@ class DuckDuckGoWebView :
             if (!isDestroyed) {
                 if (::dispatcherProvider.isInitialized) {
                     withContext(dispatcherProvider.main()) {
+                        if (!isActive) return@withContext
                         WebViewCompat.removeWebMessageListener(
                             this@DuckDuckGoWebView,
                             jsObjectName,
@@ -499,6 +503,7 @@ class DuckDuckGoWebView :
             if (!isDestroyed) {
                 if (::dispatcherProvider.isInitialized) {
                     return withContext(dispatcherProvider.main()) {
+                        if (!isActive) return@withContext null
                         return@withContext WebViewCompat.addDocumentStartJavaScript(
                             this@DuckDuckGoWebView,
                             script,
@@ -523,6 +528,7 @@ class DuckDuckGoWebView :
             if (!isDestroyed) {
                 if (::dispatcherProvider.isInitialized) {
                     return withContext(dispatcherProvider.main()) {
+                        if (!isActive) return@withContext
                         replyProxy.postMessage(subscriptionEvent)
                     }
                 }

--- a/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoWebView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/DuckDuckGoWebView.kt
@@ -35,6 +35,7 @@ import android.webkit.WebViewClient
 import androidx.core.view.NestedScrollingChild3
 import androidx.core.view.NestedScrollingChildHelper
 import androidx.core.view.ViewCompat
+import androidx.webkit.JavaScriptReplyProxy
 import androidx.webkit.ScriptHandler
 import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewCompat.WebMessageListener
@@ -43,11 +44,11 @@ import com.duckduckgo.app.browser.navigation.safeCopyBackForwardList
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ViewScope
 import dagger.android.support.AndroidSupportInjection
-import javax.inject.Inject
 import kotlinx.coroutines.withContext
 import logcat.LogPriority.ERROR
 import logcat.asLog
 import logcat.logcat
+import javax.inject.Inject
 
 /**
  * WebView subclass which allows the WebView to
@@ -57,7 +58,9 @@ import logcat.logcat
  * Originally based on https://github.com/takahirom/webview-in-coordinatorlayout for scrolling behaviour
  */
 @InjectWith(ViewScope::class)
-class DuckDuckGoWebView : WebView, NestedScrollingChild3 {
+class DuckDuckGoWebView :
+    WebView,
+    NestedScrollingChild3 {
     private var lastClampedTopY: Boolean = true // when created we are always at the top
     private var contentAllowsSwipeToRefresh: Boolean = true
     private var enableSwipeRefreshCallback: ((Boolean) -> Unit)? = null
@@ -326,17 +329,20 @@ class DuckDuckGoWebView : WebView, NestedScrollingChild3 {
     }
 
     override fun isNestedScrollingEnabled(): Boolean = nestedScrollHelper.isNestedScrollingEnabled
+
     override fun startNestedScroll(
         axes: Int,
         type: Int,
     ): Boolean = nestedScrollHelper.startNestedScroll(axes)
 
     override fun startNestedScroll(axes: Int): Boolean = nestedScrollHelper.startNestedScroll(axes)
+
     override fun stopNestedScroll(type: Int) {
         nestedScrollHelper.stopNestedScroll()
     }
 
     override fun hasNestedScrollingParent(): Boolean = nestedScrollHelper.hasNestedScrollingParent()
+
     override fun dispatchNestedScroll(
         dxConsumed: Int,
         dyConsumed: Int,
@@ -366,8 +372,7 @@ class DuckDuckGoWebView : WebView, NestedScrollingChild3 {
         dxUnconsumed: Int,
         dyUnconsumed: Int,
         offsetInWindow: IntArray?,
-    ): Boolean =
-        nestedScrollHelper.dispatchNestedScroll(dxConsumed, dyConsumed, dxUnconsumed, dyUnconsumed, offsetInWindow)
+    ): Boolean = nestedScrollHelper.dispatchNestedScroll(dxConsumed, dyConsumed, dxUnconsumed, dyUnconsumed, offsetInWindow)
 
     override fun dispatchNestedPreScroll(
         dx: Int,
@@ -382,21 +387,18 @@ class DuckDuckGoWebView : WebView, NestedScrollingChild3 {
         dy: Int,
         consumed: IntArray?,
         offsetInWindow: IntArray?,
-    ): Boolean =
-        nestedScrollHelper.dispatchNestedPreScroll(dx, dy, consumed, offsetInWindow)
+    ): Boolean = nestedScrollHelper.dispatchNestedPreScroll(dx, dy, consumed, offsetInWindow)
 
     override fun dispatchNestedFling(
         velocityX: Float,
         velocityY: Float,
         consumed: Boolean,
-    ): Boolean =
-        nestedScrollHelper.dispatchNestedFling(velocityX, velocityY, consumed)
+    ): Boolean = nestedScrollHelper.dispatchNestedFling(velocityX, velocityY, consumed)
 
     override fun dispatchNestedPreFling(
         velocityX: Float,
         velocityY: Float,
-    ): Boolean =
-        nestedScrollHelper.dispatchNestedPreFling(velocityX, velocityY)
+    ): Boolean = nestedScrollHelper.dispatchNestedPreFling(velocityX, velocityY)
 
     override fun onOverScrolled(
         scrollX: Int,
@@ -447,9 +449,7 @@ class DuckDuckGoWebView : WebView, NestedScrollingChild3 {
         }
     }
 
-    fun isDestroyed(): Boolean {
-        return isDestroyed
-    }
+    fun isDestroyed(): Boolean = isDestroyed
 
     @SuppressLint("RequiresFeature", "AddWebMessageListenerUsage")
     suspend fun safeAddWebMessageListener(
@@ -474,22 +474,21 @@ class DuckDuckGoWebView : WebView, NestedScrollingChild3 {
     }
 
     @SuppressLint("RequiresFeature", "RemoveWebMessageListenerUsage")
-    suspend fun safeRemoveWebMessageListener(
-        jsObjectName: String,
-    ) = runCatching {
-        if (!isDestroyed) {
-            if (::dispatcherProvider.isInitialized) {
-                withContext(dispatcherProvider.main()) {
-                    WebViewCompat.removeWebMessageListener(
-                        this@DuckDuckGoWebView,
-                        jsObjectName,
-                    )
+    suspend fun safeRemoveWebMessageListener(jsObjectName: String) =
+        runCatching {
+            if (!isDestroyed) {
+                if (::dispatcherProvider.isInitialized) {
+                    withContext(dispatcherProvider.main()) {
+                        WebViewCompat.removeWebMessageListener(
+                            this@DuckDuckGoWebView,
+                            jsObjectName,
+                        )
+                    }
                 }
             }
+        }.getOrElse { exception ->
+            logcat(ERROR) { "Error removing WebMessageListener: $jsObjectName: ${exception.asLog()}" }
         }
-    }.getOrElse { exception ->
-        logcat(ERROR) { "Error removing WebMessageListener: $jsObjectName: ${exception.asLog()}" }
-    }
 
     @SuppressLint("RequiresFeature", "AddDocumentStartJavaScriptUsage")
     suspend fun safeAddDocumentStartJavaScript(
@@ -515,8 +514,26 @@ class DuckDuckGoWebView : WebView, NestedScrollingChild3 {
         }
     }
 
-    companion object {
+    @SuppressLint("RequiresFeature", "PostMessageUsage")
+    suspend fun safePostMessage(
+        replyProxy: JavaScriptReplyProxy,
+        subscriptionEvent: String,
+    ) {
+        runCatching {
+            if (!isDestroyed) {
+                if (::dispatcherProvider.isInitialized) {
+                    return withContext(dispatcherProvider.main()) {
+                        replyProxy.postMessage(subscriptionEvent)
+                    }
+                }
+            }
+            null
+        }.getOrElse { e ->
+            logcat(ERROR) { "Error calling addDocumentStartJavaScript: ${e.asLog()}" }
+        }
+    }
 
+    companion object {
         /*
          * Taken from EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING
          * We can't use that value directly as it was only added on Oreo, but we can apply the value anyway.

--- a/app/src/main/java/com/duckduckgo/app/browser/RealWebViewCapabilityChecker.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/RealWebViewCapabilityChecker.kt
@@ -26,35 +26,32 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.extensions.compareSemanticVersion
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
-import javax.inject.Inject
 import kotlinx.coroutines.withContext
+import javax.inject.Inject
 
 @ContributesBinding(AppScope::class)
 class RealWebViewCapabilityChecker @Inject constructor(
     private val dispatchers: DispatcherProvider,
     private val webViewVersionProvider: WebViewVersionProvider,
 ) : WebViewCapabilityChecker {
-
-    override suspend fun isSupported(capability: WebViewCapability): Boolean {
-        return when (capability) {
+    override suspend fun isSupported(capability: WebViewCapability): Boolean =
+        when (capability) {
             DocumentStartJavaScript -> isDocumentStartJavaScriptSupported()
             WebMessageListener -> isWebMessageListenerSupported()
         }
-    }
 
-    private suspend fun isWebMessageListenerSupported(): Boolean {
-        return withContext(dispatchers.io()) {
-            webViewVersionProvider.getFullVersion()
-                .compareSemanticVersion(WEB_MESSAGE_LISTENER_WEBVIEW_VERSION)?.let { it >= 0 } ?: false
+    private suspend fun isWebMessageListenerSupported(): Boolean =
+        withContext(dispatchers.io()) {
+            webViewVersionProvider
+                .getFullVersion()
+                .compareSemanticVersion(WEB_MESSAGE_LISTENER_WEBVIEW_VERSION)
+                ?.let { it >= 0 } ?: false
         } && WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)
-    }
 
-    private fun isDocumentStartJavaScriptSupported(): Boolean {
-        return WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT)
-    }
+    private fun isDocumentStartJavaScriptSupported(): Boolean = WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT)
 
     companion object {
-        // critical fixes didn't exist until this WebView version
+        // critical fixes didn't exist until this WebView version. See https://issues.chromium.org/issues/338340758#comment42
         private const val WEB_MESSAGE_LISTENER_WEBVIEW_VERSION = "126.0.6478.40"
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/RealWebViewCompatWrapper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/RealWebViewCompatWrapper.kt
@@ -27,6 +27,8 @@ import com.duckduckgo.browser.api.webviewcompat.WebViewCompatWrapper
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
 import logcat.LogPriority.ERROR
 import logcat.asLog
@@ -63,7 +65,8 @@ class RealWebViewCompatWrapper @Inject constructor(
                 return webView.safeAddDocumentStartJavaScript(script, allowedOriginRules)
             }
             return withContext(dispatcherProvider.main()) {
-                WebViewCompat.addDocumentStartJavaScript(webView, script, allowedOriginRules)
+                if (!isActive) return@withContext null
+                return@withContext WebViewCompat.addDocumentStartJavaScript(webView, script, allowedOriginRules)
             }
         }.getOrElse { e ->
             logcat(ERROR) { "Error calling addDocumentStartJavaScript: ${e.asLog()}" }
@@ -89,6 +92,7 @@ class RealWebViewCompatWrapper @Inject constructor(
             return
         }
         return withContext(dispatcherProvider.main()) {
+            if (!isActive) return@withContext
             WebViewCompat.removeWebMessageListener(webView, jsObjectName)
         }
     }
@@ -113,6 +117,7 @@ class RealWebViewCompatWrapper @Inject constructor(
             return
         }
         return withContext(dispatcherProvider.main()) {
+            if (!isActive) return@withContext
             WebViewCompat.addWebMessageListener(webView, jsObjectName, allowedOriginRules, listener)
         }
     }
@@ -135,6 +140,7 @@ class RealWebViewCompatWrapper @Inject constructor(
             return
         }
         withContext(dispatcherProvider.main()) {
+            if (!isActive) return@withContext
             globalReplyProxy?.postMessage(subscriptionEvent)
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/RealWebViewCompatWrapper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/RealWebViewCompatWrapper.kt
@@ -26,11 +26,11 @@ import com.duckduckgo.browser.api.webviewcompat.WebViewCompatWrapper
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
-import javax.inject.Inject
 import kotlinx.coroutines.withContext
 import logcat.LogPriority.ERROR
 import logcat.asLog
 import logcat.logcat
+import javax.inject.Inject
 
 @SuppressLint(
     "RequiresFeature",
@@ -53,6 +53,11 @@ class RealWebViewCompatWrapper @Inject constructor(
                 return null
             }
 
+            if (!webView.isAttachedToWindow) {
+                logcat(ERROR) { "Error calling addDocumentStartJavaScript on detached WebView" }
+                return null
+            }
+
             if (webView is DuckDuckGoWebView) {
                 return webView.safeAddDocumentStartJavaScript(script, allowedOriginRules)
             }
@@ -65,8 +70,16 @@ class RealWebViewCompatWrapper @Inject constructor(
         }
     }
 
-    override suspend fun removeWebMessageListener(webView: WebView, jsObjectName: String) {
+    override suspend fun removeWebMessageListener(
+        webView: WebView,
+        jsObjectName: String,
+    ) {
         if (!webViewCapabilityChecker.isSupported(WebViewCapability.WebMessageListener)) {
+            return
+        }
+
+        if (!webView.isAttachedToWindow) {
+            logcat(ERROR) { "Error calling removeWebMessageListener on detached WebView" }
             return
         }
 
@@ -86,6 +99,11 @@ class RealWebViewCompatWrapper @Inject constructor(
         listener: WebViewCompat.WebMessageListener,
     ) {
         if (!webViewCapabilityChecker.isSupported(WebViewCapability.WebMessageListener)) {
+            return
+        }
+
+        if (!webView.isAttachedToWindow) {
+            logcat(ERROR) { "Error calling addWebMessageListener on detached WebView" }
             return
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
@@ -25,23 +25,28 @@ import android.webkit.PermissionRequest
 import android.webkit.SslErrorHandler
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
+import android.webkit.WebView
 import com.duckduckgo.app.browser.model.BasicAuthenticationRequest
 import com.duckduckgo.app.global.model.Site
 import com.duckduckgo.app.surrogates.SurrogateResponse
 import com.duckduckgo.app.trackerdetection.model.TrackingEvent
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.js.messaging.api.AddDocumentStartJavaScriptPlugin
 import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed
 import com.duckduckgo.site.permissions.api.SitePermissionsManager.SitePermissions
 
 interface WebViewClientListener {
-
     fun onPageContentStart(url: String)
+
     fun pageRefreshed(refreshedUrl: String)
+
     fun progressChanged(
         newProgress: Int,
         webViewNavigationState: WebViewNavigationState,
     )
+
     fun willOverrideUrl(newUrl: String)
+
     fun redirectTriggeredByGpc()
 
     fun onSitePermissionRequested(
@@ -50,16 +55,25 @@ interface WebViewClientListener {
     )
 
     fun titleReceived(newTitle: String)
+
     fun trackerDetected(event: TrackingEvent)
+
     fun pageHasHttpResources(page: String)
+
     fun pageHasHttpResources(page: Uri)
+
     fun onCertificateReceived(certificate: SslCertificate?)
 
     fun sendEmailRequested(emailAddress: String)
+
     fun sendSmsRequested(telephoneNumber: String)
+
     fun dialTelephoneNumberRequested(telephoneNumber: String)
+
     fun goFullScreen(view: View)
+
     fun exitFullScreen()
+
     fun showFileChooser(
         filePathCallback: ValueCallback<Array<Uri>>,
         fileChooserParams: WebChromeClient.FileChooserParams,
@@ -71,22 +85,35 @@ interface WebViewClientListener {
     ): Boolean
 
     fun handleNonHttpAppLink(nonHttpAppLink: SpecialUrlDetector.UrlType.NonHttpAppLink): Boolean
+
     fun handleCloakedAmpLink(initialUrl: String)
+
     fun startProcessingTrackingLink()
+
     fun openMessageInNewTab(message: Message)
+
     fun openLinkInNewTab(uri: Uri)
+
     fun recoverFromRenderProcessGone()
+
     fun requiresAuthentication(request: BasicAuthenticationRequest)
+
     fun closeCurrentTab()
+
     fun closeAndSelectSourceTab()
+
     fun upgradedToHttps()
+
     fun surrogateDetected(surrogate: SurrogateResponse)
+
     fun isDesktopSiteEnabled(): Boolean
 
     fun isTabInForeground(): Boolean
 
     fun loginDetected()
+
     fun dosAttackDetected()
+
     fun iconReceived(
         url: String,
         icon: Bitmap,
@@ -98,9 +125,16 @@ interface WebViewClientListener {
     )
 
     fun prefetchFavicon(url: String)
+
     fun linkOpenedInNewTab(): Boolean
+
     fun isActiveTab(): Boolean
-    fun onReceivedError(errorType: WebViewErrorResponse, url: String)
+
+    fun onReceivedError(
+        errorType: WebViewErrorResponse,
+        url: String,
+    )
+
     fun onReceivedMaliciousSiteWarning(
         url: Uri,
         feed: Feed,
@@ -108,21 +142,33 @@ interface WebViewClientListener {
         clientSideHit: Boolean,
         isMainframe: Boolean,
     )
+
     fun onReceivedMaliciousSiteSafe(
         url: Uri,
         isForMainFrame: Boolean,
     )
-    fun recordErrorCode(error: String, url: String)
-    fun recordHttpErrorCode(statusCode: Int, url: String)
+
+    fun recordErrorCode(
+        error: String,
+        url: String,
+    )
+
+    fun recordHttpErrorCode(
+        statusCode: Int,
+        url: String,
+    )
 
     fun getCurrentTabId(): String
 
     fun getSite(): Site?
+
     fun onReceivedSslError(
         handler: SslErrorHandler,
         errorResponse: SslErrorResponse,
     )
+
     fun onShouldOverride()
+
     fun pageFinished(
         webViewNavigationState: WebViewNavigationState,
         url: String?,
@@ -137,4 +183,6 @@ interface WebViewClientListener {
         webViewNavigationState: WebViewNavigationState,
         activeExperiments: List<Toggle>,
     )
+
+    fun addDocumentStartJavaScript(webView: WebView)
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
@@ -62,35 +62,89 @@ sealed class Command {
         val sourceTabId: String? = null,
     ) : Command()
 
-    class OpenInNewBackgroundTab(val query: String) : Command()
+    class OpenInNewBackgroundTab(
+        val query: String,
+    ) : Command()
+
     data object LaunchNewTab : Command()
+
     data object ResetHistory : Command()
-    class LaunchPrivacyPro(val uri: Uri) : Command()
+
+    class LaunchPrivacyPro(
+        val uri: Uri,
+    ) : Command()
+
     data object LaunchVpnManagement : Command()
-    class DialNumber(val telephoneNumber: String) : Command()
-    class SendSms(val telephoneNumber: String) : Command()
-    class SendEmail(val emailAddress: String) : Command()
+
+    class DialNumber(
+        val telephoneNumber: String,
+    ) : Command()
+
+    class SendSms(
+        val telephoneNumber: String,
+    ) : Command()
+
+    class SendEmail(
+        val emailAddress: String,
+    ) : Command()
+
     data object ShowKeyboard : Command()
+
     data object HideKeyboard : Command()
+
     data object HideKeyboardForChat : Command()
-    class ShowFullScreen(val view: View) : Command()
+
+    class ShowFullScreen(
+        val view: View,
+    ) : Command()
+
     class DownloadImage(
         val url: String,
         val requestUserConfirmation: Boolean,
     ) : Command()
 
-    class ShowSavedSiteAddedConfirmation(val savedSiteChangedViewState: SavedSiteChangedViewState) : Command()
-    class ShowEditSavedSiteDialog(val savedSiteChangedViewState: SavedSiteChangedViewState) : Command()
-    class DeleteSavedSiteConfirmation(val savedSite: SavedSite) : Command()
-    class DeleteFavoriteConfirmation(val savedSite: SavedSite) : Command()
+    class ShowSavedSiteAddedConfirmation(
+        val savedSiteChangedViewState: SavedSiteChangedViewState,
+    ) : Command()
 
-    class ShowFireproofWebSiteConfirmation(val fireproofWebsiteEntity: FireproofWebsiteEntity) : Command()
-    class DeleteFireproofConfirmation(val fireproofWebsiteEntity: FireproofWebsiteEntity) : Command()
-    class RefreshAndShowPrivacyProtectionEnabledConfirmation(val domain: String) : Command()
-    class RefreshAndShowPrivacyProtectionDisabledConfirmation(val domain: String) : Command()
+    class ShowEditSavedSiteDialog(
+        val savedSiteChangedViewState: SavedSiteChangedViewState,
+    ) : Command()
+
+    class DeleteSavedSiteConfirmation(
+        val savedSite: SavedSite,
+    ) : Command()
+
+    class DeleteFavoriteConfirmation(
+        val savedSite: SavedSite,
+    ) : Command()
+
+    class ShowFireproofWebSiteConfirmation(
+        val fireproofWebsiteEntity: FireproofWebsiteEntity,
+    ) : Command()
+
+    class DeleteFireproofConfirmation(
+        val fireproofWebsiteEntity: FireproofWebsiteEntity,
+    ) : Command()
+
+    class RefreshAndShowPrivacyProtectionEnabledConfirmation(
+        val domain: String,
+    ) : Command()
+
+    class RefreshAndShowPrivacyProtectionDisabledConfirmation(
+        val domain: String,
+    ) : Command()
+
     data object AskToDisableLoginDetection : Command()
-    class AskToFireproofWebsite(val fireproofWebsite: FireproofWebsiteEntity) : Command()
-    class AskToAutomateFireproofWebsite(val fireproofWebsite: FireproofWebsiteEntity) : Command()
+
+    class AskToFireproofWebsite(
+        val fireproofWebsite: FireproofWebsiteEntity,
+    ) : Command()
+
+    class AskToAutomateFireproofWebsite(
+        val fireproofWebsite: FireproofWebsiteEntity,
+    ) : Command()
+
     class ShareLink(
         val url: String,
         val title: String = "",
@@ -106,11 +160,24 @@ sealed class Command {
         val mediaSize: MediaSize,
     ) : Command()
 
-    class CopyLink(val url: String) : Command()
-    class FindInPageCommand(val searchTerm: String) : Command()
-    class BrokenSiteFeedback(val data: BrokenSiteData) : Command()
-    class ToggleReportFeedback(val opener: DashboardOpener) : Command()
+    class CopyLink(
+        val url: String,
+    ) : Command()
+
+    class FindInPageCommand(
+        val searchTerm: String,
+    ) : Command()
+
+    class BrokenSiteFeedback(
+        val data: BrokenSiteData,
+    ) : Command()
+
+    class ToggleReportFeedback(
+        val opener: DashboardOpener,
+    ) : Command()
+
     data object DismissFindInPage : Command()
+
     class ShowFileChooser(
         val filePathCallback: ValueCallback<Array<Uri>>,
         val fileChooserParams: FileChooserRequestedParams,
@@ -121,14 +188,17 @@ sealed class Command {
         val fileChooserParams: FileChooserRequestedParams,
         val inputAction: String,
     ) : Command()
+
     class ShowImageCamera(
         val filePathCallback: ValueCallback<Array<Uri>>,
         val fileChooserParams: FileChooserRequestedParams,
     ) : Command()
+
     class ShowVideoCamera(
         val filePathCallback: ValueCallback<Array<Uri>>,
         val fileChooserParams: FileChooserRequestedParams,
     ) : Command()
+
     class ShowSoundRecorder(
         val filePathCallback: ValueCallback<Array<Uri>>,
         val fileChooserParams: FileChooserRequestedParams,
@@ -139,37 +209,69 @@ sealed class Command {
         val headers: Map<String, String>,
     ) : Command()
 
-    class ShowAppLinkPrompt(val appLink: AppLink) : Command()
-    class OpenAppLink(val appLink: AppLink) : Command()
-    class ExtractUrlFromCloakedAmpLink(val initialUrl: String) : Command()
-    class LoadExtractedUrl(val extractedUrl: String) : Command()
+    class ShowAppLinkPrompt(
+        val appLink: AppLink,
+    ) : Command()
+
+    class OpenAppLink(
+        val appLink: AppLink,
+    ) : Command()
+
+    class ExtractUrlFromCloakedAmpLink(
+        val initialUrl: String,
+    ) : Command()
+
+    class LoadExtractedUrl(
+        val extractedUrl: String,
+    ) : Command()
+
     class AddHomeShortcut(
         val title: String,
         val url: String,
         val icon: Bitmap? = null,
     ) : Command()
 
-    class SubmitUrl(val url: String) : Command()
-    class SubmitChat(val query: String) : Command()
-    class LaunchPlayStore(val appPackage: String) : Command()
+    class SubmitUrl(
+        val url: String,
+    ) : Command()
+
+    class SubmitChat(
+        val query: String,
+    ) : Command()
+
+    class LaunchPlayStore(
+        val appPackage: String,
+    ) : Command()
+
     data object LaunchDefaultBrowser : Command()
+
     data object LaunchAppTPOnboarding : Command()
+
     data object LaunchAddWidget : Command()
-    class RequiresAuthentication(val request: BasicAuthenticationRequest) : Command()
+
+    class RequiresAuthentication(
+        val request: BasicAuthenticationRequest,
+    ) : Command()
+
     class SaveCredentials(
         val request: BasicAuthenticationRequest,
         val credentials: BasicAuthenticationCredentials,
     ) : Command()
 
     data object GenerateWebViewPreviewImage : Command()
+
     data object LaunchTabSwitcher : Command()
+
     data object HideWebContent : Command()
+
     data object ShowWebContent : Command()
+
     class ShowWebPageTitle(
         val title: String,
         val url: String?,
         val showDuckPlayerIcon: Boolean = false,
     ) : Command()
+
     class RefreshUserAgent(
         val url: String?,
         val isDesktop: Boolean,
@@ -180,7 +282,10 @@ sealed class Command {
         val action: () -> Unit,
     ) : Command()
 
-    class ShowDomainHasPermissionMessage(val domain: String) : Command()
+    class ShowDomainHasPermissionMessage(
+        val domain: String,
+    ) : Command()
+
     class ConvertBlobToDataUri(
         val url: String,
         val mimeType: String,
@@ -195,20 +300,40 @@ sealed class Command {
 
     data object ChildTabClosed : Command()
 
-    class CopyAliasToClipboard(val alias: String) : Command()
+    class CopyAliasToClipboard(
+        val alias: String,
+    ) : Command()
+
     class InjectEmailAddress(
         val duckAddress: String,
         val originalUrl: String,
         val autoSaveLogin: Boolean,
     ) : Command()
 
-    class ShowEmailProtectionChooseEmailPrompt(val address: String) : Command()
+    class ShowEmailProtectionChooseEmailPrompt(
+        val address: String,
+    ) : Command()
+
     data object ShowEmailProtectionInContextSignUpPrompt : Command()
-    class CancelIncomingAutofillRequest(val url: String) : Command()
-    data class LaunchAutofillSettings(val privacyProtectionEnabled: Boolean) : Command()
-    class EditWithSelectedQuery(val query: String) : Command()
-    class ShowBackNavigationHistory(val history: List<NavigationHistoryEntry>) : Command()
+
+    class CancelIncomingAutofillRequest(
+        val url: String,
+    ) : Command()
+
+    data class LaunchAutofillSettings(
+        val privacyProtectionEnabled: Boolean,
+    ) : Command()
+
+    class EditWithSelectedQuery(
+        val query: String,
+    ) : Command()
+
+    class ShowBackNavigationHistory(
+        val history: List<NavigationHistoryEntry>,
+    ) : Command()
+
     data object EmailSignEvent : Command()
+
     class ShowSitePermissionsDialog(
         val permissionsToRequest: SitePermissions,
         val request: PermissionRequest,
@@ -244,46 +369,133 @@ sealed class Command {
         val feed: Feed,
     ) : Command()
 
-    data class OpenBrokenSiteLearnMore(val url: String) : Command()
-    data class ReportBrokenSiteError(val url: String) : Command()
+    data class OpenBrokenSiteLearnMore(
+        val url: String,
+    ) : Command()
+
+    data class ReportBrokenSiteError(
+        val url: String,
+    ) : Command()
 
     // TODO (cbarreiro) Rename to SendResponseToCSS
-    data class SendResponseToJs(val data: JsCallbackData) : Command()
-    data class SendResponseToDuckPlayer(val data: JsCallbackData) : Command()
-    data class SendSubscriptions(val cssData: SubscriptionEventData, val duckPlayerData: SubscriptionEventData) : Command()
-    data class WebShareRequest(val data: JsCallbackData) : Command()
-    data class WebViewCompatWebShareRequest(val data: JsCallbackData, val onResponse: (JSONObject) -> Unit) : Command()
-    data class ScreenLock(val data: JsCallbackData) : Command()
-    data class WebViewCompatScreenLock(val data: JsCallbackData, val onResponse: (JSONObject) -> Unit) : Command()
+    data class SendResponseToJs(
+        val data: JsCallbackData,
+    ) : Command()
+
+    data class SendResponseToDuckPlayer(
+        val data: JsCallbackData,
+    ) : Command()
+
+    data class SendSubscriptions(
+        val cssData: SubscriptionEventData,
+        val duckPlayerData: SubscriptionEventData,
+    ) : Command()
+
+    data class WebShareRequest(
+        val data: JsCallbackData,
+    ) : Command()
+
+    data class WebViewCompatWebShareRequest(
+        val data: JsCallbackData,
+        val onResponse: suspend (JSONObject) -> Unit,
+    ) : Command()
+
+    data class ScreenLock(
+        val data: JsCallbackData,
+    ) : Command()
+
+    data class WebViewCompatScreenLock(
+        val data: JsCallbackData,
+        val onResponse: suspend (JSONObject) -> Unit,
+    ) : Command()
+
     data object ScreenUnlock : Command()
+
     data object ShowFaviconsPrompt : Command()
-    data class ShowSSLError(val handler: SslErrorHandler, val error: SslErrorResponse) : Command()
+
+    data class ShowSSLError(
+        val handler: SslErrorHandler,
+        val error: SslErrorResponse,
+    ) : Command()
+
     data object HideSSLError : Command()
+
     class LaunchScreen(
         val screen: String,
         val payload: String,
     ) : Command()
-    data class HideOnboardingDaxDialog(val onboardingCta: OnboardingDaxDialogCta) : Command()
-    data class HideBrokenSitePromptCta(val brokenSitePromptDialogCta: BrokenSitePromptDialogCta) : Command()
-    data class HideOnboardingDaxBubbleCta(val daxBubbleCta: DaxBubbleCta) : Command()
-    data class ShowRemoveSearchSuggestionDialog(val suggestion: AutoCompleteSuggestion) : Command()
+
+    data class HideOnboardingDaxDialog(
+        val onboardingCta: OnboardingDaxDialogCta,
+    ) : Command()
+
+    data class HideBrokenSitePromptCta(
+        val brokenSitePromptDialogCta: BrokenSitePromptDialogCta,
+    ) : Command()
+
+    data class HideOnboardingDaxBubbleCta(
+        val daxBubbleCta: DaxBubbleCta,
+    ) : Command()
+
+    data class ShowRemoveSearchSuggestionDialog(
+        val suggestion: AutoCompleteSuggestion,
+    ) : Command()
+
     data object AutocompleteItemRemoved : Command()
+
     data object OpenDuckPlayerSettings : Command()
+
     data object OpenDuckPlayerOverlayInfo : Command()
+
     data object OpenDuckPlayerPageInfo : Command()
-    class SetBrowserBackground(@DrawableRes val backgroundRes: Int) : Command()
-    class SetBrowserBackgroundColor(@ColorRes val colorRes: Int) : Command()
-    class SetBubbleDialogBackground(@DrawableRes val backgroundRes: Int) : Command()
-    class SetOnboardingDialogBackground(@DrawableRes val backgroundRes: Int) : Command()
-    class SetOnboardingDialogBackgroundColor(@ColorRes val colorRes: Int) : Command()
-    data class LaunchFireDialogFromOnboardingDialog(val onboardingCta: OnboardingDaxDialogCta) : Command()
-    data class SwitchToTab(val tabId: String) : Command()
+
+    class SetBrowserBackground(
+        @DrawableRes val backgroundRes: Int,
+    ) : Command()
+
+    class SetBrowserBackgroundColor(
+        @ColorRes val colorRes: Int,
+    ) : Command()
+
+    class SetBubbleDialogBackground(
+        @DrawableRes val backgroundRes: Int,
+    ) : Command()
+
+    class SetOnboardingDialogBackground(
+        @DrawableRes val backgroundRes: Int,
+    ) : Command()
+
+    class SetOnboardingDialogBackgroundColor(
+        @ColorRes val colorRes: Int,
+    ) : Command()
+
+    data class LaunchFireDialogFromOnboardingDialog(
+        val onboardingCta: OnboardingDaxDialogCta,
+    ) : Command()
+
+    data class SwitchToTab(
+        val tabId: String,
+    ) : Command()
+
     data object CloseCustomTab : Command()
+
     data object LaunchPopupMenu : Command()
-    data class ShowAutoconsentAnimation(val isCosmetic: Boolean) : Command()
+
+    data class ShowAutoconsentAnimation(
+        val isCosmetic: Boolean,
+    ) : Command()
+
     data object LaunchBookmarksActivity : Command()
+
     data object RefreshOmnibar : Command()
+
     data object LaunchInputScreen : Command()
-    data class ExtractSerpLogo(val currentUrl: String) : Command()
-    data class ShowSerpEasterEggLogo(val logoUrl: String) : Command()
+
+    data class ExtractSerpLogo(
+        val currentUrl: String,
+    ) : Command()
+
+    data class ShowSerpEasterEggLogo(
+        val logoUrl: String,
+    ) : Command()
 }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/gpm/webflow/ImportGooglePasswordsWebFlowFragment.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/gpm/webflow/ImportGooglePasswordsWebFlowFragment.kt
@@ -72,13 +72,13 @@ import com.duckduckgo.common.utils.FragmentViewModelFactory
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.user.agent.api.UserAgentProvider
-import javax.inject.Inject
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import logcat.LogPriority.WARN
 import logcat.logcat
+import javax.inject.Inject
 
 @InjectWith(FragmentScope::class)
 class ImportGooglePasswordsWebFlowFragment :
@@ -89,7 +89,6 @@ class ImportGooglePasswordsWebFlowFragment :
     NoOpEmailProtectionUserPromptListener,
     NoOpAutofillEventListener,
     GooglePasswordBlobConsumer.Callback {
-
     @Inject
     lateinit var userAgentProvider: UserAgentProvider
 
@@ -179,8 +178,7 @@ class ImportGooglePasswordsWebFlowFragment :
                         // no-op
                     }
                 }
-            }
-            .launchIn(lifecycleScope)
+            }.launchIn(lifecycleScope)
     }
 
     private fun observeCommands() {
@@ -201,8 +199,7 @@ class ImportGooglePasswordsWebFlowFragment :
                         showCredentialChooserDialog(command.originalUrl, command.credentials, command.triggerType)
                     }
                 }
-            }
-            .launchIn(lifecycleScope)
+            }.launchIn(lifecycleScope)
     }
 
     private suspend fun injectReauthenticationCredentials(
@@ -217,11 +214,12 @@ class ImportGooglePasswordsWebFlowFragment :
                     return@withContext
                 }
 
-                val credentials = LoginCredentials(
-                    domain = url,
-                    username = username,
-                    password = password,
-                )
+                val credentials =
+                    LoginCredentials(
+                        domain = url,
+                        username = username,
+                        password = password,
+                    )
 
                 logcat { "Injecting re-authentication credentials" }
                 browserAutofill.injectCredentials(credentials)
@@ -234,16 +232,18 @@ class ImportGooglePasswordsWebFlowFragment :
     }
 
     private fun exitFlowAsSuccess() {
-        val resultBundle = Bundle().also {
-            it.putParcelable(RESULT_KEY_DETAILS, ImportGooglePasswordResult.Success)
-        }
+        val resultBundle =
+            Bundle().also {
+                it.putParcelable(RESULT_KEY_DETAILS, ImportGooglePasswordResult.Success)
+            }
         setFragmentResult(RESULT_KEY, resultBundle)
     }
 
     private fun exitFlowAsImpossibleToImport(reason: UserCannotImportReason) {
-        val resultBundle = Bundle().also {
-            it.putParcelable(RESULT_KEY_DETAILS, ImportGooglePasswordResult.Error(reason))
-        }
+        val resultBundle =
+            Bundle().also {
+                it.putParcelable(RESULT_KEY_DETAILS, ImportGooglePasswordResult.Error(reason))
+            }
         setFragmentResult(RESULT_KEY, resultBundle)
     }
 
@@ -334,7 +334,7 @@ class ImportGooglePasswordsWebFlowFragment :
         it.setDownloadListener { url, _, _, _, _ ->
             if (url.startsWith("blob:")) {
                 lifecycleScope.launch {
-                    passwordBlobConsumer.postMessageToConvertBlobToDataUri(url)
+                    passwordBlobConsumer.postMessageToConvertBlobToDataUri(it, url)
                 }
             }
         }
@@ -371,12 +371,13 @@ class ImportGooglePasswordsWebFlowFragment :
                 return@withContext
             }
 
-            val dialog = credentialAutofillDialogFactory.autofillSelectCredentialsDialog(
-                url,
-                credentials,
-                triggerType,
-                CUSTOM_FLOW_TAB_ID,
-            )
+            val dialog =
+                credentialAutofillDialogFactory.autofillSelectCredentialsDialog(
+                    url,
+                    credentials,
+                    triggerType,
+                    CUSTOM_FLOW_TAB_ID,
+                )
             dialog.show(childFragmentManager, SELECT_CREDENTIALS_FRAGMENT_TAG)
         }
     }

--- a/browser-api/src/main/java/com/duckduckgo/browser/api/webviewcompat/WebViewCompatWrapper.kt
+++ b/browser-api/src/main/java/com/duckduckgo/browser/api/webviewcompat/WebViewCompatWrapper.kt
@@ -17,11 +17,11 @@
 package com.duckduckgo.browser.api.webviewcompat
 
 import android.webkit.WebView
+import androidx.webkit.JavaScriptReplyProxy
 import androidx.webkit.ScriptHandler
 import androidx.webkit.WebViewCompat.WebMessageListener
 
 interface WebViewCompatWrapper {
-
     suspend fun addDocumentStartJavaScript(
         webView: WebView,
         script: String,
@@ -38,5 +38,11 @@ interface WebViewCompatWrapper {
         jsObjectName: String,
         allowedOriginRules: Set<String>,
         listener: WebMessageListener,
+    )
+
+    suspend fun postMessage(
+        webView: WebView,
+        globalReplyProxy: JavaScriptReplyProxy?,
+        subscriptionEvent: String,
     )
 }

--- a/browser-api/src/main/java/com/duckduckgo/browser/api/webviewcompat/WebViewCompatWrapper.kt
+++ b/browser-api/src/main/java/com/duckduckgo/browser/api/webviewcompat/WebViewCompatWrapper.kt
@@ -42,7 +42,7 @@ interface WebViewCompatWrapper {
 
     suspend fun postMessage(
         webView: WebView,
-        globalReplyProxy: JavaScriptReplyProxy?,
+        replyProxy: JavaScriptReplyProxy?,
         subscriptionEvent: String,
     )
 }

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/features/contentscopeexperiments/RealContentScopeExperiments.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/features/contentscopeexperiments/RealContentScopeExperiments.kt
@@ -22,8 +22,8 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.FeatureTogglesInventory
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.squareup.anvil.annotations.ContributesBinding
-import javax.inject.Inject
 import kotlinx.coroutines.withContext
+import javax.inject.Inject
 
 @ContributesBinding(AppScope::class)
 class RealContentScopeExperiments @Inject constructor(
@@ -31,15 +31,15 @@ class RealContentScopeExperiments @Inject constructor(
     private val featureTogglesInventory: FeatureTogglesInventory,
     private val dispatcherProvider: DispatcherProvider,
 ) : ContentScopeExperiments {
-
-    override suspend fun getActiveExperiments(): List<Toggle> {
-        val featureName = contentScopeExperimentsFeature.self().featureName().name
-        return withContext(dispatcherProvider.io()) {
-            val experiments = if (contentScopeExperimentsFeature.self().isEnabled()) {
-                featureTogglesInventory.getAllTogglesForParent(featureName)
-            } else {
-                emptyList()
-            }
+    override suspend fun getActiveExperiments(): List<Toggle> =
+        withContext(dispatcherProvider.io()) {
+            val featureName = contentScopeExperimentsFeature.self().featureName().name
+            val experiments =
+                if (contentScopeExperimentsFeature.self().isEnabled()) {
+                    featureTogglesInventory.getAllTogglesForParent(featureName)
+                } else {
+                    emptyList()
+                }
             experiments.mapNotNull {
                 it.enroll()
                 if (it.isEnabled()) {
@@ -49,5 +49,4 @@ class RealContentScopeExperiments @Inject constructor(
                 }
             }
         }
-    }
 }

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsPostMessageWrapperPlugin.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsPostMessageWrapperPlugin.kt
@@ -28,10 +28,10 @@ import com.duckduckgo.js.messaging.api.SubscriptionEvent
 import com.duckduckgo.js.messaging.api.SubscriptionEventData
 import com.duckduckgo.js.messaging.api.WebMessagingPlugin
 import com.squareup.anvil.annotations.ContributesMultibinding
-import javax.inject.Inject
-import javax.inject.Named
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Named
 
 @ContributesMultibinding(FragmentScope::class)
 class ContentScopeScriptsPostMessageWrapperPlugin @Inject constructor(
@@ -42,18 +42,22 @@ class ContentScopeScriptsPostMessageWrapperPlugin @Inject constructor(
     @AppCoroutineScope private val coroutineScope: CoroutineScope,
 ) : PostMessageWrapperPlugin {
     @SuppressLint("PostMessageUsage")
-    override fun postMessage(message: SubscriptionEventData, webView: WebView) {
+    override fun postMessage(
+        message: SubscriptionEventData,
+        webView: WebView,
+    ) {
         coroutineScope.launch {
             if (webViewCompatContentScopeScripts.isEnabled()) {
-                webMessagingPlugin.postMessage(message)
+                webMessagingPlugin.postMessage(webView, message)
             } else {
                 jsMessageHelper.sendSubscriptionEvent(
-                    subscriptionEvent = SubscriptionEvent(
-                        context = webMessagingPlugin.context,
-                        featureName = message.featureName,
-                        subscriptionName = message.subscriptionName,
-                        params = message.params,
-                    ),
+                    subscriptionEvent =
+                        SubscriptionEvent(
+                            context = webMessagingPlugin.context,
+                            featureName = message.featureName,
+                            subscriptionName = message.subscriptionName,
+                            params = message.params,
+                        ),
                     callbackName = coreContentScopeScripts.callbackName,
                     secret = coreContentScopeScripts.secret,
                     webView = webView,

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsWebMessagingPlugin.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsWebMessagingPlugin.kt
@@ -19,10 +19,11 @@ package com.duckduckgo.contentscopescripts.impl.messaging
 import android.annotation.SuppressLint
 import android.webkit.WebView
 import androidx.annotation.VisibleForTesting
+import androidx.lifecycle.findViewTreeLifecycleOwner
+import androidx.lifecycle.lifecycleScope
 import androidx.webkit.JavaScriptReplyProxy
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.browser.api.webviewcompat.WebViewCompatWrapper
-import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.contentscopescripts.api.WebViewCompatContentScopeJsMessageHandlersPlugin
 import com.duckduckgo.contentscopescripts.impl.WebViewCompatContentScopeScripts
@@ -39,9 +40,7 @@ import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
 import com.squareup.moshi.Moshi
 import dagger.SingleInstanceIn
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import logcat.LogPriority.ERROR
 import logcat.asLog
 import logcat.logcat
@@ -60,7 +59,6 @@ class ContentScopeScriptsWebMessagingPlugin @Inject constructor(
     private val globalHandlers: PluginPoint<GlobalContentScopeJsMessageHandlersPlugin>,
     private val webViewCompatContentScopeScripts: WebViewCompatContentScopeScripts,
     private val webViewCompatWrapper: WebViewCompatWrapper,
-    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
 ) : WebMessagingPlugin {
     private val moshi = Moshi.Builder().add(JSONObjectAdapter()).build()
 
@@ -99,7 +97,7 @@ class ContentScopeScriptsWebMessagingPlugin @Inject constructor(
                                         sendToConsumer(webView, jsMessageCallback, jsMessage, replyProxy)
                                     }
                                     is SendResponse -> {
-                                        appCoroutineScope.launch {
+                                        webView.findViewTreeLifecycleOwner()?.lifecycleScope?.launch {
                                             onResponse(webView, jsMessage, replyProxy)
                                         }
                                     }
@@ -120,7 +118,7 @@ class ContentScopeScriptsWebMessagingPlugin @Inject constructor(
                                     sendToConsumer(webView, jsMessageCallback, jsMessage, replyProxy)
                                 }
                                 is SendResponse -> {
-                                    appCoroutineScope.launch {
+                                    webView.findViewTreeLifecycleOwner()?.lifecycleScope?.launch {
                                         onResponse(webView, jsMessage, replyProxy)
                                     }
                                 }

--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/ContentScopeScriptsAddDocumentStartJavaScriptPluginTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/ContentScopeScriptsAddDocumentStartJavaScriptPluginTest.kt
@@ -16,7 +16,6 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 class ContentScopeScriptsAddDocumentStartJavaScriptPluginTest {
-
     @get:Rule
     var coroutineRule = CoroutineTestRule()
 
@@ -29,48 +28,52 @@ class ContentScopeScriptsAddDocumentStartJavaScriptPluginTest {
     private lateinit var testee: ContentScopeScriptsAddDocumentStartJavaScriptPlugin
 
     @Before
-    fun setUp() = runTest {
-        whenever(mockActiveContentScopeExperiments.getActiveExperiments()).thenReturn(listOf())
-        testee = ContentScopeScriptsAddDocumentStartJavaScriptPlugin(
-            mockWebViewCompatContentScopeScripts,
-            coroutineRule.testDispatcherProvider,
-            mockWebViewCapabilityChecker,
-            mockWebViewCompatWrapper,
-            mockActiveContentScopeExperiments,
-            coroutineRule.testScope,
-        )
-    }
+    fun setUp() =
+        runTest {
+            whenever(mockActiveContentScopeExperiments.getActiveExperiments()).thenReturn(listOf())
+            testee =
+                ContentScopeScriptsAddDocumentStartJavaScriptPlugin(
+                    mockWebViewCompatContentScopeScripts,
+                    coroutineRule.testDispatcherProvider,
+                    mockWebViewCapabilityChecker,
+                    mockWebViewCompatWrapper,
+                    mockActiveContentScopeExperiments,
+                )
+        }
 
     @Test
-    fun whenFeatureIsEnabledAndCapabilitySupportedThenCallScriptInjectionWithCorrectParams() = runTest {
-        whenever(mockWebViewCompatContentScopeScripts.isEnabled()).thenReturn(true)
-        whenever(mockWebViewCapabilityChecker.isSupported(any())).thenReturn(true)
-        whenever(mockWebViewCompatContentScopeScripts.getScript(any())).thenReturn("script")
+    fun whenFeatureIsEnabledAndCapabilitySupportedThenCallScriptInjectionWithCorrectParams() =
+        runTest {
+            whenever(mockWebViewCompatContentScopeScripts.isEnabled()).thenReturn(true)
+            whenever(mockWebViewCapabilityChecker.isSupported(any())).thenReturn(true)
+            whenever(mockWebViewCompatContentScopeScripts.getScript(any())).thenReturn("script")
 
-        testee.addDocumentStartJavaScript(mockWebView)
+            testee.addDocumentStartJavaScript(mockWebView)
 
-        verify(mockWebViewCompatWrapper).addDocumentStartJavaScript(mockWebView, "script", setOf("*"))
-    }
-
-    @Test
-    fun whenFeatureIsDisabledAndCapabilitySupportedThenDoNotCallScriptInjection() = runTest {
-        whenever(mockWebViewCompatContentScopeScripts.isEnabled()).thenReturn(false)
-        whenever(mockWebViewCapabilityChecker.isSupported(any())).thenReturn(true)
-        whenever(mockWebViewCompatContentScopeScripts.getScript(any())).thenReturn("script")
-
-        testee.addDocumentStartJavaScript(mockWebView)
-
-        verify(mockWebViewCompatWrapper, never()).addDocumentStartJavaScript(any(), any(), any())
-    }
+            verify(mockWebViewCompatWrapper).addDocumentStartJavaScript(mockWebView, "script", setOf("*"))
+        }
 
     @Test
-    fun whenFeatureIsEnabledAndCapabilityNotSupportedThenDoNotCallScriptInjection() = runTest {
-        whenever(mockWebViewCompatContentScopeScripts.isEnabled()).thenReturn(true)
-        whenever(mockWebViewCapabilityChecker.isSupported(any())).thenReturn(false)
-        whenever(mockWebViewCompatContentScopeScripts.getScript(any())).thenReturn("script")
+    fun whenFeatureIsDisabledAndCapabilitySupportedThenDoNotCallScriptInjection() =
+        runTest {
+            whenever(mockWebViewCompatContentScopeScripts.isEnabled()).thenReturn(false)
+            whenever(mockWebViewCapabilityChecker.isSupported(any())).thenReturn(true)
+            whenever(mockWebViewCompatContentScopeScripts.getScript(any())).thenReturn("script")
 
-        testee.addDocumentStartJavaScript(mockWebView)
+            testee.addDocumentStartJavaScript(mockWebView)
 
-        verify(mockWebViewCompatWrapper, never()).addDocumentStartJavaScript(any(), any(), any())
-    }
+            verify(mockWebViewCompatWrapper, never()).addDocumentStartJavaScript(any(), any(), any())
+        }
+
+    @Test
+    fun whenFeatureIsEnabledAndCapabilityNotSupportedThenDoNotCallScriptInjection() =
+        runTest {
+            whenever(mockWebViewCompatContentScopeScripts.isEnabled()).thenReturn(true)
+            whenever(mockWebViewCapabilityChecker.isSupported(any())).thenReturn(false)
+            whenever(mockWebViewCompatContentScopeScripts.getScript(any())).thenReturn("script")
+
+            testee.addDocumentStartJavaScript(mockWebView)
+
+            verify(mockWebViewCompatWrapper, never()).addDocumentStartJavaScript(any(), any(), any())
+        }
 }

--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsPostMessageWrapperPluginTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsPostMessageWrapperPluginTest.kt
@@ -19,7 +19,6 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 class ContentScopeScriptsPostMessageWrapperPluginTest {
-
     @get:Rule
     var coroutineRule = CoroutineTestRule()
 
@@ -29,25 +28,28 @@ class ContentScopeScriptsPostMessageWrapperPluginTest {
     private val mockWebViewCompatContentScopeScripts: WebViewCompatContentScopeScripts = mock()
     private val mockWebView: WebView = mock()
     private val mockJsonObject: JSONObject = mock()
-    private val subscriptionEventData = SubscriptionEventData(
-        featureName = "testFeature",
-        subscriptionName = "testSubscription",
-        params = mockJsonObject,
-    )
-    private val subscriptionEvent = SubscriptionEvent(
-        context = "contentScopeScripts",
-        featureName = "testFeature",
-        subscriptionName = "testSubscription",
-        params = mockJsonObject,
-    )
+    private val subscriptionEventData =
+        SubscriptionEventData(
+            featureName = "testFeature",
+            subscriptionName = "testSubscription",
+            params = mockJsonObject,
+        )
+    private val subscriptionEvent =
+        SubscriptionEvent(
+            context = "contentScopeScripts",
+            featureName = "testFeature",
+            subscriptionName = "testSubscription",
+            params = mockJsonObject,
+        )
 
-    val testee = ContentScopeScriptsPostMessageWrapperPlugin(
-        webMessagingPlugin = mockWebMessagingPlugin,
-        jsMessageHelper = mockJsHelper,
-        coreContentScopeScripts = mockCoreContentScopeScripts,
-        webViewCompatContentScopeScripts = mockWebViewCompatContentScopeScripts,
-        coroutineScope = coroutineRule.testScope,
-    )
+    val testee =
+        ContentScopeScriptsPostMessageWrapperPlugin(
+            webMessagingPlugin = mockWebMessagingPlugin,
+            jsMessageHelper = mockJsHelper,
+            coreContentScopeScripts = mockCoreContentScopeScripts,
+            webViewCompatContentScopeScripts = mockWebViewCompatContentScopeScripts,
+            coroutineScope = coroutineRule.testScope,
+        )
 
     @Before
     fun setup() {
@@ -58,25 +60,27 @@ class ContentScopeScriptsPostMessageWrapperPluginTest {
     }
 
     @Test
-    fun whenWebViewCompatContentScopeScriptsIsEnabledThenPostMessageToWebMessagingPlugin() = runTest {
-        whenever(mockWebViewCompatContentScopeScripts.isEnabled()).thenReturn(true)
+    fun whenWebViewCompatContentScopeScriptsIsEnabledThenPostMessageToWebMessagingPlugin() =
+        runTest {
+            whenever(mockWebViewCompatContentScopeScripts.isEnabled()).thenReturn(true)
 
-        testee.postMessage(subscriptionEventData, mockWebView)
+            testee.postMessage(subscriptionEventData, mockWebView)
 
-        verify(mockWebMessagingPlugin).postMessage(subscriptionEventData)
-    }
+            verify(mockWebMessagingPlugin).postMessage(mockWebView, subscriptionEventData)
+        }
 
     @Test
-    fun whenWebViewCompatContentScopeScriptsIsNotEnabledThenPostMessageToContentScopeScriptsJsMessaging() = runTest {
-        whenever(mockWebViewCompatContentScopeScripts.isEnabled()).thenReturn(false)
+    fun whenWebViewCompatContentScopeScriptsIsNotEnabledThenPostMessageToContentScopeScriptsJsMessaging() =
+        runTest {
+            whenever(mockWebViewCompatContentScopeScripts.isEnabled()).thenReturn(false)
 
-        testee.postMessage(subscriptionEventData, mockWebView)
+            testee.postMessage(subscriptionEventData, mockWebView)
 
-        verify(mockJsHelper).sendSubscriptionEvent(
-            eq(subscriptionEvent),
-            eq("callbackName"),
-            eq("secret"),
-            eq(mockWebView),
-        )
-    }
+            verify(mockJsHelper).sendSubscriptionEvent(
+                eq(subscriptionEvent),
+                eq("callbackName"),
+                eq("secret"),
+                eq(mockWebView),
+            )
+        }
 }

--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsWebMessagingPluginTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsWebMessagingPluginTest.kt
@@ -95,7 +95,6 @@ class ContentScopeScriptsWebMessagingPluginTest {
                     globalHandlers = globalHandlers,
                     webViewCompatContentScopeScripts = webViewCompatContentScopeScripts,
                     webViewCompatWrapper = mockWebViewCompatWrapper,
-                    appCoroutineScope = coroutineRule.testScope,
                 )
         }
 

--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsWebMessagingPluginTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsWebMessagingPluginTest.kt
@@ -277,7 +277,7 @@ class ContentScopeScriptsWebMessagingPluginTest {
                 method: String,
                 id: String?,
                 data: JSONObject?,
-                onResponse: (params: JSONObject) -> Unit,
+                onResponse: suspend (params: JSONObject) -> Unit,
             ) {
                 counter++
             }

--- a/js-messaging/js-messaging-api/src/main/java/com/duckduckgo/js/messaging/api/AddDocumentStartJavaScriptPlugin.kt
+++ b/js-messaging/js-messaging-api/src/main/java/com/duckduckgo/js/messaging/api/AddDocumentStartJavaScriptPlugin.kt
@@ -24,8 +24,5 @@ import android.webkit.WebView
  * Useful for privacy protections and that need to run as early as possible and/or on iframes.
  */
 interface AddDocumentStartJavaScriptPlugin {
-
-    fun addDocumentStartJavaScript(
-        webView: WebView,
-    )
+    suspend fun addDocumentStartJavaScript(webView: WebView)
 }

--- a/js-messaging/js-messaging-api/src/main/java/com/duckduckgo/js/messaging/api/WebMessagingPlugin.kt
+++ b/js-messaging/js-messaging-api/src/main/java/com/duckduckgo/js/messaging/api/WebMessagingPlugin.kt
@@ -19,14 +19,14 @@ package com.duckduckgo.js.messaging.api
 import android.webkit.WebView
 
 interface WebMessagingPlugin {
-    fun register(
+    suspend fun register(
         jsMessageCallback: WebViewCompatMessageCallback,
         webView: WebView,
     )
 
-    fun unregister(webView: WebView)
+    suspend fun unregister(webView: WebView)
 
-    fun postMessage(
+    suspend fun postMessage(
         webView: WebView,
         subscriptionEventData: SubscriptionEventData,
     )

--- a/js-messaging/js-messaging-api/src/main/java/com/duckduckgo/js/messaging/api/WebMessagingPlugin.kt
+++ b/js-messaging/js-messaging-api/src/main/java/com/duckduckgo/js/messaging/api/WebMessagingPlugin.kt
@@ -24,11 +24,12 @@ interface WebMessagingPlugin {
         webView: WebView,
     )
 
-    fun unregister(
-        webView: WebView,
-    )
+    fun unregister(webView: WebView)
 
-    fun postMessage(subscriptionEventData: SubscriptionEventData)
+    fun postMessage(
+        webView: WebView,
+        subscriptionEventData: SubscriptionEventData,
+    )
 
     val context: String
 }

--- a/js-messaging/js-messaging-api/src/main/java/com/duckduckgo/js/messaging/api/WebViewCompatMessaging.kt
+++ b/js-messaging/js-messaging-api/src/main/java/com/duckduckgo/js/messaging/api/WebViewCompatMessaging.kt
@@ -37,13 +37,16 @@ interface WebViewCompatMessageCallback {
         method: String,
         id: String?,
         data: JSONObject?,
-        onResponse: (params: JSONObject) -> Unit,
+        onResponse: suspend (params: JSONObject) -> Unit,
     )
 }
 
 sealed interface ProcessResult {
     data object SendToConsumer : ProcessResult
-    data class SendResponse(val response: JSONObject) : ProcessResult
+
+    data class SendResponse(
+        val response: JSONObject,
+    ) : ProcessResult
 }
 
 interface WebViewCompatMessageHandler {
@@ -58,9 +61,7 @@ interface WebViewCompatMessageHandler {
      * @param onResponse A callback function to send a response back to the JavaScript code.
      */
 
-    fun process(
-        jsMessage: JsMessage,
-    ): ProcessResult?
+    fun process(jsMessage: JsMessage): ProcessResult?
 
     /**
      * Name of the feature

--- a/lint-rules/src/main/java/com/duckduckgo/lint/WebViewCompatApisUsageDetector.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/WebViewCompatApisUsageDetector.kt
@@ -21,8 +21,7 @@ class WebViewCompatApisUsageDetector : Detector(), SourceCodeScanner {
     override fun visitMethodCall(context: JavaContext, node: UCallExpression, method: PsiMethod) {
 
         webViewCompatApiUsages
-            .firstOrNull { it.methodName == method.name }
-            ?.takeIf { context.evaluator.isMemberInClass(method, it.containingClass) }
+            .firstOrNull { it.methodName == method.name && context.evaluator.isMemberInClass(method, it.containingClass) }
             ?.let { context.report(
                 it.issue,
                 node,
@@ -71,7 +70,7 @@ class WebViewCompatApisUsageDetector : Detector(), SourceCodeScanner {
         val ISSUE_POST_MESSAGE_USAGE: Issue = Issue.create(
             id = "PostMessageUsage",
             briefDescription = "Use PostMessageWrapperPlugin to post messages",
-            explanation = "Use `PluginPoint<PostMessageWrapperPlugin>` instead for backwards compatibility",
+            explanation = "Use `PluginPoint<PostMessageWrapperPlugin>` instead for backwards compatibility. If already within a `WebMessagingPlugin`, use `WebViewCompatWrapper#postMessage` instead",
             category = Category.CORRECTNESS,
             severity = Severity.ERROR,
             implementation = Implementation(
@@ -114,6 +113,11 @@ class WebViewCompatApisUsageDetector : Detector(), SourceCodeScanner {
             WebViewCompatApiUsage(
                 methodName = "postMessage",
                 containingClass = "com.duckduckgo.js.messaging.api.WebMessagingPlugin",
+                issue = ISSUE_POST_MESSAGE_USAGE
+            ),
+            WebViewCompatApiUsage(
+                methodName = "postMessage",
+                containingClass = "androidx.webkit.JavaScriptReplyProxy",
                 issue = ISSUE_POST_MESSAGE_USAGE
             )
         )

--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
@@ -17,7 +17,9 @@
 package com.duckduckgo.privacy.config.api
 
 /** List of [PrivacyFeatureName] that belong to the Privacy Configuration */
-enum class PrivacyFeatureName(val value: String) {
+enum class PrivacyFeatureName(
+    val value: String,
+) {
     ContentBlockingFeatureName("contentBlocking"),
     GpcFeatureName("gpc"),
     HttpsFeatureName("https"),
@@ -27,4 +29,4 @@ enum class PrivacyFeatureName(val value: String) {
     TrackingParametersFeatureName("trackingParameters"),
 }
 
-const val PRIVACY_REMOTE_CONFIG_URL = "https://staticcdn.duckduckgo.com/trackerblocking/config/v4/android-config.json"
+const val PRIVACY_REMOTE_CONFIG_URL = "https://duckduckgo.github.io/privacy-configuration/pr-3816/v4/android-config.json"

--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
@@ -29,4 +29,4 @@ enum class PrivacyFeatureName(
     TrackingParametersFeatureName("trackingParameters"),
 }
 
-const val PRIVACY_REMOTE_CONFIG_URL = "https://duckduckgo.github.io/privacy-configuration/pr-3816/v4/android-config.json"
+const val PRIVACY_REMOTE_CONFIG_URL = "https://staticcdn.duckduckgo.com/trackerblocking/config/v4/android-config.json"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1211506668810055?focus=true

### Description
* Check WebView attached before calling `WebViewCompat` and `postMessage` methods
* Check coroutine active before calling `WebViewCompat` and `postMessage` methods
* Launch WebViewCompat` and `postMessage` methods with `lifecycleScope` or `viewModelScope` whenever possible

### Steps to test this PR

_Feature 1_
- [x] Smoke test blob downloads
- [x] Smoke test app with `useNewWebCompatApis` enabled. Requires fresh install after setting setting `const val PRIVACY_REMOTE_CONFIG_URL = "https://duckduckgo.github.io/privacy-configuration/pr-3816/v4/android-config.json"`
- [x] Run tests in https://privacy-test-pages.site/privacy-protections/gpc/. Make sure `frame JS API ` is true 

_Message replies_ 
- [x] Launch https://w3c.github.io/web-share/demos/share-files.html
- [x] Click `Share`
- [x] Cancel native popup
- [x] Check message `Error sharing: AbortError: Share canceled` is displayed 


### UI changes
n/a
