### PR TITLE
FF not removing/adding script on page finished, only protection status changes

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -7886,7 +7886,7 @@ class BrowserTabViewModelTest {
         var postMessageCalled = false
             private set
 
-        override fun postMessage(
+        override suspend fun postMessage(
             message: SubscriptionEventData,
             webView: WebView,
         ) {

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -7512,18 +7512,6 @@ class BrowserTabViewModelTest {
 
     @UiThreadTest
     @Test
-    fun whenDestroyThenRemoveWebMessageListener() =
-        runTest {
-            val mockCallback = mock<WebViewCompatMessageCallback>()
-            val webView = DuckDuckGoWebView(context)
-            testee.configureWebView(webView, mockCallback)
-            assertTrue(fakeMessagingPlugins.plugin.registered)
-            testee.destroy(webView)
-            assertFalse(fakeMessagingPlugins.plugin.registered)
-        }
-
-    @UiThreadTest
-    @Test
     fun whenPostMessageThenCallPostContentScopeMessage() =
         runTest {
             val data = SubscriptionEventData("feature", "method", JSONObject())

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -6979,11 +6979,11 @@ class BrowserTabViewModelTest {
         }
 
     @Test
-    fun whenPageFinishedAndOnlyUpdateScriptOnProtectionsChangedDisabledThenAddDocumentStartJavaScriptOnlyToCSS() =
+    fun whenPageFinishedAndUpdateScriptOnPageFinishedEnabledThenAddDocumentStartJavaScript() =
         runTest {
             val url = "https://example.com"
             val webViewNavState = WebViewNavigationState(mockStack, 100)
-            fakeAndroidConfigBrowserFeature.onlyUpdateScriptOnProtectionsChanged().setRawStoredState(State(false))
+            fakeAndroidConfigBrowserFeature.updateScriptOnPageFinished().setRawStoredState(State(true))
 
             testee.pageFinished(mockWebView, webViewNavState, url)
 
@@ -6992,15 +6992,37 @@ class BrowserTabViewModelTest {
         }
 
     @Test
-    fun whenPageFinishedAndOnlyUpdateScriptOnProtectionsChangedEnabledThenDoNotCallAddDocumentStartJavaScript() =
+    fun whenPageFinishedAndUpdateScriptOnPageFinishedDisabledThenDoNotCallAddDocumentStartJavaScript() =
         runTest {
             val url = "https://example.com"
             val webViewNavState = WebViewNavigationState(mockStack, 100)
-            fakeAndroidConfigBrowserFeature.onlyUpdateScriptOnProtectionsChanged().setRawStoredState(State(true))
+            fakeAndroidConfigBrowserFeature.updateScriptOnPageFinished().setRawStoredState(State(false))
 
             testee.pageFinished(mockWebView, webViewNavState, url)
 
             assertEquals(0, fakeAddDocumentStartJavaScriptPlugins.cssPlugin.countInitted)
+            assertEquals(0, fakeAddDocumentStartJavaScriptPlugins.otherPlugin.countInitted)
+        }
+
+    @Test
+    fun whenPrivacyProtectionsUpdatedAndAndUpdateScriptOnPageFinishedEnabledThenAddDocumentStartJavaScript() =
+        runTest {
+            fakeAndroidConfigBrowserFeature.updateScriptOnPageFinished().setRawStoredState(State(true))
+
+            testee.privacyProtectionsUpdated(mockWebView)
+
+            assertEquals(1, fakeAddDocumentStartJavaScriptPlugins.cssPlugin.countInitted)
+            assertEquals(1, fakeAddDocumentStartJavaScriptPlugins.otherPlugin.countInitted)
+        }
+
+    @Test
+    fun whenPrivacyProtectionsUpdatedAndAndUpdateScriptOnPageFinishedDisabledThenAddDocumentStartJavaScriptOnlyOnCSS() =
+        runTest {
+            fakeAndroidConfigBrowserFeature.updateScriptOnPageFinished().setRawStoredState(State(false))
+
+            testee.privacyProtectionsUpdated(mockWebView)
+
+            assertEquals(1, fakeAddDocumentStartJavaScriptPlugins.cssPlugin.countInitted)
             assertEquals(0, fakeAddDocumentStartJavaScriptPlugins.otherPlugin.countInitted)
         }
 

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -84,10 +84,6 @@ import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.On
 import com.duckduckgo.duckplayer.api.DuckPlayer.OpenDuckPlayerInNewTab.Unavailable
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.history.api.NavigationHistory
-import com.duckduckgo.js.messaging.api.PostMessageWrapperPlugin
-import com.duckduckgo.js.messaging.api.SubscriptionEventData
-import com.duckduckgo.js.messaging.api.WebMessagingPlugin
-import com.duckduckgo.js.messaging.api.WebViewCompatMessageCallback
 import com.duckduckgo.privacy.config.api.AmpLinks
 import com.duckduckgo.subscriptions.api.Subscriptions
 import com.duckduckgo.user.agent.api.ClientBrandHintProvider
@@ -98,7 +94,6 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
-import org.json.JSONObject
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1224,7 +1224,7 @@ class BrowserTabFragment :
     private fun postBreakageReportingEvent() {
         val eventData = createBreakageReportingEventData()
         webView?.let {
-            webViewClient.postContentScopeMessage(eventData, it)
+            viewModel.postContentScopeMessage(eventData, it)
         }
     }
 
@@ -1996,7 +1996,7 @@ class BrowserTabFragment :
             is Command.RefreshAndShowPrivacyProtectionEnabledConfirmation -> {
                 webView?.let { safeWebView ->
                     lifecycleScope.launch {
-                        webViewClient.configureWebView(safeWebView, null)
+                        viewModel.privacyProtectionsUpdated(safeWebView)
                         refresh()
                         privacyProtectionEnabledConfirmation(it.domain)
                     }
@@ -2006,7 +2006,7 @@ class BrowserTabFragment :
             is Command.RefreshAndShowPrivacyProtectionDisabledConfirmation -> {
                 webView?.let { safeWebView ->
                     lifecycleScope.launch {
-                        webViewClient.configureWebView(safeWebView, null)
+                        viewModel.privacyProtectionsUpdated(safeWebView)
                         refresh()
                         privacyProtectionDisabledConfirmation(it.domain)
                     }
@@ -3208,30 +3208,28 @@ class BrowserTabFragment :
                     }
                 },
             )
-            lifecycleScope.launch {
-                webViewClient.configureWebView(
-                    it,
-                    object : WebViewCompatMessageCallback {
-                        override fun process(
-                            context: String,
-                            featureName: String,
-                            method: String,
-                            id: String?,
-                            data: JSONObject?,
-                            onResponse: suspend (JSONObject) -> Unit,
-                        ) {
-                            viewModel.webViewCompatProcessJsCallbackMessage(
-                                context = context,
-                                featureName = featureName,
-                                method = method,
-                                id = id,
-                                data = data,
-                                onResponse = onResponse,
-                            )
-                        }
-                    },
-                )
-            }
+            viewModel.configureWebView(
+                it,
+                object : WebViewCompatMessageCallback {
+                    override fun process(
+                        context: String,
+                        featureName: String,
+                        method: String,
+                        id: String?,
+                        data: JSONObject?,
+                        onResponse: suspend (JSONObject) -> Unit,
+                    ) {
+                        viewModel.webViewCompatProcessJsCallbackMessage(
+                            context = context,
+                            featureName = featureName,
+                            method = method,
+                            id = id,
+                            data = data,
+                            onResponse = onResponse,
+                        )
+                    }
+                },
+            )
 
             duckPlayerScripts.register(
                 it,

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -4238,10 +4238,12 @@ class BrowserTabViewModel @Inject constructor(
         eventData: SubscriptionEventData,
         webView: WebView,
     ) {
-        postMessageWrapperPlugins
-            .getPlugins()
-            .firstOrNull { it.context == "contentScopeScripts" }
-            ?.postMessage(eventData, webView)
+        viewModelScope.launch {
+            postMessageWrapperPlugins
+                .getPlugins()
+                .firstOrNull { it.context == "contentScopeScripts" }
+                ?.postMessage(eventData, webView)
+        }
     }
 
     private suspend fun addDocumentStartJavaScript(webView: WebView) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -4252,12 +4252,6 @@ class BrowserTabViewModel @Inject constructor(
         }
     }
 
-    override suspend fun destroy(webView: DuckDuckGoWebView) {
-        webMessagingPlugins.getPlugins().forEach { plugin ->
-            plugin.unregister(webView)
-        }
-    }
-
     suspend fun privacyProtectionsUpdated(webView: WebView) {
         if (withContext(dispatchers.io()) { androidBrowserConfig.onlyUpdateScriptOnProtectionsChanged().isEnabled() }) {
             addDocumentStartJavascriptPlugins

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1934,7 +1934,7 @@ class BrowserTabViewModel @Inject constructor(
             evaluateSerpLogoState(url)
         }
         viewModelScope.launch(dispatchers.io()) {
-            if (!androidBrowserConfig.onlyUpdateScriptOnProtectionsChanged().isEnabled()) {
+            if (androidBrowserConfig.updateScriptOnPageFinished().isEnabled()) {
                 addDocumentStartJavaScript(webView)
             }
         }
@@ -4253,7 +4253,7 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     suspend fun privacyProtectionsUpdated(webView: WebView) {
-        if (withContext(dispatchers.io()) { androidBrowserConfig.onlyUpdateScriptOnProtectionsChanged().isEnabled() }) {
+        if (withContext(dispatchers.io()) { !androidBrowserConfig.updateScriptOnPageFinished().isEnabled() }) {
             addDocumentStartJavascriptPlugins
                 .getPlugins()
                 .filter { plugin ->
@@ -4261,6 +4261,8 @@ class BrowserTabViewModel @Inject constructor(
                 }.forEach {
                     it.addDocumentStartJavaScript(webView)
                 }
+        } else {
+            addDocumentStartJavaScript(webView)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
@@ -169,6 +169,7 @@ interface WebViewClientListener {
     fun onShouldOverride()
 
     fun pageFinished(
+        webView: WebView,
         webViewNavigationState: WebViewNavigationState,
         url: String?,
     )
@@ -183,5 +184,5 @@ interface WebViewClientListener {
         activeExperiments: List<Toggle>,
     )
 
-    fun addDocumentStartJavaScript(webView: WebView)
+    suspend fun destroy(webView: DuckDuckGoWebView)
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
@@ -183,6 +183,4 @@ interface WebViewClientListener {
         webViewNavigationState: WebViewNavigationState,
         activeExperiments: List<Toggle>,
     )
-
-    suspend fun destroy(webView: DuckDuckGoWebView)
 }

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -190,5 +190,5 @@ interface AndroidBrowserConfigFeature {
     fun vpnMenuItem(): Toggle
 
     @Toggle.DefaultValue(FALSE)
-    fun onlyUpdateScriptOnProtectionsChanged(): Toggle
+    fun updateScriptOnPageFinished(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -189,6 +189,6 @@ interface AndroidBrowserConfigFeature {
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun vpnMenuItem(): Toggle
 
-    @Toggle.DefaultValue(FALSE)
+    @Toggle.DefaultValue(TRUE)
     fun updateScriptOnPageFinished(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -20,6 +20,8 @@ import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue.FALSE
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue.TRUE
 
 /**
  * This is the class that represents the browser feature flags
@@ -29,7 +31,6 @@ import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
     featureName = "androidBrowserConfig",
 )
 interface AndroidBrowserConfigFeature {
-
     /**
      * @return `true` when the remote config has the global "androidBrowserConfig" feature flag enabled
      * If the remote feature is not present defaults to `false`
@@ -187,4 +188,7 @@ interface AndroidBrowserConfigFeature {
      */
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun vpnMenuItem(): Toggle
+
+    @Toggle.DefaultValue(FALSE)
+    fun onlyUpdateScriptOnProtectionsChanged(): Toggle
 }

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/ContentScopeScriptsAddDocumentStartJavaScriptPlugin.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/ContentScopeScriptsAddDocumentStartJavaScriptPlugin.kt
@@ -20,6 +20,7 @@ import android.annotation.SuppressLint
 import android.webkit.WebView
 import androidx.webkit.ScriptHandler
 import com.duckduckgo.app.browser.api.WebViewCapabilityChecker
+import com.duckduckgo.app.browser.api.WebViewCapabilityChecker.WebViewCapability.DocumentStartJavaScript
 import com.duckduckgo.browser.api.webviewcompat.WebViewCompatWrapper
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.contentscopescripts.api.contentscopeExperiments.ContentScopeExperiments
@@ -46,7 +47,7 @@ class ContentScopeScriptsAddDocumentStartJavaScriptPlugin @Inject constructor(
     override suspend fun addDocumentStartJavaScript(webView: WebView) {
         if (!webViewCompatContentScopeScripts.isEnabled() ||
             !webViewCapabilityChecker.isSupported(
-                WebViewCapabilityChecker.WebViewCapability.DocumentStartJavaScript,
+                DocumentStartJavaScript,
             )
         ) {
             return
@@ -74,4 +75,7 @@ class ContentScopeScriptsAddDocumentStartJavaScriptPlugin @Inject constructor(
                 currentScriptString = scriptString
             }
     }
+
+    override val context: String
+        get() = "contentScopeScripts"
 }

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsPostMessageWrapperPlugin.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsPostMessageWrapperPlugin.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.contentscopescripts.impl.messaging
 
 import android.annotation.SuppressLint
 import android.webkit.WebView
-import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.contentscopescripts.impl.CoreContentScopeScripts
 import com.duckduckgo.contentscopescripts.impl.WebViewCompatContentScopeScripts
 import com.duckduckgo.di.scopes.FragmentScope
@@ -28,8 +27,6 @@ import com.duckduckgo.js.messaging.api.SubscriptionEvent
 import com.duckduckgo.js.messaging.api.SubscriptionEventData
 import com.duckduckgo.js.messaging.api.WebMessagingPlugin
 import com.squareup.anvil.annotations.ContributesMultibinding
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -39,29 +36,26 @@ class ContentScopeScriptsPostMessageWrapperPlugin @Inject constructor(
     private val jsMessageHelper: JsMessageHelper,
     private val coreContentScopeScripts: CoreContentScopeScripts,
     private val webViewCompatContentScopeScripts: WebViewCompatContentScopeScripts,
-    @AppCoroutineScope private val coroutineScope: CoroutineScope,
 ) : PostMessageWrapperPlugin {
     @SuppressLint("PostMessageUsage")
-    override fun postMessage(
+    override suspend fun postMessage(
         message: SubscriptionEventData,
         webView: WebView,
     ) {
-        coroutineScope.launch {
-            if (webViewCompatContentScopeScripts.isEnabled()) {
-                webMessagingPlugin.postMessage(webView, message)
-            } else {
-                jsMessageHelper.sendSubscriptionEvent(
-                    subscriptionEvent = SubscriptionEvent(
-                        context = webMessagingPlugin.context,
-                        featureName = message.featureName,
-                        subscriptionName = message.subscriptionName,
-                        params = message.params,
-                    ),
-                    callbackName = coreContentScopeScripts.callbackName,
-                    secret = coreContentScopeScripts.secret,
-                    webView = webView,
-                )
-            }
+        if (webViewCompatContentScopeScripts.isEnabled()) {
+            webMessagingPlugin.postMessage(webView, message)
+        } else {
+            jsMessageHelper.sendSubscriptionEvent(
+                subscriptionEvent = SubscriptionEvent(
+                    context = webMessagingPlugin.context,
+                    featureName = message.featureName,
+                    subscriptionName = message.subscriptionName,
+                    params = message.params,
+                ),
+                callbackName = coreContentScopeScripts.callbackName,
+                secret = coreContentScopeScripts.secret,
+                webView = webView,
+            )
         }
     }
 

--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsPostMessageWrapperPluginTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/messaging/ContentScopeScriptsPostMessageWrapperPluginTest.kt
@@ -1,7 +1,6 @@
 package com.duckduckgo.contentscopescripts.impl.messaging
 
 import android.webkit.WebView
-import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.contentscopescripts.impl.CoreContentScopeScripts
 import com.duckduckgo.contentscopescripts.impl.WebViewCompatContentScopeScripts
 import com.duckduckgo.js.messaging.api.JsMessageHelper
@@ -11,7 +10,6 @@ import com.duckduckgo.js.messaging.api.WebMessagingPlugin
 import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.eq
@@ -19,9 +17,6 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 class ContentScopeScriptsPostMessageWrapperPluginTest {
-    @get:Rule
-    var coroutineRule = CoroutineTestRule()
-
     private val mockWebMessagingPlugin: WebMessagingPlugin = mock()
     private val mockJsHelper: JsMessageHelper = mock()
     private val mockCoreContentScopeScripts: CoreContentScopeScripts = mock()
@@ -48,7 +43,6 @@ class ContentScopeScriptsPostMessageWrapperPluginTest {
             jsMessageHelper = mockJsHelper,
             coreContentScopeScripts = mockCoreContentScopeScripts,
             webViewCompatContentScopeScripts = mockWebViewCompatContentScopeScripts,
-            coroutineScope = coroutineRule.testScope,
         )
 
     @Before

--- a/js-messaging/js-messaging-api/src/main/java/com/duckduckgo/js/messaging/api/AddDocumentStartJavaScriptPlugin.kt
+++ b/js-messaging/js-messaging-api/src/main/java/com/duckduckgo/js/messaging/api/AddDocumentStartJavaScriptPlugin.kt
@@ -25,4 +25,6 @@ import android.webkit.WebView
  */
 interface AddDocumentStartJavaScriptPlugin {
     suspend fun addDocumentStartJavaScript(webView: WebView)
+
+    val context: String
 }

--- a/js-messaging/js-messaging-api/src/main/java/com/duckduckgo/js/messaging/api/PostMessageWrapperPlugin.kt
+++ b/js-messaging/js-messaging-api/src/main/java/com/duckduckgo/js/messaging/api/PostMessageWrapperPlugin.kt
@@ -19,7 +19,7 @@ package com.duckduckgo.js.messaging.api
 import android.webkit.WebView
 
 interface PostMessageWrapperPlugin {
-    fun postMessage(message: SubscriptionEventData, webView: WebView)
+    suspend fun postMessage(message: SubscriptionEventData, webView: WebView)
 
     val context: String
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1211506668810056?focus=true

### Description
* Add RC flag to support only removing/adding script when protection status changes, not every time page load finishes

### Steps to test this PR

_Pre-requisites_
- [ ] Add a log to `ContentScopeScriptsAddDocumentStartJavaScriptPlugin#addDocumentStartJavaScript`
- [ ] Fresh install after setting setting `const val PRIVACY_REMOTE_CONFIG_URL = "https://duckduckgo.github.io/privacy-configuration/pr-3816/v4/android-config.json"`

_Feature 1_
- [ ] Enable `updateScriptOnPageFinished` RC flag
- [ ] Check the log displays every time a page load finishes (even multiple times per page load)
- [ ] Toggle protections on and off from overflow menu and privacy dashboard and check log is displayed

_Flag disabled_
- [ ] Disable `updateScriptOnPageFinished` RC flag
- [ ] Check the log doesn't display when a page load is finished
- [ ] Toggle protections on and off from overflow menu and privacy dashboard and check log is displayed

### UI changes
n/a
