### PR TITLE
Implement custom tab handling for app links in BrowserTabViewModel.

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -3808,6 +3808,18 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenHandleAppLinkCalledAndCustomTabIsTrueThenOpenAppLink() {
+        val urlType = SpecialUrlDetector.UrlType.AppLink(uriString = exampleUrl)
+        testee.setIsCustomTab(true)
+        testee.handleAppLink(urlType, isForMainFrame = true)
+        whenever(mockAppLinksHandler.isUserQuery()).thenReturn(false)
+        whenever(ctaViewModelMockSettingsStore.showAppLinksPrompt).thenReturn(false)
+        verify(mockAppLinksHandler).handleAppLink(eq(true), eq(exampleUrl), eq(false), eq(true), appLinkCaptor.capture())
+        appLinkCaptor.lastValue.invoke()
+        assertCommandIssued<Command.OpenAppLink>()
+    }
+
+    @Test
     fun whenHandleNonHttpAppLinkCalledThenHandleNonHttpAppLink() {
         val urlType = SpecialUrlDetector.UrlType.NonHttpAppLink("market://details?id=com.example", Intent(), exampleUrl)
         assertTrue(testee.handleNonHttpAppLink(urlType))

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1029,6 +1029,7 @@ class BrowserTabFragment :
 
         if (savedInstanceState == null) {
             viewModel.onViewReady()
+            viewModel.setIsCustomTab(tabDisplayedInCustomTabScreen)
             messageFromPreviousTab?.let {
                 processMessage(it)
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -584,6 +584,7 @@ class BrowserTabViewModel @Inject constructor(
     private var isProcessingTrackingLink = false
     private var isLinkOpenedInNewTab = false
     private var allowlistRefreshTriggerJob: Job? = null
+    private var isCustomTabScreen: Boolean = false
 
     private val fireproofWebsitesObserver =
         Observer<List<FireproofWebsiteEntity>> {
@@ -796,6 +797,10 @@ class BrowserTabViewModel @Inject constructor(
         site = siteLiveData.value
 
         initialUrl?.let { buildSiteFactory(it, stillExternal = isExternal) }
+    }
+
+    fun setIsCustomTab(isCustomTab: Boolean) {
+        this.isCustomTabScreen = isCustomTab
     }
 
     fun onViewReady() {
@@ -3058,11 +3063,16 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     private fun appLinkClicked(appLink: AppLink) {
-        if (appSettingsPreferencesStore.showAppLinksPrompt || appLinksHandler.isUserQuery()) {
-            command.value = ShowAppLinkPrompt(appLink)
-            appLinksHandler.setUserQueryState(false)
-        } else {
-            command.value = OpenAppLink(appLink)
+        when {
+            // When in custom tab, always open the app link directly, without prompting.
+            isCustomTabScreen -> command.value = OpenAppLink(appLink)
+
+            appSettingsPreferencesStore.showAppLinksPrompt || appLinksHandler.isUserQuery() -> {
+                command.value = ShowAppLinkPrompt(appLink)
+                appLinksHandler.setUserQueryState(false)
+            }
+
+            else -> command.value = OpenAppLink(appLink)
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211450043710855?focus=true

### Description

Added support for better handling app links in custom tabs. When an app link is opened in a custom tab, the app will now directly open the app link without showing the app link prompt, regardless of the user's app link prompt settings.

### Steps to test this PR

_App Links in Custom Tabs_
- [x] Install from this branch.
- [x] See https://app.asana.com/1/137249556945/task/1211450043710855/comment/1211477223443413?focus=true for steps and credentials.
- [x] See attached video to understand the flow and prerequisites (DDG is custom tab and DDG -> Settings -> Permissions -> Open Links is Apps is set to either `Ask Every Time` or `Never`).

_Regular App Links_
- [x] Install from this branch.
- [x] Open the app and set prerequisites: DDG is custom tab and DDG -> Settings -> Permissions -> Open Links is Apps is set to either `Ask Every Time` or `Never`.
- [x] Navigate to a page with an app link. I.e: https://play.google.com/store/apps/details?id=com.duckduckgo.mobile.android&hl=en-US
- [x] Verify that you are prompted to open the link in the Play Store app.

### UI changes
No UI changes, only behavior changes in Custom Tab for app links.